### PR TITLE
feat(v2): land UIItty4 design system in src/_redesign/ behind ?ui=v3 …

### DIFF
--- a/frontend-v2/package.json
+++ b/frontend-v2/package.json
@@ -16,8 +16,10 @@
     "types:gen": "openapi-typescript ${VITE_OPENAPI_URL:-https://ed-finder.app/openapi.json} -o src/types/api.gen.ts"
   },
   "dependencies": {
+    "lucide-react": "^0.469.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "recharts": "^2.15.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/frontend-v2/src/_redesign/README.md
+++ b/frontend-v2/src/_redesign/README.md
@@ -1,0 +1,74 @@
+# `_redesign/` — UIItty4 design system, quarantined
+
+This directory is the **landing zone for the UIItty4 prototype** (see
+`UX_AUDIT.md` on the `UIItty4` branch for the design rationale). It is
+deliberately isolated from the rest of `frontend-v2/src/` while we migrate.
+
+## Status: Phase 1 — design system landed, mock data only
+
+- All components are copied from the `UIItty4` branch unchanged (`.jsx`, not
+  yet ported to `.tsx`).
+- All data is read from `lib/mockData.js`. **No backend calls.** Wiring to the
+  real API (`/api/local/search`, `/api/map/*`, `/api/watchlist`, etc.) lands
+  in Phase 2 via an adapter layer and per-workspace hooks.
+
+## How users opt in
+
+The redesign is gated by a feature flag in `src/main.tsx`. It does **not** load
+for default users:
+
+| Action                                   | Effect                          |
+|------------------------------------------|---------------------------------|
+| Visit `…/v2/?ui=v3`                      | Load redesign + remember choice |
+| Visit `…/v2/?ui=v2`                      | Load v2 + clear redesign choice |
+| `localStorage.setItem('uiV3','1')`+reload| Sticky redesign preview         |
+| `localStorage.removeItem('uiV3')`+reload | Back to v2                      |
+
+The redesign bundle (`RedesignApp-*.js`) and its CSS (`RedesignApp-*.css`) are
+emitted as **separate chunks** by Vite's dynamic-import code splitting, so
+opt-out users never download them.
+
+## Layout
+
+```
+_redesign/
+├── RedesignApp.jsx          # entry — mirrors UIItty4's App.js
+├── redesign.css             # global styles (brushed steel, nebula bg, sliders)
+├── components/
+│   ├── Discover/  ←  Finder workspace (filter rail + result rail + drawer + radar + EDDN feed)
+│   ├── Map/       ←  Map workspace (canvas + layer toggles)
+│   ├── Plan/      ←  FC Planner workspace
+│   ├── Track/     ←  Colony Tracker workspace
+│   ├── Shell/     ←  TopBar + StatusStrip (top + bottom HUD)
+│   ├── Tabs/      ←  Watchlist/Pinned/Compare/Optimizer/Admin stubs
+│   └── UI/        ←  Hud primitives (Panel, HudButton, RatingBar, TierPill, etc.)
+└── lib/
+    └── mockData.js          # single source of truth for the prototype
+```
+
+## What NOT to do
+
+- ❌ Don't import anything from `_redesign/` outside `_redesign/` itself or
+  `main.tsx`. The folder must remain easy to delete in one rm if we abandon
+  the design.
+- ❌ Don't import anything from `@/` (the rest of `src/`) into this folder
+  yet. Until Phase 2, the prototype is **fully self-contained**.
+- ❌ Don't add the redesign to the default render path in `main.tsx`. The
+  flag-gate is the entire safety story for production.
+
+## Phase 2 (next PR): wire to the real backend
+
+Add `_redesign/adapters/` with typed functions that return `mockData`-shaped
+objects from the live endpoints, then replace the `import { SYSTEMS, … } from
+'../../lib/mockData'` imports inside each workspace one at a time:
+
+| Workspace | Mock dependency             | Real endpoint                         |
+|-----------|------------------------------|---------------------------------------|
+| Discover  | `SYSTEMS`, `EDDN_FEED`       | `POST /api/local/search`, `GET /api/events/recent` |
+| Map       | `REGIONS`, `CLUSTERS`, `HEATMAP` | `GET /api/map/{regions,clusters/hulls,heatmap}` |
+| Drawer    | `SYSTEMS[i]` detail          | `GET /api/system/{id64}`              |
+| Tabs      | hard-coded stubs             | `/api/watchlist`, `/api/ratings/rerank`, etc. |
+
+Until those land, anyone opening the redesign sees the prototype's hand-picked
+mock data and not real galactic data — which is the desired behaviour for an
+opt-in preview.

--- a/frontend-v2/src/_redesign/RedesignApp.jsx
+++ b/frontend-v2/src/_redesign/RedesignApp.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import './redesign.css';
+import { TopBar } from './components/Shell/TopBar';
+import { StatusStrip } from './components/Shell/StatusStrip';
+import { FinderWorkspace } from './components/Discover/DiscoverWorkspace';
+import { MapWorkspace } from './components/Map/MapWorkspace';
+import { PlanWorkspace } from './components/Plan/PlanWorkspace';
+import { TrackWorkspace } from './components/Track/TrackWorkspace';
+import {
+  WatchlistTab, PinnedTab, CompareTab, OptimizerTab, AdminTab,
+} from './components/Tabs/TabStubs';
+
+function App() {
+  const [tab, setTab] = useState('finder');
+
+  return (
+    <>
+      {/* Nebula parallax layer 2 (between background and starfield) */}
+      <div className="nebula-layer-2" />
+      <div className="nebula-layer-3" />
+      {/* Starfield sits above the nebula but below the UI */}
+      <div className="starfield-overlay" />
+
+      <div className="h-screen flex flex-col overflow-hidden" data-testid="app-shell">
+        <TopBar tab={tab} onTab={setTab} />
+
+        <main className="flex-1 flex flex-col min-h-0">
+          {tab === 'finder'    && <FinderWorkspace />}
+          {tab === 'watchlist' && <WatchlistTab />}
+          {tab === 'pinned'    && <PinnedTab />}
+          {tab === 'compare'   && <CompareTab />}
+          {tab === 'optimizer' && <OptimizerTab />}
+          {tab === 'fc'        && <PlanWorkspace />}
+          {tab === 'colony'    && <TrackWorkspace />}
+          {tab === 'map'       && <MapWorkspace />}
+          {tab === 'admin'     && <AdminTab />}
+        </main>
+
+        <StatusStrip
+          visible={6}
+          watched={1}
+          topScore={89}
+          topName="Wregoe XX-1 b48-2"
+        />
+      </div>
+    </>
+  );
+}
+
+export default App;

--- a/frontend-v2/src/_redesign/components/Discover/DiscoverWorkspace.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/DiscoverWorkspace.jsx
@@ -1,0 +1,118 @@
+// Finder workspace — responsive layout, briefing collapsible, EDDN docked
+// inside the results column so nothing overlaps.
+import React, { useState } from 'react';
+import { FilterRail } from './FilterRail';
+import { ResultRail } from './ResultRail';
+import { SystemDrawer } from './SystemDrawer';
+import { EDDNFeed } from './EDDNFeed';
+import { SYSTEMS, EDDN_FEED } from '../../lib/mockData';
+
+const DEFAULT_BODY = {
+  landable: { min: 0, max: 60 },  walkable:  { min: 0, max: 60 },
+  blackHole:{ min: 0, max: 5  },  neutron:   { min: 0, max: 5  },
+  whiteDwarf:{min: 0, max: 3  },  otherStar: { min: 0, max: 30 },
+  elw:      { min: 0, max: 10 },  ww:        { min: 0, max: 20 },
+  ammonia:  { min: 0, max: 10 },  gasGiant:  { min: 0, max: 30 },
+  hmc:      { min: 0, max: 30 },  metalRich: { min: 0, max: 10 },
+  rockyIce: { min: 0, max: 25 },  rocky:     { min: 0, max: 50 },
+  icy:      { min: 0, max: 60 },  rings:     { min: 0, max: 30 },
+  geo:      { min: 0, max: 30 },  bio:       { min: 0, max: 25 },
+};
+
+const DEFAULT_TOGGLES = {
+  bio: false, geo: false, terra: false, hideCol: true, noBH: false,
+  rings: false, volcanism: false, notTidal: false, popZero: false,
+};
+
+export function FinderWorkspace() {
+  const [preset,    setPreset]    = useState('tech');
+  const [distance,  setDistance]  = useState({ min: 0, max: 500 });
+  const [perPage,   setPerPage]   = useState(50);
+  const [minRating, setMinRating] = useState(40);
+  const [body,      setBody]      = useState(DEFAULT_BODY);
+  const [economy,   setEconomy]   = useState('Any');
+  const [galaxy,    setGalaxy]    = useState(false);
+  const [sortBy,    setSortBy]    = useState('Rating ↓');
+  const [toggles,   setToggles]   = useState(DEFAULT_TOGGLES);
+  const [selected,  setSelected]  = useState(null);
+  const [eddnOpen,  setEddnOpen]  = useState(true);
+  const [watched,   setWatched]   = useState(new Set([1004]));
+
+  const setBodyKey = (k, v) => setBody((b) => ({ ...b, [k]: v }));
+  const setToggle  = (k, v) => setToggles((t) => ({ ...t, [k]: v }));
+  const reset = () => {
+    setDistance({ min: 0, max: 500 });
+    setPerPage(50);
+    setMinRating(40);
+    setBody(DEFAULT_BODY);
+    setEconomy('Any');
+    setGalaxy(false);
+    setToggles(DEFAULT_TOGGLES);
+  };
+  const toggleWatch = (id) => setWatched((s) => {
+    const n = new Set(s);
+    n.has(id) ? n.delete(id) : n.add(id);
+    return n;
+  });
+
+  // Adaptive grid: with briefing → 3-col; without → 2-col (results expand)
+  const gridCols = selected
+    ? 'grid-cols-[400px_minmax(0,1fr)_380px]'
+    : 'grid-cols-[400px_minmax(0,1fr)]';
+
+  return (
+    <div className={`flex-1 grid ${gridCols} gap-3 p-3 min-h-0 transition-[grid-template-columns] duration-300 ease-out`}>
+      {/* LEFT — filter rail */}
+      <FilterRail
+        preset={preset} onPreset={setPreset}
+        refSystem={{ name: 'Sol', x: 0, y: 0, z: 0 }}
+        distance={distance} onDistance={setDistance}
+        resultsPerPage={perPage} onResultsPerPage={setPerPage}
+        minRating={minRating} onMinRating={setMinRating}
+        bodySliders={body} onBodySlider={setBodyKey}
+        economy={economy} onEconomy={setEconomy}
+        galaxyWide={galaxy} onGalaxyWide={setGalaxy}
+        sortBy={sortBy} onSortBy={setSortBy}
+        toggles={toggles} onToggle={setToggle}
+        onSearch={() => {}}
+        onReset={reset}
+      />
+
+      {/* CENTER — results column with EDDN docked in its bottom-right */}
+      <div className="relative min-w-0">
+        <ResultRail
+          systems={SYSTEMS}
+          selectedId={selected?.id64}
+          watched={watched}
+          onSelect={setSelected}
+          onWatch={toggleWatch}
+          onCompare={() => {}}
+        />
+        {/* EDDN feed — docked inside the results column, never overlaps */}
+        {eddnOpen && (
+          <div className="absolute bottom-3 right-3 z-20">
+            <EDDNFeed feed={EDDN_FEED} onClose={() => setEddnOpen(false)} />
+          </div>
+        )}
+        {!eddnOpen && (
+          <button
+            onClick={() => setEddnOpen(true)}
+            className="absolute bottom-3 right-3 z-20 readout px-3 py-1.5 text-[10px] font-display tracking-[0.16em] hover:text-[var(--ed-orange)]"
+          >
+            ◉ EDDN LIVE
+          </button>
+        )}
+      </div>
+
+      {/* RIGHT — system briefing (collapsible) */}
+      {selected && (
+        <SystemDrawer
+          system={selected}
+          watched={watched.has(selected.id64)}
+          onClose={() => setSelected(null)}
+          onWatch={toggleWatch}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Discover/EDDNFeed.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/EDDNFeed.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Activity, Radio, X } from 'lucide-react';
+import { GlassPanel } from '../UI/Hud';
+
+export function EDDNFeed({ feed, onClose }) {
+  return (
+    <GlassPanel className="p-2.5 w-[260px] shadow-2xl" data-testid="eddn-feed">
+      <div className="flex items-center gap-2 px-1 pb-2 border-b border-[hsla(232,22%,60%,0.22)] mb-1.5">
+        <span className="relative flex w-2 h-2">
+          <span className="absolute inset-0 rounded-full bg-[var(--success)] hud-pulse" />
+          <span className="relative w-2 h-2 rounded-full bg-[var(--success)]" />
+        </span>
+        <span className="font-display text-[10px] tracking-[0.2em] text-[var(--steel-100)] flex-1">EDDN · LIVE</span>
+        <Radio size={10} className="text-[var(--steel-400)]" strokeWidth={1.6} />
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="text-[var(--steel-400)] hover:text-[var(--steel-100)] p-0.5 rounded-sm hover:bg-[hsla(232,22%,30%,0.4)]"
+            title="Hide feed"
+          >
+            <X size={10} strokeWidth={2} />
+          </button>
+        )}
+      </div>
+
+      <ul className="space-y-0.5 max-h-[230px] overflow-y-auto">
+        {feed.map((e, i) => (
+          <li
+            key={i}
+            className="px-1.5 py-1.5 rounded-md hover:bg-[hsla(232,22%,30%,0.4)] cursor-pointer group"
+          >
+            <div className="flex items-center gap-2 mb-0.5">
+              <span className="font-mono text-[9px] text-[var(--steel-500)] tabular-nums w-12 flex-shrink-0">{e.ago}</span>
+              <span className="font-display text-[9px] tracking-[0.1em] text-[var(--ed-orange-lt)] group-hover:text-glow-orange truncate">
+                {e.cmdr}
+              </span>
+            </div>
+            <div className="ml-14 -mt-0.5">
+              <span className="text-[10px] text-[var(--steel-300)]">{e.action}</span>
+              <span className="text-[10px] text-[var(--steel-500)]"> · </span>
+              <span className="font-mono text-[10px] text-[var(--steel-100)]">{e.system}</span>
+            </div>
+            <div className="ml-14 font-mono text-[9px] text-[var(--info)]">
+              {e.scoreDelta}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </GlassPanel>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Discover/FilterRail.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/FilterRail.jsx
@@ -1,0 +1,306 @@
+// FilterRail — section-panel layout matching the user's reference images.
+// Body sliders arranged in 2-up grid; section panels with collapsible headers;
+// chunky orange dual-range sliders.
+import React from 'react';
+import {
+  Compass, RefreshCw, Sparkles, RotateCcw, Crosshair, Star,
+  Globe2, Telescope, Zap, Sliders,
+} from 'lucide-react';
+import { Panel, PanelHeader, SectionPanel, HudButton, ToggleSwitch } from '../UI/Hud';
+
+const PRESETS = [
+  { id: 'farm',    label: 'Farm Colony',    hint: 'Agriculture · Terraformable · ELW' },
+  { id: 'tourist', label: 'Tourism Hub',    hint: 'Tourism · Neutron · ELW' },
+  { id: 'mining',  label: 'Mining Outpost', hint: 'Refinery · Extraction · Pristine' },
+  { id: 'tech',    label: 'High Tech',      hint: 'High Tech · Industrial · Hi-pop' },
+];
+
+const BODY_SLIDERS = [
+  { key: 'landable', label: 'Landable Bodies',    color: '#94a3b8', max: 60 },
+  { key: 'walkable', label: 'Walkable Bodies',    color: '#38bdf8', max: 60 },
+  { key: 'blackHole',label: 'Black Holes',        color: '#e2e8f0', max: 5  },
+  { key: 'neutron',  label: 'Neutron Stars',      color: '#cbd5e1', max: 5  },
+  { key: 'whiteDwarf',label:'White Dwarves',      color: '#dbeafe', max: 3  },
+  { key: 'otherStar',label: 'Other Stars',        color: '#bef264', max: 30 },
+  { key: 'elw',      label: 'Earth-like Worlds',  color: '#4ade80', max: 10 },
+  { key: 'ww',       label: 'Water Worlds',       color: '#60a5fa', max: 20 },
+  { key: 'ammonia',  label: 'Ammonia Worlds',     color: '#fb923c', max: 10 },
+  { key: 'gasGiant', label: 'Gas Giants',         color: '#fbbf24', max: 30 },
+  { key: 'hmc',      label: 'High Metal Content', color: '#a78bfa', max: 30 },
+  { key: 'metalRich',label: 'Metal Rich Bodies',  color: '#f87171', max: 10 },
+  { key: 'rockyIce', label: 'Rocky Ice Worlds',   color: '#7dd3fc', max: 25 },
+  { key: 'rocky',    label: 'Rocky Bodies',       color: '#94a3b8', max: 50 },
+  { key: 'icy',      label: 'Icy Bodies',         color: '#e0e7ff', max: 60 },
+  { key: 'rings',    label: 'Rings',              color: '#bef264', max: 30 },
+  { key: 'geo',      label: 'Bodies w/ Geologicals', color: '#d97706', max: 30 },
+  { key: 'bio',      label: 'Bodies w/ Organics',  color: '#22c55e', max: 25 },
+];
+
+const ECONOMIES = ['Any', 'Agriculture', 'Refinery', 'Industrial', 'High Tech', 'Military', 'Tourism', 'Extraction'];
+
+export function FilterRail({
+  preset, onPreset,
+  refSystem,
+  distance, onDistance,
+  resultsPerPage, onResultsPerPage,
+  minRating, onMinRating,
+  bodySliders, onBodySlider,
+  economy, onEconomy,
+  galaxyWide, onGalaxyWide,
+  sortBy, onSortBy,
+  toggles, onToggle,
+  onSearch, onReset,
+  loading,
+}) {
+  return (
+    <Panel className="h-full overflow-hidden flex flex-col">
+      <PanelHeader
+        icon={<Compass size={14} strokeWidth={1.6} />}
+        title="FINDER · FILTERS"
+        sub="186M systems · live EDDN deltas"
+        right={
+          <div className="flex items-center gap-1.5">
+            <HudButton size="sm" icon={RotateCcw} onClick={onReset}>RESET</HudButton>
+            <HudButton size="sm" icon={RefreshCw} onClick={onSearch} active>
+              {loading ? 'SCAN…' : 'SCAN'}
+            </HudButton>
+          </div>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto p-3.5 space-y-3.5">
+        {/* ── Reference system ── */}
+        <SectionPanel
+          icon={<Crosshair size={13} strokeWidth={1.8} />}
+          title="REFERENCE SYSTEM"
+        >
+          <div className="space-y-3">
+            <div className="readout px-3 py-2.5 flex items-center justify-between">
+              <span className="font-display text-[12px] tracking-[0.1em] text-[var(--ed-orange-lt)]">
+                {refSystem.name}
+              </span>
+              <span className="font-mono text-[10px] text-[var(--steel-400)] tabular-nums">
+                {refSystem.x}, {refSystem.y}, {refSystem.z}
+              </span>
+            </div>
+            <label className="flex items-center justify-between cursor-pointer group">
+              <span className="font-display text-[10px] tracking-[0.16em] text-[var(--steel-300)]">
+                GALAXY-WIDE SEARCH
+              </span>
+              <ToggleSwitch checked={galaxyWide} onChange={onGalaxyWide} />
+            </label>
+          </div>
+        </SectionPanel>
+
+        {/* ── Search radius (single sliders) ── */}
+        <SectionPanel
+          icon={<Telescope size={13} strokeWidth={1.8} />}
+          title="SEARCH RADIUS"
+        >
+          <div className="space-y-3">
+            <SingleSlider
+              label="MAX DISTANCE (LY)"
+              min={0} max={1000} step={1}
+              value={distance.max}
+              onChange={(v) => onDistance({ ...distance, max: Math.max(v, distance.min) })}
+            />
+            <SingleSlider
+              label="MIN DISTANCE (LY)"
+              min={0} max={1000} step={1}
+              value={distance.min}
+              onChange={(v) => onDistance({ ...distance, min: Math.min(v, distance.max) })}
+            />
+            <SingleSlider
+              label="RESULTS PER PAGE"
+              min={10} max={200} step={10}
+              value={resultsPerPage}
+              onChange={onResultsPerPage}
+            />
+            <button className="flex items-center gap-2 text-[10px] font-mono text-[var(--steel-400)] hover:text-[var(--ed-orange-lt)]">
+              <Zap size={10} strokeWidth={2} />
+              Jump Range Calculator
+            </button>
+          </div>
+        </SectionPanel>
+
+        {/* ── Quick presets ── */}
+        <SectionPanel
+          icon={<Sparkles size={13} strokeWidth={1.8} />}
+          title="QUICK PRESETS"
+        >
+          <div className="grid grid-cols-2 gap-2">
+            {PRESETS.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => onPreset(p.id)}
+                className={[
+                  'text-left px-3 py-2.5 rounded-[10px] border transition-all',
+                  preset === p.id
+                    ? 'border-[hsla(22,100%,50%,0.55)] bg-[hsla(22,100%,50%,0.12)] shadow-[0_0_14px_hsla(22,100%,50%,0.2)]'
+                    : 'border-[hsla(232,22%,55%,0.28)] bg-[hsla(232,18%,18%,0.45)] hover:border-[hsla(232,30%,70%,0.4)] hover:bg-[hsla(232,18%,24%,0.5)]',
+                ].join(' ')}
+              >
+                <div className={[
+                  'font-display text-[10px] tracking-[0.1em] mb-0.5',
+                  preset === p.id ? 'text-[var(--ed-orange-lt)] text-glow-orange' : 'text-[var(--steel-200)]',
+                ].join(' ')}>
+                  {p.label}
+                </div>
+                <div className="font-mono text-[9px] text-[var(--steel-400)] leading-tight">
+                  {p.hint}
+                </div>
+              </button>
+            ))}
+          </div>
+        </SectionPanel>
+
+        {/* ── Economy / rating / sort ── */}
+        <SectionPanel
+          icon={<Star size={13} strokeWidth={1.8} />}
+          title="ECONOMY · RATING"
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <SelectRow label="Primary economy" value={economy} onChange={onEconomy} options={ECONOMIES} />
+            <SelectRow label="Sort by" value={sortBy} onChange={onSortBy} options={['Rating ↓', 'Distance ↑', 'Population ↓']} />
+            <div className="col-span-2">
+              <SingleSlider label={`MIN RATING · ${minRating}`} min={0} max={100} step={1} value={minRating} onChange={onMinRating} />
+            </div>
+          </div>
+        </SectionPanel>
+
+        {/* ── BODY TYPE FILTERS — 2-up grid of dual-range sliders ── */}
+        <SectionPanel
+          icon={<Globe2 size={13} strokeWidth={1.8} />}
+          title="BODY TYPE FILTERS"
+        >
+          <div className="grid grid-cols-2 gap-x-5 gap-y-3.5">
+            {BODY_SLIDERS.map((b) => {
+              const v = bodySliders[b.key] || { min: 0, max: b.max };
+              return (
+                <DualSlider
+                  key={b.key}
+                  label={b.label}
+                  color={b.color}
+                  min={0} max={b.max}
+                  value={v}
+                  onChange={(nv) => onBodySlider(b.key, nv)}
+                />
+              );
+            })}
+          </div>
+        </SectionPanel>
+
+        {/* ── FEATURE FILTERS — toggle list ── */}
+        <SectionPanel
+          icon={<Sliders size={13} strokeWidth={1.8} />}
+          title="FEATURE FILTERS"
+        >
+          <div className="-my-1.5">
+            <ToggleRow label="Uncolonised Only"        checked={toggles.hideCol}   onChange={(c) => onToggle('hideCol', c)} />
+            <ToggleRow label="Has Biological Signals"  checked={toggles.bio}       onChange={(c) => onToggle('bio', c)} />
+            <ToggleRow label="Has Geological Signals"  checked={toggles.geo}       onChange={(c) => onToggle('geo', c)} />
+            <ToggleRow label="Has Rings"               checked={toggles.rings}     onChange={(c) => onToggle('rings', c)} />
+            <ToggleRow label="Has Terraformable Bodies"checked={toggles.terra}     onChange={(c) => onToggle('terra', c)} />
+            <ToggleRow label="Has Volcanism"           checked={toggles.volcanism} onChange={(c) => onToggle('volcanism', c)} />
+            <ToggleRow label="Not Tidally Locked"      checked={toggles.notTidal}  onChange={(c) => onToggle('notTidal', c)} />
+            <ToggleRow label="Population = 0 Only"     checked={toggles.popZero}   onChange={(c) => onToggle('popZero', c)} />
+            <ToggleRow label="Exclude Black Holes"     checked={toggles.noBH}      onChange={(c) => onToggle('noBH', c)} />
+          </div>
+        </SectionPanel>
+      </div>
+    </Panel>
+  );
+}
+
+// ── Subcomponents ────────────────────────────────────────────
+
+function SingleSlider({ label, min, max, step = 1, value, onChange }) {
+  const pct = ((value - min) / (max - min)) * 100;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <label className="font-display text-[10px] tracking-[0.16em] text-[var(--steel-300)]">{label}</label>
+        <span className="font-mono text-[12px] text-[var(--ed-orange-lt)] text-glow-orange tabular-nums">{value}</span>
+      </div>
+      <input
+        type="range"
+        className="slider-single"
+        min={min} max={max} step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{ '--val': `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+function DualSlider({ label, color, min, max, value, onChange }) {
+  const pctMin = ((value.min - min) / (max - min)) * 100;
+  const pctMax = ((value.max - min) / (max - min)) * 100;
+  const displayMax = value.max === max ? `${max}` : value.max;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-start gap-2">
+        <span
+          className="w-2 h-2 rounded-full flex-shrink-0 mt-1.5"
+          style={{ background: color, boxShadow: `0 0 8px ${color}99` }}
+        />
+        <span className="font-display text-[10px] tracking-[0.08em] text-[var(--steel-200)] leading-tight flex-1">
+          {label}
+        </span>
+        <span className="font-mono text-[10px] text-[var(--ed-orange-lt)] tabular-nums whitespace-nowrap mt-0.5">
+          {value.min} — {displayMax}
+        </span>
+      </div>
+      <div className="dual-track">
+        <div className="track-bg" />
+        <div
+          className="track-fill"
+          style={{ left: `${pctMin}%`, right: `${100 - pctMax}%` }}
+        />
+        <input
+          type="range" min={min} max={max} value={value.min}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            onChange({ ...value, min: Math.min(v, value.max) });
+          }}
+          aria-label={`${label} minimum`}
+        />
+        <input
+          type="range" min={min} max={max} value={value.max}
+          onChange={(e) => {
+            const v = Number(e.target.value);
+            onChange({ ...value, max: Math.max(v, value.min) });
+          }}
+          aria-label={`${label} maximum`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SelectRow({ label, value, onChange, options }) {
+  return (
+    <div className="space-y-1">
+      <label className="font-display text-[10px] tracking-[0.14em] text-[var(--steel-300)]">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full bg-[hsla(232,30%,8%,0.85)] border border-[hsla(232,22%,50%,0.4)] rounded-[8px] px-2.5 py-1.5 font-mono text-[11px] text-[var(--steel-100)] hover:border-[hsla(232,30%,70%,0.5)] focus:border-[var(--ed-orange-dk)] outline-none cursor-pointer"
+      >
+        {options.map((o) => <option key={o} value={o} className="bg-[hsl(232,18%,14%)]">{o}</option>)}
+      </select>
+    </div>
+  );
+}
+
+function ToggleRow({ label, checked, onChange }) {
+  return (
+    <label className="flex items-center justify-between py-2 cursor-pointer group border-b border-[hsla(232,22%,55%,0.12)] last:border-b-0">
+      <span className="font-display text-[10px] tracking-[0.12em] text-[var(--steel-200)] group-hover:text-[var(--steel-100)]">
+        {label}
+      </span>
+      <ToggleSwitch checked={checked} onChange={onChange} />
+    </label>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Discover/RatingRadar.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/RatingRadar.jsx
@@ -1,0 +1,70 @@
+// Rating radar — the headline graphic of the rating engine.
+// Recharts radar showing all 7 economy axes for a single system.
+import React from 'react';
+import { Radar, RadarChart, PolarGrid, PolarAngleAxis, ResponsiveContainer } from 'recharts';
+
+export function RatingRadar({ breakdown, suggested, size = 200 }) {
+  const data = Object.entries(breakdown).map(([k, v]) => ({
+    axis: k.length > 7 ? k.slice(0, 7) : k,
+    full: k,
+    val: v,
+    isSuggested: k === suggested?.replace(' ', ''),
+  }));
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RadarChart data={data} outerRadius="76%">
+          <PolarGrid gridType="polygon" />
+          <PolarAngleAxis dataKey="axis" tick={{ fontSize: 9 }} />
+          <Radar
+            dataKey="val"
+            stroke="#ff6a00"
+            strokeWidth={1.2}
+            fill="#ff6a00"
+            fillOpacity={0.22}
+            isAnimationActive={false}
+          />
+        </RadarChart>
+      </ResponsiveContainer>
+      <div className="absolute inset-0 pointer-events-none flex items-center justify-center">
+        <div className="text-center">
+          <div className="font-display text-[9px] tracking-[0.18em] text-[var(--steel-400)]">SUGGESTED</div>
+          <div className="font-display text-[11px] tracking-[0.14em] text-[var(--ed-orange-lt)] text-glow-orange">
+            {suggested || '—'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Per-economy mini bars — shown inline on every result row
+export function EconomyBars({ breakdown }) {
+  const max = Math.max(...Object.values(breakdown));
+  return (
+    <div className="flex items-end gap-[2px] h-4">
+      {Object.entries(breakdown).map(([k, v]) => {
+        const pct = (v / 100) * 100;
+        const isMax = v === max;
+        return (
+          <span
+            key={k}
+            title={`${k}: ${v}`}
+            className="w-[5px] bg-[var(--steel-700)] rounded-[1px] relative"
+            style={{ height: '100%' }}
+          >
+            <span
+              className="absolute bottom-0 left-0 right-0 rounded-[1px]"
+              style={{
+                height: `${pct}%`,
+                background: isMax ? 'var(--ed-orange)' : 'var(--steel-400)',
+                boxShadow: isMax ? '0 0 4px rgba(255,106,0,0.5)' : 'none',
+              }}
+            />
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Discover/ResultRail.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/ResultRail.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Panel, PanelHeader, HudButton } from '../UI/Hud';
+import { SystemRow } from './SystemRow';
+import { ListFilter, ArrowDownNarrowWide } from 'lucide-react';
+
+export function ResultRail({ systems, selectedId, watched, onSelect, onWatch, onCompare }) {
+  return (
+    <Panel className="h-full overflow-hidden flex flex-col" chamfer={false}>
+      <PanelHeader
+        icon={<ListFilter size={13} strokeWidth={1.6} />}
+        title={`RESULTS · ${systems.length} SYSTEMS`}
+        sub="Ranked by tuned weights · click to brief"
+        right={
+          <div className="flex items-center gap-1">
+            <HudButton size="sm" icon={ArrowDownNarrowWide}>SCORE</HudButton>
+          </div>
+        }
+      />
+      <div className="flex-1 overflow-y-auto divide-y divide-[var(--steel-800)]">
+        {systems.map((s, i) => (
+          <SystemRow
+            key={s.id64}
+            system={s}
+            index={i}
+            selected={selectedId === s.id64}
+            watched={watched.has(s.id64)}
+            onSelect={onSelect}
+            onWatch={onWatch}
+            onCompare={onCompare}
+          />
+        ))}
+      </div>
+    </Panel>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Discover/SystemDrawer.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/SystemDrawer.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { ratingTier, fmtPop, ECONOMIES, ECON_COLORS } from '../../lib/mockData';
+import { Panel, PanelHeader, SectionLabel, RatingBar, TierPill, HudButton } from '../UI/Hud';
+import { RatingRadar } from './RatingRadar';
+import { Bookmark, Scale, Route, MessageSquare, X, ExternalLink, MapPin, Star } from 'lucide-react';
+
+export function SystemDrawer({ system, watched, onClose, onWatch }) {
+  if (!system) {
+    return (
+      <Panel className="h-full overflow-hidden flex items-center justify-center text-center p-6" chamfer={false}>
+        <div>
+          <Star className="mx-auto mb-3 text-[var(--steel-500)]" size={28} strokeWidth={1.2} />
+          <div className="font-display text-[12px] tracking-[0.16em] text-[var(--steel-300)] mb-1">SELECT A SYSTEM</div>
+          <p className="font-mono text-[10px] text-[var(--steel-500)] leading-relaxed max-w-[200px] mx-auto">
+            Click any row in the result list — or any star on the map — to see its full rating breakdown here.
+          </p>
+        </div>
+      </Panel>
+    );
+  }
+
+  const tier = ratingTier(system.score);
+
+  return (
+    <Panel className="h-full overflow-hidden flex flex-col" chamfer={false} active>
+      <PanelHeader
+        icon={<MapPin size={13} strokeWidth={1.6} />}
+        title="SYSTEM BRIEFING"
+        sub={`${system.x}, ${system.y}, ${system.z}`}
+        right={
+          <button onClick={onClose} className="p-1 text-[var(--steel-400)] hover:text-[var(--steel-100)]">
+            <X size={14} strokeWidth={1.5} />
+          </button>
+        }
+      />
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-5">
+        {/* Headline */}
+        <div className="space-y-1.5">
+          <h2 className="font-display text-[16px] tracking-[0.06em] text-[var(--steel-100)] text-glow-orange">
+            {system.name}
+          </h2>
+          <p className="text-[12px] text-[var(--steel-300)] italic leading-snug">
+            {system.rationale}
+          </p>
+          <div className="flex items-center gap-2 pt-1">
+            <TierPill score={system.score} tier={tier} />
+            <span className="font-mono text-[10px] text-[var(--steel-400)]">
+              confidence{' '}
+              <span className="text-[var(--steel-200)] tabular-nums">
+                {(system.confidence * 100).toFixed(0)}%
+              </span>
+            </span>
+            <span className="text-[var(--steel-700)]">·</span>
+            <span className="font-mono text-[10px] text-[var(--steel-400)]">
+              {system.distance.toFixed(1)} LY
+            </span>
+          </div>
+        </div>
+
+        {/* THE HEADLINE GRAPHIC: rating radar */}
+        <div className="flex items-center justify-center py-1">
+          <RatingRadar breakdown={system.breakdown} suggested={system.economySuggestion} size={220} />
+        </div>
+
+        {/* Per-economy bars in detail */}
+        <div className="space-y-1.5">
+          <SectionLabel>ECONOMY BREAKDOWN</SectionLabel>
+          {Object.entries(system.breakdown).map(([k, v]) => (
+            <RatingBar
+              key={k}
+              label={k}
+              score={v}
+              color={ECON_COLORS[k] || 'var(--ed-orange)'}
+              size="sm"
+            />
+          ))}
+        </div>
+
+        {/* Vital stats */}
+        <div className="space-y-1.5">
+          <SectionLabel>SYSTEM VITALS</SectionLabel>
+          <div className="grid grid-cols-2 gap-2">
+            <Stat label="Population"  value={fmtPop(system.population)} />
+            <Stat label="Allegiance"  value={system.allegiance} />
+            <Stat label="Security"    value={system.security} />
+            <Stat label="Status"      value={system.is_colonised ? 'Colonised' : 'Free'} />
+            <Stat label="ELW / WW"    value={`${system.bodies.elw} / ${system.bodies.ww}`} />
+            <Stat label="Terraform"   value={system.bodies.terra} />
+            <Stat label="Bio / Geo"   value={`${system.signals.bio} / ${system.signals.geo}`} />
+            <Stat label="Landables"   value={system.bodies.landable} />
+          </div>
+        </div>
+
+        {/* Notes (placeholder) */}
+        <div className="space-y-1.5">
+          <SectionLabel>NOTES</SectionLabel>
+          <button className="w-full text-left px-3 py-2 rounded-sm border border-dashed border-[var(--steel-700)] text-[var(--steel-500)] font-mono text-[10px] hover:text-[var(--steel-300)] hover:border-[var(--steel-500)]">
+            <MessageSquare size={11} strokeWidth={1.5} className="inline mr-1.5" />
+            Add a private note about this system…
+          </button>
+        </div>
+      </div>
+
+      {/* Action footer */}
+      <footer className="border-t border-[var(--steel-700)] p-3 grid grid-cols-3 gap-1.5">
+        <HudButton
+          icon={Bookmark}
+          onClick={() => onWatch(system.id64)}
+          active={watched}
+          size="sm"
+        >
+          {watched ? 'WATCHED' : 'WATCH'}
+        </HudButton>
+        <HudButton icon={Scale}  size="sm">COMPARE</HudButton>
+        <HudButton icon={Route}  size="sm">ROUTE</HudButton>
+      </footer>
+    </Panel>
+  );
+}
+
+function Stat({ label, value }) {
+  return (
+    <div className="readout rounded-sm px-2 py-1.5">
+      <div className="font-mono text-[8px] text-[var(--steel-500)] uppercase tracking-wider">{label}</div>
+      <div className="font-display text-[12px] tracking-[0.06em] text-[var(--ed-orange-lt)]">{value}</div>
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Discover/SystemRow.jsx
+++ b/frontend-v2/src/_redesign/components/Discover/SystemRow.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { ratingTier, fmtPop } from '../../lib/mockData';
+import { EconomyBars } from './RatingRadar';
+import { RatingBar, TierPill } from '../UI/Hud';
+import { Eye, Bookmark, Scale, MapPin } from 'lucide-react';
+
+export function SystemRow({ system, index, selected, watched, onSelect, onWatch, onCompare }) {
+  const tier = ratingTier(system.score);
+  return (
+    <article
+      onClick={() => onSelect(system)}
+      className={[
+        'group relative px-3 py-2.5 border-l-2 cursor-pointer transition-colors',
+        selected
+          ? 'bg-[var(--ed-orange)]/8 border-l-[var(--ed-orange)]'
+          : 'border-l-transparent hover:bg-[var(--steel-800)]/50 hover:border-l-[var(--steel-500)]',
+        watched && !selected ? 'border-l-[var(--info)]' : '',
+      ].join(' ')}
+      data-testid={`system-row-${system.id64}`}
+    >
+      <div className="flex items-start gap-2.5">
+        {/* Index */}
+        <span className="font-mono text-[10px] text-[var(--steel-500)] mt-1 tabular-nums w-5 flex-shrink-0">
+          #{index + 1}
+        </span>
+
+        {/* Main column */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="font-display text-[12px] tracking-[0.08em] text-[var(--steel-100)] truncate flex-1">
+              {system.name}
+            </h3>
+            <TierPill score={system.score} tier={tier} />
+          </div>
+
+          {/* Rationale — ELEVATED. The "why" goes right under the name. */}
+          <p className="text-[11px] text-[var(--steel-300)] leading-snug mb-1.5">
+            {system.rationale}
+          </p>
+
+          <div className="flex items-center gap-3 text-[10px] font-mono text-[var(--steel-400)]">
+            <EconomyBars breakdown={system.breakdown} />
+            <span className="text-[var(--steel-500)]">·</span>
+            <span className="tabular-nums">{system.distance.toFixed(1)} LY</span>
+            <span className="text-[var(--steel-500)]">·</span>
+            <span>{fmtPop(system.population)}</span>
+            {system.is_colonised && (
+              <span className="px-1 py-px rounded-[2px] bg-[var(--alert)]/15 text-[var(--alert)] text-[9px]">COL</span>
+            )}
+            {system.bodies.elw > 0 && (
+              <span className="px-1 py-px rounded-[2px] bg-[#4ade80]/15 text-[#4ade80] text-[9px]">{system.bodies.elw} ELW</span>
+            )}
+            {system.stars.blackHole > 0 && (
+              <span className="px-1 py-px rounded-[2px] bg-[var(--alert)]/15 text-[var(--alert)] text-[9px]">BH</span>
+            )}
+          </div>
+        </div>
+
+        {/* Hover-revealed action cluster */}
+        <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity self-start mt-0.5">
+          <button
+            onClick={(e) => { e.stopPropagation(); onWatch(system.id64); }}
+            className={[
+              'p-1 rounded-sm hover:bg-[var(--steel-700)]',
+              watched ? 'text-[var(--info)]' : 'text-[var(--steel-400)] hover:text-[var(--steel-100)]',
+            ].join(' ')}
+            title="Watch"
+          >
+            <Eye size={13} strokeWidth={1.5} />
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); onCompare(system.id64); }}
+            className="p-1 rounded-sm text-[var(--steel-400)] hover:text-[var(--steel-100)] hover:bg-[var(--steel-700)]"
+            title="Compare"
+          >
+            <Scale size={13} strokeWidth={1.5} />
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Map/LayerToggles.jsx
+++ b/frontend-v2/src/_redesign/components/Map/LayerToggles.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Layers, Map, Boxes, Activity, Star, Route as RouteIcon, Eye, X } from 'lucide-react';
+import { GlassPanel } from '../UI/Hud';
+
+const LAYER_DEFS = [
+  { key: 'regions',   label: 'Regions',   icon: Map,      hint: '1' },
+  { key: 'clusters',  label: 'Clusters',  icon: Boxes,    hint: '2' },
+  { key: 'heatmap',   label: 'Heatmap',   icon: Activity, hint: '3' },
+  { key: 'systems',   label: 'Systems',   icon: Star,     hint: '4' },
+  { key: 'watchlist', label: 'Watchlist', icon: Eye,      hint: '5' },
+  { key: 'routes',    label: 'Routes',    icon: RouteIcon,hint: '6' },
+];
+
+export function LayerToggles({ layers, onToggle, economy, onEconomy, economies, onClose }) {
+  return (
+    <GlassPanel className="p-3 space-y-3 w-[230px] shadow-2xl" data-testid="layer-toggles">
+      <div className="flex items-center gap-2 pb-2 border-b border-[hsla(232,22%,60%,0.22)]">
+        <Layers size={13} className="text-[var(--ed-orange)]" strokeWidth={1.6} />
+        <span className="font-display text-[10px] tracking-[0.2em] text-[var(--steel-100)] flex-1">MAP LAYERS</span>
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="text-[var(--steel-400)] hover:text-[var(--steel-100)] p-0.5 rounded-sm hover:bg-[hsla(232,22%,30%,0.4)]"
+            title="Hide layers"
+          >
+            <X size={11} strokeWidth={2} />
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-1">
+        {LAYER_DEFS.map((l) => {
+          const Icon = l.icon;
+          const on = !!layers[l.key];
+          return (
+            <button
+              key={l.key}
+              onClick={() => onToggle(l.key)}
+              className={[
+                'group w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md text-left transition-colors',
+                on ? 'bg-[hsla(22,100%,50%,0.10)] text-[var(--ed-orange-lt)]' : 'text-[var(--steel-300)] hover:bg-[hsla(232,22%,28%,0.5)] hover:text-[var(--steel-100)]',
+              ].join(' ')}
+            >
+              <span
+                className={[
+                  'w-3 h-3 rounded-[3px] border transition-all flex-shrink-0',
+                  on ? 'bg-[var(--ed-orange)] border-[var(--ed-orange)] shadow-[0_0_8px_hsla(22,100%,50%,0.6)]' : 'border-[hsla(232,22%,60%,0.5)]',
+                ].join(' ')}
+              />
+              <Icon size={12} strokeWidth={1.6} />
+              <span className="font-display text-[10px] tracking-[0.14em] flex-1">{l.label}</span>
+              <span className="font-mono text-[8px] text-[var(--steel-500)] tabular-nums">{l.hint}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="pt-2 border-t border-[hsla(232,22%,60%,0.22)] space-y-1.5">
+        <div className="font-display text-[9px] tracking-[0.18em] text-[var(--steel-400)]">HEATMAP MODE</div>
+        <select
+          value={economy}
+          onChange={(e) => onEconomy(e.target.value)}
+          className="w-full bg-[hsla(232,30%,8%,0.85)] border border-[hsla(232,22%,50%,0.4)] rounded-md px-2 py-1.5 font-mono text-[10px] text-[var(--steel-100)]"
+        >
+          <option value="overall">Overall score</option>
+          {economies.map((e) => <option key={e} value={e}>{e}</option>)}
+        </select>
+      </div>
+    </GlassPanel>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Map/MapCanvas.jsx
+++ b/frontend-v2/src/_redesign/components/Map/MapCanvas.jsx
@@ -1,0 +1,185 @@
+// Map canvas — visual prototype only. Renders the 4 backend layers we wired up
+// in the audit (regions, cluster hulls, heatmap, systems) on a single SVG so
+// any reviewer can see the proposed visual hierarchy without WebGL.
+import React, { useMemo } from 'react';
+import { ratingTier } from '../../lib/mockData';
+
+export function MapCanvas({
+  systems, regions, clusters, heatmap, layers, selectedId, onSelect, viewport,
+}) {
+  // World→screen scale: 1 LY = SCALE px in the SVG viewBox (-VB/2 to VB/2)
+  const VB = 800;
+
+  const sysWithScreen = useMemo(() => systems.map((s) => ({
+    ...s,
+    sx: (s.x / 500) * (VB / 2),
+    sz: -(s.z / 500) * (VB / 2),
+  })), [systems]);
+
+  return (
+    <div className="relative w-full h-full map-canvas-bg overflow-hidden">
+      {/* Faint sweep arc — frontier indicator (decorative, hints at meaning) */}
+      <svg
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        viewBox={`-${VB / 2} -${VB / 2} ${VB} ${VB}`}
+        preserveAspectRatio="xMidYMid slice"
+      >
+        {/* ── LAYER 0: Galactic disk hint ──────────────────── */}
+        <defs>
+          <radialGradient id="diskGlow" cx="50%" cy="50%" r="50%">
+            <stop offset="0%"  stopColor="rgba(80,60,140,0.18)" />
+            <stop offset="55%" stopColor="rgba(40,20,60,0.10)" />
+            <stop offset="100%" stopColor="rgba(0,0,0,0)" />
+          </radialGradient>
+          <radialGradient id="hotCell" cx="50%" cy="50%" r="50%">
+            <stop offset="0%"  stopColor="rgba(255,106,0,0.55)" />
+            <stop offset="60%" stopColor="rgba(255,106,0,0.10)" />
+            <stop offset="100%" stopColor="rgba(255,106,0,0)" />
+          </radialGradient>
+          <radialGradient id="midCell" cx="50%" cy="50%" r="50%">
+            <stop offset="0%"  stopColor="rgba(96,165,250,0.4)" />
+            <stop offset="60%" stopColor="rgba(96,165,250,0.08)" />
+            <stop offset="100%" stopColor="rgba(96,165,250,0)" />
+          </radialGradient>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.025)" strokeWidth="0.5" />
+          </pattern>
+        </defs>
+
+        <rect x={-VB / 2} y={-VB / 2} width={VB} height={VB} fill="url(#diskGlow)" />
+        <rect x={-VB / 2} y={-VB / 2} width={VB} height={VB} fill="url(#grid)" />
+
+        {/* ── LAYER 2: Heatmap voxels ──────────────────────── */}
+        {layers.heatmap && heatmap.map((c, i) => {
+          const sx = (c.x / 500) * (VB / 2);
+          const sz = -(c.z / 500) * (VB / 2);
+          const r = 28;
+          const fill = c.score >= 65 ? 'url(#hotCell)' : 'url(#midCell)';
+          const opacity = Math.max(0.15, c.score / 100);
+          return <circle key={i} cx={sx} cy={sz} r={r} fill={fill} opacity={opacity} />;
+        })}
+
+        {/* ── LAYER 3: Cluster hulls (translucent zones) ──── */}
+        {layers.clusters && clusters.map((cl) => {
+          const sx = (cl.x / 500) * (VB / 2);
+          const sz = -(cl.z / 500) * (VB / 2);
+          const r = (cl.radius / 500) * (VB / 2);
+          const econColors = {
+            HighTech: '#42a5f5', Tourism: '#ec407a', Refinery: '#ff9133',
+            Industrial: '#ffaa33', Agriculture: '#66bb6a', Military: '#ef5350',
+          };
+          const c = econColors[cl.topEcon] || '#ff6a00';
+          return (
+            <g key={cl.id}>
+              <circle cx={sx} cy={sz} r={r} fill={c} opacity={0.07} />
+              <circle cx={sx} cy={sz} r={r} fill="none" stroke={c} strokeOpacity="0.45" strokeWidth="0.6" strokeDasharray="2 3" />
+              <text
+                x={sx}
+                y={sz - r - 4}
+                fontFamily="Aldrich, sans-serif"
+                fontSize="7"
+                letterSpacing="1.2"
+                fill={c}
+                textAnchor="middle"
+                opacity="0.85"
+              >
+                {cl.name.toUpperCase()} · {cl.topScore}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ── LAYER 1: Region labels ───────────────────────── */}
+        {layers.regions && regions.map((r) => {
+          const sx = (r.x / 500) * (VB / 2);
+          const sz = -(r.z / 500) * (VB / 2);
+          return (
+            <g key={r.id} opacity="0.6">
+              <text
+                x={sx} y={sz}
+                fontFamily="Aldrich, sans-serif"
+                fontSize="9" letterSpacing="2"
+                fill="rgba(216,228,248,0.6)" textAnchor="middle"
+              >
+                {r.name.toUpperCase()}
+              </text>
+              <text
+                x={sx} y={sz + 9}
+                fontFamily="JetBrains Mono, monospace" fontSize="6.5"
+                fill="rgba(216,228,248,0.35)" textAnchor="middle"
+              >
+                {(r.count / 1000).toFixed(0)}K · μ {r.avgScore}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* ── Sol marker ───────────────────────────────────── */}
+        <g>
+          <circle cx={0} cy={0} r="2" fill="#ffd54a" />
+          <circle cx={0} cy={0} r="6" fill="none" stroke="#ffd54a" strokeOpacity="0.45" strokeWidth="0.5" />
+          <text x={4} y={-3} fontFamily="JetBrains Mono, monospace" fontSize="6" fill="#ffd54a" opacity="0.8">SOL</text>
+        </g>
+
+        {/* ── LAYER 5+7: Systems + selection halo ─────────── */}
+        {layers.systems && sysWithScreen.map((s) => {
+          const tier = ratingTier(s.score);
+          const isSel = s.id64 === selectedId;
+          const r = isSel ? 4 : (s.score >= 80 ? 3 : 2.2);
+          return (
+            <g key={s.id64} className="cursor-pointer" onClick={() => onSelect(s)} style={{ pointerEvents: 'all' }}>
+              {/* Glow halo for high-score systems */}
+              {s.score >= 80 && (
+                <circle cx={s.sx} cy={s.sz} r={r + 5} fill={tier.color} opacity="0.18" />
+              )}
+              {isSel && (
+                <>
+                  <circle cx={s.sx} cy={s.sz} r={r + 8} fill="none" stroke="#ff6a00" strokeWidth="0.8" opacity="0.85" />
+                  <circle cx={s.sx} cy={s.sz} r={r + 12} fill="none" stroke="#ff6a00" strokeWidth="0.4" opacity="0.5" className="hud-pulse" />
+                </>
+              )}
+              <circle cx={s.sx} cy={s.sz} r={r} fill={tier.color} />
+              {(isSel || s.score >= 80) && (
+                <text
+                  x={s.sx + r + 3}
+                  y={s.sz + 1}
+                  fontFamily="JetBrains Mono, monospace"
+                  fontSize="5.5"
+                  fill={isSel ? '#ff9133' : tier.color}
+                  opacity={isSel ? 1 : 0.8}
+                >
+                  {s.name}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Reference crosshair (centred on Sol for the prototype) */}
+        <g opacity="0.5">
+          <line x1={-12} x2={-3} y1={0}   y2={0}   stroke="#ff6a00" strokeWidth="0.6" />
+          <line x1={3}   x2={12}  y1={0}   y2={0}   stroke="#ff6a00" strokeWidth="0.6" />
+          <line x1={0}   x2={0}   y1={-12} y2={-3}  stroke="#ff6a00" strokeWidth="0.6" />
+          <line x1={0}   x2={0}   y1={3}   y2={12}  stroke="#ff6a00" strokeWidth="0.6" />
+        </g>
+      </svg>
+
+      {/* Vignette */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background: 'radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.55) 100%)',
+        }}
+      />
+
+      {/* Compass */}
+      <div className="absolute top-3 left-3 glass rounded-sm px-2 py-1.5 font-mono text-[9px] text-[var(--steel-300)]">
+        <div className="flex items-center gap-2">
+          <span className="text-[var(--ed-orange-lt)]">↑ +Z</span>
+          <span className="text-[var(--steel-500)]">→ +X</span>
+        </div>
+        <div className="text-[var(--steel-500)] mt-0.5">VIEW · {viewport}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Map/MapWorkspace.jsx
+++ b/frontend-v2/src/_redesign/components/Map/MapWorkspace.jsx
@@ -1,0 +1,118 @@
+// Map workspace — combined 2D + 3D, briefing dismissible, EDDN feed closable.
+import React, { useState } from 'react';
+import { MapCanvas } from './MapCanvas';
+import { LayerToggles } from './LayerToggles';
+import { SystemDrawer } from '../Discover/SystemDrawer';
+import { EDDNFeed } from '../Discover/EDDNFeed';
+import { HudButton } from '../UI/Hud';
+import { Box, Square, Maximize2 } from 'lucide-react';
+import { SYSTEMS, REGIONS, CLUSTERS, HEATMAP, EDDN_FEED, ECONOMIES } from '../../lib/mockData';
+
+export function MapWorkspace() {
+  const [selected,    setSelected]    = useState(null);
+  const [watched,     setWatched]     = useState(new Set([1004]));
+  const [perspective, setPerspective] = useState('2d');
+  const [eddnOpen,    setEddnOpen]    = useState(true);
+  const [layersOpen,  setLayersOpen]  = useState(true);
+  const [layers, setLayers] = useState({
+    regions: true, clusters: true, heatmap: true,
+    systems: true, watchlist: true, routes: false,
+  });
+  const [economy, setEconomy] = useState('overall');
+
+  const toggleLayer = (k) => setLayers((l) => ({ ...l, [k]: !l[k] }));
+  const toggleWatch = (id) => setWatched((s) => {
+    const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n;
+  });
+
+  const grid = selected ? 'grid-cols-[minmax(0,1fr)_380px]' : 'grid-cols-[minmax(0,1fr)]';
+
+  return (
+    <div className={`flex-1 grid ${grid} gap-3 p-3 min-h-0 transition-[grid-template-columns] duration-300 ease-out`}>
+      <div className="relative panel overflow-hidden">
+        {/* 2D / 3D / FRAME toolbar */}
+        <div className="absolute top-3 left-3 z-10 glass rounded-xl flex items-center gap-1 p-1.5">
+          <HudButton
+            size="sm" icon={Square}
+            active={perspective === '2d'}
+            onClick={() => setPerspective('2d')}
+          >
+            2D
+          </HudButton>
+          <HudButton
+            size="sm" icon={Box}
+            active={perspective === '3d'}
+            onClick={() => setPerspective('3d')}
+          >
+            3D
+          </HudButton>
+          <span className="w-px h-4 bg-[hsla(232,22%,60%,0.3)] mx-1" />
+          <HudButton size="sm" icon={Maximize2}>FRAME</HudButton>
+        </div>
+
+        <MapCanvas
+          systems={SYSTEMS} regions={REGIONS}
+          clusters={CLUSTERS} heatmap={HEATMAP}
+          layers={layers}
+          selectedId={selected?.id64}
+          onSelect={setSelected}
+          viewport={`${perspective.toUpperCase()} · GALACTIC · 500 LY`}
+        />
+
+        {/* Layer toggles top-right (closable) */}
+        {layersOpen ? (
+          <div className="absolute top-3 right-3 z-10">
+            <LayerToggles
+              layers={layers} onToggle={toggleLayer}
+              economy={economy} onEconomy={setEconomy}
+              economies={ECONOMIES}
+              onClose={() => setLayersOpen(false)}
+            />
+          </div>
+        ) : (
+          <button
+            onClick={() => setLayersOpen(true)}
+            className="absolute top-3 right-3 z-10 readout px-3 py-1.5 text-[10px] font-display tracking-[0.16em] hover:text-[var(--ed-orange)]"
+          >
+            LAYERS
+          </button>
+        )}
+
+        {/* EDDN feed bottom-right (closable) */}
+        {eddnOpen ? (
+          <div className="absolute bottom-3 right-3 z-10">
+            <EDDNFeed feed={EDDN_FEED} onClose={() => setEddnOpen(false)} />
+          </div>
+        ) : (
+          <button
+            onClick={() => setEddnOpen(true)}
+            className="absolute bottom-3 right-3 z-10 readout px-3 py-1.5 text-[10px] font-display tracking-[0.16em] hover:text-[var(--ed-orange)]"
+          >
+            ◉ EDDN LIVE
+          </button>
+        )}
+
+        {/* Selection callout bottom-left */}
+        {selected && (
+          <div className="absolute bottom-3 left-3 z-10 glass rounded-xl px-3.5 py-2.5 max-w-[320px]">
+            <div className="font-display text-[11px] tracking-[0.12em] text-[var(--ed-orange-lt)] text-glow-orange mb-1">
+              {selected.name}
+            </div>
+            <div className="font-mono text-[10px] text-[var(--steel-300)] leading-snug">
+              {selected.rationale}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <SystemDrawer
+          system={selected}
+          watched={watched.has(selected.id64)}
+          onClose={() => setSelected(null)}
+          onWatch={toggleWatch}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Plan/PlanWorkspace.jsx
+++ b/frontend-v2/src/_redesign/components/Plan/PlanWorkspace.jsx
@@ -1,0 +1,119 @@
+// FC Route — waypoints rail + map with route polyline. New aesthetic.
+import React from 'react';
+import { Route, Fuel, Trash2 } from 'lucide-react';
+import { Panel, PanelHeader, SectionPanel, HudButton } from '../UI/Hud';
+import { MapCanvas } from '../Map/MapCanvas';
+import { SYSTEMS, REGIONS, CLUSTERS, HEATMAP } from '../../lib/mockData';
+
+const WAYPOINTS = [
+  { i: 1, name: 'Sol',                  x: 0,    z: 0,   leg: null,  warn: null },
+  { i: 2, name: 'Synuefe IB-S c19-12',  x: 58,   z: 88,  leg: 158.3, warn: null },
+  { i: 3, name: 'Wregoe XX-1 b48-2',    x: -118, z: -42, leg: 184.2, warn: 'tritium <30%' },
+  { i: 4, name: 'NGC 1893 OD-T b3-7',   x: -91,  z: 178, leg: 201.5, warn: null },
+];
+
+export function PlanWorkspace() {
+  const layers = { regions: false, clusters: false, heatmap: false, systems: true, watchlist: false, routes: true };
+  const total = WAYPOINTS.reduce((a, w) => a + (w.leg || 0), 0);
+  const tritium = Math.ceil(total / 500 * 8);
+
+  return (
+    <div className="flex-1 grid grid-cols-[340px_minmax(0,1fr)] gap-3 p-3 min-h-0">
+      <Panel className="overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Route size={14} strokeWidth={1.6} />}
+          title="FC ROUTE"
+          sub="Drag waypoints to reorder"
+          right={<HudButton size="sm">EXPORT</HudButton>}
+        />
+        <div className="flex-1 overflow-y-auto p-3.5 space-y-3.5">
+          {/* Summary readouts */}
+          <div className="grid grid-cols-3 gap-2">
+            {[['LEGS', WAYPOINTS.length - 1], ['LY', total.toFixed(0)], ['TRT', tritium]].map(([l, v]) => (
+              <div key={l} className="readout rounded-lg px-2 py-2 text-center">
+                <div className="font-mono text-[8px] text-[var(--steel-500)] uppercase tracking-wider">{l}</div>
+                <div className="font-display text-[16px] tracking-[0.06em] text-[var(--ed-orange-lt)] tabular-nums text-glow-orange mt-0.5">{v}</div>
+              </div>
+            ))}
+          </div>
+
+          <SectionPanel
+            icon={<Route size={13} strokeWidth={1.8} />}
+            title="WAYPOINTS"
+          >
+            <div className="space-y-2">
+              {WAYPOINTS.map((wp, idx) => (
+                <div key={idx} className="space-y-1">
+                  <div className="flex items-center gap-2 px-2.5 py-2 rounded-lg bg-[hsla(232,22%,18%,0.55)] border border-[hsla(232,22%,55%,0.28)] hover:border-[hsla(232,30%,70%,0.4)] cursor-grab">
+                    <span className="font-display text-[10px] tracking-wider text-[var(--ed-orange-lt)] w-6 tabular-nums">
+                      {String(wp.i).padStart(2, '0')}
+                    </span>
+                    <span className="font-mono text-[11px] text-[var(--steel-100)] flex-1 truncate">{wp.name}</span>
+                    <button className="text-[var(--steel-400)] hover:text-[var(--alert)] p-1">
+                      <Trash2 size={11} strokeWidth={1.5} />
+                    </button>
+                  </div>
+                  {idx < WAYPOINTS.length - 1 && (
+                    <div className="ml-3 pl-3 border-l border-dashed border-[hsla(232,22%,60%,0.3)] py-1 flex items-center gap-2">
+                      <Fuel size={10} className="text-[var(--steel-500)]" strokeWidth={1.5} />
+                      <span className="font-mono text-[10px] text-[var(--steel-300)]">
+                        {WAYPOINTS[idx + 1].leg?.toFixed(1)} LY
+                      </span>
+                      {WAYPOINTS[idx + 1].warn && (
+                        <span className="px-1.5 py-px rounded-[3px] bg-[hsla(45,95%,56%,0.15)] text-[var(--ed-amber)] text-[9px] font-mono">
+                          ⚠ {WAYPOINTS[idx + 1].warn}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+
+              <button className="w-full mt-2 px-3 py-2.5 rounded-lg border border-dashed border-[hsla(232,22%,55%,0.4)] text-[var(--steel-400)] hover:text-[var(--ed-orange-lt)] hover:border-[hsla(22,100%,50%,0.5)] font-display text-[10px] tracking-wider">
+                + ADD WAYPOINT
+              </button>
+            </div>
+          </SectionPanel>
+        </div>
+      </Panel>
+
+      {/* Map with route polyline */}
+      <div className="relative panel overflow-hidden">
+        <MapCanvas
+          systems={SYSTEMS} regions={REGIONS}
+          clusters={CLUSTERS} heatmap={HEATMAP}
+          layers={layers}
+          selectedId={null} onSelect={() => {}}
+          viewport="ROUTE PLAN"
+        />
+        <svg className="absolute inset-0 w-full h-full pointer-events-none" viewBox="-400 -400 800 800" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <marker id="arrow" viewBox="0 0 10 10" refX="6" refY="5" markerWidth="3" markerHeight="3" orient="auto">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="#ff6a00" />
+            </marker>
+          </defs>
+          {WAYPOINTS.map((wp, idx) => {
+            if (idx === 0) return null;
+            const a = WAYPOINTS[idx - 1];
+            const ax = (a.x / 500) * 400, az = -(a.z / 500) * 400;
+            const bx = (wp.x / 500) * 400, bz = -(wp.z / 500) * 400;
+            return (
+              <line key={idx} x1={ax} y1={az} x2={bx} y2={bz} stroke="#ff6a00" strokeWidth="1.4" strokeDasharray="3 2" opacity="0.85" markerEnd="url(#arrow)" />
+            );
+          })}
+          {WAYPOINTS.map((wp, idx) => {
+            const x = (wp.x / 500) * 400, z = -(wp.z / 500) * 400;
+            return (
+              <g key={`wp-${idx}`}>
+                <circle cx={x} cy={z} r="4" fill="#ff6a00" stroke="#0a0c12" strokeWidth="1" />
+                <text x={x + 5} y={z - 5} fontFamily="JetBrains Mono, monospace" fontSize="6" fill="#ff9133">
+                  {String(wp.i).padStart(2, '0')}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Shell/StatusStrip.jsx
+++ b/frontend-v2/src/_redesign/components/Shell/StatusStrip.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { KeyHint } from '../UI/Hud';
+
+export function StatusStrip({ visible, watched, topScore, topName }) {
+  return (
+    <footer
+      className="h-7 flex items-center justify-between px-4 border-t border-[hsla(232,22%,60%,0.22)] bg-[hsla(232,18%,10%,0.78)] backdrop-blur-xl text-[10px] font-mono text-[var(--steel-400)]"
+      data-testid="status-strip"
+    >
+      <div className="flex items-center gap-4">
+        <span>
+          <span className="text-[var(--steel-200)] tabular-nums">{visible}</span> visible
+        </span>
+        <span className="text-[var(--steel-700)]">·</span>
+        <span>
+          <span className="text-[var(--steel-200)] tabular-nums">{watched}</span> watchlisted
+        </span>
+        <span className="text-[var(--steel-700)]">·</span>
+        <span>
+          top score{' '}
+          <span className="text-[var(--ed-orange-lt)] text-glow-orange tabular-nums">{topScore}</span>{' '}
+          <span className="text-[var(--steel-300)]">{topName}</span>
+        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="hidden md:inline-block font-mono text-[8px] text-[var(--steel-500)] opacity-70" title="Background: Coalsack Nebula · ESO release 1539a · imaged with the Wide Field Imager on the MPG/ESO 2.2-metre telescope">
+          BG · COALSACK NEBULA · ESO/WFI · CC BY 4.0
+        </span>
+        <span className="hidden lg:flex items-center gap-3">
+          <KeyHint k="1-7" label="layers" />
+          <KeyHint k="R"   label="reset" />
+          <KeyHint k="M"   label="measure" />
+          <KeyHint k="?"   label="help" />
+        </span>
+      </div>
+    </footer>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Shell/TopBar.jsx
+++ b/frontend-v2/src/_redesign/components/Shell/TopBar.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {
+  Compass, Eye, Pin, Scale, Sliders, Route, Building2, Map, Settings,
+  Activity, Database,
+} from 'lucide-react';
+import { Readout } from '../UI/Hud';
+
+const TABS = [
+  { key: 'finder',    label: 'Finder',    icon: Compass    },
+  { key: 'watchlist', label: 'Watchlist', icon: Eye,        badge: 7 },
+  { key: 'pinned',    label: 'Pinned',    icon: Pin,        badge: 3 },
+  { key: 'compare',   label: 'Compare',   icon: Scale,      badge: 2 },
+  { key: 'optimizer', label: 'Optimizer', icon: Sliders     },
+  { key: 'fc',        label: 'FC Route',  icon: Route,      badge: 4 },
+  { key: 'colony',    label: 'Colony',    icon: Building2,  badge: 4 },
+  { key: 'map',       label: 'Map',       icon: Map         },
+  { key: 'admin',     label: 'Admin',     icon: Settings    },
+];
+
+export function TopBar({ tab, onTab }) {
+  return (
+    <header
+      className="relative flex items-stretch h-14 border-b border-[hsla(232,22%,60%,0.22)] bg-[hsla(232,18%,12%,0.78)] backdrop-blur-xl"
+      data-testid="top-bar"
+    >
+      {/* Brand */}
+      <div className="flex items-center gap-3 px-4 border-r border-[hsla(232,22%,60%,0.22)] min-w-[230px]">
+        <div className="relative w-8 h-8 flex items-center justify-center">
+          <div className="absolute inset-0 border border-[var(--ed-orange-dk)] rounded-full" />
+          <div className="absolute inset-1 border border-[var(--ed-orange)]/40 rounded-full sweep" />
+          <div className="w-1.5 h-1.5 bg-[var(--ed-orange)] rounded-full text-glow-orange" />
+        </div>
+        <div className="leading-tight">
+          <div className="font-display text-[13px] tracking-[0.22em] text-[var(--steel-100)]">ED:FINDER</div>
+          <div className="font-mono text-[9px] text-[var(--steel-400)] tracking-wider">SELF-HOSTED · v3.2</div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <nav
+        className="flex items-stretch flex-1 overflow-x-auto"
+        data-testid="tabs"
+        style={{ scrollbarWidth: 'none' }}
+      >
+        {TABS.map((t) => {
+          const Icon = t.icon;
+          const active = t.key === tab;
+          return (
+            <button
+              key={t.key}
+              onClick={() => onTab(t.key)}
+              data-testid={`tab-${t.key}`}
+              className={[
+                'group relative flex items-center gap-2 px-4 border-r border-[var(--steel-700)] transition-all whitespace-nowrap',
+                active
+                  ? 'bg-gradient-to-b from-[var(--steel-800)] to-[var(--steel-850)] text-[var(--ed-orange-lt)]'
+                  : 'text-[var(--steel-400)] hover:text-[var(--steel-200)] hover:bg-[var(--steel-850)]/60',
+              ].join(' ')}
+            >
+              {active && (
+                <span className="absolute top-0 left-0 right-0 h-[2px] bg-[var(--ed-orange)] text-glow-orange" />
+              )}
+              <Icon size={14} strokeWidth={1.6} />
+              <span className="font-display text-[10px] tracking-[0.16em]">{t.label}</span>
+              {t.badge && t.badge > 0 && (
+                <span
+                  className={[
+                    'ml-1 px-1.5 py-px rounded-[2px] font-mono text-[9px] tabular-nums',
+                    active
+                      ? 'bg-[var(--ed-orange)] text-[var(--steel-980)]'
+                      : 'bg-[var(--steel-700)] text-[var(--steel-200)]',
+                  ].join(' ')}
+                >
+                  {t.badge}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+
+      {/* Live status */}
+      <div className="flex items-center gap-2 px-4 border-l border-[hsla(232,22%,60%,0.22)]">
+        <Readout size="sm" className="flex items-center gap-1.5">
+          <span className="w-1.5 h-1.5 rounded-full bg-[var(--success)] hud-pulse" />
+          EDDN
+        </Readout>
+        <Readout size="sm" className="hidden md:flex items-center gap-1.5">
+          <Database size={9} strokeWidth={2} />
+          186.2M
+        </Readout>
+        <Readout size="sm" className="hidden lg:flex items-center gap-1.5">
+          <Activity size={9} strokeWidth={2} />
+          12ms
+        </Readout>
+      </div>
+    </header>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Tabs/SystemTable.jsx
+++ b/frontend-v2/src/_redesign/components/Tabs/SystemTable.jsx
@@ -1,0 +1,57 @@
+// Lightweight system table used by Watchlist / Pinned / Optimizer stubs.
+import React from 'react';
+import { ratingTier, fmtPop } from '../../lib/mockData';
+import { TierPill } from '../UI/Hud';
+import { Eye, Scale, Trash2 } from 'lucide-react';
+
+export function SystemTable({ systems, onSelect, watched }) {
+  return (
+    <div className="flex-1 overflow-auto">
+      <table className="w-full text-[11px]">
+        <thead className="sticky top-0 bg-[var(--steel-900)] border-b border-[var(--steel-700)]">
+          <tr className="text-left text-[var(--steel-400)] font-display tracking-[0.14em] text-[9px]">
+            <th className="px-3 py-2 w-8">#</th>
+            <th className="px-3 py-2">SYSTEM</th>
+            <th className="px-3 py-2">RATIONALE</th>
+            <th className="px-3 py-2 w-20 text-right">DIST</th>
+            <th className="px-3 py-2 w-24 text-right">POP</th>
+            <th className="px-3 py-2 w-28 text-center">SCORE</th>
+            <th className="px-3 py-2 w-20"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {systems.map((s, i) => {
+            const tier = ratingTier(s.score);
+            return (
+              <tr
+                key={s.id64}
+                onClick={() => onSelect?.(s)}
+                className="border-b border-[var(--steel-800)] hover:bg-[var(--steel-850)]/60 cursor-pointer"
+              >
+                <td className="px-3 py-2 font-mono text-[10px] text-[var(--steel-500)] tabular-nums">{i + 1}</td>
+                <td className="px-3 py-2 font-display text-[11px] tracking-[0.06em] text-[var(--steel-100)]">{s.name}</td>
+                <td className="px-3 py-2 text-[var(--steel-300)] italic max-w-[400px] truncate">{s.rationale}</td>
+                <td className="px-3 py-2 font-mono text-[10px] text-[var(--steel-300)] text-right tabular-nums">{s.distance.toFixed(1)} LY</td>
+                <td className="px-3 py-2 font-mono text-[10px] text-[var(--steel-300)] text-right">{fmtPop(s.population)}</td>
+                <td className="px-3 py-2 text-center"><TierPill score={s.score} tier={tier} /></td>
+                <td className="px-3 py-2">
+                  <div className="flex items-center justify-end gap-0.5">
+                    <button className="p-1 rounded-sm text-[var(--steel-400)] hover:text-[var(--info)] hover:bg-[var(--steel-700)]">
+                      <Eye size={11} strokeWidth={1.5} />
+                    </button>
+                    <button className="p-1 rounded-sm text-[var(--steel-400)] hover:text-[var(--ed-orange-lt)] hover:bg-[var(--steel-700)]">
+                      <Scale size={11} strokeWidth={1.5} />
+                    </button>
+                    <button className="p-1 rounded-sm text-[var(--steel-400)] hover:text-[var(--alert)] hover:bg-[var(--steel-700)]">
+                      <Trash2 size={11} strokeWidth={1.5} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Tabs/TabStubs.jsx
+++ b/frontend-v2/src/_redesign/components/Tabs/TabStubs.jsx
@@ -1,0 +1,429 @@
+// All secondary-tab workspaces — Watchlist / Pinned / Compare / Optimizer / Admin
+// Brought up to iteration-3 aesthetic: chunky brushed-steel panels, SectionPanel
+// containers, orange-pill sliders, dismissible briefing pattern matching Finder.
+import React, { useState } from 'react';
+import {
+  Eye, Pin, Scale, Sliders, Settings, Database,
+  Activity, Trash2, Bell, Server, Zap,
+} from 'lucide-react';
+import {
+  Panel, PanelHeader, SectionPanel, SectionLabel, Readout,
+  HudButton, RatingBar, TierPill,
+} from '../UI/Hud';
+import { SystemRow } from '../Discover/SystemRow';
+import { SystemDrawer } from '../Discover/SystemDrawer';
+import { SYSTEMS, ratingTier, ECON_COLORS } from '../../lib/mockData';
+
+// ── Reusable: grid that adapts to whether a row is selected ──
+function withBrief(selected) {
+  return selected
+    ? 'grid-cols-[minmax(0,1fr)_380px]'
+    : 'grid-cols-[minmax(0,1fr)]';
+}
+
+// ════════════════════════════════════════════════════════════════
+// WATCHLIST  ·  saved systems with EDDN-driven changelog
+// ════════════════════════════════════════════════════════════════
+const RECENT_CHANGES = [
+  { sys: 'Wregoe XX-1 b48-2', delta: 'score 84 → 89', reason: 'new ELW discovered',  when: '2h ago',  tier: 'good' },
+  { sys: 'HIP 22460',          delta: 'station added',  reason: 'KaelOrbital docked',  when: '7h ago',  tier: 'info' },
+  { sys: 'Pleiades RX-K',      delta: 'bio +6',         reason: 'EDDN scan',           when: '14h ago', tier: 'info' },
+  { sys: 'Synuefe IB-S c19',   delta: 'pop +1.2M',      reason: 'colonisation tick',   when: '22h ago', tier: 'warn' },
+];
+
+export function WatchlistTab() {
+  const [selected, setSelected] = useState(null);
+  const [watched, setWatched]   = useState(new Set([1001, 1002, 1003, 1004]));
+  const watchlist = SYSTEMS.filter((s) => watched.has(s.id64));
+
+  const toggleWatch = (id) => setWatched((s) => {
+    const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n;
+  });
+
+  return (
+    <div className={`flex-1 grid ${selected ? 'grid-cols-[minmax(0,1fr)_320px_380px]' : 'grid-cols-[minmax(0,1fr)_320px]'} gap-3 p-3 min-h-0 transition-[grid-template-columns] duration-300 ease-out`}>
+      <Panel className="overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Eye size={14} strokeWidth={1.6} />}
+          title={`WATCHLIST · ${watchlist.length}`}
+          sub="Live EDDN diffs · server-saved"
+          right={<HudButton size="sm" icon={Bell}>ALERTS</HudButton>}
+        />
+        <div className="flex-1 overflow-y-auto divide-y divide-[hsla(232,22%,55%,0.15)]">
+          {watchlist.map((s, i) => (
+            <SystemRow
+              key={s.id64} system={s} index={i}
+              selected={selected?.id64 === s.id64}
+              watched={true}
+              onSelect={setSelected}
+              onWatch={toggleWatch}
+              onCompare={() => {}}
+            />
+          ))}
+        </div>
+      </Panel>
+
+      <Panel className="overflow-hidden flex flex-col">
+        <PanelHeader title="RECENT CHANGES" sub="Last 24h · live feed" />
+        <div className="flex-1 overflow-y-auto p-3 space-y-2">
+          {RECENT_CHANGES.map((c, i) => {
+            const tierColor = c.tier === 'good' ? 'var(--rate-good)'
+                            : c.tier === 'warn' ? 'var(--ed-amber)'
+                            : 'var(--info)';
+            return (
+              <div key={i} className="section-panel">
+                <div className="px-3 py-2.5">
+                  <div
+                    className="font-display text-[10px] tracking-[0.12em] mb-0.5"
+                    style={{ color: tierColor }}
+                  >
+                    {c.sys}
+                  </div>
+                  <div className="font-mono text-[11px] text-[var(--steel-100)]">{c.delta}</div>
+                  <div className="flex items-center justify-between mt-1.5">
+                    <span className="font-mono text-[9px] text-[var(--steel-400)]">{c.reason}</span>
+                    <span className="font-mono text-[9px] text-[var(--steel-500)]">{c.when}</span>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </Panel>
+
+      {selected && (
+        <SystemDrawer
+          system={selected}
+          watched={watched.has(selected.id64)}
+          onClose={() => setSelected(null)}
+          onWatch={toggleWatch}
+        />
+      )}
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════════════════
+// PINNED  ·  local-storage snapshots
+// ════════════════════════════════════════════════════════════════
+export function PinnedTab() {
+  const [selected, setSelected] = useState(null);
+  const pinned = SYSTEMS.slice(2, 5);
+
+  return (
+    <div className={`flex-1 grid ${withBrief(selected)} gap-3 p-3 min-h-0 transition-[grid-template-columns] duration-300 ease-out`}>
+      <Panel className="overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Pin size={14} strokeWidth={1.6} />}
+          title={`PINNED · ${pinned.length}`}
+          sub="Local snapshots · click to brief"
+          right={<HudButton size="sm" icon={Trash2}>CLEAR ALL</HudButton>}
+        />
+        <div className="flex-1 overflow-y-auto divide-y divide-[hsla(232,22%,55%,0.15)]">
+          {pinned.map((s, i) => (
+            <SystemRow
+              key={s.id64} system={s} index={i}
+              selected={selected?.id64 === s.id64}
+              watched={false}
+              onSelect={setSelected}
+              onWatch={() => {}}
+              onCompare={() => {}}
+            />
+          ))}
+        </div>
+      </Panel>
+
+      {selected && (
+        <SystemDrawer
+          system={selected} watched={false}
+          onClose={() => setSelected(null)}
+          onWatch={() => {}}
+        />
+      )}
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════════════════
+// COMPARE  ·  side-by-side matrix with overlaid radars
+// ════════════════════════════════════════════════════════════════
+export function CompareTab() {
+  const cols = SYSTEMS.slice(0, 3);
+  const axes = Object.keys(cols[0].breakdown);
+  return (
+    <div className="flex-1 p-3 min-h-0">
+      <Panel className="h-full overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Scale size={14} strokeWidth={1.6} />}
+          title={`COMPARE · ${cols.length} SYSTEMS`}
+          sub="Side-by-side · winners highlighted"
+          right={<HudButton size="sm" icon={Trash2}>REMOVE ALL</HudButton>}
+        />
+        <div className="flex-1 overflow-auto p-4 space-y-4">
+          {/* Header strip per system */}
+          <div className="grid gap-3" style={{ gridTemplateColumns: `180px repeat(${cols.length}, 1fr)` }}>
+            <div />
+            {cols.map((s) => {
+              const tier = ratingTier(s.score);
+              return (
+                <div key={s.id64} className="section-panel">
+                  <div className="section-panel-header">
+                    <span className="font-display text-[11px] tracking-[0.1em] text-[var(--steel-100)] truncate flex-1">
+                      {s.name}
+                    </span>
+                  </div>
+                  <div className="px-3 py-2.5 flex items-center justify-between">
+                    <TierPill score={s.score} tier={tier} />
+                    <span className="font-mono text-[10px] text-[var(--steel-400)]">{s.distance.toFixed(1)} LY</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Economy axes — winner per axis highlighted */}
+          <SectionPanel
+            icon={<Database size={13} strokeWidth={1.8} />}
+            title="ECONOMY BREAKDOWN"
+          >
+            <div className="space-y-2">
+              {axes.map((axis) => {
+                const max = Math.max(...cols.map((c) => c.breakdown[axis]));
+                return (
+                  <div
+                    key={axis}
+                    className="grid gap-3 items-center"
+                    style={{ gridTemplateColumns: `180px repeat(${cols.length}, 1fr)` }}
+                  >
+                    <div className="font-mono text-[10px] text-[var(--steel-400)] uppercase tracking-wider">{axis}</div>
+                    {cols.map((s) => {
+                      const v = s.breakdown[axis];
+                      const isWin = v === max;
+                      return (
+                        <div
+                          key={s.id64}
+                          className={[
+                            'rounded-lg px-3 py-2 border transition-all',
+                            isWin
+                              ? 'border-[hsla(22,100%,50%,0.55)] bg-[hsla(22,100%,50%,0.10)] shadow-[0_0_12px_hsla(22,100%,50%,0.2)]'
+                              : 'border-[hsla(232,22%,55%,0.25)] bg-[hsla(232,18%,18%,0.45)]',
+                          ].join(' ')}
+                        >
+                          <RatingBar score={v} color={ECON_COLORS[axis] || 'var(--ed-orange)'} size="sm" />
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          </SectionPanel>
+
+          {/* Rationale row */}
+          <SectionPanel
+            icon={<Activity size={13} strokeWidth={1.8} />}
+            title="RATIONALE"
+          >
+            <div className="grid gap-3" style={{ gridTemplateColumns: `180px repeat(${cols.length}, 1fr)` }}>
+              <div />
+              {cols.map((s) => (
+                <p key={s.id64} className="text-[11px] text-[var(--steel-300)] italic leading-snug">
+                  {s.rationale}
+                </p>
+              ))}
+            </div>
+          </SectionPanel>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════════════════
+// OPTIMIZER  ·  weight-tuned re-rank with proper sliders
+// ════════════════════════════════════════════════════════════════
+const WEIGHT_DEFS = [
+  { key: 'economy',     label: 'Economy match',     def: 30 },
+  { key: 'slots',       label: 'Build slots',       def: 20 },
+  { key: 'strategic',   label: 'Strategic value',   def: 15 },
+  { key: 'safety',      label: 'Orbital safety',    def: 15 },
+  { key: 'terraforming',label: 'Terraforming',      def: 10 },
+  { key: 'diversity',   label: 'Body diversity',    def: 10 },
+];
+
+export function OptimizerTab() {
+  const [weights, setWeights] = useState(
+    Object.fromEntries(WEIGHT_DEFS.map((w) => [w.key, w.def]))
+  );
+  const [selected, setSelected] = useState(null);
+  const setW = (k, v) => setWeights((w) => ({ ...w, [k]: v }));
+  const total = Object.values(weights).reduce((a, b) => a + b, 0);
+
+  return (
+    <div className={`flex-1 grid ${selected ? 'grid-cols-[340px_minmax(0,1fr)_380px]' : 'grid-cols-[340px_minmax(0,1fr)]'} gap-3 p-3 min-h-0 transition-[grid-template-columns] duration-300 ease-out`}>
+      {/* Weights panel */}
+      <Panel className="overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Sliders size={14} strokeWidth={1.6} />}
+          title="WEIGHTS"
+          sub={`Total ${total}% · re-ranks Finder results`}
+          right={<HudButton size="sm" icon={Zap} active>RUN</HudButton>}
+        />
+        <div className="flex-1 overflow-y-auto p-3.5 space-y-3.5">
+          <SectionPanel
+            icon={<Sliders size={13} strokeWidth={1.8} />}
+            title="SCORING WEIGHTS"
+          >
+            <div className="space-y-3.5">
+              {WEIGHT_DEFS.map((w) => {
+                const val = weights[w.key];
+                const pct = val;
+                return (
+                  <div key={w.key} className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label className="font-display text-[10px] tracking-[0.16em] text-[var(--steel-200)]">
+                        {w.label}
+                      </label>
+                      <span className="font-mono text-[12px] text-[var(--ed-orange-lt)] text-glow-orange tabular-nums">
+                        {val}%
+                      </span>
+                    </div>
+                    <input
+                      type="range"
+                      className="slider-single"
+                      min={0} max={100}
+                      value={val}
+                      onChange={(e) => setW(w.key, Number(e.target.value))}
+                      style={{ '--val': `${pct}%` }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </SectionPanel>
+
+          <SectionPanel
+            icon={<Activity size={13} strokeWidth={1.8} />}
+            title="PRESETS"
+            defaultOpen={false}
+          >
+            <div className="grid grid-cols-2 gap-2">
+              {['Balanced', 'Economy first', 'Safety first', 'Pioneer'].map((p) => (
+                <button
+                  key={p}
+                  className="px-2.5 py-2 rounded-lg border border-[hsla(232,22%,55%,0.28)] bg-[hsla(232,18%,18%,0.45)] hover:border-[hsla(232,30%,70%,0.4)] font-display text-[10px] tracking-[0.1em] text-[var(--steel-200)] hover:text-[var(--steel-100)]"
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+          </SectionPanel>
+        </div>
+      </Panel>
+
+      {/* Re-ranked results */}
+      <Panel className="overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Activity size={14} strokeWidth={1.6} />}
+          title="RE-RANKED RESULTS"
+          sub="Tuned by your weights · live"
+        />
+        <div className="flex-1 overflow-y-auto divide-y divide-[hsla(232,22%,55%,0.15)]">
+          {SYSTEMS.map((s, i) => (
+            <SystemRow
+              key={s.id64} system={s} index={i}
+              selected={selected?.id64 === s.id64}
+              watched={false}
+              onSelect={setSelected}
+              onWatch={() => {}}
+              onCompare={() => {}}
+            />
+          ))}
+        </div>
+      </Panel>
+
+      {selected && (
+        <SystemDrawer
+          system={selected} watched={false}
+          onClose={() => setSelected(null)}
+          onWatch={() => {}}
+        />
+      )}
+    </div>
+  );
+}
+
+// ════════════════════════════════════════════════════════════════
+// ADMIN  ·  ops console (token-gated stub)
+// ════════════════════════════════════════════════════════════════
+export function AdminTab() {
+  return (
+    <div className="flex-1 p-3 min-h-0">
+      <Panel className="h-full overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Settings size={14} strokeWidth={1.6} />}
+          title="ADMIN · OPS CONSOLE"
+          sub="Token-gated · authenticated as ROOT"
+          right={<Readout size="sm">SECURE · TLS</Readout>}
+        />
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          <SectionPanel
+            icon={<Database size={13} strokeWidth={1.8} />}
+            title="DATABASE STATS"
+          >
+            <div className="grid grid-cols-4 gap-3">
+              {[
+                ['SYSTEMS',   '186.2M'],
+                ['BODIES',    '1.28B'],
+                ['CACHE HIT', '94.2%'],
+                ['EDDN/HR',   '14.3K'],
+              ].map(([l, v]) => (
+                <div key={l} className="readout px-3 py-3 text-center">
+                  <div className="font-mono text-[9px] text-[var(--steel-500)] uppercase tracking-wider mb-1">{l}</div>
+                  <div className="font-display text-[20px] tracking-[0.06em] text-[var(--ed-orange-lt)] tabular-nums text-glow-orange">{v}</div>
+                </div>
+              ))}
+            </div>
+          </SectionPanel>
+
+          <SectionPanel
+            icon={<Server size={13} strokeWidth={1.8} />}
+            title="LIVE METRICS"
+          >
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                ['Postgres latency p95', '12.4ms', 'good'],
+                ['Redis hit ratio',      '94.2%',  'good'],
+                ['EDDN consumer lag',    '0.3s',   'good'],
+                ['Cluster build queue',  '14 jobs','warn'],
+                ['Free disk',            '412 GB', 'good'],
+                ['Memory pressure',      '38%',    'good'],
+              ].map(([l, v, t]) => {
+                const c = t === 'warn' ? 'var(--ed-amber)' : 'var(--rate-good)';
+                return (
+                  <div key={l} className="flex items-center justify-between px-3 py-2.5 rounded-lg bg-[hsla(232,22%,18%,0.55)] border border-[hsla(232,22%,55%,0.25)]">
+                    <span className="font-mono text-[11px] text-[var(--steel-300)]">{l}</span>
+                    <span className="font-mono text-[12px] tabular-nums" style={{ color: c, textShadow: `0 0 6px ${c}66` }}>{v}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </SectionPanel>
+
+          <SectionPanel
+            icon={<Zap size={13} strokeWidth={1.8} />}
+            title="ACTIONS"
+          >
+            <div className="flex flex-wrap gap-2">
+              <HudButton>CLEAR CACHE</HudButton>
+              <HudButton>REBUILD CLUSTERS</HudButton>
+              <HudButton>FORCE EDDN RECONNECT</HudButton>
+              <HudButton>RESEED RATINGS</HudButton>
+              <HudButton>EXPORT TELEMETRY</HudButton>
+            </div>
+          </SectionPanel>
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/Track/TrackWorkspace.jsx
+++ b/frontend-v2/src/_redesign/components/Track/TrackWorkspace.jsx
@@ -1,0 +1,101 @@
+// Track / Colony — phase pipeline kanban. Iteration-3 panel aesthetic.
+import React from 'react';
+import { Building2, Clock, Hammer, CheckCircle2, Activity } from 'lucide-react';
+import { Panel, PanelHeader } from '../UI/Hud';
+
+const PHASES = [
+  { key: 'planning',  label: 'PLANNING',  icon: Clock,        color: '#60a5fa' },
+  { key: 'building',  label: 'BUILDING',  icon: Hammer,       color: '#facc15' },
+  { key: 'active',    label: 'ACTIVE',    icon: Activity,     color: '#3ddc84' },
+  { key: 'complete',  label: 'COMPLETE',  icon: CheckCircle2, color: '#ff6a00' },
+];
+
+const COLONIES = {
+  planning:  [{ name: 'Wregoe XX-1 b48-2', score: 89, suggested: 'High Tech',  pct: 12 }],
+  building:  [
+    { name: 'HIP 22460',         score: 82, suggested: 'Tourism',     pct: 64 },
+    { name: 'Synuefe IB-S c19',  score: 76, suggested: 'Refinery',    pct: 38 },
+  ],
+  active:    [{ name: 'Pleiades RX-K d8',  score: 71, suggested: 'Agriculture', pct: 100 }],
+  complete:  [],
+};
+
+export function TrackWorkspace() {
+  return (
+    <div className="flex-1 p-3 min-h-0">
+      <Panel className="h-full overflow-hidden flex flex-col">
+        <PanelHeader
+          icon={<Building2 size={14} strokeWidth={1.6} />}
+          title="COLONY PIPELINE"
+          sub="Phase by phase · driven by EDDN events"
+        />
+        <div className="flex-1 overflow-auto p-4">
+          <div className="grid grid-cols-4 gap-3 h-full">
+            {PHASES.map((p) => {
+              const Icon = p.icon;
+              const items = COLONIES[p.key];
+              return (
+                <div
+                  key={p.key}
+                  className="section-panel flex flex-col overflow-hidden"
+                  style={{ borderTopColor: p.color, borderTopWidth: 2, borderTopStyle: 'solid' }}
+                >
+                  <header className="section-panel-header">
+                    <Icon size={12} strokeWidth={1.6} style={{ color: p.color }} />
+                    <span className="font-display text-[11px] tracking-[0.18em] flex-1" style={{ color: p.color }}>
+                      {p.label}
+                    </span>
+                    <span className="font-mono text-[10px] text-[var(--steel-400)] tabular-nums">{items.length}</span>
+                  </header>
+                  <div className="flex-1 p-2.5 space-y-2 overflow-y-auto">
+                    {items.map((c, i) => (
+                      <article
+                        key={i}
+                        className="rounded-lg border border-[hsla(232,22%,55%,0.28)] bg-[hsla(232,22%,16%,0.55)] p-3 hover:border-[hsla(22,100%,50%,0.45)] transition-colors cursor-pointer"
+                      >
+                        <div className="flex items-center gap-2 mb-1.5">
+                          <span
+                            className="font-mono text-[10px] tabular-nums px-2 py-0.5 rounded-[3px]"
+                            style={{
+                              color: p.color,
+                              background: `${p.color}1a`,
+                              border: `1px solid ${p.color}55`,
+                              boxShadow: `0 0 6px ${p.color}33`,
+                            }}
+                          >
+                            {c.score}
+                          </span>
+                          <span className="font-display text-[11px] tracking-[0.06em] text-[var(--steel-100)] flex-1 truncate">
+                            {c.name}
+                          </span>
+                        </div>
+                        <div className="font-mono text-[9px] text-[var(--steel-400)] mb-2">
+                          → {c.suggested}
+                        </div>
+                        <div className="h-1.5 bg-[hsla(232,30%,5%,0.7)] rounded-full overflow-hidden">
+                          <div
+                            className="h-1.5 rounded-full"
+                            style={{ width: `${c.pct}%`, background: p.color, boxShadow: `0 0 6px ${p.color}88` }}
+                          />
+                        </div>
+                        <div className="flex items-center justify-between mt-1.5">
+                          <span className="font-mono text-[9px] text-[var(--steel-500)]">{c.pct}% complete</span>
+                          <span className="font-mono text-[9px] text-[var(--steel-500)]">3d ago</span>
+                        </div>
+                      </article>
+                    ))}
+                    {items.length === 0 && (
+                      <div className="text-center py-6 font-mono text-[9px] text-[var(--steel-500)]">
+                        — empty —
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/frontend-v2/src/_redesign/components/UI/Hud.jsx
+++ b/frontend-v2/src/_redesign/components/UI/Hud.jsx
@@ -1,0 +1,191 @@
+// HUD primitives — chunky rounded brushed-steel panels matching reference images.
+import React, { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+export function Panel({ children, className = '', active = false, ...rest }) {
+  const cls = [
+    'panel',
+    active ? 'panel-active' : '',
+    className,
+  ].filter(Boolean).join(' ');
+  return <div className={cls} {...rest}>{children}</div>;
+}
+
+export function GlassPanel({ children, className = '', ...rest }) {
+  return <div className={`glass ${className}`} {...rest}>{children}</div>;
+}
+
+export function Readout({ children, className = '', size = 'md' }) {
+  const sz = size === 'sm' ? 'px-2 py-0.5 text-[10px]'
+           : size === 'lg' ? 'px-3 py-1.5 text-sm'
+           : 'px-2.5 py-1 text-xs';
+  return <span className={`readout font-mono ${sz} ${className}`}>{children}</span>;
+}
+
+export function PanelHeader({ icon, title, sub, right, className = '' }) {
+  return (
+    <header className={`flex items-center gap-2.5 px-4 py-3 border-b border-[hsla(232,22%,60%,0.22)] ${className}`}>
+      {icon && (
+        <span className="text-[var(--ed-orange-lt)] text-glow-orange flex-shrink-0">{icon}</span>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="font-display text-[12px] tracking-[0.2em] text-[var(--steel-100)] truncate">{title}</div>
+        {sub && <div className="text-[10px] text-[var(--steel-400)] font-mono truncate mt-0.5">{sub}</div>}
+      </div>
+      {right}
+    </header>
+  );
+}
+
+// ── Section panel with header banner — the look from the reference images ──
+export function SectionPanel({ icon, title, right, defaultOpen = true, collapsible = true, children, className = '' }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className={`section-panel ${className}`}>
+      <button
+        type="button"
+        onClick={() => collapsible && setOpen((v) => !v)}
+        className="section-panel-header w-full text-left group"
+        style={{ cursor: collapsible ? 'pointer' : 'default' }}
+      >
+        {icon && <span className="text-[var(--ed-orange-lt)] flex-shrink-0">{icon}</span>}
+        <span className="font-display text-[11px] tracking-[0.22em] text-[var(--steel-100)] flex-1">{title}</span>
+        {right}
+        {collapsible && (
+          <ChevronDown
+            size={14}
+            strokeWidth={2}
+            className={`text-[var(--steel-400)] transition-transform ${open ? '' : '-rotate-90'}`}
+          />
+        )}
+      </button>
+      <div
+        className={`overflow-hidden transition-[max-height] duration-300 ease-out ${open ? '' : 'max-h-0'}`}
+        style={open ? { maxHeight: '4000px' } : undefined}
+      >
+        <div className="p-4">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export function SectionLabel({ children, className = '' }) {
+  return (
+    <div className={`flex items-center gap-2 mb-1.5 ${className}`}>
+      <span className="font-display text-[9px] tracking-[0.22em] text-[var(--steel-400)]">{children}</span>
+      <span className="flex-1 h-px bg-[hsla(232,22%,60%,0.2)]" />
+    </div>
+  );
+}
+
+export function RatingBar({ score, label, color, size = 'md' }) {
+  const w = size === 'sm' ? 'h-[3px]' : size === 'lg' ? 'h-1.5' : 'h-1';
+  const pct = Math.max(0, Math.min(100, score ?? 0));
+  return (
+    <div className="flex items-center gap-2 min-w-0">
+      {label && (
+        <span className="font-mono text-[9px] uppercase tracking-wider text-[var(--steel-400)] w-[68px] flex-shrink-0">{label}</span>
+      )}
+      <div className={`relative flex-1 ${w} bg-[hsla(232,22%,15%,0.85)] rounded-full overflow-hidden`}>
+        <div
+          className={`absolute inset-y-0 left-0 ${w} rounded-full`}
+          style={{
+            width: `${pct}%`,
+            background: color,
+            boxShadow: `0 0 8px ${color}66`,
+          }}
+        />
+      </div>
+      <span className="font-mono text-[10px] text-[var(--steel-200)] w-7 text-right tabular-nums">{score ?? '—'}</span>
+    </div>
+  );
+}
+
+export function TierPill({ score, tier }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 font-display text-[9px] tracking-[0.18em] rounded-full border"
+      style={{
+        color: tier.color,
+        borderColor: `${tier.color}88`,
+        background: `${tier.color}1a`,
+        boxShadow: `0 0 10px ${tier.color}33, inset 0 1px 0 ${tier.color}33`,
+      }}
+    >
+      <span className="font-mono text-[12px] font-bold tabular-nums">{score ?? '—'}</span>
+      <span>{tier.label}</span>
+    </span>
+  );
+}
+
+export function HudButton({ children, active = false, onClick, className = '', icon: Icon, size = 'md', title, ...rest }) {
+  const sz = size === 'sm' ? 'px-2.5 py-1.5 text-[10px]' : 'px-3.5 py-2 text-[11px]';
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={[
+        'font-display tracking-[0.14em] inline-flex items-center gap-1.5 border transition-all rounded-full',
+        sz,
+        active
+          ? 'bg-[hsla(22,100%,50%,0.18)] text-[var(--ed-orange-lt)] border-[hsla(22,100%,50%,0.5)] shadow-[0_0_14px_hsla(22,100%,50%,0.3)]'
+          : 'bg-[hsla(232,18%,28%,0.6)] text-[var(--steel-300)] border-[hsla(232,22%,60%,0.32)] hover:text-[var(--steel-100)] hover:border-[hsla(232,30%,75%,0.5)] hover:bg-[hsla(232,18%,38%,0.6)]',
+        className,
+      ].join(' ')}
+      {...rest}
+    >
+      {Icon && <Icon size={12} strokeWidth={1.75} />}
+      {children}
+    </button>
+  );
+}
+
+export function KeyHint({ k, label }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[9px] text-[var(--steel-400)] font-mono">
+      <kbd className="px-1.5 py-0.5 bg-[hsla(232,30%,12%,0.85)] border border-[hsla(232,22%,60%,0.32)] rounded-[4px] text-[var(--steel-200)] tabular-nums">
+        {k}
+      </kbd>
+      {label}
+    </span>
+  );
+}
+
+// ── Pill toggle (matches Feature Filters in reference image) ──
+export function ToggleSwitch({ checked, onChange, size = 'md' }) {
+  const w = size === 'sm' ? 32 : 40;
+  const h = size === 'sm' ? 18 : 22;
+  const tx = size === 'sm' ? 14 : 18;
+  return (
+    <span
+      onClick={() => onChange?.(!checked)}
+      className="relative cursor-pointer flex-shrink-0 transition-colors"
+      style={{
+        width: w,
+        height: h,
+        borderRadius: 999,
+        background: checked
+          ? 'linear-gradient(180deg, var(--ed-orange-lt) 0%, var(--ed-orange) 100%)'
+          : 'hsla(232, 30%, 8%, 0.85)',
+        border: `1px solid ${checked ? 'hsla(22, 100%, 35%, 0.9)' : 'hsla(232, 22%, 50%, 0.4)'}`,
+        boxShadow: checked
+          ? '0 0 12px hsla(22, 100%, 50%, 0.5), inset 0 1px 0 hsla(45, 95%, 65%, 0.4)'
+          : 'inset 0 1px 2px hsla(248, 60%, 0%, 0.5)',
+      }}
+    >
+      <span
+        className="absolute top-1/2 -translate-y-1/2 transition-all"
+        style={{
+          left: checked ? `calc(100% - ${tx + 3}px)` : '3px',
+          width: tx,
+          height: h - 6,
+          borderRadius: 999,
+          background: checked
+            ? 'linear-gradient(180deg, #fff8eb 0%, #ffd9a0 100%)'
+            : 'linear-gradient(180deg, hsl(232, 18%, 88%) 0%, hsl(232, 14%, 75%) 100%)',
+          boxShadow: '0 1px 2px hsla(0,0%,0%,0.4)',
+        }}
+      />
+    </span>
+  );
+}

--- a/frontend-v2/src/_redesign/redesign.css
+++ b/frontend-v2/src/_redesign/redesign.css
@@ -1,0 +1,437 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ═══════════════════════════════════════════════════════════
+   ED FINDER · BRUSHED STEEL OVER NEBULA
+   Soft chunky rounded panels · purple nebula bleeding through
+   ═══════════════════════════════════════════════════════════ */
+
+:root {
+    color-scheme: dark;
+
+    /* ── Brushed steel ramp ── lighter than before, "satin nickel" feel ── */
+    --steel-1000: hsl(232 28% 4%);
+    --steel-950:  hsl(232 22% 8%);
+    --steel-900:  hsl(232 18% 14%);
+    --steel-850:  hsl(232 14% 20%);
+    --steel-800:  hsl(232 12% 28%);
+    --steel-750:  hsl(232 10% 36%);
+    --steel-700:  hsl(232  9% 46%);
+    --steel-600:  hsl(232  8% 58%);
+    --steel-500:  hsl(232  9% 68%);
+    --steel-400:  hsl(232 12% 76%);
+    --steel-300:  hsl(232 18% 84%);
+    --steel-200:  hsl(232 22% 90%);
+    --steel-100:  hsl(232 28% 95%);
+
+    /* ── Nebula tints (panels pick up these in their backdrop) ── */
+    --neb-violet: hsl(266 60% 32%);
+    --neb-magenta:hsl(310 55% 35%);
+    --neb-indigo: hsl(232 60% 24%);
+    --neb-deep:   hsl(248 45% 6%);
+
+    /* Brand */
+    --ed-orange:    #ff6a00;
+    --ed-orange-lt: #ff9133;
+    --ed-orange-dk: #c44d00;
+    --ed-amber:     #ffaa33;
+
+    /* Rating tiers */
+    --rate-jackpot: #ffd54a;
+    --rate-good:    #4ade80;
+    --rate-ok:      #60a5fa;
+    --rate-poor:    #fb7185;
+
+    /* Semantic */
+    --alert:   #ff5577;
+    --success: #3ddc84;
+    --info:    #4da6ff;
+
+    /* shadcn defaults */
+    --background: 232 22% 8%;
+    --foreground: 232 28% 95%;
+    --card: 232 18% 14%;
+    --card-foreground: 232 28% 95%;
+    --popover: 232 18% 14%;
+    --popover-foreground: 232 28% 95%;
+    --primary: 22 100% 50%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 232 14% 20%;
+    --secondary-foreground: 232 28% 95%;
+    --muted: 232 14% 20%;
+    --muted-foreground: 232 12% 76%;
+    --accent: 22 100% 50%;
+    --accent-foreground: 0 0% 0%;
+    --destructive: 350 100% 60%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 232 12% 28%;
+    --input: 232 14% 20%;
+    --ring: 22 100% 50%;
+    --radius: 0.75rem;
+}
+
+* { box-sizing: border-box; }
+html, body {
+    margin: 0; padding: 0; height: 100%;
+    background: var(--neb-deep);
+    color: var(--steel-200);
+    font-family: 'Inter', system-ui, sans-serif;
+    font-size: 13px;
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+    overflow: hidden;
+}
+#root { height: 100vh; width: 100vw; position: relative; }
+
+/* ═══ NEBULA BACKGROUND ════════════════════════════════════════
+   The Coalsack Nebula — a real dark absorption nebula, ~600 LY away,
+   imaged with the Wide Field Imager on the MPG/ESO 2.2-metre telescope.
+   Source: ESO release eso1539a · CC BY 4.0 · Credit: ESO
+   https://www.eso.org/public/images/eso1539a/
+   The photo's own embedded stars and dust replace the synthetic starfield. */
+
+#root::before {
+    content: '';
+    position: fixed;
+    inset: -8%;
+    z-index: 0;
+    pointer-events: none;
+    background-image:
+      url('https://www.eso.org/public/archives/images/wallpaper3/eso1539a.jpg');
+    background-size: cover;
+    background-position: center;
+    filter: saturate(1.1) contrast(1.12) brightness(0.95);
+    /* No rotation — Coalsack is recognisable; rotating it looks uncanny.
+       Just a barely-perceptible parallax drift to keep the scene "alive". */
+    animation: nebula-drift 90s ease-in-out infinite alternate;
+}
+
+#root::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+    /* Soft corner vignette only — keeps the dark patch visible. */
+    background:
+      radial-gradient(ellipse 95% 88% at center, transparent 60%, hsla(232, 80%, 2%, 0.45) 100%);
+}
+
+/* The photographic nebula already contains thousands of real stars; the
+   secondary CSS dot-starfield is unnecessary and makes things noisy.
+   Hidden here but kept in the DOM in case other tabs want it back. */
+.starfield-overlay { display: none; }
+.nebula-layer-2    { display: none; }
+.nebula-layer-3    { display: none; }
+
+@keyframes nebula-drift {
+    0%   { transform: translate(0, 0) scale(1.06); }
+    100% { transform: translate(-1.5%, 0.8%) scale(1.10); }
+}
+
+/* Starfield (dots scattered via radial-gradients) */
+.starfield-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 2;
+    pointer-events: none;
+    background-image:
+      radial-gradient(1px 1px at 13% 22%, white 50%, transparent 51%),
+      radial-gradient(1px 1px at 84% 18%, white 50%, transparent 51%),
+      radial-gradient(1px 1px at 47% 39%, white 50%, transparent 51%),
+      radial-gradient(1.4px 1.4px at 24% 65%, white 50%, transparent 51%),
+      radial-gradient(1px 1px at 78% 72%, white 50%, transparent 51%),
+      radial-gradient(1px 1px at 9% 88%, white 50%, transparent 51%),
+      radial-gradient(1.6px 1.6px at 62% 11%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 36% 84%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 92% 47%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 55% 56%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 18% 41%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 71% 81%, white 50%, transparent 51%),
+      radial-gradient(1.2px 1.2px at 4%  60%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 88% 92%, white 50%, transparent 51%),
+      radial-gradient(0.8px 0.8px at 31% 12%, white 50%, transparent 51%);
+    background-size: 100% 100%;
+    opacity: 0.65;
+}
+
+/* All app chrome sits above the nebula */
+[data-testid="app-shell"] { position: relative; z-index: 10; }
+
+/* ═══ TYPOGRAPHY ══════════════════════════════════════════════ */
+.font-display {
+    font-family: 'Aldrich', 'Eurostile', system-ui;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+.font-mono {
+    font-family: 'JetBrains Mono', 'IBM Plex Mono', ui-monospace, monospace;
+    letter-spacing: 0.01em;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ═══ BRUSHED-STEEL PANELS ════════════════════════════════════
+   Chunky · rounded · translucent · nebula bleeds through
+   with a subtle satin-metal sheen and a top rim highlight. */
+
+.panel {
+    position: relative;
+    background:
+      linear-gradient(180deg,
+        hsla(232, 18%, 32%, 0.42) 0%,
+        hsla(232, 16%, 24%, 0.48) 50%,
+        hsla(232, 18%, 28%, 0.42) 100%);
+    backdrop-filter: blur(18px) saturate(1.35);
+    -webkit-backdrop-filter: blur(18px) saturate(1.35);
+    border: 1px solid hsla(232, 22%, 60%, 0.32);
+    border-radius: 16px;
+    box-shadow:
+      0 1px 0 hsla(232, 30%, 90%, 0.15) inset,                /* top rim */
+      0 -1px 0 hsla(232, 20%, 5%, 0.4) inset,                 /* bottom rim */
+      0 0 0 1px hsla(232, 30%, 90%, 0.04) inset,              /* edge glass */
+      0 12px 40px -8px hsla(248, 60%, 4%, 0.7),               /* deep drop */
+      0 4px 12px -4px hsla(248, 50%, 4%, 0.6);
+}
+.panel::before {
+    /* Brushed-metal grain (very subtle horizontal noise) */
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='b'%3E%3CfeTurbulence type='turbulence' baseFrequency='0.85 0.04' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1   0 0 0 0 1   0 0 0 0 1   0 0 0 0.06 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23b)'/%3E%3C/svg%3E");
+    opacity: 0.5;
+    mix-blend-mode: overlay;
+}
+.panel > * { position: relative; z-index: 1; }
+
+.panel-active {
+    border-color: hsla(22, 100%, 60%, 0.45);
+    box-shadow:
+      0 1px 0 hsla(232, 30%, 90%, 0.18) inset,
+      0 -1px 0 hsla(232, 20%, 5%, 0.4) inset,
+      0 0 0 1px hsla(22, 100%, 50%, 0.3) inset,
+      0 0 28px -4px hsla(22, 100%, 50%, 0.25),
+      0 12px 40px -8px hsla(248, 60%, 4%, 0.7);
+}
+
+/* Section sub-panel — like the SEARCH RADIUS card inside the rail */
+.section-panel {
+    position: relative;
+    background:
+      linear-gradient(180deg,
+        hsla(232, 22%, 22%, 0.55) 0%,
+        hsla(232, 18%, 16%, 0.55) 100%);
+    border: 1px solid hsla(232, 22%, 50%, 0.28);
+    border-radius: 14px;
+    box-shadow:
+      0 1px 0 hsla(232, 30%, 90%, 0.12) inset,
+      0 -1px 0 hsla(232, 20%, 5%, 0.4) inset,
+      0 6px 18px -4px hsla(248, 60%, 4%, 0.55);
+    overflow: hidden;
+}
+.section-panel-header {
+    background:
+      linear-gradient(180deg,
+        hsla(232, 28%, 32%, 0.55) 0%,
+        hsla(232, 22%, 24%, 0.45) 100%);
+    border-bottom: 1px solid hsla(232, 22%, 50%, 0.3);
+    padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* Glass panel — for floating UI over the map */
+.glass {
+    background: hsla(232, 18%, 14%, 0.78);
+    backdrop-filter: blur(20px) saturate(1.4);
+    -webkit-backdrop-filter: blur(20px) saturate(1.4);
+    border: 1px solid hsla(232, 22%, 60%, 0.32);
+    border-radius: 14px;
+    box-shadow:
+      0 1px 0 hsla(232, 30%, 90%, 0.12) inset,
+      0 12px 32px hsla(248, 60%, 4%, 0.5);
+}
+
+/* Inset readout — cockpit gauge */
+.readout {
+    background: hsla(232, 30%, 5%, 0.72);
+    border: 1px solid hsla(232, 25%, 50%, 0.3);
+    border-radius: 8px;
+    box-shadow:
+      inset 0 1px 0 hsla(248, 60%, 0%, 0.7),
+      inset 0 -1px 0 hsla(232, 30%, 90%, 0.06);
+    color: var(--ed-orange-lt);
+    font-family: 'JetBrains Mono', monospace;
+    text-shadow: 0 0 6px hsla(22, 100%, 50%, 0.45);
+}
+
+/* Glow utilities */
+.glow-orange { box-shadow: 0 0 0 1px var(--ed-orange-dk), 0 0 20px hsla(22, 100%, 50%, 0.35); }
+.text-glow-orange { text-shadow: 0 0 8px hsla(22, 100%, 50%, 0.6); }
+.text-glow-amber  { text-shadow: 0 0 8px hsla(45, 95%, 56%, 0.55); }
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: hsla(232, 22%, 50%, 0.45); border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: var(--ed-orange-dk); }
+
+:focus-visible { outline: 1px solid var(--ed-orange); outline-offset: 2px; }
+
+/* ═══ MAP CANVAS BACKDROP ════════════════════════════════════ */
+.map-canvas-bg {
+    /* Inside the Map tab the SVG canvas wants something different from the
+       general nebula — slightly darker so dots/regions read clearly. */
+    background:
+      radial-gradient(ellipse 1400px 800px at 35% 60%, hsla(266, 50%, 25%, 0.55) 0%, transparent 60%),
+      radial-gradient(ellipse 900px 500px at 75% 30%, hsla(20, 70%, 30%, 0.35) 0%, transparent 55%),
+      radial-gradient(circle at 50% 50%, hsl(245 55% 4%) 0%, hsl(232 80% 2%) 70%);
+}
+
+/* Pulse / sweep animations */
+@keyframes hud-pulse {
+    0%, 100% { opacity: 1;    transform: scale(1); }
+    50%      { opacity: 0.55; transform: scale(1.18); }
+}
+.hud-pulse { animation: hud-pulse 2.4s ease-in-out infinite; }
+
+@keyframes sweep {
+    from { transform: rotate(0deg); }
+    to   { transform: rotate(360deg); }
+}
+.sweep { animation: sweep 6s linear infinite; }
+
+/* Reset */
+button, input, select { font-family: inherit; font-size: inherit; }
+button { cursor: pointer; background: none; border: none; color: inherit; padding: 0; }
+
+/* Recharts polish */
+.recharts-polar-grid-angle line,
+.recharts-polar-grid-concentric polygon {
+    stroke: hsla(232, 25%, 70%, 0.35) !important;
+}
+.recharts-polar-angle-axis text {
+    fill: var(--steel-300) !important;
+    font-family: 'JetBrains Mono', monospace !important;
+    font-size: 9px !important;
+    letter-spacing: 0.05em;
+}
+
+/* ═══ CHUNKY ORANGE SLIDERS (matches reference images) ═══════ */
+
+/* Single slider — pill thumb on a thin track */
+input[type='range'].slider-single {
+    -webkit-appearance: none;
+    appearance: none;
+    background: transparent;
+    width: 100%;
+    height: 22px;
+    cursor: pointer;
+}
+input[type='range'].slider-single::-webkit-slider-runnable-track {
+    height: 4px;
+    background: linear-gradient(90deg,
+        var(--ed-orange) 0%,
+        var(--ed-orange) var(--val, 50%),
+        hsla(232, 22%, 22%, 0.85) var(--val, 50%),
+        hsla(232, 22%, 22%, 0.85) 100%);
+    border-radius: 2px;
+    box-shadow: inset 0 1px 2px hsla(248, 60%, 0%, 0.6);
+}
+input[type='range'].slider-single::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 22px;
+    height: 14px;
+    background: var(--ed-orange);
+    border-radius: 999px;
+    margin-top: -5px;
+    box-shadow:
+      0 0 0 1px hsla(22, 100%, 30%, 0.8),
+      0 1px 0 hsla(45, 95%, 65%, 0.5) inset,
+      0 0 12px hsla(22, 100%, 50%, 0.55);
+    cursor: pointer;
+}
+input[type='range'].slider-single::-moz-range-track {
+    height: 4px;
+    background: hsla(232, 22%, 22%, 0.85);
+    border-radius: 2px;
+}
+input[type='range'].slider-single::-moz-range-thumb {
+    width: 22px;
+    height: 14px;
+    background: var(--ed-orange);
+    border-radius: 999px;
+    border: 1px solid hsla(22, 100%, 30%, 0.8);
+    box-shadow: 0 0 12px hsla(22, 100%, 50%, 0.55);
+    cursor: pointer;
+}
+
+/* Dual-range slider container (CSS only) */
+.dual-track {
+    position: relative;
+    height: 22px;
+}
+.dual-track .track-bg {
+    position: absolute;
+    inset: 9px 0 0 0;
+    height: 4px;
+    background: hsla(232, 22%, 22%, 0.85);
+    border-radius: 2px;
+    box-shadow: inset 0 1px 2px hsla(248, 60%, 0%, 0.6);
+}
+.dual-track .track-fill {
+    position: absolute;
+    top: 9px;
+    height: 4px;
+    background: linear-gradient(90deg, var(--ed-orange-dk), var(--ed-orange));
+    border-radius: 2px;
+    box-shadow: 0 0 8px hsla(22, 100%, 50%, 0.4);
+}
+.dual-track input[type='range'] {
+    -webkit-appearance: none;
+    appearance: none;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 22px;
+    background: transparent;
+    pointer-events: none;
+}
+.dual-track input[type='range']::-webkit-slider-runnable-track {
+    background: transparent;
+    height: 22px;
+}
+.dual-track input[type='range']::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 22px;
+    height: 14px;
+    background: var(--ed-orange);
+    border-radius: 999px;
+    margin-top: 4px;
+    pointer-events: auto;
+    cursor: pointer;
+    box-shadow:
+      0 0 0 1px hsla(22, 100%, 30%, 0.8),
+      0 1px 0 hsla(45, 95%, 65%, 0.5) inset,
+      0 0 10px hsla(22, 100%, 50%, 0.55);
+}
+.dual-track input[type='range']::-moz-range-track {
+    background: transparent;
+    height: 22px;
+    border: none;
+}
+.dual-track input[type='range']::-moz-range-thumb {
+    width: 22px;
+    height: 14px;
+    background: var(--ed-orange);
+    border-radius: 999px;
+    border: 1px solid hsla(22, 100%, 30%, 0.8);
+    pointer-events: auto;
+    cursor: pointer;
+    box-shadow: 0 0 10px hsla(22, 100%, 50%, 0.55);
+}

--- a/frontend-v2/src/main.tsx
+++ b/frontend-v2/src/main.tsx
@@ -1,18 +1,62 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App';
-import './index.css';
 
 const rootEl = document.getElementById('root');
 if (!rootEl) {
   throw new Error('#root not found in index.html');
 }
+const root = createRoot(rootEl);
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// ────────────────────────────────────────────────────────────────────────────
+// Feature flag: ?ui=v3  or  localStorage.uiV3 = "1"  →  load the redesign.
+//
+// The redesign is a parallel shell living in src/_redesign/. It is dynamically
+// imported so its bundle (and its global CSS reset in redesign.css) never
+// reaches users who haven't opted in. Default users keep getting the existing
+// v2 experience exactly as before — zero behaviour change for them.
+//
+// To opt in:
+//   • visit any page with `?ui=v3` (one-shot URL preview), or
+//   • run `localStorage.setItem('uiV3', '1')` in devtools (sticky preview),
+//     reload to apply.
+//
+// To turn it off: `?ui=v2` (one-shot) or
+//   `localStorage.removeItem('uiV3')` and reload.
+// ────────────────────────────────────────────────────────────────────────────
+function shouldUseRedesign(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  const q = params.get('ui');
+  if (q === 'v3') {
+    localStorage.setItem('uiV3', '1');
+    return true;
+  }
+  if (q === 'v2') {
+    localStorage.removeItem('uiV3');
+    return false;
+  }
+  return localStorage.getItem('uiV3') === '1';
+}
+
+async function bootstrap() {
+  if (shouldUseRedesign()) {
+    const { default: RedesignApp } = await import('./_redesign/RedesignApp.jsx');
+    root.render(
+      <StrictMode>
+        <RedesignApp />
+      </StrictMode>,
+    );
+  } else {
+    await import('./index.css');
+    const { default: App } = await import('./App');
+    root.render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+  }
+}
+
+void bootstrap();
 
 // Service worker registration. vite-plugin-pwa emits /v2/sw.js at build time;
 // we register it manually here (avoids the virtual:pwa-register module which

--- a/frontend-v2/tailwind.config.js
+++ b/frontend-v2/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
   theme: {
     extend: {
       // Mirror the vanilla app's CSS variables so the v2 visual identity

--- a/frontend-v2/tsconfig.json
+++ b/frontend-v2/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "allowJs": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/frontend-v2/yarn.lock
+++ b/frontend-v2/yarn.lock
@@ -801,7 +801,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -1555,6 +1555,57 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
+"@types/d3-array@^3.0.3":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-3.2.2.tgz#e02151464d02d4a1b44646d0fcdb93faf88fde8c"
+  integrity sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+
+"@types/d3-color@*":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-3.1.3.tgz#368c961a18de721da8200e80bf3943fb53136af2"
+  integrity sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+
+"@types/d3-ease@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-ease/-/d3-ease-3.0.2.tgz#e28db1bfbfa617076f7770dd1d9a48eaa3b6c51b"
+  integrity sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+
+"@types/d3-interpolate@^3.0.1":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz#412b90e84870285f2ff8a846c6eb60344f12a41c"
+  integrity sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+  dependencies:
+    "@types/d3-color" "*"
+
+"@types/d3-path@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-3.1.1.tgz#f632b380c3aca1dba8e34aa049bcd6a4af23df8a"
+  integrity sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+
+"@types/d3-scale@^4.0.2":
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale/-/d3-scale-4.0.9.tgz#57a2f707242e6fe1de81ad7bfcccaaf606179afb"
+  integrity sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+  dependencies:
+    "@types/d3-time" "*"
+
+"@types/d3-shape@^3.1.0":
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/@types/d3-shape/-/d3-shape-3.1.8.tgz#d1516cc508753be06852cd06758e3bb54a22b0e3"
+  integrity sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+  dependencies:
+    "@types/d3-path" "*"
+
+"@types/d3-time@*", "@types/d3-time@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/d3-time/-/d3-time-3.0.4.tgz#8472feecd639691450dd8000eb33edd444e1323f"
+  integrity sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+
+"@types/d3-timer@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
+  integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+
 "@types/estree@1.0.8", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
@@ -2008,6 +2059,11 @@ chokidar@^3.6.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+clsx@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -2091,10 +2147,81 @@ cssstyle@^4.1.0:
     "@asamuzakjp/css-color" "^3.2.0"
     rrweb-cssom "^0.8.0"
 
-csstype@^3.2.2:
+csstype@^3.0.2, csstype@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+
+"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.4.tgz#15fec33b237f97ac5d7c986dc77da273a8ed0bb5"
+  integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+  dependencies:
+    internmap "1 - 2"
+
+"d3-color@1 - 3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
+  integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+
+d3-ease@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-3.0.1.tgz#9658ac38a2140d59d346160f1f6c30fda0bd12f4"
+  integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+
+"d3-format@1 - 3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+"d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz#3c47aa5b32c5b3dfb56ef3fd4342078a632b400d"
+  integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+  dependencies:
+    d3-color "1 - 3"
+
+d3-path@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-3.1.0.tgz#22df939032fb5a71ae8b1800d61ddb7851c42526"
+  integrity sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+
+d3-scale@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-4.0.2.tgz#82b38e8e8ff7080764f8dcec77bd4be393689396"
+  integrity sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+  dependencies:
+    d3-array "2.10.0 - 3"
+    d3-format "1 - 3"
+    d3-interpolate "1.2.0 - 3"
+    d3-time "2.1.1 - 3"
+    d3-time-format "2 - 4"
+
+d3-shape@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-3.2.0.tgz#a1a839cbd9ba45f28674c69d7f855bcf91dfc6a5"
+  integrity sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+  dependencies:
+    d3-path "^3.1.0"
+
+"d3-time-format@2 - 4":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-4.1.0.tgz#7ab5257a5041d11ecb4fe70a5c7d16a195bb408a"
+  integrity sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+  dependencies:
+    d3-time "1 - 3"
+
+"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-3.1.0.tgz#9310db56e992e3c0175e1ef385e545e48a9bb5c7"
+  integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+  dependencies:
+    d3-array "2 - 3"
+
+d3-timer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-3.0.1.tgz#6284d2a2708285b1abb7e201eda4380af35e63b0"
+  integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
 data-urls@^5.0.0:
   version "5.0.0"
@@ -2137,6 +2264,11 @@ debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.6, d
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
+
+decimal.js-light@^2.4.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 decimal.js@^10.4.3:
   version "10.6.0"
@@ -2200,6 +2332,14 @@ dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
@@ -2507,6 +2647,11 @@ eta@^4.5.1:
   resolved "https://registry.yarnpkg.com/eta/-/eta-4.6.0.tgz#9bf9adb6d5833f3359c7ead1d57109e6064b9430"
   integrity sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==
 
+eventemitter3@^4.0.1:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 expect-type@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
@@ -2516,6 +2661,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-equals@^5.0.1:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-5.4.0.tgz#b60073b8764f27029598447f05773c7534ba7f1e"
+  integrity sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==
 
 fast-glob@^3.3.2:
   version "3.3.3"
@@ -2877,6 +3027,11 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
@@ -3128,7 +3283,7 @@ js-levenshtein@1.1.6:
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -3263,6 +3418,18 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
+lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
 loupe@^3.1.0, loupe@^3.1.2:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
@@ -3284,6 +3451,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lucide-react@^0.469.0:
+  version "0.469.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.469.0.tgz#f16936ca6521482fef754a7eabb310e6c68e1482"
+  integrity sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==
 
 lz-string@^1.5.0:
   version "1.5.0"
@@ -3397,7 +3569,7 @@ nwsapi@^2.2.12:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.23.tgz#59712c3a88e6de2bb0b6ccc1070397267019cf6c"
   integrity sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -3648,6 +3820,15 @@ pretty-format@^27.0.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
+prop-types@^15.6.2, prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
@@ -3665,15 +3846,44 @@ react-dom@^19.1.1:
   dependencies:
     scheduler "^0.27.0"
 
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-refresh@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.17.0.tgz#b7e579c3657f23d04eccbe4ad2e58a8ed51e7e53"
   integrity sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==
+
+react-smooth@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-4.0.4.tgz#a5875f8bb61963ca61b819cedc569dc2453894b4"
+  integrity sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==
+  dependencies:
+    fast-equals "^5.0.1"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^19.1.1:
   version "19.2.5"
@@ -3693,6 +3903,27 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recharts-scale@^0.4.4:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.4.5.tgz#0969271f14e732e642fcc5bd4ab270d6e87dd1d9"
+  integrity sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==
+  dependencies:
+    decimal.js-light "^2.4.1"
+
+recharts@^2.15.0:
+  version "2.15.4"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-2.15.4.tgz#0ed3e66c0843bcf2d9f9a172caf97b1d05127a5f"
+  integrity sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==
+  dependencies:
+    clsx "^2.0.0"
+    eventemitter3 "^4.0.1"
+    lodash "^4.17.21"
+    react-is "^18.3.1"
+    react-smooth "^4.0.4"
+    recharts-scale "^0.4.4"
+    tiny-invariant "^1.3.1"
+    victory-vendor "^36.6.8"
 
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
@@ -4209,6 +4440,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tiny-invariant@^1.3.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
 tinybench@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
@@ -4438,6 +4674,26 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+victory-vendor@^36.6.8:
+  version "36.9.2"
+  resolved "https://registry.yarnpkg.com/victory-vendor/-/victory-vendor-36.9.2.tgz#668b02a448fa4ea0f788dbf4228b7e64669ff801"
+  integrity sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==
+  dependencies:
+    "@types/d3-array" "^3.0.3"
+    "@types/d3-ease" "^3.0.0"
+    "@types/d3-interpolate" "^3.0.1"
+    "@types/d3-scale" "^4.0.2"
+    "@types/d3-shape" "^3.1.0"
+    "@types/d3-time" "^3.0.0"
+    "@types/d3-timer" "^3.0.0"
+    d3-array "^3.1.6"
+    d3-ease "^3.0.1"
+    d3-interpolate "^3.0.1"
+    d3-scale "^4.0.2"
+    d3-shape "^3.1.0"
+    d3-time "^3.0.0"
+    d3-timer "^3.0.1"
 
 vite-node@2.1.9:
   version "2.1.9"


### PR DESCRIPTION
…flag

Quarantined Phase-1 import of the UIItty4 prototype. Zero impact on default users — the redesign bundle and CSS are code-split out via dynamic import and only loaded when:
  - the URL carries ?ui=v3 (also persists to localStorage), or
  - localStorage.uiV3 === '1'

Layout (frontend-v2/src/_redesign/):
  RedesignApp.jsx      mirror of UIItty4's App.js
  redesign.css         brushed-steel + nebula global styles
  components/{Discover,Map,Plan,Track,Shell,Tabs,UI}/...   17 .jsx files
  lib/mockData.js      single source of truth for the prototype

Phase 1 ships with mock data only. Real-API adapters land in a follow-up.

Build verification (yarn build / yarn typecheck / yarn test):
  - all 14 existing tests pass
  - tsc --noEmit clean
  - default chunks unchanged: index.css 33KB, App.js 112KB, react 12KB
  - new opt-in chunks: RedesignApp.css 43KB, RedesignApp.js 447KB
  - PWA service worker emits as before, scope still /v2/

Deps added: lucide-react ^0.469.0, recharts ^2.15.0
TS: allowJs true (.jsx interop)
Tailwind: content glob extended to .{js,jsx}

To opt out of an accidental flag set:
  …/v2/?ui=v2  (clears localStorage.uiV3)