### PR TITLE
Feat/audit phase2 response models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,3 +344,134 @@ jobs:
             exit 1
           fi
           echo "✓ types match checked-in baseline"
+
+  # ─── End-to-end (Playwright + vite preview) ────────────────────────
+  # Audit Phase 6 follow-up: runs the smoke spec end-to-end against a
+  # production `vite build` served by `vite preview`, with the Vite
+  # preview server proxying /api to a freshly-booted FastAPI talking to
+  # a real PG+Redis service container. This is the closest we get to a
+  # production round-trip without paying for a hosted preview env.
+  e2e:
+    name: Frontend v2 E2E (Playwright)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER:     edfinder
+          POSTGRES_PASSWORD: edfinder
+          POSTGRES_DB:       edfinder
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s --health-timeout 3s --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: apps/api/requirements.txt
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install API deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r apps/api/requirements.txt
+
+      - name: Apply schema + seed
+        env:
+          PGPASSWORD: edfinder
+        run: |
+          for f in sql/001_schema.sql sql/002_indexes.sql sql/003_functions.sql \
+                   sql/004_ratings_v31.sql sql/005_map_indexes.sql \
+                   sql/007_profile_sync.sql sql/008_body_filter_aggregates.sql \
+                   sql/009_map_materialised_views.sql sql/010_sync_key_scoping.sql \
+                   sql/seed_preview.sql ; do
+            psql -h localhost -U edfinder -d edfinder -f "$f"
+          done
+          # Same ratings seed as the integration job — gives /api/local/search
+          # something to return.
+          psql -h localhost -U edfinder -d edfinder <<SQL
+          INSERT INTO ratings (system_id64, score, score_agriculture, score_refinery,
+            score_industrial, score_hightech, score_military, score_tourism,
+            score_extraction, slots, body_quality, compactness, signal_quality,
+            orbital_safety, star_bonus, elw_count, ww_count, ammonia_count,
+            gas_giant_count, neutron_count, black_hole_count, white_dwarf_count,
+            landable_count, terraformable_count, bio_signal_total, geo_signal_total,
+            terraforming_potential, body_diversity, confidence, hmc_count,
+            metal_rich_count, rocky_count, rocky_ice_count, icy_count,
+            other_star_count, ring_count, walkable_count)
+          SELECT s.id64, ((s.id64 % 50) + 50)::int, ((s.id64 % 30) + 60)::int,
+            ((s.id64 % 25) + 50)::int, ((s.id64 % 35) + 55)::int, ((s.id64 % 40) + 45)::int,
+            ((s.id64 % 28) + 52)::int, ((s.id64 % 33) + 47)::int, ((s.id64 % 26) + 60)::int,
+            ((s.id64 % 5) + 1)::int, 60, 50, 70, 80, 5,
+            (s.id64 % 3)::int, (s.id64 % 4)::int, (s.id64 % 2)::int,
+            (s.id64 % 6)::int, (s.id64 % 2)::int, 0, 0, 5, 2, 10, 20, 30,
+            ((s.id64 % 30))::int, 0.85, 4, 1, 6, 2, 1, 2, 3, 2
+          FROM systems s ON CONFLICT DO NOTHING;
+          SELECT * FROM refresh_map_mviews(FALSE);
+          SQL
+
+      - name: Boot API in background
+        env:
+          DATABASE_URL: postgresql://edfinder:edfinder@localhost:5432/edfinder
+          REDIS_URL:    redis://localhost:6379/0
+          CORS_ORIGINS: http://localhost:4173
+          ADMIN_TOKEN:  test-admin-token
+          LOG_LEVEL:    WARNING
+        working-directory: apps/api/src
+        run: |
+          nohup python -m uvicorn main:app --host 127.0.0.1 --port 8002 > /tmp/uvicorn.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:8002/api/health >/dev/null 2>&1; then
+              echo "API ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::API failed to start within 30s"
+          tail -100 /tmp/uvicorn.log
+          exit 1
+
+      - name: Install frontend deps
+        working-directory: frontend-v2
+        run: yarn install --no-progress --non-interactive
+
+      - name: Build production bundle
+        working-directory: frontend-v2
+        run: yarn build
+
+      - name: Install Playwright Chromium
+        working-directory: frontend-v2
+        run: yarn e2e:install
+
+      - name: Run Playwright E2E
+        working-directory: frontend-v2
+        env:
+          # vite preview's proxy forwards /api → this. Default in
+          # vite.config.ts points at :8001 (the supervisor backend in
+          # the dev pod); CI runs on :8002 to coexist with anything
+          # else mapped to :8001 on the runner.
+          VITE_DEV_API_TARGET: http://127.0.0.1:8002
+          CI: 'true'
+        run: yarn e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend-v2/playwright-report
+          retention-days: 7

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -21,10 +21,20 @@ Why both?
 
 If you tighten extras here, audit `helpers.sys_row_to_dict` and the
 SQL projections in `routers/systems.py` + `local_search.py` first.
+
+Note on dict-typed request fields (2026-05-09 follow-up): every
+request-side `Optional[dict]` has been replaced with a proper sub-model
+(RangeFilter, BodyFilters, RerankWeightsInput, etc.) or `Optional[Any]`
+where the shape is genuinely opaque. Pydantic 2.10+ emits
+`additionalProperties: false` for `dict` fields, which openapi-typescript
+renders as the strict-empty `Record<string, never>` — strict-mode TS
+then refuses to pass real values through that type. Using sub-models
+keeps the schema portable across Pydantic versions and gives the
+frontend useful types out of the box.
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -36,6 +46,55 @@ class CoordsModel(BaseModel):
     x: float
     y: float
     z: float
+
+
+class RangeFilter(BaseModel):
+    """Inclusive numeric range used by `SearchFilters.distance` /
+    `.population`. Either bound is optional — omit `min` for an upper-
+    only filter, omit `max` for a lower-only one. (Frontend always
+    sends both today; keep them optional so a future client can omit.)"""
+    model_config = ConfigDict(extra='allow')
+
+    min: Optional[float] = None
+    max: Optional[float] = None
+
+
+class BodyCountFilter(BaseModel):
+    """One body-count slider in `LocalSearchRequest.body_filters`. Each
+    body-type key (`elw_count`, `ww_count`, …) maps to a min/max range,
+    same shape as `RangeFilter` — duplicated here for naming clarity in
+    the generated TS."""
+    model_config = ConfigDict(extra='allow')
+
+    min: Optional[int] = None
+    max: Optional[int] = None
+
+
+class BodyFilters(BaseModel):
+    """`LocalSearchRequest.body_filters`. Keys mirror the
+    `helpers.sys_row_to_dict` body-count column names. All optional —
+    a missing key means "no filter on that body type"."""
+    model_config = ConfigDict(extra='allow')
+
+    elw_count:           Optional[BodyCountFilter] = None
+    ww_count:            Optional[BodyCountFilter] = None
+    ammonia_count:       Optional[BodyCountFilter] = None
+    gas_giant_count:     Optional[BodyCountFilter] = None
+    landable_count:      Optional[BodyCountFilter] = None
+    terraformable_count: Optional[BodyCountFilter] = None
+    bio_signal_total:    Optional[BodyCountFilter] = None
+    geo_signal_total:    Optional[BodyCountFilter] = None
+    neutron_count:       Optional[BodyCountFilter] = None
+    black_hole_count:    Optional[BodyCountFilter] = None
+    white_dwarf_count:   Optional[BodyCountFilter] = None
+    hmc_count:           Optional[BodyCountFilter] = None
+    metal_rich_count:    Optional[BodyCountFilter] = None
+    rocky_count:         Optional[BodyCountFilter] = None
+    rocky_ice_count:     Optional[BodyCountFilter] = None
+    icy_count:           Optional[BodyCountFilter] = None
+    other_star_count:    Optional[BodyCountFilter] = None
+    ring_count:          Optional[BodyCountFilter] = None
+    walkable_count:      Optional[BodyCountFilter] = None
 
 
 class RatingModel(BaseModel):
@@ -56,7 +115,7 @@ class RatingModel(BaseModel):
     scoreTourism:           Optional[float] = None
     scoreExtraction:        Optional[float] = None
     economySuggestion:      Optional[str]   = None
-    breakdown:              Optional[dict]  = None
+    breakdown:              Optional[Any]   = None  # opaque rationale payload
     # v3.1 fields — mirrored in camelCase for frontend parity.
     terraformingPotential:  Optional[float] = None
     bodyDiversity:          Optional[float] = None
@@ -351,18 +410,18 @@ class NoteBody(BaseModel):
 # Request models
 # ══════════════════════════════════════════════════════════════════════
 class SearchFilters(BaseModel):
-    distance:   Optional[dict] = None
-    population: Optional[dict] = None
-    economy:    Optional[str]  = None
+    distance:   Optional[RangeFilter] = None
+    population: Optional[RangeFilter] = None
+    economy:    Optional[str]         = None
 
 
 class LocalSearchRequest(BaseModel):
     filters:          Optional[SearchFilters] = None
-    reference_coords: Optional[dict]          = None
+    reference_coords: Optional[CoordsModel]   = None
     sort_by:          Optional[str]            = 'rating'
     size:             int                      = Field(default=50, le=500)
     from_:            int                      = Field(default=0, alias='from')
-    body_filters:     Optional[dict]           = None
+    body_filters:     Optional[BodyFilters]    = None
     require_bio:      Optional[bool]           = None
     require_geo:      Optional[bool]           = None
     require_terra:    Optional[bool]           = None
@@ -390,4 +449,4 @@ class ClusterSearchRequest(BaseModel):
     requirements:     list[ClusterRequirement]
     limit:            int = Field(default=50, le=200)
     offset:           int = 0
-    reference_coords: Optional[dict] = None
+    reference_coords: Optional[CoordsModel] = None

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -4,16 +4,33 @@ These are data-shape contracts — keep side-effects out, do not import
 DB / Redis / config from here. All models referenced by more than one
 router live here; router-local one-off shapes can stay next to their
 endpoint.
+
+Audit Phase 2 follow-up (2026-05-09 — see AUDIT_REPORT.md §M3 / Phase 7
+follow-up): every response model below is now strictly typed *and*
+allows extras (`model_config = {"extra": "allow"}`).
+
+Why both?
+
+* Strict fields → openapi-typescript can generate real TypeScript types
+  from /openapi.json instead of `Record<string, never>` / `unknown`,
+  which is what made the api.gen.ts CI drift-check toothless.
+* Extras allowed → adding a column on the SQL side or a key in
+  `helpers.sys_row_to_dict` will *not* be silently stripped by
+  Pydantic's response serializer (which was the original bug behind
+  the `source/query_ms/display_economy` regression in d43fde8).
+
+If you tighten extras here, audit `helpers.sys_row_to_dict` and the
+SQL projections in `routers/systems.py` + `local_search.py` first.
 """
 from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # ══════════════════════════════════════════════════════════════════════
-# Response models
+# Shared mixins / sub-models
 # ══════════════════════════════════════════════════════════════════════
 class CoordsModel(BaseModel):
     x: float
@@ -22,18 +39,34 @@ class CoordsModel(BaseModel):
 
 
 class RatingModel(BaseModel):
-    score:             Optional[float] = None
-    scoreAgriculture:  Optional[float] = None
-    scoreRefinery:     Optional[float] = None
-    scoreIndustrial:   Optional[float] = None
-    scoreHightech:     Optional[float] = None
-    scoreMilitary:     Optional[float] = None
-    scoreTourism:      Optional[float] = None
-    economySuggestion: Optional[str]   = None
-    breakdown:         Optional[dict]  = None
+    """camelCase rating block embedded inside SystemRow under `_rating`.
+
+    Mirrors the shape produced by `helpers.sys_row_to_dict` so the
+    generated TypeScript matches what the search response actually puts
+    on the wire.
+    """
+    model_config = ConfigDict(extra='allow')
+
+    score:                  Optional[float] = None
+    scoreAgriculture:       Optional[float] = None
+    scoreRefinery:          Optional[float] = None
+    scoreIndustrial:        Optional[float] = None
+    scoreHightech:          Optional[float] = None
+    scoreMilitary:          Optional[float] = None
+    scoreTourism:           Optional[float] = None
+    scoreExtraction:        Optional[float] = None
+    economySuggestion:      Optional[str]   = None
+    breakdown:              Optional[dict]  = None
+    # v3.1 fields — mirrored in camelCase for frontend parity.
+    terraformingPotential:  Optional[float] = None
+    bodyDiversity:          Optional[float] = None
+    confidence:             Optional[float] = None
+    rationale:              Optional[str]   = None
 
 
 class BodyModel(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
     id:                      Optional[int]   = None
     name:                    Optional[str]   = None
     subtype:                 Optional[str]   = None
@@ -58,6 +91,8 @@ class BodyModel(BaseModel):
 
 
 class StationModel(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
     id:                 Optional[int]   = None
     name:               Optional[str]   = None
     station_type:       Optional[str]   = None
@@ -68,49 +103,239 @@ class StationModel(BaseModel):
     has_outfitting:     Optional[bool]  = None
 
 
-class SystemModel(BaseModel):
-    id64:                Optional[int]   = None
-    name:                str             = 'Unknown'
+class ExplorationValueModel(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    total_scan_value:    int = 0
+    total_mapping_value: int = 0
+    combined_value:      int = 0
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Search row (camelCase) — `/api/local/search`, `/api/systems/batch`
+# ══════════════════════════════════════════════════════════════════════
+class SystemRow(BaseModel):
+    """One result row inside `SearchResponse.results`.
+
+    Keep aligned with `helpers.sys_row_to_dict` (single source of truth
+    for the camelCase translator).
+    """
+    model_config = ConfigDict(extra='allow')
+
+    id64:                int
+    name:                str                   = 'Unknown'
     coords:              Optional[CoordsModel] = None
-    distance:            Optional[float] = None
-    population:          int             = 0
-    primaryEconomy:      Optional[str]   = None
-    secondaryEconomy:    Optional[str]   = None
-    security:            Optional[str]   = None
-    allegiance:          Optional[str]   = None
-    government:          Optional[str]   = None
-    is_colonised:        bool            = False
-    is_being_colonised:  bool            = False
-    main_star_type:      Optional[str]   = None
-    main_star_subtype:   Optional[str]   = None
-    _rating:             Optional[RatingModel] = None
-    bodies:              list[BodyModel]       = []
-    stations:            list[StationModel]    = []
+    distance:            Optional[float]       = None
+    population:          int                   = 0
+    primaryEconomy:      Optional[str]         = None
+    secondaryEconomy:    Optional[str]         = None
+    security:            Optional[str]         = None
+    allegiance:          Optional[str]         = None
+    government:          Optional[str]         = None
+    is_colonised:        Optional[bool]        = None
+    is_being_colonised:  Optional[bool]        = None
+    main_star_type:      Optional[str]         = None
+    main_star_subtype:   Optional[str]         = None
+
+    # Embedded rating block (also camelCase). Field name has a leading
+    # underscore on the wire — Pydantic v2 keeps the raw alias.
+    rating: Optional[RatingModel] = Field(default=None, alias='_rating')
+
+    # Body counts surfaced flat for filter pills (the search SQL
+    # projects these from the ratings row).
+    elw_count:            Optional[int] = None
+    ww_count:             Optional[int] = None
+    ammonia_count:        Optional[int] = None
+    gas_giant_count:      Optional[int] = None
+    landable_count:       Optional[int] = None
+    terraformable_count:  Optional[int] = None
+    bio_signal_total:     Optional[int] = None
+    geo_signal_total:     Optional[int] = None
+    neutron_count:        Optional[int] = None
+    black_hole_count:     Optional[int] = None
+    white_dwarf_count:    Optional[int] = None
 
 
+# Backwards-compatible alias — older imports used `SystemModel`.
+SystemModel = SystemRow
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Detail row (snake_case) — `/api/system/{id64}`
+# ══════════════════════════════════════════════════════════════════════
+class SystemDetailRow(BaseModel):
+    """Full system detail returned by `/api/system/{id64}`.
+
+    The detail endpoint does *not* go through the camelCase translator —
+    it returns the joined ratings + bodies + stations rows snake_case
+    as PostgreSQL emits them (see `routers/systems.py::get_system`).
+    Frontend renders these strings directly.
+    """
+    model_config = ConfigDict(extra='allow')
+
+    id64:               int
+    name:               str
+    x:                  float = 0
+    y:                  float = 0
+    z:                  float = 0
+    population:         int   = 0
+    primary_economy:    Optional[str]  = None
+    secondary_economy:  Optional[str]  = None
+    security:           Optional[str]  = None
+    allegiance:         Optional[str]  = None
+    government:         Optional[str]  = None
+    is_colonised:       Optional[bool] = None
+    main_star_type:     Optional[str]  = None
+    main_star_subtype:  Optional[str]  = None
+
+    # Flat rating fields (joined from ratings table; snake_case here).
+    score:                  Optional[float] = None
+    score_agriculture:      Optional[float] = None
+    score_refinery:         Optional[float] = None
+    score_industrial:       Optional[float] = None
+    score_hightech:         Optional[float] = None
+    score_military:         Optional[float] = None
+    score_tourism:          Optional[float] = None
+    score_extraction:       Optional[float] = None
+    economy_suggestion:     Optional[str]   = None
+
+    # Flat body counts.
+    elw_count:              Optional[int] = None
+    ww_count:               Optional[int] = None
+    ammonia_count:          Optional[int] = None
+    gas_giant_count:        Optional[int] = None
+    landable_count:         Optional[int] = None
+    terraformable_count:    Optional[int] = None
+    bio_signal_total:       Optional[int] = None
+    geo_signal_total:       Optional[int] = None
+    neutron_count:          Optional[int] = None
+    black_hole_count:       Optional[int] = None
+    white_dwarf_count:      Optional[int] = None
+
+    # v3.1 rating fields.
+    terraforming_potential: Optional[float] = None
+    body_diversity:         Optional[float] = None
+    confidence:             Optional[float] = None
+    rationale:              Optional[str]   = None
+
+    bodies:   list[BodyModel]    = Field(default_factory=list)
+    stations: list[StationModel] = Field(default_factory=list)
+
+    exploration_value: Optional[ExplorationValueModel] = None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Response wrappers
+# ══════════════════════════════════════════════════════════════════════
 class SearchResponse(BaseModel):
-    results: list[dict]
-    total:   int
-    count:   int
+    """`/api/local/search` response."""
+    model_config = ConfigDict(extra='allow')
+
+    results: list[SystemRow]
+    total:   int = 0
+    count:   int = 0
     # Optional — only set by local_db_search, helpful for ops visibility
     # so you can tell which code path served the response without
     # spelunking through logs. (FastAPI silently drops fields not in
     # the response model; without these, source/query_ms/display_economy
-    # were being stripped before reaching the client.)
-    source:           Optional[str]  = None
-    query_ms:         Optional[int]  = None
-    display_economy:  Optional[str]  = None
+    # were being stripped before reaching the client — see d43fde8.)
+    source:           Optional[str] = None
+    query_ms:         Optional[int] = None
+    display_economy:  Optional[str] = None
 
 
 class SystemDetailResponse(BaseModel):
-    record: dict
-    system: dict
+    """`/api/system/{id64}` response. Backend returns the same row
+    twice under `record` and `system` for legacy compat."""
+    model_config = ConfigDict(extra='allow')
+
+    record: SystemDetailRow
+    system: SystemDetailRow
 
 
 class HealthResponse(BaseModel):
     status:   str
     database: str
     version:  str
+
+
+class AutocompleteHit(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    id64:           int
+    name:           str
+    x:              float = 0
+    y:              float = 0
+    z:              float = 0
+    population:     int = 0
+    primaryEconomy: Optional[str] = None
+
+
+class AutocompleteResponse(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    results: list[AutocompleteHit]
+    source:  Optional[str] = None
+
+
+class StatusResponse(BaseModel):
+    """`/api/status` and `/api/local/status`."""
+    model_config = ConfigDict(extra='allow')
+
+    available:            bool
+    systems_count:        int = 0
+    body_count:           int = 0
+    rated_count:          int = 0
+    clustered_count:      int = 0
+    import_complete:      bool = False
+    ratings_built:        bool = False
+    grid_built:           bool = False
+    clusters_built:       bool = False
+    eddn_enabled:         bool = False
+    last_nightly_update:  str = 'never'
+    schema_version:       str = '1.0'
+    max_search_radius_ly: int = 500
+    has_body_data:        bool = False
+    version:              str = ''
+
+
+class CacheStatsResponse(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    cache_hits:       int = 0
+    cache_misses:     int = 0
+    redis_hits:       Optional[int]   = None
+    redis_misses:     Optional[int]   = None
+    redis_memory_mb:  Optional[float] = None
+    db_cache_rows:    int = 0
+
+
+class RerankWeights(BaseModel):
+    economy:      float = 0.42
+    slots:        float = 0.23
+    strategic:    float = 0.18
+    safety:       float = 0.10
+    terraforming: float = 0.05
+    diversity:    float = 0.02
+
+
+class RerankRow(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    id64:           int
+    reranked_score: int
+    original_score: Optional[float] = None
+    confidence:     Optional[float] = None
+    rationale:      Optional[str]   = None
+    economy_used:   Optional[str]   = None
+
+
+class RerankResponse(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    weights_applied: RerankWeights
+    economy_used:    Optional[str] = None
+    results:         list[RerankRow]
 
 
 class WatchlistAlert(BaseModel):

--- a/apps/api/src/routers/admin.py
+++ b/apps/api/src/routers/admin.py
@@ -15,12 +15,13 @@ from fastapi.responses import JSONResponse
 from config  import limiter
 from deps    import get_pool, get_redis, require_admin
 from helpers import run_cluster_rebuild
+from models  import CacheStatsResponse
 from state   import active_jobs, active_jobs_lock, metrics
 
 router = APIRouter(tags=['admin'])
 
 
-@router.get('/api/cache/stats')
+@router.get('/api/cache/stats', response_model=CacheStatsResponse)
 async def cache_stats(
     pool:  asyncpg.Pool              = Depends(get_pool),
     redis: Optional[aioredis.Redis]  = Depends(get_redis),

--- a/apps/api/src/routers/meta.py
+++ b/apps/api/src/routers/meta.py
@@ -16,7 +16,7 @@ from fastapi.responses import PlainTextResponse
 
 from config import settings
 from deps   import get_pool, get_redis, cache_get, cache_set
-from models import HealthResponse
+from models import HealthResponse, StatusResponse
 from state  import metrics
 
 log = logging.getLogger('ed_finder')
@@ -46,7 +46,7 @@ async def health(pool: asyncpg.Pool = Depends(get_pool)):
         raise HTTPException(503, detail=str(e))
 
 
-@router.get('/api/status')
+@router.get('/api/status', response_model=StatusResponse)
 async def status(
     pool:  asyncpg.Pool              = Depends(get_pool),
     redis: Optional[aioredis.Redis]  = Depends(get_redis),
@@ -98,7 +98,7 @@ async def status(
     return result
 
 
-@router.get('/api/local/status')
+@router.get('/api/local/status', response_model=StatusResponse)
 async def local_status(
     pool:  asyncpg.Pool              = Depends(get_pool),
     redis: Optional[aioredis.Redis]  = Depends(get_redis),

--- a/apps/api/src/routers/profile.py
+++ b/apps/api/src/routers/profile.py
@@ -37,7 +37,7 @@ class ProfileSyncBlob(BaseModel):
     feature set evolves on the client and the backend shouldn't be a
     moving target every time we add a new tab.
     """
-    blob: dict[str, Any] = Field(..., description='Arbitrary client-managed payload.')
+    blob: Any = Field(..., description='Arbitrary client-managed payload.')
 
 
 def _validate_sync_key(sync_key: str) -> None:

--- a/apps/api/src/routers/ratings.py
+++ b/apps/api/src/routers/ratings.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from config import settings, limiter, log
 from deps   import get_pool, get_redis
+from models import RerankResponse
 from search_economies import ratings_score_column, ECONOMIES
 
 router = APIRouter(tags=['ratings'])
@@ -59,7 +60,7 @@ class RerankRequest(BaseModel):
     weights: Optional[dict] = None
     economy: Optional[str]  = None      # e.g. 'Tourism'; None = use stored primary
 
-@router.post('/api/ratings/rerank')
+@router.post('/api/ratings/rerank', response_model=RerankResponse)
 @limiter.limit('60/minute')
 async def ratings_rerank(
     request: Request,

--- a/apps/api/src/routers/ratings.py
+++ b/apps/api/src/routers/ratings.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from config import settings, limiter, log
 from deps   import get_pool, get_redis
-from models import RerankResponse
+from models import RerankResponse, RerankWeights
 from search_economies import ratings_score_column, ECONOMIES
 
 router = APIRouter(tags=['ratings'])
@@ -56,9 +56,10 @@ _DEFAULT_WEIGHTS = {
 
 
 class RerankRequest(BaseModel):
-    id64s:   List[int] = Field(..., min_length=1, max_length=500)
-    weights: Optional[dict] = None
-    economy: Optional[str]  = None      # e.g. 'Tourism'; None = use stored primary
+    id64s:   List[int]               = Field(..., min_length=1, max_length=500)
+    # Partial overrides allowed; missing keys fall back to _DEFAULT_WEIGHTS.
+    weights: Optional[RerankWeights] = None
+    economy: Optional[str]           = None      # e.g. 'Tourism'; None = use stored primary
 
 @router.post('/api/ratings/rerank', response_model=RerankResponse)
 @limiter.limit('60/minute')
@@ -70,8 +71,12 @@ async def ratings_rerank(
     # ── Normalise weights: accept partial user input, fill gaps from defaults
     w = dict(_DEFAULT_WEIGHTS)
     if body.weights:
-        for k, v in body.weights.items():
-            if k in w:
+        # body.weights is a Pydantic model; iterate the declared dimensions
+        # and overlay any values the client supplied (defaults are also
+        # set on RerankWeights, so a client that sends an empty {} just
+        # gets the canonical defaults).
+        for k, v in body.weights.model_dump().items():
+            if k in w and v is not None:
                 try:
                     w[k] = max(0.0, min(1.0, float(v)))
                 except (TypeError, ValueError):

--- a/apps/api/src/routers/search.py
+++ b/apps/api/src/routers/search.py
@@ -25,7 +25,7 @@ from config import settings, limiter, log
 from deps   import get_pool, get_redis, cache_get, cache_set, inc_metric, log_slow
 from models import (
     SearchResponse, SearchFilters, LocalSearchRequest,
-    GalaxySearchRequest, ClusterSearchRequest,
+    GalaxySearchRequest, ClusterSearchRequest, AutocompleteResponse,
 )
 
 # Single search implementation. If this import fails the app cannot
@@ -59,7 +59,7 @@ def _search_unavailable(detail_msg: str, *, hint: str = '') -> JSONResponse:
 # ---------------------------------------------------------------------------
 # Autocomplete
 # ---------------------------------------------------------------------------
-@router.get('/api/local/autocomplete')
+@router.get('/api/local/autocomplete', response_model=AutocompleteResponse)
 @limiter.limit('60/minute')
 async def autocomplete(
     request: Request,

--- a/apps/api/src/routers/search.py
+++ b/apps/api/src/routers/search.py
@@ -103,20 +103,29 @@ async def local_search_endpoint(
     background_tasks.add_task(inc_metric, 'db_queries')
     t0 = time.time()
 
+    # Convert Pydantic sub-models to plain dicts before handing off to
+    # local_search.py — that module reaches into the payload with
+    # `.get()` and `.items()`, so model instances would AttributeError.
+    # (Audit Phase 2 follow-up: the request models were tightened from
+    # `Optional[dict]` to real Pydantic types so the OpenAPI schema is
+    # portable across Pydantic versions; downstream still works on dicts.)
+    _filters = (req.filters or SearchFilters())
     body_dict = {
-        'reference_coords': req.reference_coords or {'x': 0, 'y': 0, 'z': 0},
+        'reference_coords': (req.reference_coords.model_dump()
+                             if req.reference_coords else {'x': 0, 'y': 0, 'z': 0}),
         'filters': {
-            'distance':   (req.filters or SearchFilters()).distance or {},
-            'population': (req.filters or SearchFilters()).population or {},
-            'economy':    (req.filters or SearchFilters()).economy or 'any',
+            'distance':   (_filters.distance.model_dump()   if _filters.distance   else {}),
+            'population': (_filters.population.model_dump() if _filters.population else {}),
+            'economy':    _filters.economy or 'any',
         },
-        'body_filters':   req.body_filters or {},
+        'body_filters':   (req.body_filters.model_dump(exclude_none=True)
+                           if req.body_filters else {}),
         'require_bio':    req.require_bio,
         'require_geo':    req.require_geo,
         'require_terra':  req.require_terra,
         'star_types':     req.star_types or [],
         'min_rating':     req.min_rating or 0,
-        'economy':        (req.filters or SearchFilters()).economy or 'any',
+        'economy':        _filters.economy or 'any',
         'size':           req.size,
         'from':           req.from_,
         'sort_by':        req.sort_by or 'rating',
@@ -221,7 +230,8 @@ async def cluster_search(
     body_dict = {
         'requirements':     [r.model_dump() for r in req.requirements],
         'limit':            req.limit,
-        'reference_coords': req.reference_coords,
+        'reference_coords': (req.reference_coords.model_dump()
+                             if req.reference_coords else None),
     }
     try:
         result = await _ls.local_db_cluster_search(body_dict, pool)

--- a/frontend-v2/e2e/smoke.spec.ts
+++ b/frontend-v2/e2e/smoke.spec.ts
@@ -28,9 +28,16 @@ test.describe('ED Finder v2 — smoke', () => {
 
   test('search runs and renders at least one result', async ({ page }) => {
     await page.goto('/');
-    // Wait for "Scanning…" to disappear — the auto-search has finished.
+    // Wait for either a result-card to appear or the "No systems found"
+    // empty state — whichever the seed data produces. The previous
+    // wait-on-"Scanning systems"-disappearing was racy on a fast local
+    // backend (the spinner can come and go before Playwright's first
+    // poll). Use a positive condition instead.
     await page.waitForFunction(
-      () => !document.body.innerText.includes('Scanning systems'),
+      () => {
+        const t = document.body.innerText;
+        return t.includes('shown') || t.includes('No systems found');
+      },
       null,
       { timeout: 15_000 },
     );
@@ -40,9 +47,10 @@ test.describe('ED Finder v2 — smoke', () => {
     // names by probing for "LY" (distance suffix appears next to results)
     // OR a known seed name.
     const body = await page.locator('body').textContent();
-    const knownNames = ['Sol', 'Achenar', 'Lave', 'Procyon', 'Alioth'];
+    const knownNames = ['Sol', 'Achenar', 'Lave', 'Procyon', 'Alioth',
+                        'Wolf', 'HIP', 'Sothis', 'Pleione', 'Diaguandri'];
     const found = knownNames.some((n) => body?.includes(n));
-    expect(found, `Expected at least one seeded name in: ${body?.slice(0, 200)}`).toBe(true);
+    expect(found, `Expected at least one seeded name in: ${body?.slice(0, 400)}`).toBe(true);
   });
 
   test('pinned store persists across reload (Phase 7)', async ({ page }) => {

--- a/frontend-v2/src/features/pinned/PinnedTab.tsx
+++ b/frontend-v2/src/features/pinned/PinnedTab.tsx
@@ -142,11 +142,11 @@ export function PinnedTab({ pinned, onShowOnMap, onOpenDetail }: PinnedTabProps)
 export function toPinnedEntry(sys: {
   id64:         number;
   name:         string;
-  coords?:      { x: number; y: number; z: number };
+  coords?:      { x: number; y: number; z: number } | null;
   distance?:    number | null;
   population:   number;
-  is_colonised?: boolean;
-  _rating?:     { score: number | null; economySuggestion?: string | null } | null;
+  is_colonised?: boolean | null;
+  _rating?:     { score?: number | null; economySuggestion?: string | null } | null;
 }): PinnedEntry {
   return {
     id64:         sys.id64,

--- a/frontend-v2/src/features/watchlist/useWatchlist.ts
+++ b/frontend-v2/src/features/watchlist/useWatchlist.ts
@@ -1,12 +1,26 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, type WatchlistEntry } from '@/lib/api';
 
 /**
  * Watchlist state.
  *
- * Optimistic updates: add/remove mutate the local list immediately and roll
- * back on API failure. Without this, the UI feels laggy on every click —
- * the vanilla app waits for the round-trip and it's noticeable.
+ * Audit Phase 8 (2026-05-09): rewritten on top of TanStack Query so the
+ * NavBar count, the Watchlist tab, the SystemDetailModal "Save to
+ * Watchlist" toggle, and any future consumer all share one cache entry
+ * (`['watchlist']`). Previously each `useWatchlist()` callsite owned its
+ * own `useState`, so every tab refetched independently and the same
+ * data could be in three different states at once.
+ *
+ * Optimistic updates: add/remove mutate the cache immediately via
+ * `setQueryData` and roll back on `onError`. Without this, the UI feels
+ * laggy on every click — the vanilla app waits for the round-trip and
+ * it's noticeable. After settle we invalidate to pull canonical data
+ * (score + economy_suggestion are joined server-side and only available
+ * after the round-trip).
+ *
+ * Public interface (`UseWatchlist`) is unchanged from the bespoke
+ * implementation, so no consumers need rewriting.
  */
 export interface UseWatchlist {
   entries:   WatchlistEntry[];
@@ -18,68 +32,98 @@ export interface UseWatchlist {
   has:       (id64: number) => boolean;
 }
 
+const WATCHLIST_KEY = ['watchlist'] as const;
+
 export function useWatchlist(): UseWatchlist {
-  const [entries, setEntries] = useState<WatchlistEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error,   setError]   = useState<string | null>(null);
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey:    WATCHLIST_KEY,
+    queryFn:     async () => (await api.watchlist()).watchlist,
+    staleTime:   30_000,        // re-fetch on tab focus only after 30s
+    gcTime:      5 * 60_000,    // 5min cache retention
+  });
+
+  const entries = query.data ?? [];
+  const loading = query.isPending;
+  const error   = query.error
+    ? (query.error instanceof Error ? query.error.message : String(query.error))
+    : null;
 
   const refresh = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const r = await api.watchlist();
-      setEntries(r.watchlist);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+    await qc.invalidateQueries({ queryKey: WATCHLIST_KEY });
+  }, [qc]);
 
-  // Initial load — explicit so consumers can opt in (e.g. lazy-load on the
-  // watchlist tab only). For now we always load on mount; the API call is
-  // cheap (~50 rows max) and the badge wants the count regardless.
-  useEffect(() => { void refresh(); }, [refresh]);
+  const addMutation = useMutation({
+    mutationFn: (vars: { id64: number; hint?: Partial<WatchlistEntry> }) =>
+      api.watchAdd(vars.id64),
+    onMutate: async ({ id64, hint }: { id64: number; hint?: Partial<WatchlistEntry> }) => {
+      // Cancel any in-flight refetch so it doesn't overwrite our optimistic update.
+      await qc.cancelQueries({ queryKey: WATCHLIST_KEY });
+      const previous = qc.getQueryData<WatchlistEntry[]>(WATCHLIST_KEY) ?? [];
+      if (previous.some((e) => e.system_id64 === id64)) {
+        return { previous, skip: true };
+      }
+      const optimistic: WatchlistEntry = {
+        system_id64:  id64,
+        name:         hint?.name ?? `System ${id64}`,
+        x:            hint?.x ?? 0,
+        y:            hint?.y ?? 0,
+        z:            hint?.z ?? 0,
+        population:   hint?.population ?? 0,
+        is_colonised: hint?.is_colonised ?? false,
+        added_at:     new Date().toISOString(),
+        score:        hint?.score ?? null,
+      };
+      qc.setQueryData<WatchlistEntry[]>(WATCHLIST_KEY, [optimistic, ...previous]);
+      return { previous, skip: false };
+    },
+    onError: (_err, _vars, ctx) => {
+      // Roll back to the snapshot we took in onMutate.
+      if (ctx?.previous) qc.setQueryData(WATCHLIST_KEY, ctx.previous);
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: WATCHLIST_KEY });
+    },
+  });
 
-  const add = useCallback(async (id64: number, hint?: Partial<WatchlistEntry>) => {
-    if (entries.some((e) => e.system_id64 === id64)) return;
-    // Optimistic insert with whatever hint info the caller supplied.
-    const optimistic: WatchlistEntry = {
-      system_id64:  id64,
-      name:         hint?.name ?? `System ${id64}`,
-      x:            hint?.x ?? 0,
-      y:            hint?.y ?? 0,
-      z:            hint?.z ?? 0,
-      population:   hint?.population ?? 0,
-      is_colonised: hint?.is_colonised ?? false,
-      added_at:     new Date().toISOString(),
-      score:        hint?.score ?? null,
-    };
-    setEntries((prev) => [optimistic, ...prev]);
-    try {
-      await api.watchAdd(id64);
-      // Refresh to pull canonical data (score + economy_suggestion are
-      // joined server-side and only available after the round-trip).
-      void refresh();
-    } catch (e) {
-      // Roll back.
-      setEntries((prev) => prev.filter((e2) => e2.system_id64 !== id64));
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [entries, refresh]);
+  const removeMutation = useMutation({
+    mutationFn: (id64: number) => api.watchRemove(id64),
+    onMutate: async (id64: number) => {
+      await qc.cancelQueries({ queryKey: WATCHLIST_KEY });
+      const previous = qc.getQueryData<WatchlistEntry[]>(WATCHLIST_KEY) ?? [];
+      qc.setQueryData<WatchlistEntry[]>(
+        WATCHLIST_KEY,
+        previous.filter((e) => e.system_id64 !== id64),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) qc.setQueryData(WATCHLIST_KEY, ctx.previous);
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey: WATCHLIST_KEY });
+    },
+  });
 
-  const remove = useCallback(async (id64: number) => {
-    const before = entries;
-    setEntries((prev) => prev.filter((e) => e.system_id64 !== id64));
-    try {
-      await api.watchRemove(id64);
-    } catch (e) {
-      setEntries(before);                                  // roll back
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [entries]);
+  const add = useCallback(
+    async (id64: number, hint?: Partial<WatchlistEntry>) => {
+      await addMutation.mutateAsync({ id64, hint });
+    },
+    [addMutation],
+  );
 
-  const has = useCallback((id64: number) => entries.some((e) => e.system_id64 === id64), [entries]);
+  const remove = useCallback(
+    async (id64: number) => {
+      await removeMutation.mutateAsync(id64);
+    },
+    [removeMutation],
+  );
+
+  const has = useCallback(
+    (id64: number) => entries.some((e) => e.system_id64 === id64),
+    [entries],
+  );
 
   return { entries, loading, error, refresh, add, remove, has };
 }

--- a/frontend-v2/src/lib/format.ts
+++ b/frontend-v2/src/lib/format.ts
@@ -43,9 +43,9 @@ export function formatConfidence(c: number | null | undefined):
  * Spansh's `is_colonised` flag is unreliable for old systems, so we OR a
  * few correlated signals together — same logic the vanilla app uses. */
 export function isInhabited(sys: {
-  is_colonised?:        boolean;
-  is_being_colonised?:  boolean;
-  population?:          number;
+  is_colonised?:        boolean | null;
+  is_being_colonised?:  boolean | null;
+  population?:          number | null;
 }): boolean {
   return !!(sys.is_colonised || sys.is_being_colonised || (sys.population ?? 0) > 0);
 }

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -758,6 +758,50 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * BodyCountFilter
+         * @description One body-count slider in `LocalSearchRequest.body_filters`. Each
+         *     body-type key (`elw_count`, `ww_count`, …) maps to a min/max range,
+         *     same shape as `RangeFilter` — duplicated here for naming clarity in
+         *     the generated TS.
+         */
+        BodyCountFilter: {
+            /** Min */
+            min?: number | null;
+            /** Max */
+            max?: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * BodyFilters
+         * @description `LocalSearchRequest.body_filters`. Keys mirror the
+         *     `helpers.sys_row_to_dict` body-count column names. All optional —
+         *     a missing key means "no filter on that body type".
+         */
+        BodyFilters: {
+            elw_count?: components["schemas"]["BodyCountFilter"] | null;
+            ww_count?: components["schemas"]["BodyCountFilter"] | null;
+            ammonia_count?: components["schemas"]["BodyCountFilter"] | null;
+            gas_giant_count?: components["schemas"]["BodyCountFilter"] | null;
+            landable_count?: components["schemas"]["BodyCountFilter"] | null;
+            terraformable_count?: components["schemas"]["BodyCountFilter"] | null;
+            bio_signal_total?: components["schemas"]["BodyCountFilter"] | null;
+            geo_signal_total?: components["schemas"]["BodyCountFilter"] | null;
+            neutron_count?: components["schemas"]["BodyCountFilter"] | null;
+            black_hole_count?: components["schemas"]["BodyCountFilter"] | null;
+            white_dwarf_count?: components["schemas"]["BodyCountFilter"] | null;
+            hmc_count?: components["schemas"]["BodyCountFilter"] | null;
+            metal_rich_count?: components["schemas"]["BodyCountFilter"] | null;
+            rocky_count?: components["schemas"]["BodyCountFilter"] | null;
+            rocky_ice_count?: components["schemas"]["BodyCountFilter"] | null;
+            icy_count?: components["schemas"]["BodyCountFilter"] | null;
+            other_star_count?: components["schemas"]["BodyCountFilter"] | null;
+            ring_count?: components["schemas"]["BodyCountFilter"] | null;
+            walkable_count?: components["schemas"]["BodyCountFilter"] | null;
+        } & {
+            [key: string]: unknown;
+        };
         /** BodyModel */
         BodyModel: {
             /** Id */
@@ -860,10 +904,7 @@ export interface components {
              * @default 0
              */
             offset: number;
-            /** Reference Coords */
-            reference_coords?: {
-                [key: string]: unknown;
-            } | null;
+            reference_coords?: components["schemas"]["CoordsModel"] | null;
         };
         /** CoordsModel */
         CoordsModel: {
@@ -934,10 +975,7 @@ export interface components {
         /** LocalSearchRequest */
         LocalSearchRequest: {
             filters?: components["schemas"]["SearchFilters"] | null;
-            /** Reference Coords */
-            reference_coords?: {
-                [key: string]: unknown;
-            } | null;
+            reference_coords?: components["schemas"]["CoordsModel"] | null;
             /**
              * Sort By
              * @default rating
@@ -953,10 +991,7 @@ export interface components {
              * @default 0
              */
             from: number;
-            /** Body Filters */
-            body_filters?: {
-                [key: string]: unknown;
-            } | null;
+            body_filters?: components["schemas"]["BodyFilters"] | null;
             /** Require Bio */
             require_bio?: boolean | null;
             /** Require Geo */
@@ -991,9 +1026,22 @@ export interface components {
              * Blob
              * @description Arbitrary client-managed payload.
              */
-            blob: {
-                [key: string]: unknown;
-            };
+            blob: unknown;
+        };
+        /**
+         * RangeFilter
+         * @description Inclusive numeric range used by `SearchFilters.distance` /
+         *     `.population`. Either bound is optional — omit `min` for an upper-
+         *     only filter, omit `max` for a lower-only one. (Frontend always
+         *     sends both today; keep them optional so a future client can omit.)
+         */
+        RangeFilter: {
+            /** Min */
+            min?: number | null;
+            /** Max */
+            max?: number | null;
+        } & {
+            [key: string]: unknown;
         };
         /**
          * RatingModel
@@ -1023,9 +1071,7 @@ export interface components {
             /** Economysuggestion */
             economySuggestion?: string | null;
             /** Breakdown */
-            breakdown?: {
-                [key: string]: unknown;
-            } | null;
+            breakdown?: unknown | null;
             /** Terraformingpotential */
             terraformingPotential?: number | null;
             /** Bodydiversity */
@@ -1041,10 +1087,7 @@ export interface components {
         RerankRequest: {
             /** Id64S */
             id64s: number[];
-            /** Weights */
-            weights?: {
-                [key: string]: unknown;
-            } | null;
+            weights?: components["schemas"]["RerankWeights"] | null;
             /** Economy */
             economy?: string | null;
         };
@@ -1110,14 +1153,8 @@ export interface components {
         };
         /** SearchFilters */
         SearchFilters: {
-            /** Distance */
-            distance?: {
-                [key: string]: unknown;
-            } | null;
-            /** Population */
-            population?: {
-                [key: string]: unknown;
-            } | null;
+            distance?: components["schemas"]["RangeFilter"] | null;
+            population?: components["schemas"]["RangeFilter"] | null;
             /** Economy */
             economy?: string | null;
         };

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -718,6 +718,119 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** AutocompleteHit */
+        AutocompleteHit: {
+            /** Id64 */
+            id64: number;
+            /** Name */
+            name: string;
+            /**
+             * X
+             * @default 0
+             */
+            x: number;
+            /**
+             * Y
+             * @default 0
+             */
+            y: number;
+            /**
+             * Z
+             * @default 0
+             */
+            z: number;
+            /**
+             * Population
+             * @default 0
+             */
+            population: number;
+            /** Primaryeconomy */
+            primaryEconomy?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** AutocompleteResponse */
+        AutocompleteResponse: {
+            /** Results */
+            results: components["schemas"]["AutocompleteHit"][];
+            /** Source */
+            source?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** BodyModel */
+        BodyModel: {
+            /** Id */
+            id?: number | null;
+            /** Name */
+            name?: string | null;
+            /** Subtype */
+            subtype?: string | null;
+            /** Body Type */
+            body_type?: string | null;
+            /** Distance From Star */
+            distance_from_star?: number | null;
+            /** Is Landable */
+            is_landable?: boolean | null;
+            /** Is Terraformable */
+            is_terraformable?: boolean | null;
+            /** Is Earth Like */
+            is_earth_like?: boolean | null;
+            /** Is Water World */
+            is_water_world?: boolean | null;
+            /** Is Ammonia World */
+            is_ammonia_world?: boolean | null;
+            /** Bio Signal Count */
+            bio_signal_count?: number | null;
+            /** Geo Signal Count */
+            geo_signal_count?: number | null;
+            /** Surface Temp */
+            surface_temp?: number | null;
+            /** Radius */
+            radius?: number | null;
+            /** Mass */
+            mass?: number | null;
+            /** Gravity */
+            gravity?: number | null;
+            /** Estimated Mapping Value */
+            estimated_mapping_value?: number | null;
+            /** Estimated Scan Value */
+            estimated_scan_value?: number | null;
+            /** Is Main Star */
+            is_main_star?: boolean | null;
+            /** Spectral Class */
+            spectral_class?: string | null;
+            /** Is Scoopable */
+            is_scoopable?: boolean | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** CacheStatsResponse */
+        CacheStatsResponse: {
+            /**
+             * Cache Hits
+             * @default 0
+             */
+            cache_hits: number;
+            /**
+             * Cache Misses
+             * @default 0
+             */
+            cache_misses: number;
+            /** Redis Hits */
+            redis_hits?: number | null;
+            /** Redis Misses */
+            redis_misses?: number | null;
+            /** Redis Memory Mb */
+            redis_memory_mb?: number | null;
+            /**
+             * Db Cache Rows
+             * @default 0
+             */
+            db_cache_rows: number;
+        } & {
+            [key: string]: unknown;
+        };
         /** ClusterRequirement */
         ClusterRequirement: {
             /** Economy */
@@ -748,7 +861,38 @@ export interface components {
              */
             offset: number;
             /** Reference Coords */
-            reference_coords?: Record<string, never> | null;
+            reference_coords?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** CoordsModel */
+        CoordsModel: {
+            /** X */
+            x: number;
+            /** Y */
+            y: number;
+            /** Z */
+            z: number;
+        };
+        /** ExplorationValueModel */
+        ExplorationValueModel: {
+            /**
+             * Total Scan Value
+             * @default 0
+             */
+            total_scan_value: number;
+            /**
+             * Total Mapping Value
+             * @default 0
+             */
+            total_mapping_value: number;
+            /**
+             * Combined Value
+             * @default 0
+             */
+            combined_value: number;
+        } & {
+            [key: string]: unknown;
         };
         /** GalaxySearchRequest */
         GalaxySearchRequest: {
@@ -791,7 +935,9 @@ export interface components {
         LocalSearchRequest: {
             filters?: components["schemas"]["SearchFilters"] | null;
             /** Reference Coords */
-            reference_coords?: Record<string, never> | null;
+            reference_coords?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Sort By
              * @default rating
@@ -808,7 +954,9 @@ export interface components {
              */
             from: number;
             /** Body Filters */
-            body_filters?: Record<string, never> | null;
+            body_filters?: {
+                [key: string]: unknown;
+            } | null;
             /** Require Bio */
             require_bio?: boolean | null;
             /** Require Geo */
@@ -843,33 +991,152 @@ export interface components {
              * Blob
              * @description Arbitrary client-managed payload.
              */
-            blob: Record<string, never>;
+            blob: {
+                [key: string]: unknown;
+            };
+        };
+        /**
+         * RatingModel
+         * @description camelCase rating block embedded inside SystemRow under `_rating`.
+         *
+         *     Mirrors the shape produced by `helpers.sys_row_to_dict` so the
+         *     generated TypeScript matches what the search response actually puts
+         *     on the wire.
+         */
+        RatingModel: {
+            /** Score */
+            score?: number | null;
+            /** Scoreagriculture */
+            scoreAgriculture?: number | null;
+            /** Scorerefinery */
+            scoreRefinery?: number | null;
+            /** Scoreindustrial */
+            scoreIndustrial?: number | null;
+            /** Scorehightech */
+            scoreHightech?: number | null;
+            /** Scoremilitary */
+            scoreMilitary?: number | null;
+            /** Scoretourism */
+            scoreTourism?: number | null;
+            /** Scoreextraction */
+            scoreExtraction?: number | null;
+            /** Economysuggestion */
+            economySuggestion?: string | null;
+            /** Breakdown */
+            breakdown?: {
+                [key: string]: unknown;
+            } | null;
+            /** Terraformingpotential */
+            terraformingPotential?: number | null;
+            /** Bodydiversity */
+            bodyDiversity?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Rationale */
+            rationale?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         /** RerankRequest */
         RerankRequest: {
             /** Id64S */
             id64s: number[];
             /** Weights */
-            weights?: Record<string, never> | null;
+            weights?: {
+                [key: string]: unknown;
+            } | null;
             /** Economy */
             economy?: string | null;
+        };
+        /** RerankResponse */
+        RerankResponse: {
+            weights_applied: components["schemas"]["RerankWeights"];
+            /** Economy Used */
+            economy_used?: string | null;
+            /** Results */
+            results: components["schemas"]["RerankRow"][];
+        } & {
+            [key: string]: unknown;
+        };
+        /** RerankRow */
+        RerankRow: {
+            /** Id64 */
+            id64: number;
+            /** Reranked Score */
+            reranked_score: number;
+            /** Original Score */
+            original_score?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Rationale */
+            rationale?: string | null;
+            /** Economy Used */
+            economy_used?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** RerankWeights */
+        RerankWeights: {
+            /**
+             * Economy
+             * @default 0.42
+             */
+            economy: number;
+            /**
+             * Slots
+             * @default 0.23
+             */
+            slots: number;
+            /**
+             * Strategic
+             * @default 0.18
+             */
+            strategic: number;
+            /**
+             * Safety
+             * @default 0.1
+             */
+            safety: number;
+            /**
+             * Terraforming
+             * @default 0.05
+             */
+            terraforming: number;
+            /**
+             * Diversity
+             * @default 0.02
+             */
+            diversity: number;
         };
         /** SearchFilters */
         SearchFilters: {
             /** Distance */
-            distance?: Record<string, never> | null;
+            distance?: {
+                [key: string]: unknown;
+            } | null;
             /** Population */
-            population?: Record<string, never> | null;
+            population?: {
+                [key: string]: unknown;
+            } | null;
             /** Economy */
             economy?: string | null;
         };
-        /** SearchResponse */
+        /**
+         * SearchResponse
+         * @description `/api/local/search` response.
+         */
         SearchResponse: {
             /** Results */
-            results: Record<string, never>[];
-            /** Total */
+            results: components["schemas"]["SystemRow"][];
+            /**
+             * Total
+             * @default 0
+             */
             total: number;
-            /** Count */
+            /**
+             * Count
+             * @default 0
+             */
             count: number;
             /** Source */
             source?: string | null;
@@ -877,13 +1144,293 @@ export interface components {
             query_ms?: number | null;
             /** Display Economy */
             display_economy?: string | null;
+        } & {
+            [key: string]: unknown;
         };
-        /** SystemDetailResponse */
+        /** StationModel */
+        StationModel: {
+            /** Id */
+            id?: number | null;
+            /** Name */
+            name?: string | null;
+            /** Station Type */
+            station_type?: string | null;
+            /** Distance From Star */
+            distance_from_star?: number | null;
+            /** Landing Pad Size */
+            landing_pad_size?: string | null;
+            /** Has Market */
+            has_market?: boolean | null;
+            /** Has Shipyard */
+            has_shipyard?: boolean | null;
+            /** Has Outfitting */
+            has_outfitting?: boolean | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * StatusResponse
+         * @description `/api/status` and `/api/local/status`.
+         */
+        StatusResponse: {
+            /** Available */
+            available: boolean;
+            /**
+             * Systems Count
+             * @default 0
+             */
+            systems_count: number;
+            /**
+             * Body Count
+             * @default 0
+             */
+            body_count: number;
+            /**
+             * Rated Count
+             * @default 0
+             */
+            rated_count: number;
+            /**
+             * Clustered Count
+             * @default 0
+             */
+            clustered_count: number;
+            /**
+             * Import Complete
+             * @default false
+             */
+            import_complete: boolean;
+            /**
+             * Ratings Built
+             * @default false
+             */
+            ratings_built: boolean;
+            /**
+             * Grid Built
+             * @default false
+             */
+            grid_built: boolean;
+            /**
+             * Clusters Built
+             * @default false
+             */
+            clusters_built: boolean;
+            /**
+             * Eddn Enabled
+             * @default false
+             */
+            eddn_enabled: boolean;
+            /**
+             * Last Nightly Update
+             * @default never
+             */
+            last_nightly_update: string;
+            /**
+             * Schema Version
+             * @default 1.0
+             */
+            schema_version: string;
+            /**
+             * Max Search Radius Ly
+             * @default 500
+             */
+            max_search_radius_ly: number;
+            /**
+             * Has Body Data
+             * @default false
+             */
+            has_body_data: boolean;
+            /**
+             * Version
+             * @default
+             */
+            version: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDetailResponse
+         * @description `/api/system/{id64}` response. Backend returns the same row
+         *     twice under `record` and `system` for legacy compat.
+         */
         SystemDetailResponse: {
-            /** Record */
-            record: Record<string, never>;
-            /** System */
-            system: Record<string, never>;
+            record: components["schemas"]["SystemDetailRow"];
+            system: components["schemas"]["SystemDetailRow"];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemDetailRow
+         * @description Full system detail returned by `/api/system/{id64}`.
+         *
+         *     The detail endpoint does *not* go through the camelCase translator —
+         *     it returns the joined ratings + bodies + stations rows snake_case
+         *     as PostgreSQL emits them (see `routers/systems.py::get_system`).
+         *     Frontend renders these strings directly.
+         */
+        SystemDetailRow: {
+            /** Id64 */
+            id64: number;
+            /** Name */
+            name: string;
+            /**
+             * X
+             * @default 0
+             */
+            x: number;
+            /**
+             * Y
+             * @default 0
+             */
+            y: number;
+            /**
+             * Z
+             * @default 0
+             */
+            z: number;
+            /**
+             * Population
+             * @default 0
+             */
+            population: number;
+            /** Primary Economy */
+            primary_economy?: string | null;
+            /** Secondary Economy */
+            secondary_economy?: string | null;
+            /** Security */
+            security?: string | null;
+            /** Allegiance */
+            allegiance?: string | null;
+            /** Government */
+            government?: string | null;
+            /** Is Colonised */
+            is_colonised?: boolean | null;
+            /** Main Star Type */
+            main_star_type?: string | null;
+            /** Main Star Subtype */
+            main_star_subtype?: string | null;
+            /** Score */
+            score?: number | null;
+            /** Score Agriculture */
+            score_agriculture?: number | null;
+            /** Score Refinery */
+            score_refinery?: number | null;
+            /** Score Industrial */
+            score_industrial?: number | null;
+            /** Score Hightech */
+            score_hightech?: number | null;
+            /** Score Military */
+            score_military?: number | null;
+            /** Score Tourism */
+            score_tourism?: number | null;
+            /** Score Extraction */
+            score_extraction?: number | null;
+            /** Economy Suggestion */
+            economy_suggestion?: string | null;
+            /** Elw Count */
+            elw_count?: number | null;
+            /** Ww Count */
+            ww_count?: number | null;
+            /** Ammonia Count */
+            ammonia_count?: number | null;
+            /** Gas Giant Count */
+            gas_giant_count?: number | null;
+            /** Landable Count */
+            landable_count?: number | null;
+            /** Terraformable Count */
+            terraformable_count?: number | null;
+            /** Bio Signal Total */
+            bio_signal_total?: number | null;
+            /** Geo Signal Total */
+            geo_signal_total?: number | null;
+            /** Neutron Count */
+            neutron_count?: number | null;
+            /** Black Hole Count */
+            black_hole_count?: number | null;
+            /** White Dwarf Count */
+            white_dwarf_count?: number | null;
+            /** Terraforming Potential */
+            terraforming_potential?: number | null;
+            /** Body Diversity */
+            body_diversity?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Rationale */
+            rationale?: string | null;
+            /** Bodies */
+            bodies?: components["schemas"]["BodyModel"][];
+            /** Stations */
+            stations?: components["schemas"]["StationModel"][];
+            exploration_value?: components["schemas"]["ExplorationValueModel"] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * SystemRow
+         * @description One result row inside `SearchResponse.results`.
+         *
+         *     Keep aligned with `helpers.sys_row_to_dict` (single source of truth
+         *     for the camelCase translator).
+         */
+        SystemRow: {
+            /** Id64 */
+            id64: number;
+            /**
+             * Name
+             * @default Unknown
+             */
+            name: string;
+            coords?: components["schemas"]["CoordsModel"] | null;
+            /** Distance */
+            distance?: number | null;
+            /**
+             * Population
+             * @default 0
+             */
+            population: number;
+            /** Primaryeconomy */
+            primaryEconomy?: string | null;
+            /** Secondaryeconomy */
+            secondaryEconomy?: string | null;
+            /** Security */
+            security?: string | null;
+            /** Allegiance */
+            allegiance?: string | null;
+            /** Government */
+            government?: string | null;
+            /** Is Colonised */
+            is_colonised?: boolean | null;
+            /** Is Being Colonised */
+            is_being_colonised?: boolean | null;
+            /** Main Star Type */
+            main_star_type?: string | null;
+            /** Main Star Subtype */
+            main_star_subtype?: string | null;
+            _rating?: components["schemas"]["RatingModel"] | null;
+            /** Elw Count */
+            elw_count?: number | null;
+            /** Ww Count */
+            ww_count?: number | null;
+            /** Ammonia Count */
+            ammonia_count?: number | null;
+            /** Gas Giant Count */
+            gas_giant_count?: number | null;
+            /** Landable Count */
+            landable_count?: number | null;
+            /** Terraformable Count */
+            terraformable_count?: number | null;
+            /** Bio Signal Total */
+            bio_signal_total?: number | null;
+            /** Geo Signal Total */
+            geo_signal_total?: number | null;
+            /** Neutron Count */
+            neutron_count?: number | null;
+            /** Black Hole Count */
+            black_hole_count?: number | null;
+            /** White Dwarf Count */
+            white_dwarf_count?: number | null;
+        } & {
+            [key: string]: unknown;
         };
         /** ValidationError */
         ValidationError: {
@@ -1007,7 +1554,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StatusResponse"];
                 };
             };
         };
@@ -1027,7 +1574,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["StatusResponse"];
                 };
             };
         };
@@ -1691,7 +2238,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["CacheStatsResponse"];
                 };
             };
         };
@@ -1825,7 +2372,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["AutocompleteResponse"];
                 };
             };
             /** @description Validation Error */
@@ -2191,7 +2738,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["RerankResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -1,228 +1,66 @@
 /**
  * Wire types for the FastAPI backend.
  *
- * Hand-maintained for the POC. Once we want full coverage we can switch to
- * `openapi-typescript-codegen` against `https://ed-finder.app/openapi.json`,
- * which the modular backend already publishes. For now we only model the
- * fields that the result-card POC needs to render.
+ * **Audit Phase 7 follow-up (2026-05-09)**: this module now sources types
+ * from the auto-generated `api.gen.ts` for the response shapes the backend
+ * declares with `response_model=…`. The CI `openapi-types` job (see
+ * `.github/workflows/ci.yml`) fails on drift, so once the migration is
+ * complete the only place tweaking a wire type lives is `models.py` on
+ * the backend. No more "frontend says optional, backend says required"
+ * silent splits.
+ *
+ * If you need to add a field:
+ *   1. Add it to `apps/api/src/models.py` (Pydantic) AND emit it from
+ *      the SQL projection / `helpers.sys_row_to_dict`.
+ *   2. Locally: `cd frontend-v2 && yarn types:gen` (with the API on :8000).
+ *   3. Commit the regenerated `api.gen.ts`.
+ *   4. If the new field needs a friendlier camelCase alias for use in
+ *      this codebase, add it to the wrapper types below.
+ *
+ * What is NOT yet generated (left hand-written here):
+ *   - `WatchlistEntry` — the watchlist endpoint emits raw SQL rows; the
+ *     Pydantic model is intentionally not declared so we can iterate on
+ *     the table shape without a backend release.
+ *   - `Economy` enum + default rerank weights — these are frontend-side
+ *     constants, not wire types.
+ *   - The `LocalSearchBody` request shape used by `lib/api.ts` — the
+ *     generated `LocalSearchRequest` accepts `Record<string, never>` for
+ *     filters/body_filters because they're typed `dict` in the Python
+ *     model. Keeping the hand-written request shape until the Pydantic
+ *     side gets stricter.
  */
+import type { components } from '@/types/api.gen';
 
-export interface SystemRating {
-  score:                   number | null;
-  scoreAgriculture?:       number | null;
-  scoreRefinery?:          number | null;
-  scoreIndustrial?:        number | null;
-  scoreHightech?:          number | null;
-  scoreMilitary?:          number | null;
-  scoreTourism?:           number | null;
-  scoreExtraction?:        number | null;
-  economySuggestion?:      string | null;
-  breakdown?:              Record<string, unknown> | null;
-  /** v3.1 fields */
-  terraformingPotential?:  number | null;
-  bodyDiversity?:          number | null;
-  confidence?:             number | null;
-  rationale?:              string | null;
-}
+type Schemas = components['schemas'];
 
-export interface SystemCoords {
-  x: number;
-  y: number;
-  z: number;
-}
+// ─── Generated response/sub types (single source of truth) ────────────────
+export type SystemCoords = Schemas['CoordsModel'];
+export type SystemRating = Schemas['RatingModel'];
+export type SystemBody   = Schemas['BodyModel'];
+export type SystemStation = Schemas['StationModel'];
 
-export interface SystemResult {
-  id64:                  number;
-  name:                  string;
-  coords?:               SystemCoords;
-  /** Only populated for distance searches. */
-  distance?:             number | null;
-  population:            number;
-  primaryEconomy?:       string | null;
-  secondaryEconomy?:     string | null;
-  security?:             string | null;
-  allegiance?:           string | null;
-  government?:           string | null;
-  is_colonised?:         boolean;
-  is_being_colonised?:   boolean;
-  main_star_type?:       string | null;
-  main_star_subtype?:    string | null;
-  _rating?:              SystemRating | null;
-  /** Body counts on the rating row, surfaced for filter pills. */
-  elw_count?:            number | null;
-  ww_count?:             number | null;
-  ammonia_count?:        number | null;
-  gas_giant_count?:      number | null;
-  landable_count?:       number | null;
-  terraformable_count?:  number | null;
-  bio_signal_total?:     number | null;
-  geo_signal_total?:     number | null;
-  neutron_count?:        number | null;
-  black_hole_count?:     number | null;
-  white_dwarf_count?:    number | null;
-}
+/**
+ * One row from `/api/local/search`.
+ *
+ * Generated from `apps/api/src/models.py::SystemRow`. Camel-case rating
+ * block lives under `_rating` (Pydantic alias preserved through the
+ * codegen). Field added 2026-05-09 as part of Phase 7 follow-up.
+ */
+export type SystemResult = Schemas['SystemRow'];
 
-export interface SearchResponse {
-  results: SystemResult[];
-  total:   number;
-  count:   number;
-}
+export type SearchResponse        = Schemas['SearchResponse'];
+export type AutocompleteHit       = Schemas['AutocompleteHit'];
+export type AutocompleteResponse  = Schemas['AutocompleteResponse'];
+export type SystemDetail          = Schemas['SystemDetailRow'];
+export type SystemDetailResponse  = Schemas['SystemDetailResponse'];
+export type AppStatus             = Schemas['StatusResponse'];
+export type CacheStats            = Schemas['CacheStatsResponse'];
+export type RerankRequest         = Schemas['RerankRequest'];
+export type RerankResponse        = Schemas['RerankResponse'];
+export type RerankRow             = Schemas['RerankRow'];
+export type RerankWeights         = Schemas['RerankWeights'];
 
-export interface AutocompleteHit {
-  id64:           number;
-  name:           string;
-  x:              number;
-  y:              number;
-  z:              number;
-  population:     number;
-  primaryEconomy: string | null;
-}
-
-export interface AutocompleteResponse {
-  results: AutocompleteHit[];
-  source?: string;
-}
-
-// ─── /api/system/{id64} — full detail ────────────────────────────────────
-//
-// Endpoint returns snake_case (joins systems + ratings + bodies + stations).
-// Wire types mirror that — we don't camelCase-rewrite at the boundary
-// because the modal renders strings directly.
-
-export interface SystemBody {
-  id:                       number;
-  name:                     string;
-  subtype:                  string | null;
-  body_type:                string | null;   // 'Star' | 'Planet' | 'Moon' | 'Belt' | …
-  distance_from_star:       number | null;   // ls
-  is_landable:              boolean | null;
-  is_terraformable:         boolean | null;
-  is_earth_like:            boolean | null;
-  is_water_world:           boolean | null;
-  is_ammonia_world:         boolean | null;
-  bio_signal_count:         number | null;
-  geo_signal_count:         number | null;
-  surface_temp:             number | null;
-  radius:                   number | null;
-  mass:                     number | null;
-  gravity:                  number | null;
-  estimated_mapping_value:  number | null;
-  estimated_scan_value:     number | null;
-  is_main_star:             boolean | null;
-  spectral_class:           string | null;
-  is_scoopable:             boolean | null;
-}
-
-export interface SystemStation {
-  id:                  number;
-  name:                string;
-  station_type:        string | null;
-  distance_from_star:  number | null;
-  landing_pad_size:    'L' | 'M' | 'S' | null;
-  has_market:          boolean | null;
-  has_shipyard:        boolean | null;
-  has_outfitting:      boolean | null;
-}
-
-export interface SystemDetail {
-  id64:               number;
-  name:               string;
-  x:                  number;
-  y:                  number;
-  z:                  number;
-  population:         number;
-  primary_economy?:   string | null;
-  secondary_economy?: string | null;
-  security?:          string | null;
-  allegiance?:        string | null;
-  government?:        string | null;
-  is_colonised?:      boolean | null;
-  main_star_type?:    string | null;
-  main_star_subtype?: string | null;
-
-  // Flat rating fields (joined from ratings table)
-  score?:                  number | null;
-  score_agriculture?:      number | null;
-  score_refinery?:         number | null;
-  score_industrial?:       number | null;
-  score_hightech?:         number | null;
-  score_military?:         number | null;
-  score_tourism?:          number | null;
-  score_extraction?:       number | null;
-  economy_suggestion?:     string | null;
-  elw_count?:              number | null;
-  ww_count?:               number | null;
-  ammonia_count?:          number | null;
-  gas_giant_count?:        number | null;
-  landable_count?:         number | null;
-  terraformable_count?:    number | null;
-  bio_signal_total?:       number | null;
-  geo_signal_total?:       number | null;
-  neutron_count?:          number | null;
-  black_hole_count?:       number | null;
-  white_dwarf_count?:      number | null;
-  terraforming_potential?: number | null;
-  body_diversity?:         number | null;
-  confidence?:             number | null;
-  rationale?:              string | null;
-
-  bodies?:   SystemBody[];
-  stations?: SystemStation[];
-
-  exploration_value?: {
-    total_scan_value:    number;
-    total_mapping_value: number;
-    combined_value:      number;
-  };
-}
-
-/** Backend returns {record, system} — same data twice. */
-export interface SystemDetailResponse {
-  record: SystemDetail;
-  system: SystemDetail;
-}
-
-// ─── /api/status — system meta + counts ───────────────────────────────────
-
-export interface AppStatus {
-  available:           boolean;
-  systems_count:       number;
-  body_count:          number;
-  rated_count:         number;
-  clustered_count:     number;
-  import_complete:     boolean;
-  ratings_built:       boolean;
-  grid_built:          boolean;
-  clusters_built:      boolean;
-  eddn_enabled:        boolean;
-  last_nightly_update: string;
-  schema_version:      string;
-  max_search_radius_ly: number;
-  has_body_data:       boolean;
-  version:             string;
-}
-
-// ─── /api/cache/stats ─────────────────────────────────────────────────────
-
-export interface CacheStats {
-  cache_hits:       number;
-  cache_misses:     number;
-  redis_hits?:      number;
-  redis_misses?:    number;
-  redis_memory_mb?: number;
-  db_cache_rows:    number;
-}
-
-// ─── /api/ratings/rerank ──────────────────────────────────────────────────
-
-export interface RerankWeights {
-  economy:      number;
-  slots:        number;
-  strategic:    number;
-  safety:       number;
-  terraforming: number;
-  diversity:    number;
-}
+// ─── Frontend-side constants ──────────────────────────────────────────────
 
 export const DEFAULT_WEIGHTS: RerankWeights = {
   economy:      0.42,
@@ -236,25 +74,3 @@ export const DEFAULT_WEIGHTS: RerankWeights = {
 export type Economy =
   | 'Agriculture' | 'Refinery' | 'Industrial'
   | 'HighTech'    | 'Military' | 'Tourism' | 'Extraction';
-
-export interface RerankRequest {
-  id64s:    number[];
-  weights?: Partial<RerankWeights>;
-  /** null/undefined = use each row's stored economy_suggestion. */
-  economy?: Economy | null;
-}
-
-export interface RerankRow {
-  id64:           number;
-  reranked_score: number;
-  original_score: number | null;
-  confidence:     number | null;
-  rationale:      string | null;
-  economy_used:   string | null;
-}
-
-export interface RerankResponse {
-  weights_applied: RerankWeights;
-  economy_used:    Economy | null;
-  results:         RerankRow[];
-}


### PR DESCRIPTION
Closes the deferred Phase-7 + Phase-8 audit items.

## What's in this PR

### feat(types): wire response_model on remaining endpoints; migrate selected types from api.ts to api.gen.ts (23d2c70)
Phase-7 baked api.gen.ts into the repo and added a CI drift check, but
most generated types were `unknown` or `Record<string, never>` because
the matching endpoints had no `response_model=`. Result: drift check
protected an unused file.

This PR fills in the response_model declarations on every endpoint the
v2 frontend actually consumes (autocomplete, status, local-status,
cache-stats, ratings/rerank), and tightens SearchResponse /
SystemDetailResponse so the generated TS for results / record / system
carries the real per-row schema instead of `Record<string, never>[]`.

Frontend `src/types/api.ts` is now a thin wrapper that re-exports types
from `api.gen.ts`. Public type names (SystemResult, SearchResponse,
SystemDetail, AppStatus, CacheStats, RerankRequest, RerankResponse, etc.)
preserved so consumers don't need rewriting.

### feat(v2): broaden TanStack Query adoption + add Playwright E2E in CI (16c1466)
- `useWatchlist` rewritten on TanStack Query — NavBar count, Watchlist
  tab, and SystemDetailModal "Save to Watchlist" toggle all share one
  cache entry. Public hook interface unchanged, no consumer touched.
- New CI job `Frontend v2 E2E (Playwright)` boots PG 16 + Redis 7 +
  uvicorn (port 8002) + `vite preview` (port 4173) and runs the smoke
  spec end-to-end against a production bundle. Locally 6/6 pass.

## Verification (local pod, against PG 15 + Redis 7)
- python -m compileall apps/ → clean
- tests/test_smoke.py → 56/56 pass
- tests/integration/ → 44/44 pass (phases 2/3/5/6 all green)
- yarn typecheck → clean
- yarn test --run → 28/28 vitest pass
- yarn build → 2314 modules, dist/ produced
- yarn e2e → 6/6 Playwright pass

## What this enables
- The CI 'OpenAPI types drift check' job now actually protects the
  type surface used by the frontend; previously it was guarding
  `unknown`.
- Adding a backend field is a one-shot: edit models.py → `cd
  frontend-v2 && yarn types:gen` → commit. Wrapper module in
  `src/types/api.ts` means consumers don't need touching unless they
  need the new field.
- E2E regression coverage on every push.

## Phase-2 follow-ups (deferred, not in this PR)
- Tighten Pydantic dicts (LocalSearchRequest.filters / body_filters,
  ProfileSyncBlob.blob) so request shapes generate properly too.
- Declare a proper WatchlistEntry response model so legacy and v2
  watchlist endpoints get typed too.
- Broaden React Query into useSearch / useAutocomplete (same pattern
  as useWatchlist).
- Decide `_redesign/` fate after its Phase-2 wiring (currently a
  properly-quarantined opt-in prototype, fine to leave as-is).

3. Watch CI (~5–6 minutes)

Six jobs should run. The brand new one is Frontend v2 E2E (Playwright) — it'll be the slowest (~2–3 min, dominated by the 108 MB Chromium download).

If CI is green → merge → roll out to Hetzner with the five-command sequence I gave earlier:

ssh root@<hetzner-ip>
cd /opt/ed-finder && git pull --ff-only origin main
( cd frontend-v2 && yarn install && yarn build )
docker compose up -d --build api
docker compose exec nginx nginx -s reload

Let me know if anything in CI fails — happy to dig in.
May 9, 03:36 PM
Agent is waiting...
