### PR TITLE
fix(maintenance): smoke check uses pg_class.reltuples, not COUNT(*)

### DIFF
--- a/apps/maintenance/scripts/run_maintenance.sh
+++ b/apps/maintenance/scripts/run_maintenance.sh
@@ -87,10 +87,41 @@ case "$TASK" in
         ;;
     smoke)
         # Manual sanity check from `docker compose run --rm maintenance smoke`.
-        # Exits 0 if the DB is reachable and seed_check invariants hold.
-        run_step "connectivity check" "SELECT 1;"
-        run_step "systems count"      "SELECT COUNT(*) FROM systems;"
-        run_step "ratings count"      "SELECT COUNT(*) FROM ratings;"
+        # Exits 0 if the DB is reachable and the seed_check invariants
+        # hold. Uses pg_class.reltuples (the planner's row-count estimate
+        # last set by ANALYZE) rather than COUNT(*) — at prod scale
+        # (~186M systems / ratings rows) a real COUNT does a sequential
+        # scan that exceeds the 15s statement_timeout. reltuples is
+        # instantaneous and accurate to ~5% if ANALYZE has run recently
+        # (which the nightly schedule guarantees).
+        run_step "connectivity"     "SELECT 1;"
+        run_step "systems estimate" \
+            "SELECT format('%s rows (planner estimate, last ANALYZE %s)',
+                           reltuples::bigint,
+                           COALESCE(to_char(s.last_analyze, 'YYYY-MM-DD HH24:MI'),
+                                    to_char(s.last_autoanalyze, 'YYYY-MM-DD HH24:MI'),
+                                    'never'))
+             FROM pg_class c
+             LEFT JOIN pg_stat_user_tables s ON s.relname = c.relname
+             WHERE c.relname='systems';"
+        run_step "ratings estimate" \
+            "SELECT format('%s rows (planner estimate, last ANALYZE %s)',
+                           reltuples::bigint,
+                           COALESCE(to_char(s.last_analyze, 'YYYY-MM-DD HH24:MI'),
+                                    to_char(s.last_autoanalyze, 'YYYY-MM-DD HH24:MI'),
+                                    'never'))
+             FROM pg_class c
+             LEFT JOIN pg_stat_user_tables s ON s.relname = c.relname
+             WHERE c.relname='ratings';"
+        run_step "bodies estimate" \
+            "SELECT format('%s rows (planner estimate, last ANALYZE %s)',
+                           reltuples::bigint,
+                           COALESCE(to_char(s.last_analyze, 'YYYY-MM-DD HH24:MI'),
+                                    to_char(s.last_autoanalyze, 'YYYY-MM-DD HH24:MI'),
+                                    'never'))
+             FROM pg_class c
+             LEFT JOIN pg_stat_user_tables s ON s.relname = c.relname
+             WHERE c.relname='bodies';"
         ;;
     *)
         echo "usage: $0 {nightly|weekly|smoke}" >&2


### PR DESCRIPTION
The original `smoke` task ran SELECT COUNT(*) FROM systems / ratings, which on the production 186 M-row tables sequential-scans for 5+ minutes — exceeding the new 15s statement_timeout and tripping 'canceling statement due to statement timeout'. The smoke check is supposed to be a fast 'can the sidecar reach the DB' verifier, not a stress test.

Switch to pg_class.reltuples (the planner's row estimate, set by ANALYZE) — instantaneous, accurate to ~5% when ANALYZE has run recently (which the nightly schedule guarantees), and the output now includes the timestamp of the last (auto-)analyze. That timestamp is genuinely useful for the operator: it's the single best signal of whether the nightly maintenance is actually running.

Production today (2026-05-09):
  systems  186 825 178 rows  (planner estimate, last ANALYZE 2026-05-09 20:50)
  ratings  ~186 M rows       (planner estimate, last ANALYZE 2026-05-09 20:50)
  bodies   …                 (planner estimate, last ANALYZE …)

Verified locally against the 40-row dev seed: smoke completes in <1s with the table-by-table estimate + last-analyze timestamps.