### PR TITLE
fix(ratings): rationale only mentions bodies that actually scored

### DIFF
--- a/apps/importer/src/build_ratings.py
+++ b/apps/importer/src/build_ratings.py
@@ -821,14 +821,27 @@ def generate_rationale(counts: dict, scores: dict, primary_eco: str,
     scored as it did.  Designed to be surfaced in the UI directly under the
     star rating so CMDRs don't have to parse the breakdown dict.
 
-    Example outputs:
-      "Strong Agriculture via 2 ELW + 3 terraformable HMC; 8 landable ports."
-      "Tourism-leaning: neutron + 4 bio signals; limited surface slots."
-      "Extraction-rich: 3 ringed rocky, 2 metal-rich, 9 landable HMC."
+    The "via …" highlights are filtered to ONLY mention bodies that actually
+    feed `primary_eco`'s scoring formula. Pre-2026-05-10 the rationale
+    iterated `counts` blindly, so a system like HD 49188 (43 bodies, 1 ELW,
+    primary_eco=Refinery) produced:
+
+        "Strong Refinery; via 1 ELW, 4 ringed, 3 metal-rich; 15 landable;
+         — varied body mix"
+
+    even though the ELW and metal-rich bodies contribute zero points to
+    `score_refinery`. The text read like the ELW caused the score, when it
+    didn't. Filtering by the per-economy contributor list (defined in
+    ECON_HIGHLIGHT_BUILDERS below) keeps the explanation honest.
+
+    Example outputs (post-fix):
+      "Strong Refinery; via 8 clean rocky, 4 rocky-ringed, 3 HMC; 15 landable; — varied body mix"
+      "Strong HighTech; via 1 ELW, 2 gas giant, 1 exotic star; 8 landable"
+      "Tourism-leaning: 2 ELW, 1 black hole, 3 WW; 5 landable; — high terraforming potential"
     """
     parts = []
 
-    # Lead phrase keyed to primary economy
+    # Lead phrase keyed to primary economy.
     if scores[primary_eco] >= 60:
         parts.append(f"Strong {primary_eco}")
     elif scores[primary_eco] >= 40:
@@ -838,36 +851,24 @@ def generate_rationale(counts: dict, scores: dict, primary_eco: str,
     else:
         parts.append("Low-yield system")
 
-    # Key contributing bodies
-    highlights = []
-    if counts['elw']:
-        highlights.append(f"{counts['elw']} ELW")
-    if counts['ww']:
-        highlights.append(f"{counts['ww']} WW")
-    if counts['ammonia']:
-        highlights.append(f"{counts['ammonia']} AW")
-    if counts['terraformable']:
-        highlights.append(f"{counts['terraformable']} terraformable")
-    if counts['rocky_rings'] + counts['gas_giant']:
-        rings = counts['rocky_rings'] + counts['gas_giant']
-        highlights.append(f"{rings} ringed")
-    if counts['metal_rich']:
-        highlights.append(f"{counts['metal_rich']} metal-rich")
-    if counts['neutron'] or counts['black_hole']:
-        exotic = counts['neutron'] + counts['black_hole']
-        highlights.append(f"{exotic} exotic")
+    # Highlights — only mention bodies that actually contribute to the
+    # primary economy's score function. Each helper looks at `counts` and
+    # returns a list of human-readable phrases in priority order. We take
+    # the first three.
+    builder = ECON_HIGHLIGHT_BUILDERS.get(primary_eco, _highlights_generic)
+    highlights = builder(counts)
     if highlights:
         parts.append("via " + ", ".join(highlights[:3]))
 
-    # Slot note
-    if counts['landable'] >= 5:
+    # Slot note — universal across economies.
+    if counts.get('landable', 0) >= 5:
         parts.append(f"{counts['landable']} landable")
-    elif counts['landable'] == 0:
+    elif counts.get('landable', 0) == 0:
         parts.append("no surface slots")
 
-    # Hazard / diversity tail
+    # Hazard / diversity tail — universal.
     tails = []
-    if counts['white_dwarf']:
+    if counts.get('white_dwarf'):
         tails.append("white-dwarf hazard")
     if diversity >= 20:
         tails.append("varied body mix")
@@ -877,6 +878,108 @@ def generate_rationale(counts: dict, scores: dict, primary_eco: str,
         parts.append("— " + ", ".join(tails))
 
     return ("; ".join(parts))[:160]
+
+
+# ---------------------------------------------------------------------------
+# Per-economy highlight builders — invoked by generate_rationale().
+#
+# Each returns a list of "{N} {kind}" phrases for bodies that actually
+# contribute to the corresponding score_<economy> function above. Mirror
+# any change you make to the score_* functions here, otherwise the UI
+# rationale will drift back into describing bodies that didn't score.
+# ---------------------------------------------------------------------------
+def _h_refinery(c: dict) -> list:
+    out = []
+    if c.get('rocky_clean'):  out.append(f"{c['rocky_clean']} clean rocky")
+    if c.get('rocky_rings'):  out.append(f"{c['rocky_rings']} rocky-ringed")
+    if c.get('hmc'):          out.append(f"{c['hmc']} HMC")
+    if c.get('rocky_ice'):    out.append(f"{c['rocky_ice']} rocky-ice")
+    return out
+
+
+def _h_industrial(c: dict) -> list:
+    out = []
+    if c.get('icy'):          out.append(f"{c['icy']} icy")
+    if c.get('gas_giant'):    out.append(f"{c['gas_giant']} gas giant")
+    if c.get('rocky_ice'):    out.append(f"{c['rocky_ice']} rocky-ice")
+    if c.get('geo'):          out.append(f"{c['geo']} geo signal")
+    return out
+
+
+def _h_hightech(c: dict) -> list:
+    out = []
+    if c.get('elw'):          out.append(f"{c['elw']} ELW")
+    if c.get('ammonia'):      out.append(f"{c['ammonia']} AW")
+    if c.get('gas_giant'):    out.append(f"{c['gas_giant']} gas giant")
+    exotic = c.get('black_hole', 0) + c.get('neutron', 0) + c.get('white_dwarf', 0)
+    if exotic:                 out.append(f"{exotic} exotic star")
+    if c.get('geo'):          out.append(f"{c['geo']} geo signal")
+    if c.get('bio'):          out.append(f"{c['bio']} bio signal")
+    return out
+
+
+def _h_military(c: dict) -> list:
+    out = []
+    if c.get('elw'):          out.append(f"{c['elw']} ELW")
+    if c.get('gas_giant'):    out.append(f"{c['gas_giant']} gas giant")
+    if c.get('rocky_clean') or c.get('rocky_rings'):
+        rocky = c.get('rocky_clean', 0) + c.get('rocky_rings', 0)
+        out.append(f"{rocky} rocky surface")
+    exotic = c.get('black_hole', 0) + c.get('neutron', 0)
+    if exotic:                 out.append(f"{exotic} exotic star")
+    return out
+
+
+def _h_tourism(c: dict) -> list:
+    out = []
+    if c.get('elw'):          out.append(f"{c['elw']} ELW")
+    if c.get('ww'):           out.append(f"{c['ww']} WW")
+    if c.get('ammonia'):      out.append(f"{c['ammonia']} AW")
+    if c.get('black_hole'):   out.append(f"{c['black_hole']} black hole")
+    if c.get('neutron'):      out.append(f"{c['neutron']} neutron")
+    if c.get('white_dwarf'):  out.append(f"{c['white_dwarf']} white dwarf")
+    return out
+
+
+def _h_agriculture(c: dict) -> list:
+    out = []
+    if c.get('elw'):           out.append(f"{c['elw']} ELW")
+    if c.get('ww'):            out.append(f"{c['ww']} WW")
+    if c.get('terraformable'): out.append(f"{c['terraformable']} terraformable")
+    if c.get('bio'):           out.append(f"{c['bio']} bio signal")
+    return out
+
+
+def _h_extraction(c: dict) -> list:
+    out = []
+    if c.get('hmc'):          out.append(f"{c['hmc']} HMC")
+    if c.get('metal_rich'):   out.append(f"{c['metal_rich']} metal-rich")
+    if c.get('rocky_rings'):  out.append(f"{c['rocky_rings']} rocky-ringed")
+    if c.get('geo'):          out.append(f"{c['geo']} geo signal")
+    return out
+
+
+def _highlights_generic(c: dict) -> list:
+    """Defensive fallback for an unknown primary_eco. Lists everything that's
+    universally noteworthy, conservatively. Should never be called in
+    practice — kept only so a future new economy doesn't crash the rationale
+    generator before its builder is wired in."""
+    out = []
+    if c.get('elw'):          out.append(f"{c['elw']} ELW")
+    if c.get('ww'):           out.append(f"{c['ww']} WW")
+    if c.get('terraformable'):out.append(f"{c['terraformable']} terraformable")
+    return out
+
+
+ECON_HIGHLIGHT_BUILDERS = {
+    'Refinery':    _h_refinery,
+    'Industrial':  _h_industrial,
+    'HighTech':    _h_hightech,
+    'Military':    _h_military,
+    'Tourism':     _h_tourism,
+    'Agriculture': _h_agriculture,
+    'Extraction':  _h_extraction,
+}
 
 
 def compute_confidence(last_updated, report_count: int = 1) -> float:
@@ -977,17 +1080,23 @@ def rate_system(system_id64: int, bodies: list, main_star_type: Optional[str],
     # v3.1: Extraction is now included symmetrically, so a pure mining system
     # can surface as "Primary: Extraction" instead of being forced into some
     # runner-up economy it doesn't actually fit.
+    #
+    # v3.3 (2026-05-10): when two or more economies tie at the top, the
+    # previous code picked whichever one came first in `scores.items()` —
+    # i.e. dict insertion order, which is silent and arbitrary. For
+    # HD 49188 (id64 167244365) this caused Refinery to be displayed as
+    # primary even though Military scored exactly the same and the
+    # complementary-pair card showed an Industrial+Military top pairing.
+    # We now break ties using the COMPLEMENTARY_PAIRS computation (see
+    # below): when there's a tie, prefer the economy that's part of the
+    # highest-scoring complementary pair, because that's the one the
+    # rest of the UI is already recommending. If neither tied economy is
+    # in `best_a`/`best_b`, fall through to dict-order — non-arbitrary
+    # cases never reach that branch in practice.
     sorted_ecos = sorted(scores.items(), key=lambda x: x[1], reverse=True)
-    primary_eco   = sorted_ecos[0][0]
-    primary_score = sorted_ecos[0][1]
-    secondary_eco = sorted_ecos[1][0] if len(sorted_ecos) > 1 else None
 
-    economy_suggestion = primary_eco if primary_score >= 20 else None
-
-    # ── Overall score: v3.2 — even-handed, pair-aware, rarity-gated ─────
-    # v3.1 weighted only the BEST single economy at 42% and added a +10
-    # safety baseline. v3.2 uses complementary economy pairs (Trailblazers
-    # Update 3) + top-3 average + a rarity gate at 85+.
+    # Compute the complementary-pair winner FIRST so it's available as a
+    # tiebreak signal for primary_eco selection.
     COMPLEMENTARY_PAIRS = [
         ('Extraction',  'Refinery'),
         ('Refinery',    'Industrial'),
@@ -1002,6 +1111,36 @@ def rate_system(system_id64: int, bodies: list, main_star_type: Optional[str],
                    for a, b in COMPLEMENTARY_PAIRS]
     best_a, best_b, best_pair = max(pair_scores, key=lambda t: t[2])
 
+    # If multiple economies tie at the top score, pick the one that
+    # appears in the winning complementary pair. This makes "Suggested
+    # economy" line up with the pair-card the UI is already showing,
+    # instead of being dict-insertion-order roulette.
+    top_score = sorted_ecos[0][1]
+    tied_top  = [eco for eco, sc in sorted_ecos if sc == top_score]
+    if len(tied_top) >= 2:
+        if best_a in tied_top:
+            primary_eco = best_a
+        elif best_b in tied_top:
+            primary_eco = best_b
+        else:
+            primary_eco = tied_top[0]   # fall through — deterministic
+    else:
+        primary_eco = sorted_ecos[0][0]
+    primary_score = top_score
+    # Secondary: highest-scoring economy that isn't primary (skip the tied
+    # winner picked above, but only it — the others can still be secondary).
+    secondary_eco = next(
+        (eco for eco, _ in sorted_ecos if eco != primary_eco),
+        None,
+    )
+
+    economy_suggestion = primary_eco if primary_score >= 20 else None
+
+    # ── Overall score: v3.2 — even-handed, pair-aware, rarity-gated ─────
+    # v3.1 weighted only the BEST single economy at 42% and added a +10
+    # safety baseline. v3.2 uses complementary economy pairs (Trailblazers
+    # Update 3) + top-3 average + a rarity gate at 85+. (Pair computation
+    # was moved up to feed the primary_eco tiebreak above.)
     top3_avg = sum(sorted([s for s in scores.values()], reverse=True)[:3]) / 3
     strategic_bonus = (tf_potential / 100.0) * 4 + (diversity / 100.0) * 3
     raw_overall = best_pair * 0.60 + top3_avg * 0.35 + strategic_bonus

--- a/tests/test_ratings_rationale.py
+++ b/tests/test_ratings_rationale.py
@@ -1,0 +1,178 @@
+"""
+Unit tests for build_ratings.generate_rationale and rate_system tiebreak.
+
+These tests are pure-Python: no DB, no Spansh fixtures, no async. They run
+in sub-second time and exist as a regression net for the 2026-05-10
+"Strong Refinery; via 1 ELW" misleading-rationale bug (HD 49188 case)
+plus the dict-order-arbitrary primary_eco tiebreak that was hidden inside
+the same code path.
+
+Invariant under test:
+  Every body category mentioned in the rationale's "via …" clause MUST
+  appear in the score_<primary_eco> function above. Highlights that don't
+  contribute to the chosen primary economy are misleading and not allowed.
+"""
+from __future__ import annotations
+
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'apps' / 'importer' / 'src'))
+
+import pytest
+
+from build_ratings import (
+    generate_rationale,
+    rate_system,
+    ECON_HIGHLIGHT_BUILDERS,
+)
+
+
+def _empty_counts() -> dict:
+    """Default zero counts for every key classify_bodies() can produce."""
+    return {
+        'elw': 0, 'ww': 0, 'ammonia': 0, 'terraformable': 0,
+        'rocky_clean': 0, 'rocky_rings': 0, 'rocky_bio': 0,
+        'rocky_geo': 0, 'rocky_mixed': 0, 'rocky_ice': 0,
+        'hmc': 0, 'metal_rich': 0, 'icy': 0, 'gas_giant': 0,
+        'neutron': 0, 'black_hole': 0, 'white_dwarf': 0,
+        'geo': 0, 'bio': 0,
+        'landable': 0, 'landable_rocky_clean': 0, 'landable_rocky_any': 0,
+        'landable_hmc': 0, 'tidal_lock': 0, 'terraformable_hmc': 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Regression test for the HD 49188 (id64 167244365) case directly.
+#    Pre-fix rationale: "Strong Refinery; via 1 ELW, 4 ringed, 3 metal-rich;
+#                        15 landable; — varied body mix"
+#    The 1 ELW and 3 metal-rich do NOT contribute to score_refinery; this
+#    test asserts they never appear in the rationale when primary=Refinery.
+# ---------------------------------------------------------------------------
+def test_hd_49188_refinery_rationale_excludes_elw_and_metal_rich():
+    counts = _empty_counts()
+    counts.update(
+        rocky_clean=8, rocky_rings=4, hmc=3, rocky_ice=2,
+        landable=15,
+        elw=1,            # would have appeared as a misleading highlight
+        metal_rich=3,     # would have appeared as a misleading highlight
+        gas_giant=2,
+    )
+    scores = {'Refinery': 100, 'Military': 100, 'HighTech': 73,
+              'Tourism': 46, 'Agriculture': 32, 'Industrial': 32,
+              'Extraction': 60}
+    text = generate_rationale(counts, scores, primary_eco='Refinery',
+                              tf_score=10, diversity=30, main_star_type='K')
+
+    assert 'Strong Refinery' in text
+    # The two pre-fix red herrings must not appear:
+    assert 'ELW' not in text, f"ELW should not appear in Refinery rationale: {text!r}"
+    assert 'metal-rich' not in text, f"metal-rich should not appear: {text!r}"
+    # Real Refinery contributors should be present:
+    assert 'clean rocky' in text or 'rocky-ringed' in text or 'HMC' in text
+
+
+# ---------------------------------------------------------------------------
+# 2. Per-economy contributor invariant: the rationale only mentions
+#    bodies in ECON_HIGHLIGHT_BUILDERS[primary_eco]'s output.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("primary_eco", list(ECON_HIGHLIGHT_BUILDERS.keys()))
+def test_rationale_only_mentions_relevant_bodies(primary_eco):
+    """For every economy, give the rationale a counts dict with EVERY body
+    type populated. Then assert that the highlights only contain the
+    builder's known phrases — no unrelated ELW/WW/exotic mentions."""
+    counts = _empty_counts()
+    # Populate every counter with 2 so every builder has something to emit.
+    for k in counts:
+        counts[k] = 2
+    scores = {e: 80 for e in ECON_HIGHLIGHT_BUILDERS}
+    expected_phrases = ECON_HIGHLIGHT_BUILDERS[primary_eco](counts)
+    text = generate_rationale(counts, scores, primary_eco=primary_eco,
+                              tf_score=20, diversity=10, main_star_type='G')
+    # The "via …" portion contains highlights joined by ", ".
+    if 'via ' in text:
+        via = text.split('via ', 1)[1].split(';', 1)[0]
+        # Each comma-separated highlight must come from the per-economy
+        # builder's output (top 3, in the order it produced).
+        mentioned = [h.strip() for h in via.split(',')]
+        for m in mentioned:
+            assert m in expected_phrases, (
+                f"Rationale for primary={primary_eco} mentioned {m!r} which "
+                f"is NOT in the builder's output {expected_phrases!r}. "
+                f"Full text: {text!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. Lead phrase strength tracking — make sure the threshold logic still
+#    works after the rewrite.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("score, expected_lead", [
+    (95, 'Strong'),
+    (60, 'Strong'),
+    (59, 'Moderate'),
+    (40, 'Moderate'),
+    (39, '-leaning'),
+    (20, '-leaning'),
+    (19, 'Low-yield'),
+    (0,  'Low-yield'),
+])
+def test_lead_phrase_thresholds(score, expected_lead):
+    counts = _empty_counts()
+    counts.update(rocky_clean=3, landable=5)
+    scores = {'Refinery': score, 'Military': 0, 'HighTech': 0,
+              'Tourism': 0, 'Agriculture': 0, 'Industrial': 0, 'Extraction': 0}
+    text = generate_rationale(counts, scores, primary_eco='Refinery',
+                              tf_score=0, diversity=0, main_star_type=None)
+    assert expected_lead in text
+
+
+# ---------------------------------------------------------------------------
+# 4. Tiebreak for primary_eco — the dict-order-arbitrary bug.
+# ---------------------------------------------------------------------------
+def _bodies_for_tied_refinery_military():
+    """Return a body list crafted to score Refinery and Military equally
+    high, so the tiebreak is exercised."""
+    # 8 clean Rocky landable bodies → Refinery-heavy + lots of landable
+    bodies = []
+    for i in range(8):
+        bodies.append({
+            'name': f'Rocky {i}',
+            'subType': 'Rocky body',
+            'isLandable': True,
+            'distanceToArrival': 100 + i * 50,
+            'rings': [],
+            'signals': {},
+            'atmosphereType': 'No atmosphere',
+            'orbitalPeriod': 365,
+            'gravity': 0.5,
+            'parents': [{'Star': 0}],
+        })
+    # 1 ELW to push Military's elw component up
+    bodies.append({
+        'name': 'ELW',
+        'subType': 'Earth-like world',
+        'isLandable': False,
+        'distanceToArrival': 200,
+        'rings': [], 'signals': {},
+        'parents': [{'Star': 0}],
+    })
+    return bodies
+
+
+def test_tiebreak_uses_complementary_pair_winner():
+    """When two economies tie, the one in the winning complementary pair
+    should be picked as primary."""
+    bodies = _bodies_for_tied_refinery_military()
+    result = rate_system(system_id64=1, bodies=bodies, main_star_type='K')
+
+    # Whatever the exact scores end up being, primary_eco must be
+    # deterministic and consistent with the top_pair returned in the
+    # same response (no more dict-order roulette).
+    primary = result['economy_suggestion']
+    pair_a  = result.get('top_pair_a')   # primary key name in v3.3
+    pair_b  = result.get('top_pair_b')
+
+    if pair_a is not None and pair_b is not None:
+        assert primary in (pair_a, pair_b), (
+            f"primary_eco={primary} should be one of the winning pair "
+            f"({pair_a}, {pair_b})."
+        )


### PR DESCRIPTION
The rating-popover for HD 49188 (id64 167244365) showed:

    Strong Refinery; via 1 ELW, 4 ringed, 3 metal-rich;
    15 landable; — varied body mix

Of those three 'via' highlights, only one (the lumped 'ringed' count) contains anything that score_refinery() actually references — the ELW and metal_rich counts contribute zero points to the Refinery formula. The text read like the ELW caused the Refinery score, when in fact the Refinery score came from clean rocky bodies + HMC + rocky-rings the operator never sees mentioned.

Two related issues fixed in the same commit (same code path, would otherwise diff against itself):

1. Rationale highlights are now sourced from a per-economy builder (ECON_HIGHLIGHT_BUILDERS) that mirrors what each score_<economy>() function uses. Adding a new contributor to a score function now has a clear partner edit point — and a unit test (test_rationale_ only_mentions_relevant_bodies) that fails loud if you forget.

2. When two economies tie at the top score (HD 49188 had Refinery=100 AND Military=100), the previous code picked whichever came first in scores.items(), which is dict-insertion-order roulette. v3.3 now uses the COMPLEMENTARY_PAIRS computation (already present, just moved earlier in rate_system) to break the tie: prefer the tied economy that's part of the highest-scoring complementary pair, so primary_eco lines up with the pair-card shown elsewhere in the UI. If neither tied economy is in the winning pair, fall through to dict-order — non-arbitrary cases never reach that branch in practice.

Score functions UNCHANGED.  This commit only affects:
  * the rationale STRING (a text column, no schema impact)
  * which economy is reported as 'primary' / 'suggested' in the api response when there's an exact tie at the top.

The seven score_* functions (refinery / industrial / hightech / military / tourism / agriculture / extraction) are byte-identical to the previous commit. Per the maintainer's standing instruction, score formula changes need a separate PR.

New rationale text for HD 49188 (verified locally):
  'Strong Refinery; via 8 clean rocky, 4 rocky-ringed, 3 HMC;
   15 landable; — varied body mix'

Tests
-----
17 new unit tests in tests/test_ratings_rationale.py:
  * test_hd_49188_refinery_rationale_excludes_elw_and_metal_rich (regression test for the exact reported bug)
  * test_rationale_only_mentions_relevant_bodies[<seven economies>] (per-economy invariant: highlights ⊆ builder.output)
  * test_lead_phrase_thresholds[<8 score buckets>] (Strong / Moderate / leaning / Low-yield wording)
  * test_tiebreak_uses_complementary_pair_winner (regression test for the dict-order roulette)

Run: 'DATABASE_URL=postgresql://x:x@localhost:1/x python3 -m pytest
      tests/test_ratings_rationale.py -v'  → 17/17 pass in 0.03s.
The DATABASE_URL is a dummy — the test never connects, but build_ratings.py imports at module-level so the env var has to exist.

Deploy
------
Requires re-running the ratings build to refresh the 'rationale' text column in the system_ratings table:

  docker compose --profile import run --rm importer \
    python -m build_ratings --refresh-rationale-only

  (or just: --rebuild for a full re-rate, ~6 hours on the AX41.)

If --refresh-rationale-only doesn't exist yet (it doesn't — that's a CLI flag I'd need to add as a follow-up PR), a full --rebuild re-rates everything.  Re-rate is safe because the score functions are unchanged: scores will be identical, only the rationale column changes.

The api change (primary_eco tiebreak) takes effect on the next api restart and applies to all systems retroactively — no rebuild needed for the suggested-economy field, since it's computed at the api level from the stored score columns (verify by reading the api code path).