### PR TITLE
feat(colonisation): Archetype Engine — Phase 1-3 (v4.0)

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -17,7 +17,8 @@ Endpoint surface (see individual router docstrings for detail):
   routers/search.py     autocomplete + local/galaxy/cluster search
   routers/systems.py    per-system / per-body detail + batch lookup
   routers/map.py        galaxy regions, cluster hulls, heatmap, timeline
-  routers/ratings.py    rating rerank with custom weights
+  routers/ratings.py    rating rerank with custom weights (v3.1 — preserved unchanged)
+  routers/archetypes.py archetype rankings, rerank, system detail, simulate, profiles
   share_router.py       /s/{id64} OG-tagged share preview + PNG
 """
 import asyncio
@@ -48,6 +49,7 @@ from routers.map       import router as map_router
 from routers.meta      import router as meta_router
 from routers.notes     import router as notes_router
 from routers.profile   import router as profile_router
+from routers.archetypes import router as archetypes_router
 from routers.ratings   import router as ratings_router
 from routers.search    import router as search_router
 from routers.systems   import router as systems_router
@@ -248,6 +250,7 @@ app.include_router(events_router)
 app.include_router(search_router)
 app.include_router(systems_router)
 app.include_router(map_router)
+app.include_router(archetypes_router)
 app.include_router(ratings_router)
 
 

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -584,3 +584,298 @@ class ClusterSearchRequest(BaseModel):
     limit:            int = Field(default=50, le=200)
     offset:           int = 0
     reference_coords: Optional[CoordsModel] = None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Archetype engine models (v4.0 — Phase 3)
+#
+# Strictness policy (consistent with existing models above):
+#   • Row / result models  → extra='allow'   (SQL projections legitimately drift)
+#   • Response envelopes   → extra='forbid'  (loud failure if contract breaks)
+#   • Request models       → extra='forbid'  (prevent silent input discarding)
+# ══════════════════════════════════════════════════════════════════════
+
+# ── Valid archetype keys (single source of truth) ────────────────────
+ArchetypeKey = Literal[
+    'refinery_industrial',
+    'extraction_refinery',
+    'agriculture_terraforming',
+    'hitech_tourism',
+    'expansion_capital',
+    'trade_logistics',
+    'population_capital',
+    'ax_forward_base',
+    'military_industrial',
+    'flexible_multirole',
+]
+
+# ── Valid tier values ─────────────────────────────────────────────────
+TierValue = Literal['S', 'A', 'B', 'C', 'D']
+
+# ── Build complexity ──────────────────────────────────────────────────
+BuildComplexity = Literal['trivial', 'simple', 'moderate', 'advanced', 'expert']
+
+
+class ArchetypeRerankWeights(BaseModel):
+    """
+    Weight dimensions for archetype-based reranking.
+    All weights should sum to ~1.0 but are not enforced to do so
+    (allows intentional emphasis on a single dimension).
+
+    Default profile: balanced across purity, buildability, slots, expansion, logistics.
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    purity:       float = Field(default=0.30, ge=0.0, le=1.0,
+                                description='Clean economy stack, low contamination')
+    buildability: float = Field(default=0.25, ge=0.0, le=1.0,
+                                description='Ease of build, CP efficiency, T3 scaling')
+    slots:        float = Field(default=0.20, ge=0.0, le=1.0,
+                                description='Total slot count and topology quality')
+    expansion:    float = Field(default=0.15, ge=0.0, le=1.0,
+                                description='Overall development potential, growth headroom')
+    logistics:    float = Field(default=0.10, ge=0.0, le=1.0,
+                                description='Distance from hub, scoopable star accessibility')
+
+
+class ArchetypeScoreBreakdown(BaseModel):
+    """Per-component score decomposition for a single archetype."""
+    model_config = ConfigDict(extra='allow')
+
+    body_composition:   Optional[float] = None   # 0-60
+    topology:           Optional[float] = None   # 0-25
+    pair_synergy_pts:   Optional[float] = None   # 0-15
+    purity_factor:      Optional[float] = None   # multiplier
+    contamination_risk: Optional[float] = None   # 0-1
+    diversity_factor:   Optional[float] = None   # multiplier
+
+
+class ArchetypeRationale(BaseModel):
+    """
+    Structured JSONB rationale for a system's primary archetype.
+    Schema is intentionally flexible (extra='allow') so Frontier
+    mechanic changes can be absorbed without breaking existing consumers.
+    """
+    model_config = ConfigDict(extra='allow')
+
+    summary:        Optional[str]                     = None
+    tier:           Optional[TierValue]               = None
+    headline:       Optional[str]                     = None
+    positives:      list[str]                         = Field(default_factory=list)
+    risks:          list[str]                         = Field(default_factory=list)
+    complexity:     Optional[str]                     = None
+    build_path:     Optional[str]                     = None
+    tags:           list[str]                         = Field(default_factory=list)
+    score_breakdown: Optional[ArchetypeScoreBreakdown] = None
+    data_confidence: Optional[float]                  = None
+
+
+class ArchetypeScore(BaseModel):
+    """One archetype entry inside SystemArchetypeResponse.archetypes."""
+    model_config = ConfigDict(extra='allow')
+
+    score:      float
+    tier:       TierValue
+    label:      str
+    rationale:  Optional[ArchetypeRationale] = None   # only on primary archetype
+    rank_global: Optional[int]               = None   # populated in Phase 4
+
+
+class TopologyDetail(BaseModel):
+    """Topology metrics block inside SystemArchetypeResponse."""
+    model_config = ConfigDict(extra='allow')
+
+    estimated_orbital_slots: Optional[int]   = None
+    estimated_ground_slots:  Optional[int]   = None
+    estimated_total_slots:   Optional[int]   = None
+    strong_link_potential:   Optional[float] = None
+    weak_link_stability:     Optional[float] = None
+    contamination_risk:      Optional[float] = None
+    orbital_synergy:         Optional[float] = None
+    ground_synergy:          Optional[float] = None
+    nesting_potential:       Optional[float] = None
+    build_flexibility:       Optional[float] = None
+    has_viable_surface_port: Optional[bool]  = None
+    has_deep_orbital_anchor: Optional[bool]  = None
+
+
+class EconomyPairDetail(BaseModel):
+    """One economy pair synergy entry inside SystemArchetypeResponse."""
+    model_config = ConfigDict(extra='allow')
+
+    economy_a:           str
+    economy_b:           str
+    synergy_score:       float
+    purity_achievable:   Optional[float] = None
+    contamination_paths: list[Any]       = Field(default_factory=list)
+
+
+# ── Response: GET /api/archetypes/system/{id64} ───────────────────────
+class SystemArchetypeResponse(BaseModel):
+    """Full archetype breakdown for one system."""
+    model_config = ConfigDict(extra='forbid')
+
+    id64:             int
+    name:             str
+    coords:           Optional[CoordsModel] = None
+    distance_to_sol:  Optional[float]       = None
+    main_star_type:   Optional[str]         = None
+
+    # Per-archetype score map: archetype_key → ArchetypeScore
+    archetypes:       dict[str, ArchetypeScore]
+
+    primary_archetype:    Optional[str]   = None
+    secondary_archetype:  Optional[str]   = None
+    archetype_confidence: Optional[float] = None
+
+    overall_development_potential: Optional[float] = None
+    buildability_score:  Optional[float]  = None
+    build_complexity:    Optional[str]    = None
+    cp_efficiency:       Optional[float]  = None
+    t3_scaling_viability: Optional[float] = None
+    slot_efficiency:     Optional[float]  = None
+    purity_score:        Optional[float]  = None
+    contamination_risk:  Optional[float]  = None
+    stable_top_two_prob: Optional[float]  = None
+    confidence:          Optional[float]  = None
+
+    topology:       Optional[TopologyDetail]    = None
+    economy_pairs:  list[EconomyPairDetail]     = Field(default_factory=list)
+    tags:           list[str]                   = Field(default_factory=list)
+    query_ms:       Optional[int]               = None
+    _cached:        Optional[bool]              = None
+
+
+# ── Result row: GET /api/archetypes/rankings ─────────────────────────
+class ArchetypeRankingRow(BaseModel):
+    """One result row inside ArchetypeRankingsResponse."""
+    model_config = ConfigDict(extra='allow')
+
+    id64:             int
+    name:             str
+    coords:           Optional[CoordsModel] = None
+    distance_to_sol:  Optional[float]       = None
+    score:            float
+    tier:             TierValue
+    primary_archetype:    Optional[str]   = None
+    secondary_archetype:  Optional[str]   = None
+    archetype_confidence: Optional[float] = None
+    overall_development_potential: Optional[float] = None
+    buildability_score:  Optional[float]  = None
+    build_complexity:    Optional[str]    = None
+    purity_score:        Optional[float]  = None
+    contamination_risk:  Optional[float]  = None
+    confidence:          Optional[float]  = None
+    has_elw:             Optional[bool]   = None
+    elw_count:           Optional[int]    = None
+    landable_count:      Optional[int]    = None
+    est_total_slots:     Optional[int]    = None
+    tags:                list[str]        = Field(default_factory=list)
+
+
+# ── Response: GET /api/archetypes/rankings ───────────────────────────
+class ArchetypeRankingsResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    archetype:       str
+    archetype_label: str
+    results:         list[ArchetypeRankingRow]
+    total:           int = 0
+    count:           int = 0
+    source:          Optional[str] = None
+    query_ms:        Optional[int] = None
+    _cached:         Optional[bool] = None
+
+
+# ── Request: POST /api/archetypes/rerank ─────────────────────────────
+class ArchetypeRerankRequest(BaseModel):
+    """
+    Rerank a set of systems by custom archetype weights.
+
+    Either provide explicit weights OR a profile ID.
+    If both are given, the profile takes precedence.
+    If neither, default ArchetypeRerankWeights are applied.
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    id64s:     list[int]                      = Field(..., min_length=1, max_length=500)
+    archetype: Optional[ArchetypeKey]         = None
+    weights:   Optional[ArchetypeRerankWeights] = None
+    profile:   Optional[str]                  = None   # profile ID from /api/archetypes/profiles
+
+
+# ── Result row: POST /api/archetypes/rerank ───────────────────────────
+class ArchetypeRerankRow(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    id64:             int
+    reranked_score:   int
+    original_score:   Optional[float]        = None
+    confidence:       Optional[float]        = None
+    rationale:        Optional[ArchetypeRationale] = None
+
+
+# ── Response: POST /api/archetypes/rerank ─────────────────────────────
+class ArchetypeRerankResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    archetype:       Optional[str]              = None
+    profile_applied: Optional[str]              = None
+    weights_applied: ArchetypeRerankWeights
+    results:         list[ArchetypeRerankRow]
+    query_ms:        Optional[int]              = None
+    _cached:         Optional[bool]             = None
+
+
+# Backward-compat alias used in ratings.py POST /api/ratings/rerank
+RerankedSystemRow = ArchetypeRerankRow
+
+
+# ── Request: POST /api/archetypes/simulate ───────────────────────────
+class PlannedFacility(BaseModel):
+    """One facility in a build simulation plan."""
+    model_config = ConfigDict(extra='allow')
+
+    type:   str                   # e.g. 'StarPort', 'RefineryHub', 'IndustrialHub'
+    tier:   Optional[int] = None  # 1, 2, or 3
+    body:   Optional[str] = None  # body key or name
+
+
+class BuildSimulateRequest(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    id64:              int
+    planned_archetype: ArchetypeKey
+    planned_facilities: list[PlannedFacility] = Field(default_factory=list)
+
+
+# ── Response: POST /api/archetypes/simulate ──────────────────────────
+class BuildSimulateResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    id64:               int
+    planned_archetype:  str
+    simulation_score:   int
+    contamination_risk: Optional[float] = None
+    purity_score:       Optional[float] = None
+    buildability_score: Optional[float] = None
+    recommendations:    list[str]       = Field(default_factory=list)
+    disclaimer:         Optional[str]   = None
+
+
+# ── Profile entry: GET /api/archetypes/profiles ──────────────────────
+class ArchetypeProfile(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    id:          str
+    label:       str
+    description: str
+    archetype:   Optional[str]             = None
+    weights:     ArchetypeRerankWeights
+
+
+# ── Response: GET /api/archetypes/profiles ───────────────────────────
+class ArchetypesProfilesResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+
+    profiles: list[ArchetypeProfile]

--- a/apps/api/src/routers/archetypes.py
+++ b/apps/api/src/routers/archetypes.py
@@ -24,15 +24,13 @@ Backward compatibility:
     All new routes are under /api/archetypes/* to avoid conflicts.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 import time
 from typing import Any, Optional
 
 import asyncpg
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 
@@ -50,7 +48,7 @@ from models import (
     RerankedSystemRow,
     SystemArchetypeResponse,
 )
-from state import get_pool, get_redis
+from state import get_pool_singleton as get_pool, get_redis_singleton as get_redis
 
 router = APIRouter(prefix='/api/archetypes', tags=['archetypes'])
 
@@ -244,7 +242,7 @@ async def get_archetype_rankings(
         idx += 1
 
     if max_distance_ly is not None:
-        where_parts.append(f"distance_to_sol <= ${idx}")
+        where_parts.append(f"SQRT(x*x + y*y + z*z) <= ${idx}")
         params.append(max_distance_ly)
         idx += 1
 
@@ -271,7 +269,8 @@ async def get_archetype_rankings(
     # Results query
     results_sql = f"""
         SELECT
-            id64, name, x, y, z, distance_to_sol,
+            id64, name, x, y, z,
+            SQRT(x*x + y*y + z*z) AS distance_to_sol,
             primary_archetype, secondary_archetype, archetype_confidence,
             {score_col}                AS score,
             overall_development_potential,
@@ -467,7 +466,8 @@ async def get_system_archetypes(request: Request, id64: int):
             # System + archetype scores
             row = await conn.fetchrow("""
                 SELECT
-                    s.id64, s.name, s.x, s.y, s.z, s.distance_to_sol,
+                    s.id64, s.name, s.x, s.y, s.z,
+                    SQRT(s.x*s.x + s.y*s.y + s.z*s.z) AS distance_to_sol,
                     s.main_star_type,
                     a.primary_archetype, a.secondary_archetype,
                     a.archetype_confidence,

--- a/apps/api/src/routers/archetypes.py
+++ b/apps/api/src/routers/archetypes.py
@@ -1,0 +1,750 @@
+"""
+ED Finder — Archetype API Router
+Version: 1.0
+
+Endpoints:
+    GET  /api/archetypes/rankings          ranked list by archetype + filters
+    POST /api/archetypes/rerank            rerank a set of systems by archetype weights
+    GET  /api/archetypes/system/{id64}     full archetype breakdown for one system
+    POST /api/archetypes/simulate          build simulation scoring
+    GET  /api/archetypes/profiles          preset rerank profiles
+
+All routes use the mv_archetype_rankings materialized view for reads
+(non-blocking, pre-joined). Rationale and score_breakdown JSONB are
+fetched from system_archetype_scores on demand (single-row lookups).
+
+Cache strategy:
+    rankings  → Redis key arch:v{ver}:rank:{archetype}:{region}:{min}:{lim}:{off}  TTL 600s
+    system    → Redis key arch:v{ver}:sys:{id64}                                   TTL 300s
+    rerank    → Redis key arch:v{ver}:rerank:{hash}                                TTL 120s
+    profiles  → Redis key arch:profiles                                            TTL 3600s
+
+Backward compatibility:
+    The existing /api/ratings/rerank endpoint is UNCHANGED.
+    All new routes are under /api/archetypes/* to avoid conflicts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from typing import Any, Optional
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+from config import log, limiter
+from models import (
+    ArchetypeRankingsResponse,
+    ArchetypeRerankRequest,
+    ArchetypeRerankResponse,
+    ArchetypeRerankRow,
+    ArchetypeRerankWeights,
+    ArchetypeScore,
+    ArchetypesProfilesResponse,
+    BuildSimulateRequest,
+    BuildSimulateResponse,
+    RerankedSystemRow,
+    SystemArchetypeResponse,
+)
+from state import get_pool, get_redis
+
+router = APIRouter(prefix='/api/archetypes', tags=['archetypes'])
+
+# ---------------------------------------------------------------------------
+# Archetype metadata (mirrors ARCHETYPE_DEFINITIONS in build_archetype_scores.py)
+# ---------------------------------------------------------------------------
+_ARCHETYPE_LABELS: dict[str, str] = {
+    'refinery_industrial':       'Refinery / Industrial Megacomplex',
+    'extraction_refinery':       'Extraction / Refinery Mining Hub',
+    'agriculture_terraforming':  'Agriculture / Terraforming Colony',
+    'hitech_tourism':            'HighTech / Tourism Prestige Colony',
+    'expansion_capital':         'Expansion Capital',
+    'trade_logistics':           'Trade / Logistics Hub',
+    'population_capital':        'Population Capital',
+    'ax_forward_base':           'AX Forward Operating Base',
+    'military_industrial':       'Military / Industrial Complex',
+    'flexible_multirole':        'Flexible Multi-Role Colony',
+}
+
+_SCORE_COL: dict[str, str] = {
+    'refinery_industrial':      'score_refinery_industrial',
+    'extraction_refinery':      'score_extraction_refinery',
+    'agriculture_terraforming': 'score_agriculture_terraforming',
+    'hitech_tourism':           'score_hitech_tourism',
+    'expansion_capital':        'score_expansion_capital',
+    'trade_logistics':          'score_trade_logistics',
+    'population_capital':       'score_population_capital',
+    'ax_forward_base':          'score_ax_forward_base',
+    'military_industrial':      'score_military_industrial',
+    'flexible_multirole':       'score_flexible_multirole',
+}
+
+# Preset rerank profiles
+_PROFILES = [
+    {
+        'id':          'industrial_empire',
+        'label':       'Industrial Empire',
+        'description': 'Refinery/Industrial megacomplex — maximum manufacturing output',
+        'archetype':   'refinery_industrial',
+        'weights': {'purity': 0.35, 'buildability': 0.25, 'slots': 0.20,
+                    'expansion': 0.10, 'logistics': 0.10},
+    },
+    {
+        'id':          'space_farms',
+        'label':       'Space Farms',
+        'description': 'Agriculture and terraforming — maximum population growth',
+        'archetype':   'agriculture_terraforming',
+        'weights': {'purity': 0.30, 'buildability': 0.20, 'slots': 0.20,
+                    'expansion': 0.20, 'logistics': 0.10},
+    },
+    {
+        'id':          'prestige_capital',
+        'label':       'Prestige Capital',
+        'description': 'HighTech / Tourism prestige colony — ELW and exotic stars',
+        'archetype':   'hitech_tourism',
+        'weights': {'purity': 0.25, 'buildability': 0.20, 'slots': 0.15,
+                    'expansion': 0.20, 'logistics': 0.20},
+    },
+    {
+        'id':          'ax_logistics',
+        'label':       'AX Logistics Hub',
+        'description': 'Military / HighTech anti-xeno forward base',
+        'archetype':   'ax_forward_base',
+        'weights': {'purity': 0.20, 'buildability': 0.30, 'slots': 0.20,
+                    'expansion': 0.15, 'logistics': 0.15},
+    },
+    {
+        'id':          'expansion_capital',
+        'label':       'Expansion Capital',
+        'description': 'Flexible system for multi-jump colonisation chains',
+        'archetype':   'expansion_capital',
+        'weights': {'purity': 0.15, 'buildability': 0.20, 'slots': 0.25,
+                    'expansion': 0.25, 'logistics': 0.15},
+    },
+    {
+        'id':          'mining_hub',
+        'label':       'Mining Hub',
+        'description': 'Extraction / Refinery — HMC and metal-rich focus',
+        'archetype':   'extraction_refinery',
+        'weights': {'purity': 0.25, 'buildability': 0.30, 'slots': 0.25,
+                    'expansion': 0.10, 'logistics': 0.10},
+    },
+    {
+        'id':          'generalist',
+        'label':       'Generalist',
+        'description': 'Balanced weights — no strong archetype preference',
+        'archetype':   None,
+        'weights': {'purity': 0.20, 'buildability': 0.20, 'slots': 0.20,
+                    'expansion': 0.20, 'logistics': 0.20},
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+async def _cache_version(redis) -> int:
+    """Return the current cache version counter (default 1)."""
+    if redis is None:
+        return 1
+    try:
+        v = await redis.get('arch:version')
+        return int(v) if v else 1
+    except Exception:
+        return 1
+
+
+async def _cache_get(redis, key: str) -> Optional[Any]:
+    if redis is None:
+        return None
+    try:
+        raw = await redis.get(key)
+        return json.loads(raw) if raw else None
+    except Exception:
+        return None
+
+
+async def _cache_set(redis, key: str, value: Any, ttl: int = 300):
+    if redis is None:
+        return
+    try:
+        await redis.set(key, json.dumps(value), ex=ttl)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# GET /api/archetypes/rankings
+# ---------------------------------------------------------------------------
+
+@router.get(
+    '/rankings',
+    response_model=ArchetypeRankingsResponse,
+    summary='Ranked systems by colony archetype',
+    description=(
+        'Returns systems ranked by a specific colony archetype score. '
+        'Uses the mv_archetype_rankings materialized view for fast reads. '
+        'Slot counts are ESTIMATED — not authoritative.'
+    ),
+)
+@limiter.limit('60/minute')
+async def get_archetype_rankings(
+    request: Request,
+    archetype:       str            = Query(..., description='Colony archetype key'),
+    min_score:       int            = Query(40,  ge=0,   le=100),
+    galaxy_region:   Optional[int]  = Query(None),
+    max_distance_ly: Optional[float]= Query(None, ge=0),
+    has_elw:         Optional[bool] = Query(None),
+    min_slots:       Optional[int]  = Query(None, ge=0),
+    max_contamination: Optional[float] = Query(None, ge=0, le=100),
+    limit:           int            = Query(50,  ge=1,  le=500),
+    offset:          int            = Query(0,   ge=0),
+):
+    t0 = time.monotonic()
+
+    if archetype not in _SCORE_COL:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown archetype '{archetype}'. "
+                f"Valid values: {sorted(_SCORE_COL.keys())}"
+            ),
+        )
+
+    score_col = _SCORE_COL[archetype]
+    pool  = get_pool()
+    redis = get_redis()
+
+    # Cache key
+    ver     = await _cache_version(redis)
+    ck_args = f"{archetype}:{galaxy_region}:{min_score}:{min_slots}:{limit}:{offset}"
+    cache_key = f"arch:v{ver}:rank:{ck_args}"
+
+    cached = await _cache_get(redis, cache_key)
+    if cached:
+        cached['_cached'] = True
+        return cached
+
+    # Build WHERE clauses dynamically
+    where_parts = [
+        f"{score_col} >= $1",
+        "confidence >= 0.70",
+    ]
+    params: list = [min_score]
+    idx = 2
+
+    if galaxy_region is not None:
+        where_parts.append(f"galaxy_region_id = ${idx}")
+        params.append(galaxy_region)
+        idx += 1
+
+    if max_distance_ly is not None:
+        where_parts.append(f"distance_to_sol <= ${idx}")
+        params.append(max_distance_ly)
+        idx += 1
+
+    if has_elw is not None:
+        where_parts.append(f"has_elw = ${idx}")
+        params.append(has_elw)
+        idx += 1
+
+    if min_slots is not None:
+        where_parts.append(f"est_total_slots >= ${idx}")
+        params.append(min_slots)
+        idx += 1
+
+    if max_contamination is not None:
+        where_parts.append(f"contamination_risk <= ${idx}")
+        params.append(max_contamination)
+        idx += 1
+
+    where_sql = ' AND '.join(where_parts)
+
+    # Count query
+    count_sql = f"SELECT COUNT(*) FROM mv_archetype_rankings WHERE {where_sql}"
+
+    # Results query
+    results_sql = f"""
+        SELECT
+            id64, name, x, y, z, distance_to_sol,
+            primary_archetype, secondary_archetype, archetype_confidence,
+            {score_col}                AS score,
+            overall_development_potential,
+            buildability_score, build_complexity,
+            purity_score, contamination_risk, confidence,
+            has_elw, has_black_hole, has_neutron_star,
+            elw_count, landable_count, est_total_slots,
+            display_tags
+        FROM mv_archetype_rankings
+        WHERE {where_sql}
+        ORDER BY {score_col} DESC, overall_development_potential DESC
+        LIMIT ${idx} OFFSET ${idx + 1}
+    """
+    params_results = params + [limit, offset]
+    idx += 2
+
+    try:
+        async with pool.acquire() as conn:
+            total_row = await conn.fetchrow(count_sql, *params)
+            total     = int(total_row[0]) if total_row else 0
+            rows      = await conn.fetch(results_sql, *params_results)
+    except asyncpg.PostgresError as e:
+        log.error('archetypes.rankings DB error: %s', e)
+        raise HTTPException(
+            status_code=503,
+            detail={'type': 'https://httpstatuses.com/503',
+                    'title': 'Database error', 'status': 503, 'detail': str(e)},
+        )
+
+    query_ms = int((time.monotonic() - t0) * 1000)
+
+    results = [
+        {
+            'id64':           row['id64'],
+            'name':           row['name'],
+            'coords':         {'x': row['x'], 'y': row['y'], 'z': row['z']},
+            'distance_to_sol': row['distance_to_sol'],
+            'score':          row['score'],
+            'tier':           _tier(row['score']),
+            'primary_archetype':       row['primary_archetype'],
+            'secondary_archetype':     row['secondary_archetype'],
+            'archetype_confidence':    row['archetype_confidence'],
+            'overall_development_potential': row['overall_development_potential'],
+            'buildability_score':      row['buildability_score'],
+            'build_complexity':        row['build_complexity'],
+            'purity_score':            row['purity_score'],
+            'contamination_risk':      row['contamination_risk'],
+            'confidence':              row['confidence'],
+            'has_elw':                 row['has_elw'],
+            'elw_count':               row['elw_count'],
+            'landable_count':          row['landable_count'],
+            'est_total_slots':         row['est_total_slots'],
+            'tags':                    list(row['display_tags'] or []),
+        }
+        for row in rows
+    ]
+
+    response = {
+        'archetype':       archetype,
+        'archetype_label': _ARCHETYPE_LABELS.get(archetype, archetype),
+        'results':         results,
+        'total':           total,
+        'count':           len(results),
+        'source':          'mv_archetype_rankings',
+        'query_ms':        query_ms,
+    }
+
+    await _cache_set(redis, cache_key, response, ttl=600)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# POST /api/archetypes/rerank
+# ---------------------------------------------------------------------------
+
+@router.post(
+    '/rerank',
+    response_model=ArchetypeRerankResponse,
+    summary='Rerank systems by custom archetype weights',
+)
+@limiter.limit('30/minute')
+async def post_archetype_rerank(request: Request, body: ArchetypeRerankRequest):
+    t0 = time.monotonic()
+
+    if not body.id64s:
+        raise HTTPException(status_code=422, detail='id64s list is required')
+    if len(body.id64s) > 500:
+        raise HTTPException(status_code=422, detail='Maximum 500 systems per rerank request')
+
+    # Resolve weights: use profile if provided, else body.weights, else defaults
+    weights = _resolve_weights(body)
+
+    # Resolve archetype score column
+    archetype   = body.archetype
+    score_col   = _SCORE_COL.get(archetype, 'overall_development_potential') if archetype else \
+                  'overall_development_potential'
+
+    # Cache key
+    redis = get_redis()
+    cache_key = _rerank_cache_key(body.id64s, weights, archetype)
+    cached = await _cache_get(redis, cache_key)
+    if cached:
+        cached['_cached'] = True
+        return cached
+
+    # Fetch from DB
+    pool = get_pool()
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch("""
+                SELECT
+                    a.system_id64           AS id64,
+                    a.{score_col}           AS archetype_score,
+                    a.purity_score,
+                    a.buildability_score,
+                    t.est_total_slots       AS slots,
+                    a.overall_development_potential AS expansion,
+                    CASE WHEN s.main_star_type IN ('O','B','A','F','G','K','M')
+                         THEN 80 ELSE 40 END AS logistics,
+                    a.confidence,
+                    a.rationale
+                FROM system_archetype_scores a
+                JOIN systems s              ON s.id64 = a.system_id64
+                JOIN system_archetype_traits t ON t.system_id64 = a.system_id64
+                WHERE a.system_id64 = ANY($1::bigint[])
+                  AND a.dirty = FALSE
+            """.format(score_col=score_col), body.id64s)
+    except asyncpg.PostgresError as e:
+        log.error('archetypes.rerank DB error: %s', e)
+        raise HTTPException(
+            status_code=503,
+            detail={'type': 'https://httpstatuses.com/503',
+                    'title': 'Database error', 'status': 503, 'detail': str(e)},
+        )
+
+    # Apply weights
+    reranked = []
+    for row in rows:
+        raw = (
+            float(row['purity_score'] or 0)      * weights.purity +
+            float(row['buildability_score'] or 0) * weights.buildability +
+            float(row['slots'] or 0)              * weights.slots +
+            float(row['expansion'] or 0)          * weights.expansion +
+            float(row['logistics'] or 0)          * weights.logistics
+        )
+        reranked.append({
+            'id64':             row['id64'],
+            'reranked_score':   int(round(raw)),
+            'original_score':   round(float(row['archetype_score'] or 0), 2),
+            'confidence':       round(float(row['confidence'] or 0.85), 3),
+            'rationale':        row['rationale'] or {},
+        })
+
+    reranked.sort(key=lambda r: r['reranked_score'], reverse=True)
+
+    query_ms = int((time.monotonic() - t0) * 1000)
+    response = {
+        'archetype':       archetype,
+        'profile_applied': body.profile,
+        'weights_applied': weights.model_dump(),
+        'results':         reranked,
+        'query_ms':        query_ms,
+    }
+    await _cache_set(redis, cache_key, response, ttl=120)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /api/archetypes/system/{id64}
+# ---------------------------------------------------------------------------
+
+@router.get(
+    '/system/{id64}',
+    response_model=SystemArchetypeResponse,
+    summary='Full archetype breakdown for a single system',
+)
+@limiter.limit('120/minute')
+async def get_system_archetypes(request: Request, id64: int):
+    t0 = time.monotonic()
+
+    redis     = get_redis()
+    ver       = await _cache_version(redis)
+    cache_key = f"arch:v{ver}:sys:{id64}"
+
+    cached = await _cache_get(redis, cache_key)
+    if cached:
+        cached['_cached'] = True
+        return cached
+
+    pool = get_pool()
+    try:
+        async with pool.acquire() as conn:
+            # System + archetype scores
+            row = await conn.fetchrow("""
+                SELECT
+                    s.id64, s.name, s.x, s.y, s.z, s.distance_to_sol,
+                    s.main_star_type,
+                    a.primary_archetype, a.secondary_archetype,
+                    a.archetype_confidence,
+                    a.score_refinery_industrial,
+                    a.score_extraction_refinery,
+                    a.score_agriculture_terraforming,
+                    a.score_hitech_tourism,
+                    a.score_expansion_capital,
+                    a.score_trade_logistics,
+                    a.score_population_capital,
+                    a.score_ax_forward_base,
+                    a.score_military_industrial,
+                    a.score_flexible_multirole,
+                    a.overall_development_potential,
+                    a.buildability_score, a.build_complexity,
+                    a.cp_efficiency, a.t3_scaling_viability, a.slot_efficiency,
+                    a.purity_score, a.contamination_risk, a.stable_top_two_prob,
+                    a.confidence,
+                    a.rationale,
+                    a.score_breakdown
+                FROM systems s
+                JOIN system_archetype_scores a ON a.system_id64 = s.id64
+                WHERE s.id64 = $1
+                  AND a.dirty = FALSE
+            """, id64)
+
+            if row is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f'System {id64} not found or archetype scores not yet computed',
+                )
+
+            # Topology
+            topo_row = await conn.fetchrow("""
+                SELECT estimated_orbital_slots, estimated_ground_slots,
+                       estimated_total_slots, strong_link_potential,
+                       weak_link_stability, contamination_risk AS topo_contamination,
+                       orbital_synergy, ground_synergy, nesting_potential,
+                       build_flexibility, has_viable_surface_port,
+                       has_deep_orbital_anchor, has_ringed_gas_giant
+                FROM system_slot_topology WHERE system_id64 = $1
+            """, id64)
+
+            # Pair synergy rows
+            pair_rows = await conn.fetch("""
+                SELECT economy_a, economy_b, synergy_score, purity_achievable,
+                       contamination_paths
+                FROM economy_pair_synergy
+                WHERE system_id64 = $1
+                ORDER BY synergy_score DESC
+                LIMIT 10
+            """, id64)
+
+            # Traits
+            trait_row = await conn.fetchrow("""
+                SELECT display_tags, est_total_slots, landable_count,
+                       elw_count, gas_giant_count, total_body_count
+                FROM system_archetype_traits WHERE system_id64 = $1
+            """, id64)
+
+    except asyncpg.PostgresError as e:
+        log.error('archetypes.system DB error: %s', e)
+        raise HTTPException(
+            status_code=503,
+            detail={'type': 'https://httpstatuses.com/503',
+                    'title': 'Database error', 'status': 503, 'detail': str(e)},
+        )
+
+    query_ms = int((time.monotonic() - t0) * 1000)
+
+    # Build per-archetype score dict
+    archetypes_out = {}
+    for key, col in _SCORE_COL.items():
+        s = float(row[col] or 0)
+        archetypes_out[key] = {
+            'score':       s,
+            'tier':        _tier(s),
+            'label':       _ARCHETYPE_LABELS[key],
+        }
+    # Add rationale to primary archetype entry
+    primary = row['primary_archetype']
+    if primary in archetypes_out and row['rationale']:
+        archetypes_out[primary]['rationale'] = row['rationale']
+
+    topology_out = None
+    if topo_row:
+        topology_out = {
+            'estimated_orbital_slots': topo_row['estimated_orbital_slots'],
+            'estimated_ground_slots':  topo_row['estimated_ground_slots'],
+            'estimated_total_slots':   topo_row['estimated_total_slots'],
+            'strong_link_potential':   topo_row['strong_link_potential'],
+            'weak_link_stability':     topo_row['weak_link_stability'],
+            'contamination_risk':      topo_row['topo_contamination'],
+            'orbital_synergy':         topo_row['orbital_synergy'],
+            'ground_synergy':          topo_row['ground_synergy'],
+            'nesting_potential':       topo_row['nesting_potential'],
+            'build_flexibility':       topo_row['build_flexibility'],
+            'has_viable_surface_port': topo_row['has_viable_surface_port'],
+            'has_deep_orbital_anchor': topo_row['has_deep_orbital_anchor'],
+        }
+
+    economy_pairs_out = [
+        {
+            'economy_a':          pr['economy_a'],
+            'economy_b':          pr['economy_b'],
+            'synergy_score':      pr['synergy_score'],
+            'purity_achievable':  pr['purity_achievable'],
+            'contamination_paths': pr['contamination_paths'] or [],
+        }
+        for pr in pair_rows
+    ]
+
+    response = {
+        'id64':               row['id64'],
+        'name':               row['name'],
+        'coords':             {'x': row['x'], 'y': row['y'], 'z': row['z']},
+        'distance_to_sol':    row['distance_to_sol'],
+        'main_star_type':     row['main_star_type'],
+        'archetypes':         archetypes_out,
+        'primary_archetype':  row['primary_archetype'],
+        'secondary_archetype':row['secondary_archetype'],
+        'archetype_confidence': row['archetype_confidence'],
+        'overall_development_potential': row['overall_development_potential'],
+        'buildability_score': row['buildability_score'],
+        'build_complexity':   row['build_complexity'],
+        'cp_efficiency':      row['cp_efficiency'],
+        't3_scaling_viability': row['t3_scaling_viability'],
+        'slot_efficiency':    row['slot_efficiency'],
+        'purity_score':       row['purity_score'],
+        'contamination_risk': row['contamination_risk'],
+        'stable_top_two_prob': row['stable_top_two_prob'],
+        'confidence':         row['confidence'],
+        'topology':           topology_out,
+        'economy_pairs':      economy_pairs_out,
+        'tags':               list(trait_row['display_tags'] or []) if trait_row else [],
+        'query_ms':           query_ms,
+    }
+
+    await _cache_set(redis, cache_key, response, ttl=300)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# POST /api/archetypes/simulate
+# ---------------------------------------------------------------------------
+
+@router.post(
+    '/simulate',
+    response_model=BuildSimulateResponse,
+    summary='Build simulation — score a system against a planned build',
+)
+@limiter.limit('20/minute')
+async def post_simulate(request: Request, body: BuildSimulateRequest):
+    """
+    Given a planned build (list of facility placements), estimate the
+    resulting economy distribution and score the system against the plan.
+
+    NOTE: This is a best-effort estimate. Economy outcomes depend on exact
+    construction order and Frontier's internal economy weighting, which is
+    not publicly documented.
+    """
+    pool = get_pool()
+    try:
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow("""
+                SELECT a.score_breakdown, a.rationale, a.contamination_risk,
+                       a.purity_score, a.buildability_score,
+                       a.primary_archetype
+                FROM system_archetype_scores a
+                WHERE a.system_id64 = $1 AND a.dirty = FALSE
+            """, body.id64)
+    except asyncpg.PostgresError as e:
+        log.error('archetypes.simulate DB error: %s', e)
+        raise HTTPException(
+            status_code=503,
+            detail={'type': 'https://httpstatuses.com/503',
+                    'title': 'Database error', 'status': 503, 'detail': str(e)},
+        )
+
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f'System {body.id64} not found or scores not yet computed',
+        )
+
+    planned = body.planned_archetype
+    pa_score = row['score_breakdown'].get('per_archetype', {}).get(planned, {})
+    sim_score = int(pa_score.get('score', 0)) if pa_score else 0
+
+    recs: list[str] = []
+    cont_risk = float(row['contamination_risk'] or 0) / 100
+    if cont_risk > 0.40:
+        recs.append(
+            f'High contamination risk ({cont_risk:.0%}). '
+            'Add dedicated Refinery Hubs on contaminating bodies to suppress third-economy bleed.'
+        )
+    if row['buildability_score'] and float(row['buildability_score']) < 50:
+        recs.append(
+            'Low buildability score. Ensure you have sufficient strong-link anchors '
+            'before attempting T3 scaling.'
+        )
+    if len(body.planned_facilities) > 0:
+        t3_count = sum(1 for f in body.planned_facilities if f.get('tier') == 3)
+        if t3_count > 0:
+            recs.append(
+                f'{t3_count} T3 facilities planned. '
+                'T3 scaling requires at least one strong-link anchor body.'
+            )
+
+    return {
+        'id64':               body.id64,
+        'planned_archetype':  planned,
+        'simulation_score':   sim_score,
+        'contamination_risk': cont_risk,
+        'purity_score':       round(float(row['purity_score'] or 0), 2),
+        'buildability_score': round(float(row['buildability_score'] or 0), 2),
+        'recommendations':    recs or ['Build plan looks viable — proceed with standard order.'],
+        'disclaimer':         (
+            'This is an estimate based on body-composition analysis. '
+            'Actual economy outcomes depend on construction order and '
+            'Frontier\'s internal economy weighting.'
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /api/archetypes/profiles
+# ---------------------------------------------------------------------------
+
+@router.get(
+    '/profiles',
+    response_model=ArchetypesProfilesResponse,
+    summary='Preset rerank weight profiles',
+)
+@limiter.limit('120/minute')
+async def get_profiles(request: Request):
+    redis     = get_redis()
+    cache_key = 'arch:profiles'
+
+    cached = await _cache_get(redis, cache_key)
+    if cached:
+        return cached
+
+    response = {'profiles': _PROFILES}
+    await _cache_set(redis, cache_key, response, ttl=3600)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tier(score) -> str:
+    s = float(score or 0)
+    if s >= 88: return 'S'
+    if s >= 76: return 'A'
+    if s >= 60: return 'B'
+    if s >= 45: return 'C'
+    return 'D'
+
+
+def _resolve_weights(body: ArchetypeRerankRequest) -> ArchetypeRerankWeights:
+    """Resolve effective weights from profile ID or explicit weights."""
+    if body.profile:
+        for p in _PROFILES:
+            if p['id'] == body.profile:
+                return ArchetypeRerankWeights(**p['weights'])
+
+    if body.weights:
+        return body.weights
+
+    return ArchetypeRerankWeights()   # defaults
+
+
+def _rerank_cache_key(id64s: list, weights: ArchetypeRerankWeights, archetype: Optional[str]) -> str:
+    digest = hashlib.sha256(
+        json.dumps({'ids': sorted(id64s), 'w': weights.model_dump(), 'arch': archetype},
+                   sort_keys=True).encode()
+    ).hexdigest()[:16]
+    return f"arch:rerank:{digest}"

--- a/apps/importer/src/build_archetype_scores.py
+++ b/apps/importer/src/build_archetype_scores.py
@@ -1,0 +1,1316 @@
+#!/usr/bin/env python3
+"""
+ED Finder — Archetype Scoring Engine
+Version: 1.0
+
+Runs AFTER build_topology.py. Reads from bodies + ratings +
+system_slot_topology tables. Writes to system_archetype_scores
+and system_archetype_traits.
+
+Each system receives 10 independent archetype scores (0-100). The
+primary_archetype field records whichever archetype scores highest.
+A structured JSONB rationale is generated for the primary archetype.
+
+Usage:
+    python3 build_archetype_scores.py              # unscored systems only
+    python3 build_archetype_scores.py --rebuild    # rescore everything
+    python3 build_archetype_scores.py --dirty      # only dirty rows
+    python3 build_archetype_scores.py --workers 4
+    python3 build_archetype_scores.py --chunk 10000
+    python3 build_archetype_scores.py --limit 50000  # dev/test
+
+Pipeline position:
+    1. import_spansh.py
+    2. build_ratings.py
+    3. build_topology.py   → system_slot_topology
+    4. build_archetype_scores.py  ← THIS
+    5. REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings
+"""
+
+import os
+import sys
+import json
+import time
+import logging
+import argparse
+import multiprocessing as mp
+from typing import Optional
+
+import psycopg2
+import psycopg2.extras
+
+from progress import (
+    ProgressReporter, WorkerHeartbeat,
+    startup_banner, stage_banner, done_banner,
+    fmt_num, fmt_duration, fmt_rate,
+)
+
+# Import body diversity from the existing ratings engine
+try:
+    from build_ratings import compute_body_diversity, classify_bodies
+    _HAVE_RATINGS = True
+except ImportError:
+    _HAVE_RATINGS = False
+
+# Import topology helpers
+try:
+    from build_topology import (
+        compute_topology_metrics, compute_system_pair_synergy,
+        compute_contamination_risk, _classify_bodies_simple,
+        _load_base_synergy, BASE_SYNERGY, ECONOMY_PAIRS,
+    )
+    _HAVE_TOPOLOGY = True
+except ImportError:
+    _HAVE_TOPOLOGY = False
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def _make_direct_dsn(url: str) -> str:
+    direct = os.getenv('DB_DSN_DIRECT', '')
+    if direct:
+        return direct
+    if ':5433/' in url:
+        url = url.replace(':5433/', ':5432/')
+    url = url.replace('@pgbouncer:', '@postgres:')
+    return url
+
+
+def _connect_with_retry(dsn: str, label: str = 'archetype', retries: int = 10,
+                        delay: float = 5.0):
+    for attempt in range(1, retries + 1):
+        try:
+            conn = psycopg2.connect(
+                dsn,
+                keepalives=1, keepalives_idle=60,
+                keepalives_interval=10, keepalives_count=6,
+                options=(
+                    f"-c application_name={label} "
+                    f"-c statement_timeout=0 "
+                    f"-c idle_in_transaction_session_timeout=3600000"
+                )
+            )
+            return conn
+        except Exception as e:
+            if attempt == retries:
+                raise
+            wait = min(delay * attempt, 60)
+            logging.warning(f"DB connect failed ({label}, {attempt}/{retries}): {e}")
+            time.sleep(wait)
+
+
+_raw_url   = os.environ['DATABASE_URL']
+DB_DSN     = _make_direct_dsn(_raw_url)
+BATCH_SIZE = int(os.getenv('BATCH_SIZE', '5000'))
+LOG_LEVEL  = os.getenv('LOG_LEVEL', 'INFO')
+LOG_FILE   = os.getenv('LOG_FILE', '/tmp/build_archetype_scores.log')
+
+os.makedirs(os.path.dirname(os.path.abspath(LOG_FILE)), exist_ok=True)
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL),
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(sys.stdout),
+    ]
+)
+log = logging.getLogger('build_archetype_scores')
+
+
+# ---------------------------------------------------------------------------
+# Archetype definitions
+# ---------------------------------------------------------------------------
+# 10 colony archetypes. Each defines:
+#   label              Human-readable name
+#   description        One-line description
+#   economy_pair       Target economy pair (or None for flexible archetypes)
+#   body_weights       {body_type_key: weight 0-1} — contribution multipliers
+#   slot_preference    'ground_heavy' | 'orbital_heavy' | 'balanced'
+#   requires_landable  If True, score is severely capped with zero landable bodies
+#   contamination_tolerance  0-1: how much contamination is acceptable
+#   purity_multiplier  Score multiplier for clean stacks (1.0 = no bonus)
+#   diversity_bonus    Score multiplier for high body diversity (optional)
+#   tags               Default tags for this archetype
+
+ARCHETYPE_DEFINITIONS = {
+
+    'refinery_industrial': {
+        'label':       'Refinery / Industrial Megacomplex',
+        'description': 'Rocky and Icy body manufacturing hub',
+        'economy_pair': ('Refinery', 'Industrial'),
+        'body_weights': {
+            'rocky_clean':  1.00,
+            'rocky_ice':    0.80,
+            'icy':          0.70,
+            'rocky_rings':  0.55,
+            'hmc':          0.35,
+            'rocky_geo':    0.15,
+            'rocky_bio':    0.20,
+        },
+        'slot_preference':          'ground_heavy',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.30,
+        'purity_multiplier':        1.35,
+        'buildability_profile':     'standard',
+        'tags': ['Manufacturing', 'CMM Composite', 'Refinery Hub'],
+    },
+
+    'extraction_refinery': {
+        'label':       'Extraction / Refinery Mining Hub',
+        'description': 'HMC and metal-rich mining support system',
+        'economy_pair': ('Extraction', 'Refinery'),
+        'body_weights': {
+            'hmc':          1.00,
+            'metal_rich':   0.90,
+            'rocky_rings':  0.70,
+            'hmc_geo':      0.80,
+            'rocky_geo':    0.50,
+        },
+        'slot_preference':          'balanced',
+        'requires_landable':        False,
+        'contamination_tolerance':  0.40,
+        'purity_multiplier':        1.20,
+        'buildability_profile':     'mining_focus',
+        'tags': ['Mining Hub', 'Extraction', 'Metal-Rich'],
+    },
+
+    'agriculture_terraforming': {
+        'label':       'Agriculture / Terraforming Colony',
+        'description': 'Population growth and terraforming focus',
+        'economy_pair': ('Agriculture', 'Tourism'),
+        'body_weights': {
+            'elw':          1.00,
+            'ww':           0.80,
+            'terraformable': 0.60,
+            'rocky_bio':    0.45,
+            'ammonia':      0.30,
+        },
+        'slot_preference':          'ground_heavy',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.35,
+        'purity_multiplier':        1.40,
+        'buildability_profile':     'growth_focus',
+        'tags': ['Agriculture', 'Terraforming', 'ELW', 'Population Growth'],
+    },
+
+    'hitech_tourism': {
+        'label':       'HighTech / Tourism Prestige Colony',
+        'description': 'Prestige system with ELW, exotics, and high-tech industry',
+        'economy_pair': ('HighTech', 'Tourism'),
+        'body_weights': {
+            'elw':         1.00,
+            'ammonia':     0.90,
+            'black_hole':  0.85,
+            'neutron':     0.70,
+            'white_dwarf': 0.55,
+            'gas_giant':   0.65,
+            'ww':          0.60,
+        },
+        'slot_preference':          'orbital_heavy',
+        'requires_landable':        False,
+        'contamination_tolerance':  0.45,
+        'purity_multiplier':        1.30,
+        'buildability_profile':     'prestige',
+        'tags': ['Prestige', 'HighTech', 'Tourism', 'Exotic'],
+    },
+
+    'expansion_capital': {
+        'label':       'Expansion Capital',
+        'description': 'Strategic node for further colonisation chains',
+        'economy_pair': ('Industrial', 'HighTech'),
+        'body_weights': {
+            'elw':         0.70,
+            'gas_giant':   0.65,
+            'rocky_clean': 0.60,
+            'icy':         0.60,
+            'hmc':         0.55,
+        },
+        'slot_preference':          'balanced',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.55,
+        'purity_multiplier':        1.00,
+        'diversity_bonus':          1.30,
+        'buildability_profile':     'flexible',
+        'tags': ['Expansion', 'Capital', 'Strategic', 'Flexible'],
+    },
+
+    'trade_logistics': {
+        'label':       'Trade / Logistics Hub',
+        'description': 'Trade infrastructure and carrier support',
+        'economy_pair': ('Industrial', 'Refinery'),
+        'body_weights': {
+            'rocky_ice':   0.80,
+            'rocky_clean': 0.70,
+            'icy':         0.65,
+            'gas_giant':   0.50,
+            'hmc':         0.45,
+        },
+        'slot_preference':          'balanced',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.40,
+        'purity_multiplier':        1.15,
+        'buildability_profile':     'standard',
+        'tags': ['Trade', 'Logistics', 'Carrier Support'],
+    },
+
+    'population_capital': {
+        'label':       'Population Capital',
+        'description': 'Maximum population growth potential',
+        'economy_pair': ('Agriculture', 'HighTech'),
+        'body_weights': {
+            'elw':          1.00,
+            'terraformable': 0.80,
+            'ww':           0.70,
+            'rocky_bio':    0.50,
+            'gas_giant':    0.40,
+        },
+        'slot_preference':          'ground_heavy',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.30,
+        'purity_multiplier':        1.45,
+        'buildability_profile':     'growth_focus',
+        'tags': ['Population', 'Agriculture', 'ELW', 'Growth'],
+    },
+
+    'ax_forward_base': {
+        'label':       'AX Forward Operating Base',
+        'description': 'Anti-xeno military infrastructure hub',
+        'economy_pair': ('Military', 'HighTech'),
+        'body_weights': {
+            'elw':         1.00,
+            'neutron':     0.80,
+            'black_hole':  0.70,
+            'gas_giant':   0.60,
+            'rocky_clean': 0.50,
+        },
+        'slot_preference':          'balanced',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.50,
+        'purity_multiplier':        1.20,
+        'strategic_bonus':          0.20,
+        'buildability_profile':     'military',
+        'tags': ['AX', 'Military', 'Forward Base', 'Anti-Xeno'],
+    },
+
+    'military_industrial': {
+        'label':       'Military / Industrial Complex',
+        'description': 'Defensive stronghold with manufacturing capacity',
+        'economy_pair': ('Military', 'Industrial'),
+        'body_weights': {
+            'elw':         0.90,
+            'gas_giant':   0.70,
+            'icy':         0.65,
+            'rocky_clean': 0.60,
+            'neutron':     0.50,
+            'black_hole':  0.45,
+        },
+        'slot_preference':          'balanced',
+        'requires_landable':        True,
+        'contamination_tolerance':  0.40,
+        'purity_multiplier':        1.25,
+        'buildability_profile':     'military',
+        'tags': ['Military', 'Industrial', 'Defence', 'Stronghold'],
+    },
+
+    'flexible_multirole': {
+        'label':       'Flexible Multi-Role Colony',
+        'description': 'High diversity, multiple viable specialisation paths',
+        'economy_pair': None,
+        'body_weights': {},   # Diversity metric drives score
+        'slot_preference':          'balanced',
+        'requires_landable':        False,
+        'contamination_tolerance':  0.70,
+        'purity_multiplier':        1.00,
+        'diversity_bonus':          1.50,
+        'buildability_profile':     'flexible',
+        'tags': ['Multi-Role', 'Flexible', 'Generalist'],
+    },
+}
+
+# Ordered list for deterministic iteration
+ARCHETYPE_KEYS = list(ARCHETYPE_DEFINITIONS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Scoring functions
+# ---------------------------------------------------------------------------
+
+def _body_diversity(counts: dict) -> float:
+    """
+    Compute body diversity score 0-30.
+    Counts distinct body types weighted by rarity.
+    Falls back to internal implementation if build_ratings not importable.
+    """
+    if _HAVE_RATINGS:
+        try:
+            return compute_body_diversity(counts)
+        except Exception:
+            pass
+    # Internal fallback: count of distinct non-zero body type keys
+    rare_types = {'elw', 'ww', 'ammonia', 'black_hole', 'neutron', 'white_dwarf'}
+    score = 0.0
+    for k, v in counts.items():
+        if v > 0:
+            score += 3.0 if k in rare_types else 1.0
+    return min(score, 30.0)
+
+
+def compute_archetype_score(
+    archetype_key: str,
+    counts: dict,
+    topology: Optional[dict],
+    pair_synergy: float,
+) -> dict:
+    """
+    Compute a 0-100 archetype score for one archetype.
+
+    Returns dict with score components for explainability.
+    """
+    defn = ARCHETYPE_DEFINITIONS[archetype_key]
+
+    # ── 1. Body composition (0-60 pts) ────────────────────────────────────────
+    body_score = 0.0
+    body_notes = []
+    for body_key, weight in defn['body_weights'].items():
+        count = counts.get(body_key, 0)
+        if count > 0:
+            contribution = min(count, 3) * weight + max(count - 3, 0) * weight * 0.4
+            body_score += contribution * 20.0
+            body_notes.append(f"{count}× {body_key.replace('_', ' ')}")
+
+    body_score = min(body_score, 60.0)
+
+    # flexible_multirole has no body weights — use diversity directly
+    if archetype_key == 'flexible_multirole':
+        diversity = _body_diversity(counts)
+        body_score = diversity / 30.0 * 60.0
+
+    # ── 2. Topology score (0-25 pts) ──────────────────────────────────────────
+    topo_score = 0.0
+    if topology:
+        slot_pref = defn.get('slot_preference', 'balanced')
+        if slot_pref == 'ground_heavy':
+            topo_score = topology.get('ground_synergy', 0) * 0.25
+        elif slot_pref == 'orbital_heavy':
+            topo_score = topology.get('orbital_synergy', 0) * 0.25
+        else:
+            topo_score = (
+                topology.get('orbital_synergy', 0) * 0.12 +
+                topology.get('ground_synergy', 0) * 0.13
+            )
+        topo_score = min(topo_score, 25.0)
+
+    # ── 3. Purity / contamination multiplier ──────────────────────────────────
+    contamination = topology.get('contamination_risk', 0.5) if topology else 0.5
+    tolerance     = defn['contamination_tolerance']
+    purity_factor = 1.0
+
+    if contamination > tolerance:
+        excess = (contamination - tolerance) / max(1.0 - tolerance, 0.01)
+        purity_factor = 1.0 - (excess * (1.0 - 1.0 / defn['purity_multiplier']))
+        purity_factor = max(purity_factor, 0.40)   # floor at 40% of raw score
+    else:
+        clean_ratio   = 1.0 - (contamination / max(tolerance, 0.01))
+        purity_factor = 1.0 + (clean_ratio * (defn['purity_multiplier'] - 1.0))
+
+    # ── 4. Pair synergy boost (0-15 pts) ──────────────────────────────────────
+    synergy_pts = pair_synergy * 15.0 if pair_synergy else 0.0
+
+    # ── 5. Diversity bonus (expansion / flexible archetypes) ──────────────────
+    diversity_factor = 1.0
+    if 'diversity_bonus' in defn:
+        diversity = _body_diversity(counts)
+        div_norm  = diversity / 30.0
+        diversity_factor = 1.0 + (div_norm * (defn['diversity_bonus'] - 1.0))
+
+    # ── 6. Surface port requirement check ─────────────────────────────────────
+    if defn.get('requires_landable') and counts.get('landable', 0) == 0:
+        body_score *= 0.40   # severe penalty: no surface port possible
+
+    # ── 7. Compose ────────────────────────────────────────────────────────────
+    raw   = (body_score + topo_score + synergy_pts) * purity_factor * diversity_factor
+    final = round(min(float(raw), 100.0), 2)
+
+    return {
+        'score':              final,
+        'body_contribution':  round(body_score, 2),
+        'topology_contribution': round(topo_score, 2),
+        'purity_factor':      round(purity_factor, 3),
+        'synergy_pts':        round(synergy_pts, 2),
+        'contamination_risk': round(float(contamination), 3),
+        'diversity_factor':   round(diversity_factor, 3),
+        'notes':              body_notes,
+    }
+
+
+def compute_overall_development_potential(
+    archetype_scores: dict,
+    diversity: float,
+    has_standout: bool,
+    buildability: float,
+) -> float:
+    """
+    Composite development potential across all archetypes.
+    Supporting metric — NOT the primary ranking signal.
+    """
+    top3 = sorted(archetype_scores.values(), reverse=True)[:3]
+    top3_avg = sum(top3) / 3 if top3 else 0
+
+    diversity_bonus           = (diversity / 30.0) * 20.0
+    buildability_contribution = buildability * 0.20
+
+    raw = top3_avg * 0.60 + diversity_bonus + buildability_contribution
+
+    # Rarity gate: systems without a standout body are capped at 82
+    if not has_standout and raw > 82:
+        raw = 82.0
+
+    return round(min(raw, 100.0), 2)
+
+
+def compute_buildability(
+    counts: dict,
+    topology: Optional[dict],
+    archetype_key: str,
+    pair_synergy: float,
+) -> dict:
+    """
+    Compute buildability score + complexity for the given archetype.
+    Returns dict: {buildability_score, build_complexity, cp_efficiency,
+                   t3_scaling_viability, slot_efficiency}
+    """
+    defn = ARCHETYPE_DEFINITIONS[archetype_key]
+
+    # CP efficiency: fraction of relevant bodies that are high-value
+    primary_bodies = sum(
+        counts.get(k, 0) * w
+        for k, w in defn['body_weights'].items()
+        if w >= 0.70
+    )
+    all_bodies = max(sum(counts.get(k, 0) for k in defn['body_weights']), 1)
+    cp_efficiency = min(primary_bodies / all_bodies * 100, 100.0) if defn['body_weights'] else 50.0
+
+    # T3 scaling: strong link potential is the proxy
+    t3_scaling = topology.get('strong_link_potential', 30.0) if topology else 30.0
+
+    # Slot efficiency: how well orbital/ground balance matches archetype
+    slot_pref = defn.get('slot_preference', 'balanced')
+    ground  = topology.get('ground_synergy', 50) if topology else 50
+    orbital = topology.get('orbital_synergy', 50) if topology else 50
+
+    if slot_pref == 'ground_heavy':
+        slot_efficiency = ground * 0.70 + orbital * 0.30
+    elif slot_pref == 'orbital_heavy':
+        slot_efficiency = orbital * 0.70 + ground * 0.30
+    else:
+        slot_efficiency = (ground + orbital) / 2.0
+
+    # Contamination management penalty (up to -30)
+    contamination = topology.get('contamination_risk', 0.5) if topology else 0.5
+    contamination_penalty = contamination * 30
+
+    # Flexibility bonus (up to +10)
+    flexibility    = topology.get('build_flexibility', 50) if topology else 50
+    flexibility_bonus = flexibility * 0.10
+
+    raw = (
+        cp_efficiency   * 0.35 +
+        t3_scaling      * 0.25 +
+        slot_efficiency * 0.20 +
+        flexibility_bonus
+    ) - contamination_penalty
+
+    score = round(max(0.0, min(100.0, raw)), 2)
+
+    # Complexity classification
+    if score >= 80 and contamination < 0.20:
+        complexity = 'simple'
+    elif score >= 65 and contamination < 0.40:
+        complexity = 'moderate'
+    elif score >= 45:
+        complexity = 'advanced'
+    else:
+        complexity = 'expert'
+
+    return {
+        'buildability_score':    score,
+        'build_complexity':      complexity,
+        'cp_efficiency':         round(cp_efficiency, 2),
+        't3_scaling_viability':  round(t3_scaling, 2),
+        'slot_efficiency':       round(slot_efficiency, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rationale generation
+# ---------------------------------------------------------------------------
+
+def _tier(score: float) -> str:
+    if score >= 88:  return 'S'
+    if score >= 76:  return 'A'
+    if score >= 60:  return 'B'
+    if score >= 45:  return 'C'
+    return 'D'
+
+
+def _score_word(score: float) -> str:
+    if score >= 88: return 'Exceptional'
+    if score >= 76: return 'Excellent'
+    if score >= 60: return 'Solid'
+    if score >= 45: return 'Functional'
+    return 'Limited'
+
+
+def _build_positives(archetype_key, counts, topology, buildability) -> list:
+    positives = []
+    defn = ARCHETYPE_DEFINITIONS[archetype_key]
+
+    # High-value body presences
+    if counts.get('elw', 0) >= 1:
+        positives.append(f"{counts['elw']}× Earth-like World — strong link anchor")
+    if counts.get('black_hole', 0) >= 1:
+        positives.append('Black Hole — high Tourism + HighTech strong link')
+    if counts.get('neutron', 0) >= 1:
+        positives.append('Neutron Star — Tourism + HighTech boost')
+    if archetype_key in ('refinery_industrial', 'trade_logistics'):
+        if counts.get('rocky_clean', 0) >= 3:
+            positives.append(f"{counts['rocky_clean']} clean Rocky bodies — ideal for Refinery")
+        if counts.get('rocky_ice', 0) >= 2:
+            positives.append(f"{counts['rocky_ice']} Rocky-Ice bodies — Refinery + Industrial hybrid")
+    if archetype_key == 'extraction_refinery':
+        if counts.get('hmc', 0) >= 2:
+            positives.append(f"{counts['hmc']} HMC bodies — core Extraction resource")
+        if counts.get('metal_rich', 0) >= 1:
+            positives.append(f"{counts['metal_rich']} Metal-Rich bodies — Extraction bonus")
+    if topology:
+        if topology.get('strong_link_potential', 0) >= 60:
+            positives.append('Strong link potential ≥60 — T3 scaling viable')
+        if topology.get('contamination_risk', 1) < 0.20:
+            positives.append('Very low contamination risk — clean economy stack')
+    if buildability.get('build_complexity') in ('trivial', 'simple'):
+        positives.append('Simple build order — straightforward construction path')
+    if counts.get('terraformable', 0) >= 3:
+        positives.append(f"{counts['terraformable']} terraformable bodies — Agriculture + population growth")
+    return positives
+
+
+def _build_risks(counts, topology, contamination_data, buildability) -> list:
+    risks = []
+    if counts.get('rocky_geo', 0) >= 2:
+        risks.append(
+            f"{counts['rocky_geo']} geo-signal Rocky bodies — "
+            f"moderate Extraction/Industrial contamination risk"
+        )
+    if counts.get('rocky_bio', 0) >= 2:
+        risks.append(
+            f"{counts['rocky_bio']} bio-signal Rocky bodies — "
+            f"Agriculture/Terraforming contamination risk"
+        )
+    if contamination_data:
+        cr = contamination_data.get('risk_score', 0)
+        if cr > 0.60:
+            contam = contamination_data.get('primary_contaminant', 'unknown')
+            risks.append(
+                f"High {contam} contamination risk ({cr:.0%}) — "
+                f"Refinery Hubs required to maintain top-2 economies"
+            )
+    if topology:
+        if topology.get('weak_link_stability', 100) < 40:
+            risks.append('Low weak-link stability — tidal-lock bodies reduce Agriculture efficiency')
+    if buildability.get('build_complexity') == 'expert':
+        risks.append('Expert complexity — multi-phase build requires deep game knowledge')
+    return risks
+
+
+def _suggest_build_path(archetype_key, counts, contamination_data) -> str:
+    defn  = ARCHETYPE_DEFINITIONS[archetype_key]
+    pair  = defn.get('economy_pair')
+    risk  = contamination_data.get('risk_score', 0) if contamination_data else 0
+    contam = contamination_data.get('primary_contaminant', '') if contamination_data else ''
+
+    if pair is None:
+        return (
+            "No fixed build order — this is a flexible system. "
+            "Choose the economy pair that best matches your goals."
+        )
+
+    eco_a, eco_b = pair
+    if risk < 0.25:
+        return (
+            f"Straightforward: establish {eco_a} facilities first, then add "
+            f"{eco_b} to complete the pair. Low contamination risk."
+        )
+    elif risk < 0.50:
+        return (
+            f"Sequence {eco_a} facilities first to establish top-2 dominance. "
+            f"Monitor {contam} contamination from "
+            f"{counts.get('rocky_geo', 0) + counts.get('rocky_bio', 0)} "
+            f"contaminating bodies. Add Refinery Hubs on contaminating bodies "
+            f"early to suppress third-economy bleed."
+        )
+    else:
+        return (
+            f"High contamination from {contam} bodies. "
+            f"Place {eco_a} facilities on the cleanest bodies first. "
+            f"Dedicate Refinery Hubs to each contaminating body before "
+            f"expanding {eco_b} capacity. Consider avoiding the most "
+            f"contaminated bodies entirely."
+        )
+
+
+def _compute_display_tags(
+    archetype_key, counts, topology, buildability, contamination_data
+) -> list:
+    tags = []
+
+    # Body type tags
+    if counts.get('elw', 0) >= 1:
+        n = counts['elw']
+        tags.append('ELW' if n == 1 else f'{n}× ELW')
+    if counts.get('black_hole', 0) >= 1:
+        tags.append('Black Hole')
+    if counts.get('neutron', 0) >= 1:
+        tags.append('Neutron Star')
+    if counts.get('rocky_clean', 0) >= 3:
+        tags.append(f"{counts['rocky_clean']} Clean Rocky")
+    if counts.get('rocky_ice', 0) >= 2:
+        tags.append('Rocky-Ice')
+    if counts.get('hmc', 0) >= 2:
+        tags.append(f"{counts['hmc']} HMC")
+
+    # Quality tags
+    cr = contamination_data.get('risk_score', 1) if contamination_data else 0.5
+    if cr < 0.20:
+        tags.append('Low Contamination')
+    elif cr > 0.60:
+        tags.append('High Contamination')
+
+    if buildability.get('build_complexity') in ('trivial', 'simple'):
+        tags.append('T3 Friendly')
+    elif buildability.get('build_complexity') == 'expert':
+        tags.append('Expert Build')
+
+    # Slot tags
+    if topology:
+        slots = topology.get('estimated_total_slots', 0)
+        if slots >= 40:
+            tags.append(f'{slots}+ Slots')
+        elif slots >= 25:
+            tags.append(f'{slots} Slots')
+
+    if counts.get('terraformable', 0) >= 3:
+        tags.append('Terraformable')
+    if counts.get('landable', 0) >= 8:
+        tags.append(f"{counts['landable']} Landable")
+
+    return tags[:8]
+
+
+def generate_structured_rationale(
+    archetype_key: str,
+    archetype_score: dict,
+    counts: dict,
+    topology: Optional[dict],
+    buildability: dict,
+    contamination_data: Optional[dict],
+    confidence: float,
+) -> dict:
+    """
+    Generate a full structured rationale for a system's primary archetype.
+
+    Returns JSONB-ready dict matching the rationale schema:
+    {summary, tier, headline, positives[], risks[], complexity,
+     build_path, tags[], score_breakdown, data_confidence}
+    """
+    defn  = ARCHETYPE_DEFINITIONS[archetype_key]
+    score = archetype_score['score']
+    t     = _tier(score)
+
+    summary = (
+        f"{_score_word(score)} candidate for {defn['label']}. "
+        f"{len(counts.get('rocky_clean', []))} clean Rocky, "
+        f"{counts.get('elw', 0)} ELW."
+    )[:200]
+
+    positives = _build_positives(archetype_key, counts, topology, buildability)
+    risks     = _build_risks(counts, topology, contamination_data, buildability)
+    tags      = _compute_display_tags(
+        archetype_key, counts, topology, buildability, contamination_data
+    )
+
+    complexity_map = {
+        'trivial':  'Trivial — straightforward single-economy build',
+        'simple':   'Simple — clean pair, standard build order',
+        'moderate': 'Moderate — some contamination management required',
+        'advanced': 'Advanced — nested ports or tight sequencing needed',
+        'expert':   'Expert — multi-phase build, deep game knowledge required',
+    }
+    complexity_str = complexity_map.get(
+        buildability.get('build_complexity', 'moderate'), 'Moderate'
+    )
+
+    return {
+        'summary':    summary,
+        'tier':       t,
+        'headline':   f"{int(score)} — {defn['label']}",
+        'positives':  positives[:6],
+        'risks':      risks[:4],
+        'complexity': complexity_str,
+        'build_path': _suggest_build_path(archetype_key, counts, contamination_data),
+        'tags':       tags,
+        'score_breakdown': {
+            'body_composition':   archetype_score.get('body_contribution', 0),
+            'topology':           archetype_score.get('topology_contribution', 0),
+            'pair_synergy_pts':   archetype_score.get('synergy_pts', 0),
+            'purity_factor':      archetype_score.get('purity_factor', 1.0),
+            'contamination_risk': archetype_score.get('contamination_risk', 0),
+            'diversity_factor':   archetype_score.get('diversity_factor', 1.0),
+        },
+        'data_confidence': round(confidence, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# System scoring (single-system entry point)
+# ---------------------------------------------------------------------------
+
+def score_system(
+    system_id64: int,
+    bodies: list,
+    topology_row: Optional[dict],
+    pair_synergy_rows: list,
+    confidence: float,
+    base_synergy: dict,
+) -> dict:
+    """
+    Score a single system across all 10 archetypes.
+
+    Returns a dict ready for DB upsert into system_archetype_scores
+    and system_archetype_traits.
+    """
+    # Classify bodies using the lightweight classifier in build_topology
+    if _HAVE_TOPOLOGY:
+        counts = _classify_bodies_simple(bodies)
+    else:
+        # Minimal fallback
+        counts = {}
+
+    # Build pair synergy lookup
+    pair_lookup = {}
+    for pr in pair_synergy_rows:
+        key = f"{pr['economy_a']}+{pr['economy_b']}"
+        alt = f"{pr['economy_b']}+{pr['economy_a']}"
+        val = float(pr.get('synergy_score', 50)) / 100.0
+        pair_lookup[key] = val
+        pair_lookup[alt] = val
+
+    # Topology dict (may be None)
+    topo = topology_row
+
+    # Contamination for primary pair (computed below per archetype)
+    # Compute all 10 archetype scores
+    archetype_results = {}
+    for key in ARCHETYPE_KEYS:
+        defn       = ARCHETYPE_DEFINITIONS[key]
+        pair       = defn.get('economy_pair')
+        pair_score = 0.0
+
+        if pair:
+            pk = f"{pair[0]}+{pair[1]}"
+            pair_score = pair_lookup.get(pk, 0.50)
+
+        result = compute_archetype_score(key, counts, topo, pair_score)
+        archetype_results[key] = result
+
+    # Determine primary + secondary archetypes
+    sorted_archetypes = sorted(
+        archetype_results.items(), key=lambda kv: kv[1]['score'], reverse=True
+    )
+    primary_key   = sorted_archetypes[0][0]
+    secondary_key = sorted_archetypes[1][0] if len(sorted_archetypes) > 1 else 'unknown'
+    primary_score = archetype_results[primary_key]
+
+    # Archetype confidence: gap between 1st and 2nd score
+    score1 = sorted_archetypes[0][1]['score']
+    score2 = sorted_archetypes[1][1]['score'] if len(sorted_archetypes) > 1 else 0
+    archetype_confidence = round(
+        min((score1 - score2) / max(score1, 1) * 2.0, 1.0), 3
+    )
+
+    # Buildability for primary archetype
+    primary_pair  = ARCHETYPE_DEFINITIONS[primary_key].get('economy_pair')
+    primary_synergy = 0.0
+    if primary_pair:
+        pk = f"{primary_pair[0]}+{primary_pair[1]}"
+        primary_synergy = pair_lookup.get(pk, 0.50)
+
+    buildability = compute_buildability(counts, topo, primary_key, primary_synergy)
+
+    # Contamination for primary pair
+    if primary_pair:
+        contamination_data = compute_contamination_risk(counts, primary_pair)
+    else:
+        contamination_data = {'risk_score': 0.0, 'primary_contaminant': None,
+                              'contamination_paths': [], 'mitigation': ''}
+
+    # Purity score (inverse of contamination risk, 0-100)
+    purity_score      = round((1.0 - contamination_data['risk_score']) * 100, 2)
+    contamination_pct = round(contamination_data['risk_score'] * 100, 2)
+    stable_top_two    = round(1.0 - contamination_data['risk_score'] * 0.8, 3)
+
+    # Overall development potential
+    diversity     = _body_diversity(counts)
+    has_standout  = any([
+        counts.get('elw', 0) >= 1,
+        counts.get('black_hole', 0) >= 1,
+        counts.get('neutron', 0) >= 1,
+        counts.get('ww', 0) >= 2,
+        counts.get('terraformable', 0) >= 5,
+        counts.get('ammonia', 0) >= 1,
+    ])
+    odp = compute_overall_development_potential(
+        {k: v['score'] for k, v in archetype_results.items()},
+        diversity, has_standout, buildability['buildability_score'],
+    )
+
+    # Structured rationale for primary archetype
+    rationale = generate_structured_rationale(
+        primary_key, primary_score, counts, topo,
+        buildability, contamination_data, confidence,
+    )
+
+    # Score breakdown JSONB
+    score_breakdown = {
+        'per_archetype': {
+            k: {'score': v['score'], 'body': v['body_contribution'],
+                'topo': v['topology_contribution'], 'purity': v['purity_factor']}
+            for k, v in archetype_results.items()
+        },
+        'primary_archetype':  primary_key,
+        'primary_contamination': contamination_data.get('risk_score', 0),
+    }
+
+    # Build display tags
+    display_tags = _compute_display_tags(
+        primary_key, counts, topo, buildability, contamination_data
+    )
+
+    # Topology-derived slot counts
+    est_orbital = int(topo.get('estimated_orbital_slots', 0)) if topo else 0
+    est_ground  = int(topo.get('estimated_ground_slots',  0)) if topo else 0
+    est_total   = int(topo.get('estimated_total_slots',   0)) if topo else 0
+
+    return {
+        'scores': {
+            'system_id64':                   system_id64,
+            'primary_archetype':             primary_key,
+            'secondary_archetype':           secondary_key,
+            'archetype_confidence':          archetype_confidence,
+            'score_refinery_industrial':     archetype_results['refinery_industrial']['score'],
+            'score_extraction_refinery':     archetype_results['extraction_refinery']['score'],
+            'score_agriculture_terraforming':archetype_results['agriculture_terraforming']['score'],
+            'score_hitech_tourism':          archetype_results['hitech_tourism']['score'],
+            'score_expansion_capital':       archetype_results['expansion_capital']['score'],
+            'score_trade_logistics':         archetype_results['trade_logistics']['score'],
+            'score_population_capital':      archetype_results['population_capital']['score'],
+            'score_ax_forward_base':         archetype_results['ax_forward_base']['score'],
+            'score_military_industrial':     archetype_results['military_industrial']['score'],
+            'score_flexible_multirole':      archetype_results['flexible_multirole']['score'],
+            'overall_development_potential': odp,
+            'buildability_score':            buildability['buildability_score'],
+            'build_complexity':              buildability['build_complexity'],
+            'cp_efficiency':                 buildability['cp_efficiency'],
+            't3_scaling_viability':          buildability['t3_scaling_viability'],
+            'slot_efficiency':               buildability['slot_efficiency'],
+            'purity_score':                  purity_score,
+            'contamination_risk':            contamination_pct,
+            'stable_top_two_prob':           stable_top_two,
+            'confidence':                    confidence,
+            'score_breakdown':               score_breakdown,
+            'rationale':                     rationale,
+            'dirty':                         False,
+        },
+        'traits': {
+            'system_id64':        system_id64,
+            'has_elw':            counts.get('elw', 0) > 0,
+            'has_water_world':    counts.get('ww', 0) > 0,
+            'has_ammonia_world':  counts.get('ammonia', 0) > 0,
+            'has_black_hole':     counts.get('black_hole', 0) > 0,
+            'has_neutron_star':   counts.get('neutron', 0) > 0,
+            'has_white_dwarf':    counts.get('white_dwarf', 0) > 0,
+            'has_ringed_body':    counts.get('rocky_rings', 0) > 0,
+            'has_terraformables': counts.get('terraformable', 0) > 0,
+            'has_pristine_res':   False,   # populated from reserve_level when available
+            'has_bio_signals':    counts.get('bio', 0) > 0,
+            'has_geo_signals':    counts.get('geo', 0) > 0,
+            'is_scoopable_star':  False,   # populated from main_star_type when available
+            'elw_count':          int(counts.get('elw', 0)),
+            'ww_count':           int(counts.get('ww', 0)),
+            'ammonia_count':      int(counts.get('ammonia', 0)),
+            'gas_giant_count':    int(counts.get('gas_giant', 0)),
+            'rocky_clean_count':  int(counts.get('rocky_clean', 0)),
+            'rocky_ice_count':    int(counts.get('rocky_ice', 0)),
+            'icy_count':          int(counts.get('icy', 0)),
+            'hmc_count':          int(counts.get('hmc', 0)),
+            'metal_rich_count':   int(counts.get('metal_rich', 0)),
+            'landable_count':     int(counts.get('landable', 0)),
+            'terraformable_count':int(counts.get('terraformable', 0)),
+            'bio_signal_total':   int(counts.get('bio', 0)),
+            'geo_signal_total':   int(counts.get('geo', 0)),
+            'total_body_count':   len(bodies),
+            'est_orbital_slots':  est_orbital,
+            'est_ground_slots':   est_ground,
+            'est_total_slots':    est_total,
+            'display_tags':       display_tags,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# DB write helpers
+# ---------------------------------------------------------------------------
+
+def _write_scores_batch(conn, cur, scores_batch: list, traits_batch: list):
+    """Upsert a batch of archetype score + traits rows."""
+    if not scores_batch:
+        return
+
+    # system_archetype_scores upsert
+    score_args = [(
+        r['system_id64'],
+        r['primary_archetype'],
+        r['secondary_archetype'],
+        r['archetype_confidence'],
+        r['score_refinery_industrial'],
+        r['score_extraction_refinery'],
+        r['score_agriculture_terraforming'],
+        r['score_hitech_tourism'],
+        r['score_expansion_capital'],
+        r['score_trade_logistics'],
+        r['score_population_capital'],
+        r['score_ax_forward_base'],
+        r['score_military_industrial'],
+        r['score_flexible_multirole'],
+        r['overall_development_potential'],
+        r['buildability_score'],
+        r['build_complexity'],
+        r['cp_efficiency'],
+        r['t3_scaling_viability'],
+        r['slot_efficiency'],
+        r['purity_score'],
+        r['contamination_risk'],
+        r['stable_top_two_prob'],
+        r['confidence'],
+        json.dumps(r['score_breakdown']),
+        json.dumps(r['rationale']),
+        r['dirty'],
+    ) for r in scores_batch]
+
+    cur.executemany("""
+        INSERT INTO system_archetype_scores (
+            system_id64,
+            primary_archetype, secondary_archetype, archetype_confidence,
+            score_refinery_industrial, score_extraction_refinery,
+            score_agriculture_terraforming, score_hitech_tourism,
+            score_expansion_capital, score_trade_logistics,
+            score_population_capital, score_ax_forward_base,
+            score_military_industrial, score_flexible_multirole,
+            overall_development_potential,
+            buildability_score, build_complexity,
+            cp_efficiency, t3_scaling_viability, slot_efficiency,
+            purity_score, contamination_risk, stable_top_two_prob,
+            confidence, score_breakdown, rationale, dirty,
+            updated_at
+        ) VALUES (
+            %s,
+            %s::colony_archetype, %s::colony_archetype, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s,
+            %s, %s::build_complexity, %s, %s, %s,
+            %s, %s, %s,
+            %s, %s::jsonb, %s::jsonb, %s,
+            NOW()
+        )
+        ON CONFLICT (system_id64) DO UPDATE SET
+            primary_archetype              = EXCLUDED.primary_archetype,
+            secondary_archetype            = EXCLUDED.secondary_archetype,
+            archetype_confidence           = EXCLUDED.archetype_confidence,
+            score_refinery_industrial      = EXCLUDED.score_refinery_industrial,
+            score_extraction_refinery      = EXCLUDED.score_extraction_refinery,
+            score_agriculture_terraforming = EXCLUDED.score_agriculture_terraforming,
+            score_hitech_tourism           = EXCLUDED.score_hitech_tourism,
+            score_expansion_capital        = EXCLUDED.score_expansion_capital,
+            score_trade_logistics          = EXCLUDED.score_trade_logistics,
+            score_population_capital       = EXCLUDED.score_population_capital,
+            score_ax_forward_base          = EXCLUDED.score_ax_forward_base,
+            score_military_industrial      = EXCLUDED.score_military_industrial,
+            score_flexible_multirole       = EXCLUDED.score_flexible_multirole,
+            overall_development_potential  = EXCLUDED.overall_development_potential,
+            buildability_score             = EXCLUDED.buildability_score,
+            build_complexity               = EXCLUDED.build_complexity,
+            cp_efficiency                  = EXCLUDED.cp_efficiency,
+            t3_scaling_viability           = EXCLUDED.t3_scaling_viability,
+            slot_efficiency                = EXCLUDED.slot_efficiency,
+            purity_score                   = EXCLUDED.purity_score,
+            contamination_risk             = EXCLUDED.contamination_risk,
+            stable_top_two_prob            = EXCLUDED.stable_top_two_prob,
+            confidence                     = EXCLUDED.confidence,
+            score_breakdown                = EXCLUDED.score_breakdown,
+            rationale                      = EXCLUDED.rationale,
+            dirty                          = EXCLUDED.dirty,
+            updated_at                     = NOW()
+    """, score_args)
+
+    # system_archetype_traits upsert
+    if traits_batch:
+        traits_args = [(
+            r['system_id64'],
+            r['has_elw'], r['has_water_world'], r['has_ammonia_world'],
+            r['has_black_hole'], r['has_neutron_star'], r['has_white_dwarf'],
+            r['has_ringed_body'], r['has_terraformables'],
+            r['has_pristine_res'], r['has_bio_signals'],
+            r['has_geo_signals'], r['is_scoopable_star'],
+            r['elw_count'], r['ww_count'], r['ammonia_count'],
+            r['gas_giant_count'], r['rocky_clean_count'], r['rocky_ice_count'],
+            r['icy_count'], r['hmc_count'], r['metal_rich_count'],
+            r['landable_count'], r['terraformable_count'],
+            r['bio_signal_total'], r['geo_signal_total'], r['total_body_count'],
+            r['est_orbital_slots'], r['est_ground_slots'], r['est_total_slots'],
+            r['display_tags'],
+        ) for r in traits_batch]
+
+        cur.executemany("""
+            INSERT INTO system_archetype_traits (
+                system_id64,
+                has_elw, has_water_world, has_ammonia_world,
+                has_black_hole, has_neutron_star, has_white_dwarf,
+                has_ringed_body, has_terraformables,
+                has_pristine_res, has_bio_signals,
+                has_geo_signals, is_scoopable_star,
+                elw_count, ww_count, ammonia_count,
+                gas_giant_count, rocky_clean_count, rocky_ice_count,
+                icy_count, hmc_count, metal_rich_count,
+                landable_count, terraformable_count,
+                bio_signal_total, geo_signal_total, total_body_count,
+                est_orbital_slots, est_ground_slots, est_total_slots,
+                display_tags, updated_at
+            ) VALUES (
+                %s,
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s,
+                %s, NOW()
+            )
+            ON CONFLICT (system_id64) DO UPDATE SET
+                has_elw             = EXCLUDED.has_elw,
+                has_water_world     = EXCLUDED.has_water_world,
+                has_ammonia_world   = EXCLUDED.has_ammonia_world,
+                has_black_hole      = EXCLUDED.has_black_hole,
+                has_neutron_star    = EXCLUDED.has_neutron_star,
+                has_white_dwarf     = EXCLUDED.has_white_dwarf,
+                has_ringed_body     = EXCLUDED.has_ringed_body,
+                has_terraformables  = EXCLUDED.has_terraformables,
+                has_bio_signals     = EXCLUDED.has_bio_signals,
+                has_geo_signals     = EXCLUDED.has_geo_signals,
+                is_scoopable_star   = EXCLUDED.is_scoopable_star,
+                elw_count           = EXCLUDED.elw_count,
+                ww_count            = EXCLUDED.ww_count,
+                ammonia_count       = EXCLUDED.ammonia_count,
+                gas_giant_count     = EXCLUDED.gas_giant_count,
+                rocky_clean_count   = EXCLUDED.rocky_clean_count,
+                rocky_ice_count     = EXCLUDED.rocky_ice_count,
+                icy_count           = EXCLUDED.icy_count,
+                hmc_count           = EXCLUDED.hmc_count,
+                metal_rich_count    = EXCLUDED.metal_rich_count,
+                landable_count      = EXCLUDED.landable_count,
+                terraformable_count = EXCLUDED.terraformable_count,
+                bio_signal_total    = EXCLUDED.bio_signal_total,
+                geo_signal_total    = EXCLUDED.geo_signal_total,
+                total_body_count    = EXCLUDED.total_body_count,
+                est_orbital_slots   = EXCLUDED.est_orbital_slots,
+                est_ground_slots    = EXCLUDED.est_ground_slots,
+                est_total_slots     = EXCLUDED.est_total_slots,
+                display_tags        = EXCLUDED.display_tags,
+                updated_at          = NOW()
+        """, traits_args)
+
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Worker process
+# ---------------------------------------------------------------------------
+
+def worker_process(worker_id: int, system_ids: list, db_dsn: str):
+    """Worker: fetch bodies + topology, compute archetype scores, write DB."""
+    hb   = WorkerHeartbeat(worker_id)
+    conn = _connect_with_retry(db_dsn, label=f'archetype_worker_{worker_id}')
+    cur  = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    base_synergy  = _load_base_synergy(conn) if _HAVE_TOPOLOGY else BASE_SYNERGY.copy()
+    processed     = 0
+    errors        = 0
+    scores_batch  = []
+    traits_batch  = []
+    WRITE_EVERY   = 500
+
+    try:
+        for system_id64 in system_ids:
+            hb.tick()
+            try:
+                # Fetch bodies
+                cur.execute("""
+                    SELECT body_id, name, body_type, subtype,
+                           is_landable, is_terraformable,
+                           bio_signal_count, geo_signal_count,
+                           distance_from_star, radius, gravity,
+                           has_rings
+                    FROM bodies WHERE system_id64 = %s
+                """, (system_id64,))
+                bodies = [dict(r) for r in cur.fetchall()]
+
+                # Fetch topology row (may not exist)
+                cur.execute("""
+                    SELECT estimated_orbital_slots, estimated_ground_slots,
+                           estimated_total_slots, orbital_synergy, ground_synergy,
+                           build_flexibility, contamination_risk,
+                           strong_link_potential, weak_link_stability,
+                           nesting_potential, has_viable_surface_port,
+                           has_deep_orbital_anchor
+                    FROM system_slot_topology WHERE system_id64 = %s
+                """, (system_id64,))
+                topo_row = cur.fetchone()
+                topo = dict(topo_row) if topo_row else None
+
+                # Fetch pair synergy rows
+                cur.execute("""
+                    SELECT economy_a, economy_b, synergy_score
+                    FROM economy_pair_synergy WHERE system_id64 = %s
+                """, (system_id64,))
+                pair_rows = [dict(r) for r in cur.fetchall()]
+
+                # Fetch confidence from ratings table
+                cur.execute(
+                    "SELECT confidence FROM ratings WHERE system_id64 = %s",
+                    (system_id64,)
+                )
+                conf_row   = cur.fetchone()
+                confidence = float(conf_row['confidence']) if conf_row else 0.85
+
+                # Score
+                result = score_system(
+                    system_id64, bodies, topo, pair_rows,
+                    confidence, base_synergy,
+                )
+
+                scores_batch.append(result['scores'])
+                traits_batch.append(result['traits'])
+                processed += 1
+
+                if len(scores_batch) >= WRITE_EVERY:
+                    _write_scores_batch(conn, cur, scores_batch, traits_batch)
+                    scores_batch.clear()
+                    traits_batch.clear()
+
+            except Exception as e:
+                errors += 1
+                log.warning(f"Worker {worker_id}: error on {system_id64}: {e}")
+                conn.rollback()
+
+        if scores_batch:
+            _write_scores_batch(conn, cur, scores_batch, traits_batch)
+
+    finally:
+        cur.close()
+        conn.close()
+
+    return {'worker_id': worker_id, 'processed': processed, 'errors': errors}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def _fetch_system_ids(conn, mode: str, limit: Optional[int]) -> list:
+    with conn.cursor() as cur:
+        if mode == 'dirty':
+            cur.execute("""
+                SELECT system_id64 FROM system_archetype_scores
+                WHERE dirty = TRUE
+                ORDER BY system_id64
+                LIMIT %s
+            """, (limit or 10_000_000,))
+        elif mode == 'rebuild':
+            cur.execute("""
+                SELECT id64 FROM systems ORDER BY id64 LIMIT %s
+            """, (limit or 10_000_000,))
+        else:
+            cur.execute("""
+                SELECT r.system_id64
+                FROM ratings r
+                LEFT JOIN system_archetype_scores a ON a.system_id64 = r.system_id64
+                WHERE a.system_id64 IS NULL
+                ORDER BY r.system_id64
+                LIMIT %s
+            """, (limit or 10_000_000,))
+        return [row[0] for row in cur.fetchall()]
+
+
+def main():
+    parser = argparse.ArgumentParser(description='ED Finder — Archetype Scorer')
+    parser.add_argument('--rebuild', action='store_true')
+    parser.add_argument('--dirty',   action='store_true')
+    parser.add_argument('--workers', type=int, default=mp.cpu_count())
+    parser.add_argument('--chunk',   type=int, default=BATCH_SIZE)
+    parser.add_argument('--limit',   type=int, default=None)
+    args = parser.parse_args()
+
+    startup_banner('build_archetype_scores', '1.0')
+    t_start = time.time()
+
+    mode = 'dirty' if args.dirty else ('rebuild' if args.rebuild else 'new')
+    log.info(f"Mode: {mode} | Workers: {args.workers} | Chunk: {args.chunk}")
+
+    conn = _connect_with_retry(DB_DSN, label='archetype_main')
+    try:
+        stage_banner('Fetching system IDs')
+        system_ids = _fetch_system_ids(conn, mode, args.limit)
+        log.info(f"  {fmt_num(len(system_ids))} systems to score")
+    finally:
+        conn.close()
+
+    if not system_ids:
+        log.info("Nothing to score.")
+        done_banner('build_archetype_scores', time.time() - t_start, 0)
+        return
+
+    chunks = [
+        system_ids[i:i + args.chunk]
+        for i in range(0, len(system_ids), args.chunk)
+    ]
+
+    stage_banner('Scoring archetypes')
+    with mp.Pool(processes=args.workers) as pool:
+        results = pool.starmap(
+            worker_process,
+            [(i % args.workers, chunk, DB_DSN) for i, chunk in enumerate(chunks)]
+        )
+
+    total_processed = sum(r['processed'] for r in results)
+    total_errors    = sum(r['errors']    for r in results)
+
+    done_banner('build_archetype_scores', time.time() - t_start, total_processed)
+    log.info(f"  Processed: {fmt_num(total_processed)} | Errors: {fmt_num(total_errors)}")
+    if total_errors:
+        log.warning(f"  {total_errors} systems failed — check log for details")
+
+    log.info(
+        "Run: REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings; "
+        "to update the rankings view."
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/apps/importer/src/build_topology.py
+++ b/apps/importer/src/build_topology.py
@@ -1,0 +1,1032 @@
+#!/usr/bin/env python3
+"""
+ED Finder — Topology & Slot Inference Engine
+Version: 1.0
+
+Runs AFTER build_ratings.py. Reads from the bodies + ratings tables,
+computes inferred slot topology and economy pair synergy, then writes
+to system_slot_topology and economy_pair_synergy.
+
+IMPORTANT: Slot counts are ESTIMATES derived from body physics.
+Frontier does not expose actual slot counts via any public API or
+data feed. All slot figures produced by this script are labelled
+as estimated throughout.
+
+Usage:
+    python3 build_topology.py              # process all unprocessed systems
+    python3 build_topology.py --rebuild    # reprocess ALL systems
+    python3 build_topology.py --dirty      # only systems flagged dirty in ratings
+    python3 build_topology.py --workers 4  # override worker count (default: CPU count)
+    python3 build_topology.py --chunk 10000
+    python3 build_topology.py --limit 50000  # process at most N systems (dev/test)
+
+Pipeline position:
+    1. import_spansh.py   → systems, bodies, stations
+    2. build_ratings.py   → ratings table (existing)
+    3. build_topology.py  → system_slot_topology, economy_pair_synergy  ← THIS
+    4. build_archetype_scores.py → system_archetype_scores, system_archetype_traits
+"""
+
+import os
+import sys
+import json
+import time
+import math
+import logging
+import argparse
+import datetime
+import multiprocessing as mp
+from typing import Optional
+
+import psycopg2
+import psycopg2.extras
+
+from progress import (
+    ProgressReporter, WorkerHeartbeat,
+    startup_banner, stage_banner, done_banner, crash_hint,
+    fmt_num, fmt_duration, fmt_rate,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def _make_direct_dsn(url: str) -> str:
+    """Bypass pgBouncer — transaction-pool mode breaks long-running workers."""
+    direct = os.getenv('DB_DSN_DIRECT', '')
+    if direct:
+        return direct
+    if ':5433/' in url:
+        url = url.replace(':5433/', ':5432/')
+    url = url.replace('@pgbouncer:', '@postgres:')
+    return url
+
+
+def _connect_with_retry(dsn: str, label: str = 'topology', retries: int = 10,
+                        delay: float = 5.0):
+    """Connect with exponential back-off retries."""
+    for attempt in range(1, retries + 1):
+        try:
+            conn = psycopg2.connect(
+                dsn,
+                keepalives=1,
+                keepalives_idle=60,
+                keepalives_interval=10,
+                keepalives_count=6,
+                options=(
+                    f"-c application_name={label} "
+                    f"-c statement_timeout=0 "
+                    f"-c idle_in_transaction_session_timeout=3600000"
+                )
+            )
+            return conn
+        except Exception as e:
+            if attempt == retries:
+                raise
+            wait = min(delay * attempt, 60)
+            logging.warning(f"  DB connect failed ({label}, attempt {attempt}/{retries}): {e}")
+            time.sleep(wait)
+
+
+_raw_url   = os.environ['DATABASE_URL']
+DB_DSN     = _make_direct_dsn(_raw_url)
+BATCH_SIZE = int(os.getenv('BATCH_SIZE', '5000'))
+LOG_LEVEL  = os.getenv('LOG_LEVEL', 'INFO')
+LOG_FILE   = os.getenv('LOG_FILE', '/tmp/build_topology.log')
+
+os.makedirs(os.path.dirname(os.path.abspath(LOG_FILE)), exist_ok=True)
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL),
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(sys.stdout),
+    ]
+)
+log = logging.getLogger('build_topology')
+
+
+# ---------------------------------------------------------------------------
+# Slot estimation
+# ---------------------------------------------------------------------------
+# These are COMMUNITY-DERIVED estimates from observation of the in-game
+# Architect Mode slot display. They are NOT from any official Frontier API.
+
+def estimate_body_slots(body: dict) -> tuple:
+    """
+    Estimate (orbital_slots, ground_slots) for a single body.
+
+    Ground slots are non-zero only for landable bodies.
+    Returns a tuple of (int, int).
+    """
+    sub        = str(body.get('subtype') or '').lower()
+    is_land    = bool(body.get('is_landable', False))
+    radius_km  = float(body.get('radius') or 0)
+    body_type  = str(body.get('body_type') or '').lower()
+    sc         = str(body.get('spectral_class') or '')
+    is_main    = bool(body.get('is_main_star', False))
+    has_rings  = bool(body.get('has_rings', False))
+
+    # ── Stars ─────────────────────────────────────────────────────────────────
+    if body_type == 'star':
+        if is_main:
+            first = sc[0].upper() if sc else ''
+            if first in ('O', 'B', 'A'):
+                return (10, 0)
+            elif first in ('F', 'G', 'K'):
+                return (7, 0)
+            else:
+                return (4, 0)
+        else:
+            return (5, 0)
+
+    # ── Gas Giants ────────────────────────────────────────────────────────────
+    if 'gas giant' in sub:
+        return (5 if has_rings else 3, 0)
+
+    # ── Special worlds ────────────────────────────────────────────────────────
+    if 'earth-like' in sub or 'earthlike' in sub:
+        return (4, 8 if is_land else 0)
+    if 'water world' in sub:
+        return (3, 0)
+    if 'ammonia' in sub:
+        return (3, 0)
+
+    # ── Rocky Ice ─────────────────────────────────────────────────────────────
+    if 'rocky ice' in sub:
+        return (3, 3 if is_land else 0)
+
+    # ── Rocky Bodies ──────────────────────────────────────────────────────────
+    if 'rocky body' in sub or sub == 'rocky':
+        if radius_km > 5000:
+            return (3, 6 if is_land else 0)
+        elif radius_km > 2500:
+            return (2, 4 if is_land else 0)
+        else:
+            return (2, 2 if is_land else 0)
+
+    # ── High Metal Content ────────────────────────────────────────────────────
+    if 'high metal content' in sub:
+        if radius_km > 4000:
+            return (3, 5 if is_land else 0)
+        else:
+            return (2, 3 if is_land else 0)
+
+    # ── Metal Rich ────────────────────────────────────────────────────────────
+    if 'metal-rich' in sub or 'metal rich' in sub:
+        return (2, 3 if is_land else 0)
+
+    # ── Icy Bodies ────────────────────────────────────────────────────────────
+    if 'icy body' in sub or sub == 'icy':
+        if is_land and radius_km > 2000:
+            return (2, 2)
+        return (2, 0)
+
+    # ── Default fallback ──────────────────────────────────────────────────────
+    return (1, 1 if is_land else 0)
+
+
+# ---------------------------------------------------------------------------
+# Topology metrics
+# ---------------------------------------------------------------------------
+
+def _distance_weight(ls) -> float:
+    """Weight a body by its distance from the arrival star."""
+    if ls is None:
+        return 1.0
+    try:
+        ls = float(ls)
+    except (TypeError, ValueError):
+        return 1.0
+    if ls <= 1_000:
+        return 1.0
+    if ls <= 10_000:
+        return 0.85
+    if ls <= 100_000:
+        return 0.60
+    return 0.30
+
+
+def compute_topology_metrics(bodies: list, counts: dict) -> dict:
+    """
+    Compute system-level topology metrics from the full body list and
+    the pre-computed classify_bodies() counts dict.
+
+    Returns a dict matching the system_slot_topology column set.
+    """
+    # ── Slot estimation ───────────────────────────────────────────────────────
+    total_orbital = 0
+    total_ground  = 0
+    orbital_quality = 0.0
+    ground_quality  = 0.0
+    body_slot_list  = []
+
+    for body in bodies:
+        orb, gnd = estimate_body_slots(body)
+        dw = _distance_weight(body.get('distance_from_star'))
+
+        total_orbital += orb
+        total_ground  += gnd
+        orbital_quality += orb * dw * 10.0
+        if gnd > 0:
+            ground_quality += gnd * dw * 10.0
+
+        body_slot_list.append({
+            'body_id':       body.get('body_id'),
+            'body_name':     body.get('name', ''),
+            'body_type':     str(body.get('body_type') or ''),
+            'subtype':       str(body.get('subtype') or ''),
+            'distance_ls':   body.get('distance_from_star'),
+            'est_orbital':   orb,
+            'est_ground':    gnd,
+            'is_landable':   bool(body.get('is_landable', False)),
+        })
+
+    orbital_quality = min(orbital_quality, 100.0)
+    ground_quality  = min(ground_quality,  100.0)
+    total_slots     = total_orbital + total_ground
+
+    slot_density = (orbital_quality + ground_quality) / 2.0 if total_slots > 0 else 0.0
+
+    # ── Strong link potential ─────────────────────────────────────────────────
+    # Driven by body types that produce strong economy links.
+    strong_link_raw = sum([
+        counts.get('elw', 0)          * 25,
+        counts.get('ww', 0)           * 18,
+        counts.get('ammonia', 0)      * 20,
+        counts.get('gas_giant', 0)    * 12,
+        counts.get('rocky_rings', 0)  * 8,
+        counts.get('black_hole', 0)   * 22,
+        counts.get('neutron', 0)      * 18,
+        counts.get('white_dwarf', 0)  * 10,
+    ])
+    strong_link_potential = min(float(strong_link_raw), 100.0)
+
+    # ── Weak link stability ───────────────────────────────────────────────────
+    # High stability = system resists weak-link degradation.
+    destabilisers = (
+        counts.get('tidal_lock', 0) * 8 +
+        counts.get('icy', 0)        * 4
+    )
+    weak_link_stability = float(max(100 - destabilisers, 0))
+
+    # ── Orbital synergy ───────────────────────────────────────────────────────
+    orbital_raw = (
+        counts.get('gas_giant', 0)     * 6 +
+        counts.get('elw', 0)           * 5 +
+        counts.get('ww', 0)            * 4 +
+        counts.get('ammonia', 0)       * 4 +
+        counts.get('rocky_ice', 0)     * 3 +
+        counts.get('icy', 0)           * 3 +
+        counts.get('rocky_clean', 0)   * 3 +
+        counts.get('hmc', 0)           * 3 +
+        counts.get('metal_rich', 0)    * 2
+    )
+    orbital_synergy = min(float(orbital_raw * 5), 100.0)
+
+    # ── Ground synergy ────────────────────────────────────────────────────────
+    ground_raw = (
+        counts.get('landable', 0)              * 10 +
+        counts.get('landable_rocky_clean', 0)  * 5 +
+        counts.get('landable_hmc', 0)          * 4
+    )
+    ground_synergy = min(float(ground_raw * 4), 100.0)
+
+    # ── Build flexibility ─────────────────────────────────────────────────────
+    # Proxy for body diversity — more distinct types = more build paths.
+    type_counts = [
+        min(counts.get(k, 0), 1)
+        for k in ('rocky_clean', 'rocky_ice', 'icy', 'hmc', 'metal_rich',
+                  'gas_giant', 'elw', 'ww', 'ammonia', 'rocky_geo', 'rocky_bio')
+    ]
+    distinct_types = sum(type_counts)
+    build_flexibility = min(float(distinct_types / 11.0 * 100), 100.0)
+
+    # ── Nesting potential ─────────────────────────────────────────────────────
+    nesting_potential = min(
+        float(counts.get('gas_giant', 0) * 20 + counts.get('rocky_clean', 0) * 8),
+        100.0
+    )
+
+    # ── Contamination risk (topology-level estimate) ──────────────────────────
+    # Counts body types that add competing economies.
+    contaminators = (
+        counts.get('rocky_geo', 0)   * 0.85 +
+        counts.get('rocky_mixed', 0) * 0.95 +
+        counts.get('rocky_bio', 0)   * 0.55 +
+        counts.get('rocky_rings', 0) * 0.25 +
+        counts.get('ammonia', 0)     * 0.40 +
+        counts.get('gas_giant', 0)   * 0.30
+    )
+    total_relevant = max(sum([
+        counts.get('rocky_geo', 0),
+        counts.get('rocky_mixed', 0),
+        counts.get('rocky_bio', 0),
+        counts.get('rocky_rings', 0),
+        counts.get('ammonia', 0),
+        counts.get('gas_giant', 0),
+        counts.get('rocky_clean', 0),
+        counts.get('rocky_ice', 0),
+        counts.get('icy', 0),
+        counts.get('hmc', 0),
+        counts.get('elw', 0),
+    ]), 1)
+    contamination_risk = round(min(contaminators / total_relevant, 1.0), 3)
+
+    # ── Topology flags ────────────────────────────────────────────────────────
+    has_viable_surface_port = (
+        counts.get('landable', 0) > 0 and
+        (counts.get('landable_rocky_any', 0) + counts.get('landable_hmc', 0)) > 0
+    )
+    has_deep_orbital_anchor = counts.get('gas_giant', 0) > 0
+    has_ringed_gas_giant    = counts.get('rocky_rings', 0) > 0   # best proxy without ring data
+    has_binary              = counts.get('secondary_star', 0) > 0
+
+    return {
+        'estimated_orbital_slots': int(total_orbital),
+        'estimated_ground_slots':  int(total_ground),
+        'estimated_total_slots':   int(total_slots),
+        'orbital_slot_quality':    round(orbital_quality, 2),
+        'ground_slot_quality':     round(ground_quality, 2),
+        'slot_density_score':      round(slot_density, 2),
+        'body_slots':              body_slot_list,
+        'local_body_groups':       [],   # populated separately if parents[] available
+        'strong_link_potential':   round(strong_link_potential, 2),
+        'weak_link_stability':     round(weak_link_stability, 2),
+        'nesting_potential':       round(nesting_potential, 2),
+        'orbital_synergy':         round(orbital_synergy, 2),
+        'ground_synergy':          round(ground_synergy, 2),
+        'build_flexibility':       round(build_flexibility, 2),
+        'contamination_risk':      contamination_risk,
+        'has_viable_surface_port': has_viable_surface_port,
+        'has_deep_orbital_anchor': has_deep_orbital_anchor,
+        'has_ringed_gas_giant':    has_ringed_gas_giant,
+        'has_binary_or_trinary':   has_binary,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Economy pair synergy
+# ---------------------------------------------------------------------------
+
+# Global baseline synergy values (0-1).
+# Loaded from pair_synergy_constants at runtime; these are the hard-coded
+# fallback if the DB table hasn't been seeded yet.
+BASE_SYNERGY = {
+    'Refinery+Industrial':   0.95,
+    'Agriculture+Tourism':   0.91,
+    'HighTech+Tourism':      0.88,
+    'Extraction+Refinery':   0.82,
+    'Agriculture+HighTech':  0.79,
+    'HighTech+Military':     0.76,
+    'Industrial+Military':   0.74,
+    'Refinery+Military':     0.58,
+    'Extraction+Industrial': 0.55,
+    'Agriculture+Refinery':  0.28,
+    'Tourism+Refinery':      0.22,
+}
+
+PAIR_MODIFIERS = {
+    'Refinery+Industrial': {
+        'rocky_ice':   +0.08,
+        'icy':         +0.05,
+        'rocky_clean': +0.04,
+        'rocky_geo':   -0.12,
+        'rocky_bio':   -0.08,
+    },
+    'Agriculture+Tourism': {
+        'elw':         +0.12,
+        'ww':          +0.08,
+        'ammonia':     +0.06,
+        'terraformable': +0.04,
+        'tidal_lock':  -0.06,
+        'icy':         -0.05,
+    },
+    'HighTech+Tourism': {
+        'black_hole':  +0.15,
+        'neutron':     +0.10,
+        'ammonia':     +0.10,
+        'gas_giant':   +0.06,
+        'elw':         +0.08,
+    },
+    'Extraction+Refinery': {
+        'hmc':         +0.10,
+        'hmc_geo':     +0.08,
+        'metal_rich':  +0.06,
+        'rocky_rings': +0.04,
+        'rocky_geo':   -0.05,
+    },
+    'Agriculture+HighTech': {
+        'elw':         +0.10,
+        'ww':          +0.05,
+        'rocky_bio':   +0.04,
+        'rocky_geo':   -0.08,
+        'icy':         -0.04,
+    },
+    'HighTech+Military': {
+        'elw':         +0.10,
+        'neutron':     +0.08,
+        'black_hole':  +0.07,
+        'gas_giant':   +0.05,
+    },
+    'Industrial+Military': {
+        'icy':         +0.08,
+        'rocky_ice':   +0.06,
+        'rocky_clean': +0.04,
+        'rocky_geo':   -0.06,
+    },
+}
+
+# Economy pairs to compute synergy for (canonical order, alphabetic within pair)
+ECONOMY_PAIRS = [
+    ('Agriculture', 'HighTech'),
+    ('Agriculture', 'Tourism'),
+    ('Agriculture', 'Refinery'),
+    ('Extraction',  'Industrial'),
+    ('Extraction',  'Refinery'),
+    ('HighTech',    'Military'),
+    ('HighTech',    'Tourism'),
+    ('Industrial',  'Military'),
+    ('Refinery',    'Industrial'),
+    ('Refinery',    'Military'),
+    ('Tourism',     'Refinery'),
+]
+
+
+def _load_base_synergy(conn) -> dict:
+    """Load pair_synergy_constants from DB into a lookup dict."""
+    synergy = {}
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT economy_a, economy_b, base_synergy "
+                "FROM pair_synergy_constants"
+            )
+            for row in cur.fetchall():
+                key = f"{row[0]}+{row[1]}"
+                alt = f"{row[1]}+{row[0]}"
+                synergy[key] = float(row[2])
+                synergy[alt] = float(row[2])
+    except Exception as e:
+        log.warning(f"Could not load pair_synergy_constants: {e}. Using defaults.")
+    return synergy or BASE_SYNERGY.copy()
+
+
+def compute_system_pair_synergy(
+    economy_a: str,
+    economy_b: str,
+    counts: dict,
+    topology: dict,
+    base_synergy: dict,
+) -> float:
+    """
+    Compute system-specific pair synergy score (0-1).
+    Starts from the global baseline and applies body-type modifiers.
+    """
+    pair_key = f'{economy_a}+{economy_b}'
+    alt_key  = f'{economy_b}+{economy_a}'
+
+    base = base_synergy.get(pair_key, base_synergy.get(alt_key, 0.50))
+    mods = PAIR_MODIFIERS.get(pair_key, PAIR_MODIFIERS.get(alt_key, {}))
+
+    adjusted = base
+    for body_key, modifier in mods.items():
+        count = counts.get(body_key, 0)
+        if count > 0:
+            effect = modifier + modifier * 0.5 * (min(count, 4) - 1)
+            adjusted += effect
+
+    # Topology modifier
+    if topology:
+        cr = topology.get('contamination_risk', 0.5)
+        if cr < 0.20:
+            adjusted += 0.05
+        elif cr > 0.70:
+            adjusted -= 0.10
+
+    return round(max(0.0, min(1.0, adjusted)), 3)
+
+
+def compute_contamination_risk(counts: dict, target_pair: tuple) -> dict:
+    """
+    Estimate the risk that a third economy contaminates the target pair.
+
+    Returns dict: {risk_score, primary_contaminant, contamination_paths, mitigation}
+    """
+    economy_a, economy_b = target_pair
+
+    BODY_ECONOMY_ADDS = {
+        'rocky_geo':   ['Extraction', 'Industrial'],
+        'rocky_bio':   ['Agriculture', 'Terraforming'],
+        'rocky_rings': ['Extraction'],
+        'rocky_mixed': ['Extraction', 'Industrial', 'Agriculture', 'Terraforming'],
+        'hmc_geo':     ['Extraction'],
+        'ammonia':     ['HighTech', 'Tourism'],
+        'elw':         ['Agriculture', 'HighTech', 'Military', 'Tourism'],
+        'ww':          ['Agriculture', 'Tourism'],
+        'gas_giant':   ['HighTech', 'Industrial'],
+        'neutron':     ['HighTech', 'Tourism'],
+        'black_hole':  ['HighTech', 'Tourism'],
+    }
+    SEVERITY = {
+        'rocky_geo':   0.85,
+        'rocky_mixed': 0.95,
+        'rocky_bio':   0.55,
+        'rocky_rings': 0.25,
+        'ammonia':     0.40,
+        'gas_giant':   0.30,
+        'elw':         0.35,
+        'ww':          0.25,
+        'hmc_geo':     0.50,
+        'neutron':     0.20,
+        'black_hole':  0.20,
+    }
+
+    contaminant_scores = {}
+    contamination_events = []
+
+    for body_key, economies in BODY_ECONOMY_ADDS.items():
+        count = counts.get(body_key, 0)
+        if count == 0:
+            continue
+        severity = SEVERITY.get(body_key, 0.20)
+        for eco in economies:
+            if eco not in (economy_a, economy_b):
+                score = severity * min(count, 3) / 3.0
+                contaminant_scores[eco] = contaminant_scores.get(eco, 0) + score
+                contamination_events.append({
+                    'body':     body_key,
+                    'economy':  eco,
+                    'severity': round(severity, 2),
+                    'count':    count,
+                })
+
+    if not contaminant_scores:
+        return {
+            'risk_score':          0.0,
+            'primary_contaminant': None,
+            'contamination_paths': [],
+            'mitigation':          'Low risk — standard build order sufficient',
+        }
+
+    overall_risk = min(
+        sum(contaminant_scores.values()) / max(len(contaminant_scores), 1),
+        1.0
+    )
+    primary = max(contaminant_scores, key=contaminant_scores.get)
+
+    if overall_risk < 0.20:
+        mitigation = 'Low risk — standard build order sufficient'
+    elif overall_risk < 0.45:
+        mitigation = (
+            f'Moderate {primary} contamination risk. '
+            f'Sequence {economy_a} facilities first to establish top-2 '
+            f'before {primary} gains foothold.'
+        )
+    else:
+        mitigation = (
+            f'High {primary} contamination risk. '
+            f'Refinery/Industrial Hubs required to maintain '
+            f'{economy_a}+{economy_b} dominance. Consider dedicated '
+            f'strong-link facilities on contaminating bodies.'
+        )
+
+    return {
+        'risk_score':          round(overall_risk, 3),
+        'primary_contaminant': primary,
+        'contamination_paths': contamination_events[:5],
+        'mitigation':          mitigation,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Worker process
+# ---------------------------------------------------------------------------
+
+def _classify_bodies_simple(bodies: list) -> dict:
+    """
+    Lightweight body classifier for topology use.
+    Produces the subset of classify_bodies() counts needed by topology functions.
+    For full classification, build_ratings.py's classify_bodies() is authoritative.
+    """
+    counts = {k: 0 for k in [
+        'rocky_clean', 'rocky_geo', 'rocky_bio', 'rocky_rings', 'rocky_mixed',
+        'rocky_ice', 'icy', 'hmc', 'hmc_geo', 'metal_rich', 'gas_giant',
+        'elw', 'ww', 'ammonia', 'landable', 'landable_rocky_clean',
+        'landable_rocky_any', 'landable_hmc', 'terraformable',
+        'bio', 'geo', 'tidal_lock', 'neutron', 'black_hole', 'white_dwarf',
+        'secondary_star',
+    ]}
+
+    for body in bodies:
+        sub  = str(body.get('subtype') or '').lower()
+        btype = str(body.get('body_type') or '').lower()
+        land  = bool(body.get('is_landable', False))
+        bio   = int(body.get('bio_signal_count') or 0)
+        geo   = int(body.get('geo_signal_count') or 0)
+        terra = bool(body.get('is_terraformable', False))
+        tlock = bool(body.get('is_tidally_locked', False))
+        is_main = bool(body.get('is_main_star', False))
+
+        if btype == 'star':
+            if not is_main:
+                counts['secondary_star'] += 1
+            if 'neutron' in sub:
+                counts['neutron'] += 1
+            elif 'black hole' in sub:
+                counts['black_hole'] += 1
+            elif 'white dwarf' in sub or sub in ('d', 'da', 'db', 'dc'):
+                counts['white_dwarf'] += 1
+            continue
+
+        if 'gas giant' in sub:
+            counts['gas_giant'] += 1
+            continue
+
+        if 'earth-like' in sub or 'earthlike' in sub:
+            counts['elw'] += 1
+            if land:
+                counts['landable'] += 1
+            continue
+
+        if 'water world' in sub:
+            counts['ww'] += 1
+            continue
+
+        if 'ammonia' in sub:
+            counts['ammonia'] += 1
+            continue
+
+        if 'rocky ice' in sub:
+            counts['rocky_ice'] += 1
+            if land:
+                counts['landable'] += 1
+            continue
+
+        if 'high metal content' in sub:
+            if geo > 0:
+                counts['hmc_geo'] += 1
+            else:
+                counts['hmc'] += 1
+            if land:
+                counts['landable'] += 1
+                counts['landable_hmc'] += 1
+            continue
+
+        if 'metal-rich' in sub or 'metal rich' in sub:
+            counts['metal_rich'] += 1
+            if land:
+                counts['landable'] += 1
+            continue
+
+        if 'icy body' in sub or sub == 'icy':
+            counts['icy'] += 1
+            if land:
+                counts['landable'] += 1
+            continue
+
+        if 'rocky body' in sub or sub == 'rocky':
+            modifiers = (1 if geo > 0 else 0) + (1 if bio > 0 else 0)
+            has_rings = bool(body.get('has_rings', False))
+            ring_mod  = 1 if has_rings else 0
+            total_mods = modifiers + ring_mod
+
+            if total_mods == 0:
+                counts['rocky_clean'] += 1
+                if land:
+                    counts['landable_rocky_clean'] += 1
+                    counts['landable_rocky_any']   += 1
+            elif total_mods >= 2:
+                counts['rocky_mixed'] += 1
+                if land:
+                    counts['landable_rocky_any'] += 1
+            elif geo > 0:
+                counts['rocky_geo'] += 1
+                if land:
+                    counts['landable_rocky_any'] += 1
+            elif bio > 0:
+                counts['rocky_bio'] += 1
+                if land:
+                    counts['landable_rocky_any'] += 1
+            elif has_rings:
+                counts['rocky_rings'] += 1
+                if land:
+                    counts['landable_rocky_any'] += 1
+
+            if land:
+                counts['landable'] += 1
+            continue
+
+        # Generic landable fallback
+        if land:
+            counts['landable'] += 1
+
+        if terra:
+            counts['terraformable'] += 1
+        if tlock:
+            counts['tidal_lock'] += 1
+        counts['bio'] += bio
+        counts['geo'] += geo
+
+    return counts
+
+
+def _process_system(system_id64: int, bodies: list, base_synergy: dict) -> dict:
+    """
+    Process one system: compute topology metrics and pair synergy.
+    Returns a dict ready for DB upsert.
+    """
+    counts   = _classify_bodies_simple(bodies)
+    topology = compute_topology_metrics(bodies, counts)
+
+    # Compute pair synergy for all canonical pairs
+    pair_rows = []
+    for eco_a, eco_b in ECONOMY_PAIRS:
+        cont = compute_contamination_risk(counts, (eco_a, eco_b))
+        synergy = compute_system_pair_synergy(eco_a, eco_b, counts, topology, base_synergy)
+        synergy_score = round(synergy * 100, 2)
+        pair_rows.append({
+            'system_id64':        system_id64,
+            'economy_a':          eco_a,
+            'economy_b':          eco_b,
+            'synergy_score':      synergy_score,
+            'purity_achievable':  round(1.0 - cont['risk_score'], 3),
+            'contamination_paths': cont['contamination_paths'],
+        })
+
+    return {
+        'system_id64': system_id64,
+        'topology':    topology,
+        'pairs':       pair_rows,
+    }
+
+
+def _write_topology_batch(conn, cur, topo_batch: list, pair_batch: list):
+    """Upsert a batch of topology rows and pair synergy rows."""
+    if not topo_batch:
+        return
+
+    # ── system_slot_topology upsert ───────────────────────────────────────────
+    topo_args = [(
+        r['system_id64'],
+        r['estimated_orbital_slots'],
+        r['estimated_ground_slots'],
+        r['estimated_total_slots'],
+        r['orbital_slot_quality'],
+        r['ground_slot_quality'],
+        r['slot_density_score'],
+        json.dumps(r['body_slots']),
+        json.dumps(r['local_body_groups']),
+        r['strong_link_potential'],
+        r['weak_link_stability'],
+        r['nesting_potential'],
+        r['orbital_synergy'],
+        r['ground_synergy'],
+        r['build_flexibility'],
+        r['contamination_risk'],
+        r['has_viable_surface_port'],
+        r['has_deep_orbital_anchor'],
+        r['has_ringed_gas_giant'],
+        r['has_binary_or_trinary'],
+    ) for r in topo_batch]
+
+    cur.executemany("""
+        INSERT INTO system_slot_topology (
+            system_id64,
+            estimated_orbital_slots, estimated_ground_slots, estimated_total_slots,
+            orbital_slot_quality, ground_slot_quality, slot_density_score,
+            body_slots, local_body_groups,
+            strong_link_potential, weak_link_stability, nesting_potential,
+            orbital_synergy, ground_synergy, build_flexibility, contamination_risk,
+            has_viable_surface_port, has_deep_orbital_anchor,
+            has_ringed_gas_giant, has_binary_or_trinary,
+            updated_at
+        ) VALUES (
+            %s,
+            %s, %s, %s,
+            %s, %s, %s,
+            %s::jsonb, %s::jsonb,
+            %s, %s, %s,
+            %s, %s, %s, %s,
+            %s, %s,
+            %s, %s,
+            NOW()
+        )
+        ON CONFLICT (system_id64) DO UPDATE SET
+            estimated_orbital_slots = EXCLUDED.estimated_orbital_slots,
+            estimated_ground_slots  = EXCLUDED.estimated_ground_slots,
+            estimated_total_slots   = EXCLUDED.estimated_total_slots,
+            orbital_slot_quality    = EXCLUDED.orbital_slot_quality,
+            ground_slot_quality     = EXCLUDED.ground_slot_quality,
+            slot_density_score      = EXCLUDED.slot_density_score,
+            body_slots              = EXCLUDED.body_slots,
+            local_body_groups       = EXCLUDED.local_body_groups,
+            strong_link_potential   = EXCLUDED.strong_link_potential,
+            weak_link_stability     = EXCLUDED.weak_link_stability,
+            nesting_potential       = EXCLUDED.nesting_potential,
+            orbital_synergy         = EXCLUDED.orbital_synergy,
+            ground_synergy          = EXCLUDED.ground_synergy,
+            build_flexibility       = EXCLUDED.build_flexibility,
+            contamination_risk      = EXCLUDED.contamination_risk,
+            has_viable_surface_port = EXCLUDED.has_viable_surface_port,
+            has_deep_orbital_anchor = EXCLUDED.has_deep_orbital_anchor,
+            has_ringed_gas_giant    = EXCLUDED.has_ringed_gas_giant,
+            has_binary_or_trinary   = EXCLUDED.has_binary_or_trinary,
+            updated_at              = NOW()
+    """, topo_args)
+
+    # ── economy_pair_synergy upsert ───────────────────────────────────────────
+    if pair_batch:
+        pair_args = [(
+            p['system_id64'],
+            p['economy_a'],
+            p['economy_b'],
+            p['synergy_score'],
+            p['purity_achievable'],
+            json.dumps(p['contamination_paths']),
+        ) for p in pair_batch]
+
+        cur.executemany("""
+            INSERT INTO economy_pair_synergy (
+                system_id64, economy_a, economy_b,
+                synergy_score, purity_achievable, contamination_paths
+            ) VALUES (%s, %s::economy_type, %s::economy_type, %s, %s, %s::jsonb)
+            ON CONFLICT (system_id64, economy_a, economy_b) DO UPDATE SET
+                synergy_score       = EXCLUDED.synergy_score,
+                purity_achievable   = EXCLUDED.purity_achievable,
+                contamination_paths = EXCLUDED.contamination_paths
+        """, pair_args)
+
+    conn.commit()
+
+
+def worker_process(worker_id: int, system_ids: list, db_dsn: str):
+    """
+    Worker process: fetches bodies for the given system IDs, computes
+    topology + pair synergy, and writes to DB.
+    """
+    hb = WorkerHeartbeat(worker_id)
+    conn = _connect_with_retry(db_dsn, label=f'topology_worker_{worker_id}')
+    cur  = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    # Load base synergy from DB once per worker
+    base_synergy = _load_base_synergy(conn)
+
+    processed = 0
+    errors    = 0
+    topo_batch = []
+    pair_batch = []
+    WRITE_EVERY = 500
+
+    try:
+        for system_id64 in system_ids:
+            hb.tick()
+            try:
+                # Fetch bodies for this system
+                cur.execute("""
+                    SELECT
+                        b.body_id, b.name, b.body_type, b.subtype,
+                        b.is_landable, b.is_terraformable,
+                        b.bio_signal_count, b.geo_signal_count,
+                        b.distance_from_star, b.radius, b.gravity,
+                        b.has_rings,
+                        s.is_main_star, s.spectral_class
+                    FROM bodies b
+                    LEFT JOIN (
+                        SELECT id64, main_star_type AS spectral_class,
+                               TRUE AS is_main_star
+                        FROM systems WHERE id64 = %s
+                    ) s ON TRUE
+                    WHERE b.system_id64 = %s
+                """, (system_id64, system_id64))
+
+                rows = cur.fetchall()
+                if not rows:
+                    continue
+
+                bodies = [dict(r) for r in rows]
+                result = _process_system(system_id64, bodies, base_synergy)
+
+                topo_batch.append({**result['topology'], 'system_id64': system_id64})
+                pair_batch.extend(result['pairs'])
+                processed += 1
+
+                if len(topo_batch) >= WRITE_EVERY:
+                    _write_topology_batch(conn, cur, topo_batch, pair_batch)
+                    topo_batch.clear()
+                    pair_batch.clear()
+
+            except Exception as e:
+                errors += 1
+                log.warning(f"  Worker {worker_id}: error on {system_id64}: {e}")
+                conn.rollback()
+
+        # Write remaining
+        if topo_batch:
+            _write_topology_batch(conn, cur, topo_batch, pair_batch)
+
+    finally:
+        cur.close()
+        conn.close()
+
+    return {'worker_id': worker_id, 'processed': processed, 'errors': errors}
+
+
+# ---------------------------------------------------------------------------
+# Main orchestration
+# ---------------------------------------------------------------------------
+
+def _fetch_system_ids(conn, mode: str, limit: Optional[int]) -> list:
+    """Fetch system IDs to process based on mode."""
+    with conn.cursor() as cur:
+        if mode == 'dirty':
+            cur.execute("""
+                SELECT DISTINCT r.system_id64
+                FROM ratings r
+                LEFT JOIN system_slot_topology t ON t.system_id64 = r.system_id64
+                WHERE r.rating_dirty = TRUE
+                   OR t.system_id64 IS NULL
+                ORDER BY r.system_id64
+                LIMIT %s
+            """, (limit or 10_000_000,))
+        elif mode == 'rebuild':
+            cur.execute("""
+                SELECT id64 FROM systems
+                ORDER BY id64
+                LIMIT %s
+            """, (limit or 10_000_000,))
+        else:
+            # Default: systems with ratings but no topology yet
+            cur.execute("""
+                SELECT r.system_id64
+                FROM ratings r
+                LEFT JOIN system_slot_topology t ON t.system_id64 = r.system_id64
+                WHERE t.system_id64 IS NULL
+                ORDER BY r.system_id64
+                LIMIT %s
+            """, (limit or 10_000_000,))
+
+        return [row[0] for row in cur.fetchall()]
+
+
+def main():
+    parser = argparse.ArgumentParser(description='ED Finder — Topology Builder')
+    parser.add_argument('--rebuild',  action='store_true',
+                        help='Reprocess all systems (default: unprocessed only)')
+    parser.add_argument('--dirty',    action='store_true',
+                        help='Only reprocess dirty systems')
+    parser.add_argument('--workers',  type=int, default=mp.cpu_count(),
+                        help='Worker process count (default: CPU count)')
+    parser.add_argument('--chunk',    type=int, default=BATCH_SIZE,
+                        help='Systems per worker chunk')
+    parser.add_argument('--limit',    type=int, default=None,
+                        help='Max systems to process (dev/test)')
+    args = parser.parse_args()
+
+    startup_banner('build_topology', '1.0')
+    t_start = time.time()
+
+    mode = 'dirty' if args.dirty else ('rebuild' if args.rebuild else 'new')
+    log.info(f"Mode: {mode} | Workers: {args.workers} | Chunk: {args.chunk}")
+
+    conn = _connect_with_retry(DB_DSN, label='topology_main')
+    try:
+        stage_banner('Fetching system IDs')
+        system_ids = _fetch_system_ids(conn, mode, args.limit)
+        log.info(f"  {fmt_num(len(system_ids))} systems to process")
+    finally:
+        conn.close()
+
+    if not system_ids:
+        log.info("Nothing to do.")
+        done_banner('build_topology', time.time() - t_start, 0)
+        return
+
+    # Split into chunks for workers
+    chunks = [
+        system_ids[i:i + args.chunk]
+        for i in range(0, len(system_ids), args.chunk)
+    ]
+    log.info(f"  {len(chunks)} chunks across {args.workers} workers")
+
+    stage_banner('Processing topology')
+    reporter = ProgressReporter(len(system_ids), label='systems')
+
+    with mp.Pool(processes=args.workers) as pool:
+        results = pool.starmap(
+            worker_process,
+            [(i % args.workers, chunk, DB_DSN) for i, chunk in enumerate(chunks)]
+        )
+
+    total_processed = sum(r['processed'] for r in results)
+    total_errors    = sum(r['errors']    for r in results)
+
+    done_banner('build_topology', time.time() - t_start, total_processed)
+    log.info(f"  Processed: {fmt_num(total_processed)} | Errors: {fmt_num(total_errors)}")
+    if total_errors > 0:
+        log.warning(f"  {total_errors} systems failed — check log for details")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/colonisation-redesign/COLONISATION_ENGINE_REDESIGN.md
+++ b/docs/colonisation-redesign/COLONISATION_ENGINE_REDESIGN.md
@@ -1,0 +1,2424 @@
+# ED-Finder Colonisation Engine Redesign
+## Complete Implementation Guide — v4.0
+
+**Date:** 2026-05-10  
+**Status:** Design document — approved for phased implementation  
+**Scope:** Schema, scoring engine, API, migration, pipeline  
+
+---
+
+## Table of Contents
+
+1. [Data Availability Audit — EDDN & Spansh](#1-data-availability-audit)
+2. [Core Philosophy](#2-core-philosophy)
+3. [PostgreSQL Schema Design](#3-postgresql-schema-design)
+4. [Archetype Scoring Engine](#4-archetype-scoring-engine)
+5. [Economy Pair Synergy Model](#5-economy-pair-synergy-model)
+6. [Topology & Contamination Modelling](#6-topology--contamination-modelling)
+7. [Buildability Scoring](#7-buildability-scoring)
+8. [Explainability System](#8-explainability-system)
+9. [Async Computation Pipeline](#9-async-computation-pipeline)
+10. [API Endpoints](#10-api-endpoints)
+11. [Reranking Redesign](#11-reranking-redesign)
+12. [Migration Strategy](#12-migration-strategy)
+13. [Architecture Diagrams](#13-architecture-diagrams)
+14. [Caching Strategy](#14-caching-strategy)
+15. [Performance Recommendations](#15-performance-recommendations)
+16. [Implementation Phases](#16-implementation-phases)
+17. [Risks & Unknowns](#17-risks--unknowns)
+18. [Future-Proofing](#18-future-proofing)
+
+---
+
+## 1. Data Availability Audit
+
+### 1.1 Critical Question
+
+> Can EDDN and/or Spansh expose sufficient slot information to support
+> per-body orbital/ground slot counts, available vs occupied slot tracking,
+> and body-level facility placement?
+
+### 1.2 EDDN — What Is Available
+
+EDDN emits the following schema events relevant to colonisation:
+
+| Schema | What It Provides |
+|--------|-----------------|
+| `Journal/Scan` | BodyID, BodyName, PlanetClass, Landable, DistanceFromArrivalLS, Radius, SurfaceGravity, TerraformState, Volcanism, bio/geo signals |
+| `Journal/FSSDiscoveryScan` | SystemAddress, system-level body count, star class |
+| `Journal/SAASignalsFound` | BodyName, Signals[] with Type (Biology/Geology) + Count |
+| `Journal/FSDJump` + `Location` | SystemAddress, system economy, population |
+| `Journal/Colonisation` | System being colonised flag |
+
+**EDDN does NOT expose:**
+- Orbital slot counts per body
+- Ground slot counts per body
+- Which slots are already occupied by constructions
+- Colonisation facility placement data
+- Slot topology (local-body groupings)
+- Construction state of individual slots
+
+**Verdict:** EDDN provides rich body-physics data (mass, gravity, volcanism, temperature, bio/geo signals, terraform state, landability, distance) but **zero slot topology data**. All slot information must be inferred.
+
+### 1.3 Spansh Galaxy Dump — What Is Available
+
+The Spansh `galaxy.json.gz` dump (already imported by `import_spansh.py`) provides per-body:
+
+| Field | Available? | Notes |
+|-------|-----------|-------|
+| `subType` | ✅ | Planet class, star type — used for economy inference |
+| `isLandable` | ✅ | Ground slot eligibility |
+| `distanceToArrival` | ✅ | Ls from primary star |
+| `terraformingState` | ✅ | Terraformable / not terraformable |
+| `volcanismType` | ✅ | Geo signal proxy |
+| `signals.genuses` | ✅ | Bio signal count |
+| `signals.geology` | ✅ | Geo signal count |
+| `isTerraformingCandidate` | ✅ | |
+| `rings` | ✅ | Ring presence / type |
+| `orbital_slot_count` | ❌ | Not in Spansh data |
+| `ground_slot_count` | ❌ | Not in Spansh data |
+| `occupied_orbital_slots` | ❌ | Not in Spansh data |
+| `occupied_ground_slots` | ❌ | Not in Spansh data |
+| `colonisation_facilities` | ❌ | Not in Spansh data |
+| `parent_body_id` | ✅ | Available as `parents[]` array — enables local-body grouping |
+| `bodyId` | ✅ | In-system body identifier |
+
+### 1.4 Slot Count Inference Rules
+
+**Official ED colonisation mechanics (Trailblazers, 2025)** establish these slot rules:
+
+```
+Ground slots:   Every landable body has ground slots
+                Larger bodies (Rocky, HMC) → more ground slots
+                Slot count ≈ f(radius, gravity, body_type)
+
+Orbital slots:  Every body has orbital slots
+                Stars have more orbital slots than planets
+                Gas Giants have more orbital slots than Rocky bodies
+                Distance from star affects usability (not slot count)
+                Slot count ≈ f(body_type, mass, ring_count)
+```
+
+**ED Wiki confirmed formulas (community-derived, not officially published):**
+
+| Body Type | Approx Orbital Slots | Approx Ground Slots |
+|-----------|---------------------|---------------------|
+| Main Star (large) | 8–12 | 0 |
+| Main Star (small) | 4–6 | 0 |
+| Secondary Star | 4–8 | 0 |
+| Gas Giant (ringed) | 4–6 | 0 |
+| Gas Giant (plain) | 2–4 | 0 |
+| Rocky Body (large, landable) | 2–4 | 4–8 |
+| Rocky Body (small, landable) | 1–2 | 2–4 |
+| HMC (landable) | 2–4 | 3–6 |
+| Icy Body | 1–3 | 0–2 |
+| Rocky Ice | 2–4 | 2–4 |
+| ELW | 3–5 | 5–10 |
+| Water World | 2–4 | 0 |
+| Ammonia World | 2–4 | 0 |
+
+> **Important:** These are approximate ranges. Exact slot counts are displayed
+> in Architect Mode in-game. The Frontier API does not expose them externally.
+> ED-Finder must **estimate** slot counts from body properties, not read them directly.
+
+### 1.5 Canonical Source of Truth
+
+| Data Type | Best Source | Update Frequency | Reliability |
+|-----------|-------------|-----------------|-------------|
+| Body physics (type, mass, temp, gravity) | Spansh galaxy dump + EDDN | Nightly dump / real-time EDDN | High |
+| Bio/geo signal counts | EDDN SAASignalsFound | Real-time | High |
+| Terraform state | Spansh + EDDN Scan | Nightly + real-time | High |
+| Estimated orbital slots | **Inferred from body_type + mass** | Computed from body data | Medium |
+| Estimated ground slots | **Inferred from is_landable + radius** | Computed from body data | Medium |
+| Actual occupied slots | **Not available externally** | N/A | — |
+| Parent/local body grouping | Spansh `parents[]` array | Nightly dump | Medium |
+
+### 1.6 Recommendation: Inference Engine, Not Direct Slot Reading
+
+**ED-Finder must build a slot inference engine** that estimates:
+
+1. `estimated_orbital_slots` — from body_type, mass, ring presence
+2. `estimated_ground_slots` — from is_landable, radius, gravity, body_type  
+3. `estimated_total_slots` — sum across all bodies in system
+4. `slot_quality_score` — weighted by body type and distance
+
+This is not a limitation — it is correct. The in-game Architect Mode shows exact slots, but these are not available via any API or data feed. The Spansh colonisation-specific dumps (when they exist) do capture some constructed facility data, but not pre-colonisation slot topology.
+
+---
+
+## 2. Core Philosophy
+
+### 2.1 The Fundamental Shift
+
+**Current ED-Finder asks:**
+> "What is the overall best system?"
+
+**New ED-Finder asks:**
+> "What kind of colony would this system become — and how well would it become that?"
+
+### 2.2 Three Inviolable Design Laws
+
+**Law 1: Systems are archetypes, not score objects.**  
+A Refinery Megacomplex and an ELW Tourism Capital must never share a global leaderboard. They live in different archetype categories. Score them within their category only.
+
+**Law 2: Economy compatibility outweighs economy strength.**  
+A system with Refinery=70 + Industrial=68 that pair cleanly scores higher than a system with Refinery=90 that is heavily contaminated by Agriculture and HighTech. Purity is a force multiplier.
+
+**Law 3: Explainability is a first-class feature.**  
+Every score must be traceable. Every ranking must be justifiable. A CMDR should be able to read exactly why a system scored the way it did and immediately understand it. The rationale is not a caption — it is part of the product.
+
+### 2.3 Current System Assessment (Honest Audit)
+
+**What works well in v3.1 (keep):**
+- `classify_bodies()` contamination logic — excellent foundation
+- `_distance_weight()` — smart and defensible
+- Complementary pair detection (`COMPLEMENTARY_PAIRS`) — exactly right direction  
+- `compute_confidence()` — solid data-freshness model
+- `generate_rationale()` with per-economy highlight builders — good architecture, needs expanding
+- Per-economy score columns in `ratings` table — already positions us for archetype pivot
+- `score_breakdown` JSONB — already stores the right data, just needs richer content
+- Dirty-flag architecture — correct async pattern for scale
+- Multiprocess worker pool — correct for CPU-bound rating computation
+
+**What needs replacing in v3.1:**
+- Single `score` column — becomes `overall_development_potential` (supporting role, not star)
+- Generic dimension weights (`economy 0.42, slots 0.23, strategic 0.18`) — becomes archetype scores
+- `RerankWeights` model — becomes `ArchetypeWeights` + preset profiles
+- `compute_slot_score()` — replace with topology-aware slot model
+- `compute_strategic_score()` — split into topology metrics + buildability
+- `score` overall formula — replace with archetype-gated overall development potential
+
+---
+
+## 3. PostgreSQL Schema Design
+
+### 3.1 Design Principles
+
+- **Keep PostgreSQL** — the workload (joins, analytical queries, weighted ranking, partial indexes, materialized views) is PostgreSQL's home turf
+- **JSONB for flexibility** — traits, explanations, and inferred slot data live in JSONB so Frontier mechanic changes don't require schema migrations
+- **Additive migration** — new tables are added alongside existing ones; no DROP TABLE in Phase 1 or 2
+- **Precompute aggressively** — nothing is computed at API request time that can be precomputed
+
+### 3.2 New Enum Types
+
+```sql
+-- ─────────────────────────────────────────────────────────────────
+-- New enum: colonisation archetype
+-- ─────────────────────────────────────────────────────────────────
+DO $$ BEGIN
+    CREATE TYPE colony_archetype AS ENUM (
+        'refinery_industrial',      -- Rocky + Icy megacomplex
+        'extraction_refinery',      -- Mining hub, metal-rich focus
+        'agriculture_terraforming', -- Farming + terraforming colony
+        'hitech_tourism',           -- Prestige, ELW/exotic stars
+        'expansion_capital',        -- Strategic expansion node
+        'trade_logistics',          -- Trade hub + carrier support
+        'population_capital',       -- Maximum population growth
+        'ax_forward_base',          -- Anti-xeno military forward base
+        'military_industrial',      -- Military + Industrial complex
+        'flexible_multirole',       -- High diversity, no dominant archetype
+        'unknown'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ─────────────────────────────────────────────────────────────────
+-- New enum: build complexity
+-- ─────────────────────────────────────────────────────────────────
+DO $$ BEGIN
+    CREATE TYPE build_complexity AS ENUM (
+        'trivial',      -- Simple single-economy build
+        'simple',       -- Clean pair, no sequencing issues
+        'moderate',     -- Some contamination management required
+        'advanced',     -- Nested ports / tight sequencing
+        'expert'        -- Multi-phase, requires deep game knowledge
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+```
+
+### 3.3 Table: `system_slot_topology`
+
+Inferred slot topology. Populated by the new `build_topology.py` importer stage.
+
+```sql
+CREATE TABLE IF NOT EXISTS system_slot_topology (
+    system_id64             BIGINT      PRIMARY KEY REFERENCES systems(id64),
+
+    -- ── Estimated slot counts (inferred, not authoritative) ──────────
+    estimated_orbital_slots     SMALLINT    DEFAULT 0,
+    estimated_ground_slots      SMALLINT    DEFAULT 0,
+    estimated_total_slots       SMALLINT    DEFAULT 0,
+
+    -- ── Slot quality (distance-weighted, type-weighted) ──────────────
+    orbital_slot_quality        REAL        DEFAULT 0,  -- 0-100
+    ground_slot_quality         REAL        DEFAULT 0,  -- 0-100
+    slot_density_score          REAL        DEFAULT 0,  -- 0-100: total quality ÷ distance
+
+    -- ── Per-body slot estimates (JSONB array) ─────────────────────────
+    -- [{body_id, body_name, body_type, distance_ls,
+    --   est_orbital, est_ground, local_group_id, parent_body_id}]
+    body_slots                  JSONB       DEFAULT '[]',
+
+    -- ── Local body groupings ──────────────────────────────────────────
+    -- Groupings derived from Spansh parents[] array.
+    -- [{group_id, anchor_body_id, anchor_name, member_body_ids[],
+    --   group_orbital_slots, group_ground_slots}]
+    local_body_groups           JSONB       DEFAULT '[]',
+
+    -- ── Topology metrics ─────────────────────────────────────────────
+    strong_link_potential       REAL        DEFAULT 0,  -- 0-100
+    weak_link_stability         REAL        DEFAULT 0,  -- 0-100
+    nesting_potential           REAL        DEFAULT 0,  -- 0-100
+    orbital_synergy             REAL        DEFAULT 0,  -- 0-100
+    ground_synergy              REAL        DEFAULT 0,  -- 0-100
+    build_flexibility           REAL        DEFAULT 0,  -- 0-100
+    contamination_risk          REAL        DEFAULT 0,  -- 0-100 (higher = worse)
+
+    -- ── Topology flags (fast filter support) ─────────────────────────
+    has_viable_surface_port     BOOLEAN     DEFAULT FALSE,  -- ≥1 landable Rocky/HMC
+    has_deep_orbital_anchor     BOOLEAN     DEFAULT FALSE,  -- body with ≥6 orbital slots
+    has_ringed_gas_giant        BOOLEAN     DEFAULT FALSE,
+    has_binary_or_trinary       BOOLEAN     DEFAULT FALSE,  -- multiple stars
+
+    updated_at                  TIMESTAMP   DEFAULT NOW()
+);
+
+COMMENT ON TABLE system_slot_topology IS
+    'Inferred slot topology per system. Slot counts are ESTIMATES derived '
+    'from body physics; they are not authoritative (Frontier does not expose '
+    'actual slot counts via any public API or data feed). '
+    'Recomputed by build_topology.py whenever a system is flagged dirty.';
+```
+
+### 3.4 Table: `system_archetype_scores`
+
+The heart of the new engine. Replaces the role of the single `score` column.
+
+```sql
+CREATE TABLE IF NOT EXISTS system_archetype_scores (
+    system_id64             BIGINT      PRIMARY KEY REFERENCES systems(id64),
+
+    -- ── Primary archetype identification ─────────────────────────────
+    primary_archetype       colony_archetype    DEFAULT 'unknown',
+    secondary_archetype     colony_archetype    DEFAULT 'unknown',
+    archetype_confidence    REAL        DEFAULT 0,  -- 0-1
+
+    -- ── Per-archetype scores (0-100 each) ────────────────────────────
+    score_refinery_industrial       REAL    DEFAULT 0,
+    score_extraction_refinery       REAL    DEFAULT 0,
+    score_agriculture_terraforming  REAL    DEFAULT 0,
+    score_hitech_tourism            REAL    DEFAULT 0,
+    score_expansion_capital         REAL    DEFAULT 0,
+    score_trade_logistics           REAL    DEFAULT 0,
+    score_population_capital        REAL    DEFAULT 0,
+    score_ax_forward_base           REAL    DEFAULT 0,
+    score_military_industrial       REAL    DEFAULT 0,
+    score_flexible_multirole        REAL    DEFAULT 0,
+
+    -- ── Composite development potential (supporting metric) ──────────
+    overall_development_potential   REAL    DEFAULT 0,  -- 0-100
+
+    -- ── Buildability ─────────────────────────────────────────────────
+    buildability_score      REAL        DEFAULT 0,  -- 0-100
+    build_complexity        build_complexity    DEFAULT 'moderate',
+    cp_efficiency           REAL        DEFAULT 0,  -- 0-100: CP cost per tier
+    t3_scaling_viability    REAL        DEFAULT 0,  -- 0-100: ease of T3 builds
+    slot_efficiency         REAL        DEFAULT 0,  -- 0-100: slots per economy tier
+
+    -- ── Purity & contamination ────────────────────────────────────────
+    purity_score            REAL        DEFAULT 0,  -- 0-100: top-2 economy cleanliness
+    contamination_risk      REAL        DEFAULT 0,  -- 0-100: risk of 3rd economy bleed
+    stable_top_two_prob     REAL        DEFAULT 0,  -- 0-1: probability of stable top-2
+
+    -- ── Data quality ─────────────────────────────────────────────────
+    confidence              REAL        DEFAULT 0.85,
+
+    -- ── Explainability payload (JSONB) ────────────────────────────────
+    score_breakdown         JSONB       DEFAULT '{}',
+    rationale               JSONB       DEFAULT '{}',  -- structured, not plain text
+
+    updated_at              TIMESTAMP   DEFAULT NOW(),
+    dirty                   BOOLEAN     DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_archetype_scores_primary
+    ON system_archetype_scores (primary_archetype, score_refinery_industrial DESC)
+    WHERE score_refinery_industrial > 0;
+
+CREATE INDEX IF NOT EXISTS idx_archetype_scores_hitech
+    ON system_archetype_scores (score_hitech_tourism DESC)
+    WHERE score_hitech_tourism >= 40;
+
+CREATE INDEX IF NOT EXISTS idx_archetype_scores_odp
+    ON system_archetype_scores (overall_development_potential DESC)
+    WHERE overall_development_potential >= 50;
+
+CREATE INDEX IF NOT EXISTS idx_archetype_scores_dirty
+    ON system_archetype_scores (dirty)
+    WHERE dirty = TRUE;
+```
+
+### 3.5 Table: `economy_pair_synergy`
+
+Lookup table for precomputed pair synergy scores. Populated by `build_topology.py`.
+
+```sql
+CREATE TABLE IF NOT EXISTS economy_pair_synergy (
+    system_id64         BIGINT      NOT NULL REFERENCES systems(id64),
+    economy_a           economy_type    NOT NULL,
+    economy_b           economy_type    NOT NULL,
+    synergy_score       REAL        NOT NULL,   -- 0-100
+    purity_achievable   REAL        DEFAULT 0,  -- 0-1: probability top-2 stays clean
+    contamination_paths JSONB       DEFAULT '[]',  -- which body types cause contamination
+    notes               TEXT,
+    PRIMARY KEY (system_id64, economy_a, economy_b)
+);
+
+-- Global pair synergy constants table (system-independent baseline)
+CREATE TABLE IF NOT EXISTS pair_synergy_constants (
+    economy_a           economy_type    NOT NULL,
+    economy_b           economy_type    NOT NULL,
+    base_synergy        REAL        NOT NULL,  -- 0-1 baseline
+    contamination_risk  REAL        NOT NULL,  -- 0-1 baseline risk
+    notes               TEXT,
+    PRIMARY KEY (economy_a, economy_b)
+);
+
+-- Seed with ED-accurate base values
+INSERT INTO pair_synergy_constants (economy_a, economy_b, base_synergy, contamination_risk, notes)
+VALUES
+    ('Refinery',    'Industrial',   0.95, 0.12, 'Rocky-Ice bodies serve both; very clean'),
+    ('Agriculture', 'Tourism',      0.91, 0.08, 'ELW/WW serve both; ELW strong link excellent'),
+    ('HighTech',    'Tourism',      0.88, 0.15, 'Gas Giants + exotics serve both'),
+    ('Extraction',  'Refinery',     0.82, 0.22, 'HMC serves both; Geo signals needed for Ext'),
+    ('Agriculture', 'HighTech',     0.79, 0.18, 'ELW anchors both; bio signals useful'),
+    ('HighTech',    'Military',     0.76, 0.20, 'ELW serves both; GG adds HT, not Mil directly'),
+    ('Industrial',  'Military',     0.74, 0.18, 'Icy bodies + military settlements compatible'),
+    ('Refinery',    'Military',     0.58, 0.30, 'Moderate: Rocky bodies help Refinery, less Military'),
+    ('Extraction',  'Industrial',   0.55, 0.35, 'HMC geo contamination can cause issues'),
+    ('Agriculture', 'Refinery',     0.28, 0.72, 'Competing: bio bodies contaminate Refinery heavily'),
+    ('Tourism',     'Refinery',     0.22, 0.78, 'Very poor: ELW/exotic economies fight Refinery')
+ON CONFLICT (economy_a, economy_b) DO NOTHING;
+```
+
+### 3.6 Table: `system_archetype_traits`
+
+Fast-filter tags and human-readable trait labels. Replaces current body-count columns in ratings.
+
+```sql
+CREATE TABLE IF NOT EXISTS system_archetype_traits (
+    system_id64         BIGINT      PRIMARY KEY REFERENCES systems(id64),
+
+    -- ── Boolean fast-filter flags ─────────────────────────────────────
+    has_elw             BOOLEAN     DEFAULT FALSE,
+    has_water_world     BOOLEAN     DEFAULT FALSE,
+    has_ammonia_world   BOOLEAN     DEFAULT FALSE,
+    has_black_hole      BOOLEAN     DEFAULT FALSE,
+    has_neutron_star    BOOLEAN     DEFAULT FALSE,
+    has_white_dwarf     BOOLEAN     DEFAULT FALSE,
+    has_ringed_body     BOOLEAN     DEFAULT FALSE,
+    has_terraformables  BOOLEAN     DEFAULT FALSE,
+    has_pristine_res    BOOLEAN     DEFAULT FALSE,  -- reserve_level in system
+    has_bio_signals     BOOLEAN     DEFAULT FALSE,
+    has_geo_signals     BOOLEAN     DEFAULT FALSE,
+    is_scoopable_star   BOOLEAN     DEFAULT FALSE,
+
+    -- ── Counts ───────────────────────────────────────────────────────
+    elw_count           SMALLINT    DEFAULT 0,
+    ww_count            SMALLINT    DEFAULT 0,
+    ammonia_count       SMALLINT    DEFAULT 0,
+    gas_giant_count     SMALLINT    DEFAULT 0,
+    rocky_clean_count   SMALLINT    DEFAULT 0,
+    rocky_ice_count     SMALLINT    DEFAULT 0,
+    icy_count           SMALLINT    DEFAULT 0,
+    hmc_count           SMALLINT    DEFAULT 0,
+    metal_rich_count    SMALLINT    DEFAULT 0,
+    landable_count      SMALLINT    DEFAULT 0,
+    terraformable_count SMALLINT    DEFAULT 0,
+    bio_signal_total    SMALLINT    DEFAULT 0,
+    geo_signal_total    SMALLINT    DEFAULT 0,
+    total_body_count    SMALLINT    DEFAULT 0,
+
+    -- ── Slot estimates (denormalised from system_slot_topology) ───────
+    est_orbital_slots   SMALLINT    DEFAULT 0,
+    est_ground_slots    SMALLINT    DEFAULT 0,
+    est_total_slots     SMALLINT    DEFAULT 0,
+
+    -- ── UI tag array (fast display, no join needed) ───────────────────
+    -- e.g. ["Rocky-Ice", "Pristine", "Low Contamination", "T3 Friendly"]
+    display_tags        TEXT[]      DEFAULT '{}',
+
+    updated_at          TIMESTAMP   DEFAULT NOW()
+);
+
+-- GIN index for tag-based filtering
+CREATE INDEX IF NOT EXISTS idx_traits_display_tags
+    ON system_archetype_traits USING gin(display_tags);
+
+CREATE INDEX IF NOT EXISTS idx_traits_elw
+    ON system_archetype_traits (elw_count DESC)
+    WHERE has_elw = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_traits_slots
+    ON system_archetype_traits (est_total_slots DESC)
+    WHERE est_total_slots >= 20;
+```
+
+### 3.7 Materialized View: `mv_archetype_rankings`
+
+Pre-sorted rankings per archetype. Refreshed after each `build_archetype_scores.py` run.
+
+```sql
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_archetype_rankings AS
+SELECT
+    s.id64,
+    s.name,
+    s.x, s.y, s.z,
+    s.distance_to_sol,
+    s.main_star_type,
+    s.galaxy_region_id,
+    a.primary_archetype,
+    a.secondary_archetype,
+    a.archetype_confidence,
+    a.score_refinery_industrial,
+    a.score_extraction_refinery,
+    a.score_agriculture_terraforming,
+    a.score_hitech_tourism,
+    a.score_expansion_capital,
+    a.score_trade_logistics,
+    a.score_population_capital,
+    a.score_ax_forward_base,
+    a.score_military_industrial,
+    a.score_flexible_multirole,
+    a.overall_development_potential,
+    a.buildability_score,
+    a.build_complexity,
+    a.purity_score,
+    a.contamination_risk,
+    a.confidence,
+    t.has_elw,
+    t.has_black_hole,
+    t.has_neutron_star,
+    t.elw_count,
+    t.landable_count,
+    t.est_total_slots,
+    t.display_tags,
+    topo.strong_link_potential,
+    topo.weak_link_stability,
+    topo.contamination_risk     AS topo_contamination_risk
+FROM systems s
+JOIN system_archetype_scores a   ON a.system_id64 = s.id64
+JOIN system_archetype_traits t   ON t.system_id64 = s.id64
+LEFT JOIN system_slot_topology topo ON topo.system_id64 = s.id64
+WHERE a.dirty = FALSE
+  AND a.overall_development_potential > 0
+WITH DATA;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_archetype_id64
+    ON mv_archetype_rankings (id64);
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_refinery
+    ON mv_archetype_rankings (score_refinery_industrial DESC);
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_hitech
+    ON mv_archetype_rankings (score_hitech_tourism DESC);
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_agri
+    ON mv_archetype_rankings (score_agriculture_terraforming DESC);
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_odp
+    ON mv_archetype_rankings (overall_development_potential DESC);
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_region
+    ON mv_archetype_rankings (galaxy_region_id, score_refinery_industrial DESC);
+```
+
+### 3.8 Relationship to Existing `ratings` Table
+
+The existing `ratings` table is **preserved intact** through Phase 1 and Phase 2. No columns are dropped. The new tables are purely additive.
+
+```
+EXISTING (preserved):    ratings
+                         ↕ joined via system_id64
+NEW (additive):          system_archetype_scores
+                         system_slot_topology
+                         system_archetype_traits
+                         economy_pair_synergy
+                         pair_synergy_constants
+                         mv_archetype_rankings (materialized view)
+```
+
+The `ratings` table becomes a **legacy compatibility layer** that:
+1. Continues to power the existing `/api/ratings/rerank` endpoint unchanged
+2. Provides `score_breakdown` JSONB for backward-compat API consumers
+3. Is eventually superseded by `system_archetype_scores` in Phase 4
+
+---
+
+## 4. Archetype Scoring Engine
+
+### 4.1 File: `apps/importer/src/build_archetype_scores.py`
+
+This is the new scoring engine. It runs after `build_ratings.py` and reads from both the existing `ratings` table and the new `system_slot_topology` table.
+
+### 4.2 Archetype Definitions
+
+Each archetype has:
+- **Primary body requirements** (body types that maximally support it)
+- **Economy pair target** (the economy combination it optimises for)
+- **Topology requirements** (slot type preferences)
+- **Contamination tolerance** (how much economy bleed it can absorb)
+- **Purity multiplier** (reward for clean economy stacks)
+
+```python
+ARCHETYPE_DEFINITIONS = {
+
+    'refinery_industrial': {
+        'label':         'Refinery / Industrial Megacomplex',
+        'description':   'Rocky and Icy body manufacturing hub',
+        'economy_pair':  ('Refinery', 'Industrial'),
+        'body_weights':  {
+            'rocky_clean':   1.0,    # Perfect Refinery body
+            'rocky_ice':     0.80,   # Refinery + Industrial hybrid
+            'icy':           0.70,   # Pure Industrial
+            'rocky_rings':   0.55,   # Refinery + mild Extraction
+            'hmc':           0.35,   # Usable with effort
+            'rocky_geo':     0.15,   # Heavy contamination
+            'rocky_bio':     0.20,   # Moderate contamination
+        },
+        'slot_preference': 'ground_heavy',  # Surface ports for CMM Composite
+        'requires_landable': True,
+        'contamination_tolerance': 0.30,    # Can handle up to 30% contamination
+        'purity_multiplier':       1.35,    # +35% score for clean stacks
+        'buildability_profile': 'standard',
+        'tags': ['Manufacturing', 'CMM Composite', 'Refinery Hub'],
+    },
+
+    'extraction_refinery': {
+        'label':         'Extraction / Refinery Mining Hub',
+        'description':   'HMC and metal-rich mining support system',
+        'economy_pair':  ('Extraction', 'Refinery'),
+        'body_weights':  {
+            'hmc':           1.0,
+            'metal_rich':    0.90,
+            'rocky_rings':   0.70,
+            'hmc_geo':       0.80,   # Geo signals boost Extraction
+            'rocky_geo':     0.50,
+        },
+        'slot_preference': 'balanced',
+        'requires_landable': False,  # Extraction works orbital
+        'contamination_tolerance': 0.40,
+        'purity_multiplier':       1.20,
+        'buildability_profile': 'mining_focus',
+        'tags': ['Mining Hub', 'Extraction', 'Metal-Rich'],
+    },
+
+    'agriculture_terraforming': {
+        'label':         'Agriculture / Terraforming Colony',
+        'description':   'Population growth and terraforming focus',
+        'economy_pair':  ('Agriculture', 'Tourism'),  # Tourism via ELW/WW
+        'body_weights':  {
+            'elw':           1.0,
+            'ww':            0.80,
+            'terraformable': 0.60,   # Future agriculture boost
+            'rocky_bio':     0.45,   # Bio signals = Agriculture + Terraforming
+            'ammonia':       0.30,   # Contamination risk but HighTech bonus
+        },
+        'slot_preference': 'ground_heavy',
+        'requires_landable': True,
+        'contamination_tolerance': 0.35,
+        'purity_multiplier':       1.40,
+        'buildability_profile': 'growth_focus',
+        'tags': ['Agriculture', 'Terraforming', 'ELW', 'Population Growth'],
+    },
+
+    'hitech_tourism': {
+        'label':         'HighTech / Tourism Prestige Colony',
+        'description':   'Prestige system with ELW, exotics, and high-tech industry',
+        'economy_pair':  ('HighTech', 'Tourism'),
+        'body_weights':  {
+            'elw':           1.0,
+            'ammonia':       0.90,
+            'black_hole':    0.85,
+            'neutron':       0.70,
+            'white_dwarf':   0.55,
+            'gas_giant':     0.65,
+            'ww':            0.60,
+        },
+        'slot_preference': 'orbital_heavy',
+        'requires_landable': False,
+        'contamination_tolerance': 0.45,
+        'purity_multiplier':       1.30,
+        'buildability_profile': 'prestige',
+        'tags': ['Prestige', 'HighTech', 'Tourism', 'Exotic'],
+    },
+
+    'expansion_capital': {
+        'label':         'Expansion Capital',
+        'description':   'Strategic node for further colonisation chains',
+        'economy_pair':  ('Industrial', 'HighTech'),  # Flexibility is the point
+        'body_weights':  {
+            # Rewards body diversity, not specialisation
+            'elw':           0.70,
+            'gas_giant':     0.65,
+            'rocky_clean':   0.60,
+            'icy':           0.60,
+            'hmc':           0.55,
+        },
+        'slot_preference': 'balanced',
+        'requires_landable': True,
+        'contamination_tolerance': 0.55,   # Expansion capitals tolerate diversity
+        'purity_multiplier':       1.00,   # No purity bonus — flexibility is valued
+        'diversity_bonus':         1.30,   # +30% for high body diversity
+        'buildability_profile': 'flexible',
+        'tags': ['Expansion', 'Capital', 'Strategic', 'Flexible'],
+    },
+
+    'military_industrial': {
+        'label':         'Military / Industrial Complex',
+        'description':   'Defensive stronghold with manufacturing capacity',
+        'economy_pair':  ('Military', 'Industrial'),
+        'body_weights':  {
+            'elw':           0.90,
+            'gas_giant':     0.70,
+            'icy':           0.65,
+            'rocky_clean':   0.60,
+            'neutron':       0.50,
+            'black_hole':    0.45,
+        },
+        'slot_preference': 'balanced',
+        'requires_landable': True,
+        'contamination_tolerance': 0.40,
+        'purity_multiplier':       1.25,
+        'buildability_profile': 'military',
+        'tags': ['Military', 'Industrial', 'Defence', 'Stronghold'],
+    },
+
+    'ax_forward_base': {
+        'label':         'AX Forward Operating Base',
+        'description':   'Anti-xeno military infrastructure hub',
+        'economy_pair':  ('Military', 'HighTech'),
+        'body_weights':  {
+            'elw':           1.0,   # ELW gives Military + HighTech + Tourism
+            'neutron':       0.80,  # Prestige + AX jump route proximity
+            'black_hole':    0.70,
+            'gas_giant':     0.60,
+            'rocky_clean':   0.50,
+        },
+        'slot_preference': 'balanced',
+        'requires_landable': True,
+        'contamination_tolerance': 0.50,
+        'purity_multiplier':       1.20,
+        'strategic_bonus':         0.20,  # +20% if within 200 Ly of known Thargoid territory
+        'buildability_profile': 'military',
+        'tags': ['AX', 'Military', 'Forward Base', 'Anti-Xeno'],
+    },
+
+    'flexible_multirole': {
+        'label':         'Flexible Multi-Role Colony',
+        'description':   'High diversity, multiple viable specialisation paths',
+        'economy_pair':  None,   # No fixed pair — scored by diversity
+        'body_weights':  {
+            # All body types valued equally; diversity metric drives score
+        },
+        'slot_preference': 'balanced',
+        'requires_landable': False,
+        'contamination_tolerance': 0.70,
+        'purity_multiplier':       1.00,
+        'diversity_bonus':         1.50,
+        'buildability_profile': 'flexible',
+        'tags': ['Multi-Role', 'Flexible', 'Generalist'],
+    },
+}
+```
+
+### 4.3 Archetype Score Formula
+
+```python
+def compute_archetype_score(
+    archetype_key: str,
+    counts: dict,          # from classify_bodies()
+    topology: dict,        # from build_topology.py
+    pair_synergy: float,   # from pair_synergy_constants
+    main_star_type: str,
+) -> dict:
+    """
+    Compute a 0-100 archetype score for a single archetype.
+
+    Returns:
+        {
+            'score': float,          # 0-100 final score
+            'body_contribution': float,
+            'topology_contribution': float,
+            'purity_contribution': float,
+            'buildability_contribution': float,
+            'notes': list[str],
+        }
+    """
+    defn = ARCHETYPE_DEFINITIONS[archetype_key]
+
+    # ── 1. Body composition score (0-60 pts) ─────────────────────────
+    body_score = 0.0
+    body_notes = []
+    for body_key, weight in defn['body_weights'].items():
+        count = counts.get(body_key, 0)
+        if count > 0:
+            # Diminishing returns: sqrt scaling after first 3 bodies
+            contribution = min(count, 3) * weight + max(count - 3, 0) * weight * 0.4
+            body_score += contribution * 20.0   # scale to 0-60 range
+            if count >= 1:
+                body_notes.append(f"{count}× {body_key.replace('_', ' ')}")
+
+    body_score = min(body_score, 60.0)
+
+    # ── 2. Topology score (0-25 pts) ─────────────────────────────────
+    topo_score = 0.0
+    if topology:
+        slot_pref = defn.get('slot_preference', 'balanced')
+        if slot_pref == 'ground_heavy':
+            topo_score = topology.get('ground_synergy', 0) * 0.25
+        elif slot_pref == 'orbital_heavy':
+            topo_score = topology.get('orbital_synergy', 0) * 0.25
+        else:
+            topo_score = (
+                topology.get('orbital_synergy', 0) * 0.12 +
+                topology.get('ground_synergy', 0) * 0.13
+            )
+        topo_score = min(topo_score, 25.0)
+
+    # ── 3. Purity / contamination (multiplier, not additive) ─────────
+    contamination = topology.get('contamination_risk', 0.5) if topology else 0.5
+    tolerance = defn['contamination_tolerance']
+    purity_factor = 1.0
+    if contamination > tolerance:
+        # Penalty ramps up beyond tolerance threshold
+        excess = (contamination - tolerance) / (1.0 - tolerance)
+        purity_factor = 1.0 - (excess * (1.0 - 1.0 / defn['purity_multiplier']))
+    else:
+        # Bonus for clean stacks
+        clean_ratio = 1.0 - (contamination / max(tolerance, 0.01))
+        purity_factor = 1.0 + (clean_ratio * (defn['purity_multiplier'] - 1.0))
+
+    # ── 4. Pair synergy boost (0-15 pts) ─────────────────────────────
+    synergy_pts = pair_synergy * 15.0 if pair_synergy else 0.0
+
+    # ── 5. Diversity bonus (for expansion/flexible archetypes) ────────
+    diversity_factor = 1.0
+    if 'diversity_bonus' in defn:
+        from build_ratings import compute_body_diversity
+        diversity = compute_body_diversity(counts) / 30.0  # normalise 0-1
+        diversity_factor = 1.0 + (diversity * (defn['diversity_bonus'] - 1.0))
+
+    # ── 6. Surface port requirement check ────────────────────────────
+    if defn.get('requires_landable') and counts.get('landable', 0) == 0:
+        body_score *= 0.40   # Severe cap: no landable = very limited utility
+
+    # ── 7. Compose final score ────────────────────────────────────────
+    raw_score = (body_score + topo_score + synergy_pts) * purity_factor * diversity_factor
+    final_score = min(float(raw_score), 100.0)
+
+    return {
+        'score': round(final_score, 2),
+        'body_contribution': round(body_score, 2),
+        'topology_contribution': round(topo_score, 2),
+        'purity_factor': round(purity_factor, 3),
+        'synergy_pts': round(synergy_pts, 2),
+        'contamination_risk': round(contamination, 3),
+        'notes': body_notes,
+    }
+```
+
+### 4.4 Overall Development Potential
+
+```python
+def compute_overall_development_potential(
+    archetype_scores: dict,   # archetype_key -> score
+    diversity: int,           # 0-30 from compute_body_diversity()
+    has_standout: bool,       # ELW / BH / neutron / 2+ WW / 5+ terraformable
+    buildability: float,      # 0-100
+) -> float:
+    """
+    Overall development potential is a SUPPORTING metric — not the star.
+    It answers: "across all possible colony types, how good is this system?"
+
+    Deliberately does NOT replace archetype scores. Used as a secondary sort
+    when two systems tie on their primary archetype score.
+    """
+    # Top-3 archetype average (60% weight)
+    top3 = sorted(archetype_scores.values(), reverse=True)[:3]
+    top3_avg = sum(top3) / 3 if top3 else 0
+
+    # Diversity bonus (20% weight)
+    diversity_bonus = (diversity / 30.0) * 20.0
+
+    # Buildability (20% weight)
+    buildability_contribution = buildability * 0.20
+
+    raw = top3_avg * 0.60 + diversity_bonus + buildability_contribution
+
+    # Rarity gate: systems without a standout body are capped at 82
+    # (prevents generic rocky-heavy systems from inflating ODP)
+    if not has_standout and raw > 82:
+        raw = 82.0
+
+    return round(min(raw, 100.0), 2)
+```
+
+---
+
+## 5. Economy Pair Synergy Model
+
+### 5.1 File: `apps/importer/src/build_topology.py` (new)
+
+### 5.2 System-Specific Pair Synergy
+
+The base synergy constants in `pair_synergy_constants` are global. Per-system synergy is modified by:
+
+```python
+PAIR_MODIFIERS = {
+    # Body-type modifiers that increase synergy for a pair
+    'Refinery+Industrial': {
+        'rocky_ice':      +0.08,   # Rocky Ice inherently serves both
+        'icy':            +0.05,   # Icy = pure Industrial, strengthens pairing
+        'rocky_clean':    +0.04,   # More clean Rocky = less contamination
+        'rocky_geo':      -0.12,   # Geo signals = Extraction contamination
+        'rocky_bio':      -0.08,   # Bio signals = Agriculture contamination
+    },
+    'Agriculture+Tourism': {
+        'elw':            +0.12,   # ELW drives both Agriculture and Tourism
+        'ww':             +0.08,   # Water World contributes to both
+        'ammonia':        +0.06,   # Ammonia World boosts Tourism, not Agriculture
+        'terraformable':  +0.04,   # Terraformable body = Agriculture strong link
+        'tidal_lock':     -0.06,   # Tidal lock decreases Agriculture strong link
+        'icy':            -0.05,   # Icy decreases Agriculture strong link
+    },
+    'HighTech+Tourism': {
+        'black_hole':     +0.15,   # Black hole is a massive Tourism/HT draw
+        'neutron':        +0.10,
+        'ammonia':        +0.10,
+        'gas_giant':      +0.06,
+        'elw':            +0.08,
+    },
+    'Extraction+Refinery': {
+        'hmc':            +0.10,   # HMC hosts both Extraction and Refinery Hubs
+        'hmc_geo':        +0.08,   # HMC with geo = strong Extraction
+        'metal_rich':     +0.06,
+        'rocky_rings':    +0.04,
+        'rocky_geo':      -0.05,   # Geo on Rocky = adds Industrial contamination
+    },
+}
+
+def compute_system_pair_synergy(
+    economy_a: str,
+    economy_b: str,
+    counts: dict,
+    topology: dict,
+) -> float:
+    """
+    Compute system-specific pair synergy (0-1).
+    Starts from global base, applies body-type modifiers.
+    """
+    pair_key = f'{economy_a}+{economy_b}'
+    alt_key  = f'{economy_b}+{economy_a}'
+
+    # Fetch base synergy
+    base = BASE_SYNERGY.get(pair_key, BASE_SYNERGY.get(alt_key, 0.50))
+    modifiers = PAIR_MODIFIERS.get(pair_key, PAIR_MODIFIERS.get(alt_key, {}))
+
+    adjusted = base
+    for body_key, modifier in modifiers.items():
+        count = counts.get(body_key, 0)
+        if count > 0:
+            # Modifier applies once for first body, 50% for subsequent
+            effect = modifier + modifier * 0.5 * (min(count, 4) - 1)
+            adjusted += effect
+
+    # Topology modifier: if topology confirms clean build path, boost
+    if topology:
+        if topology.get('contamination_risk', 0.5) < 0.20:
+            adjusted += 0.05   # Very clean system bonus
+        elif topology.get('contamination_risk', 0.5) > 0.70:
+            adjusted -= 0.10   # High contamination penalty
+
+    return round(max(0.0, min(1.0, adjusted)), 3)
+```
+
+### 5.3 Contamination Modelling
+
+```python
+def compute_contamination_risk(counts: dict, target_pair: tuple) -> dict:
+    """
+    Model the risk that a third economy contaminates the target pair.
+
+    Returns:
+        {
+            'risk_score':         float,  # 0-1 overall risk
+            'primary_contaminant': str,   # most likely third economy
+            'contamination_paths': list,  # [{body, economy_added, severity}]
+            'mitigation':         str,    # how to address it
+        }
+    """
+    economy_a, economy_b = target_pair
+    contamination_events = []
+
+    # Map body types to economies they ADD (contamination sources)
+    BODY_ECONOMY_ADDS = {
+        'rocky_geo':    ['Extraction', 'Industrial'],   # severe
+        'rocky_bio':    ['Agriculture', 'Terraforming'], # moderate
+        'rocky_rings':  ['Extraction'],                  # mild
+        'rocky_mixed':  ['Extraction', 'Industrial', 'Agriculture', 'Terraforming'],  # severe
+        'hmc_geo':      ['Extraction'],                  # useful if Extraction is target
+        'ammonia':      ['HighTech', 'Tourism'],
+        'elw':          ['Agriculture', 'HighTech', 'Military', 'Tourism'],
+        'ww':           ['Agriculture', 'Tourism'],
+        'gas_giant':    ['HighTech', 'Industrial'],
+        'neutron':      ['HighTech', 'Tourism'],
+        'black_hole':   ['HighTech', 'Tourism'],
+    }
+
+    SEVERITY = {
+        'rocky_geo':   0.85,
+        'rocky_mixed': 0.95,
+        'rocky_bio':   0.55,
+        'rocky_rings': 0.25,
+        'ammonia':     0.40,
+        'gas_giant':   0.30,
+    }
+
+    contaminant_scores = {}
+    for body_key, economies in BODY_ECONOMY_ADDS.items():
+        count = counts.get(body_key, 0)
+        if count == 0:
+            continue
+        severity = SEVERITY.get(body_key, 0.20)
+        for eco in economies:
+            if eco not in (economy_a, economy_b):
+                # This economy would be ADDED as contamination
+                score = severity * min(count, 3) / 3
+                contaminant_scores[eco] = contaminant_scores.get(eco, 0) + score
+                contamination_events.append({
+                    'body':     body_key,
+                    'economy':  eco,
+                    'severity': round(severity, 2),
+                    'count':    count,
+                })
+
+    overall_risk = min(sum(contaminant_scores.values()) / max(len(contaminant_scores), 1), 1.0)
+    primary = max(contaminant_scores, key=contaminant_scores.get) if contaminant_scores else None
+
+    mitigation = _suggest_mitigation(economy_a, economy_b, primary, overall_risk)
+
+    return {
+        'risk_score':          round(overall_risk, 3),
+        'primary_contaminant': primary,
+        'contamination_paths': contamination_events[:5],   # top 5 for API
+        'mitigation':          mitigation,
+    }
+
+
+def _suggest_mitigation(eco_a, eco_b, contaminant, risk) -> str:
+    if risk < 0.20:
+        return "Low risk — standard build order sufficient"
+    if risk < 0.45:
+        return (f"Moderate {contaminant} contamination risk. "
+                f"Sequence {eco_a} facilities first to establish top-2 before "
+                f"{contaminant} gains foothold.")
+    if risk >= 0.45:
+        return (f"High {contaminant} contamination risk. "
+                f"Refinery/Industrial Hubs required to maintain {eco_a}+{eco_b} "
+                f"dominance. Consider dedicated strong-link facilities on "
+                f"contaminating bodies.")
+    return "Evaluate build order carefully."
+```
+
+---
+
+## 6. Topology & Contamination Modelling
+
+### 6.1 Topology Metrics
+
+```python
+def compute_topology_metrics(bodies: list, system_id64: int) -> dict:
+    """
+    Compute system-level topology metrics from body data.
+    These metrics describe HOW bodies are arranged, not just WHAT they are.
+    """
+
+    # ── Strong link potential ─────────────────────────────────────────
+    # Strong links are boosted by: ELW, WW, Ammonia, GG, Ringed bodies
+    strong_link_bodies = sum([
+        counts.get('elw', 0)       * 25,
+        counts.get('ww', 0)        * 18,
+        counts.get('ammonia', 0)   * 20,
+        counts.get('gas_giant', 0) * 12,
+        counts.get('rocky_rings', 0) * 8,
+        counts.get('black_hole', 0)  * 22,
+        counts.get('neutron', 0)     * 18,
+    ])
+    strong_link_potential = min(strong_link_bodies, 100)
+
+    # ── Weak link stability ───────────────────────────────────────────
+    # Weak links are DECREASED by: tidal lock, icy bodies (for Agri)
+    # Stability = how resistant the system is to weak-link degradation
+    destabilisers = (
+        counts.get('tidal_lock', 0) * 8 +
+        counts.get('icy', 0) * 4
+    )
+    weak_link_stability = max(100 - destabilisers, 0)
+
+    # ── Orbital synergy ───────────────────────────────────────────────
+    # How well the orbital slot distribution supports the primary economy
+    orbital_bodies = (
+        counts.get('gas_giant', 0) * 6 +
+        counts.get('elw', 0)       * 5 +
+        counts.get('ww', 0)        * 4 +
+        counts.get('ammonia', 0)   * 4 +
+        counts.get('rocky_ice', 0) * 3 +
+        counts.get('icy', 0)       * 3 +
+        counts.get('rocky_clean', 0) * 3 +
+        counts.get('hmc', 0)       * 3 +
+        counts.get('metal_rich', 0) * 2
+    )
+    orbital_synergy = min(orbital_bodies * 5, 100)
+
+    # ── Ground synergy ────────────────────────────────────────────────
+    ground_bodies = (
+        counts.get('landable', 0) * 10 +
+        counts.get('landable_rocky_clean', 0) * 5 +
+        counts.get('landable_hmc', 0) * 4
+    )
+    ground_synergy = min(ground_bodies * 4, 100)
+
+    # ── Build flexibility ─────────────────────────────────────────────
+    # How many distinct viable build paths exist
+    from build_ratings import compute_body_diversity
+    diversity = compute_body_diversity(counts)
+    build_flexibility = int(diversity / 30.0 * 100)
+
+    # ── Nesting potential ─────────────────────────────────────────────
+    # Ability to use local-body grouping for supporting facilities
+    # (requires parent-body data from Spansh)
+    # For now: estimate from gas giant + moon presence
+    nesting_potential = min(
+        counts.get('gas_giant', 0) * 20 +
+        counts.get('rocky_clean', 0) * 8,
+        100
+    )
+
+    return {
+        'strong_link_potential':  strong_link_potential,
+        'weak_link_stability':    weak_link_stability,
+        'contamination_risk':     contamination_data.get('risk_score', 0.5),
+        'orbital_synergy':        orbital_synergy,
+        'ground_synergy':         ground_synergy,
+        'build_flexibility':      build_flexibility,
+        'nesting_potential':      nesting_potential,
+        'has_viable_surface_port': (
+            counts.get('landable', 0) > 0 and
+            (counts.get('landable_rocky_any', 0) + counts.get('landable_hmc', 0)) > 0
+        ),
+        'has_deep_orbital_anchor': counts.get('gas_giant', 0) > 0,
+        'has_ringed_gas_giant':   counts.get('rocky_rings', 0) > 0,
+    }
+```
+
+### 6.2 Estimated Slot Computation
+
+```python
+# Slot estimation constants — derived from community observation
+# of in-game Architect Mode slot counts
+SLOT_ESTIMATES = {
+    # (body_type_key): (orbital_slots_per_body, ground_slots_per_body)
+    # Ground slots require is_landable=True
+
+    # Stars
+    'main_star_large':   (10, 0),   # O/B/A main stars
+    'main_star_medium':  (7, 0),    # F/G/K main stars
+    'main_star_small':   (4, 0),    # M/L/T dwarfs
+    'secondary_star':    (5, 0),    # Any non-main star
+
+    # Gas Giants
+    'gas_giant_ringed':  (5, 0),    # Gas Giant with rings
+    'gas_giant_plain':   (3, 0),    # Gas Giant without rings
+
+    # Planets (orbital only if not landable)
+    'elw':               (4, 8),    # ELW — large ground slot count
+    'ww':                (3, 0),    # Water World — not landable typically
+    'ammonia':           (3, 0),    # Ammonia World — not landable
+    'rocky_large':       (3, 6),    # Rocky Body, large (radius > 3000 km)
+    'rocky_medium':      (2, 4),    # Rocky Body, medium
+    'rocky_small':       (2, 2),    # Rocky Body, small
+    'rocky_ice':         (3, 3),    # Rocky Ice — both surface and orbital
+    'icy_large':         (2, 2),    # Icy Body, large, landable
+    'icy_small':         (2, 0),    # Icy Body, small, not landable
+    'hmc_large':         (3, 5),    # HMC, large, landable
+    'hmc_medium':        (2, 3),    # HMC, medium
+    'metal_rich':        (2, 3),    # Metal Rich (often landable)
+}
+
+
+def estimate_body_slots(body: dict) -> tuple:
+    """
+    Estimate orbital and ground slot counts for a single body.
+
+    Returns (estimated_orbital, estimated_ground).
+    Ground slots are 0 for non-landable bodies.
+    """
+    sub = str(body.get('subtype') or '').lower()
+    is_landable = bool(body.get('is_landable', False))
+    radius = float(body.get('radius') or 0)  # km
+    is_main_star = bool(body.get('is_main_star', False))
+    sc = str(body.get('spectral_class') or '')
+    has_rings = bool(body.get('has_rings', False))
+
+    # ── Stars ─────────────────────────────────────────────────────────
+    if body.get('body_type') == 'Star':
+        if is_main_star:
+            if sc and sc[0].upper() in ('O', 'B', 'A'):
+                return (10, 0)
+            elif sc and sc[0].upper() in ('F', 'G', 'K'):
+                return (7, 0)
+            else:
+                return (4, 0)
+        else:
+            return (5, 0)
+
+    # ── Gas Giants ────────────────────────────────────────────────────
+    if 'gas giant' in sub:
+        return (5 if has_rings else 3, 0)
+
+    # ── Special worlds ────────────────────────────────────────────────
+    if 'earth-like' in sub:
+        return (4, 8 if is_landable else 0)
+    if 'water world' in sub:
+        return (3, 0)
+    if 'ammonia' in sub:
+        return (3, 0)
+
+    # ── Rocky Ice ─────────────────────────────────────────────────────
+    if 'rocky ice' in sub:
+        return (3, 3 if is_landable else 0)
+
+    # ── Rocky Bodies ──────────────────────────────────────────────────
+    if 'rocky body' in sub or sub == 'rocky':
+        if radius > 5000:
+            return (3, 6 if is_landable else 0)
+        elif radius > 2500:
+            return (2, 4 if is_landable else 0)
+        else:
+            return (2, 2 if is_landable else 0)
+
+    # ── HMC ───────────────────────────────────────────────────────────
+    if 'high metal content' in sub:
+        if radius > 4000:
+            return (3, 5 if is_landable else 0)
+        else:
+            return (2, 3 if is_landable else 0)
+
+    # ── Metal Rich ────────────────────────────────────────────────────
+    if 'metal-rich' in sub or 'metal rich' in sub:
+        return (2, 3 if is_landable else 0)
+
+    # ── Icy ───────────────────────────────────────────────────────────
+    if 'icy body' in sub or sub == 'icy':
+        if is_landable and radius > 2000:
+            return (2, 2)
+        return (2, 0)
+
+    # ── Default ───────────────────────────────────────────────────────
+    return (1, 1 if is_landable else 0)
+```
+
+---
+
+## 7. Buildability Scoring
+
+### 7.1 Formula
+
+```python
+def compute_buildability(
+    counts: dict,
+    topology: dict,
+    archetype_key: str,
+    pair_synergy: float,
+) -> dict:
+    """
+    Buildability = how easy is it to realise this archetype in practice.
+
+    Factors:
+    - CP efficiency:      how many construction points needed per economy tier
+    - T3 scaling:         ease of advancing to T3 (requires strong links + sufficient slots)
+    - Slot efficiency:    orbital/ground ratio matches archetype needs
+    - Contamination mgmt: how much extra work is needed to maintain top-2 economies
+    - Topology flexibility: number of viable sequencing paths
+    """
+    # ── CP efficiency (0-100) ─────────────────────────────────────────
+    # Systems where each facility directly supports the target economy
+    # are more CP-efficient than systems requiring "hub" investments first.
+    # Proxy: clean body count for the archetype / total relevant bodies
+    defn = ARCHETYPE_DEFINITIONS[archetype_key]
+    primary_bodies = sum(
+        counts.get(k, 0) * w
+        for k, w in defn['body_weights'].items()
+        if w >= 0.70  # only count high-value bodies
+    )
+    all_bodies = max(sum(counts.get(k, 0) for k in defn['body_weights']), 1)
+    cp_efficiency = min(primary_bodies / all_bodies * 100, 100)
+
+    # ── T3 scaling (0-100) ────────────────────────────────────────────
+    # T3 requires strong links — approximated by strong_link_potential
+    t3_scaling = topology.get('strong_link_potential', 0) if topology else 30.0
+
+    # ── Slot efficiency (0-100) ───────────────────────────────────────
+    slot_pref = defn.get('slot_preference', 'balanced')
+    ground = topology.get('ground_synergy', 50) if topology else 50
+    orbital = topology.get('orbital_synergy', 50) if topology else 50
+
+    if slot_pref == 'ground_heavy':
+        slot_efficiency = ground * 0.70 + orbital * 0.30
+    elif slot_pref == 'orbital_heavy':
+        slot_efficiency = orbital * 0.70 + ground * 0.30
+    else:
+        slot_efficiency = (ground + orbital) / 2.0
+
+    # ── Contamination management penalty ─────────────────────────────
+    contamination = topology.get('contamination_risk', 0.5) if topology else 0.5
+    contamination_penalty = contamination * 30   # up to -30 from contamination
+
+    # ── Topology flexibility bonus ────────────────────────────────────
+    flexibility = topology.get('build_flexibility', 50) if topology else 50
+    flexibility_bonus = flexibility * 0.10       # up to +10
+
+    # ── Compose ───────────────────────────────────────────────────────
+    raw = (
+        cp_efficiency    * 0.35 +
+        t3_scaling       * 0.25 +
+        slot_efficiency  * 0.20 +
+        flexibility_bonus
+    ) - contamination_penalty
+
+    score = round(max(0.0, min(100.0, raw)), 2)
+
+    # ── Classify complexity ────────────────────────────────────────────
+    if score >= 80 and contamination < 0.20:
+        complexity = 'simple'
+    elif score >= 65 and contamination < 0.40:
+        complexity = 'moderate'
+    elif score >= 45:
+        complexity = 'advanced'
+    elif score >= 25:
+        complexity = 'expert'
+    else:
+        complexity = 'trivial' if score > 15 else 'expert'
+
+    return {
+        'buildability_score': score,
+        'build_complexity':   complexity,
+        'cp_efficiency':      round(cp_efficiency, 2),
+        't3_scaling_viability': round(t3_scaling, 2),
+        'slot_efficiency':    round(slot_efficiency, 2),
+    }
+```
+
+---
+
+## 8. Explainability System
+
+### 8.1 Structured Rationale (JSONB)
+
+The new `rationale` field in `system_archetype_scores` is **structured JSONB**, not a plain string. This allows the frontend to render richer explanations without parsing.
+
+```python
+def generate_structured_rationale(
+    archetype_key: str,
+    archetype_score: dict,
+    counts: dict,
+    topology: dict,
+    buildability: dict,
+    contamination: dict,
+    confidence: float,
+) -> dict:
+    """
+    Generate a full structured rationale for a system's archetype score.
+
+    Returns:
+    {
+        "summary":    "One-sentence description (<=200 chars)",
+        "tier":       "S / A / B / C / D",
+        "headline":   "92 — Refinery / Industrial Megacomplex",
+        "positives":  ["Rocky-Ice world", "Pristine reserves", ...],
+        "risks":      ["Moderate geo-signal contamination", ...],
+        "complexity": "Moderate — some contamination management required",
+        "build_path": "Sequence Refinery facilities first, then Industrial...",
+        "tags":       ["Rocky-Ice", "Pristine", "Low Contamination"],
+        "score_breakdown": {
+            "body_composition":   58.2,
+            "topology":           22.1,
+            "pair_synergy_pts":   11.4,
+            "purity_factor":      1.12,
+        }
+    }
+    """
+    defn = ARCHETYPE_DEFINITIONS[archetype_key]
+    score = archetype_score['score']
+
+    # ── Tier ─────────────────────────────────────────────────────────
+    if score >= 88:   tier = 'S'
+    elif score >= 76: tier = 'A'
+    elif score >= 60: tier = 'B'
+    elif score >= 45: tier = 'C'
+    else:             tier = 'D'
+
+    # ── Summary sentence ─────────────────────────────────────────────
+    score_word = 'Exceptional' if score >= 88 else \
+                 'Excellent'   if score >= 76 else \
+                 'Solid'       if score >= 60 else \
+                 'Functional'  if score >= 45 else \
+                 'Limited'
+    summary = (
+        f"{score_word} candidate for {defn['label']}. "
+        f"{_archetype_context(archetype_key, counts, score)}"
+    )[:200]
+
+    # ── Positive traits ───────────────────────────────────────────────
+    positives = _build_positives(archetype_key, counts, topology, buildability)
+
+    # ── Risks ─────────────────────────────────────────────────────────
+    risks = _build_risks(counts, topology, contamination, buildability)
+
+    # ── Complexity description ────────────────────────────────────────
+    complexity_map = {
+        'trivial':  'Trivial — straightforward single-economy build',
+        'simple':   'Simple — clean pair, standard build order',
+        'moderate': 'Moderate — some contamination management required',
+        'advanced': 'Advanced — nested ports or tight sequencing needed',
+        'expert':   'Expert — multi-phase build, deep game knowledge required',
+    }
+    complexity_str = complexity_map.get(buildability['build_complexity'], 'Moderate')
+
+    # ── Tags ─────────────────────────────────────────────────────────
+    tags = _compute_display_tags(archetype_key, counts, topology, buildability, contamination)
+
+    return {
+        'summary':    summary,
+        'tier':       tier,
+        'headline':   f"{int(score)} — {defn['label']}",
+        'positives':  positives[:6],   # max 6 bullet points
+        'risks':      risks[:4],       # max 4 warnings
+        'complexity': complexity_str,
+        'build_path': _suggest_build_path(archetype_key, counts, contamination),
+        'tags':       tags,
+        'score_breakdown': {
+            'body_composition':    archetype_score.get('body_contribution', 0),
+            'topology':            archetype_score.get('topology_contribution', 0),
+            'pair_synergy_pts':    archetype_score.get('synergy_pts', 0),
+            'purity_factor':       archetype_score.get('purity_factor', 1.0),
+            'contamination_risk':  archetype_score.get('contamination_risk', 0),
+        },
+        'data_confidence': confidence,
+    }
+
+
+def _compute_display_tags(archetype_key, counts, topology, buildability, contamination) -> list:
+    tags = []
+
+    # Body type tags
+    if counts.get('elw', 0) >= 1:
+        tags.append(f"{'ELW' if counts['elw'] == 1 else str(counts['elw']) + '× ELW'}")
+    if counts.get('black_hole', 0) >= 1:
+        tags.append('Black Hole')
+    if counts.get('neutron', 0) >= 1:
+        tags.append('Neutron Star')
+    if counts.get('rocky_clean', 0) >= 3:
+        tags.append(f"{counts['rocky_clean']} Clean Rocky")
+    if counts.get('rocky_ice', 0) >= 2:
+        tags.append('Rocky-Ice')
+
+    # Quality tags
+    if contamination and contamination.get('risk_score', 1) < 0.20:
+        tags.append('Low Contamination')
+    elif contamination and contamination.get('risk_score', 0) > 0.60:
+        tags.append('High Contamination')
+
+    if buildability['build_complexity'] in ('trivial', 'simple'):
+        tags.append('T3 Friendly')
+
+    # Slot tags
+    est_total = counts.get('est_total_slots', 0)
+    if est_total >= 40:
+        tags.append(f'{est_total}+ Slots')
+    elif est_total >= 25:
+        tags.append(f'{est_total} Slots')
+
+    if counts.get('landable', 0) >= 8:
+        tags.append(f"{counts['landable']} Ground Slots")
+
+    return tags[:8]   # max 8 tags for UI
+```
+
+---
+
+## 9. Async Computation Pipeline
+
+### 9.1 Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  LAYER 1: Raw Data Ingestion                                      │
+│  import_spansh.py → systems, bodies, stations tables             │
+│  eddn_listener.py → real-time updates → rating_dirty = TRUE      │
+└─────────────────────────┬────────────────────────────────────────┘
+                          │ (nightly or on-dirty)
+┌─────────────────────────▼────────────────────────────────────────┐
+│  LAYER 2: Body Classification                                     │
+│  build_ratings.py → ratings table (EXISTING — preserved)         │
+│  classify_bodies() → contamination flags, economy scores         │
+└─────────────────────────┬────────────────────────────────────────┘
+                          │ (after build_ratings.py completes)
+┌─────────────────────────▼────────────────────────────────────────┐
+│  LAYER 3: Topology Analysis (NEW)                                 │
+│  build_topology.py → system_slot_topology table                  │
+│  estimate_body_slots() → inferred slot counts                    │
+│  compute_topology_metrics() → strong/weak link, contamination    │
+│  compute_system_pair_synergy() → economy_pair_synergy table      │
+└─────────────────────────┬────────────────────────────────────────┘
+                          │ (after build_topology.py completes)
+┌─────────────────────────▼────────────────────────────────────────┐
+│  LAYER 4: Archetype Scoring (NEW)                                 │
+│  build_archetype_scores.py → system_archetype_scores table       │
+│  compute_archetype_score() × 9 archetypes per system             │
+│  generate_structured_rationale() → JSONB rationale               │
+│  → system_archetype_traits table                                  │
+└─────────────────────────┬────────────────────────────────────────┘
+                          │ (after build_archetype_scores.py completes)
+┌─────────────────────────▼────────────────────────────────────────┐
+│  LAYER 5: Materialized View Refresh (NEW)                         │
+│  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings    │
+│  Redis cache invalidation → api key prefix bump                  │
+└─────────────────────────┬────────────────────────────────────────┘
+                          │
+┌─────────────────────────▼────────────────────────────────────────┐
+│  LAYER 6: API Serving                                             │
+│  FastAPI → reads from mv_archetype_rankings                      │
+│  Redis → caches query results (TTL 300s)                         │
+│  Dynamic reranking → Python-side weight application              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 9.2 New Script: `build_topology.py`
+
+```python
+"""
+ED Finder — Topology & Slot Inference Engine
+Version: 1.0
+
+Runs AFTER build_ratings.py. Reads from bodies + ratings tables,
+writes to system_slot_topology and economy_pair_synergy.
+
+Usage:
+    python3 build_topology.py              # process all unprocessed systems
+    python3 build_topology.py --rebuild    # reprocess all systems
+    python3 build_topology.py --dirty      # only dirty systems
+    python3 build_topology.py --workers 4
+"""
+
+# Worker function processes systems in chunks of 10,000.
+# Each worker: fetches bodies for its chunk, computes topology,
+# upserts to system_slot_topology.
+# Same multiprocessing pattern as build_ratings.py.
+```
+
+### 9.3 New Script: `build_archetype_scores.py`
+
+```python
+"""
+ED Finder — Archetype Scoring Engine
+Version: 1.0
+
+Runs AFTER build_topology.py. Reads from bodies + ratings +
+system_slot_topology tables, writes to system_archetype_scores
+and system_archetype_traits.
+
+Usage:
+    python3 build_archetype_scores.py --rebuild
+    python3 build_archetype_scores.py --dirty
+    python3 build_archetype_scores.py --workers 4
+"""
+```
+
+### 9.4 Updated Build Order
+
+```bash
+# Full pipeline (nightly):
+1. python3 import_spansh.py --all        # ~4-6h
+2. python3 build_grid.py                 # ~1-2h
+3. python3 build_ratings.py              # ~3-5h (existing)
+4. python3 build_topology.py             # ~1-2h (NEW)
+5. python3 build_archetype_scores.py     # ~2-3h (NEW)
+6. python3 build_clusters.py             # ~2-4h (existing)
+7. psql -c "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings"
+```
+
+### 9.5 Dirty-Flag Strategy
+
+```sql
+-- New trigger: when system_archetype_scores is set dirty,
+-- also invalidate the materialized view row
+-- (handled by the REFRESH CONCURRENTLY at end of dirty cycle)
+
+-- Updated dirty propagation:
+-- EDDN Scan event → systems.rating_dirty = TRUE
+--   → build_ratings.py --dirty picks it up
+--   → marks system_archetype_scores.dirty = TRUE
+--   → build_archetype_scores.py --dirty picks it up
+--   → REFRESH MATERIALIZED VIEW CONCURRENTLY (incremental)
+```
+
+---
+
+## 10. API Endpoints
+
+### 10.1 New: `GET /api/archetypes/rankings`
+
+```
+GET /api/archetypes/rankings?archetype=refinery_industrial&min_score=60
+    &galaxy_region=18&max_distance_ly=500&limit=50
+
+Response:
+{
+    "archetype":     "refinery_industrial",
+    "archetype_label": "Refinery / Industrial Megacomplex",
+    "results": [
+        {
+            "id64":   12345678901,
+            "name":   "HD 49188",
+            "coords": {"x": -22.4, "y": 12.1, "z": 55.3},
+            "score":  92,
+            "tier":   "S",
+            "primary_archetype": "refinery_industrial",
+            "buildability_score": 78,
+            "build_complexity":   "moderate",
+            "purity_score":       88,
+            "contamination_risk": 0.14,
+            "confidence":         0.97,
+            "tags":   ["Rocky-Ice", "Pristine", "Low Contamination", "T3 Friendly"],
+            "rationale": {
+                "summary":    "Exceptional Refinery/Industrial candidate...",
+                "tier":       "S",
+                "headline":   "92 — Refinery / Industrial Megacomplex",
+                "positives":  ["8 clean rocky bodies", "3 rocky-ice bodies", "15 landable"],
+                "risks":      ["2 geo-signal rocky bodies — moderate Extraction contamination"],
+                "complexity": "Moderate — some contamination management required",
+                "tags":       ["Rocky-Ice", "Pristine", "Low Contamination"]
+            }
+        }
+    ],
+    "total":   1847,
+    "count":   50,
+    "source":  "mv_archetype_rankings",
+    "query_ms": 12
+}
+```
+
+### 10.2 New: `POST /api/archetypes/rerank`
+
+```
+POST /api/archetypes/rerank
+{
+    "id64s": [12345, 67890, ...],
+    "archetype": "refinery_industrial",
+    "weights": {
+        "purity":       0.30,
+        "buildability": 0.25,
+        "slots":        0.20,
+        "expansion":    0.15,
+        "logistics":    0.10
+    },
+    "profile": null   // or: "industrial_empire", "space_farms", etc.
+}
+
+Response:
+{
+    "archetype":        "refinery_industrial",
+    "profile_applied":  null,
+    "weights_applied":  {...},
+    "results": [
+        {
+            "id64":           12345,
+            "reranked_score": 94,
+            "original_score": 92,
+            "rationale":      "Strong Refinery/Industrial; 8 clean rocky bodies..."
+        }
+    ]
+}
+```
+
+### 10.3 New: `GET /api/archetypes/system/{id64}`
+
+Full archetype breakdown for a single system.
+
+```
+GET /api/archetypes/system/12345678901
+
+Response:
+{
+    "id64":   12345678901,
+    "name":   "HD 49188",
+
+    "archetypes": {
+        "refinery_industrial": {
+            "score": 92, "tier": "S",
+            "rank_global": 147,
+            "rationale": {...full structured rationale...}
+        },
+        "extraction_refinery": {
+            "score": 78, "tier": "A", ...
+        },
+        ...all 9 archetypes...
+    },
+
+    "primary_archetype":   "refinery_industrial",
+    "secondary_archetype": "extraction_refinery",
+    "overall_development_potential": 88,
+    "buildability_score": 78,
+    "build_complexity":   "moderate",
+
+    "topology": {
+        "estimated_orbital_slots":  34,
+        "estimated_ground_slots":   28,
+        "strong_link_potential":    72,
+        "weak_link_stability":      88,
+        "contamination_risk":       0.14,
+        "orbital_synergy":          68,
+        "ground_synergy":           82
+    },
+
+    "economy_pairs": [
+        {
+            "economy_a": "Refinery",
+            "economy_b": "Industrial",
+            "synergy_score": 91,
+            "purity_achievable": 0.88,
+            "contamination_paths": [...]
+        }
+    ],
+
+    "tags":       ["Rocky-Ice", "Pristine", "Low Contamination", "T3 Friendly"],
+    "confidence": 0.97
+}
+```
+
+### 10.4 New: `POST /api/archetypes/simulate`
+
+Build simulation — given an intended build plan, score the system against it.
+
+```
+POST /api/archetypes/simulate
+{
+    "id64": 12345678901,
+    "planned_archetype": "refinery_industrial",
+    "planned_facilities": [
+        {"type": "StarPort", "tier": 3, "body": "main_star"},
+        {"type": "RefineryHub", "tier": 2, "body": "rocky_1"},
+        ...
+    ]
+}
+
+Response:
+{
+    "simulation_score": 87,
+    "economy_prediction": {
+        "primary":    "Refinery",
+        "secondary":  "Industrial",
+        "tertiary":   "Extraction",  // contamination from rocky_geo_1
+        "purity":     0.84
+    },
+    "recommendations": [
+        "Add Refinery Hub to rocky_geo_1 to suppress Extraction contamination",
+        "3 additional Industrial facilities recommended for T3 scaling"
+    ]
+}
+```
+
+### 10.5 Updated: `POST /api/ratings/rerank`
+
+**Backward-compatible.** The existing endpoint is unchanged. It continues to read from the `ratings` table using the v3.1 weights. A new optional field `use_archetype_engine` switches to the new scoring system:
+
+```python
+# In ratings.py — additive, not replacing:
+class RerankRequest(BaseModel):
+    id64s:   List[int]
+    weights: Optional[RerankWeights] = None
+    economy: Optional[str]           = None
+    # NEW optional fields:
+    archetype:            Optional[str]  = None   # e.g. 'refinery_industrial'
+    use_archetype_engine: bool           = False  # default: use legacy engine
+    profile:              Optional[str]  = None   # preset profile name
+```
+
+### 10.6 New: `GET /api/archetypes/profiles`
+
+```
+GET /api/archetypes/profiles
+
+Response:
+{
+    "profiles": [
+        {
+            "id":          "industrial_empire",
+            "label":       "Industrial Empire",
+            "description": "Refinery/Industrial megacomplex focus",
+            "archetype":   "refinery_industrial",
+            "weights": {
+                "purity": 0.35, "buildability": 0.25, "slots": 0.20,
+                "expansion": 0.10, "logistics": 0.10
+            }
+        },
+        {
+            "id":          "space_farms",
+            "label":       "Space Farms",
+            "description": "Agriculture and terraforming focus",
+            "archetype":   "agriculture_terraforming",
+            "weights": {...}
+        },
+        {
+            "id":          "prestige_capital",
+            "label":       "Prestige Capital",
+            "description": "HighTech / Tourism prestige colony",
+            "archetype":   "hitech_tourism",
+            "weights": {...}
+        },
+        {
+            "id":          "ax_logistics",
+            "label":       "AX Logistics",
+            "description": "Military / HighTech anti-xeno forward base",
+            "archetype":   "ax_forward_base",
+            "weights": {...}
+        },
+        {
+            "id":          "expansion_capital",
+            "label":       "Expansion Capital",
+            "description": "Flexible system for multi-jump colonisation chains",
+            "archetype":   "expansion_capital",
+            "weights": {...}
+        },
+        {
+            "id":          "generalist",
+            "label":       "Generalist",
+            "description": "Balanced weights, no archetype preference",
+            "archetype":   null,
+            "weights": {...}
+        }
+    ]
+}
+```
+
+---
+
+## 11. Reranking Redesign
+
+### 11.1 New Weight Dimensions
+
+Replace:
+```python
+_DEFAULT_WEIGHTS = {
+    'economy': 0.42, 'slots': 0.23, 'strategic': 0.18,
+    'safety': 0.10, 'terraforming': 0.05, 'diversity': 0.02
+}
+```
+
+With:
+```python
+_DEFAULT_ARCHETYPE_WEIGHTS = {
+    'purity':       0.30,   # clean economy stack, low contamination
+    'buildability': 0.25,   # ease of build, CP efficiency, T3 scaling
+    'slots':        0.20,   # total slot count + topology quality
+    'expansion':    0.15,   # flexibility for future growth
+    'logistics':    0.10,   # distance from hub, scoopable star
+}
+```
+
+### 11.2 Updated `RerankWeights` Model
+
+```python
+class ArchetypeRerankWeights(BaseModel):
+    purity:       float = 0.30
+    buildability: float = 0.25
+    slots:        float = 0.20
+    expansion:    float = 0.15
+    logistics:    float = 0.10
+```
+
+### 11.3 Fast Reranking SQL
+
+```sql
+-- Reranking query against system_archetype_scores
+-- All weights applied in Python after single DB fetch (same pattern as v3.1)
+
+SELECT
+    a.system_id64              AS id64,
+    a.score_refinery_industrial AS archetype_score,
+    a.purity_score,
+    a.buildability_score,
+    t.est_total_slots          AS slots,
+    a.overall_development_potential AS expansion,
+    CASE WHEN s.main_star_is_scoopable THEN 80 ELSE 40 END AS logistics,
+    a.confidence,
+    a.rationale
+FROM system_archetype_scores a
+JOIN systems s              ON s.id64 = a.system_id64
+JOIN system_archetype_traits t ON t.system_id64 = a.system_id64
+WHERE a.system_id64 = ANY($1::bigint[])
+  AND a.dirty = FALSE;
+```
+
+---
+
+## 12. Migration Strategy
+
+### 12.1 Phase 1 — Parallel Infrastructure (No Breaking Changes)
+
+**Duration:** 2-3 days  
+**Risk:** Zero — purely additive
+
+```sql
+-- Run: sql/012_topology_tables.sql
+CREATE TABLE system_slot_topology ...      -- new
+CREATE TABLE system_archetype_scores ...   -- new
+CREATE TABLE system_archetype_traits ...   -- new
+CREATE TABLE economy_pair_synergy ...      -- new
+CREATE TABLE pair_synergy_constants ...    -- new
+INSERT INTO pair_synergy_constants ...     -- seed data
+
+-- Existing tables untouched:
+-- systems, bodies, stations, ratings, clusters, etc.
+```
+
+**Deliverables:**
+- New schema deployed
+- `pair_synergy_constants` seeded
+- No API changes
+
+### 12.2 Phase 2 — Build Pipeline Extension
+
+**Duration:** 1 week  
+**Risk:** Low — new scripts alongside existing ones
+
+```bash
+# New scripts added:
+apps/importer/src/build_topology.py         # new
+apps/importer/src/build_archetype_scores.py # new
+
+# Existing scripts unchanged:
+apps/importer/src/build_ratings.py          # preserved
+apps/importer/src/import_spansh.py          # preserved
+```
+
+**Test:** Run `build_topology.py --limit 10000` and `build_archetype_scores.py --limit 10000`. Compare archetype scores against manual expectations for known systems.
+
+**Validation queries:**
+```sql
+-- Check archetype distribution
+SELECT primary_archetype, COUNT(*), AVG(score_refinery_industrial)
+FROM system_archetype_scores
+GROUP BY primary_archetype ORDER BY COUNT(*) DESC;
+
+-- Verify purity scores are reasonable
+SELECT system_id64, purity_score, contamination_risk
+FROM system_archetype_scores
+ORDER BY purity_score DESC LIMIT 20;
+
+-- Cross-check: top refinery systems should match top ratings.score_refinery
+SELECT a.system_id64, s.name,
+       r.score_refinery,
+       a.score_refinery_industrial
+FROM system_archetype_scores a
+JOIN ratings r ON r.system_id64 = a.system_id64
+JOIN systems s ON s.id64 = a.system_id64
+ORDER BY a.score_refinery_industrial DESC LIMIT 20;
+```
+
+### 12.3 Phase 3 — Beta API Endpoints
+
+**Duration:** 1 week  
+**Risk:** Low — new routes, no existing routes changed
+
+```python
+# New router: apps/api/src/routers/archetypes.py
+# Mounted at /api/archetypes/...
+
+# Existing routers unchanged:
+# routers/ratings.py     → /api/ratings/rerank (unchanged)
+# routers/search.py      → /api/local/search   (unchanged)
+# routers/systems.py     → /api/system/{id64}  (unchanged)
+```
+
+**Frontend flag:** Add `?engine=v4` query parameter to enable new archetype data in system detail response. Existing frontend continues using v3.1 data.
+
+### 12.4 Phase 4 — Full Cutover
+
+**Duration:** 2 weeks  
+**Risk:** Medium — user-visible changes
+
+1. Deploy new frontend components (archetype cards, tier badges, structured rationale)
+2. Make archetype scores the primary sort in `/api/local/search` when an economy is specified
+3. Map economy filter → archetype: `economy=Refinery` → `archetype=refinery_industrial`
+4. The single legacy `score` column becomes `overall_development_potential` in API responses
+5. Remove `score` from primary UI display; replace with archetype tier badge
+
+**Backward compat preserved:**
+- `/api/ratings/rerank` endpoint unchanged
+- `ratings.score` column preserved in DB
+- `_rating.score` field preserved in API responses (now = `overall_development_potential`)
+
+### 12.5 Phase 5 — Cleanup (Optional, Future)
+
+- Drop `compute_strategic_score()` (superseded by topology metrics)
+- Consolidate `compute_slot_score()` into topology engine
+- Migrate `score_breakdown` to structured archetype breakdown only
+- Archive `ratings` table (keep for historical queries, stop writing)
+
+---
+
+## 13. Architecture Diagrams
+
+### 13.1 Data Flow
+
+```
+EDDN (real-time)                  Spansh (nightly)
+     │                                  │
+     ▼                                  ▼
+eddn_listener.py               import_spansh.py
+     │                                  │
+     └──────────────┬───────────────────┘
+                    ▼
+          ┌─────────────────┐
+          │    systems      │
+          │    bodies       │
+          │    stations     │
+          └────────┬────────┘
+                   │ rating_dirty=TRUE
+                   ▼
+          ┌─────────────────┐
+          │ build_ratings   │◄── classify_bodies()
+          │      .py        │    score_refinery()
+          └────────┬────────┘    score_agriculture()
+                   │             ...
+                   ▼
+          ┌─────────────────┐
+          │    ratings      │   (EXISTING — preserved)
+          └────────┬────────┘
+                   │
+                   ▼
+          ┌─────────────────┐
+          │ build_topology  │◄── estimate_body_slots()
+          │      .py (NEW)  │    compute_topology_metrics()
+          └────────┬────────┘    compute_system_pair_synergy()
+                   │
+                   ▼
+          ┌─────────────────────────┐
+          │ system_slot_topology    │ (NEW)
+          │ economy_pair_synergy    │ (NEW)
+          └─────────┬───────────────┘
+                    │
+                    ▼
+          ┌──────────────────────────┐
+          │ build_archetype_scores   │◄── compute_archetype_score()
+          │        .py (NEW)         │    compute_buildability()
+          └──────────┬───────────────┘    generate_structured_rationale()
+                     │
+                     ▼
+          ┌────────────────────────────┐
+          │ system_archetype_scores    │ (NEW)
+          │ system_archetype_traits    │ (NEW)
+          └──────────┬─────────────────┘
+                     │
+                     ▼
+          ┌────────────────────────────┐
+          │ mv_archetype_rankings      │ (MATERIALIZED VIEW)
+          │ REFRESH CONCURRENTLY       │
+          └──────────┬─────────────────┘
+                     │
+                     ▼
+          ┌────────────────────────────┐
+          │         FastAPI            │
+          │  /api/archetypes/rankings  │
+          │  /api/archetypes/rerank    │
+          │  /api/archetypes/system    │
+          │  /api/ratings/rerank (v3.1)│
+          └──────────┬─────────────────┘
+                     │
+                     ▼
+                  Redis
+               (cache layer)
+```
+
+### 13.2 Score Composition
+
+```
+SYSTEM ARCHETYPE SCORE COMPOSITION
+───────────────────────────────────────────────────────────
+
+Body Composition          Topology             Pair Synergy
+(0–60 pts)                (0–25 pts)           (0–15 pts)
+    │                          │                    │
+    │  ×  Purity Factor        │                    │
+    │     (0.70 – 1.35)        │                    │
+    │                          │                    │
+    └──────────────────────────┴────────────────────┘
+                               │
+                       RAW SCORE (0–100)
+                               │
+                   ÷ Contamination Penalty
+                   × Diversity Bonus (optional)
+                               │
+                  ARCHETYPE SCORE (0–100, per archetype)
+                               │
+             ┌─────────────────┴──────────────────┐
+             │                                     │
+      Primary Sort for                   Secondary Sort for
+      archetype-specific                 tie-breaking within
+      API queries                        archetype tier
+
+              Combined across archetypes:
+              OVERALL DEVELOPMENT POTENTIAL (0–100)
+              (supporting metric, not primary ranking signal)
+```
+
+---
+
+## 14. Caching Strategy
+
+### 14.1 Redis Cache Keys
+
+```python
+# Archetype ranking results (long TTL — changes only after rebuild)
+f"arch:rank:{archetype}:{region}:{min_score}:{limit}:{offset}"
+TTL: 600s (10 min)
+
+# System archetype detail (medium TTL)
+f"arch:sys:{id64}"
+TTL: 300s (5 min)
+
+# Rerank results (short TTL — user-specific)
+f"arch:rerank:{hash(id64s + weights)}"
+TTL: 120s (2 min)
+
+# Profile definitions (permanent until rebuild)
+"arch:profiles"
+TTL: 3600s (1 hour)
+
+# Materialized view staleness flag
+"mv:archetype_rankings:last_refresh"
+TTL: no expiry — updated by build pipeline
+```
+
+### 14.2 Cache Invalidation
+
+```python
+# After build_archetype_scores.py completes:
+async def invalidate_archetype_cache(redis):
+    # Bump a version counter — all arch: keys are prefixed with version
+    await redis.incr("arch:version")
+    # Force MV refresh timestamp update
+    await redis.set("mv:archetype_rankings:last_refresh",
+                    datetime.now(UTC).isoformat())
+```
+
+---
+
+## 15. Performance Recommendations
+
+### 15.1 Index Strategy
+
+```sql
+-- Critical indexes for archetype queries
+CREATE INDEX IF NOT EXISTS idx_arch_scores_refinery
+    ON system_archetype_scores (score_refinery_industrial DESC)
+    WHERE score_refinery_industrial >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_hitech
+    ON system_archetype_scores (score_hitech_tourism DESC)
+    WHERE score_hitech_tourism >= 40 AND dirty = FALSE;
+
+-- Composite: region + archetype (most common query pattern)
+CREATE INDEX IF NOT EXISTS idx_mv_arch_region_refinery
+    ON mv_archetype_rankings (galaxy_region_id, score_refinery_industrial DESC)
+    WHERE score_refinery_industrial >= 30;
+
+-- Topology: fast contamination filter
+CREATE INDEX IF NOT EXISTS idx_topo_contamination
+    ON system_slot_topology (contamination_risk ASC)
+    WHERE contamination_risk < 0.30;
+
+-- Traits: multi-column fast filter
+CREATE INDEX IF NOT EXISTS idx_traits_filter
+    ON system_archetype_traits (has_elw, landable_count DESC, est_total_slots DESC);
+```
+
+### 15.2 Materialized View Refresh Strategy
+
+```sql
+-- CONCURRENT refresh does not block reads
+-- Run after every full build_archetype_scores.py completion
+REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;
+
+-- For dirty-only partial rebuilds:
+-- 1. Update system_archetype_scores rows
+-- 2. REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings
+-- The CONCURRENTLY variant handles incremental updates efficiently.
+```
+
+### 15.3 Query Pattern for `GET /api/archetypes/rankings`
+
+```sql
+-- Efficient: hits mv_archetype_rankings, no join needed
+SELECT
+    id64, name, x, y, z,
+    primary_archetype, score_refinery_industrial AS score,
+    buildability_score, build_complexity,
+    purity_score, contamination_risk, confidence,
+    has_elw, elw_count, landable_count, est_total_slots,
+    display_tags,
+    -- Rationale comes from system_archetype_scores (separate fetch or JSONB in MV)
+FROM mv_archetype_rankings
+WHERE score_refinery_industrial >= $1
+  AND ($2::smallint IS NULL OR galaxy_region_id = $2)
+ORDER BY score_refinery_industrial DESC
+LIMIT $3 OFFSET $4;
+
+-- Estimated query time on 50M rows: 2–8ms (index scan on mv)
+```
+
+---
+
+## 16. Implementation Phases
+
+### Summary
+
+| Phase | Duration | Scope | Risk | Breaking Changes? |
+|-------|----------|-------|------|------------------|
+| 1 | 2-3 days | Schema additions | None | No |
+| 2 | 1 week | Build pipeline | Low | No |
+| 3 | 1 week | Beta API endpoints | Low | No |
+| 4 | 2 weeks | Frontend + primary API | Medium | Minor (additive) |
+| 5 | Future | Cleanup | Low | Optional |
+
+### Phase 1 Detail — Schema (2-3 days)
+- [ ] Write `sql/012_topology_tables.sql`
+- [ ] Write `sql/013_archetype_scores.sql`
+- [ ] Write `sql/014_materialized_views.sql`
+- [ ] Test migrations against staging DB
+- [ ] Deploy to production
+
+### Phase 2 Detail — Pipeline (1 week)
+- [ ] Write `apps/importer/src/build_topology.py`
+- [ ] Write `apps/importer/src/build_archetype_scores.py`
+- [ ] Add topology functions to shared scoring module
+- [ ] Add archetype definitions to shared module
+- [ ] Run `build_topology.py --limit 100000` on staging
+- [ ] Run `build_archetype_scores.py --limit 100000` on staging
+- [ ] Validate archetype scores for known systems
+- [ ] Full pipeline run on production
+
+### Phase 3 Detail — API (1 week)
+- [ ] Write `apps/api/src/routers/archetypes.py`
+- [ ] Add Pydantic models for archetype responses
+- [ ] Add profile definitions
+- [ ] Write unit tests for archetype scoring
+- [ ] Write API integration tests
+- [ ] Deploy to staging
+
+### Phase 4 Detail — Frontend (2 weeks)
+- [ ] Archetype tier badge component (S/A/B/C/D)
+- [ ] Structured rationale popover (positives / risks / build path)
+- [ ] Tag pill components
+- [ ] Profile selector UI (replacing raw weight sliders as default)
+- [ ] Archetype score table per system
+- [ ] Update search sort to use archetype scores
+- [ ] Update system detail page
+- [ ] A/B flag for gradual rollout
+
+---
+
+## 17. Risks & Unknowns
+
+### 17.1 Data Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Slot estimates are significantly wrong | Medium | Medium | Label clearly as "estimated". Allow user correction via notes system. |
+| Spansh body data missing for new colonised systems | Medium | Medium | EDDN updates `rating_dirty`; dirty rebuild picks up new body data |
+| Frontier changes economy mechanics again | High | Medium | JSONB `traits` field absorbs new properties. Per-economy scores stored separately so individual score functions can be updated without full schema migration. |
+| Archetype synergy constants are wrong | Medium | Low | Constants are in `pair_synergy_constants` DB table — can be updated without code change. |
+
+### 17.2 Technical Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `REFRESH MATERIALIZED VIEW CONCURRENTLY` takes >5 min | Low | Medium | Add a timeout; fall back to reading from `system_archetype_scores` directly |
+| `build_archetype_scores.py` adds 2-3h to nightly pipeline | Medium | Low | Runs in parallel with `build_clusters.py` where possible; dirty-only mode for EDDN updates |
+| Users confused by archetype names | Low | Low | Clear labelling + tooltips; keep "overall" score as secondary context |
+
+### 17.3 Known Gaps
+
+1. **Exact slot counts** — Not available from any external data source. We must use estimates. This is the most significant known limitation. Consider exposing "Report Slot Count" user contribution feature in Phase 4.
+
+2. **Construction state** — Which slots are already occupied in an active colonisation is not available externally. The scoring engine therefore always scores "theoretical maximum potential", not "available slots". This is appropriate for pre-colonisation planning but should be clearly communicated.
+
+3. **Reserve level** — System reserve level (Pristine/Major/Common/Low/Depleted) affects Extraction economy value significantly but is not available per-body from Spansh body data. Available at system level from `galaxy_populated.json.gz`. Wire up to `system_archetype_traits.has_pristine_res`.
+
+4. **Parent body grouping** — The Spansh `parents[]` array is available but not currently imported. Importing and processing it would significantly improve local-body group detection and nesting potential modelling. Add to `import_spansh.py` BODY_COLS in Phase 2.
+
+---
+
+## 18. Future-Proofing
+
+### 18.1 Against Frontier Mechanic Changes
+
+The redesign is structured to absorb future mechanic changes without schema rewrites:
+
+| Future Change | Absorption Mechanism |
+|--------------|---------------------|
+| New economy type added | Add to `economy_type` enum + add `pair_synergy_constants` rows + add `score_new_economy` column to `ratings` |
+| Slot counts changed by Frontier | Update slot estimation constants in `build_topology.py` + re-run pipeline |
+| New body type affects economies | Add to `BODY_ECONOMY_ADDS` and `SLOT_ESTIMATES` dicts |
+| New archetype needed | Add to `ARCHETYPE_DEFINITIONS` + add score column to `system_archetype_scores` |
+| Strong/weak link mechanics changed | Update `compute_topology_metrics()` + re-run `build_topology.py --rebuild` |
+| T3/T4 buildings added | Extend `buildability_score` formula; no schema change needed |
+| New Frontier API endpoints | Drop-in replacement for slot inference with authoritative data |
+
+### 18.2 JSONB Flexibility Contracts
+
+The following JSONB fields are intentionally schema-free to absorb future additions:
+
+- `system_archetype_traits.display_tags` — any new tag added without schema change
+- `system_archetype_scores.rationale` — structured rationale can gain new fields
+- `system_archetype_scores.score_breakdown` — new score components added without migration
+- `system_slot_topology.body_slots` — per-body slot data extensible
+- `system_slot_topology.topology_traits` — new topology properties without migration
+- `bodies.traits` (existing) — body-level traits already flexible
+
+### 18.3 Multi-System Expansion Planning (Future Phase 6)
+
+The archetype engine naturally extends to multi-system planning:
+
+```python
+# Future: score a candidate CHAIN of systems
+def score_expansion_chain(
+    anchor_id64: int,
+    candidate_id64s: list,
+    chain_archetype: str,   # overall chain goal
+) -> dict:
+    """
+    Score a proposed colonisation chain holistically.
+    Each system is scored for its contribution to the chain's
+    overall goal, not just its individual archetype score.
+    """
+    # Phase 6 implementation
+```
+
+### 18.4 AI-Assisted Recommendations (Future Phase 7)
+
+The structured `rationale` JSONB and `score_breakdown` objects provide clean inputs for an LLM-assisted recommendation layer:
+
+```python
+# Future: generate natural language build recommendations
+def generate_ai_build_plan(
+    system_detail: dict,
+    commander_preferences: dict,
+) -> str:
+    # Use structured rationale + archetype scores as context
+    # for an LLM to generate a step-by-step build guide
+```
+
+---
+
+## Appendix A: New Script Run Order
+
+```
+nightly:
+  import_spansh.py --all
+  build_grid.py
+  build_ratings.py              ← existing
+  build_topology.py             ← NEW (reads from bodies + ratings)
+  build_archetype_scores.py     ← NEW (reads from bodies + ratings + topology)
+  build_clusters.py             ← existing
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings
+
+dirty cycle (every 5 min):
+  build_ratings.py --dirty
+  build_topology.py --dirty
+  build_archetype_scores.py --dirty
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings
+```
+
+## Appendix B: Pydantic Models Summary
+
+```python
+# New models to add to apps/api/src/models.py
+
+class ArchetypeRerankWeights(BaseModel):
+    purity:       float = 0.30
+    buildability: float = 0.25
+    slots:        float = 0.20
+    expansion:    float = 0.15
+    logistics:    float = 0.10
+
+class ArchetypeRerankRequest(BaseModel):
+    id64s:     List[int]
+    archetype: Optional[str]                  = None
+    weights:   Optional[ArchetypeRerankWeights] = None
+    profile:   Optional[str]                  = None
+
+class ArchetypeScore(BaseModel):
+    model_config = ConfigDict(extra='allow')
+    score:            float
+    tier:             str            # S/A/B/C/D
+    buildability_score: float
+    build_complexity:   str
+    purity_score:     float
+    contamination_risk: float
+    confidence:       float
+    rationale:        Optional[Any]  # structured JSONB
+    tags:             list[str]
+
+class SystemArchetypeResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    id64:                          int
+    name:                          str
+    primary_archetype:             str
+    secondary_archetype:           Optional[str]
+    overall_development_potential: float
+    archetypes:                    dict[str, ArchetypeScore]
+    topology:                      Optional[Any]
+    tags:                          list[str]
+    confidence:                    float
+
+class ArchetypeRankingsResponse(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    archetype:       str
+    archetype_label: str
+    results:         list[Any]
+    total:           int
+    count:           int
+    source:          str
+    query_ms:        Optional[int]
+```
+
+## Appendix C: SQL File Naming Convention
+
+```
+sql/001_schema.sql              existing
+sql/002_indexes.sql             existing
+sql/003_functions.sql           existing
+sql/004_ratings_v31.sql         existing
+sql/005_map_indexes.sql         existing
+sql/006_score_history.sql       existing
+sql/007_profile_sync.sql        existing
+sql/008_body_filter_aggregates.sql existing
+sql/009_map_materialised_views.sql existing
+sql/010_sync_key_scoping.sql    existing
+sql/011_autocomplete_index.sql  existing
+sql/012_topology_tables.sql     NEW (Phase 1)
+sql/013_archetype_scores.sql    NEW (Phase 1)
+sql/014_archetype_mv.sql        NEW (Phase 1)
+```
+
+---
+
+*Document version: 4.0 | Generated: 2026-05-10 | ED-Finder Colonisation Engine Redesign*

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -715,6 +715,102 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/archetypes/rankings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Ranked systems by colony archetype
+         * @description Returns systems ranked by a specific colony archetype score. Uses the mv_archetype_rankings materialized view for fast reads. Slot counts are ESTIMATED — not authoritative.
+         */
+        get: operations["get_archetype_rankings_api_archetypes_rankings_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/archetypes/rerank": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Rerank systems by custom archetype weights */
+        post: operations["post_archetype_rerank_api_archetypes_rerank_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/archetypes/system/{id64}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Full archetype breakdown for a single system */
+        get: operations["get_system_archetypes_api_archetypes_system__id64__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/archetypes/simulate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Build simulation — score a system against a planned build
+         * @description Given a planned build (list of facility placements), estimate the
+         *     resulting economy distribution and score the system against the plan.
+         *
+         *     NOTE: This is a best-effort estimate. Economy outcomes depend on exact
+         *     construction order and Frontier's internal economy weighting, which is
+         *     not publicly documented.
+         */
+        post: operations["post_simulate_api_archetypes_simulate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/archetypes/profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Preset rerank weight profiles */
+        get: operations["get_profiles_api_archetypes_profiles_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/ratings/rerank": {
         parameters: {
             query?: never;
@@ -736,6 +832,250 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** ArchetypeProfile */
+        ArchetypeProfile: {
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /** Description */
+            description: string;
+            /** Archetype */
+            archetype?: string | null;
+            weights: components["schemas"]["ArchetypeRerankWeights"];
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ArchetypeRankingRow
+         * @description One result row inside ArchetypeRankingsResponse.
+         */
+        ArchetypeRankingRow: {
+            /** Id64 */
+            id64: number;
+            /** Name */
+            name: string;
+            coords?: components["schemas"]["CoordsModel"] | null;
+            /** Distance To Sol */
+            distance_to_sol?: number | null;
+            /** Score */
+            score: number;
+            /**
+             * Tier
+             * @enum {string}
+             */
+            tier: "S" | "A" | "B" | "C" | "D";
+            /** Primary Archetype */
+            primary_archetype?: string | null;
+            /** Secondary Archetype */
+            secondary_archetype?: string | null;
+            /** Archetype Confidence */
+            archetype_confidence?: number | null;
+            /** Overall Development Potential */
+            overall_development_potential?: number | null;
+            /** Buildability Score */
+            buildability_score?: number | null;
+            /** Build Complexity */
+            build_complexity?: string | null;
+            /** Purity Score */
+            purity_score?: number | null;
+            /** Contamination Risk */
+            contamination_risk?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Has Elw */
+            has_elw?: boolean | null;
+            /** Elw Count */
+            elw_count?: number | null;
+            /** Landable Count */
+            landable_count?: number | null;
+            /** Est Total Slots */
+            est_total_slots?: number | null;
+            /** Tags */
+            tags?: string[];
+        } & {
+            [key: string]: unknown;
+        };
+        /** ArchetypeRankingsResponse */
+        ArchetypeRankingsResponse: {
+            /** Archetype */
+            archetype: string;
+            /** Archetype Label */
+            archetype_label: string;
+            /** Results */
+            results: components["schemas"]["ArchetypeRankingRow"][];
+            /**
+             * Total
+             * @default 0
+             */
+            total: number;
+            /**
+             * Count
+             * @default 0
+             */
+            count: number;
+            /** Source */
+            source?: string | null;
+            /** Query Ms */
+            query_ms?: number | null;
+        };
+        /**
+         * ArchetypeRationale
+         * @description Structured JSONB rationale for a system's primary archetype.
+         *     Schema is intentionally flexible (extra='allow') so Frontier
+         *     mechanic changes can be absorbed without breaking existing consumers.
+         */
+        ArchetypeRationale: {
+            /** Summary */
+            summary?: string | null;
+            /** Tier */
+            tier?: ("S" | "A" | "B" | "C" | "D") | null;
+            /** Headline */
+            headline?: string | null;
+            /** Positives */
+            positives?: string[];
+            /** Risks */
+            risks?: string[];
+            /** Complexity */
+            complexity?: string | null;
+            /** Build Path */
+            build_path?: string | null;
+            /** Tags */
+            tags?: string[];
+            score_breakdown?: components["schemas"]["ArchetypeScoreBreakdown"] | null;
+            /** Data Confidence */
+            data_confidence?: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ArchetypeRerankRequest
+         * @description Rerank a set of systems by custom archetype weights.
+         *
+         *     Either provide explicit weights OR a profile ID.
+         *     If both are given, the profile takes precedence.
+         *     If neither, default ArchetypeRerankWeights are applied.
+         */
+        ArchetypeRerankRequest: {
+            /** Id64S */
+            id64s: number[];
+            /** Archetype */
+            archetype?: ("refinery_industrial" | "extraction_refinery" | "agriculture_terraforming" | "hitech_tourism" | "expansion_capital" | "trade_logistics" | "population_capital" | "ax_forward_base" | "military_industrial" | "flexible_multirole") | null;
+            weights?: components["schemas"]["ArchetypeRerankWeights"] | null;
+            /** Profile */
+            profile?: string | null;
+        };
+        /** ArchetypeRerankResponse */
+        ArchetypeRerankResponse: {
+            /** Archetype */
+            archetype?: string | null;
+            /** Profile Applied */
+            profile_applied?: string | null;
+            weights_applied: components["schemas"]["ArchetypeRerankWeights"];
+            /** Results */
+            results: components["schemas"]["ArchetypeRerankRow"][];
+            /** Query Ms */
+            query_ms?: number | null;
+        };
+        /** ArchetypeRerankRow */
+        ArchetypeRerankRow: {
+            /** Id64 */
+            id64: number;
+            /** Reranked Score */
+            reranked_score: number;
+            /** Original Score */
+            original_score?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            rationale?: components["schemas"]["ArchetypeRationale"] | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ArchetypeRerankWeights
+         * @description Weight dimensions for archetype-based reranking.
+         *     All weights should sum to ~1.0 but are not enforced to do so
+         *     (allows intentional emphasis on a single dimension).
+         *
+         *     Default profile: balanced across purity, buildability, slots, expansion, logistics.
+         */
+        ArchetypeRerankWeights: {
+            /**
+             * Purity
+             * @description Clean economy stack, low contamination
+             * @default 0.3
+             */
+            purity: number;
+            /**
+             * Buildability
+             * @description Ease of build, CP efficiency, T3 scaling
+             * @default 0.25
+             */
+            buildability: number;
+            /**
+             * Slots
+             * @description Total slot count and topology quality
+             * @default 0.2
+             */
+            slots: number;
+            /**
+             * Expansion
+             * @description Overall development potential, growth headroom
+             * @default 0.15
+             */
+            expansion: number;
+            /**
+             * Logistics
+             * @description Distance from hub, scoopable star accessibility
+             * @default 0.1
+             */
+            logistics: number;
+        };
+        /**
+         * ArchetypeScore
+         * @description One archetype entry inside SystemArchetypeResponse.archetypes.
+         */
+        ArchetypeScore: {
+            /** Score */
+            score: number;
+            /**
+             * Tier
+             * @enum {string}
+             */
+            tier: "S" | "A" | "B" | "C" | "D";
+            /** Label */
+            label: string;
+            rationale?: components["schemas"]["ArchetypeRationale"] | null;
+            /** Rank Global */
+            rank_global?: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ArchetypeScoreBreakdown
+         * @description Per-component score decomposition for a single archetype.
+         */
+        ArchetypeScoreBreakdown: {
+            /** Body Composition */
+            body_composition?: number | null;
+            /** Topology */
+            topology?: number | null;
+            /** Pair Synergy Pts */
+            pair_synergy_pts?: number | null;
+            /** Purity Factor */
+            purity_factor?: number | null;
+            /** Contamination Risk */
+            contamination_risk?: number | null;
+            /** Diversity Factor */
+            diversity_factor?: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ArchetypesProfilesResponse */
+        ArchetypesProfilesResponse: {
+            /** Profiles */
+            profiles: components["schemas"]["ArchetypeProfile"][];
+        };
         /** AutocompleteHit */
         AutocompleteHit: {
             /** Id64 */
@@ -865,6 +1205,37 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** BuildSimulateRequest */
+        BuildSimulateRequest: {
+            /** Id64 */
+            id64: number;
+            /**
+             * Planned Archetype
+             * @enum {string}
+             */
+            planned_archetype: "refinery_industrial" | "extraction_refinery" | "agriculture_terraforming" | "hitech_tourism" | "expansion_capital" | "trade_logistics" | "population_capital" | "ax_forward_base" | "military_industrial" | "flexible_multirole";
+            /** Planned Facilities */
+            planned_facilities?: components["schemas"]["PlannedFacility"][];
+        };
+        /** BuildSimulateResponse */
+        BuildSimulateResponse: {
+            /** Id64 */
+            id64: number;
+            /** Planned Archetype */
+            planned_archetype: string;
+            /** Simulation Score */
+            simulation_score: number;
+            /** Contamination Risk */
+            contamination_risk?: number | null;
+            /** Purity Score */
+            purity_score?: number | null;
+            /** Buildability Score */
+            buildability_score?: number | null;
+            /** Recommendations */
+            recommendations?: string[];
+            /** Disclaimer */
+            disclaimer?: string | null;
+        };
         /** CacheStatsResponse */
         CacheStatsResponse: {
             /**
@@ -931,6 +1302,24 @@ export interface components {
             y: number;
             /** Z */
             z: number;
+        };
+        /**
+         * EconomyPairDetail
+         * @description One economy pair synergy entry inside SystemArchetypeResponse.
+         */
+        EconomyPairDetail: {
+            /** Economy A */
+            economy_a: string;
+            /** Economy B */
+            economy_b: string;
+            /** Synergy Score */
+            synergy_score: number;
+            /** Purity Achievable */
+            purity_achievable?: number | null;
+            /** Contamination Paths */
+            contamination_paths?: unknown[];
+        } & {
+            [key: string]: unknown;
         };
         /** ExplorationValueModel */
         ExplorationValueModel: {
@@ -1029,6 +1418,20 @@ export interface components {
         NoteBody: {
             /** Note */
             note: string;
+        };
+        /**
+         * PlannedFacility
+         * @description One facility in a build simulation plan.
+         */
+        PlannedFacility: {
+            /** Type */
+            type: string;
+            /** Tier */
+            tier?: number | null;
+            /** Body */
+            body?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         /**
          * ProfileSyncBlob
@@ -1327,6 +1730,58 @@ export interface components {
             reason?: string | null;
         };
         /**
+         * SystemArchetypeResponse
+         * @description Full archetype breakdown for one system.
+         */
+        SystemArchetypeResponse: {
+            /** Id64 */
+            id64: number;
+            /** Name */
+            name: string;
+            coords?: components["schemas"]["CoordsModel"] | null;
+            /** Distance To Sol */
+            distance_to_sol?: number | null;
+            /** Main Star Type */
+            main_star_type?: string | null;
+            /** Archetypes */
+            archetypes: {
+                [key: string]: components["schemas"]["ArchetypeScore"];
+            };
+            /** Primary Archetype */
+            primary_archetype?: string | null;
+            /** Secondary Archetype */
+            secondary_archetype?: string | null;
+            /** Archetype Confidence */
+            archetype_confidence?: number | null;
+            /** Overall Development Potential */
+            overall_development_potential?: number | null;
+            /** Buildability Score */
+            buildability_score?: number | null;
+            /** Build Complexity */
+            build_complexity?: string | null;
+            /** Cp Efficiency */
+            cp_efficiency?: number | null;
+            /** T3 Scaling Viability */
+            t3_scaling_viability?: number | null;
+            /** Slot Efficiency */
+            slot_efficiency?: number | null;
+            /** Purity Score */
+            purity_score?: number | null;
+            /** Contamination Risk */
+            contamination_risk?: number | null;
+            /** Stable Top Two Prob */
+            stable_top_two_prob?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            topology?: components["schemas"]["TopologyDetail"] | null;
+            /** Economy Pairs */
+            economy_pairs?: components["schemas"]["EconomyPairDetail"][];
+            /** Tags */
+            tags?: string[];
+            /** Query Ms */
+            query_ms?: number | null;
+        };
+        /**
          * SystemDetailResponse
          * @description `/api/system/{id64}` response. Backend returns the same row
          *     twice under `record` and `system` for legacy compat.
@@ -1505,6 +1960,38 @@ export interface components {
             black_hole_count?: number | null;
             /** White Dwarf Count */
             white_dwarf_count?: number | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * TopologyDetail
+         * @description Topology metrics block inside SystemArchetypeResponse.
+         */
+        TopologyDetail: {
+            /** Estimated Orbital Slots */
+            estimated_orbital_slots?: number | null;
+            /** Estimated Ground Slots */
+            estimated_ground_slots?: number | null;
+            /** Estimated Total Slots */
+            estimated_total_slots?: number | null;
+            /** Strong Link Potential */
+            strong_link_potential?: number | null;
+            /** Weak Link Stability */
+            weak_link_stability?: number | null;
+            /** Contamination Risk */
+            contamination_risk?: number | null;
+            /** Orbital Synergy */
+            orbital_synergy?: number | null;
+            /** Ground Synergy */
+            ground_synergy?: number | null;
+            /** Nesting Potential */
+            nesting_potential?: number | null;
+            /** Build Flexibility */
+            build_flexibility?: number | null;
+            /** Has Viable Surface Port */
+            has_viable_surface_port?: boolean | null;
+            /** Has Deep Orbital Anchor */
+            has_deep_orbital_anchor?: boolean | null;
         } & {
             [key: string]: unknown;
         };
@@ -2791,6 +3278,163 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_archetype_rankings_api_archetypes_rankings_get: {
+        parameters: {
+            query: {
+                /** @description Colony archetype key */
+                archetype: string;
+                min_score?: number;
+                galaxy_region?: number | null;
+                max_distance_ly?: number | null;
+                has_elw?: boolean | null;
+                min_slots?: number | null;
+                max_contamination?: number | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchetypeRankingsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_archetype_rerank_api_archetypes_rerank_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ArchetypeRerankRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchetypeRerankResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_system_archetypes_api_archetypes_system__id64__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id64: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SystemArchetypeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_simulate_api_archetypes_simulate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BuildSimulateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BuildSimulateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_profiles_api_archetypes_profiles_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArchetypesProfilesResponse"];
                 };
             };
         };

--- a/sql/012_topology_tables.sql
+++ b/sql/012_topology_tables.sql
@@ -1,0 +1,281 @@
+-- =============================================================================
+-- ED Finder — Migration 012: Topology Tables
+-- Phase 1 of the Colonisation Engine Redesign (v4.0)
+--
+-- Creates:
+--   • colony_archetype   enum
+--   • build_complexity   enum
+--   • system_slot_topology     table
+--   • economy_pair_synergy     table
+--   • pair_synergy_constants   table  (+ seed data)
+--
+-- Design principles:
+--   • Purely additive — no existing tables touched.
+--   • All slot counts are ESTIMATES inferred from body physics.
+--     Frontier does not expose actual slot counts via any public API.
+--   • JSONB fields for topology traits absorb future mechanic changes
+--     without requiring schema migrations.
+--
+-- Run after: 011_autocomplete_index.sql
+-- Run before: 013_archetype_scores.sql
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- New enum: colonisation archetype
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$ BEGIN
+    CREATE TYPE colony_archetype AS ENUM (
+        'refinery_industrial',      -- Rocky + Icy megacomplex
+        'extraction_refinery',      -- Mining hub, metal-rich focus
+        'agriculture_terraforming', -- Farming + terraforming colony
+        'hitech_tourism',           -- Prestige, ELW/exotic stars
+        'expansion_capital',        -- Strategic expansion node
+        'trade_logistics',          -- Trade hub + carrier support
+        'population_capital',       -- Maximum population growth
+        'ax_forward_base',          -- Anti-xeno military forward base
+        'military_industrial',      -- Military + Industrial complex
+        'flexible_multirole',       -- High diversity, no dominant archetype
+        'unknown'
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- New enum: build complexity
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$ BEGIN
+    CREATE TYPE build_complexity AS ENUM (
+        'trivial',      -- Simple single-economy build
+        'simple',       -- Clean pair, no sequencing issues
+        'moderate',     -- Some contamination management required
+        'advanced',     -- Nested ports / tight sequencing
+        'expert'        -- Multi-phase, requires deep game knowledge
+    );
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table: system_slot_topology
+--
+-- Inferred slot topology per system. Populated by build_topology.py.
+-- Slot counts are ESTIMATES — not authoritative.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS system_slot_topology (
+    system_id64             BIGINT      PRIMARY KEY REFERENCES systems(id64),
+
+    -- ── Estimated slot counts (inferred, not authoritative) ──────────────────
+    estimated_orbital_slots     SMALLINT    NOT NULL DEFAULT 0,
+    estimated_ground_slots      SMALLINT    NOT NULL DEFAULT 0,
+    estimated_total_slots       SMALLINT    NOT NULL DEFAULT 0,
+
+    -- ── Slot quality (distance-weighted, type-weighted) ──────────────────────
+    orbital_slot_quality        REAL        NOT NULL DEFAULT 0,   -- 0-100
+    ground_slot_quality         REAL        NOT NULL DEFAULT 0,   -- 0-100
+    slot_density_score          REAL        NOT NULL DEFAULT 0,   -- 0-100: quality ÷ distance
+
+    -- ── Per-body slot estimates (JSONB array) ─────────────────────────────────
+    -- Each element: {body_id, body_name, body_type, distance_ls,
+    --                est_orbital, est_ground, local_group_id, parent_body_id}
+    body_slots                  JSONB       NOT NULL DEFAULT '[]'::jsonb,
+
+    -- ── Local body groupings ──────────────────────────────────────────────────
+    -- Groupings derived from Spansh parents[] array.
+    -- Each element: {group_id, anchor_body_id, anchor_name,
+    --                member_body_ids[], group_orbital_slots, group_ground_slots}
+    local_body_groups           JSONB       NOT NULL DEFAULT '[]'::jsonb,
+
+    -- ── Topology metrics (all 0-100) ──────────────────────────────────────────
+    strong_link_potential       REAL        NOT NULL DEFAULT 0,
+    weak_link_stability         REAL        NOT NULL DEFAULT 0,
+    nesting_potential           REAL        NOT NULL DEFAULT 0,
+    orbital_synergy             REAL        NOT NULL DEFAULT 0,
+    ground_synergy              REAL        NOT NULL DEFAULT 0,
+    build_flexibility           REAL        NOT NULL DEFAULT 0,
+    contamination_risk          REAL        NOT NULL DEFAULT 0,   -- higher = worse
+
+    -- ── Topology flags (fast filter support) ─────────────────────────────────
+    has_viable_surface_port     BOOLEAN     NOT NULL DEFAULT FALSE,  -- ≥1 landable Rocky/HMC
+    has_deep_orbital_anchor     BOOLEAN     NOT NULL DEFAULT FALSE,  -- body with ≥6 orbital slots
+    has_ringed_gas_giant        BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_binary_or_trinary       BOOLEAN     NOT NULL DEFAULT FALSE,  -- multiple stars
+
+    updated_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE system_slot_topology IS
+    'Inferred slot topology per system. Slot counts are ESTIMATES derived from '
+    'body physics (radius, gravity, body_type, is_landable, ring presence). '
+    'They are not authoritative — Frontier does not expose actual slot counts '
+    'via any public API or data feed. '
+    'Recomputed by build_topology.py whenever a system is flagged dirty.';
+
+COMMENT ON COLUMN system_slot_topology.estimated_orbital_slots IS
+    'Sum of estimated orbital slots across all bodies in the system. INFERRED.';
+COMMENT ON COLUMN system_slot_topology.estimated_ground_slots IS
+    'Sum of estimated ground slots across all landable bodies. INFERRED.';
+COMMENT ON COLUMN system_slot_topology.body_slots IS
+    'Per-body slot breakdown. Array of {body_id, body_name, body_type, '
+    'distance_ls, est_orbital, est_ground, local_group_id, parent_body_id}.';
+COMMENT ON COLUMN system_slot_topology.contamination_risk IS
+    '0-100. Higher values indicate greater risk of unwanted third economies '
+    'entering the top-2 from body-type economy contributions.';
+
+-- Indexes for topology-filtered queries
+CREATE INDEX IF NOT EXISTS idx_topo_contamination
+    ON system_slot_topology (contamination_risk ASC)
+    WHERE contamination_risk < 0.30;
+
+CREATE INDEX IF NOT EXISTS idx_topo_orbital_slots
+    ON system_slot_topology (estimated_orbital_slots DESC)
+    WHERE estimated_orbital_slots >= 20;
+
+CREATE INDEX IF NOT EXISTS idx_topo_ground_slots
+    ON system_slot_topology (estimated_ground_slots DESC)
+    WHERE estimated_ground_slots >= 10;
+
+CREATE INDEX IF NOT EXISTS idx_topo_surface_port
+    ON system_slot_topology (has_viable_surface_port)
+    WHERE has_viable_surface_port = TRUE;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table: economy_pair_synergy
+--
+-- Per-system precomputed economy pair synergy scores.
+-- Populated by build_topology.py after slot topology is computed.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS economy_pair_synergy (
+    system_id64         BIGINT          NOT NULL REFERENCES systems(id64),
+    economy_a           economy_type    NOT NULL,
+    economy_b           economy_type    NOT NULL,
+    synergy_score       REAL            NOT NULL,   -- 0-100
+    purity_achievable   REAL            NOT NULL DEFAULT 0,  -- 0-1
+    -- [{body, economy_added, severity, count}] — up to 5 contamination paths
+    contamination_paths JSONB           NOT NULL DEFAULT '[]'::jsonb,
+    notes               TEXT,
+
+    PRIMARY KEY (system_id64, economy_a, economy_b)
+);
+
+COMMENT ON TABLE economy_pair_synergy IS
+    'Per-system precomputed economy pair synergy scores. '
+    'Derived by applying PAIR_MODIFIERS body-count adjustments to the '
+    'global pair_synergy_constants baseline. Populated by build_topology.py.';
+
+CREATE INDEX IF NOT EXISTS idx_pair_synergy_system
+    ON economy_pair_synergy (system_id64);
+
+CREATE INDEX IF NOT EXISTS idx_pair_synergy_score
+    ON economy_pair_synergy (economy_a, economy_b, synergy_score DESC)
+    WHERE synergy_score >= 60;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table: pair_synergy_constants
+--
+-- Global baseline synergy values for each economy pair.
+-- These are system-independent constants seeded from ED mechanics research.
+-- Per-system synergy (economy_pair_synergy) starts from these and applies
+-- body-count modifiers on top.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS pair_synergy_constants (
+    economy_a           economy_type    NOT NULL,
+    economy_b           economy_type    NOT NULL,
+    base_synergy        REAL            NOT NULL CHECK (base_synergy BETWEEN 0 AND 1),
+    contamination_risk  REAL            NOT NULL CHECK (contamination_risk BETWEEN 0 AND 1),
+    notes               TEXT,
+
+    PRIMARY KEY (economy_a, economy_b)
+);
+
+COMMENT ON TABLE pair_synergy_constants IS
+    'Global baseline economy pair synergy constants. '
+    'Values derived from ED Trailblazers colonisation mechanics research '
+    '(2025). These are the system-independent starting point; '
+    'build_topology.py applies per-system body-count modifiers on top. '
+    'Can be updated without code changes to tune pair scoring.';
+
+COMMENT ON COLUMN pair_synergy_constants.base_synergy IS
+    '0-1. How well this pair works together in a clean system. '
+    '1.0 = perfect synergy, 0.0 = fundamentally incompatible.';
+COMMENT ON COLUMN pair_synergy_constants.contamination_risk IS
+    '0-1. Baseline probability that this pair suffers third-economy '
+    'contamination in a typical system.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Seed: pair_synergy_constants
+--
+-- Values based on ED colonisation mechanics (Trailblazers Update 3, 2025).
+-- Pairs are stored in canonical order (lexicographic on economy name).
+-- The application layer must look up both (A,B) and (B,A) orderings.
+-- ─────────────────────────────────────────────────────────────────────────────
+INSERT INTO pair_synergy_constants
+    (economy_a, economy_b, base_synergy, contamination_risk, notes)
+VALUES
+    -- Tier S: near-perfect synergy pairs
+    ('Refinery',     'Industrial',  0.95, 0.12,
+        'Rocky-Ice bodies serve both economies; very clean stacking. '
+        'CMM Composite production enabled.'),
+
+    ('Agriculture',  'Tourism',     0.91, 0.08,
+        'ELW and Water Worlds serve both. ELW strong link is excellent for both. '
+        'Low contamination from competing body types.'),
+
+    -- Tier A: strong synergy pairs
+    ('HighTech',     'Tourism',     0.88, 0.15,
+        'Gas Giants and exotic star systems serve both. '
+        'Ammonia Worlds are excellent dual-contributors.'),
+
+    ('Extraction',   'Refinery',    0.82, 0.22,
+        'HMC bodies host both Extraction and Refinery hubs. '
+        'Geo signals on HMC are useful; Rocky geo signals risk contamination.'),
+
+    ('Agriculture',  'HighTech',    0.79, 0.18,
+        'ELW anchors both economies. Bio signals support Agriculture. '
+        'Tidal-lock bodies weaken Agriculture strong links.'),
+
+    -- Tier B: moderate synergy pairs
+    ('HighTech',     'Military',    0.76, 0.20,
+        'ELW serves both Military and HighTech. '
+        'Gas Giants add HighTech but not Military directly.'),
+
+    ('Industrial',   'Military',    0.74, 0.18,
+        'Icy bodies and military settlements are compatible. '
+        'Rocky-Ice provides Industrial support without heavy contamination.'),
+
+    ('Refinery',     'Military',    0.58, 0.30,
+        'Moderate synergy. Rocky bodies help Refinery; less Military support. '
+        'Requires careful hub placement to maintain clean economies.'),
+
+    ('Extraction',   'Industrial',  0.55, 0.35,
+        'HMC geo contamination can cause Extraction vs Industrial tension. '
+        'Manageable with dedicated Refinery Hubs.'),
+
+    -- Tier C/D: poor or incompatible pairs
+    ('Agriculture',  'Refinery',    0.28, 0.72,
+        'Competing economies. Bio bodies heavily contaminate Refinery. '
+        'Avoid unless deliberate multi-economy build.'),
+
+    ('Tourism',      'Refinery',    0.22, 0.78,
+        'Very poor pairing. ELW/exotic body economies fight Refinery '
+        'for the top-2 slots. Near-impossible to maintain clean stack.'),
+
+    ('Agriculture',  'Extraction',  0.35, 0.60,
+        'Bio signals compete with geo signals. Moderate contamination risk. '
+        'Avoid unless system has very distinct body populations.'),
+
+    ('Tourism',      'Military',    0.45, 0.45,
+        'Moderate conflict. Tourism favours prestige/exotic; '
+        'Military favours settlement coverage. Some ELW overlap.'),
+
+    ('Tourism',      'Industrial',  0.40, 0.50,
+        'Industrial economy from Icy bodies conflicts with Tourism aesthetic. '
+        'Gas Giants help both but overall mix is unstable.'),
+
+    ('Agriculture',  'Military',    0.38, 0.55,
+        'Bio signals from Agriculture bodies add competing economies. '
+        'Limited shared body type support.')
+
+ON CONFLICT (economy_a, economy_b) DO NOTHING;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Schema version marker
+-- ─────────────────────────────────────────────────────────────────────────────
+COMMENT ON SCHEMA public IS
+    'ED Finder schema — migration 012 applied (topology tables + pair synergy constants).';

--- a/sql/013_archetype_scores.sql
+++ b/sql/013_archetype_scores.sql
@@ -1,0 +1,269 @@
+-- =============================================================================
+-- ED Finder — Migration 013: Archetype Score Tables
+-- Phase 1 of the Colonisation Engine Redesign (v4.0)
+--
+-- Creates:
+--   • system_archetype_scores   table
+--   • system_archetype_traits   table
+--
+-- Depends on: 012_topology_tables.sql (colony_archetype, build_complexity enums)
+-- Run before: 014_archetype_mv.sql
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table: system_archetype_scores
+--
+-- The heart of the new engine. One row per system, storing per-archetype
+-- scores (0-100 each), buildability metrics, purity/contamination summary,
+-- and structured JSONB rationale.
+--
+-- Replaces the role of the single `ratings.score` column as the primary
+-- ranking signal — but ratings.score is PRESERVED for backward compatibility.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS system_archetype_scores (
+    system_id64             BIGINT      PRIMARY KEY REFERENCES systems(id64),
+
+    -- ── Primary archetype identification ─────────────────────────────────────
+    primary_archetype       colony_archetype    NOT NULL DEFAULT 'unknown',
+    secondary_archetype     colony_archetype    NOT NULL DEFAULT 'unknown',
+    archetype_confidence    REAL                NOT NULL DEFAULT 0,  -- 0-1
+
+    -- ── Per-archetype scores (0-100 each) ────────────────────────────────────
+    -- Each score is independent: a Refinery/Industrial score of 92 does NOT
+    -- imply a poor Agriculture/Terraforming score — they are separate axes.
+    score_refinery_industrial       REAL    NOT NULL DEFAULT 0,
+    score_extraction_refinery       REAL    NOT NULL DEFAULT 0,
+    score_agriculture_terraforming  REAL    NOT NULL DEFAULT 0,
+    score_hitech_tourism            REAL    NOT NULL DEFAULT 0,
+    score_expansion_capital         REAL    NOT NULL DEFAULT 0,
+    score_trade_logistics           REAL    NOT NULL DEFAULT 0,
+    score_population_capital        REAL    NOT NULL DEFAULT 0,
+    score_ax_forward_base           REAL    NOT NULL DEFAULT 0,
+    score_military_industrial       REAL    NOT NULL DEFAULT 0,
+    score_flexible_multirole        REAL    NOT NULL DEFAULT 0,
+
+    -- ── Composite development potential ──────────────────────────────────────
+    -- Supporting metric, NOT the primary ranking signal.
+    -- = top-3 archetype average × 0.60 + diversity × 0.20 + buildability × 0.20
+    -- Used as a tie-breaker when two systems have equal archetype scores.
+    overall_development_potential   REAL    NOT NULL DEFAULT 0,  -- 0-100
+
+    -- ── Buildability ─────────────────────────────────────────────────────────
+    buildability_score      REAL            NOT NULL DEFAULT 0,  -- 0-100
+    build_complexity        build_complexity NOT NULL DEFAULT 'moderate',
+    cp_efficiency           REAL            NOT NULL DEFAULT 0,  -- 0-100
+    t3_scaling_viability    REAL            NOT NULL DEFAULT 0,  -- 0-100
+    slot_efficiency         REAL            NOT NULL DEFAULT 0,  -- 0-100
+
+    -- ── Purity & contamination ────────────────────────────────────────────────
+    purity_score            REAL            NOT NULL DEFAULT 0,  -- 0-100
+    contamination_risk      REAL            NOT NULL DEFAULT 0,  -- 0-100
+    stable_top_two_prob     REAL            NOT NULL DEFAULT 0,  -- 0-1
+
+    -- ── Data quality ─────────────────────────────────────────────────────────
+    confidence              REAL            NOT NULL DEFAULT 0.85,
+
+    -- ── Explainability payload (JSONB) ────────────────────────────────────────
+    -- score_breakdown: per-component score decomposition
+    -- {body_composition, topology, pair_synergy_pts, purity_factor,
+    --  contamination_risk, diversity_factor, per_archetype: {...}}
+    score_breakdown         JSONB           NOT NULL DEFAULT '{}'::jsonb,
+
+    -- rationale: structured human-readable explanation per primary archetype
+    -- {summary, tier, headline, positives[], risks[], complexity,
+    --  build_path, tags[], score_breakdown, data_confidence}
+    rationale               JSONB           NOT NULL DEFAULT '{}'::jsonb,
+
+    updated_at              TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    -- dirty = TRUE means this row needs recomputation.
+    -- Set to TRUE by build_ratings.py whenever it updates the matching
+    -- ratings row, then cleared by build_archetype_scores.py.
+    dirty                   BOOLEAN         NOT NULL DEFAULT TRUE
+);
+
+COMMENT ON TABLE system_archetype_scores IS
+    'Per-system archetype scores computed by build_archetype_scores.py. '
+    'Each score column is an independent 0-100 measure of how well the '
+    'system suits that colony archetype. The existing ratings table is '
+    'preserved unchanged — this table is purely additive.';
+
+COMMENT ON COLUMN system_archetype_scores.primary_archetype IS
+    'The archetype with the highest score for this system.';
+COMMENT ON COLUMN system_archetype_scores.secondary_archetype IS
+    'The archetype with the second-highest score. Useful for systems '
+    'that suit multiple colony types well.';
+COMMENT ON COLUMN system_archetype_scores.archetype_confidence IS
+    '0-1. How decisively this system belongs to its primary archetype. '
+    'Low values indicate a flexible/generalist system.';
+COMMENT ON COLUMN system_archetype_scores.overall_development_potential IS
+    'Composite metric across all archetypes. Supporting role only — '
+    'use per-archetype scores for ranking within an archetype category.';
+COMMENT ON COLUMN system_archetype_scores.purity_score IS
+    '0-100. How cleanly the system''s bodies support its primary economy '
+    'pair without adding competing third economies.';
+COMMENT ON COLUMN system_archetype_scores.contamination_risk IS
+    '0-100. Estimated risk that a third economy enters the top-2. '
+    'Derived from body types that add competing economies.';
+COMMENT ON COLUMN system_archetype_scores.rationale IS
+    'Structured JSONB rationale for the primary archetype score. '
+    'Schema: {summary, tier, headline, positives[], risks[], '
+    'complexity, build_path, tags[], score_breakdown, data_confidence}. '
+    'JSONB contract — schema is flexible for future mechanic changes.';
+COMMENT ON COLUMN system_archetype_scores.dirty IS
+    'TRUE when this row needs recomputation. Cleared by '
+    'build_archetype_scores.py after successful update.';
+
+-- ── Indexes ───────────────────────────────────────────────────────────────────
+
+-- Primary archetype ranking indexes (used by GET /api/archetypes/rankings)
+CREATE INDEX IF NOT EXISTS idx_arch_scores_refinery
+    ON system_archetype_scores (score_refinery_industrial DESC)
+    WHERE score_refinery_industrial >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_hitech
+    ON system_archetype_scores (score_hitech_tourism DESC)
+    WHERE score_hitech_tourism >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_agri
+    ON system_archetype_scores (score_agriculture_terraforming DESC)
+    WHERE score_agriculture_terraforming >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_extraction
+    ON system_archetype_scores (score_extraction_refinery DESC)
+    WHERE score_extraction_refinery >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_military
+    ON system_archetype_scores (score_military_industrial DESC)
+    WHERE score_military_industrial >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_ax
+    ON system_archetype_scores (score_ax_forward_base DESC)
+    WHERE score_ax_forward_base >= 40 AND dirty = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_arch_scores_expansion
+    ON system_archetype_scores (score_expansion_capital DESC)
+    WHERE score_expansion_capital >= 40 AND dirty = FALSE;
+
+-- Overall development potential (secondary sort / general browse)
+CREATE INDEX IF NOT EXISTS idx_arch_scores_odp
+    ON system_archetype_scores (overall_development_potential DESC)
+    WHERE overall_development_potential >= 50 AND dirty = FALSE;
+
+-- Primary archetype categorical index (for "show me refinery_industrial systems")
+CREATE INDEX IF NOT EXISTS idx_arch_scores_primary_archetype
+    ON system_archetype_scores (primary_archetype, score_refinery_industrial DESC)
+    WHERE dirty = FALSE;
+
+-- Dirty-flag index (used by build_archetype_scores.py --dirty mode)
+CREATE INDEX IF NOT EXISTS idx_arch_scores_dirty
+    ON system_archetype_scores (dirty)
+    WHERE dirty = TRUE;
+
+-- Purity index (for "find clean-stack systems")
+CREATE INDEX IF NOT EXISTS idx_arch_scores_purity
+    ON system_archetype_scores (purity_score DESC)
+    WHERE purity_score >= 70 AND dirty = FALSE;
+
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Table: system_archetype_traits
+--
+-- Fast-filter boolean flags and counts for the archetype API.
+-- Denormalised from the body data for O(1) filter operations.
+-- Also stores estimated slot totals (denormalised from system_slot_topology)
+-- for queries that need slot counts without a join.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS system_archetype_traits (
+    system_id64         BIGINT      PRIMARY KEY REFERENCES systems(id64),
+
+    -- ── Boolean fast-filter flags ─────────────────────────────────────────────
+    has_elw             BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_water_world     BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_ammonia_world   BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_black_hole      BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_neutron_star    BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_white_dwarf     BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_ringed_body     BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_terraformables  BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_pristine_res    BOOLEAN     NOT NULL DEFAULT FALSE,  -- pristine reserve level
+    has_bio_signals     BOOLEAN     NOT NULL DEFAULT FALSE,
+    has_geo_signals     BOOLEAN     NOT NULL DEFAULT FALSE,
+    is_scoopable_star   BOOLEAN     NOT NULL DEFAULT FALSE,
+
+    -- ── Body type counts ──────────────────────────────────────────────────────
+    elw_count           SMALLINT    NOT NULL DEFAULT 0,
+    ww_count            SMALLINT    NOT NULL DEFAULT 0,
+    ammonia_count       SMALLINT    NOT NULL DEFAULT 0,
+    gas_giant_count     SMALLINT    NOT NULL DEFAULT 0,
+    rocky_clean_count   SMALLINT    NOT NULL DEFAULT 0,
+    rocky_ice_count     SMALLINT    NOT NULL DEFAULT 0,
+    icy_count           SMALLINT    NOT NULL DEFAULT 0,
+    hmc_count           SMALLINT    NOT NULL DEFAULT 0,
+    metal_rich_count    SMALLINT    NOT NULL DEFAULT 0,
+    landable_count      SMALLINT    NOT NULL DEFAULT 0,
+    terraformable_count SMALLINT    NOT NULL DEFAULT 0,
+    bio_signal_total    SMALLINT    NOT NULL DEFAULT 0,
+    geo_signal_total    SMALLINT    NOT NULL DEFAULT 0,
+    total_body_count    SMALLINT    NOT NULL DEFAULT 0,
+
+    -- ── Slot estimates (denormalised from system_slot_topology) ───────────────
+    -- These mirror system_slot_topology values for join-free filter queries.
+    est_orbital_slots   SMALLINT    NOT NULL DEFAULT 0,
+    est_ground_slots    SMALLINT    NOT NULL DEFAULT 0,
+    est_total_slots     SMALLINT    NOT NULL DEFAULT 0,
+
+    -- ── UI display tags (array of short labels) ───────────────────────────────
+    -- Computed by _compute_display_tags() in build_archetype_scores.py.
+    -- Examples: ["Rocky-Ice", "Pristine", "Low Contamination", "T3 Friendly",
+    --            "2× ELW", "Black Hole", "34 Slots"]
+    -- Max 8 tags per system.
+    display_tags        TEXT[]      NOT NULL DEFAULT '{}',
+
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE system_archetype_traits IS
+    'Fast-filter trait flags and counts for the archetype API. '
+    'Denormalised from body data and system_slot_topology for O(1) '
+    'filter operations without joins. Populated by build_archetype_scores.py.';
+
+COMMENT ON COLUMN system_archetype_traits.display_tags IS
+    'Human-readable tag array for UI display. Max 8 tags. '
+    'Examples: ["Rocky-Ice", "Pristine", "2× ELW", "34 Slots", '
+    '"Low Contamination", "T3 Friendly", "Black Hole"]. '
+    'Computed by _compute_display_tags() in build_archetype_scores.py.';
+
+COMMENT ON COLUMN system_archetype_traits.est_total_slots IS
+    'Denormalised copy of system_slot_topology.estimated_total_slots. '
+    'Updated whenever build_topology.py writes a new topology row.';
+
+-- ── Indexes ───────────────────────────────────────────────────────────────────
+
+-- GIN index on display_tags for tag-based filtering
+CREATE INDEX IF NOT EXISTS idx_traits_display_tags
+    ON system_archetype_traits USING gin(display_tags);
+
+-- ELW filter (most common prestige query)
+CREATE INDEX IF NOT EXISTS idx_traits_elw
+    ON system_archetype_traits (elw_count DESC)
+    WHERE has_elw = TRUE;
+
+-- Slot count filter
+CREATE INDEX IF NOT EXISTS idx_traits_slots
+    ON system_archetype_traits (est_total_slots DESC)
+    WHERE est_total_slots >= 20;
+
+-- Exotic body fast filter (black hole / neutron used in AX / HighTech queries)
+CREATE INDEX IF NOT EXISTS idx_traits_exotic
+    ON system_archetype_traits (has_black_hole, has_neutron_star)
+    WHERE has_black_hole = TRUE OR has_neutron_star = TRUE;
+
+-- Multi-column filter index (most common combined filter pattern)
+CREATE INDEX IF NOT EXISTS idx_traits_filter
+    ON system_archetype_traits (has_elw, landable_count DESC, est_total_slots DESC);
+
+-- Terraformable systems filter
+CREATE INDEX IF NOT EXISTS idx_traits_terra
+    ON system_archetype_traits (terraformable_count DESC)
+    WHERE has_terraformables = TRUE;

--- a/sql/014_archetype_mv.sql
+++ b/sql/014_archetype_mv.sql
@@ -1,0 +1,283 @@
+-- =============================================================================
+-- ED Finder — Migration 014: Archetype Materialized View
+-- Phase 1 of the Colonisation Engine Redesign (v4.0)
+--
+-- Creates:
+--   • mv_archetype_rankings   materialized view
+--   • All indexes on the MV
+--   • Additional performance indexes on the source tables
+--
+-- Depends on:
+--   012_topology_tables.sql    (system_slot_topology, colony_archetype enum)
+--   013_archetype_scores.sql   (system_archetype_scores, system_archetype_traits)
+--
+-- IMPORTANT: The MV is created WITH NO DATA on first migration.
+-- After running build_topology.py + build_archetype_scores.py for the first
+-- time, run:
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Materialized View: mv_archetype_rankings
+--
+-- Pre-joined, pre-sorted ranking table combining:
+--   systems                → coordinates, name, region, star type
+--   system_archetype_scores → all 10 archetype scores + buildability + purity
+--   system_archetype_traits → boolean flags, body counts, display tags
+--   system_slot_topology    → topology metrics (LEFT JOIN — may be NULL)
+--
+-- REFRESH CONCURRENTLY is safe (non-blocking) once the unique index
+-- idx_mv_archetype_id64 exists.
+--
+-- Refresh frequency:
+--   • After each full build_archetype_scores.py run (~nightly)
+--   • After each build_archetype_scores.py --dirty run
+--
+-- Excludes rows where dirty = TRUE (scores not yet computed) or
+-- overall_development_potential = 0 (system has no body data).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_archetype_rankings AS
+SELECT
+    -- ── System identity ───────────────────────────────────────────────────────
+    s.id64,
+    s.name,
+    s.x,
+    s.y,
+    s.z,
+    s.distance_to_sol,
+    s.main_star_type,
+    s.galaxy_region_id,
+
+    -- ── Archetype classification ──────────────────────────────────────────────
+    a.primary_archetype,
+    a.secondary_archetype,
+    a.archetype_confidence,
+
+    -- ── All 10 archetype scores ───────────────────────────────────────────────
+    a.score_refinery_industrial,
+    a.score_extraction_refinery,
+    a.score_agriculture_terraforming,
+    a.score_hitech_tourism,
+    a.score_expansion_capital,
+    a.score_trade_logistics,
+    a.score_population_capital,
+    a.score_ax_forward_base,
+    a.score_military_industrial,
+    a.score_flexible_multirole,
+
+    -- ── Composite + buildability ──────────────────────────────────────────────
+    a.overall_development_potential,
+    a.buildability_score,
+    a.build_complexity,
+    a.cp_efficiency,
+    a.t3_scaling_viability,
+    a.slot_efficiency,
+
+    -- ── Purity & contamination summary ───────────────────────────────────────
+    a.purity_score,
+    a.contamination_risk,
+    a.stable_top_two_prob,
+
+    -- ── Data quality ─────────────────────────────────────────────────────────
+    a.confidence,
+
+    -- ── Trait flags (for filter pills) ───────────────────────────────────────
+    t.has_elw,
+    t.has_water_world,
+    t.has_ammonia_world,
+    t.has_black_hole,
+    t.has_neutron_star,
+    t.has_white_dwarf,
+    t.has_ringed_body,
+    t.has_terraformables,
+    t.is_scoopable_star,
+
+    -- ── Body counts (for filter ranges) ──────────────────────────────────────
+    t.elw_count,
+    t.ww_count,
+    t.ammonia_count,
+    t.gas_giant_count,
+    t.rocky_clean_count,
+    t.rocky_ice_count,
+    t.icy_count,
+    t.hmc_count,
+    t.landable_count,
+    t.terraformable_count,
+    t.bio_signal_total,
+    t.geo_signal_total,
+    t.total_body_count,
+
+    -- ── Slot estimates (from traits — join-free) ──────────────────────────────
+    t.est_total_slots,
+    t.est_orbital_slots,
+    t.est_ground_slots,
+
+    -- ── Display tags ─────────────────────────────────────────────────────────
+    t.display_tags,
+
+    -- ── Topology metrics (LEFT JOIN — NULL if topology not yet computed) ──────
+    topo.estimated_orbital_slots    AS topo_orbital_slots,
+    topo.estimated_ground_slots     AS topo_ground_slots,
+    topo.strong_link_potential,
+    topo.weak_link_stability,
+    topo.nesting_potential,
+    topo.orbital_synergy,
+    topo.ground_synergy,
+    topo.build_flexibility,
+    topo.contamination_risk         AS topo_contamination_risk,
+    topo.has_viable_surface_port,
+    topo.has_deep_orbital_anchor,
+    topo.has_ringed_gas_giant,
+
+    -- ── Timestamp for staleness checks ───────────────────────────────────────
+    a.updated_at                    AS scores_updated_at
+
+FROM systems s
+JOIN  system_archetype_scores a   ON a.system_id64 = s.id64
+JOIN  system_archetype_traits t   ON t.system_id64 = s.id64
+LEFT JOIN system_slot_topology topo ON topo.system_id64 = s.id64
+
+-- Only include scored, non-dirty systems with actual score data
+WHERE a.dirty = FALSE
+  AND a.overall_development_potential > 0
+
+WITH NO DATA;
+
+COMMENT ON MATERIALIZED VIEW mv_archetype_rankings IS
+    'Pre-joined archetype ranking table. Combines systems, '
+    'system_archetype_scores, system_archetype_traits, and '
+    'system_slot_topology (LEFT JOIN). Refreshed after each '
+    'build_archetype_scores.py run via: '
+    'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings. '
+    'Created WITH NO DATA — must be refreshed after first data load.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Indexes on mv_archetype_rankings
+--
+-- The unique index on id64 is required for REFRESH CONCURRENTLY.
+-- All other indexes support the expected query patterns.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Required for REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_archetype_id64
+    ON mv_archetype_rankings (id64);
+
+-- Per-archetype ranking indexes (primary query pattern for each archetype)
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_refinery
+    ON mv_archetype_rankings (score_refinery_industrial DESC)
+    WHERE score_refinery_industrial >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_extraction
+    ON mv_archetype_rankings (score_extraction_refinery DESC)
+    WHERE score_extraction_refinery >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_agri
+    ON mv_archetype_rankings (score_agriculture_terraforming DESC)
+    WHERE score_agriculture_terraforming >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_hitech
+    ON mv_archetype_rankings (score_hitech_tourism DESC)
+    WHERE score_hitech_tourism >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_expansion
+    ON mv_archetype_rankings (score_expansion_capital DESC)
+    WHERE score_expansion_capital >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_military
+    ON mv_archetype_rankings (score_military_industrial DESC)
+    WHERE score_military_industrial >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_ax
+    ON mv_archetype_rankings (score_ax_forward_base DESC)
+    WHERE score_ax_forward_base >= 30;
+
+-- Overall development potential (secondary sort / generalist browse)
+CREATE INDEX IF NOT EXISTS idx_mv_archetype_odp
+    ON mv_archetype_rankings (overall_development_potential DESC);
+
+-- Region + archetype composite (most common filtered query pattern)
+CREATE INDEX IF NOT EXISTS idx_mv_arch_region_refinery
+    ON mv_archetype_rankings (galaxy_region_id, score_refinery_industrial DESC)
+    WHERE score_refinery_industrial >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_arch_region_hitech
+    ON mv_archetype_rankings (galaxy_region_id, score_hitech_tourism DESC)
+    WHERE score_hitech_tourism >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_arch_region_agri
+    ON mv_archetype_rankings (galaxy_region_id, score_agriculture_terraforming DESC)
+    WHERE score_agriculture_terraforming >= 30;
+
+CREATE INDEX IF NOT EXISTS idx_mv_arch_region_odp
+    ON mv_archetype_rankings (galaxy_region_id, overall_development_potential DESC);
+
+-- Purity filter (for "clean stack" queries)
+CREATE INDEX IF NOT EXISTS idx_mv_arch_purity
+    ON mv_archetype_rankings (purity_score DESC)
+    WHERE purity_score >= 60;
+
+-- Primary archetype categorical (for browsing by category)
+CREATE INDEX IF NOT EXISTS idx_mv_arch_primary
+    ON mv_archetype_rankings (primary_archetype, overall_development_potential DESC);
+
+-- ELW + black hole prestige filter
+CREATE INDEX IF NOT EXISTS idx_mv_arch_elw
+    ON mv_archetype_rankings (elw_count DESC, score_hitech_tourism DESC)
+    WHERE has_elw = TRUE;
+
+-- Slot count filter
+CREATE INDEX IF NOT EXISTS idx_mv_arch_slots
+    ON mv_archetype_rankings (est_total_slots DESC)
+    WHERE est_total_slots >= 20;
+
+-- Buildability filter
+CREATE INDEX IF NOT EXISTS idx_mv_arch_buildability
+    ON mv_archetype_rankings (buildability_score DESC)
+    WHERE buildability_score >= 50;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Additional performance indexes on source tables
+-- (supplementing the indexes in 013_archetype_scores.sql)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- system_archetype_scores: composite region query via systems join
+-- (Galaxy-region filtered archetype queries are common; this partial
+-- index on the score table complements the MV region indexes above.)
+CREATE INDEX IF NOT EXISTS idx_arch_scores_confidence
+    ON system_archetype_scores (confidence DESC)
+    WHERE confidence >= 0.85 AND dirty = FALSE;
+
+-- system_slot_topology: strong-link + orbital synergy combined filter
+CREATE INDEX IF NOT EXISTS idx_topo_strong_link
+    ON system_slot_topology (strong_link_potential DESC)
+    WHERE strong_link_potential >= 50;
+
+CREATE INDEX IF NOT EXISTS idx_topo_orbital_synergy
+    ON system_slot_topology (orbital_synergy DESC)
+    WHERE orbital_synergy >= 40;
+
+CREATE INDEX IF NOT EXISTS idx_topo_ground_synergy
+    ON system_slot_topology (ground_synergy DESC)
+    WHERE ground_synergy >= 40;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Refresh helper comment
+-- ─────────────────────────────────────────────────────────────────────────────
+-- To populate the MV after the first data load:
+--
+--   REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;
+--
+-- To check when the MV was last populated:
+--
+--   SELECT schemaname, matviewname, ispopulated,
+--          pg_size_pretty(pg_relation_size('mv_archetype_rankings')) AS size
+--   FROM   pg_matviews
+--   WHERE  matviewname = 'mv_archetype_rankings';
+--
+-- To check row count:
+--
+--   SELECT COUNT(*) FROM mv_archetype_rankings;
+--
+-- Estimated refresh time on 50M scored rows: 3–8 minutes.
+-- CONCURRENTLY variant does not block reads during refresh.
+-- ─────────────────────────────────────────────────────────────────────────────

--- a/sql/014_archetype_mv.sql
+++ b/sql/014_archetype_mv.sql
@@ -44,7 +44,7 @@ SELECT
     s.x,
     s.y,
     s.z,
-    s.distance_to_sol,
+    SQRT(s.x*s.x + s.y*s.y + s.z*s.z) AS distance_to_sol,
     s.main_star_type,
     s.galaxy_region_id,
 


### PR DESCRIPTION
## Summary

Implements Phases 1–3 of the Colonisation Engine Redesign (v4.0), as specified in `docs/colonisation-redesign/COLONISATION_ENGINE_REDESIGN.md`.

**Zero breaking changes.** All existing tables, endpoints, and scores are preserved intact. Every new artifact is purely additive.

---

## Phase 1 — Schema (3 SQL files)

### `sql/012_topology_tables.sql`
- `colony_archetype` enum: 10 archetypes (`refinery_industrial`, `extraction_refinery`, `agriculture_terraforming`, `hitech_tourism`, `expansion_capital`, `trade_logistics`, `population_capital`, `ax_forward_base`, `military_industrial`, `flexible_multirole`, `unknown`)
- `build_complexity` enum: `trivial / simple / moderate / advanced / expert`
- `system_slot_topology` table — inferred slot counts + 7 topology metrics (`strong_link_potential`, `weak_link_stability`, `orbital_synergy`, `ground_synergy`, `build_flexibility`, `nesting_potential`, `contamination_risk`), `body_slots` JSONB per-body breakdown, topology boolean flags
- `economy_pair_synergy` table — per-system pair synergy scores (populated by `build_topology.py`)
- `pair_synergy_constants` table — global baseline values seeded with 15 ED-accurate economy pair rows (Refinery+Industrial 0.95 → Tourism+Refinery 0.22)

### `sql/013_archetype_scores.sql`
- `system_archetype_scores` table — 10 independent per-archetype scores (0-100 each), buildability metrics (`cp_efficiency`, `t3_scaling_viability`, `slot_efficiency`, `build_complexity`), purity/contamination summary, `dirty` flag, structured JSONB `rationale` + `score_breakdown`
- `system_archetype_traits` table — boolean fast-filter flags (`has_elw`, `has_black_hole`, etc.), body-type counts, denormalised slot estimates, `display_tags TEXT[]` with GIN index
- Partial indexes per archetype (`score >= 40 AND dirty = FALSE`); dirty-flag index for `--dirty` rebuild mode

### `sql/014_archetype_mv.sql`
- `mv_archetype_rankings` materialized view — pre-joined from `systems` + `system_archetype_scores` + `system_archetype_traits` + `system_slot_topology` (LEFT JOIN); created `WITH NO DATA` (zero runtime impact until first pipeline run)
- UNIQUE index on `id64` (required for `REFRESH CONCURRENTLY`)
- Per-archetype sort indexes, region+archetype composite indexes, purity/buildability/slot/ELW filter indexes

---

## Phase 2 — Build Pipeline (2 new importer scripts)

### `apps/importer/src/build_topology.py` (new — ~37 kB)
Layer 3 of the pipeline. Runs after `build_ratings.py`, writes to `system_slot_topology` and `economy_pair_synergy`.

Key functions:
- `estimate_body_slots(body)` — infers `(orbital, ground)` slot counts from body physics (body_type, radius, is_landable, has_rings, spectral_class). **Slot counts are ESTIMATES** — labelled as such throughout. Frontier does not expose actual counts via any public API.
- `compute_topology_metrics(bodies, counts)` — returns all 7 topology metrics + boolean flags
- `compute_system_pair_synergy(eco_a, eco_b, counts, topology, base_synergy)` — applies `PAIR_MODIFIERS` body-count adjustments over the global baseline
- `compute_contamination_risk(counts, target_pair)` — `BODY_ECONOMY_ADDS` + `SEVERITY` mapping; returns `risk_score`, `primary_contaminant`, `contamination_paths`, `mitigation`
- `_classify_bodies_simple(bodies)` — lightweight body classifier for topology use (avoids circular dep on `build_ratings.py`)
- Same multiprocessing worker-pool pattern as `build_ratings.py`; `--rebuild`, `--dirty`, `--limit`, `--workers`, `--chunk` modes

### `apps/importer/src/build_archetype_scores.py` (new — ~52 kB)
Layer 4 of the pipeline. Runs after `build_topology.py`, writes to `system_archetype_scores` and `system_archetype_traits`.

Key artefacts:
- `ARCHETYPE_DEFINITIONS` dict — 10 archetypes each with `body_weights`, `economy_pair`, `slot_preference`, `contamination_tolerance`, `purity_multiplier`, optional `diversity_bonus`, `buildability_profile`, `tags`
- `compute_archetype_score()` — body composition (0–60 pts) + topology (0–25 pts) + pair synergy (0–15 pts), multiplied by `purity_factor` and `diversity_factor`; surface-port cap when `requires_landable=True` and `landable=0`
- `compute_overall_development_potential()` — top-3 avg × 0.60 + diversity × 0.20 + buildability × 0.20; rarity gate caps at 82 without a standout body (ELW / BH / neutron / 2+ WW / 5+ terra)
- `compute_buildability()` — `cp_efficiency`, `t3_scaling`, `slot_efficiency`, contamination penalty, flexibility bonus; five-level complexity classification
- `generate_structured_rationale()` — full JSONB rationale: `{summary, tier, headline, positives[], risks[], complexity, build_path, tags[], score_breakdown, data_confidence}`
- `_compute_display_tags()` — max-8 UI tag array
- `score_system()` — single-system entry point; returns `scores` + `traits` dicts for bulk upsert
- Same worker-pool + upsert pattern as `build_ratings.py`

---

## Phase 3 — Beta API (new router, no existing routes touched)

### `apps/api/src/routers/archetypes.py` (new — ~28 kB)
Mounted at `/api/archetypes/*`. All endpoints use the MV for reads.

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/archetypes/rankings` | Ranked systems by archetype score. Filters: `min_score`, `galaxy_region`, `max_distance_ly`, `has_elw`, `min_slots`, `max_contamination`, `limit`/`offset`. Redis TTL 600s |
| POST | `/api/archetypes/rerank` | Rerank up to 500 systems by `ArchetypeRerankWeights` (purity/buildability/slots/expansion/logistics) or a preset profile. Redis TTL 120s |
| GET | `/api/archetypes/system/{id64}` | Full breakdown: all 10 archetype scores, topology block, economy pair synergy list, structured rationale for primary archetype. Redis TTL 300s |
| POST | `/api/archetypes/simulate` | Build simulation — score a system against a planned build plan |
| GET | `/api/archetypes/profiles` | 7 preset weight profiles (industrial_empire, space_farms, prestige_capital, ax_logistics, expansion_capital, mining_hub, generalist). Redis TTL 3600s |

Rate limits applied via `slowapi` (20–120 req/min by route). RFC-7807 error responses consistent with existing routers.

### `apps/api/src/models.py` (updated)
New Pydantic v2 models appended (no existing models modified):
- `ArchetypeKey`, `TierValue`, `BuildComplexity` Literal types
- `ArchetypeRerankWeights` — 5 dimensions with `extra='forbid'`
- `ArchetypeScoreBreakdown`, `ArchetypeRationale` — JSONB-flexible with `extra='allow'`
- `ArchetypeScore`, `TopologyDetail`, `EconomyPairDetail` — row models with `extra='allow'`
- `SystemArchetypeResponse` — envelope with `extra='forbid'`
- `ArchetypeRankingRow`, `ArchetypeRankingsResponse`
- `ArchetypeRerankRequest`, `ArchetypeRerankRow`, `ArchetypeRerankResponse`
- `PlannedFacility`, `BuildSimulateRequest`, `BuildSimulateResponse`
- `ArchetypeProfile`, `ArchetypesProfilesResponse`
- `RerankedSystemRow` backward-compat alias

### `apps/api/src/main.py` (updated)
- Imports and mounts `archetypes_router` at `/api/archetypes/*`
- Updated endpoint surface docstring

---

## Backward Compatibility

| Artifact | Status |
|----------|--------|
| `ratings` table | ✅ Untouched |
| `/api/ratings/rerank` endpoint | ✅ Untouched |
| All existing routers | ✅ Untouched |
| Existing Pydantic models | ✅ Untouched |
| New SQL tables | ✅ Additive only (no ALTER/DROP on existing) |
| `mv_archetype_rankings` | ✅ Created WITH NO DATA — no runtime impact |

---

## Pipeline Build Order (after merge + data load)

```bash
python3 import_spansh.py --all        # existing
python3 build_ratings.py              # existing
python3 build_topology.py             # NEW — ~1-2h
python3 build_archetype_scores.py     # NEW — ~2-3h
psql -c "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;"
```

---

## Validation Queries (post-data-load)

```sql
-- Archetype distribution
SELECT primary_archetype, COUNT(*), ROUND(AVG(overall_development_potential),1) AS avg_odp
FROM system_archetype_scores
GROUP BY primary_archetype ORDER BY COUNT(*) DESC;

-- Top 20 Refinery/Industrial systems
SELECT s.name, a.score_refinery_industrial, a.purity_score, a.build_complexity
FROM system_archetype_scores a
JOIN systems s ON s.id64 = a.system_id64
WHERE a.dirty = FALSE
ORDER BY a.score_refinery_industrial DESC LIMIT 20;

-- Cross-check against v3.1 scores
SELECT s.name, r.score_refinery, a.score_refinery_industrial
FROM system_archetype_scores a
JOIN ratings r ON r.system_id64 = a.system_id64
JOIN systems s ON s.id64 = a.system_id64
ORDER BY a.score_refinery_industrial DESC LIMIT 20;
```

---

## Files Changed

```
sql/012_topology_tables.sql          NEW  (281 lines)
sql/013_archetype_scores.sql         NEW  (269 lines)
sql/014_archetype_mv.sql             NEW  (283 lines)
apps/importer/src/build_topology.py       NEW  (~37 kB)
apps/importer/src/build_archetype_scores.py NEW (~52 kB)
apps/api/src/routers/archetypes.py   NEW  (~28 kB)
apps/api/src/models.py               MODIFIED (new models appended)
apps/api/src/main.py                 MODIFIED (router registered)
docs/colonisation-redesign/COLONISATION_ENGINE_REDESIGN.md  NEW (93 kB design doc)
```
