### PR TITLE
Implement Stage 4A port economy propagation

### DIFF
--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -945,6 +945,8 @@ class SimulateBuildResponse(BaseModel):
     economy_composition: dict[str, float] = Field(default_factory=dict)
     economy_order:       list[str] = Field(default_factory=list)
     economy_stack:       dict[str, Any] = Field(default_factory=dict)
+    port_economy_states: list[dict[str, Any]] = Field(default_factory=list)
+    influence_ledger:    list[dict[str, Any]] = Field(default_factory=list)
     inherited_economies: list[SimulationInheritedEconomy] = Field(default_factory=list)
     topology:            dict[str, Any] = Field(default_factory=dict)
     services:            dict[str, Any] = Field(default_factory=dict)
@@ -972,6 +974,7 @@ class RecommendedBuildPlan(BaseModel):
     composition_score:  float
     buildability_score: float
     economy_result:     dict[str, float] = Field(default_factory=dict)
+    port_economy_summary: list[str] = Field(default_factory=list)
     cp_result:          SimulationCPResult
     build_order:        list[SimulateBuildPlacement] = Field(default_factory=list)
     strengths:          list[str] = Field(default_factory=list)

--- a/apps/api/src/routers/simulate.py
+++ b/apps/api/src/routers/simulate.py
@@ -183,6 +183,7 @@ async def get_recommended_builds(
             composition_score=simulation.composition_score,
             buildability_score=simulation.buildability_score,
             economy_result=simulation.economy_composition,
+            port_economy_summary=_port_economy_summary(simulation),
             cp_result=simulation.cp,
             build_order=draft.request.placements,
             strengths=simulation.strengths[:4],
@@ -395,6 +396,27 @@ def _decision_explanation(
         'sensitive_assumptions': assumptions,
         'confidence_summary': _confidence_summary(simulation),
     }
+
+
+def _port_economy_summary(simulation: SimulateBuildResponse) -> list[str]:
+    summaries: list[str] = []
+    states = simulation.port_economy_states or []
+    if not states:
+        return summaries
+    main = states[0]
+    top_two = [str(item) for item in main.get('top_two', []) if item]
+    if top_two:
+        summaries.append(f'Main port economy: {" / ".join(top_two[:2])}')
+    sources = main.get('contamination_sources') or []
+    if sources:
+        source = sources[0]
+        economy = source.get('economy') or 'off-pair economy'
+        source_name = source.get('source_name') or 'another source'
+        influence_type = str(source.get('influence_type') or 'influence').replace('_', ' ')
+        summaries.append(f'Contamination source: {influence_type} {economy} from {source_name}')
+    elif main.get('tertiary_economies'):
+        summaries.append(f'Tertiary pressure: {", ".join(main.get("tertiary_economies", [])[:2])}')
+    return summaries[:2]
 
 
 def _confidence_summary(simulation: SimulateBuildResponse) -> str:

--- a/apps/api/src/simulation/build_preview.py
+++ b/apps/api/src/simulation/build_preview.py
@@ -55,6 +55,12 @@ from mechanics.versions import MECHANICS_VERSION
 from simulation.build_order import simulate_build_order
 from simulation.economy_stack import analyse_economy_stack
 from simulation.mechanics_trace import trace_simulation
+from simulation.port_economy import (
+    aggregate_port_strengths,
+    build_port_economy_states,
+    influence_ledger_to_dict,
+    port_states_to_dict,
+)
 from simulation.services import model_services
 from simulation.topology_graph import GraphPlacement, build_topology_graph, infer_location_type
 
@@ -155,7 +161,11 @@ def simulate_build_preview(
     warnings.extend(topology_graph.warnings)
     _extend_topology_notes(topology_graph, warnings, mechanics_notes)
 
-    economy_strengths = _simulate_economies(resolved, topology_graph)
+    port_economy_states, influence_ledger = build_port_economy_states(
+        placements=resolved,
+        topology_graph=topology_graph,
+    )
+    economy_strengths = aggregate_port_strengths(port_economy_states)
     links = _links_to_response(topology_graph)
     economy_composition = _to_percentages(economy_strengths)
     economy_order = sorted(economy_composition, key=economy_composition.get, reverse=True)
@@ -199,6 +209,8 @@ def simulate_build_preview(
         economy_stack=stack_result.to_dict(),
         services=services,
         confidence_signals=confidence_signals,
+        port_economy_states=port_economy_states,
+        influence_ledger=influence_ledger,
     )
     complexity = _complexity(cp, buildability, composition, confidence)
     final_score = round(
@@ -241,6 +253,8 @@ def simulate_build_preview(
         'economy_composition': economy_composition,
         'economy_order': economy_order,
         'economy_stack': stack_result.to_dict(),
+        'port_economy_states': port_states_to_dict(port_economy_states),
+        'influence_ledger': influence_ledger_to_dict(influence_ledger),
         'inherited_economies': [_profile_to_response(profile) for profile in inherited_profiles],
         'topology': _topology_to_response(topology_graph),
         'services': services,

--- a/apps/api/src/simulation/mechanics_trace.py
+++ b/apps/api/src/simulation/mechanics_trace.py
@@ -43,6 +43,8 @@ TRACE_CATEGORIES = [
     'weak_link_effects',
     'pass_through_effects',
     'converted_port_effects',
+    'port_economy_effects',
+    'influence_ledger_effects',
     'regional_effects',
     'purity_effects',
     'contamination_effects',
@@ -64,6 +66,8 @@ def trace_simulation(
     economy_stack: dict[str, Any],
     services: dict[str, Any],
     confidence_signals: list[ConfidenceSignal],
+    port_economy_states: list[Any] | None = None,
+    influence_ledger: list[Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     trace = empty_trace()
 
@@ -123,6 +127,63 @@ def trace_simulation(
             confidence=ConfidenceLevel.INFERRED.value,
             source=SOURCE_FRONTIER_LINKS,
         ).to_dict())
+
+    for state in port_economy_states or []:
+        top_two = getattr(state, 'top_two', []) or []
+        label = getattr(state, 'port_name', 'Main Port')
+        trace['port_economy_effects'].append(MechanicsTraceEvent(
+            category='port_economy_effects',
+            label=label,
+            description=(
+                f'{label} port economy state created with '
+                f'{", ".join(top_two) if top_two else "no protected top-two economies"}.'
+            ),
+            value_after=round(float(getattr(state, 'purity_score', 0.0) or 0.0), 1),
+            confidence=ConfidenceLevel.INFERRED.value,
+            source=SOURCE_MEGA_GUIDE,
+        ).to_dict())
+        if top_two:
+            trace['port_economy_effects'].append(MechanicsTraceEvent(
+                category='port_economy_effects',
+                label=f'{label} top-two protection',
+                description=f'{label} protects {" / ".join(top_two)} as the dominant local economy pair.',
+                confidence=ConfidenceLevel.INFERRED.value,
+                source=SOURCE_MEGA_GUIDE,
+            ).to_dict())
+        for influence in getattr(state, 'contamination_sources', []) or []:
+            trace['contamination_effects'].append(MechanicsTraceEvent(
+                category='contamination_effects',
+                label=f'{getattr(influence, "source_name", "Source")} -> {label}',
+                description=(
+                    f'{getattr(influence, "economy", "Economy")} contamination source detected via '
+                    f'{getattr(influence, "influence_type", "influence")}.'
+                ),
+                delta=round(float(getattr(influence, 'value', 0.0) or 0.0), 3),
+                confidence=ConfidenceLevel.INFERRED.value,
+                source=SOURCE_FRONTIER_LINKS,
+            ).to_dict())
+
+    for influence in influence_ledger or []:
+        influence_type = getattr(influence, 'influence_type', '')
+        value = float(getattr(influence, 'value', 0.0) or 0.0)
+        if value >= 0.4 or influence_type in {'weak_link', 'pass_through'}:
+            trace['influence_ledger_effects'].append(MechanicsTraceEvent(
+                category='influence_ledger_effects',
+                label=f'{getattr(influence, "source_name", "Source")} -> {getattr(influence, "target_port_name", "Main Port")}',
+                description=str(getattr(influence, 'reason', '') or f'{influence_type} influence recorded in the ledger.'),
+                delta=round(value, 3),
+                confidence=str(getattr(influence, 'confidence', ConfidenceLevel.INFERRED.value)),
+                source=SOURCE_FRONTIER_LINKS,
+            ).to_dict())
+            if influence_type == 'weak_link':
+                trace['contamination_effects'].append(MechanicsTraceEvent(
+                    category='contamination_effects',
+                    label=f'Weak-link contamination: {getattr(influence, "target_port_name", "Main Port")}',
+                    description=str(getattr(influence, 'reason', 'Weak-link contamination pressure recorded.')),
+                    delta=round(value, 3),
+                    confidence=ConfidenceLevel.INFERRED.value,
+                    source=SOURCE_FRONTIER_LINKS,
+                ).to_dict())
 
     for step in cp.get('timeline', []):
         for warning in step.get('warnings', []):

--- a/apps/api/src/simulation/port_economy.py
+++ b/apps/api/src/simulation/port_economy.py
@@ -1,0 +1,414 @@
+"""Per-port economy propagation and influence ledger for Simulation Preview.
+
+This module is intentionally additive. It consumes the existing topology graph,
+resolved placements, and body inheritance profiles, then builds a transparent
+ledger explaining how each Main Port receives economy pressure.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+from mechanics.economy_rules import FACILITY_ECONOMY_WEIGHTS
+
+
+INFLUENCE_DIRECT_FACILITY = 'direct_facility'
+INFLUENCE_BODY_INHERITANCE = 'body_inheritance'
+INFLUENCE_STRONG_LINK = 'strong_link'
+INFLUENCE_WEAK_LINK = 'weak_link'
+INFLUENCE_PASS_THROUGH = 'pass_through'
+INFLUENCE_CONVERTED_PORT = 'converted_port'
+INFLUENCE_MODIFIER = 'modifier'
+INFLUENCE_REGIONAL_CONTEXT = 'regional_context'
+
+_CONFIDENCE_INFERRED = 'inferred'
+_CONFIDENCE_COMMUNITY_OBSERVED = 'community_observed'
+_CONFIDENCE_LOW = 'low'
+_TERTIARY_THRESHOLD = 15.0
+_MAJOR_INFLUENCE_THRESHOLD = 0.4
+
+
+@dataclass(frozen=True)
+class EconomyInfluence:
+    source_id: str
+    source_name: str
+    source_type: str
+    target_port_id: str
+    target_port_name: str
+    local_body_id: str | None
+    economy: str
+    value: float
+    influence_type: str
+    link_type: str | None
+    confidence: str
+    reason: str
+    caveats: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data['value'] = round(float(self.value), 3)
+        return data
+
+
+@dataclass
+class PortEconomyState:
+    port_id: str
+    port_name: str
+    local_body_id: str | None
+    body_name: str | None
+    location_type: str
+    effective_role: str
+    inherited_economies: dict[str, float] = field(default_factory=dict)
+    direct_economies: dict[str, float] = field(default_factory=dict)
+    strong_link_economies: dict[str, float] = field(default_factory=dict)
+    weak_link_economies: dict[str, float] = field(default_factory=dict)
+    pass_through_economies: dict[str, float] = field(default_factory=dict)
+    converted_port_economies: dict[str, float] = field(default_factory=dict)
+    final_economy_strengths: dict[str, float] = field(default_factory=dict)
+    final_economy_composition: dict[str, float] = field(default_factory=dict)
+    economy_order: list[str] = field(default_factory=list)
+    top_two: list[str] = field(default_factory=list)
+    tertiary_economies: list[str] = field(default_factory=list)
+    purity_score: float = 0.0
+    contamination_risk: str = 'low'
+    contamination_sources: list[EconomyInfluence] = field(default_factory=list)
+    influences: list[EconomyInfluence] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    strengths: list[str] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data['inherited_economies'] = _round_map(self.inherited_economies)
+        data['direct_economies'] = _round_map(self.direct_economies)
+        data['strong_link_economies'] = _round_map(self.strong_link_economies)
+        data['weak_link_economies'] = _round_map(self.weak_link_economies)
+        data['pass_through_economies'] = _round_map(self.pass_through_economies)
+        data['converted_port_economies'] = _round_map(self.converted_port_economies)
+        data['final_economy_strengths'] = _round_map(self.final_economy_strengths)
+        data['final_economy_composition'] = _round_map(self.final_economy_composition, ndigits=1)
+        data['purity_score'] = round(float(self.purity_score), 1)
+        data['contamination_sources'] = [item.to_dict() for item in self.contamination_sources]
+        data['influences'] = [item.to_dict() for item in self.influences]
+        return data
+
+
+def build_port_economy_states(
+    *,
+    placements: list[Any],
+    topology_graph: Any,
+) -> tuple[list[PortEconomyState], list[EconomyInfluence]]:
+    """Build per-Main-Port economy states and a flat influence ledger."""
+    role_by_key = {
+        _placement_key(item.placement): item.effective_role
+        for item in getattr(topology_graph, 'classified_placements', [])
+    }
+    resolved_by_key = {_resolved_key(item): item for item in placements}
+    graph_by_key = {_graph_key(item): item for group in getattr(topology_graph, 'local_body_groups', []) for item in group.facilities}
+
+    states: dict[str, PortEconomyState] = {}
+    port_by_body_location: dict[tuple[str | None, str], Any] = {}
+
+    for group in getattr(topology_graph, 'local_body_groups', []):
+        for port, role in ((getattr(group, 'main_surface_port', None), 'main_surface_port'), (getattr(group, 'main_orbital_port', None), 'main_orbital_port')):
+            if port is None:
+                continue
+            state = PortEconomyState(
+                port_id=port.facility_id,
+                port_name=port.facility_name,
+                local_body_id=group.local_body_id,
+                body_name=group.body_name,
+                location_type=port.location_type,
+                effective_role=role_by_key.get(_graph_key(port), role),
+            )
+            states[_port_key(port)] = state
+            port_by_body_location[(group.local_body_id, port.location_type)] = port
+
+    if not states:
+        return [], []
+
+    for group in getattr(topology_graph, 'local_body_groups', []):
+        for graph_placement in group.facilities:
+            resolved = resolved_by_key.get(_graph_key(graph_placement))
+            if resolved is None:
+                continue
+            profile = getattr(resolved, 'economy_profile', None)
+            if profile is None or not getattr(profile, 'weights', None):
+                continue
+            target = _local_direct_target(graph_placement, group)
+            if target is None:
+                continue
+            state = states.get(_port_key(target))
+            if state is None:
+                continue
+            source_type = 'port' if graph_placement.facility.is_port else 'facility'
+            base_weight = _economy_weight(graph_placement.facility)
+            inherited = bool(getattr(profile, 'inherited', False) and graph_placement.facility.is_port)
+            for economy, share in profile.weights.items():
+                value = float(base_weight) * float(share)
+                if value <= 0:
+                    continue
+                influence_type = INFLUENCE_BODY_INHERITANCE if inherited else INFLUENCE_DIRECT_FACILITY
+                caveats = list(getattr(profile, 'caveats', []) or [])
+                reason = (
+                    f'{graph_placement.facility_name} inherits {economy} from local body economy profile.'
+                    if inherited else
+                    f'{graph_placement.facility_name} directly contributes {economy} to the local Main Port economy stack.'
+                )
+                confidence = _profile_confidence(profile) if inherited else _CONFIDENCE_COMMUNITY_OBSERVED
+                influence = EconomyInfluence(
+                    source_id=graph_placement.facility_id,
+                    source_name=graph_placement.facility_name,
+                    source_type=source_type,
+                    target_port_id=target.facility_id,
+                    target_port_name=target.facility_name,
+                    local_body_id=group.local_body_id,
+                    economy=str(economy),
+                    value=value,
+                    influence_type=influence_type,
+                    link_type=None,
+                    confidence=confidence,
+                    reason=reason,
+                    caveats=caveats,
+                )
+                _add_influence(state, influence)
+                _add_value(state.inherited_economies if inherited else state.direct_economies, str(economy), value)
+
+    for link in getattr(topology_graph, 'strong_links', []):
+        state = states.get(_port_key_from_id(link.receiver_port_id, getattr(link, 'local_body_id', None)))
+        if state is None or not link.economy:
+            continue
+        source_graph = graph_by_key.get((link.source_facility_id, str(link.local_body_id), _graph_build_order_lookup(graph_by_key, link.source_facility_id, str(link.local_body_id))))
+        source_type = 'converted_port' if _is_converted(topology_graph, link.source_facility_id, link.local_body_id) else 'facility'
+        caveats = list(getattr(link, 'caveats', []) or [])
+        if source_type == 'converted_port':
+            caveats.append('Converted-port support behaviour is inferred and should be verified in-game.')
+        influence_type = INFLUENCE_CONVERTED_PORT if source_type == 'converted_port' else INFLUENCE_STRONG_LINK
+        influence = EconomyInfluence(
+            source_id=link.source_facility_id,
+            source_name=link.source_facility_name,
+            source_type=source_type,
+            target_port_id=link.receiver_port_id,
+            target_port_name=link.receiver_port_name,
+            local_body_id=link.local_body_id,
+            economy=str(link.economy),
+            value=float(link.value),
+            influence_type=influence_type,
+            link_type='strong',
+            confidence=_CONFIDENCE_INFERRED,
+            reason=getattr(link, 'note', '') or f'{link.source_facility_name} strongly links to {link.receiver_port_name}.',
+            caveats=_unique(caveats),
+        )
+        _add_influence(state, influence)
+        _add_value(state.converted_port_economies if source_type == 'converted_port' else state.strong_link_economies, str(link.economy), float(link.value))
+        if source_graph is None:
+            continue
+
+    for link in getattr(topology_graph, 'weak_links', []):
+        state = states.get(_port_key_from_id(link.receiver_port_id, getattr(link, 'target_body_id', None)))
+        if state is None or not link.economy:
+            continue
+        source_type = 'converted_port' if _is_converted(topology_graph, link.source_facility_id, link.source_body_id) else 'facility'
+        caveats = ['Weak links are fixed at 0.05 and only target non-local Main Ports.']
+        if source_type == 'converted_port':
+            caveats.append('Converted-port weak-link emission is inferred and should be verified in-game.')
+        influence_type = INFLUENCE_CONVERTED_PORT if source_type == 'converted_port' else INFLUENCE_WEAK_LINK
+        influence = EconomyInfluence(
+            source_id=link.source_facility_id,
+            source_name=link.source_facility_name,
+            source_type=source_type,
+            target_port_id=link.receiver_port_id,
+            target_port_name=link.receiver_port_name,
+            local_body_id=link.target_body_id,
+            economy=str(link.economy),
+            value=float(link.value),
+            influence_type=influence_type,
+            link_type='weak',
+            confidence=_CONFIDENCE_INFERRED,
+            reason=getattr(link, 'note', '') or f'{link.source_facility_name} weakly links to {link.receiver_port_name}.',
+            caveats=caveats,
+        )
+        _add_influence(state, influence)
+        _add_value(state.converted_port_economies if source_type == 'converted_port' else state.weak_link_economies, str(link.economy), float(link.value))
+
+    counted_strong = {(link.source_facility_id, link.local_body_id, link.receiver_port_id) for link in getattr(topology_graph, 'strong_links', [])}
+    for link in getattr(topology_graph, 'pass_through_links', []):
+        state = states.get(_port_key_from_id(link.orbital_receiver_id, getattr(link, 'local_body_id', None)))
+        if state is None or not link.economy:
+            continue
+        if (link.source_facility_id, link.local_body_id, link.orbital_receiver_id) in counted_strong:
+            continue
+        caveats = list(getattr(link, 'caveats', []) or [])
+        influence = EconomyInfluence(
+            source_id=link.source_facility_id,
+            source_name=link.source_facility_name,
+            source_type='port' if link.source_facility_id == link.surface_port_id else 'facility',
+            target_port_id=link.orbital_receiver_id,
+            target_port_name=link.orbital_receiver_name,
+            local_body_id=link.local_body_id,
+            economy=str(link.economy),
+            value=float(link.value),
+            influence_type=INFLUENCE_PASS_THROUGH,
+            link_type='pass_through',
+            confidence=_CONFIDENCE_INFERRED,
+            reason=getattr(link, 'note', '') or f'{link.source_facility_name} passes influence through {link.surface_port_name}.',
+            caveats=caveats,
+        )
+        _add_influence(state, influence)
+        _add_value(state.pass_through_economies, str(link.economy), float(link.value))
+
+    for state in states.values():
+        _finalise_state(state)
+
+    ordered_states = sorted(states.values(), key=lambda item: (str(item.local_body_id or ''), item.location_type, item.port_id))
+    ledger = [influence for state in ordered_states for influence in state.influences]
+    return ordered_states, ledger
+
+
+def aggregate_port_strengths(port_states: list[PortEconomyState]) -> dict[str, float]:
+    strengths: dict[str, float] = {}
+    for state in port_states:
+        for economy, value in state.final_economy_strengths.items():
+            _add_value(strengths, economy, value)
+    return strengths
+
+
+def _local_direct_target(graph_placement: Any, group: Any) -> Optional[Any]:
+    if graph_placement.facility.is_port:
+        if graph_placement == getattr(group, 'main_surface_port', None) or graph_placement == getattr(group, 'main_orbital_port', None):
+            return graph_placement
+    if graph_placement.location_type == 'surface':
+        return getattr(group, 'main_surface_port', None) or getattr(group, 'main_orbital_port', None)
+    return getattr(group, 'main_orbital_port', None) or getattr(group, 'main_surface_port', None)
+
+
+def _add_influence(state: PortEconomyState, influence: EconomyInfluence) -> None:
+    state.influences.append(influence)
+    _add_value(state.final_economy_strengths, influence.economy, influence.value)
+
+
+def _add_value(target: dict[str, float], economy: str, value: float) -> None:
+    if not economy or value <= 0:
+        return
+    target[economy] = target.get(economy, 0.0) + float(value)
+
+
+def _finalise_state(state: PortEconomyState) -> None:
+    total = sum(max(0.0, value) for value in state.final_economy_strengths.values())
+    if total <= 0:
+        state.final_economy_composition = {}
+        state.economy_order = []
+        state.top_two = []
+        state.tertiary_economies = []
+        state.purity_score = 0.0
+        state.contamination_risk = 'low'
+        state.recommendations.append('Add local support facilities or body-backed colony ports to form a visible economy stack.')
+        return
+
+    ordered = sorted(state.final_economy_strengths.items(), key=lambda item: item[1], reverse=True)
+    state.economy_order = [economy for economy, _ in ordered]
+    state.final_economy_composition = {economy: (value / total) * 100.0 for economy, value in ordered}
+    state.top_two = state.economy_order[:2]
+    state.tertiary_economies = [economy for economy in state.economy_order[2:] if state.final_economy_composition.get(economy, 0.0) >= _TERTIARY_THRESHOLD]
+    state.purity_score = sum(state.final_economy_composition.get(economy, 0.0) for economy in state.top_two)
+
+    if state.purity_score >= 85 and not state.tertiary_economies:
+        state.contamination_risk = 'low'
+    elif state.purity_score >= 70:
+        state.contamination_risk = 'medium'
+    else:
+        state.contamination_risk = 'high'
+
+    if state.top_two:
+        state.strengths.append(f'{state.port_name} protects {" / ".join(state.top_two)} as its top economy pair.')
+    if state.tertiary_economies:
+        joined = ', '.join(state.tertiary_economies)
+        state.warnings.append(f'{joined} is above the tertiary pressure threshold for {state.port_name}.')
+        state.recommendations.append(f'Reduce or isolate {joined} sources if the intended top-two economy pair should remain dominant.')
+    if state.contamination_risk != 'low':
+        state.recommendations.append('Prefer same-body support for the desired pair and move off-pair emitters to bodies without Main Ports.')
+    else:
+        state.recommendations.append('Maintain the current local support pattern; contamination pressure is currently contained.')
+
+    contamination = set(state.tertiary_economies)
+    if len(state.top_two) < 2 and len(state.economy_order) > 1:
+        contamination.update(state.economy_order[1:])
+    state.contamination_sources = [
+        influence for influence in state.influences
+        if influence.economy in contamination
+    ]
+
+
+def _economy_weight(facility: Any) -> float:
+    if facility.is_port and not facility.is_colony_port:
+        return FACILITY_ECONOMY_WEIGHTS['specialised_port']
+    if facility.is_colony_port:
+        return FACILITY_ECONOMY_WEIGHTS['colony_port']
+    return FACILITY_ECONOMY_WEIGHTS['support_or_default']
+
+
+def _profile_confidence(profile: Any) -> str:
+    confidence = float(getattr(profile, 'confidence', 0.0) or 0.0)
+    if confidence >= 0.75:
+        return _CONFIDENCE_INFERRED
+    return _CONFIDENCE_LOW
+
+
+def _round_map(values: dict[str, float], *, ndigits: int = 3) -> dict[str, float]:
+    return {key: round(float(value), ndigits) for key, value in sorted(values.items(), key=lambda item: item[1], reverse=True)}
+
+
+def _unique(items: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item and item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result
+
+
+def _placement_key(placement: Any) -> tuple[str, str, int]:
+    return (placement.facility_id, str(placement.local_body_id or 'system'), int(placement.build_order))
+
+
+def _graph_key(placement: Any) -> tuple[str, str, int]:
+    return (placement.facility_id, str(placement.local_body_id or 'system'), int(placement.build_order))
+
+
+def _resolved_key(placement: Any) -> tuple[str, str, int]:
+    return (
+        placement.facility.id,
+        str(placement.spec.local_body_id or 'system'),
+        int(placement.spec.build_order),
+    )
+
+
+def _port_key(port: Any) -> str:
+    return _port_key_from_id(port.facility_id, port.local_body_id)
+
+
+def _port_key_from_id(port_id: str, local_body_id: str | None) -> str:
+    return f'{local_body_id or "system"}::{port_id}'
+
+
+def _graph_build_order_lookup(graph_by_key: dict[tuple[str, str, int], Any], facility_id: str, local_body_id: str) -> int:
+    for candidate_facility_id, candidate_body_id, build_order in graph_by_key:
+        if candidate_facility_id == facility_id and candidate_body_id == local_body_id:
+            return build_order
+    return 0
+
+
+def _is_converted(topology_graph: Any, facility_id: str, local_body_id: str | None) -> bool:
+    for port in getattr(topology_graph, 'converted_ports', []):
+        if port.facility_id == facility_id and str(port.local_body_id or 'system') == str(local_body_id or 'system'):
+            return True
+    return False
+
+
+def port_states_to_dict(port_states: list[PortEconomyState]) -> list[dict[str, Any]]:
+    return [state.to_dict() for state in port_states]
+
+
+def influence_ledger_to_dict(ledger: list[EconomyInfluence]) -> list[dict[str, Any]]:
+    return [item.to_dict() for item in ledger]

--- a/apps/api/src/simulation/port_economy.py
+++ b/apps/api/src/simulation/port_economy.py
@@ -7,7 +7,7 @@ ledger explaining how each Main Port receives economy pressure.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from mechanics.economy_rules import FACILITY_ECONOMY_WEIGHTS
 
@@ -23,9 +23,9 @@ INFLUENCE_REGIONAL_CONTEXT = 'regional_context'
 
 _CONFIDENCE_INFERRED = 'inferred'
 _CONFIDENCE_COMMUNITY_OBSERVED = 'community_observed'
-_CONFIDENCE_LOW = 'low'
+_CONFIDENCE_ESTIMATED = 'estimated'
+_BODY_INHERITANCE_LOW_CONFIDENCE_CAVEAT = 'Body inheritance confidence is below the verified threshold.'
 _TERTIARY_THRESHOLD = 15.0
-_MAJOR_INFLUENCE_THRESHOLD = 0.4
 
 
 @dataclass(frozen=True)
@@ -104,10 +104,7 @@ def build_port_economy_states(
         for item in getattr(topology_graph, 'classified_placements', [])
     }
     resolved_by_key = {_resolved_key(item): item for item in placements}
-    graph_by_key = {_graph_key(item): item for group in getattr(topology_graph, 'local_body_groups', []) for item in group.facilities}
-
     states: dict[str, PortEconomyState] = {}
-    port_by_body_location: dict[tuple[str | None, str], Any] = {}
 
     for group in getattr(topology_graph, 'local_body_groups', []):
         for port, role in ((getattr(group, 'main_surface_port', None), 'main_surface_port'), (getattr(group, 'main_orbital_port', None), 'main_orbital_port')):
@@ -122,7 +119,6 @@ def build_port_economy_states(
                 effective_role=role_by_key.get(_graph_key(port), role),
             )
             states[_port_key(port)] = state
-            port_by_body_location[(group.local_body_id, port.location_type)] = port
 
     if not states:
         return [], []
@@ -135,7 +131,14 @@ def build_port_economy_states(
             profile = getattr(resolved, 'economy_profile', None)
             if profile is None or not getattr(profile, 'weights', None):
                 continue
-            target = _local_direct_target(graph_placement, group)
+            # Direct influence is reserved for Main Ports: colony ports may inherit
+            # body economies and specialised Main Ports may carry their own economy.
+            # Support facilities deliberately contribute through strong, weak,
+            # pass-through, or converted-port links so their economy is not counted
+            # once as direct pressure and again as linked pressure.
+            if not _is_direct_port_influence_source(graph_placement, group):
+                continue
+            target = graph_placement
             if target is None:
                 continue
             state = states.get(_port_key(target))
@@ -150,12 +153,14 @@ def build_port_economy_states(
                     continue
                 influence_type = INFLUENCE_BODY_INHERITANCE if inherited else INFLUENCE_DIRECT_FACILITY
                 caveats = list(getattr(profile, 'caveats', []) or [])
+                confidence = _profile_confidence(profile) if inherited else _CONFIDENCE_COMMUNITY_OBSERVED
+                if inherited and confidence == _CONFIDENCE_ESTIMATED:
+                    caveats.append(_BODY_INHERITANCE_LOW_CONFIDENCE_CAVEAT)
                 reason = (
                     f'{graph_placement.facility_name} inherits {economy} from local body economy profile.'
                     if inherited else
                     f'{graph_placement.facility_name} directly contributes {economy} to the local Main Port economy stack.'
                 )
-                confidence = _profile_confidence(profile) if inherited else _CONFIDENCE_COMMUNITY_OBSERVED
                 influence = EconomyInfluence(
                     source_id=graph_placement.facility_id,
                     source_name=graph_placement.facility_name,
@@ -178,7 +183,6 @@ def build_port_economy_states(
         state = states.get(_port_key_from_id(link.receiver_port_id, getattr(link, 'local_body_id', None)))
         if state is None or not link.economy:
             continue
-        source_graph = graph_by_key.get((link.source_facility_id, str(link.local_body_id), _graph_build_order_lookup(graph_by_key, link.source_facility_id, str(link.local_body_id))))
         source_type = 'converted_port' if _is_converted(topology_graph, link.source_facility_id, link.local_body_id) else 'facility'
         caveats = list(getattr(link, 'caveats', []) or [])
         if source_type == 'converted_port':
@@ -201,8 +205,6 @@ def build_port_economy_states(
         )
         _add_influence(state, influence)
         _add_value(state.converted_port_economies if source_type == 'converted_port' else state.strong_link_economies, str(link.economy), float(link.value))
-        if source_graph is None:
-            continue
 
     for link in getattr(topology_graph, 'weak_links', []):
         state = states.get(_port_key_from_id(link.receiver_port_id, getattr(link, 'target_body_id', None)))
@@ -273,13 +275,10 @@ def aggregate_port_strengths(port_states: list[PortEconomyState]) -> dict[str, f
     return strengths
 
 
-def _local_direct_target(graph_placement: Any, group: Any) -> Optional[Any]:
-    if graph_placement.facility.is_port:
-        if graph_placement == getattr(group, 'main_surface_port', None) or graph_placement == getattr(group, 'main_orbital_port', None):
-            return graph_placement
-    if graph_placement.location_type == 'surface':
-        return getattr(group, 'main_surface_port', None) or getattr(group, 'main_orbital_port', None)
-    return getattr(group, 'main_orbital_port', None) or getattr(group, 'main_surface_port', None)
+def _is_direct_port_influence_source(graph_placement: Any, group: Any) -> bool:
+    if not graph_placement.facility.is_port:
+        return False
+    return graph_placement == getattr(group, 'main_surface_port', None) or graph_placement == getattr(group, 'main_orbital_port', None)
 
 
 def _add_influence(state: PortEconomyState, influence: EconomyInfluence) -> None:
@@ -351,7 +350,7 @@ def _profile_confidence(profile: Any) -> str:
     confidence = float(getattr(profile, 'confidence', 0.0) or 0.0)
     if confidence >= 0.75:
         return _CONFIDENCE_INFERRED
-    return _CONFIDENCE_LOW
+    return _CONFIDENCE_ESTIMATED
 
 
 def _round_map(values: dict[str, float], *, ndigits: int = 3) -> dict[str, float]:
@@ -390,13 +389,6 @@ def _port_key(port: Any) -> str:
 
 def _port_key_from_id(port_id: str, local_body_id: str | None) -> str:
     return f'{local_body_id or "system"}::{port_id}'
-
-
-def _graph_build_order_lookup(graph_by_key: dict[tuple[str, str, int], Any], facility_id: str, local_body_id: str) -> int:
-    for candidate_facility_id, candidate_body_id, build_order in graph_by_key:
-        if candidate_facility_id == facility_id and candidate_body_id == local_body_id:
-            return build_order
-    return 0
 
 
 def _is_converted(topology_graph: Any, facility_id: str, local_body_id: str | None) -> bool:

--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -54,14 +54,23 @@ how confident is ED-Finder?"
 
 ## Stage 4 - Topology/Economy Engine V2
 
-Future work after trust-layer hardening.
+Stage 4 begins with Stage 4A, an additive per-port economy propagation layer that keeps the Stage 2/3 deterministic preview and trust layer intact.
 
-- Full graph propagation.
+- Stage 4A per-Main-Port economy states.
+- Stage 4A influence ledger covering body inheritance, direct facility influence, strong links, weak links, pass-through effects, and converted ports.
+- System-level economy aggregation from port states while preserving existing response fields.
+- Simulation Preview Port Economy Breakdown and collapsed Influence Ledger display.
+- Recommended Build card summary for main-port economy and contamination source.
+- Mechanics trace events for port-state creation, top-two protection, major influence sources, weak-link contamination, and pass-through influence.
+
+Remaining Stage 4 work:
+
 - Service dependency graph.
 - Advanced contamination modelling.
 - Converted-port confidence refinement.
 - Local-body cluster strategy.
 - Pass-through validation against observed builds.
+- Richer visual graph rendering once more observations exist.
 
 ## Stage 5 - Optimiser V1
 
@@ -107,5 +116,4 @@ Longer-term destination.
 
 ## Current Guardrail
 
-Do not add more gameplay mechanics until Stage 3 remains easy to test, explain,
-and debug. The engine should be conservative when mechanics are unknown.
+Do not add unsupported gameplay mechanics until the deterministic preview remains easy to test, explain, and debug. Stage 4A should remain conservative: it explains existing topology/economy rules per port and labels inferred behaviour rather than inventing new mechanics.

--- a/docs/colonisation-redesign/port-economy-propagation.md
+++ b/docs/colonisation-redesign/port-economy-propagation.md
@@ -1,0 +1,47 @@
+# Stage 4A: Per-Port Economy Propagation and Influence Ledger
+
+Stage 4A adds a per-port explainability layer to ED-Finder’s deterministic colonisation simulation. The previous Stage 2/3 engine already modelled facility economy contributions, body inheritance, strong links, fixed weak links, pass-through effects, converted-port caveats, CP timeline, services, confidence signals, and mechanics trace. Stage 4A keeps those systems intact, but changes the economy explanation from a single system-level economy soup into explicit **Main Port economy states** backed by a structured **influence ledger**.
+
+## PortEconomyState
+
+A `PortEconomyState` represents the economy stack for one Main Port selected by the topology graph. Each state records the port identity, local body, location type, effective role, inherited economies, direct facility economies, strong-link economies, weak-link economies, pass-through economies, converted-port economies, final strengths, final percentage composition, protected top two, tertiary economies, purity score, contamination risk, contamination sources, warnings, strengths, recommendations, and the full set of ledger influences that explain the state.
+
+| Field Group | Purpose |
+|---|---|
+| Port identity | Identifies the Main Port, body/local body, location type, and topology role. |
+| Influence buckets | Separates inherited, direct, strong-link, weak-link, pass-through, and converted-port pressure. |
+| Final stack | Produces final strengths, percentages, economy order, top two, tertiary economies, purity, and contamination risk. |
+| Explainability | Lists influence entries, contamination sources, warnings, strengths, and recommendations. |
+
+## Influence Ledger
+
+Every economy contribution that reaches a Main Port is represented as an `EconomyInfluence` entry. The ledger is intentionally verbose so the UI and tests can trace economy pressure back to concrete sources instead of displaying raw aggregate percentages only.
+
+| Ledger Field | Meaning |
+|---|---|
+| `source_id`, `source_name`, `source_type` | The facility, port, converted port, or body-derived source of the influence. |
+| `target_port_id`, `target_port_name` | The Main Port receiving the economy pressure. |
+| `local_body_id` | The local body context for the influence. |
+| `economy`, `value` | The affected economy and numeric strength. |
+| `influence_type`, `link_type` | Whether the contribution is direct, inherited, strong, weak, pass-through, converted, modifier, or regional context. |
+| `confidence`, `reason`, `caveats` | Explainability metadata for the mechanic and any limitations. |
+
+## Propagation Rules
+
+The implementation consumes the existing topology graph. Main Ports are selected exactly as in Stage 2: highest tier first, then earliest build order, separately for surface and orbital ports. Main Ports receive weak links but do not emit weak links. Weak links target non-local Main Ports only and remain fixed at `0.05`. Strong links use the existing source/emitter tier value and strong-link modifier rules. Pass-through entries are recorded where surface influence is passed to an orbital Main Port, while avoiding duplicate system-level inflation. Converted ports are represented as caveated influences because their support-emitter behaviour remains inferred.
+
+## Aggregation into System Economy
+
+System-level `economy_composition`, `economy_order`, and `economy_stack` are still returned for backward compatibility. Stage 4A now derives the system-level strengths from the final strengths of all `PortEconomyState` objects. If a simulated build has no Main Ports, `port_economy_states` and `influence_ledger` are empty and the preview remains safe to render.
+
+## Contamination Tracing
+
+For each port, the top two economies are treated as protected. Economies outside the top two that exceed the tertiary threshold are marked as contamination pressure. The related ledger entries become `contamination_sources`, allowing the UI to explain whether pressure comes from a weak link, a pass-through effect, body inheritance, converted port, or direct facility influence.
+
+## Verified and Inferred Behaviour
+
+Strong-link and weak-link structure follows the existing Frontier/community documented topology rules already used by the Stage 2 graph. Body economy inheritance, economy purity scoring, converted-port support behaviour, pass-through propagation, and contamination thresholds remain inferred simulation rules and are labelled as such in ledger confidence and mechanics trace output.
+
+## Limitations and Future Improvements
+
+Stage 4A is not a full optimiser and does not attempt to choose the best build automatically. It does not invent unsupported Elite Dangerous mechanics. Future work can refine converted-port confidence, validate pass-through behaviour against more observed builds, add service-aware ranking, and provide richer port-to-port visual graph rendering once more in-game observations are available.

--- a/docs/colonisation-redesign/port-economy-propagation.md
+++ b/docs/colonisation-redesign/port-economy-propagation.md
@@ -1,21 +1,36 @@
 # Stage 4A: Per-Port Economy Propagation and Influence Ledger
 
-Stage 4A adds a per-port explainability layer to ED-Finder’s deterministic colonisation simulation. The previous Stage 2/3 engine already modelled facility economy contributions, body inheritance, strong links, fixed weak links, pass-through effects, converted-port caveats, CP timeline, services, confidence signals, and mechanics trace. Stage 4A keeps those systems intact, but changes the economy explanation from a single system-level economy soup into explicit **Main Port economy states** backed by a structured **influence ledger**.
+Stage 4A adds a per-port explainability layer to ED-Finder’s deterministic colonisation simulation. The Stage 2/3 engine already models facility catalogue data, local-body topology, Main Port selection, strong links, fixed weak links, pass-through effects, converted-port caveats, CP timeline, service states, confidence signals, and mechanics trace. Stage 4A keeps those systems intact while changing the explanation from a single system-level economy soup into explicit **Main Port economy states** backed by a structured **influence ledger**.
+
+## Chosen Counting Model
+
+The hardened Stage 4A model separates direct port influence from support-facility link influence. **Main Ports** can contribute direct influence when they are colony or specialised ports, including body-inheritance influence for colony ports. **Support facilities** do not also create a separate `direct_facility` contribution to the same Main Port. Instead, support-facility economy pressure reaches ports through the topology graph as `strong_link`, `weak_link`, `pass_through`, or `converted_port` influence.
+
+| Source Type | Normal Influence Path | Counting Rule |
+|---|---|---|
+| Colony Main Port | `body_inheritance` | The Main Port receives inherited body economies from its local body profile. |
+| Specialised Main Port | `direct_facility` | The Main Port may contribute its own explicit economy directly to its local stack. |
+| Support facility on same body | `strong_link` | The support facility contributes through the strong-link path only, not as direct pressure plus strong pressure. |
+| Support facility on another body | `weak_link` | The support facility contributes fixed weak pressure only to non-local Main Ports. |
+| Surface support passing to orbital port | `pass_through` | The support’s influence can pass through the Surface Main Port to the Orbital Main Port without creating an additional direct support entry. |
+| Converted support port | `converted_port` | Converted-port support behaviour is represented as caveated linked influence. |
+
+This model was chosen because it makes the ledger easier to audit. A support facility should normally appear once per intended topology path, so a same-body support facility does not quietly become both `direct_facility` and `strong_link` influence against the same Main Port.
 
 ## PortEconomyState
 
-A `PortEconomyState` represents the economy stack for one Main Port selected by the topology graph. Each state records the port identity, local body, location type, effective role, inherited economies, direct facility economies, strong-link economies, weak-link economies, pass-through economies, converted-port economies, final strengths, final percentage composition, protected top two, tertiary economies, purity score, contamination risk, contamination sources, warnings, strengths, recommendations, and the full set of ledger influences that explain the state.
+A `PortEconomyState` represents the economy stack for one Main Port selected by the topology graph. Each state records the port identity, local body, location type, effective role, inherited economies, direct economies, strong-link economies, weak-link economies, pass-through economies, converted-port economies, final strengths, final percentage composition, protected top two, tertiary economies, purity score, contamination risk, contamination sources, warnings, strengths, recommendations, and the full set of ledger influences that explain the state.
 
 | Field Group | Purpose |
 |---|---|
 | Port identity | Identifies the Main Port, body/local body, location type, and topology role. |
-| Influence buckets | Separates inherited, direct, strong-link, weak-link, pass-through, and converted-port pressure. |
+| Influence buckets | Separates inherited, direct-port, strong-link, weak-link, pass-through, and converted-port pressure. |
 | Final stack | Produces final strengths, percentages, economy order, top two, tertiary economies, purity, and contamination risk. |
 | Explainability | Lists influence entries, contamination sources, warnings, strengths, and recommendations. |
 
 ## Influence Ledger
 
-Every economy contribution that reaches a Main Port is represented as an `EconomyInfluence` entry. The ledger is intentionally verbose so the UI and tests can trace economy pressure back to concrete sources instead of displaying raw aggregate percentages only.
+Every economy contribution that reaches a Main Port is represented as an `EconomyInfluence` entry. The ledger is intentionally explicit so the UI and tests can trace economy pressure back to concrete sources instead of displaying raw aggregate percentages only.
 
 | Ledger Field | Meaning |
 |---|---|
@@ -28,19 +43,32 @@ Every economy contribution that reaches a Main Port is represented as an `Econom
 
 ## Propagation Rules
 
-The implementation consumes the existing topology graph. Main Ports are selected exactly as in Stage 2: highest tier first, then earliest build order, separately for surface and orbital ports. Main Ports receive weak links but do not emit weak links. Weak links target non-local Main Ports only and remain fixed at `0.05`. Strong links use the existing source/emitter tier value and strong-link modifier rules. Pass-through entries are recorded where surface influence is passed to an orbital Main Port, while avoiding duplicate system-level inflation. Converted ports are represented as caveated influences because their support-emitter behaviour remains inferred.
+The implementation consumes the existing topology graph. Main Ports are selected exactly as in Stage 2: highest tier first, then earliest build order, separately for surface and orbital ports. Main Ports receive weak links but do not emit weak links. Weak links target non-local Main Ports only and remain fixed at `0.05`. Strong links use the existing source/emitter tier value and strong-link modifier rules.
+
+Pass-through entries are recorded where surface influence is passed to an orbital Main Port. The ledger avoids duplicate pass-through inflation by skipping pass-through entries that would repeat an already-counted strong influence into the same orbital receiver. Converted ports are represented as caveated influences because their support-emitter behaviour remains inferred.
 
 ## Aggregation into System Economy
 
-System-level `economy_composition`, `economy_order`, and `economy_stack` are still returned for backward compatibility. Stage 4A now derives the system-level strengths from the final strengths of all `PortEconomyState` objects. If a simulated build has no Main Ports, `port_economy_states` and `influence_ledger` are empty and the preview remains safe to render.
+System-level `economy_composition`, `economy_order`, and `economy_stack` are still returned for backward compatibility. Stage 4A derives system-level strengths from the final strengths of all `PortEconomyState` objects. If a simulated build has no Main Ports, `port_economy_states` and `influence_ledger` are empty and the preview remains safe to render.
 
 ## Contamination Tracing
 
-For each port, the top two economies are treated as protected. Economies outside the top two that exceed the tertiary threshold are marked as contamination pressure. The related ledger entries become `contamination_sources`, allowing the UI to explain whether pressure comes from a weak link, a pass-through effect, body inheritance, converted port, or direct facility influence.
+For each port, the top two economies are treated as protected. Economies outside the top two that exceed the tertiary threshold are marked as contamination pressure. The related ledger entries become `contamination_sources`, allowing the UI to explain whether pressure comes from a weak link, pass-through effect, body inheritance, converted port, or direct Main Port influence.
+
+## Confidence Labels
+
+Influence entries use the standard ED-Finder confidence vocabulary. The ledger should not emit ad hoc labels such as `low`. Low-confidence body inheritance is represented as `estimated` and receives a caveat explaining that the body inheritance confidence is below the verified threshold.
+
+| Confidence Label | Stage 4A Usage |
+|---|---|
+| `community_observed` | Explicit specialised Main Port direct economy pressure. |
+| `inferred` | Model-derived body inheritance above the confidence threshold, strong links, weak links, pass-through links, and converted-port effects. |
+| `estimated` | Body inheritance with lower source confidence. |
+| `unknown`, `speculative`, `observed`, `verified` | Reserved for other ED-Finder mechanics where those labels are already appropriate. |
 
 ## Verified and Inferred Behaviour
 
-Strong-link and weak-link structure follows the existing Frontier/community documented topology rules already used by the Stage 2 graph. Body economy inheritance, economy purity scoring, converted-port support behaviour, pass-through propagation, and contamination thresholds remain inferred simulation rules and are labelled as such in ledger confidence and mechanics trace output.
+Strong-link and weak-link structure follows the existing topology graph rules already used by the Stage 2 simulation. Body economy inheritance, economy purity scoring, converted-port support behaviour, pass-through propagation, and contamination thresholds remain inferred simulation rules and are labelled as such in ledger confidence and mechanics trace output.
 
 ## Limitations and Future Improvements
 

--- a/docs/colonisation-redesign/stage-2-topology-economy.md
+++ b/docs/colonisation-redesign/stage-2-topology-economy.md
@@ -125,6 +125,21 @@ Simulation responses include:
 Recommended builds consume this output and lightly blend regional fit only after
 the internal simulation score is computed.
 
+## Stage 4A Additive Layer: Per-Port Economy Propagation
+
+Stage 4A extends this Stage 2 topology/economy architecture without replacing it. The topology graph remains the source of truth for local body grouping, Main Surface Port and Main Orbital Port selection, strong links, weak links, pass-through links, and converted-port detection. The new `simulation.port_economy` module consumes that graph and creates a `PortEconomyState` for each Main Port.
+
+The key architectural change is that the simulation now builds an influence ledger first, then derives each port’s economy stack, then aggregates those port states back into the backward-compatible system-level fields. This preserves existing API fields such as `economy_composition`, `economy_order`, `economy_stack`, `links`, and `topology`, while adding `port_economy_states` and `influence_ledger` for explainability.
+
+| Stage 2 System | Stage 4A Extension |
+|---|---|
+| Topology graph chooses Main Ports and links. | Port economy states consume those Main Ports and links. |
+| Economy stack reports system-level percentages. | Each Main Port reports its own stack and contamination sources. |
+| Mechanics trace explains broad economy/link effects. | Mechanics trace also records port-state creation, top-two protection, major influences, weak-link contamination, and pass-through influence. |
+| Converted ports are surfaced as caveated topology entries. | Converted-port influence appears in the ledger with caveats. |
+
+This layer remains deterministic and explanatory. It does not optimise builds and does not add unsupported mechanics beyond the already documented inferred rules.
+
 ## Limitations And Future Work
 
 Stage 2 is still a planner preview, not a full optimiser. It does not claim to

--- a/docs/colonisation-redesign/stage-2-topology-economy.md
+++ b/docs/colonisation-redesign/stage-2-topology-economy.md
@@ -21,15 +21,14 @@ Main ports are selected from topology rules:
 
 Economy strength now comes from these deterministic sources:
 
-- Direct facility economy contribution.
-- Inherited body profile economies for colony ports.
-- Strong links into same-body main ports.
-- Fixed weak links into main ports on other bodies.
+- Direct Main Port economy contribution for specialised Main Ports.
+- Inherited body profile economies for colony Main Ports.
+- Strong links from same-body support facilities into Main Ports.
+- Fixed weak links from support facilities into Main Ports on other bodies.
 - Surface-to-orbital pass-through links.
 - Converted ports acting as support emitters, with caveats.
 
-Pass-through links are visible in the API, but a support facility is not counted
-twice when its same-body strong link has already contributed.
+Support facilities are not counted as both direct pressure and link pressure against the same Main Port. Their normal contribution path is the topology graph: strong links, weak links, pass-through links, or converted-port links. Pass-through links are visible in the API, but a support facility is not counted twice when its same-body strong link has already contributed to the same receiver.
 
 ## Strong And Weak Links
 
@@ -129,7 +128,7 @@ the internal simulation score is computed.
 
 Stage 4A extends this Stage 2 topology/economy architecture without replacing it. The topology graph remains the source of truth for local body grouping, Main Surface Port and Main Orbital Port selection, strong links, weak links, pass-through links, and converted-port detection. The new `simulation.port_economy` module consumes that graph and creates a `PortEconomyState` for each Main Port.
 
-The key architectural change is that the simulation now builds an influence ledger first, then derives each port’s economy stack, then aggregates those port states back into the backward-compatible system-level fields. This preserves existing API fields such as `economy_composition`, `economy_order`, `economy_stack`, `links`, and `topology`, while adding `port_economy_states` and `influence_ledger` for explainability.
+The key architectural change is that the simulation now builds an influence ledger first, then derives each port’s economy stack, then aggregates those port states back into the backward-compatible system-level fields. This preserves existing API fields such as `economy_composition`, `economy_order`, `economy_stack`, `links`, and `topology`, while adding `port_economy_states` and `influence_ledger` for explainability. Influence entries use the standard confidence vocabulary; low-confidence body inheritance is labelled `estimated` with a caveat rather than using a non-standard `low` label.
 
 | Stage 2 System | Stage 4A Extension |
 |---|---|

--- a/frontend-v2/src/features/system-detail/BuildPlanCard.test.tsx
+++ b/frontend-v2/src/features/system-detail/BuildPlanCard.test.tsx
@@ -14,6 +14,7 @@ function plan(): RecommendedBuildPlan {
     composition_score: 82,
     buildability_score: 86,
     economy_result: { Refinery: 42, Industrial: 38, Extraction: 8 },
+    port_economy_summary: ['Main port economy: Refinery / Industrial'],
     cp_result: {
       yellow_cp_final: 4,
       green_cp_final: 1,

--- a/frontend-v2/src/features/system-detail/BuildPlanCard.tsx
+++ b/frontend-v2/src/features/system-detail/BuildPlanCard.tsx
@@ -48,6 +48,15 @@ export function BuildPlanCard({
         </div>
       </div>
 
+      {plan.port_economy_summary.length > 0 && (
+        <div className="mt-3 rounded border border-cyan/25 bg-cyan/5 px-2 py-2">
+          <div className="font-mono text-[9px] uppercase tracking-[0.14em] text-cyan">Port economy</div>
+          <div className="mt-1 space-y-1 font-mono text-[10px] text-silver-dk">
+            {plan.port_economy_summary.slice(0, 2).map((item) => <div key={item}>{item}</div>)}
+          </div>
+        </div>
+      )}
+
       {economyRows.length > 0 && (
         <div className="mt-3 space-y-1.5">
           {economyRows.map(([economy, value]) => (

--- a/frontend-v2/src/features/system-detail/DataConfidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/DataConfidencePanel.test.tsx
@@ -28,6 +28,8 @@ function result(): SimulateBuildResponse {
     economy_composition: {},
     economy_order: [],
     economy_stack: {},
+    port_economy_states: [],
+    influence_ledger: [],
     inherited_economies: [],
     topology: {},
     services: {},

--- a/frontend-v2/src/features/system-detail/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreview.tsx
@@ -569,6 +569,7 @@ function SimulationResult({ result }: { result: SimulateBuildResponse }) {
       <DataConfidencePanel result={result} />
       <EconomyBars composition={result.economy_composition} order={result.economy_order} />
       <EconomyStackPanel stack={result.economy_stack} />
+      <PortEconomyPanel states={result.port_economy_states} ledger={result.influence_ledger} />
       <InheritedEconomyPanel profiles={result.inherited_economies} />
       <TopologyPanel topology={result.topology} />
       <CpSummary cp={result.cp} />
@@ -727,6 +728,93 @@ function EconomyStackPanel({ stack }: { stack: SimulateBuildResponse['economy_st
           {warning}
         </div>
       ))}
+    </div>
+  );
+}
+
+function PortEconomyPanel({
+  states,
+  ledger,
+}: {
+  states: SimulateBuildResponse['port_economy_states'];
+  ledger: SimulateBuildResponse['influence_ledger'];
+}) {
+  if ((!states || states.length === 0) && (!ledger || ledger.length === 0)) return null;
+  return (
+    <div className="rounded-chunk-lg border border-cyan/25 bg-cyan/5 p-3">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-cyan">
+        Port Economy Breakdown
+      </div>
+      {states && states.length > 0 ? (
+        <div className="space-y-3">
+          {states.map((state) => {
+            const topInfluences = [...(state.influences ?? [])]
+              .sort((a, b) => b.value - a.value)
+              .slice(0, 4);
+            return (
+              <div key={`${state.local_body_id ?? 'system'}-${state.port_id}`} className="rounded border border-border/60 bg-bg3/45 px-2 py-2">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <div className="font-mono text-[11px] text-silver">{state.port_name}</div>
+                    <div className="mt-0.5 font-mono text-[10px] text-silver-dk">
+                      {state.body_name || (state.local_body_id ? `Body ${state.local_body_id}` : 'System-wide')} · {titleCase(state.location_type)} · {titleCase(state.effective_role)}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap justify-end gap-1.5 font-mono text-[10px]">
+                    {state.top_two.map((economy) => <Chip key={economy} tone="good">{economy}</Chip>)}
+                    {state.tertiary_economies.map((economy) => <Chip key={economy} tone="warn">{economy} tertiary</Chip>)}
+                    <Chip>{Math.round(state.purity_score)} purity</Chip>
+                    <Chip tone={state.contamination_risk === 'low' ? 'good' : 'warn'}>{titleCase(state.contamination_risk)} risk</Chip>
+                  </div>
+                </div>
+                {topInfluences.length > 0 && (
+                  <div className="mt-2 space-y-1">
+                    {topInfluences.map((influence) => (
+                      <div key={`${influence.source_id}-${influence.influence_type}-${influence.economy}-${influence.value}`} className="grid grid-cols-[minmax(0,1fr)_70px_42px] gap-2 font-mono text-[10px] text-silver-dk">
+                        <span className="truncate">{influence.source_name} · {titleCase(influence.influence_type)}</span>
+                        <span className="truncate text-silver">{influence.economy}</span>
+                        <span className="text-right text-cyan tabular-nums">{influence.value.toFixed(2)}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {[...(state.warnings ?? []), ...(state.recommendations ?? [])].slice(0, 2).map((item) => (
+                  <div key={item} className="mt-2 rounded border border-gold/30 bg-gold/5 px-2 py-1 font-mono text-[10px] leading-snug text-gold">
+                    {item}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded border border-border/60 bg-bg3/45 px-2 py-2 font-mono text-[10px] text-silver-dk">
+          No Main Ports are present yet, so there are no per-port economy states.
+        </div>
+      )}
+      {ledger && ledger.length > 0 && (
+        <details className="mt-3 rounded border border-border/60 bg-bg2/55 px-2 py-2">
+          <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-silver">
+            Influence Ledger
+          </summary>
+          <div className="mt-2 space-y-1.5">
+            {ledger.slice(0, 12).map((influence) => (
+              <div key={`${influence.source_id}-${influence.target_port_id}-${influence.influence_type}-${influence.economy}-${influence.value}`} className="rounded border border-border/50 bg-bg3/45 px-2 py-1.5">
+                <div className="grid gap-1 font-mono text-[10px] text-silver-dk sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_92px_70px_42px]">
+                  <span className="truncate"><span className="text-silver">Source:</span> {influence.source_name}</span>
+                  <span className="truncate"><span className="text-silver">Target:</span> {influence.target_port_name}</span>
+                  <span>{titleCase(influence.influence_type)}</span>
+                  <span>{influence.economy}</span>
+                  <span className="text-right text-cyan tabular-nums">{influence.value.toFixed(2)}</span>
+                </div>
+                <div className="mt-1 font-mono text-[10px] leading-snug text-silver-dk">
+                  <span className="text-silver">{titleCase(influence.confidence)}:</span> {influence.reason}
+                </div>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
     </div>
   );
 }

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -1913,6 +1913,8 @@ export interface components {
             economy_result?: {
                 [key: string]: number;
             };
+            /** Port Economy Summary */
+            port_economy_summary?: string[];
             cp_result: components["schemas"]["SimulationCPResult"];
             /** Build Order */
             build_order?: components["schemas"]["SimulateBuildPlacement"][];
@@ -2203,6 +2205,10 @@ export interface components {
             economy_order?: string[];
             /** Economy Stack */
             economy_stack?: Record<string, never>;
+            /** Port Economy States */
+            port_economy_states?: Record<string, never>[];
+            /** Influence Ledger */
+            influence_ledger?: Record<string, never>[];
             /** Inherited Economies */
             inherited_economies?: components["schemas"]["SimulationInheritedEconomy"][];
             /** Topology */

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -138,6 +138,49 @@ export interface SimulationLinks {
   weak_links: SimulationLink[];
 }
 
+export interface EconomyInfluence {
+  source_id: string;
+  source_name: string;
+  source_type: string;
+  target_port_id: string;
+  target_port_name: string;
+  local_body_id?: string | null;
+  economy: string;
+  value: number;
+  influence_type: string;
+  link_type?: string | null;
+  confidence: string;
+  reason: string;
+  caveats: string[];
+}
+
+export interface PortEconomyState {
+  port_id: string;
+  port_name: string;
+  local_body_id?: string | null;
+  body_name?: string | null;
+  location_type: string;
+  effective_role: string;
+  inherited_economies: Record<string, number>;
+  direct_economies: Record<string, number>;
+  strong_link_economies: Record<string, number>;
+  weak_link_economies: Record<string, number>;
+  pass_through_economies: Record<string, number>;
+  converted_port_economies: Record<string, number>;
+  final_economy_strengths: Record<string, number>;
+  final_economy_composition: Record<string, number>;
+  economy_order: string[];
+  top_two: string[];
+  tertiary_economies: string[];
+  purity_score: number;
+  contamination_risk: string;
+  contamination_sources: EconomyInfluence[];
+  influences: EconomyInfluence[];
+  warnings: string[];
+  strengths: string[];
+  recommendations: string[];
+}
+
 export interface SimulationInheritedEconomy {
   source_body_id?: string | null;
   source_body_name?: string | null;
@@ -164,6 +207,8 @@ export interface SimulateBuildResponse {
   economy_composition: Record<string, number>;
   economy_order: string[];
   economy_stack: Record<string, unknown>;
+  port_economy_states: PortEconomyState[];
+  influence_ledger: EconomyInfluence[];
   inherited_economies: SimulationInheritedEconomy[];
   topology: Record<string, unknown>;
   services: Record<string, { status: string; reason: string; requirements: string[] }>;
@@ -198,6 +243,7 @@ export interface RecommendedBuildPlan {
   composition_score: number;
   buildability_score: number;
   economy_result: Record<string, number>;
+  port_economy_summary: string[];
   cp_result: SimulationCPResult;
   build_order: SimulateBuildPlacement[];
   strengths: string[];

--- a/implementation_plan_stage_4a.md
+++ b/implementation_plan_stage_4a.md
@@ -1,0 +1,13 @@
+# Stage 4A Implementation Plan
+
+The current Stage 2/3 architecture already separates deterministic build preview, topology graph generation, economy stack scoring, mechanics trace, services, CP timeline, confidence signals, recommended-build ranking, and frontend preview rendering. Stage 4A should therefore be implemented as an additive port-level explainability layer that consumes the existing topology graph and resolved placements rather than replacing the existing economy simulation.
+
+## Planned Steps
+
+1. Add a new backend module `apps/api/src/simulation/port_economy.py` containing `EconomyInfluence` and `PortEconomyState` dataclasses plus a function that builds a per-port influence ledger from resolved placements, local body groups, strong links, weak links, pass-through links, converted ports, and body inheritance.
+2. Integrate the new module into `simulate_build_preview()` so port states are calculated before the legacy system-level economy output, then aggregate `economy_composition`, `economy_order`, `economy_stack`, contamination risk, strengths, warnings, and recommendations from those port states while keeping existing fields present.
+3. Extend the backend Pydantic response model with `port_economy_states` and `influence_ledger` while preserving current fields and compatibility.
+4. Extend mechanics trace with port economy creation, top-two protection, major influence, contamination, weak-link contamination, and pass-through influence events.
+5. Update frontend TypeScript wire types, Simulation Preview rendering, and Recommended Build cards with compact port economy summaries and a collapsed influence ledger.
+6. Add tests for port-level influence behavior, response contract compatibility, trace events, no-port safety, and frontend build/typecheck behavior.
+7. Update colonisation redesign documentation to describe the new per-port economy state, influence ledger, aggregation behavior, verified/inferred mechanics, limitations, and future improvements.

--- a/tests/test_port_economy.py
+++ b/tests/test_port_economy.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+os.environ.setdefault('CORS_ORIGINS', 'http://test')
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+
+from domain.facilities import FacilityTemplate
+from simulation.build_preview import PreviewContext, PreviewPlacement, simulate_build_preview
+
+
+STANDARD_CONFIDENCE_LABELS = {
+    'observed',
+    'verified',
+    'community_observed',
+    'inferred',
+    'estimated',
+    'speculative',
+    'unknown',
+}
+
+
+def facility(
+    id: str,
+    economy: str | None,
+    *,
+    tier: int = 1,
+    is_port: bool = False,
+    is_colony_port: bool = False,
+    is_support_facility: bool = False,
+    allowed_location: str = 'orbital_or_surface',
+) -> FacilityTemplate:
+    return FacilityTemplate(
+        id=id,
+        name=id.replace('_', ' ').title(),
+        category='port' if is_port else 'support',
+        tier=tier,
+        economy=economy,
+        is_port=is_port,
+        is_colony_port=is_colony_port,
+        is_support_facility=is_support_facility,
+        yellow_cp_generated=8 if is_support_facility else 0,
+        green_cp_generated=1 if is_support_facility else 0,
+        yellow_cp_cost=0,
+        green_cp_cost=0,
+        strong_link_value=0,
+        weak_link_value=0.05,
+        allowed_location=allowed_location,
+        pad_size='L' if is_port else None,
+        prerequisites=[],
+        economy_effects={},
+        stat_effects={'data_confidence': 'observed'},
+    )
+
+
+PORT = facility('coriolis', None, tier=2, is_port=True, allowed_location='orbital')
+T3_PORT = facility('orbis_t3', None, tier=3, is_port=True, allowed_location='orbital')
+SURFACE_PORT = facility('surface_port', 'Industrial', tier=2, is_port=True, allowed_location='surface')
+EXTRACTION_PORT = facility('asteroid_base', 'Extraction', tier=2, is_port=True, allowed_location='orbital')
+COLONY_SHIP = facility('colony_ship', 'Colony', tier=1, is_port=True, is_colony_port=True, allowed_location='orbital')
+REFINERY = facility('refinery', 'Refinery', is_support_facility=True, allowed_location='surface')
+INDUSTRIAL = facility('industrial', 'Industrial', is_support_facility=True)
+EXTRACTION = facility('extraction', 'Extraction', is_support_facility=True)
+
+
+def catalogue() -> dict[str, FacilityTemplate]:
+    items = [PORT, T3_PORT, SURFACE_PORT, EXTRACTION_PORT, COLONY_SHIP, REFINERY, INDUSTRIAL, EXTRACTION]
+    return {item.id: item for item in items}
+
+
+def ctx() -> PreviewContext:
+    return PreviewContext(
+        system_id64=42,
+        estimated_orbital_slots=8,
+        estimated_ground_slots=8,
+        slot_confidence=0.9,
+        local_body_profiles={'1': {'body_name': 'Rocky Prime', 'base_economies': ['Refinery'], 'subtype': 'rocky body'}},
+    )
+
+
+def run(plan: list[PreviewPlacement], target: str = 'refinery_industrial', context: PreviewContext | None = None):
+    return simulate_build_preview(
+        system_id64=42,
+        target_archetype=target,
+        placements=plan,
+        catalogue=catalogue(),
+        context=context or ctx(),
+    )
+
+
+def ledger_for(result: dict, *, source_id: str | None = None, influence_type: str | None = None) -> list[dict]:
+    rows = result['influence_ledger']
+    if source_id is not None:
+        rows = [row for row in rows if row['source_id'] == source_id]
+    if influence_type is not None:
+        rows = [row for row in rows if row['influence_type'] == influence_type]
+    return rows
+
+
+def state_for(result: dict, port_id: str) -> dict:
+    return next(state for state in result['port_economy_states'] if state['port_id'] == port_id)
+
+
+def test_same_body_support_uses_link_path_to_correct_main_port():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('refinery', '1', build_order=2),
+    ])
+
+    refinery_entries = ledger_for(result, source_id='refinery')
+    assert [entry['influence_type'] for entry in refinery_entries] == ['strong_link']
+    assert refinery_entries[0]['target_port_id'] == 'coriolis'
+
+
+def test_support_facilities_are_not_double_counted_as_direct_and_linked_pressure():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('refinery', '1', build_order=2),
+    ])
+
+    main = state_for(result, 'coriolis')
+    assert 'Refinery' not in main['direct_economies']
+    assert main['strong_link_economies']['Refinery'] == 0.4
+    assert main['final_economy_strengths']['Refinery'] == 0.4
+    assert not ledger_for(result, source_id='refinery', influence_type='direct_facility')
+
+
+def test_weak_link_support_targets_only_non_local_main_ports():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('orbis_t3', '2', build_order=2),
+        PreviewPlacement('industrial', '1', build_order=3),
+    ])
+
+    weak_entries = ledger_for(result, source_id='industrial', influence_type='weak_link')
+    assert weak_entries
+    assert {entry['target_port_id'] for entry in weak_entries} == {'orbis_t3'}
+    assert all(entry['target_port_id'] != 'coriolis' for entry in weak_entries)
+    assert all(entry['value'] == 0.05 for entry in weak_entries)
+
+
+def test_pass_through_appears_without_duplicate_orbital_strong_inflation():
+    result = run([
+        PreviewPlacement('surface_port', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('orbis_t3', '1', build_order=2),
+        PreviewPlacement('refinery', '1', build_order=3),
+    ])
+
+    orbital = state_for(result, 'orbis_t3')
+    assert orbital['pass_through_economies']['Refinery'] == 0.4
+    assert 'Refinery' not in orbital['strong_link_economies']
+    assert any(entry['influence_type'] == 'pass_through' and entry['target_port_id'] == 'orbis_t3' for entry in result['influence_ledger'])
+
+
+def test_converted_port_appears_with_caveat():
+    result = run([
+        PreviewPlacement('orbis_t3', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('asteroid_base', '1', build_order=2),
+        PreviewPlacement('coriolis', '2', build_order=3),
+    ])
+
+    converted_entries = ledger_for(result, source_id='asteroid_base', influence_type='converted_port')
+    assert converted_entries
+    assert any(entry['caveats'] for entry in converted_entries)
+
+
+def test_port_level_stack_identifies_top_two():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('refinery', '1', build_order=2),
+        PreviewPlacement('industrial', '1', build_order=3),
+    ])
+
+    main = state_for(result, 'coriolis')
+    assert main['top_two'] == ['Refinery', 'Industrial']
+
+
+def test_tertiary_economy_above_threshold_becomes_contamination_source():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('refinery', '1', build_order=2),
+        PreviewPlacement('industrial', '1', build_order=3),
+        PreviewPlacement('extraction', '1', build_order=4),
+    ])
+
+    main = state_for(result, 'coriolis')
+    assert 'Extraction' in main['tertiary_economies']
+    assert any(source['economy'] == 'Extraction' for source in main['contamination_sources'])
+
+
+def test_elw_mixed_inheritance_creates_body_inheritance_ledger_entries():
+    context = ctx()
+    context.local_body_profiles['7'] = {
+        'body_id': '7',
+        'body_name': 'ELW Prime',
+        'base_economy': 'Tourism',
+        'base_economies': ['Tourism', 'HighTech', 'Agriculture', 'Military'],
+        'modifier_economies': [],
+        'purity': 0.45,
+        'confidence': 0.72,
+        'strategic_tags': ['elw_mixed'],
+        'caveats': ['ELW is mixed economy: Agriculture, HighTech, Military, and Tourism; not Industrial.'],
+    }
+
+    result = run([PreviewPlacement('colony_ship', '7', is_primary_port=True, build_order=1)], context=context)
+
+    entries = ledger_for(result, source_id='colony_ship', influence_type='body_inheritance')
+    expected = {'Tourism', 'HighTech', 'Agriculture', 'Military'}
+    assert entries
+    assert {entry['target_port_id'] for entry in entries} == {'colony_ship'}
+    assert {entry['economy'] for entry in entries} == expected
+    assert any('mixed economy' in caveat for entry in entries for caveat in entry['caveats'])
+    assert any('below the verified threshold' in caveat for entry in entries for caveat in entry['caveats'])
+    main = state_for(result, 'colony_ship')
+    assert set(main['inherited_economies']) == expected
+    assert any('broad-spectrum' in warning or 'mixed economy' in warning for warning in result['warnings'])
+
+
+def test_no_port_simulation_returns_empty_port_outputs():
+    result = run([
+        PreviewPlacement('refinery', '1', build_order=1),
+        PreviewPlacement('industrial', '2', build_order=2),
+    ])
+
+    assert result['port_economy_states'] == []
+    assert result['influence_ledger'] == []
+
+
+def test_all_influence_confidence_labels_are_standard():
+    context = ctx()
+    context.local_body_profiles['7'] = {
+        'body_id': '7',
+        'body_name': 'Low Confidence ELW',
+        'base_economies': ['Tourism', 'HighTech', 'Agriculture', 'Military'],
+        'purity': 0.45,
+        'confidence': 0.5,
+        'strategic_tags': ['elw_mixed'],
+    }
+    result = run([
+        PreviewPlacement('colony_ship', '7', is_primary_port=True, build_order=1),
+        PreviewPlacement('coriolis', '2', build_order=2),
+        PreviewPlacement('refinery', '2', build_order=3),
+    ], context=context)
+
+    labels = {entry['confidence'] for entry in result['influence_ledger']}
+    assert labels
+    assert labels <= STANDARD_CONFIDENCE_LABELS
+    assert 'low' not in labels

--- a/tests/test_stage2_golden_scenario.py
+++ b/tests/test_stage2_golden_scenario.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from simulation.build_preview import PreviewPlacement
+from tests.test_port_economy import ctx, run
+
+
+def test_stage2_refinery_industrial_golden_scenario_has_stage4a_outputs():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('orbis_t3', '2', build_order=2),
+        PreviewPlacement('refinery', '1', build_order=3),
+        PreviewPlacement('industrial', '1', build_order=4),
+    ])
+
+    assert result['economy_composition']
+    assert result['port_economy_states']
+    main = next(state for state in result['port_economy_states'] if state['port_id'] == 'coriolis')
+    assert set(main['top_two']) == {'Refinery', 'Industrial'}
+    assert any(entry['influence_type'] == 'strong_link' for entry in result['influence_ledger'])
+    assert any(entry['influence_type'] == 'weak_link' for entry in result['influence_ledger'])
+    assert result['mechanics_trace']['port_economy_effects']
+    assert result['mechanics_trace']['influence_ledger_effects']
+
+
+def test_stage2_elw_golden_scenario_has_broad_body_inheritance_stage4a_outputs():
+    context = ctx()
+    context.local_body_profiles['7'] = {
+        'body_id': '7',
+        'body_name': 'ELW Prime',
+        'base_economy': 'Tourism',
+        'base_economies': ['Tourism', 'HighTech', 'Agriculture', 'Military'],
+        'modifier_economies': [],
+        'purity': 0.45,
+        'confidence': 0.8,
+        'strategic_tags': ['elw_mixed'],
+        'caveats': ['ELW is mixed economy: Agriculture, HighTech, Military, and Tourism; not Industrial.'],
+    }
+
+    result = run([PreviewPlacement('colony_ship', '7', is_primary_port=True, build_order=1)], context=context)
+
+    expected = {'Tourism', 'HighTech', 'Agriculture', 'Military'}
+    entries = [entry for entry in result['influence_ledger'] if entry['influence_type'] == 'body_inheritance']
+    assert {entry['economy'] for entry in entries} == expected
+    assert {entry['target_port_id'] for entry in entries} == {'colony_ship'}
+    assert set(result['port_economy_states'][0]['inherited_economies']) == expected
+    assert result['economy_composition']
+    assert result['mechanics_trace']['port_economy_effects']

--- a/tests/test_stage2_simulation.py
+++ b/tests/test_stage2_simulation.py
@@ -221,3 +221,61 @@ def test_service_strong_link_unlock_and_locked_requirement():
     locked = model_services([type('P', (), {'facility': BLACK_MARKET})()], locked_graph)['black_market']
     assert locked['status'] == 'locked'
     assert locked['requirements']
+
+
+def test_port_economy_state_and_ledger_explain_main_port_stack():
+    result = run([
+        PreviewPlacement('coriolis', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('refinery', '1', build_order=2),
+        PreviewPlacement('industrial', '1', build_order=3),
+        PreviewPlacement('orbis_t3', '2', build_order=4),
+        PreviewPlacement('extraction', '2', build_order=5),
+    ])
+
+    assert result['port_economy_states']
+    main = next(state for state in result['port_economy_states'] if state['port_id'] == 'coriolis')
+    assert main['top_two'][:2] == ['Industrial', 'Refinery']
+    assert main['strong_link_economies']['Refinery'] == 0.4
+    assert main['weak_link_economies']['Extraction'] == 0.05
+    assert any(item['influence_type'] == 'strong_link' for item in result['influence_ledger'])
+    assert any(item['influence_type'] == 'weak_link' for item in result['influence_ledger'])
+    assert 'port_economy_effects' in result['mechanics_trace']
+    assert result['mechanics_trace']['port_economy_effects']
+
+
+def test_pass_through_ledger_targets_orbital_without_duplicate_system_inflation():
+    result = run([
+        PreviewPlacement('surface_port', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('orbis_t3', '1', build_order=2),
+        PreviewPlacement('refinery', '1', build_order=3),
+    ])
+
+    pass_through = [item for item in result['influence_ledger'] if item['influence_type'] == 'pass_through']
+    assert pass_through
+    assert all(item['target_port_id'] == 'orbis_t3' for item in pass_through)
+    assert result['economy_composition']
+    assert result['economy_order']
+
+
+def test_converted_port_appears_in_ledger_with_caveat():
+    result = run([
+        PreviewPlacement('orbis_t3', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('asteroid_base', '1', build_order=2),
+        PreviewPlacement('coriolis', '2', build_order=3),
+    ])
+
+    converted_entries = [item for item in result['influence_ledger'] if item['influence_type'] == 'converted_port']
+    assert converted_entries
+    assert any(item['caveats'] for item in converted_entries)
+
+
+def test_empty_no_port_simulation_keeps_response_shape_without_crashing():
+    result = run([
+        PreviewPlacement('refinery', '1', build_order=1),
+        PreviewPlacement('industrial', '2', build_order=2),
+    ])
+
+    assert result['port_economy_states'] == []
+    assert result['influence_ledger'] == []
+    assert 'economy_composition' in result
+    assert 'links' in result


### PR DESCRIPTION
## Summary\n- Add per-port economy state propagation and influence ledger\n- Harden support-facility counting to avoid direct-plus-link double counting\n- Add Stage 4A focused and golden scenario tests\n- Update Simulation Preview, recommended-build summaries, mechanics trace, API types, and docs\n\n## Validation\n- python3.11 -m py_compile on modified backend modules/tests\n- pytest focused Stage 4A/backend suites: 53 passed\n- npm run typecheck\n- npm run build