### PR TITLE
Implement Stage 4B service graph and Stage 4C CP repair

### DIFF
--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -942,6 +942,7 @@ class SimulateBuildResponse(BaseModel):
     confidence:          float
     cp:                  SimulationCPResult
     cp_timeline:         list[dict[str, Any]] = Field(default_factory=list)
+    cp_repair_suggestions: list[dict[str, Any]] = Field(default_factory=list)
     economy_composition: dict[str, float] = Field(default_factory=dict)
     economy_order:       list[str] = Field(default_factory=list)
     economy_stack:       dict[str, Any] = Field(default_factory=dict)

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -950,6 +950,8 @@ class SimulateBuildResponse(BaseModel):
     inherited_economies: list[SimulationInheritedEconomy] = Field(default_factory=list)
     topology:            dict[str, Any] = Field(default_factory=dict)
     services:            dict[str, Any] = Field(default_factory=dict)
+    port_service_states: list[dict[str, Any]] = Field(default_factory=list)
+    service_unlock_ledger: list[dict[str, Any]] = Field(default_factory=list)
     data_quality:        dict[str, str] = Field(default_factory=dict)
     confidence_signals:  list[dict[str, Any]] = Field(default_factory=list)
     mechanics_trace:     dict[str, list[dict[str, Any]]] = Field(default_factory=dict)

--- a/apps/api/src/simulation/build_preview.py
+++ b/apps/api/src/simulation/build_preview.py
@@ -53,6 +53,7 @@ from mechanics.scoring_rules import (
 )
 from mechanics.versions import MECHANICS_VERSION
 from simulation.build_order import simulate_build_order
+from simulation.cp_repair import build_cp_repair_suggestions, cp_repair_suggestions_to_dict
 from simulation.economy_stack import analyse_economy_stack
 from simulation.mechanics_trace import trace_simulation
 from simulation.port_economy import (
@@ -160,6 +161,7 @@ def simulate_build_preview(
         warnings.append('No valid facilities are selected yet. Add at least one facility to preview a build.')
 
     cp = simulate_build_order(resolved).to_cp_dict()
+    cp_repair_suggestions = build_cp_repair_suggestions(placements=resolved, cp=cp)
     warnings.extend(cp['warnings'])
 
     topology_graph = build_topology_graph(_graph_placements(resolved, context))
@@ -222,6 +224,7 @@ def simulate_build_preview(
         influence_ledger=influence_ledger,
         port_service_states=port_service_states,
         service_unlock_ledger=service_unlock_ledger,
+        cp_repair_suggestions=cp_repair_suggestions,
     )
     complexity = _complexity(cp, buildability, composition, confidence)
     final_score = round(
@@ -261,6 +264,7 @@ def simulate_build_preview(
             'warnings': cp['warnings'],
         },
         'cp_timeline': cp['timeline'],
+        'cp_repair_suggestions': cp_repair_suggestions_to_dict(cp_repair_suggestions),
         'economy_composition': economy_composition,
         'economy_order': economy_order,
         'economy_stack': stack_result.to_dict(),

--- a/apps/api/src/simulation/build_preview.py
+++ b/apps/api/src/simulation/build_preview.py
@@ -61,6 +61,11 @@ from simulation.port_economy import (
     influence_ledger_to_dict,
     port_states_to_dict,
 )
+from simulation.service_graph import (
+    build_port_service_states,
+    port_service_states_to_dict,
+    service_unlock_ledger_to_dict,
+)
 from simulation.services import model_services
 from simulation.topology_graph import GraphPlacement, build_topology_graph, infer_location_type
 
@@ -180,6 +185,10 @@ def simulate_build_preview(
         'recommendations': stack_result.recommendations,
     }
     services = model_services(resolved, topology_graph)
+    port_service_states, service_unlock_ledger = build_port_service_states(
+        placements=resolved,
+        topology_graph=topology_graph,
+    )
 
     warnings.extend(composition['warnings'])
     strengths.extend(composition['strengths'])
@@ -211,6 +220,8 @@ def simulate_build_preview(
         confidence_signals=confidence_signals,
         port_economy_states=port_economy_states,
         influence_ledger=influence_ledger,
+        port_service_states=port_service_states,
+        service_unlock_ledger=service_unlock_ledger,
     )
     complexity = _complexity(cp, buildability, composition, confidence)
     final_score = round(
@@ -258,6 +269,8 @@ def simulate_build_preview(
         'inherited_economies': [_profile_to_response(profile) for profile in inherited_profiles],
         'topology': _topology_to_response(topology_graph),
         'services': services,
+        'port_service_states': port_service_states_to_dict(port_service_states),
+        'service_unlock_ledger': service_unlock_ledger_to_dict(service_unlock_ledger),
         'data_quality': default_data_quality(),
         'confidence_signals': signals_to_dict(confidence_signals),
         'mechanics_trace': mechanics_trace,

--- a/apps/api/src/simulation/cp_repair.py
+++ b/apps/api/src/simulation/cp_repair.py
@@ -1,0 +1,213 @@
+"""Small CP sequence repair assistant for Simulation Preview.
+
+This module does not optimise the full build order. It reads the already-produced
+CP timeline and emits conservative, actionable repair suggestions for the user's
+current sequence.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from mechanics.cp_rules import LATE_T3_BUILD_ORDER_THRESHOLD
+
+STANDARD_CONFIDENCE_LABELS = {
+    'observed',
+    'verified',
+    'community_observed',
+    'inferred',
+    'estimated',
+    'speculative',
+    'unknown',
+}
+
+SEVERITY_ORDER = {
+    'critical': 0,
+    'high': 1,
+    'medium': 2,
+    'low': 3,
+    'info': 4,
+}
+
+
+@dataclass(frozen=True)
+class CPRepairSuggestion:
+    type: str
+    severity: str
+    summary: str
+    reason: str
+    affected_steps: list[int]
+    expected_effect: str
+    action: str
+    confidence: str = 'inferred'
+    caveats: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def build_cp_repair_suggestions(*, placements: list[Any], cp: dict[str, Any]) -> list[CPRepairSuggestion]:
+    timeline = list(cp.get('timeline') or [])
+    if not placements or not timeline:
+        return []
+
+    placement_by_step = {int(item.spec.build_order): item for item in placements}
+    suggestions: list[CPRepairSuggestion] = []
+
+    negative_steps = [step for step in timeline if _is_negative_step(step)]
+    for step in negative_steps:
+        suggestions.append(_cp_negative_suggestion(step))
+        move = _move_support_earlier_suggestion(step, placements)
+        if move is not None:
+            suggestions.append(move)
+        primary = _primary_port_suggestion(step, placement_by_step)
+        if primary is not None:
+            suggestions.append(primary)
+
+    for step in timeline:
+        t3 = _t3_escalation_suggestion(step, placement_by_step)
+        if t3 is not None:
+            suggestions.append(t3)
+
+    fragile = _fragile_sequence_suggestion(timeline, cp)
+    if fragile is not None:
+        suggestions.append(fragile)
+
+    return _dedupe_and_sort(suggestions)
+
+
+def cp_repair_suggestions_to_dict(suggestions: list[CPRepairSuggestion]) -> list[dict[str, Any]]:
+    return [suggestion.to_dict() for suggestion in suggestions]
+
+
+def _is_negative_step(step: dict[str, Any]) -> bool:
+    return int(step.get('yellow_after', 0)) < 0 or int(step.get('green_after', 0)) < 0
+
+
+def _cp_negative_suggestion(step: dict[str, Any]) -> CPRepairSuggestion:
+    step_no = int(step.get('step', 0))
+    yellow_after = int(step.get('yellow_after', 0))
+    green_after = int(step.get('green_after', 0))
+    deficit = abs(min(0, yellow_after)) + abs(min(0, green_after))
+    severity = 'critical' if deficit >= 10 else 'high'
+    return CPRepairSuggestion(
+        type='cp_negative_detected',
+        severity=severity,
+        summary=f'CP goes negative at step {step_no}',
+        reason=f'{step.get("facility_name", "This step")} leaves the sequence at Yellow {yellow_after} and Green {green_after}.',
+        affected_steps=[step_no],
+        expected_effect='Repairing the first deficit should make the current order easier to build without changing final scoring.',
+        action='Move CP-generating support earlier, mark the intended first port as primary if appropriate, or move this paid port later.',
+        confidence='inferred',
+        caveats=['This is a local repair suggestion, not proof of the globally optimal build order.'],
+    )
+
+
+def _move_support_earlier_suggestion(step: dict[str, Any], placements: list[Any]) -> CPRepairSuggestion | None:
+    step_no = int(step.get('step', 0))
+    needs_green = int(step.get('green_after', 0)) < 0
+    candidates = [
+        item for item in placements
+        if int(item.spec.build_order) > step_no
+        and not item.facility.is_port
+        and (int(item.facility.yellow_cp_generated or 0) > 0 or int(item.facility.green_cp_generated or 0) > 0)
+        and (not needs_green or int(item.facility.green_cp_generated or 0) > 0)
+    ]
+    if not candidates:
+        return None
+    candidate = sorted(candidates, key=lambda item: int(item.spec.build_order))[0]
+    return CPRepairSuggestion(
+        type='move_cp_generator_earlier',
+        severity='high' if _is_negative_step(step) else 'medium',
+        summary=f'Move {candidate.facility.name} before step {step_no}',
+        reason=f'{candidate.facility.name} currently appears at step {candidate.spec.build_order} after a CP deficit has already occurred.',
+        affected_steps=[step_no, int(candidate.spec.build_order)],
+        expected_effect='Generating CP before the deficit should reduce or remove the temporary negative balance.',
+        action=f'Move {candidate.facility.name} from step {candidate.spec.build_order} to before step {step_no}.',
+        confidence='inferred',
+        caveats=['The simulator does not reorder every dependency; confirm the moved facility is still valid in the intended build plan.'],
+    )
+
+
+def _primary_port_suggestion(step: dict[str, Any], placement_by_step: dict[int, Any]) -> CPRepairSuggestion | None:
+    step_no = int(step.get('step', 0))
+    placement = placement_by_step.get(step_no)
+    if placement is None or not placement.facility.is_port or placement.spec.is_primary_port:
+        return None
+    return CPRepairSuggestion(
+        type='mark_primary_port',
+        severity='high',
+        summary=f'Mark {placement.facility.name} as the primary port',
+        reason=f'{placement.facility.name} is the paid port at the CP-negative step and is not currently using the primary-port exemption.',
+        affected_steps=[step_no],
+        expected_effect='Using the primary-port exemption on the intended first Main Port should remove that port CP charge from this sequence.',
+        action=f'Mark {placement.facility.name} at step {step_no} as the primary port if it is intended to be the initial colony Main Port.',
+        confidence='inferred',
+        caveats=['Only one port should receive the primary-port exemption; do not apply this if another port is intentionally primary.'],
+    )
+
+
+def _t3_escalation_suggestion(step: dict[str, Any], placement_by_step: dict[int, Any]) -> CPRepairSuggestion | None:
+    warnings = ' '.join(step.get('warnings') or [])
+    step_no = int(step.get('step', 0))
+    placement = placement_by_step.get(step_no)
+    if 'T3 ports earlier' not in warnings:
+        if placement is None or not placement.facility.is_port or placement.facility.tier != 3:
+            return None
+        if placement.spec.is_primary_port or step_no <= LATE_T3_BUILD_ORDER_THRESHOLD:
+            return None
+    facility_name = step.get('facility_name') or getattr(getattr(placement, 'facility', None), 'name', 'T3 port')
+    return CPRepairSuggestion(
+        type='port_escalation_pressure',
+        severity='medium',
+        summary=f'Review T3 timing for {facility_name}',
+        reason='Late T3 or paid-port sequencing can increase CP pressure in this order.',
+        affected_steps=[step_no],
+        expected_effect='Moving the T3 port earlier or using a valid primary-port exemption may reduce escalation pressure.',
+        action=f'Review whether {facility_name} should be earlier in the order or designated primary where appropriate.',
+        confidence='inferred',
+        caveats=['T3 escalation guidance is conservative and does not attempt a full reorder optimisation.'],
+    )
+
+
+def _fragile_sequence_suggestion(timeline: list[dict[str, Any]], cp: dict[str, Any]) -> CPRepairSuggestion | None:
+    if int(cp.get('yellow_cp_final', 0)) < 0 or int(cp.get('green_cp_final', 0)) < 0:
+        return None
+    if not timeline:
+        return None
+    min_yellow = min(int(step.get('yellow_after', 0)) for step in timeline)
+    min_green = min(int(step.get('green_after', 0)) for step in timeline)
+    final_step = int(timeline[-1].get('step', 0))
+    final_green = int(cp.get('green_cp_final', 0))
+    green_before_final = [int(step.get('green_after', 0)) for step in timeline[:-1]]
+    fragile_green_final = final_green > 0 and green_before_final and max(green_before_final) <= 0
+    if min_yellow > 0 and min_green > 0 and not fragile_green_final:
+        return None
+    affected = [int(step.get('step', 0)) for step in timeline if int(step.get('yellow_after', 0)) <= 0 or int(step.get('green_after', 0)) <= 0]
+    if fragile_green_final and final_step not in affected:
+        affected.append(final_step)
+    return CPRepairSuggestion(
+        type='sequence_is_valid_but_fragile',
+        severity='medium',
+        summary='This sequence is valid but fragile',
+        reason='One or both CP balances reach zero or only become safely positive at the end, leaving little buffer if the build order changes.',
+        affected_steps=affected[:6],
+        expected_effect='Moving CP-generating support earlier would create a safer buffer.',
+        action='Move an early CP-generating support facility before the first low-buffer step if practical.',
+        confidence='inferred',
+        caveats=['This suggestion is suppressed when the sequence already ends CP-negative because deficit repairs are more important.'],
+    )
+
+
+def _dedupe_and_sort(suggestions: list[CPRepairSuggestion]) -> list[CPRepairSuggestion]:
+    seen: set[tuple[str, tuple[int, ...], str]] = set()
+    result: list[CPRepairSuggestion] = []
+    for suggestion in suggestions:
+        if suggestion.confidence not in STANDARD_CONFIDENCE_LABELS:
+            continue
+        key = (suggestion.type, tuple(suggestion.affected_steps), suggestion.summary)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(suggestion)
+    return sorted(result, key=lambda item: (SEVERITY_ORDER.get(item.severity, 99), item.affected_steps or [999], item.type))

--- a/apps/api/src/simulation/cp_repair.py
+++ b/apps/api/src/simulation/cp_repair.py
@@ -29,9 +29,28 @@ SEVERITY_ORDER = {
     'info': 4,
 }
 
+MAX_REPAIRS_PER_PROBLEM = 3
+MAX_REPAIRS_TOTAL = 6
+
+
+@dataclass(frozen=True)
+class CPRepairAction:
+    action_type: str
+    facility_template_id: str | None = None
+    facility_name: str | None = None
+    from_step: int | None = None
+    to_step: int | None = None
+    target_step: int | None = None
+    set_primary_port: bool | None = None
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
 
 @dataclass(frozen=True)
 class CPRepairSuggestion:
+    suggestion_id: str
     type: str
     severity: str
     summary: str
@@ -39,11 +58,14 @@ class CPRepairSuggestion:
     affected_steps: list[int]
     expected_effect: str
     action: str
+    suggested_action: CPRepairAction | None
     confidence: str = 'inferred'
     caveats: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        data['suggested_action'] = self.suggested_action.to_dict() if self.suggested_action else None
+        return data
 
 
 def build_cp_repair_suggestions(*, placements: list[Any], cp: dict[str, Any]) -> list[CPRepairSuggestion]:
@@ -55,25 +77,43 @@ def build_cp_repair_suggestions(*, placements: list[Any], cp: dict[str, Any]) ->
     suggestions: list[CPRepairSuggestion] = []
 
     negative_steps = [step for step in timeline if _is_negative_step(step)]
+    first_pressure_step = int(negative_steps[0].get('step', 0)) if negative_steps else None
     for step in negative_steps:
         suggestions.append(_cp_negative_suggestion(step))
         move = _move_support_earlier_suggestion(step, placements)
         if move is not None:
             suggestions.append(move)
-        primary = _primary_port_suggestion(step, placement_by_step)
-        if primary is not None:
-            suggestions.append(primary)
+        else:
+            delay = _delay_expensive_port_suggestion(step, placement_by_step)
+            if delay is not None:
+                suggestions.append(delay)
+            add = _add_cp_generator_suggestion(step)
+            if add is not None:
+                suggestions.append(add)
+
+    fragile = _fragile_sequence_suggestion(timeline, cp)
+    if fragile is not None:
+        suggestions.append(fragile)
+        if first_pressure_step is None and fragile.affected_steps:
+            first_pressure_step = min(fragile.affected_steps)
+
+    primary = _primary_port_suggestion(placements, first_pressure_step)
+    if primary is not None:
+        suggestions.append(primary)
 
     for step in timeline:
         t3 = _t3_escalation_suggestion(step, placement_by_step)
         if t3 is not None:
             suggestions.append(t3)
 
-    fragile = _fragile_sequence_suggestion(timeline, cp)
-    if fragile is not None:
-        suggestions.append(fragile)
+    reduce_paid_ports = _reduce_paid_port_count_suggestion(placements, negative_steps)
+    if reduce_paid_ports is not None:
+        suggestions.append(reduce_paid_ports)
+    split_plan = _split_advanced_plan_suggestion(negative_steps)
+    if split_plan is not None:
+        suggestions.append(split_plan)
 
-    return _dedupe_and_sort(suggestions)
+    return _dedupe_sort_and_cap(suggestions)
 
 
 def cp_repair_suggestions_to_dict(suggestions: list[CPRepairSuggestion]) -> list[dict[str, Any]]:
@@ -91,6 +131,7 @@ def _cp_negative_suggestion(step: dict[str, Any]) -> CPRepairSuggestion:
     deficit = abs(min(0, yellow_after)) + abs(min(0, green_after))
     severity = 'critical' if deficit >= 10 else 'high'
     return CPRepairSuggestion(
+        suggestion_id=f'cp_negative_step_{step_no}',
         type='cp_negative_detected',
         severity=severity,
         summary=f'CP goes negative at step {step_no}',
@@ -98,6 +139,11 @@ def _cp_negative_suggestion(step: dict[str, Any]) -> CPRepairSuggestion:
         affected_steps=[step_no],
         expected_effect='Repairing the first deficit should make the current order easier to build without changing final scoring.',
         action='Move CP-generating support earlier, mark the intended first port as primary if appropriate, or move this paid port later.',
+        suggested_action=CPRepairAction(
+            action_type='review_sequence',
+            target_step=step_no,
+            notes=['Review the nearby paid port, primary-port choice, and CP-generating support order.'],
+        ),
         confidence='inferred',
         caveats=['This is a local repair suggestion, not proof of the globally optimal build order.'],
     )
@@ -116,34 +162,116 @@ def _move_support_earlier_suggestion(step: dict[str, Any], placements: list[Any]
     if not candidates:
         return None
     candidate = sorted(candidates, key=lambda item: int(item.spec.build_order))[0]
+    from_step = int(candidate.spec.build_order)
+    earliest_repair_step = max(1, step_no - 1)
+    target_phrase = (
+        f'before step {step_no}, after any required initial anchor'
+        if step_no > 1 else
+        'as early as the sequence allows before the CP-negative paid port'
+    )
     return CPRepairSuggestion(
+        suggestion_id=f'move_{_slug(candidate.facility.id)}_before_step_{step_no}',
         type='move_cp_generator_earlier',
         severity='high' if _is_negative_step(step) else 'medium',
-        summary=f'Move {candidate.facility.name} before step {step_no}',
-        reason=f'{candidate.facility.name} currently appears at step {candidate.spec.build_order} after a CP deficit has already occurred.',
-        affected_steps=[step_no, int(candidate.spec.build_order)],
+        summary=f'Move {candidate.facility.name} earlier',
+        reason=f'{candidate.facility.name} currently appears at step {from_step} after a CP deficit has already occurred.',
+        affected_steps=[step_no, from_step],
         expected_effect='Generating CP before the deficit should reduce or remove the temporary negative balance.',
-        action=f'Move {candidate.facility.name} from step {candidate.spec.build_order} to before step {step_no}.',
+        action=f'Move {candidate.facility.name} {target_phrase}.',
+        suggested_action=CPRepairAction(
+            action_type='move_facility_earlier',
+            facility_template_id=candidate.facility.id,
+            facility_name=candidate.facility.name,
+            from_step=from_step,
+            to_step=earliest_repair_step,
+            notes=['Do not move support before the initial colony anchor unless that is valid in-game.'],
+        ),
         confidence='inferred',
-        caveats=['The simulator does not reorder every dependency; confirm the moved facility is still valid in the intended build plan.'],
+        caveats=[
+            'The simulator does not reorder every dependency; confirm the moved facility is still valid in the intended build plan.',
+            'Do not move support before the initial colony anchor unless that is valid in-game.',
+        ],
     )
 
 
-def _primary_port_suggestion(step: dict[str, Any], placement_by_step: dict[int, Any]) -> CPRepairSuggestion | None:
+def _primary_port_suggestion(placements: list[Any], pressure_step: int | None) -> CPRepairSuggestion | None:
+    if pressure_step is None:
+        return None
+    if any(item.facility.is_port and item.spec.is_primary_port for item in placements):
+        return None
+    ports = sorted((item for item in placements if item.facility.is_port), key=lambda item: int(item.spec.build_order))
+    if not ports:
+        return None
+    port = ports[0]
+    port_step = int(port.spec.build_order)
+    if port_step > pressure_step:
+        return None
+    return CPRepairSuggestion(
+        suggestion_id=f'mark_primary_{_slug(port.facility.id)}_step_{port_step}',
+        type='mark_primary_port',
+        severity='high',
+        summary=f'Mark {port.facility.name} as the primary port',
+        reason=f'{port.facility.name} is the earliest port and no primary port is currently marked before the early CP pressure point.',
+        affected_steps=[port_step, pressure_step] if pressure_step != port_step else [port_step],
+        expected_effect='Using the primary-port exemption on the intended first Main Port should reduce early paid-port CP pressure.',
+        action=f'Mark {port.facility.name} at step {port_step} as the primary port if it is intended to be the initial colony Main Port.',
+        suggested_action=CPRepairAction(
+            action_type='mark_primary_port',
+            facility_template_id=port.facility.id,
+            facility_name=port.facility.name,
+            target_step=port_step,
+            set_primary_port=True,
+            notes=['Only one port should receive the primary-port exemption.', 'Only use this if this is genuinely the first/primary colony port in-game.'],
+        ),
+        confidence='inferred',
+        caveats=['Only use this if this is genuinely the first/primary colony port in-game.'],
+    )
+
+
+def _delay_expensive_port_suggestion(step: dict[str, Any], placement_by_step: dict[int, Any]) -> CPRepairSuggestion | None:
     step_no = int(step.get('step', 0))
     placement = placement_by_step.get(step_no)
     if placement is None or not placement.facility.is_port or placement.spec.is_primary_port:
         return None
     return CPRepairSuggestion(
-        type='mark_primary_port',
+        suggestion_id=f'delay_{_slug(placement.facility.id)}_step_{step_no}',
+        type='delay_expensive_port',
         severity='high',
-        summary=f'Mark {placement.facility.name} as the primary port',
-        reason=f'{placement.facility.name} is the paid port at the CP-negative step and is not currently using the primary-port exemption.',
+        summary=f'Delay {placement.facility.name} until CP is available',
+        reason=f'{placement.facility.name} is a paid port at the CP-negative step and no later CP generator was available to move earlier.',
         affected_steps=[step_no],
-        expected_effect='Using the primary-port exemption on the intended first Main Port should remove that port CP charge from this sequence.',
-        action=f'Mark {placement.facility.name} at step {step_no} as the primary port if it is intended to be the initial colony Main Port.',
+        expected_effect='Delaying the paid port until after more CP generation should reduce the temporary deficit.',
+        action=f'Move {placement.facility.name} later, after CP-generating support has created enough buffer.',
+        suggested_action=CPRepairAction(
+            action_type='delay_facility',
+            facility_template_id=placement.facility.id,
+            facility_name=placement.facility.name,
+            from_step=step_no,
+            notes=['Choose the later step after enough support has generated CP; this assistant does not compute a full replacement order.'],
+        ),
         confidence='inferred',
-        caveats=['Only one port should receive the primary-port exemption; do not apply this if another port is intentionally primary.'],
+        caveats=['This is a conservative local repair; verify the delayed port still fits the intended colony sequence.'],
+    )
+
+
+def _add_cp_generator_suggestion(step: dict[str, Any]) -> CPRepairSuggestion | None:
+    step_no = int(step.get('step', 0))
+    return CPRepairSuggestion(
+        suggestion_id=f'add_cp_generator_before_step_{step_no}',
+        type='add_cp_generator',
+        severity='high',
+        summary=f'Add CP-generating support before step {step_no}',
+        reason='No later CP-generating support was available to move earlier for this deficit.',
+        affected_steps=[step_no],
+        expected_effect='Adding support that generates the missing CP before the deficit should make the paid step easier to afford.',
+        action=f'Add or move a CP-generating support facility before step {step_no}, after any required initial anchor.',
+        suggested_action=CPRepairAction(
+            action_type='add_cp_generator',
+            target_step=step_no,
+            notes=['Do not assume a specific facility template; choose a valid CP-generating support facility for the plan.'],
+        ),
+        confidence='inferred',
+        caveats=['No specific facility is recommended because this pass is not a full optimiser.'],
     )
 
 
@@ -157,7 +285,9 @@ def _t3_escalation_suggestion(step: dict[str, Any], placement_by_step: dict[int,
         if placement.spec.is_primary_port or step_no <= LATE_T3_BUILD_ORDER_THRESHOLD:
             return None
     facility_name = step.get('facility_name') or getattr(getattr(placement, 'facility', None), 'name', 'T3 port')
+    facility_id = getattr(getattr(placement, 'facility', None), 'id', 't3_port')
     return CPRepairSuggestion(
+        suggestion_id=f'review_t3_timing_step_{step_no}',
         type='port_escalation_pressure',
         severity='medium',
         summary=f'Review T3 timing for {facility_name}',
@@ -165,6 +295,13 @@ def _t3_escalation_suggestion(step: dict[str, Any], placement_by_step: dict[int,
         affected_steps=[step_no],
         expected_effect='Moving the T3 port earlier or using a valid primary-port exemption may reduce escalation pressure.',
         action=f'Review whether {facility_name} should be earlier in the order or designated primary where appropriate.',
+        suggested_action=CPRepairAction(
+            action_type='review_sequence',
+            facility_template_id=facility_id,
+            facility_name=facility_name,
+            target_step=step_no,
+            notes=['T3 timing advice is conservative and should be checked against the intended staged build.'],
+        ),
         confidence='inferred',
         caveats=['T3 escalation guidance is conservative and does not attempt a full reorder optimisation.'],
     )
@@ -187,27 +324,94 @@ def _fragile_sequence_suggestion(timeline: list[dict[str, Any]], cp: dict[str, A
     if fragile_green_final and final_step not in affected:
         affected.append(final_step)
     return CPRepairSuggestion(
+        suggestion_id='fragile_sequence',
         type='sequence_is_valid_but_fragile',
         severity='medium',
         summary='This sequence is valid but fragile',
         reason='One or both CP balances reach zero or only become safely positive at the end, leaving little buffer if the build order changes.',
         affected_steps=affected[:6],
         expected_effect='Moving CP-generating support earlier would create a safer buffer.',
-        action='Move an early CP-generating support facility before the first low-buffer step if practical.',
+        action='Move an early CP-generating support facility before the first low-buffer step if practical, after any required initial anchor.',
+        suggested_action=CPRepairAction(
+            action_type='review_sequence',
+            target_step=min(affected) if affected else None,
+            notes=['This is a buffer improvement, not a required repair for a currently negative final balance.'],
+        ),
         confidence='inferred',
         caveats=['This suggestion is suppressed when the sequence already ends CP-negative because deficit repairs are more important.'],
     )
 
 
-def _dedupe_and_sort(suggestions: list[CPRepairSuggestion]) -> list[CPRepairSuggestion]:
-    seen: set[tuple[str, tuple[int, ...], str]] = set()
-    result: list[CPRepairSuggestion] = []
+def _reduce_paid_port_count_suggestion(placements: list[Any], negative_steps: list[dict[str, Any]]) -> CPRepairSuggestion | None:
+    paid_ports = [item for item in placements if item.facility.is_port and not item.spec.is_primary_port and item.facility.tier in {2, 3}]
+    if len(paid_ports) < 3 or not negative_steps:
+        return None
+    affected = [int(step.get('step', 0)) for step in negative_steps[:3]]
+    return CPRepairSuggestion(
+        suggestion_id='reduce_paid_t2_t3_port_count',
+        type='reduce_paid_t2_t3_port_count',
+        severity='medium',
+        summary='Reduce paid T2/T3 port pressure in the first phase',
+        reason='Multiple paid T2/T3 ports are present while the sequence has CP deficits.',
+        affected_steps=affected,
+        expected_effect='Simplifying the first phase can reduce escalating port CP pressure before adding more ports later.',
+        action='Move one or more paid T2/T3 ports into a later phase after CP support is online.',
+        suggested_action=CPRepairAction(
+            action_type='review_sequence',
+            notes=['This assistant does not choose which port to remove; review the staged plan manually.'],
+        ),
+        confidence='inferred',
+        caveats=['This is a staging suggestion, not a recommendation to remove ports from the final colony design.'],
+    )
+
+
+def _split_advanced_plan_suggestion(negative_steps: list[dict[str, Any]]) -> CPRepairSuggestion | None:
+    severe_steps = [int(step.get('step', 0)) for step in negative_steps]
+    if len(severe_steps) < 3:
+        return None
+    return CPRepairSuggestion(
+        suggestion_id='split_advanced_plan',
+        type='split_advanced_plan',
+        severity='medium',
+        summary='Split this advanced build into a simpler first phase',
+        reason='Several CP-negative steps suggest the current order may be trying to place too much before enough CP support is online.',
+        affected_steps=severe_steps[:6],
+        expected_effect='A smaller first phase should be easier to stabilise before adding later ports or expensive facilities.',
+        action='Split the build into a CP-generating first phase and a later expansion phase.',
+        suggested_action=CPRepairAction(
+            action_type='split_plan',
+            notes=['This is planning guidance only; no automatic phase split is computed.'],
+        ),
+        confidence='inferred',
+        caveats=['A full optimiser is intentionally deferred.'],
+    )
+
+
+def _dedupe_sort_and_cap(suggestions: list[CPRepairSuggestion]) -> list[CPRepairSuggestion]:
+    seen: set[str] = set()
+    ordered: list[CPRepairSuggestion] = []
     for suggestion in suggestions:
-        if suggestion.confidence not in STANDARD_CONFIDENCE_LABELS:
+        if suggestion.confidence not in STANDARD_CONFIDENCE_LABELS or not suggestion.suggestion_id:
             continue
-        key = (suggestion.type, tuple(suggestion.affected_steps), suggestion.summary)
-        if key in seen:
+        if suggestion.suggestion_id in seen:
             continue
-        seen.add(key)
-        result.append(suggestion)
-    return sorted(result, key=lambda item: (SEVERITY_ORDER.get(item.severity, 99), item.affected_steps or [999], item.type))
+        seen.add(suggestion.suggestion_id)
+        ordered.append(suggestion)
+
+    ordered = sorted(ordered, key=lambda item: (SEVERITY_ORDER.get(item.severity, 99), item.affected_steps or [999], item.type))
+    per_problem: dict[int, int] = {}
+    capped: list[CPRepairSuggestion] = []
+    for suggestion in ordered:
+        problem_key = min(suggestion.affected_steps) if suggestion.affected_steps else -1
+        count = per_problem.get(problem_key, 0)
+        if count >= MAX_REPAIRS_PER_PROBLEM:
+            continue
+        capped.append(suggestion)
+        per_problem[problem_key] = count + 1
+        if len(capped) >= MAX_REPAIRS_TOTAL:
+            break
+    return capped
+
+
+def _slug(value: str) -> str:
+    return ''.join(char if char.isalnum() else '_' for char in value.lower()).strip('_') or 'item'

--- a/apps/api/src/simulation/mechanics_trace.py
+++ b/apps/api/src/simulation/mechanics_trace.py
@@ -49,6 +49,7 @@ TRACE_CATEGORIES = [
     'purity_effects',
     'contamination_effects',
     'cp_effects',
+    'cp_repair_effects',
     'service_unlock_effects',
     'port_service_effects',
     'service_unlock_ledger_effects',
@@ -72,6 +73,7 @@ def trace_simulation(
     influence_ledger: list[Any] | None = None,
     port_service_states: list[Any] | None = None,
     service_unlock_ledger: list[Any] | None = None,
+    cp_repair_suggestions: list[Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     trace = empty_trace()
 
@@ -208,6 +210,15 @@ def trace_simulation(
             description=str(warning),
             confidence=ConfidenceLevel.INFERRED.value,
             source=SOURCE_MEGA_GUIDE,
+        ).to_dict())
+
+    for suggestion in cp_repair_suggestions or []:
+        trace['cp_repair_effects'].append(MechanicsTraceEvent(
+            category='cp_repair_effects',
+            label=str(getattr(suggestion, 'summary', 'CP repair suggestion')),
+            description=str(getattr(suggestion, 'reason', '') or getattr(suggestion, 'expected_effect', '') or 'CP repair suggestion recorded.'),
+            confidence=str(getattr(suggestion, 'confidence', ConfidenceLevel.INFERRED.value)),
+            source='CP repair assistant',
         ).to_dict())
 
     for service, detail in services.items():

--- a/apps/api/src/simulation/mechanics_trace.py
+++ b/apps/api/src/simulation/mechanics_trace.py
@@ -50,6 +50,8 @@ TRACE_CATEGORIES = [
     'contamination_effects',
     'cp_effects',
     'service_unlock_effects',
+    'port_service_effects',
+    'service_unlock_ledger_effects',
     'confidence_adjustments',
 ]
 
@@ -68,6 +70,8 @@ def trace_simulation(
     confidence_signals: list[ConfidenceSignal],
     port_economy_states: list[Any] | None = None,
     influence_ledger: list[Any] | None = None,
+    port_service_states: list[Any] | None = None,
+    service_unlock_ledger: list[Any] | None = None,
 ) -> dict[str, list[dict[str, Any]]]:
     trace = empty_trace()
 
@@ -215,6 +219,30 @@ def trace_simulation(
             description=str(detail.get('reason') or 'Service unlock state modelled from catalogue rules.'),
             confidence=ConfidenceLevel.UNKNOWN.value if detail.get('status') == 'unknown' else ConfidenceLevel.INFERRED.value,
         ).to_dict())
+
+    for state in port_service_states or []:
+        label = getattr(state, 'port_name', 'Main Port')
+        active = len(getattr(state, 'active_services', {}) or {})
+        locked = len(getattr(state, 'locked_services', {}) or {})
+        unknown = len(getattr(state, 'unknown_services', {}) or {})
+        trace['port_service_effects'].append(MechanicsTraceEvent(
+            category='port_service_effects',
+            label=label,
+            description=f'{label} service state created with {active} active, {locked} locked, and {unknown} unknown services.',
+            confidence=ConfidenceLevel.INFERRED.value,
+            source='Service dependency graph',
+        ).to_dict())
+
+    for entry in service_unlock_ledger or []:
+        status = getattr(entry, 'status', '')
+        if status == 'active' or getattr(entry, 'unlock_type', '') in {'strong_link_unlock', 'unknown_rule'}:
+            trace['service_unlock_ledger_effects'].append(MechanicsTraceEvent(
+                category='service_unlock_ledger_effects',
+                label=f'{getattr(entry, "target_port_name", "Main Port")} {getattr(entry, "service", "service")}',
+                description=str(getattr(entry, 'reason', '') or 'Service unlock ledger entry recorded.'),
+                confidence=str(getattr(entry, 'confidence', ConfidenceLevel.INFERRED.value)),
+                source='Service dependency graph',
+            ).to_dict())
 
     for signal in confidence_signals:
         trace['confidence_adjustments'].append(MechanicsTraceEvent(

--- a/apps/api/src/simulation/service_graph.py
+++ b/apps/api/src/simulation/service_graph.py
@@ -33,7 +33,12 @@ LINK_SYSTEM = 'system'
 
 CONFIDENCE_COMMUNITY_OBSERVED = 'community_observed'
 CONFIDENCE_INFERRED = 'inferred'
+CONFIDENCE_SPECULATIVE = 'speculative'
 CONFIDENCE_UNKNOWN = 'unknown'
+
+_QUALIFIED_UNLOCK_CAVEAT = 'This service rule has qualifiers that ED-Finder cannot fully verify yet.'
+_PASS_THROUGH_SERVICE_CAVEAT = 'Pass-through service unlock behaviour is not yet verified; economy pass-through does not automatically imply service pass-through.'
+_CONVERTED_PORT_SERVICE_CAVEAT = 'Converted-port service unlock behaviour is inferred and should be verified in-game.'
 
 # Conservative hints for useful locked-service recommendations when no placed
 # facility currently documents that service. These are based on the bundled
@@ -78,6 +83,8 @@ class PortServiceState:
     body_name: str | None
     location_type: str
     effective_role: str
+    port_tier: int = 0
+    port_economy: str | None = None
     active_services: dict[str, ServiceUnlockEntry] = field(default_factory=dict)
     locked_services: dict[str, ServiceUnlockEntry] = field(default_factory=dict)
     unknown_services: dict[str, ServiceUnlockEntry] = field(default_factory=dict)
@@ -122,6 +129,8 @@ def build_port_service_states(
                 body_name=group.body_name,
                 location_type=port.location_type,
                 effective_role=role_by_key.get(_graph_key(port), role),
+                port_tier=getattr(port.facility, 'tier', 0) or 0,
+                port_economy=getattr(port, 'economy', None),
             )
             states[_port_key(port)] = state
 
@@ -172,7 +181,16 @@ def _apply_documented_unlocks(
     topology_graph: Any,
     graph_by_id_body: dict[tuple[str, str], Any],
 ) -> None:
-    strong_by_source = {link.source_facility_id: link for link in getattr(topology_graph, 'strong_links', [])}
+    strong_links = list(getattr(topology_graph, 'strong_links', []))
+    converted_keys = {
+        (port.facility_id, str(port.local_body_id or 'system'))
+        for port in getattr(topology_graph, 'converted_ports', [])
+    }
+    pass_through_links = list(getattr(topology_graph, 'pass_through_links', []))
+    pass_through_sources = {
+        (link.source_facility_id, str(link.local_body_id or 'system'))
+        for link in pass_through_links
+    }
     for placement in placements:
         facility = placement.facility
         graph_placement = graph_by_id_body.get((facility.id, str(placement.spec.local_body_id or 'system')))
@@ -184,35 +202,59 @@ def _apply_documented_unlocks(
             if not services:
                 continue
             if raw_type == 'Strong Link Unlock':
-                link = strong_by_source.get(facility.id)
-                if link is not None:
-                    state = states.get(_port_key_from_id(link.receiver_port_id, link.local_body_id))
-                    if state is None:
-                        continue
-                    for service in services:
-                        entry = ServiceUnlockEntry(
-                            service=service,
-                            status=SERVICE_STATUS_ACTIVE,
-                            source_id=facility.id,
-                            source_name=facility.name,
-                            source_type=source_type,
-                            target_port_id=link.receiver_port_id,
-                            target_port_name=link.receiver_port_name,
-                            local_body_id=link.local_body_id,
-                            unlock_type=UNLOCK_STRONG_LINK,
-                            link_type=LINK_STRONG,
-                            confidence=CONFIDENCE_COMMUNITY_OBSERVED,
-                            reason=f'{facility.name} strongly links to {link.receiver_port_name} and unlocks {_service_label(service)}.',
-                            requirements=[],
-                            caveats=_rule_caveats(text),
-                        )
-                        _record_entry(state, entry)
+                matching_links = _matching_strong_links(strong_links, placement)
+                if matching_links:
+                    for link in matching_links:
+                        state = states.get(_port_key_from_id(link.receiver_port_id, link.local_body_id))
+                        if state is None:
+                            continue
+                        source_key = (facility.id, str(placement.spec.local_body_id or 'system'))
+                        for service in services:
+                            caveats = _rule_caveats(text)
+                            confidence = CONFIDENCE_COMMUNITY_OBSERVED
+                            if source_key in converted_keys:
+                                caveats.append(_CONVERTED_PORT_SERVICE_CAVEAT)
+                                confidence = CONFIDENCE_INFERRED
+                            entry = ServiceUnlockEntry(
+                                service=service,
+                                status=SERVICE_STATUS_ACTIVE,
+                                source_id=facility.id,
+                                source_name=facility.name,
+                                source_type=source_type,
+                                target_port_id=link.receiver_port_id,
+                                target_port_name=link.receiver_port_name,
+                                local_body_id=link.local_body_id,
+                                unlock_type=UNLOCK_STRONG_LINK,
+                                link_type=LINK_STRONG,
+                                confidence=confidence,
+                                reason=f'{facility.name} strongly links to {link.receiver_port_name} and unlocks {_service_label(service)}.',
+                                requirements=[],
+                                caveats=_unique(caveats),
+                            )
+                            _record_entry(state, entry)
+                    _record_unverified_pass_through_entries(
+                        states=states,
+                        pass_through_links=pass_through_links,
+                        placement=placement,
+                        services=services,
+                        source_type=source_type,
+                        text=text,
+                    )
                 else:
                     target_states = _candidate_local_states(states, graph_placement)
                     for state in target_states:
                         for service in services:
                             if service in state.active_services:
                                 continue
+                            source_key = (facility.id, str(placement.spec.local_body_id or 'system'))
+                            caveats = _rule_caveats(text)
+                            confidence = CONFIDENCE_COMMUNITY_OBSERVED
+                            if source_key in pass_through_sources:
+                                caveats.append(_PASS_THROUGH_SERVICE_CAVEAT)
+                                confidence = CONFIDENCE_UNKNOWN
+                            if source_key in converted_keys:
+                                caveats.append(_CONVERTED_PORT_SERVICE_CAVEAT)
+                                confidence = CONFIDENCE_INFERRED
                             entry = ServiceUnlockEntry(
                                 service=service,
                                 status=SERVICE_STATUS_LOCKED,
@@ -224,18 +266,24 @@ def _apply_documented_unlocks(
                                 local_body_id=state.local_body_id,
                                 unlock_type=UNLOCK_STRONG_LINK,
                                 link_type=LINK_STRONG,
-                                confidence=CONFIDENCE_COMMUNITY_OBSERVED,
+                                confidence=confidence,
                                 reason=f'{facility.name} documents {_service_label(service)}, but it is not strongly linked to {state.port_name}.',
                                 requirements=[f'Strong-link {facility.name} to {state.port_name} on local body {state.local_body_id or "system"}.'],
-                                caveats=_rule_caveats(text),
+                                caveats=_unique(caveats),
                             )
                             _record_entry(state, entry)
             else:
                 for state in states.values():
                     for service in services:
+                        status, confidence, reason, requirements, caveats = _classify_system_unlock_for_port(
+                            service=service,
+                            text=text,
+                            facility_name=facility.name,
+                            state=state,
+                        )
                         entry = ServiceUnlockEntry(
                             service=service,
-                            status=SERVICE_STATUS_ACTIVE,
+                            status=status,
                             source_id=facility.id,
                             source_name=facility.name,
                             source_type=source_type,
@@ -244,12 +292,101 @@ def _apply_documented_unlocks(
                             local_body_id=state.local_body_id,
                             unlock_type=UNLOCK_SYSTEM,
                             link_type=LINK_SYSTEM,
-                            confidence=CONFIDENCE_COMMUNITY_OBSERVED,
-                            reason=f'{_service_label(service)} is documented as a system unlock from {facility.name}.',
-                            requirements=[],
-                            caveats=_rule_caveats(text),
+                            confidence=confidence,
+                            reason=reason,
+                            requirements=requirements,
+                            caveats=caveats,
                         )
                         _record_entry(state, entry)
+
+
+def _record_unverified_pass_through_entries(
+    *,
+    states: dict[str, PortServiceState],
+    pass_through_links: list[Any],
+    placement: Any,
+    services: list[str],
+    source_type: str,
+    text: str,
+) -> None:
+    body_id = str(placement.spec.local_body_id or 'system')
+    for link in pass_through_links:
+        if link.source_facility_id != placement.facility.id or str(link.local_body_id or 'system') != body_id:
+            continue
+        state = states.get(_port_key_from_id(link.orbital_receiver_id, link.local_body_id))
+        if state is None:
+            continue
+        for service in services:
+            if service in state.active_services:
+                continue
+            entry = ServiceUnlockEntry(
+                service=service,
+                status=SERVICE_STATUS_UNKNOWN,
+                source_id=placement.facility.id,
+                source_name=placement.facility.name,
+                source_type=source_type,
+                target_port_id=state.port_id,
+                target_port_name=state.port_name,
+                local_body_id=state.local_body_id,
+                unlock_type=UNLOCK_UNKNOWN,
+                link_type=LINK_PASS_THROUGH,
+                confidence=CONFIDENCE_UNKNOWN,
+                reason=f'{placement.facility.name} has pass-through topology toward {state.port_name}, but service pass-through is not verified for {_service_label(service)}.',
+                requirements=[],
+                caveats=_unique([*_rule_caveats(text), _PASS_THROUGH_SERVICE_CAVEAT]),
+            )
+            _record_entry(state, entry)
+
+
+def _matching_strong_links(strong_links: list[Any], placement: Any) -> list[Any]:
+    body_id = str(placement.spec.local_body_id or 'system')
+    return [
+        link for link in strong_links
+        if link.source_facility_id == placement.facility.id and str(link.local_body_id or 'system') == body_id
+    ]
+
+
+def _classify_system_unlock_for_port(
+    *,
+    service: str,
+    text: str,
+    facility_name: str,
+    state: PortServiceState,
+) -> tuple[str, str, str, list[str], list[str]]:
+    fragment = _service_fragment(text, service)
+    caveats = _rule_caveats(fragment)
+    if not _unlock_has_qualifiers(fragment):
+        return (
+            SERVICE_STATUS_ACTIVE,
+            CONFIDENCE_COMMUNITY_OBSERVED,
+            f'{_service_label(service)} is documented as an unqualified system unlock from {facility_name}.',
+            [],
+            caveats,
+        )
+    match = _port_matches_service_qualifier(fragment, state)
+    if match is True:
+        return (
+            SERVICE_STATUS_ACTIVE,
+            CONFIDENCE_COMMUNITY_OBSERVED,
+            f'{_service_label(service)} qualifier appears to match {state.port_name}: {fragment}.',
+            [],
+            caveats,
+        )
+    if match is False:
+        return (
+            SERVICE_STATUS_LOCKED,
+            CONFIDENCE_INFERRED,
+            f'{_service_label(service)} is documented by {facility_name}, but {state.port_name} does not satisfy the qualifier: {fragment}.',
+            [f'Use a Main Port that satisfies this catalogue qualifier: {fragment}.'],
+            caveats,
+        )
+    return (
+        SERVICE_STATUS_UNKNOWN,
+        CONFIDENCE_UNKNOWN,
+        f'{_service_label(service)} has catalogue qualifiers that ED-Finder cannot fully verify for {state.port_name}: {fragment}.',
+        [],
+        _unique([*caveats, _QUALIFIED_UNLOCK_CAVEAT]),
+    )
 
 
 def _candidate_local_states(states: dict[str, PortServiceState], graph_placement: Any | None) -> list[PortServiceState]:
@@ -335,12 +472,55 @@ def _services_in_text(text: str) -> list[str]:
     return sorted(service for service, phrases in SERVICE_PHRASES.items() if any(phrase in lowered for phrase in phrases))
 
 
+def _service_fragment(text: str, service: str) -> str:
+    clauses = [clause.strip() for clause in text.replace(';', ',').split(',') if clause.strip()]
+    phrases = SERVICE_PHRASES.get(service, [])
+    for clause in clauses:
+        lowered = clause.lower()
+        if any(phrase in lowered for phrase in phrases):
+            return clause
+    return text
+
+
+def _unlock_has_qualifiers(text: str) -> bool:
+    lowered = text.lower()
+    markers = (' at ', ' non-', 'only ', 'outpost', 'outposts', 'port', 'ports', 'surface', 'orbital', 'industrial', 'military', 'pirate', 'scientific')
+    return any(marker in lowered for marker in markers)
+
+
+def _port_matches_service_qualifier(text: str, state: PortServiceState) -> bool | None:
+    lowered = text.lower()
+    if 't1 surface' in lowered:
+        return state.location_type == 'surface' and state.port_tier == 1
+    if 't2 orbital' in lowered:
+        return state.location_type == 'orbital' and state.port_tier == 2
+    if 'surface port' in lowered or 'surface ports' in lowered:
+        return state.location_type == 'surface'
+    if 'orbital port' in lowered or 'orbital ports' in lowered:
+        return state.location_type == 'orbital'
+    # Outpost/faction/economy qualifiers are not yet reliably mapped to every
+    # port template, so they remain unknown instead of being over-activated.
+    if any(marker in lowered for marker in ('outpost', 'outposts', 'non-', 'pirate', 'scientific', 'military', 'industrial')):
+        return None
+    return None
+
+
 def _rule_caveats(text: str) -> list[str]:
     lowered = text.lower()
     caveats: list[str] = []
-    if ' at ' in lowered or ' non-' in lowered or ' or ' in lowered:
-        caveats.append('Catalogue unlock text contains port-type or facility-type qualifiers; Stage 4B models this conservatively.')
+    if _unlock_has_qualifiers(text) or ' or ' in lowered:
+        caveats.append('This service rule has qualifiers that ED-Finder cannot fully verify yet.')
     return caveats
+
+
+def _unique(items: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item and item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result
 
 
 def _service_label(service: str) -> str:

--- a/apps/api/src/simulation/service_graph.py
+++ b/apps/api/src/simulation/service_graph.py
@@ -1,0 +1,383 @@
+"""Per-port service dependency graph and unlock ledger for Simulation Preview.
+
+Stage 4B is intentionally additive. It keeps the existing system-level service
+model intact, then explains service availability at each Main Port using the
+current topology graph and documented facility-catalogue unlock text.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from mechanics.service_rules import (
+    MODELLED_SERVICES,
+    SERVICE_STATUS_ACTIVE,
+    SERVICE_STATUS_LOCKED,
+    SERVICE_STATUS_UNKNOWN,
+)
+from simulation.services import SERVICE_PHRASES
+
+
+UNLOCK_PORT_DEFAULT = 'port_default'
+UNLOCK_SYSTEM = 'system_unlock'
+UNLOCK_STRONG_LINK = 'strong_link_unlock'
+UNLOCK_LOCAL_BODY = 'local_body_unlock'
+UNLOCK_INFERRED = 'inferred_unlock'
+UNLOCK_UNKNOWN = 'unknown_rule'
+
+LINK_NONE = 'none'
+LINK_STRONG = 'strong'
+LINK_WEAK = 'weak'
+LINK_PASS_THROUGH = 'pass_through'
+LINK_SYSTEM = 'system'
+
+CONFIDENCE_COMMUNITY_OBSERVED = 'community_observed'
+CONFIDENCE_INFERRED = 'inferred'
+CONFIDENCE_UNKNOWN = 'unknown'
+
+# Conservative hints for useful locked-service recommendations when no placed
+# facility currently documents that service. These are based on the bundled
+# catalogue's documented unlock text and are phrased as suggestions, not hidden
+# scoring mechanics.
+_SERVICE_REQUIREMENT_HINTS = {
+    'black_market': 'Build Pirate Base on the same local body with a strong link to this Main Port.',
+    'universal_cartographics': 'Build Relay Station, Comm Station, Satellite, Research Station, or Exploration support where its documented unlock rule can apply.',
+    'vista_genomics': 'Build Medical, Scientific, Relay Station, Comm Station, or Satellite support where its documented unlock rule can apply.',
+    'shipyard': 'Build Military, Industrial, or High Tech support where the documented Shipyard unlock rule can apply.',
+    'outfitting': 'Build Military, Industrial, or High Tech support where the documented Outfitting unlock rule can apply.',
+    'crew_lounge': 'Build Space Bar support where the documented Crew Lounge unlock rule can apply.',
+}
+
+
+@dataclass(frozen=True)
+class ServiceUnlockEntry:
+    service: str
+    status: str
+    source_id: str | None
+    source_name: str | None
+    source_type: str | None
+    target_port_id: str
+    target_port_name: str
+    local_body_id: str | None
+    unlock_type: str
+    link_type: str | None
+    confidence: str
+    reason: str
+    requirements: list[str] = field(default_factory=list)
+    caveats: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class PortServiceState:
+    port_id: str
+    port_name: str
+    local_body_id: str | None
+    body_name: str | None
+    location_type: str
+    effective_role: str
+    active_services: dict[str, ServiceUnlockEntry] = field(default_factory=dict)
+    locked_services: dict[str, ServiceUnlockEntry] = field(default_factory=dict)
+    unknown_services: dict[str, ServiceUnlockEntry] = field(default_factory=dict)
+    service_sources: list[ServiceUnlockEntry] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    recommendations: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data['active_services'] = {key: entry.to_dict() for key, entry in sorted(self.active_services.items())}
+        data['locked_services'] = {key: entry.to_dict() for key, entry in sorted(self.locked_services.items())}
+        data['unknown_services'] = {key: entry.to_dict() for key, entry in sorted(self.unknown_services.items())}
+        data['service_sources'] = [entry.to_dict() for entry in self.service_sources]
+        return data
+
+
+def build_port_service_states(
+    *,
+    placements: list[Any],
+    topology_graph: Any,
+) -> tuple[list[PortServiceState], list[ServiceUnlockEntry]]:
+    role_by_key = {
+        _placement_key(item.placement): item.effective_role
+        for item in getattr(topology_graph, 'classified_placements', [])
+    }
+    resolved_by_graph_key = {_resolved_key(item): item for item in placements}
+    graph_by_id_body = {
+        (placement.facility_id, str(placement.local_body_id or 'system')): placement
+        for group in getattr(topology_graph, 'local_body_groups', [])
+        for placement in group.facilities
+    }
+
+    states: dict[str, PortServiceState] = {}
+    for group in getattr(topology_graph, 'local_body_groups', []):
+        for port, role in ((getattr(group, 'main_surface_port', None), 'main_surface_port'), (getattr(group, 'main_orbital_port', None), 'main_orbital_port')):
+            if port is None:
+                continue
+            state = PortServiceState(
+                port_id=port.facility_id,
+                port_name=port.facility_name,
+                local_body_id=group.local_body_id,
+                body_name=group.body_name,
+                location_type=port.location_type,
+                effective_role=role_by_key.get(_graph_key(port), role),
+            )
+            states[_port_key(port)] = state
+
+    if not states:
+        return [], []
+
+    _add_port_default_services(states)
+    _apply_documented_unlocks(
+        states=states,
+        placements=placements,
+        topology_graph=topology_graph,
+        graph_by_id_body=graph_by_id_body,
+    )
+    for state in states.values():
+        _fill_missing_services(state)
+        _finalise_state(state)
+
+    ordered_states = sorted(states.values(), key=lambda item: (str(item.local_body_id or ''), item.location_type, item.port_id))
+    ledger = [entry for state in ordered_states for entry in state.service_sources]
+    return ordered_states, ledger
+
+
+def _add_port_default_services(states: dict[str, PortServiceState]) -> None:
+    for state in states.values():
+        entry = ServiceUnlockEntry(
+            service='commodity_market',
+            status=SERVICE_STATUS_ACTIVE,
+            source_id=state.port_id,
+            source_name=state.port_name,
+            source_type='port',
+            target_port_id=state.port_id,
+            target_port_name=state.port_name,
+            local_body_id=state.local_body_id,
+            unlock_type=UNLOCK_PORT_DEFAULT,
+            link_type=LINK_NONE,
+            confidence=CONFIDENCE_INFERRED,
+            reason=f'{_service_label("commodity_market")} is treated as a default Main Port service in the preview.',
+            requirements=[],
+            caveats=['Default port services are modelled conservatively until port-type-specific observations are richer.'],
+        )
+        _record_entry(state, entry)
+
+
+def _apply_documented_unlocks(
+    *,
+    states: dict[str, PortServiceState],
+    placements: list[Any],
+    topology_graph: Any,
+    graph_by_id_body: dict[tuple[str, str], Any],
+) -> None:
+    strong_by_source = {link.source_facility_id: link for link in getattr(topology_graph, 'strong_links', [])}
+    for placement in placements:
+        facility = placement.facility
+        graph_placement = graph_by_id_body.get((facility.id, str(placement.spec.local_body_id or 'system')))
+        source_type = 'port' if facility.is_port else 'facility'
+        for unlock in _facility_unlocks(facility):
+            text = str(unlock.get('description') or '')
+            raw_type = str(unlock.get('type') or '')
+            services = _services_in_text(text)
+            if not services:
+                continue
+            if raw_type == 'Strong Link Unlock':
+                link = strong_by_source.get(facility.id)
+                if link is not None:
+                    state = states.get(_port_key_from_id(link.receiver_port_id, link.local_body_id))
+                    if state is None:
+                        continue
+                    for service in services:
+                        entry = ServiceUnlockEntry(
+                            service=service,
+                            status=SERVICE_STATUS_ACTIVE,
+                            source_id=facility.id,
+                            source_name=facility.name,
+                            source_type=source_type,
+                            target_port_id=link.receiver_port_id,
+                            target_port_name=link.receiver_port_name,
+                            local_body_id=link.local_body_id,
+                            unlock_type=UNLOCK_STRONG_LINK,
+                            link_type=LINK_STRONG,
+                            confidence=CONFIDENCE_COMMUNITY_OBSERVED,
+                            reason=f'{facility.name} strongly links to {link.receiver_port_name} and unlocks {_service_label(service)}.',
+                            requirements=[],
+                            caveats=_rule_caveats(text),
+                        )
+                        _record_entry(state, entry)
+                else:
+                    target_states = _candidate_local_states(states, graph_placement)
+                    for state in target_states:
+                        for service in services:
+                            if service in state.active_services:
+                                continue
+                            entry = ServiceUnlockEntry(
+                                service=service,
+                                status=SERVICE_STATUS_LOCKED,
+                                source_id=facility.id,
+                                source_name=facility.name,
+                                source_type=source_type,
+                                target_port_id=state.port_id,
+                                target_port_name=state.port_name,
+                                local_body_id=state.local_body_id,
+                                unlock_type=UNLOCK_STRONG_LINK,
+                                link_type=LINK_STRONG,
+                                confidence=CONFIDENCE_COMMUNITY_OBSERVED,
+                                reason=f'{facility.name} documents {_service_label(service)}, but it is not strongly linked to {state.port_name}.',
+                                requirements=[f'Strong-link {facility.name} to {state.port_name} on local body {state.local_body_id or "system"}.'],
+                                caveats=_rule_caveats(text),
+                            )
+                            _record_entry(state, entry)
+            else:
+                for state in states.values():
+                    for service in services:
+                        entry = ServiceUnlockEntry(
+                            service=service,
+                            status=SERVICE_STATUS_ACTIVE,
+                            source_id=facility.id,
+                            source_name=facility.name,
+                            source_type=source_type,
+                            target_port_id=state.port_id,
+                            target_port_name=state.port_name,
+                            local_body_id=state.local_body_id,
+                            unlock_type=UNLOCK_SYSTEM,
+                            link_type=LINK_SYSTEM,
+                            confidence=CONFIDENCE_COMMUNITY_OBSERVED,
+                            reason=f'{_service_label(service)} is documented as a system unlock from {facility.name}.',
+                            requirements=[],
+                            caveats=_rule_caveats(text),
+                        )
+                        _record_entry(state, entry)
+
+
+def _candidate_local_states(states: dict[str, PortServiceState], graph_placement: Any | None) -> list[PortServiceState]:
+    if graph_placement is None:
+        return list(states.values())
+    local = [state for state in states.values() if str(state.local_body_id or 'system') == str(graph_placement.local_body_id or 'system')]
+    return local or list(states.values())
+
+
+def _fill_missing_services(state: PortServiceState) -> None:
+    for service in sorted(MODELLED_SERVICES):
+        if service in state.active_services or service in state.locked_services:
+            continue
+        if service in _SERVICE_REQUIREMENT_HINTS:
+            entry = ServiceUnlockEntry(
+                service=service,
+                status=SERVICE_STATUS_LOCKED,
+                source_id=None,
+                source_name=None,
+                source_type=None,
+                target_port_id=state.port_id,
+                target_port_name=state.port_name,
+                local_body_id=state.local_body_id,
+                unlock_type=UNLOCK_INFERRED,
+                link_type=None,
+                confidence=CONFIDENCE_INFERRED,
+                reason=f'{_service_label(service)} is not active at {state.port_name}; a documented support source is not currently satisfying the rule.',
+                requirements=[_SERVICE_REQUIREMENT_HINTS[service]],
+                caveats=['Locked recommendation is inferred from documented catalogue unlock text and should be checked against in-game observations.'],
+            )
+        else:
+            entry = ServiceUnlockEntry(
+                service=service,
+                status=SERVICE_STATUS_UNKNOWN,
+                source_id=None,
+                source_name=None,
+                source_type=None,
+                target_port_id=state.port_id,
+                target_port_name=state.port_name,
+                local_body_id=state.local_body_id,
+                unlock_type=UNLOCK_UNKNOWN,
+                link_type=None,
+                confidence=CONFIDENCE_UNKNOWN,
+                reason=f'{_service_label(service)} unlock behaviour is not yet verified for this port/facility combination.',
+                requirements=[],
+                caveats=['Treat as unknown until observed in-game or confirmed by source data.'],
+            )
+        _record_entry(state, entry)
+
+
+def _finalise_state(state: PortServiceState) -> None:
+    if state.locked_services:
+        locked = ', '.join(_service_label(service) for service in sorted(state.locked_services)[:3])
+        state.recommendations.append(f'Build or reposition documented support if {locked} is desired at {state.port_name}.')
+    if 'black_market' in state.locked_services or 'black_market' in state.active_services:
+        state.recommendations.append('Avoid Pirate Base unless Black Market is worth the economy and contamination trade-off.')
+    unknown_count = len(state.unknown_services)
+    if unknown_count:
+        state.warnings.append(f'{unknown_count} service rule(s) remain unknown for {state.port_name}.')
+
+
+def _record_entry(state: PortServiceState, entry: ServiceUnlockEntry) -> None:
+    state.service_sources.append(entry)
+    if entry.status == SERVICE_STATUS_ACTIVE:
+        state.active_services[entry.service] = entry
+        state.locked_services.pop(entry.service, None)
+        state.unknown_services.pop(entry.service, None)
+    elif entry.status == SERVICE_STATUS_LOCKED:
+        if entry.service not in state.active_services:
+            state.locked_services.setdefault(entry.service, entry)
+    else:
+        if entry.service not in state.active_services and entry.service not in state.locked_services:
+            state.unknown_services.setdefault(entry.service, entry)
+
+
+def _facility_unlocks(facility: Any) -> list[dict[str, Any]]:
+    stat_effects = getattr(facility, 'stat_effects', {}) or {}
+    return [item for item in stat_effects.get('unlocks', []) if isinstance(item, dict)]
+
+
+def _services_in_text(text: str) -> list[str]:
+    lowered = text.lower()
+    return sorted(service for service, phrases in SERVICE_PHRASES.items() if any(phrase in lowered for phrase in phrases))
+
+
+def _rule_caveats(text: str) -> list[str]:
+    lowered = text.lower()
+    caveats: list[str] = []
+    if ' at ' in lowered or ' non-' in lowered or ' or ' in lowered:
+        caveats.append('Catalogue unlock text contains port-type or facility-type qualifiers; Stage 4B models this conservatively.')
+    return caveats
+
+
+def _service_label(service: str) -> str:
+    if service == 'universal_cartographics':
+        return 'Universal Cartographics'
+    if service == 'vista_genomics':
+        return 'Vista Genomics'
+    return service.replace('_', ' ').title()
+
+
+def _placement_key(placement: Any) -> tuple[str, str, int]:
+    return (placement.facility_id, str(placement.local_body_id or 'system'), int(placement.build_order))
+
+
+def _graph_key(placement: Any) -> tuple[str, str, int]:
+    return (placement.facility_id, str(placement.local_body_id or 'system'), int(placement.build_order))
+
+
+def _resolved_key(placement: Any) -> tuple[str, str, int]:
+    return (
+        placement.facility.id,
+        str(placement.spec.local_body_id or 'system'),
+        int(placement.spec.build_order),
+    )
+
+
+def _port_key(port: Any) -> str:
+    return _port_key_from_id(port.facility_id, port.local_body_id)
+
+
+def _port_key_from_id(port_id: str, local_body_id: str | None) -> str:
+    return f'{local_body_id or "system"}::{port_id}'
+
+
+def port_service_states_to_dict(port_states: list[PortServiceState]) -> list[dict[str, Any]]:
+    return [state.to_dict() for state in port_states]
+
+
+def service_unlock_ledger_to_dict(ledger: list[ServiceUnlockEntry]) -> list[dict[str, Any]]:
+    return [entry.to_dict() for entry in ledger]

--- a/docs/colonisation-redesign/cp-sequence-repair.md
+++ b/docs/colonisation-redesign/cp-sequence-repair.md
@@ -27,10 +27,11 @@ The repair assistant uses only deterministic data that the simulator already has
 
 ## Suggestion Shape
 
-Each suggestion includes `type`, `severity`, `confidence`, `summary`, `reason`, `affected_steps`, `expected_effect`, `action`, and `caveats`. The shape is designed for UI display and mechanics trace output, not raw JSON dumping.
+Each suggestion includes `suggestion_id`, `type`, `severity`, `confidence`, `summary`, `reason`, `affected_steps`, `expected_effect`, a readable `action`, an optional structured `suggested_action`, and `caveats`. The shape is designed for UI display and mechanics trace output today, while staying structured enough for future “apply this repair” functionality. It is not intended for raw JSON dumping in the UI.
 
 | Field | Meaning |
 |---|---|
+| `suggestion_id` | Stable deterministic identifier such as `cp_negative_step_3` or `move_support_green_before_step_3`. |
 | `type` | Stable machine-readable suggestion type. |
 | `severity` | `critical`, `high`, `medium`, `low`, or `info`. |
 | `confidence` | Standard confidence label, currently `inferred` for deterministic repair heuristics. |
@@ -38,7 +39,8 @@ Each suggestion includes `type`, `severity`, `confidence`, `summary`, `reason`, 
 | `reason` | Why the suggestion was produced. |
 | `affected_steps` | Timeline steps most relevant to the suggestion. |
 | `expected_effect` | What the change is expected to improve. |
-| `action` | User-facing practical change. |
+| `action` | User-facing practical change retained for humans. |
+| `suggested_action` | Optional structured action payload for future automation or apply-repair workflows. |
 | `caveats` | Scope limits and assumptions. |
 
 ## Suggestion Types
@@ -47,7 +49,11 @@ Each suggestion includes `type`, `severity`, `confidence`, `summary`, `reason`, 
 |---|---|---|
 | `cp_negative_detected` | A timeline step ends with negative Yellow or Green CP. | `high` or `critical` |
 | `move_cp_generator_earlier` | A later support facility generates useful CP after a deficit has already occurred. | `high` |
-| `mark_primary_port` | A CP-negative step is a non-primary port that may be intended as the initial Main Port. | `high` |
+| `mark_primary_port` | No primary port is set and the earliest port appears before or at early CP pressure. | `high` |
+| `delay_expensive_port` | A paid port causes a deficit and no later CP generator is available to move earlier. | `high` |
+| `add_cp_generator` | A deficit remains and no specific move-earlier candidate is available. | `high` |
+| `reduce_paid_t2_t3_port_count` | Multiple paid T2/T3 ports create pressure during CP deficits. | `medium` |
+| `split_advanced_plan` | Several high/critical CP problems suggest the plan should be staged. | `medium` |
 | `port_escalation_pressure` | Existing CP timeline warnings or late T3 timing indicate port escalation pressure. | `medium` |
 | `sequence_is_valid_but_fragile` | The sequence ends non-negative but reaches zero/low-buffer balances or only becomes safely positive at the end. | `medium` |
 
@@ -59,13 +65,25 @@ Severity is intentionally simple. CP-negative steps are high priority, and large
 
 The assistant uses standard ED-Finder confidence labels only. Current repair suggestions use `inferred` because they are deterministic heuristics based on the timeline, not verified optimiser proofs. The assistant never emits non-standard labels such as `likely`, `guessed`, or `conditional`.
 
+## Structured Suggested Actions
+
+The readable `action` string remains the primary UI text. The nested `suggested_action` object adds stable fields such as `action_type`, `facility_template_id`, `facility_name`, `from_step`, `to_step`, `target_step`, `set_primary_port`, and `notes`. Action types are intentionally limited to `move_facility_earlier`, `mark_primary_port`, `delay_facility`, `add_cp_generator`, `review_sequence`, and `split_plan`.
+
+## Stable IDs and Output Caps
+
+Every suggestion has a deterministic `suggestion_id` so frontend cards and tests can track them without random UUIDs. The assistant also caps output to at most three suggestions for the same first affected problem step and six suggestions total. This keeps the repair assistant concise and prevents it from becoming a wall of advice.
+
 ## Primary-Port Exemption Caveats
 
-The primary-port suggestion is emitted only when the CP-negative step is a non-primary port. It is suppressed for already-primary ports. The suggestion text reminds the user that only the intended initial colony Main Port should receive the exemption.
+The primary-port suggestion is emitted when no primary port is marked, a port exists, and the earliest port appears before or at the first CP-negative or fragile pressure point. It is suppressed for already-primary builds and no-port builds. The suggestion text reminds the user that only the intended initial colony Main Port should receive the exemption.
 
 ## T3 Escalation Caveats
 
 T3/paid-port escalation suggestions rely on existing CP warnings and conservative timing rules. They recommend reviewing timing or primary-port designation, but they do not claim the suggested move is globally optimal.
+
+## Move-Earlier Caveats
+
+Move-earlier suggestions avoid claiming that support can always be built before step 1. The readable action uses cautious wording such as moving support as early as the sequence allows before the CP-negative paid port, and the structured action may still carry `to_step = 1` as the earliest simulated repair point. The caveat reminds the user not to move support before the initial colony anchor unless that is valid in-game.
 
 ## Fragile Sequence Detection
 

--- a/docs/colonisation-redesign/cp-sequence-repair.md
+++ b/docs/colonisation-redesign/cp-sequence-repair.md
@@ -1,0 +1,76 @@
+# CP Sequence Repair Assistant
+
+The CP sequence repair assistant is an additive Simulation Preview feature. It reads the existing CP timeline and emits small, conservative repair suggestions for the user’s current build order. It does **not** replace the CP simulator, it does **not** change `cp` or `cp_timeline`, and it does **not** attempt to find the globally optimal build order.
+
+## Purpose
+
+The existing CP timeline can show when a sequence goes CP-negative. The repair assistant adds a practical explanation layer so ED-Finder can say what small change would probably fix or reduce the problem. The intended product behaviour is: **“Here is the smallest practical change that would probably fix the CP problem — and here is how confident we are.”**
+
+| Output | Purpose |
+|---|---|
+| `cp_repair_suggestions` | Compact list of structured repair suggestions. |
+| `mechanics_trace.cp_repair_effects` | Trace entries explaining why repair suggestions were emitted. |
+| `cp` | Existing CP totals, unchanged. |
+| `cp_timeline` | Existing stepwise CP timeline, unchanged. |
+
+## Inputs Used
+
+The repair assistant uses only deterministic data that the simulator already has: resolved placements, facility CP generation, port tier, primary-port flag, build order, existing CP timeline balances, and existing CP warnings. It does not search all possible permutations.
+
+| Input | Use |
+|---|---|
+| Placement order | Determines which steps are affected and whether a later CP generator can be moved earlier. |
+| Facility CP generation | Identifies candidate support facilities for `move_cp_generator_earlier`. |
+| Port tier and primary flag | Identifies primary-port exemption and T3/paid-port pressure. |
+| CP timeline balances | Detects negative steps and fragile valid sequences. |
+| Existing CP warnings | Reuses T3 escalation warnings rather than introducing a separate escalation model. |
+
+## Suggestion Shape
+
+Each suggestion includes `type`, `severity`, `confidence`, `summary`, `reason`, `affected_steps`, `expected_effect`, `action`, and `caveats`. The shape is designed for UI display and mechanics trace output, not raw JSON dumping.
+
+| Field | Meaning |
+|---|---|
+| `type` | Stable machine-readable suggestion type. |
+| `severity` | `critical`, `high`, `medium`, `low`, or `info`. |
+| `confidence` | Standard confidence label, currently `inferred` for deterministic repair heuristics. |
+| `summary` | Short UI title. |
+| `reason` | Why the suggestion was produced. |
+| `affected_steps` | Timeline steps most relevant to the suggestion. |
+| `expected_effect` | What the change is expected to improve. |
+| `action` | User-facing practical change. |
+| `caveats` | Scope limits and assumptions. |
+
+## Suggestion Types
+
+| Type | When Emitted | Typical Severity |
+|---|---|---|
+| `cp_negative_detected` | A timeline step ends with negative Yellow or Green CP. | `high` or `critical` |
+| `move_cp_generator_earlier` | A later support facility generates useful CP after a deficit has already occurred. | `high` |
+| `mark_primary_port` | A CP-negative step is a non-primary port that may be intended as the initial Main Port. | `high` |
+| `port_escalation_pressure` | Existing CP timeline warnings or late T3 timing indicate port escalation pressure. | `medium` |
+| `sequence_is_valid_but_fragile` | The sequence ends non-negative but reaches zero/low-buffer balances or only becomes safely positive at the end. | `medium` |
+
+## Severity Model
+
+Severity is intentionally simple. CP-negative steps are high priority, and larger deficits are critical. T3 timing and fragile-but-valid sequences are medium priority because they may be worth improving but do not necessarily block the build.
+
+## Confidence Model
+
+The assistant uses standard ED-Finder confidence labels only. Current repair suggestions use `inferred` because they are deterministic heuristics based on the timeline, not verified optimiser proofs. The assistant never emits non-standard labels such as `likely`, `guessed`, or `conditional`.
+
+## Primary-Port Exemption Caveats
+
+The primary-port suggestion is emitted only when the CP-negative step is a non-primary port. It is suppressed for already-primary ports. The suggestion text reminds the user that only the intended initial colony Main Port should receive the exemption.
+
+## T3 Escalation Caveats
+
+T3/paid-port escalation suggestions rely on existing CP warnings and conservative timing rules. They recommend reviewing timing or primary-port designation, but they do not claim the suggested move is globally optimal.
+
+## Fragile Sequence Detection
+
+A valid sequence can still be fragile when it ends non-negative but has no useful CP buffer during the order. The assistant emits `sequence_is_valid_but_fragile` when balances reach zero or Green CP only becomes safely positive near the final step. This helps users avoid sequences that break easily when a build step moves.
+
+## Limitations and Future Optimiser Path
+
+This stage is a repair assistant, not a full optimiser. It does not search every build-order permutation, does not rank all possible repairs, and does not validate every downstream dependency after a proposed move. Future optimiser work can use these structured suggestions as explainability inputs once a full search strategy exists.

--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -58,14 +58,17 @@ Stage 4 begins with Stage 4A, an additive per-port economy propagation layer tha
 
 - Stage 4A per-Main-Port economy states.
 - Stage 4A influence ledger covering body inheritance, direct facility influence, strong links, weak links, pass-through effects, and converted ports.
-- System-level economy aggregation from port states while preserving existing response fields.
-- Simulation Preview Port Economy Breakdown and collapsed Influence Ledger display.
+- Stage 4B per-Main-Port service states.
+- Stage 4B service unlock ledger covering port defaults, system unlocks, strong-link unlocks, inferred locked requirements, and unknown rules.
+- System-level economy and service compatibility while preserving existing response fields.
+- Simulation Preview Port Economy Breakdown, Influence Ledger, Port Service Graph, and Service Unlock Ledger displays.
 - Recommended Build card summary for main-port economy and contamination source.
-- Mechanics trace events for port-state creation, top-two protection, major influence sources, weak-link contamination, and pass-through influence.
+- Mechanics trace events for port-state creation, top-two protection, major influence sources, weak-link contamination, pass-through influence, port-service-state creation, and service unlock decisions.
 
 Remaining Stage 4 work:
 
-- Service dependency graph.
+- Advanced service unlock qualifier validation.
+- Service-aware recommendation scoring after the graph is stable.
 - Advanced contamination modelling.
 - Converted-port confidence refinement.
 - Local-body cluster strategy.

--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -60,6 +60,7 @@ Stage 4 begins with Stage 4A, an additive per-port economy propagation layer tha
 - Stage 4A influence ledger covering body inheritance, direct facility influence, strong links, weak links, pass-through effects, and converted ports.
 - Stage 4B per-Main-Port service states.
 - Stage 4B service unlock ledger covering port defaults, system unlocks, strong-link unlocks, inferred locked requirements, and unknown rules.
+- CP sequence repair assistant that reads the existing CP timeline and emits small repair suggestions without changing CP totals or running a full optimiser.
 - System-level economy and service compatibility while preserving existing response fields.
 - Simulation Preview Port Economy Breakdown, Influence Ledger, Port Service Graph, and Service Unlock Ledger displays.
 - Recommended Build card summary for main-port economy and contamination source.
@@ -69,6 +70,7 @@ Remaining Stage 4 work:
 
 - Advanced service unlock qualifier validation.
 - Service-aware recommendation scoring after the graph is stable.
+- Full build-order optimiser that can search alternatives beyond local CP sequence repairs.
 - Advanced contamination modelling.
 - Converted-port confidence refinement.
 - Local-body cluster strategy.

--- a/docs/colonisation-redesign/service-dependency-graph.md
+++ b/docs/colonisation-redesign/service-dependency-graph.md
@@ -1,21 +1,36 @@
 # Stage 4B: Per-Port Service Dependency Graph and Service Unlock Ledger
 
-Stage 4B adds a per-port service explainability layer to ED-Finder’s deterministic Simulation Preview. It does not replace the existing system-level `services` field. Instead, it adds `port_service_states` and `service_unlock_ledger` so the application can explain which services are active, locked, or unknown at each Main Port.
+Stage 4B adds a conservative per-port service explainability layer to ED-Finder’s deterministic Simulation Preview. It does not replace the existing system-level `services` field. Instead, it adds `port_service_states` and `service_unlock_ledger` so the application can explain which services are active, locked, or unknown at each Main Port without making service unlocks appear more certain than the source data allows.
 
 ## Product Outcome
 
-Stage 4A explained why a port receives a particular economy stack. Stage 4B applies the same explainability principle to services. The preview can now say that a port has a service because it is a default Main Port service, because a facility documents a system unlock, or because a support facility strongly links to that port and documents a strong-link unlock.
+Stage 4A explained why a port receives a particular economy stack. Stage 4B applies the same explainability principle to services. The preview can now say that a port has a service because it is a default Main Port service, because a facility documents an unqualified system unlock, or because a support facility strongly links to that specific port and documents a strong-link unlock.
 
 | Output | Purpose |
 |---|---|
 | `port_service_states` | Per-Main-Port service state with active, locked, and unknown services. |
 | `service_unlock_ledger` | Flat ledger of every service decision, including source, target, status, unlock type, link type, confidence, reason, requirements, and caveats. |
-| `services` | Existing backward-compatible system-level service state, preserved unchanged. |
+| `services` | Existing backward-compatible legacy/system-level service state, preserved for existing clients. |
 | `mechanics_trace` | Adds port service and service unlock ledger trace categories. |
+
+## Conservative Unlock Model
+
+The Stage 4B service graph is intentionally cautious. It is better for ED-Finder to say **unknown** or **locked with a qualifier caveat** than to say **active** when a service rule is conditional and the target port cannot be proven to satisfy that condition.
+
+| Rule Type | Classification |
+|---|---|
+| Fully unqualified system unlock | Active system-wide in the per-port graph. |
+| Qualified system unlock and target clearly matches | Active at the matching port only. |
+| Qualified system unlock and target clearly does not match | Locked with a requirement explaining the qualifier. |
+| Qualified system unlock and target cannot be confidently evaluated | Unknown with a caveat. |
+| Strong-link unlock | Active only at the Main Port reached by the matching strong link. |
+| Weak-link target of a strong-link source | Not active from the weak link. |
+| Pass-through path | Unknown/caveated unless a verified service pass-through rule is later added. |
+| Converted-port source/path | Inferred/caveated and should be verified in-game. |
 
 ## PortServiceState
 
-A `PortServiceState` represents service availability for one Main Port selected by the topology graph. It includes the port identity, local body, location type, topology role, active services, locked services, unknown services, all service decision entries, warnings, and recommendations.
+A `PortServiceState` represents service availability for one Main Port selected by the topology graph. It includes the port identity, local body, location type, topology role, port tier, active services, locked services, unknown services, all service decision entries, warnings, and recommendations.
 
 | Service Bucket | Meaning |
 |---|---|
@@ -32,36 +47,33 @@ Every service decision is represented as a `ServiceUnlockEntry`. The ledger is i
 | `service`, `status` | The service identifier and whether it is `active`, `locked`, or `unknown`. |
 | `source_id`, `source_name`, `source_type` | The facility or port that caused the decision, when known. |
 | `target_port_id`, `target_port_name`, `local_body_id` | The Main Port receiving the service state. |
-| `unlock_type`, `link_type` | Whether the decision came from a port default, system unlock, strong-link unlock, local-body unlock, inferred unlock, or unknown rule. |
+| `unlock_type`, `link_type` | Whether the decision came from a port default, system unlock, strong-link unlock, local-body unlock, inferred unlock, pass-through caveat, or unknown rule. |
 | `confidence`, `reason`, `requirements`, `caveats` | Explainability metadata for the rule and any missing requirements. |
 
-## Unlock Types
+## Strong-Link Matching
 
-The service graph recognises the documented unlock text already present in the facility catalogue. `Strong Link Unlock` entries require an actual strong link to the target Main Port before becoming active. Other documented unlocks are treated as conservative system unlocks while preserving caveats for port-type or facility-type qualifiers.
+Strong-link service unlocks are placement-specific. The graph matches a service-unlocking placement against strong links using the source facility id and the source local body, so repeated uses of the same facility template on different bodies do not collapse into one service source. A Relay Station on Body 1 unlocks services for the Body 1 Main Port, while another Relay Station on Body 2 unlocks services for the Body 2 Main Port.
 
-| Unlock Type | Link Type | Stage 4B Behaviour |
-|---|---|---|
-| `port_default` | `none` | Commodity Market is treated as a conservative default Main Port service. |
-| `system_unlock` | `system` | A placed facility with documented system unlock text activates the service in the per-port graph. |
-| `strong_link_unlock` | `strong` | A placed support facility must strongly link to the Main Port before the service is active there. |
-| `local_body_unlock` | `none` | Reserved for future rules where catalogue data supports local-body-only service availability. |
-| `inferred_unlock` | `none` | Used for locked recommendations inferred from documented catalogue unlock text when no active source satisfies the requirement. |
-| `unknown_rule` | `null` | Used when ED-Finder cannot verify the service behaviour for this build. |
+Weak links do not satisfy strong-link service unlocks. If a support facility strongly links to one Main Port and weak-links to another, the strong-linked port may receive the service, while the weak-linked target remains locked or unknown.
+
+## Qualified System Unlocks
+
+Catalogue text with qualifiers is not globally activated. Qualifiers include text such as `at T1 surface ports`, `at non-Military Outposts`, `at Pirate Outposts`, `at Scientific Outposts`, `at Military Outposts`, economy-type restrictions, location restrictions, and other conditional phrases. Stage 4B currently supports only simple deterministic matches such as T1 surface and T2 orbital. Outpost/faction/economy qualifiers remain unknown unless later data makes them deterministic.
 
 ## Confidence Labels
 
-The service graph uses the standard ED-Finder confidence vocabulary. Documented catalogue unlock decisions use `community_observed`, inferred locked recommendations use `inferred`, and unknown service rules use `unknown`. No non-standard confidence labels are introduced.
+The service graph uses the standard ED-Finder confidence vocabulary. Documented catalogue unlock decisions use `community_observed`, inferred locked recommendations use `inferred`, converted-port service behaviour may use `inferred`, and unknown/pass-through service behaviour uses `unknown`. No non-standard confidence labels are introduced.
 
 | Confidence | Usage |
 |---|---|
-| `community_observed` | Documented catalogue service unlock text, including strong-link and system unlocks. |
-| `inferred` | Conservative default services and locked recommendations derived from known service families. |
-| `unknown` | Services without enough verified rule data for the current port/facility combination. |
+| `community_observed` | Documented catalogue service unlock text where the target condition is satisfied. |
+| `inferred` | Conservative default services, locked recommendations, and converted-port service entries that need in-game verification. |
+| `unknown` | Services without enough verified rule data, including unverified pass-through behaviour and unresolved qualifiers. |
 
 ## Backward Compatibility
 
-Existing API fields remain in place. The original `services` object is still returned and continues to represent system-level service modelling. Stage 4B adds the per-port graph beside that output, which lets older consumers continue working while newer UI components display more detailed service explanations.
+Existing API fields remain in place. The original `services` object is still returned and continues to represent the legacy/system-level service summary. The per-port `port_service_states` and `service_unlock_ledger` fields are the preferred explainability source for new UI because they include target ports, unlock paths, caveats, and requirements.
 
 ## Limitations and Future Improvements
 
-Stage 4B is not a full optimiser and does not add service-aware ranking. Some catalogue unlock descriptions contain qualifiers such as port type, settlement type, or economy type. Where those qualifiers cannot yet be fully resolved from deterministic data, the ledger marks the rule with caveats and uses conservative language. Future work can refine port-type matching, validate service unlocks from more observed builds, and add service-aware recommendation scoring after the graph is stable.
+Stage 4B is not a full optimiser and does not add service-aware ranking. Some catalogue unlock descriptions contain qualifiers such as port type, settlement type, economy type, or outpost family. Where those qualifiers cannot yet be fully resolved from deterministic data, the ledger marks the rule with caveats and uses conservative unknown or locked states. Future work can refine port-type matching, validate service pass-through and converted-port service behaviour from more observed builds, and add service-aware recommendation scoring after the graph is stable.

--- a/docs/colonisation-redesign/service-dependency-graph.md
+++ b/docs/colonisation-redesign/service-dependency-graph.md
@@ -1,0 +1,67 @@
+# Stage 4B: Per-Port Service Dependency Graph and Service Unlock Ledger
+
+Stage 4B adds a per-port service explainability layer to ED-Finder’s deterministic Simulation Preview. It does not replace the existing system-level `services` field. Instead, it adds `port_service_states` and `service_unlock_ledger` so the application can explain which services are active, locked, or unknown at each Main Port.
+
+## Product Outcome
+
+Stage 4A explained why a port receives a particular economy stack. Stage 4B applies the same explainability principle to services. The preview can now say that a port has a service because it is a default Main Port service, because a facility documents a system unlock, or because a support facility strongly links to that port and documents a strong-link unlock.
+
+| Output | Purpose |
+|---|---|
+| `port_service_states` | Per-Main-Port service state with active, locked, and unknown services. |
+| `service_unlock_ledger` | Flat ledger of every service decision, including source, target, status, unlock type, link type, confidence, reason, requirements, and caveats. |
+| `services` | Existing backward-compatible system-level service state, preserved unchanged. |
+| `mechanics_trace` | Adds port service and service unlock ledger trace categories. |
+
+## PortServiceState
+
+A `PortServiceState` represents service availability for one Main Port selected by the topology graph. It includes the port identity, local body, location type, topology role, active services, locked services, unknown services, all service decision entries, warnings, and recommendations.
+
+| Service Bucket | Meaning |
+|---|---|
+| `active_services` | Services currently modelled as available at the target Main Port. |
+| `locked_services` | Services with a documented or inferred requirement that is not currently satisfied. |
+| `unknown_services` | Services where ED-Finder does not have enough verified rule data to claim active or locked. |
+
+## ServiceUnlockEntry
+
+Every service decision is represented as a `ServiceUnlockEntry`. The ledger is intentionally explicit so the UI can display readable explanations instead of raw JSON or opaque service labels.
+
+| Field | Meaning |
+|---|---|
+| `service`, `status` | The service identifier and whether it is `active`, `locked`, or `unknown`. |
+| `source_id`, `source_name`, `source_type` | The facility or port that caused the decision, when known. |
+| `target_port_id`, `target_port_name`, `local_body_id` | The Main Port receiving the service state. |
+| `unlock_type`, `link_type` | Whether the decision came from a port default, system unlock, strong-link unlock, local-body unlock, inferred unlock, or unknown rule. |
+| `confidence`, `reason`, `requirements`, `caveats` | Explainability metadata for the rule and any missing requirements. |
+
+## Unlock Types
+
+The service graph recognises the documented unlock text already present in the facility catalogue. `Strong Link Unlock` entries require an actual strong link to the target Main Port before becoming active. Other documented unlocks are treated as conservative system unlocks while preserving caveats for port-type or facility-type qualifiers.
+
+| Unlock Type | Link Type | Stage 4B Behaviour |
+|---|---|---|
+| `port_default` | `none` | Commodity Market is treated as a conservative default Main Port service. |
+| `system_unlock` | `system` | A placed facility with documented system unlock text activates the service in the per-port graph. |
+| `strong_link_unlock` | `strong` | A placed support facility must strongly link to the Main Port before the service is active there. |
+| `local_body_unlock` | `none` | Reserved for future rules where catalogue data supports local-body-only service availability. |
+| `inferred_unlock` | `none` | Used for locked recommendations inferred from documented catalogue unlock text when no active source satisfies the requirement. |
+| `unknown_rule` | `null` | Used when ED-Finder cannot verify the service behaviour for this build. |
+
+## Confidence Labels
+
+The service graph uses the standard ED-Finder confidence vocabulary. Documented catalogue unlock decisions use `community_observed`, inferred locked recommendations use `inferred`, and unknown service rules use `unknown`. No non-standard confidence labels are introduced.
+
+| Confidence | Usage |
+|---|---|
+| `community_observed` | Documented catalogue service unlock text, including strong-link and system unlocks. |
+| `inferred` | Conservative default services and locked recommendations derived from known service families. |
+| `unknown` | Services without enough verified rule data for the current port/facility combination. |
+
+## Backward Compatibility
+
+Existing API fields remain in place. The original `services` object is still returned and continues to represent system-level service modelling. Stage 4B adds the per-port graph beside that output, which lets older consumers continue working while newer UI components display more detailed service explanations.
+
+## Limitations and Future Improvements
+
+Stage 4B is not a full optimiser and does not add service-aware ranking. Some catalogue unlock descriptions contain qualifiers such as port type, settlement type, or economy type. Where those qualifiers cannot yet be fully resolved from deterministic data, the ledger marks the rule with caveats and uses conservative language. Future work can refine port-type matching, validate service unlocks from more observed builds, and add service-aware recommendation scoring after the graph is stable.

--- a/docs/colonisation-redesign/stage-2-topology-economy.md
+++ b/docs/colonisation-redesign/stage-2-topology-economy.md
@@ -138,7 +138,7 @@ The key architectural change is that the simulation now builds an influence ledg
 | Converted ports are surfaced as caveated topology entries. | Converted-port influence appears in the ledger with caveats. |
 | System-level service modelling reports active, locked, or unknown service states. | Stage 4B adds per-port service states and a service unlock ledger while preserving the existing `services` field. |
 
-This layer remains deterministic and explanatory. It does not optimise builds and does not add unsupported mechanics beyond the already documented inferred rules.
+This layer remains deterministic and explanatory. It does not optimise builds and does not add unsupported mechanics beyond the already documented inferred rules. The CP sequence repair assistant follows the same rule: it suggests small repairs to the current order while preserving the existing CP timeline and avoiding a full optimiser claim.
 
 ## Stage 4B Additive Layer: Per-Port Service Dependency Graph
 

--- a/docs/colonisation-redesign/stage-2-topology-economy.md
+++ b/docs/colonisation-redesign/stage-2-topology-economy.md
@@ -136,8 +136,15 @@ The key architectural change is that the simulation now builds an influence ledg
 | Economy stack reports system-level percentages. | Each Main Port reports its own stack and contamination sources. |
 | Mechanics trace explains broad economy/link effects. | Mechanics trace also records port-state creation, top-two protection, major influences, weak-link contamination, and pass-through influence. |
 | Converted ports are surfaced as caveated topology entries. | Converted-port influence appears in the ledger with caveats. |
+| System-level service modelling reports active, locked, or unknown service states. | Stage 4B adds per-port service states and a service unlock ledger while preserving the existing `services` field. |
 
 This layer remains deterministic and explanatory. It does not optimise builds and does not add unsupported mechanics beyond the already documented inferred rules.
+
+## Stage 4B Additive Layer: Per-Port Service Dependency Graph
+
+Stage 4B extends the same explainability pattern to services. The existing `services` response remains a backward-compatible system-level summary. The new `port_service_states` and `service_unlock_ledger` fields explain, per Main Port, which services are active, locked, or unknown; which facility or port caused each decision; whether the decision came from a port default, system unlock, strong-link unlock, inferred requirement, or unknown rule; and what is missing when a service is locked.
+
+Strong-link service unlocks require an actual strong link to the target Main Port. System unlock text remains conservative and caveated where catalogue descriptions include unresolved port-type or facility-type qualifiers. Unknown service behaviour remains labelled `unknown` rather than treated as false.
 
 ## Limitations And Future Work
 

--- a/docs/colonisation-redesign/stage-2-topology-economy.md
+++ b/docs/colonisation-redesign/stage-2-topology-economy.md
@@ -142,9 +142,9 @@ This layer remains deterministic and explanatory. It does not optimise builds an
 
 ## Stage 4B Additive Layer: Per-Port Service Dependency Graph
 
-Stage 4B extends the same explainability pattern to services. The existing `services` response remains a backward-compatible system-level summary. The new `port_service_states` and `service_unlock_ledger` fields explain, per Main Port, which services are active, locked, or unknown; which facility or port caused each decision; whether the decision came from a port default, system unlock, strong-link unlock, inferred requirement, or unknown rule; and what is missing when a service is locked.
+Stage 4B extends the same explainability pattern to services. The existing `services` response remains a backward-compatible legacy/system-level summary. The new `port_service_states` and `service_unlock_ledger` fields explain, per Main Port, which services are active, locked, or unknown; which facility or port caused each decision; whether the decision came from a port default, system unlock, strong-link unlock, inferred requirement, pass-through caveat, converted-port caveat, or unknown rule; and what is missing when a service is locked.
 
-Strong-link service unlocks require an actual strong link to the target Main Port. System unlock text remains conservative and caveated where catalogue descriptions include unresolved port-type or facility-type qualifiers. Unknown service behaviour remains labelled `unknown` rather than treated as false.
+Strong-link service unlocks require an actual placement-specific strong link to the target Main Port. Weak links do not unlock strong-link services. Qualified system unlock text is not globally activated: simple deterministic qualifiers such as T1 surface or T2 orbital can be evaluated, while unresolved outpost/economy/faction-style qualifiers are marked unknown or locked with caveats. Pass-through service unlock behaviour is not assumed from economy pass-through, and converted-port service behaviour remains caveated. Unknown service behaviour remains labelled `unknown` rather than treated as false.
 
 ## Limitations And Future Work
 

--- a/frontend-v2/src/features/system-detail/CpRepairPanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/CpRepairPanel.test.tsx
@@ -6,6 +6,7 @@ import type { SimulateBuildResponse } from '@/types/api';
 describe('CpRepairPanel', () => {
   it('renders a high-priority CP repair suggestion without raw JSON', () => {
     const suggestions: SimulateBuildResponse['cp_repair_suggestions'] = [{
+      suggestion_id: 'move_refinery_hub_before_step_3',
       type: 'move_cp_generator_earlier',
       severity: 'high',
       summary: 'Move Refinery Hub before Ocellus Starport',
@@ -13,6 +14,14 @@ describe('CpRepairPanel', () => {
       affected_steps: [3, 5],
       expected_effect: 'Generating CP before the expensive port should reduce the temporary deficit.',
       action: 'Move Refinery Hub from step 5 to step 2.',
+      suggested_action: {
+        action_type: 'move_facility_earlier',
+        facility_template_id: 'refinery_hub',
+        facility_name: 'Refinery Hub',
+        from_step: 5,
+        to_step: 2,
+        notes: ['Do not move support before the initial colony anchor unless valid.'],
+      },
       confidence: 'inferred',
       caveats: ['This is a local repair suggestion, not a full optimiser result.'],
     }];
@@ -24,6 +33,7 @@ describe('CpRepairPanel', () => {
     expect(screen.getByText('High priority')).toBeTruthy();
     expect(screen.getByText(/Yellow CP goes negative/)).toBeTruthy();
     expect(screen.queryByText(/"type"/)).toBeNull();
+    expect(screen.getByText(/Action type:/)).toBeTruthy();
   });
 
   it('renders nothing for an empty suggestion list', () => {

--- a/frontend-v2/src/features/system-detail/CpRepairPanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/CpRepairPanel.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CpRepairPanel } from './SimulationPreview';
+import type { SimulateBuildResponse } from '@/types/api';
+
+describe('CpRepairPanel', () => {
+  it('renders a high-priority CP repair suggestion without raw JSON', () => {
+    const suggestions: SimulateBuildResponse['cp_repair_suggestions'] = [{
+      type: 'move_cp_generator_earlier',
+      severity: 'high',
+      summary: 'Move Refinery Hub before Ocellus Starport',
+      reason: 'Yellow CP goes negative at step 3.',
+      affected_steps: [3, 5],
+      expected_effect: 'Generating CP before the expensive port should reduce the temporary deficit.',
+      action: 'Move Refinery Hub from step 5 to step 2.',
+      confidence: 'inferred',
+      caveats: ['This is a local repair suggestion, not a full optimiser result.'],
+    }];
+
+    render(<CpRepairPanel suggestions={suggestions} />);
+
+    expect(screen.getByText('CP Repair Suggestions')).toBeTruthy();
+    expect(screen.getByText('Move Refinery Hub before Ocellus Starport')).toBeTruthy();
+    expect(screen.getByText('High priority')).toBeTruthy();
+    expect(screen.getByText(/Yellow CP goes negative/)).toBeTruthy();
+    expect(screen.queryByText(/"type"/)).toBeNull();
+  });
+
+  it('renders nothing for an empty suggestion list', () => {
+    const { container } = render(<CpRepairPanel suggestions={[]} />);
+    expect(container.textContent).toBe('');
+  });
+});

--- a/frontend-v2/src/features/system-detail/DataConfidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/DataConfidencePanel.test.tsx
@@ -25,6 +25,7 @@ function result(): SimulateBuildResponse {
       warnings: [],
     },
     cp_timeline: [],
+    cp_repair_suggestions: [],
     economy_composition: {},
     economy_order: [],
     economy_stack: {},

--- a/frontend-v2/src/features/system-detail/DataConfidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/DataConfidencePanel.test.tsx
@@ -33,6 +33,8 @@ function result(): SimulateBuildResponse {
     inherited_economies: [],
     topology: {},
     services: {},
+    port_service_states: [],
+    service_unlock_ledger: [],
     data_quality: {
       slots: 'estimated',
       facility_catalogue: 'community_observed',

--- a/frontend-v2/src/features/system-detail/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreview.tsx
@@ -1167,11 +1167,21 @@ export function CpRepairPanel({ suggestions }: { suggestions: SimulateBuildRespo
               {suggestion.affected_steps.length > 0 && <div><span className="text-silver">Affected steps:</span> {suggestion.affected_steps.join(', ')}</div>}
               <div><span className="text-silver">Confidence:</span> {titleCase(suggestion.confidence)}</div>
             </div>
-            {suggestion.caveats.length > 0 && (
+            {(suggestion.caveats.length > 0 || suggestion.suggested_action) && (
               <details className="mt-2 rounded border border-border/50 bg-bg2/45 px-2 py-1">
-                <summary className="cursor-pointer font-mono text-[10px] text-gold">Caveats</summary>
+                <summary className="cursor-pointer font-mono text-[10px] text-gold">Caveats and structured action</summary>
                 <div className="mt-1 space-y-1 font-mono text-[10px] leading-snug text-silver-dk">
                   {suggestion.caveats.map((caveat) => <div key={caveat}>{caveat}</div>)}
+                  {suggestion.suggested_action && (
+                    <div>
+                      <span className="text-silver">Action type:</span> {titleCase(suggestion.suggested_action.action_type)}
+                      {suggestion.suggested_action.facility_name && <span> · {suggestion.suggested_action.facility_name}</span>}
+                      {suggestion.suggested_action.from_step != null && <span> · from step {suggestion.suggested_action.from_step}</span>}
+                      {suggestion.suggested_action.to_step != null && <span> · to step {suggestion.suggested_action.to_step}</span>}
+                      {suggestion.suggested_action.target_step != null && <span> · target step {suggestion.suggested_action.target_step}</span>}
+                    </div>
+                  )}
+                  {suggestion.suggested_action?.notes.map((note) => <div key={note}>{note}</div>)}
                 </div>
               </details>
             )}

--- a/frontend-v2/src/features/system-detail/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreview.tsx
@@ -992,6 +992,9 @@ function PortServicePanel({
                 <div className="mt-1 font-mono text-[10px] leading-snug text-silver-dk">
                   <span className="text-silver">{titleCase(entry.confidence)}:</span> {entry.reason}
                 </div>
+                {entry.caveats.slice(0, 1).map((caveat) => (
+                  <div key={caveat} className="mt-1 font-mono text-[10px] leading-snug text-gold">{caveat}</div>
+                ))}
               </div>
             ))}
           </div>
@@ -1021,6 +1024,7 @@ function ServiceEntryGroup({
           {entry.source_name && <span> · {entry.source_name}</span>}
           <span> · {titleCase(entry.unlock_type)}</span>
           {entry.requirements.length > 0 && <div className="mt-0.5 text-gold">{entry.requirements[0]}</div>}
+          {entry.caveats.length > 0 && <div className="mt-0.5 text-gold">{entry.caveats[0]}</div>}
         </div>
       ))}
     </div>

--- a/frontend-v2/src/features/system-detail/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreview.tsx
@@ -575,6 +575,7 @@ function SimulationResult({ result }: { result: SimulateBuildResponse }) {
       <CpSummary cp={result.cp} />
       <CpTimelinePanel timeline={result.cp_timeline} />
       <ServicesPanel services={result.services} />
+      <PortServicePanel states={result.port_service_states} ledger={result.service_unlock_ledger} />
 
       <div className="grid gap-2">
         {result.strengths.length > 0 && <Message title="Why this works" tone="good" items={result.strengths} />}
@@ -919,6 +920,109 @@ function ServicesPanel({ services }: { services: SimulateBuildResponse['services
           </div>
         ))}
       </div>
+    </div>
+  );
+}
+
+function PortServicePanel({
+  states,
+  ledger,
+}: {
+  states: SimulateBuildResponse['port_service_states'];
+  ledger: SimulateBuildResponse['service_unlock_ledger'];
+}) {
+  if ((!states || states.length === 0) && (!ledger || ledger.length === 0)) return null;
+  return (
+    <div className="rounded-chunk-lg border border-green/25 bg-green/5 p-3">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-green">
+        Port Service Graph
+      </div>
+      {states && states.length > 0 ? (
+        <div className="space-y-3">
+          {states.map((state) => {
+            const active = Object.values(state.active_services ?? {});
+            const locked = Object.values(state.locked_services ?? {});
+            const unknown = Object.values(state.unknown_services ?? {});
+            return (
+              <div key={`${state.local_body_id ?? 'system'}-${state.port_id}`} className="rounded border border-border/60 bg-bg3/45 px-2 py-2">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <div className="font-mono text-[11px] text-silver">{state.port_name}</div>
+                    <div className="mt-0.5 font-mono text-[10px] text-silver-dk">
+                      {state.body_name || (state.local_body_id ? `Body ${state.local_body_id}` : 'System-wide')} · {titleCase(state.location_type)} · {titleCase(state.effective_role)}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap justify-end gap-1.5 font-mono text-[10px]">
+                    <Chip tone="good">{active.length} active</Chip>
+                    <Chip tone={locked.length > 0 ? 'warn' : 'default'}>{locked.length} locked</Chip>
+                    <Chip>{unknown.length} unknown</Chip>
+                  </div>
+                </div>
+                <ServiceEntryGroup title="Active services" entries={active.slice(0, 4)} tone="good" />
+                <ServiceEntryGroup title="Locked services" entries={locked.slice(0, 4)} tone="warn" />
+                <ServiceEntryGroup title="Unknown" entries={unknown.slice(0, 3)} tone="default" />
+                {[...(state.warnings ?? []), ...(state.recommendations ?? [])].slice(0, 2).map((item) => (
+                  <div key={item} className="mt-2 rounded border border-gold/30 bg-gold/5 px-2 py-1 font-mono text-[10px] leading-snug text-gold">
+                    {item}
+                  </div>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded border border-border/60 bg-bg3/45 px-2 py-2 font-mono text-[10px] text-silver-dk">
+          No Main Ports are present yet, so there are no per-port service states.
+        </div>
+      )}
+      {ledger && ledger.length > 0 && (
+        <details className="mt-3 rounded border border-border/60 bg-bg2/55 px-2 py-2">
+          <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-silver">
+            Service Unlock Ledger
+          </summary>
+          <div className="mt-2 space-y-1.5">
+            {ledger.slice(0, 14).map((entry) => (
+              <div key={`${entry.target_port_id}-${entry.service}-${entry.status}-${entry.unlock_type}-${entry.source_id ?? 'none'}`} className="rounded border border-border/50 bg-bg3/45 px-2 py-1.5">
+                <div className="grid gap-1 font-mono text-[10px] text-silver-dk sm:grid-cols-[92px_72px_minmax(0,1fr)_minmax(0,1fr)]">
+                  <span className={serviceTone(entry.status)}>{titleCase(entry.status)}</span>
+                  <span>{titleCase(entry.unlock_type)}</span>
+                  <span className="truncate"><span className="text-silver">Service:</span> {titleCase(entry.service)}</span>
+                  <span className="truncate"><span className="text-silver">Target:</span> {entry.target_port_name}</span>
+                </div>
+                <div className="mt-1 font-mono text-[10px] leading-snug text-silver-dk">
+                  <span className="text-silver">{titleCase(entry.confidence)}:</span> {entry.reason}
+                </div>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function ServiceEntryGroup({
+  title,
+  entries,
+  tone,
+}: {
+  title: string;
+  entries: SimulateBuildResponse['service_unlock_ledger'];
+  tone: 'good' | 'warn' | 'default';
+}) {
+  if (!entries || entries.length === 0) return null;
+  const titleClass = tone === 'good' ? 'text-green' : tone === 'warn' ? 'text-gold' : 'text-silver-dk';
+  return (
+    <div className="mt-2 space-y-1">
+      <div className={`font-mono text-[9px] uppercase tracking-[0.14em] ${titleClass}`}>{title}</div>
+      {entries.map((entry) => (
+        <div key={`${entry.service}-${entry.status}-${entry.source_id ?? 'none'}`} className="rounded border border-border/50 bg-bg2/45 px-2 py-1 font-mono text-[10px] text-silver-dk">
+          <span className="text-silver">{titleCase(entry.service)}</span>
+          {entry.source_name && <span> · {entry.source_name}</span>}
+          <span> · {titleCase(entry.unlock_type)}</span>
+          {entry.requirements.length > 0 && <div className="mt-0.5 text-gold">{entry.requirements[0]}</div>}
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend-v2/src/features/system-detail/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreview.tsx
@@ -573,6 +573,7 @@ function SimulationResult({ result }: { result: SimulateBuildResponse }) {
       <InheritedEconomyPanel profiles={result.inherited_economies} />
       <TopologyPanel topology={result.topology} />
       <CpSummary cp={result.cp} />
+      <CpRepairPanel suggestions={result.cp_repair_suggestions} />
       <CpTimelinePanel timeline={result.cp_timeline} />
       <ServicesPanel services={result.services} />
       <PortServicePanel states={result.port_service_states} ledger={result.service_unlock_ledger} />
@@ -1139,6 +1140,52 @@ function CpSummary({ cp }: { cp: SimulateBuildResponse['cp'] }) {
       )}
     </div>
   );
+}
+
+export function CpRepairPanel({ suggestions }: { suggestions: SimulateBuildResponse['cp_repair_suggestions'] }) {
+  if (!suggestions || suggestions.length === 0) return null;
+  const order: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  const sorted = [...suggestions].sort((a, b) => (order[a.severity] ?? 99) - (order[b.severity] ?? 99));
+  return (
+    <div className="rounded-chunk-lg border border-gold/35 bg-gold/5 p-3">
+      <div className="mb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-gold">
+        CP Repair Suggestions
+      </div>
+      <div className="space-y-2">
+        {sorted.slice(0, 3).map((suggestion) => (
+          <div key={`${suggestion.type}-${suggestion.summary}-${suggestion.affected_steps.join('-')}`} className="rounded border border-border/60 bg-bg3/45 px-2 py-2">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="font-mono text-[11px] text-silver">{suggestion.summary}</div>
+                <div className="mt-1 font-mono text-[10px] leading-snug text-silver-dk">{suggestion.reason}</div>
+              </div>
+              <Chip tone={repairSeverityTone(suggestion.severity)}>{titleCase(suggestion.severity)} priority</Chip>
+            </div>
+            <div className="mt-2 grid gap-1.5 font-mono text-[10px] text-silver-dk sm:grid-cols-2">
+              <div><span className="text-silver">Expected effect:</span> {suggestion.expected_effect}</div>
+              <div><span className="text-silver">Action:</span> {suggestion.action}</div>
+              {suggestion.affected_steps.length > 0 && <div><span className="text-silver">Affected steps:</span> {suggestion.affected_steps.join(', ')}</div>}
+              <div><span className="text-silver">Confidence:</span> {titleCase(suggestion.confidence)}</div>
+            </div>
+            {suggestion.caveats.length > 0 && (
+              <details className="mt-2 rounded border border-border/50 bg-bg2/45 px-2 py-1">
+                <summary className="cursor-pointer font-mono text-[10px] text-gold">Caveats</summary>
+                <div className="mt-1 space-y-1 font-mono text-[10px] leading-snug text-silver-dk">
+                  {suggestion.caveats.map((caveat) => <div key={caveat}>{caveat}</div>)}
+                </div>
+              </details>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function repairSeverityTone(severity: string): 'good' | 'warn' | 'default' {
+  if (severity === 'critical' || severity === 'high' || severity === 'medium') return 'warn';
+  if (severity === 'low') return 'good';
+  return 'default';
 }
 
 function LinkSummary({ result }: { result: SimulateBuildResponse }) {

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -2197,6 +2197,8 @@ export interface components {
             cp: components["schemas"]["SimulationCPResult"];
             /** Cp Timeline */
             cp_timeline?: Record<string, never>[];
+            /** Cp Repair Suggestions */
+            cp_repair_suggestions?: Record<string, never>[];
             /** Economy Composition */
             economy_composition?: {
                 [key: string]: number;

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -2215,6 +2215,10 @@ export interface components {
             topology?: Record<string, never>;
             /** Services */
             services?: Record<string, never>;
+            /** Port Service States */
+            port_service_states?: Record<string, never>[];
+            /** Service Unlock Ledger */
+            service_unlock_ledger?: Record<string, never>[];
             /** Data Quality */
             data_quality?: {
                 [key: string]: string;

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -110,7 +110,19 @@ export interface SimulationCPResult {
   warnings: string[];
 }
 
+export interface CPRepairAction {
+  action_type: string;
+  facility_template_id?: string | null;
+  facility_name?: string | null;
+  from_step?: number | null;
+  to_step?: number | null;
+  target_step?: number | null;
+  set_primary_port?: boolean | null;
+  notes: string[];
+}
+
 export interface CPRepairSuggestion {
+  suggestion_id: string;
   type: string;
   severity: 'critical' | 'high' | 'medium' | 'low' | 'info' | string;
   summary: string;
@@ -118,6 +130,7 @@ export interface CPRepairSuggestion {
   affected_steps: number[];
   expected_effect: string;
   action: string;
+  suggested_action?: CPRepairAction | null;
   confidence: string;
   caveats: string[];
 }

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -110,6 +110,18 @@ export interface SimulationCPResult {
   warnings: string[];
 }
 
+export interface CPRepairSuggestion {
+  type: string;
+  severity: 'critical' | 'high' | 'medium' | 'low' | 'info' | string;
+  summary: string;
+  reason: string;
+  affected_steps: number[];
+  expected_effect: string;
+  action: string;
+  confidence: string;
+  caveats: string[];
+}
+
 export interface SimulationTimelineStep {
   step: number;
   facility_template_id: string;
@@ -236,6 +248,7 @@ export interface SimulateBuildResponse {
   confidence: number;
   cp: SimulationCPResult;
   cp_timeline: SimulationTimelineStep[];
+  cp_repair_suggestions: CPRepairSuggestion[];
   economy_composition: Record<string, number>;
   economy_order: string[];
   economy_stack: Record<string, unknown>;

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -181,6 +181,38 @@ export interface PortEconomyState {
   recommendations: string[];
 }
 
+export interface ServiceUnlockEntry {
+  service: string;
+  status: 'active' | 'locked' | 'unknown' | string;
+  source_id?: string | null;
+  source_name?: string | null;
+  source_type?: string | null;
+  target_port_id: string;
+  target_port_name: string;
+  local_body_id?: string | null;
+  unlock_type: string;
+  link_type?: string | null;
+  confidence: string;
+  reason: string;
+  requirements: string[];
+  caveats: string[];
+}
+
+export interface PortServiceState {
+  port_id: string;
+  port_name: string;
+  local_body_id?: string | null;
+  body_name?: string | null;
+  location_type: string;
+  effective_role: string;
+  active_services: Record<string, ServiceUnlockEntry>;
+  locked_services: Record<string, ServiceUnlockEntry>;
+  unknown_services: Record<string, ServiceUnlockEntry>;
+  service_sources: ServiceUnlockEntry[];
+  warnings: string[];
+  recommendations: string[];
+}
+
 export interface SimulationInheritedEconomy {
   source_body_id?: string | null;
   source_body_name?: string | null;
@@ -212,6 +244,8 @@ export interface SimulateBuildResponse {
   inherited_economies: SimulationInheritedEconomy[];
   topology: Record<string, unknown>;
   services: Record<string, { status: string; reason: string; requirements: string[] }>;
+  port_service_states: PortServiceState[];
+  service_unlock_ledger: ServiceUnlockEntry[];
   data_quality: Record<string, string>;
   confidence_signals: Array<{ area: string; level: string; reason: string; impact?: number | null }>;
   mechanics_trace: Record<string, Array<{

--- a/tests/test_cp_repair.py
+++ b/tests/test_cp_repair.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+os.environ.setdefault('CORS_ORIGINS', 'http://test')
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+
+from domain.facilities import FacilityTemplate
+from models import SimulateBuildResponse
+from simulation.build_preview import PreviewContext, PreviewPlacement, simulate_build_preview
+
+
+STANDARD_CONFIDENCE_LABELS = {
+    'observed',
+    'verified',
+    'community_observed',
+    'inferred',
+    'estimated',
+    'speculative',
+    'unknown',
+}
+
+
+def facility(
+    id: str,
+    *,
+    tier: int = 1,
+    is_port: bool = False,
+    yellow_generated: int = 0,
+    green_generated: int = 0,
+    yellow_cost: int = 0,
+    green_cost: int = 0,
+    allowed_location: str = 'orbital_or_surface',
+) -> FacilityTemplate:
+    return FacilityTemplate(
+        id=id,
+        name=id.replace('_', ' ').title(),
+        category='port' if is_port else 'support',
+        tier=tier,
+        economy='Industrial' if not is_port else None,
+        is_port=is_port,
+        is_colony_port=False,
+        is_support_facility=not is_port,
+        yellow_cp_generated=yellow_generated,
+        green_cp_generated=green_generated,
+        yellow_cp_cost=yellow_cost,
+        green_cp_cost=green_cost,
+        strong_link_value=0,
+        weak_link_value=0.05,
+        allowed_location=allowed_location,
+        pad_size='L' if is_port else None,
+        prerequisites=[],
+        economy_effects={},
+        stat_effects={'data_confidence': 'observed', 'unlocks': []},
+    )
+
+
+CATALOGUE = {
+    't2_port': facility('t2_port', tier=2, is_port=True, allowed_location='orbital'),
+    't3_port': facility('t3_port', tier=3, is_port=True, allowed_location='orbital'),
+    'support_small': facility('support_small', yellow_generated=20, green_generated=0),
+    'support_green': facility('support_green', yellow_generated=20, green_generated=20),
+    'support_big': facility('support_big', yellow_generated=120, green_generated=80),
+}
+
+
+def run(plan: list[PreviewPlacement]) -> dict:
+    return simulate_build_preview(
+        system_id64=9001,
+        target_archetype='industrial_refinery',
+        placements=plan,
+        catalogue=CATALOGUE,
+        context=PreviewContext(
+            system_id64=9001,
+            estimated_orbital_slots=8,
+            estimated_ground_slots=8,
+            slot_confidence=0.9,
+        ),
+    )
+
+
+def suggestions(result: dict, suggestion_type: str | None = None) -> list[dict]:
+    items = result['cp_repair_suggestions']
+    if suggestion_type:
+        return [item for item in items if item['type'] == suggestion_type]
+    return items
+
+
+def test_empty_or_no_placement_simulation_returns_empty_cp_repair_suggestions():
+    result = run([])
+
+    assert result['cp_repair_suggestions'] == []
+    SimulateBuildResponse.model_validate(result)
+
+
+def test_cp_negative_step_produces_high_or_critical_repair_suggestion():
+    result = run([
+        PreviewPlacement('t2_port', '1', build_order=1),
+    ])
+
+    negative = suggestions(result, 'cp_negative_detected')
+    assert negative
+    assert negative[0]['severity'] in {'high', 'critical'}
+    assert negative[0]['affected_steps'] == [1]
+
+
+def test_later_cp_generating_support_produces_move_earlier_suggestion():
+    result = run([
+        PreviewPlacement('t2_port', '1', build_order=1),
+        PreviewPlacement('support_green', '1', build_order=2),
+    ])
+
+    move = suggestions(result, 'move_cp_generator_earlier')
+    assert move
+    assert move[0]['affected_steps'] == [1, 2]
+    assert 'Move Support Green from step 2 to before step 1' in move[0]['action']
+
+
+def test_first_non_primary_port_with_early_cp_pressure_suggests_primary_port():
+    result = run([
+        PreviewPlacement('t2_port', '1', build_order=1),
+        PreviewPlacement('support_green', '1', build_order=2),
+    ])
+
+    primary = suggestions(result, 'mark_primary_port')
+    assert primary
+    assert primary[0]['affected_steps'] == [1]
+
+
+def test_already_primary_port_does_not_duplicate_primary_suggestion():
+    result = run([
+        PreviewPlacement('t2_port', '1', is_primary_port=True, build_order=1),
+    ])
+
+    assert suggestions(result, 'mark_primary_port') == []
+
+
+def test_late_t3_or_paid_port_pressure_produces_escalation_suggestion():
+    result = run([
+        PreviewPlacement('support_big', '1', build_order=1),
+        PreviewPlacement('support_small', '1', build_order=2),
+        PreviewPlacement('t2_port', '1', build_order=3),
+        PreviewPlacement('t3_port', '1', build_order=4),
+    ])
+
+    escalation = suggestions(result, 'port_escalation_pressure')
+    assert escalation
+    assert escalation[0]['severity'] == 'medium'
+
+
+def test_valid_but_fragile_sequence_produces_fragile_suggestion():
+    result = run([
+        PreviewPlacement('support_small', '1', build_order=1),
+        PreviewPlacement('t2_port', '1', build_order=2),
+    ])
+
+    fragile = suggestions(result, 'sequence_is_valid_but_fragile')
+    assert fragile
+    assert fragile[0]['severity'] == 'medium'
+
+
+def test_stable_sequence_produces_no_high_severity_suggestions():
+    result = run([
+        PreviewPlacement('support_big', '1', build_order=1),
+        PreviewPlacement('t2_port', '1', build_order=2),
+    ])
+
+    assert not [item for item in suggestions(result) if item['severity'] in {'high', 'critical'}]
+
+
+def test_cp_repair_suggestions_use_standard_confidence_labels_and_trace_events():
+    result = run([
+        PreviewPlacement('t2_port', '1', build_order=1),
+        PreviewPlacement('support_green', '1', build_order=2),
+    ])
+
+    assert {item['confidence'] for item in result['cp_repair_suggestions']} <= STANDARD_CONFIDENCE_LABELS
+    assert result['mechanics_trace']['cp_repair_effects']
+    SimulateBuildResponse.model_validate(result)

--- a/tests/test_cp_repair.py
+++ b/tests/test_cp_repair.py
@@ -108,6 +108,8 @@ def test_cp_negative_step_produces_high_or_critical_repair_suggestion():
     assert negative
     assert negative[0]['severity'] in {'high', 'critical'}
     assert negative[0]['affected_steps'] == [1]
+    assert negative[0]['suggestion_id'] == 'cp_negative_step_1'
+    assert negative[0]['suggested_action']['action_type'] == 'review_sequence'
 
 
 def test_later_cp_generating_support_produces_move_earlier_suggestion():
@@ -119,7 +121,11 @@ def test_later_cp_generating_support_produces_move_earlier_suggestion():
     move = suggestions(result, 'move_cp_generator_earlier')
     assert move
     assert move[0]['affected_steps'] == [1, 2]
-    assert 'Move Support Green from step 2 to before step 1' in move[0]['action']
+    assert move[0]['suggestion_id'] == 'move_support_green_before_step_1'
+    assert move[0]['suggested_action']['action_type'] == 'move_facility_earlier'
+    assert move[0]['suggested_action']['facility_template_id'] == 'support_green'
+    assert 'before step 1' not in move[0]['action']
+    assert any('initial colony anchor' in caveat for caveat in move[0]['caveats'])
 
 
 def test_first_non_primary_port_with_early_cp_pressure_suggests_primary_port():
@@ -131,6 +137,28 @@ def test_first_non_primary_port_with_early_cp_pressure_suggests_primary_port():
     primary = suggestions(result, 'mark_primary_port')
     assert primary
     assert primary[0]['affected_steps'] == [1]
+    assert primary[0]['suggested_action']['action_type'] == 'mark_primary_port'
+    assert primary[0]['suggested_action']['set_primary_port'] is True
+
+
+def test_step1_non_primary_port_and_later_cp_negative_step_suggests_primary_port():
+    result = run([
+        PreviewPlacement('support_small', '1', build_order=1),
+        PreviewPlacement('t2_port', '1', build_order=2),
+        PreviewPlacement('t2_port', '1', build_order=3),
+    ])
+
+    primary = suggestions(result, 'mark_primary_port')
+    assert primary
+    assert primary[0]['affected_steps'][0] == 2
+
+
+def test_no_port_simulation_does_not_produce_primary_suggestion():
+    result = run([
+        PreviewPlacement('support_small', '1', build_order=1),
+    ])
+
+    assert suggestions(result, 'mark_primary_port') == []
 
 
 def test_already_primary_port_does_not_duplicate_primary_suggestion():
@@ -181,5 +209,36 @@ def test_cp_repair_suggestions_use_standard_confidence_labels_and_trace_events()
     ])
 
     assert {item['confidence'] for item in result['cp_repair_suggestions']} <= STANDARD_CONFIDENCE_LABELS
+    assert all(item['suggestion_id'] for item in result['cp_repair_suggestions'])
+    actionable = [item for item in result['cp_repair_suggestions'] if item['type'] != 'sequence_is_valid_but_fragile']
+    assert all(item['suggested_action'] is not None for item in actionable)
     assert result['mechanics_trace']['cp_repair_effects']
     SimulateBuildResponse.model_validate(result)
+
+
+def test_add_cp_generator_and_delay_expensive_port_appear_when_no_move_earlier_repair_exists():
+    result = run([
+        PreviewPlacement('t2_port', '1', build_order=1),
+    ])
+
+    assert suggestions(result, 'delay_expensive_port')
+    assert suggestions(result, 'add_cp_generator')
+    assert suggestions(result, 'delay_expensive_port')[0]['suggested_action']['action_type'] == 'delay_facility'
+    assert suggestions(result, 'add_cp_generator')[0]['suggested_action']['action_type'] == 'add_cp_generator'
+
+
+def test_suggestion_output_is_capped_and_retains_high_severity_items():
+    result = run([
+        PreviewPlacement('t2_port', '1', build_order=1),
+        PreviewPlacement('t2_port', '1', build_order=2),
+        PreviewPlacement('t2_port', '1', build_order=3),
+        PreviewPlacement('t3_port', '1', build_order=4),
+        PreviewPlacement('t3_port', '1', build_order=5),
+        PreviewPlacement('support_big', '1', build_order=6),
+    ])
+
+    items = result['cp_repair_suggestions']
+    assert len(items) <= 6
+    assert any(item['severity'] in {'high', 'critical'} for item in items)
+    first_step_items = [item for item in items if item['affected_steps'] and min(item['affected_steps']) == 1]
+    assert len(first_step_items) <= 3

--- a/tests/test_service_graph.py
+++ b/tests/test_service_graph.py
@@ -62,6 +62,7 @@ def facility(
 
 PORT = facility('ocellus', None, tier=2, is_port=True, allowed_location='orbital')
 OTHER_PORT = facility('orbis', None, tier=2, is_port=True, allowed_location='orbital')
+SURFACE_PORT = facility('surface_t1', None, tier=1, is_port=True, allowed_location='surface')
 RELAY = facility('relay_station', 'HighTech', is_support_facility=True, unlocks=[
     {'type': 'Strong Link Unlock', 'description': 'UC & VG, Commodities at Pirate, Scientific or Military Outposts'}
 ])
@@ -71,11 +72,17 @@ PIRATE = facility('pirate_base', 'Contraband', is_support_facility=True, unlocks
 MILITARY = facility('military_installation', 'Military', is_support_facility=True, unlocks=[
     {'type': 'System Unlock', 'description': 'Military Hub, Shipyard at T1 surface ports, Outfitting at non-Military Outposts'}
 ])
+UNQUALIFIED = facility('system_shipyard', 'Industrial', is_support_facility=True, unlocks=[
+    {'type': 'System Unlock', 'description': 'Shipyard'}
+])
+CONVERTED_SERVICE_PORT = facility('service_outpost', 'HighTech', tier=1, is_port=True, allowed_location='orbital', unlocks=[
+    {'type': 'Strong Link Unlock', 'description': 'UC'}
+])
 REFINERY = facility('refinery', 'Refinery', is_support_facility=True)
 
 
 def catalogue() -> dict[str, FacilityTemplate]:
-    items = [PORT, OTHER_PORT, RELAY, PIRATE, MILITARY, REFINERY]
+    items = [PORT, OTHER_PORT, SURFACE_PORT, RELAY, PIRATE, MILITARY, UNQUALIFIED, CONVERTED_SERVICE_PORT, REFINERY]
     return {item.id: item for item in items}
 
 
@@ -152,16 +159,33 @@ def test_unlinked_strong_link_unlock_is_locked_with_requirement():
     assert any(entry['requirements'] for entry in entries)
 
 
-def test_system_unlock_applies_to_each_main_port_without_removing_legacy_services():
+def test_unqualified_system_unlock_applies_to_each_main_port_without_removing_legacy_services():
     result = run([
         PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
         PreviewPlacement('orbis', '2', build_order=2),
-        PreviewPlacement('military_installation', '2', build_order=3),
+        PreviewPlacement('system_shipyard', '2', build_order=3),
     ])
 
     assert result['services']['shipyard']['status'] == 'active'
     assert all('shipyard' in state['active_services'] for state in result['port_service_states'])
     assert all(state['active_services']['shipyard']['unlock_type'] == 'system_unlock' for state in result['port_service_states'])
+
+
+def test_qualified_system_unlock_does_not_activate_on_non_matching_or_uncertain_ports():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('surface_t1', '2', build_order=2),
+        PreviewPlacement('military_installation', '2', build_order=3),
+    ])
+
+    orbital = state_for(result, 'ocellus')
+    surface = state_for(result, 'surface_t1')
+    assert 'shipyard' not in orbital['active_services']
+    assert orbital['locked_services']['shipyard']['status'] == 'locked'
+    assert 'shipyard' in surface['active_services']
+    assert 'outfitting' not in orbital['active_services']
+    assert orbital['unknown_services']['outfitting']['status'] == 'unknown'
+    assert any('qualifiers' in caveat for caveat in orbital['unknown_services']['outfitting']['caveats'])
 
 
 def test_unknown_and_locked_services_remain_explainable():
@@ -192,3 +216,65 @@ def test_service_unlock_ledger_uses_standard_confidence_labels_and_trace_events(
     assert result['mechanics_trace']['port_service_effects']
     assert result['mechanics_trace']['service_unlock_ledger_effects']
     SimulateBuildResponse.model_validate(result)
+
+
+def test_duplicate_same_template_strong_link_unlocks_match_each_local_port():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('relay_station', '1', build_order=2),
+        PreviewPlacement('orbis', '2', build_order=3),
+        PreviewPlacement('relay_station', '2', build_order=4),
+    ])
+
+    ocellus = state_for(result, 'ocellus')
+    orbis = state_for(result, 'orbis')
+    assert ocellus['active_services']['universal_cartographics']['target_port_id'] == 'ocellus'
+    assert orbis['active_services']['universal_cartographics']['target_port_id'] == 'orbis'
+    active_uc = service_entries(result, service='universal_cartographics', status='active', unlock_type='strong_link_unlock')
+    assert {entry['target_port_id'] for entry in active_uc} == {'ocellus', 'orbis'}
+
+
+def test_weak_link_does_not_unlock_strong_link_service_on_non_local_port():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('relay_station', '1', build_order=2),
+        PreviewPlacement('orbis', '2', build_order=3),
+    ])
+
+    ocellus = state_for(result, 'ocellus')
+    orbis = state_for(result, 'orbis')
+    assert 'universal_cartographics' in ocellus['active_services']
+    assert 'universal_cartographics' not in orbis['active_services']
+    assert orbis['locked_services'].get('universal_cartographics') or orbis['unknown_services'].get('universal_cartographics')
+
+
+def test_pass_through_service_behaviour_is_unknown_and_caveated():
+    result = run([
+        PreviewPlacement('surface_t1', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('orbis', '1', build_order=2),
+        PreviewPlacement('relay_station', '1', build_order=3),
+    ])
+
+    surface = state_for(result, 'surface_t1')
+    orbital = state_for(result, 'orbis')
+    assert 'universal_cartographics' in surface['active_services']
+    assert 'universal_cartographics' not in orbital['active_services']
+    pass_through_entries = [
+        entry for entry in result['service_unlock_ledger']
+        if entry['target_port_id'] == 'orbis' and entry['service'] == 'universal_cartographics' and entry['link_type'] == 'pass_through'
+    ]
+    assert pass_through_entries
+    assert pass_through_entries[0]['status'] == 'unknown'
+    assert any('Pass-through service unlock behaviour' in caveat for caveat in pass_through_entries[0]['caveats'])
+
+
+def test_converted_port_service_behaviour_is_caveated_and_not_verified():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('service_outpost', '1', build_order=2),
+    ])
+
+    entries = service_entries(result, service='universal_cartographics', status='active', unlock_type='strong_link_unlock')
+    assert entries
+    assert entries[0]['confidence'] == 'inferred'
+    assert any('Converted-port service unlock behaviour' in caveat for caveat in entries[0]['caveats'])

--- a/tests/test_service_graph.py
+++ b/tests/test_service_graph.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+os.environ.setdefault('CORS_ORIGINS', 'http://test')
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+
+from domain.facilities import FacilityTemplate
+from models import SimulateBuildResponse
+from simulation.build_preview import PreviewContext, PreviewPlacement, simulate_build_preview
+
+
+STANDARD_CONFIDENCE_LABELS = {
+    'observed',
+    'verified',
+    'community_observed',
+    'inferred',
+    'estimated',
+    'speculative',
+    'unknown',
+}
+
+
+def facility(
+    id: str,
+    economy: str | None,
+    *,
+    tier: int = 1,
+    is_port: bool = False,
+    is_support_facility: bool = False,
+    allowed_location: str = 'orbital_or_surface',
+    unlocks: list[dict] | None = None,
+) -> FacilityTemplate:
+    return FacilityTemplate(
+        id=id,
+        name=id.replace('_', ' ').title(),
+        category='port' if is_port else 'support',
+        tier=tier,
+        economy=economy,
+        is_port=is_port,
+        is_colony_port=False,
+        is_support_facility=is_support_facility,
+        yellow_cp_generated=8 if is_support_facility else 0,
+        green_cp_generated=1 if is_support_facility else 0,
+        yellow_cp_cost=0,
+        green_cp_cost=0,
+        strong_link_value=0,
+        weak_link_value=0.05,
+        allowed_location=allowed_location,
+        pad_size='L' if is_port else None,
+        prerequisites=[],
+        economy_effects={},
+        stat_effects={'data_confidence': 'observed', 'unlocks': unlocks or []},
+    )
+
+
+PORT = facility('ocellus', None, tier=2, is_port=True, allowed_location='orbital')
+OTHER_PORT = facility('orbis', None, tier=2, is_port=True, allowed_location='orbital')
+RELAY = facility('relay_station', 'HighTech', is_support_facility=True, unlocks=[
+    {'type': 'Strong Link Unlock', 'description': 'UC & VG, Commodities at Pirate, Scientific or Military Outposts'}
+])
+PIRATE = facility('pirate_base', 'Contraband', is_support_facility=True, unlocks=[
+    {'type': 'Strong Link Unlock', 'description': 'Black Market'}
+])
+MILITARY = facility('military_installation', 'Military', is_support_facility=True, unlocks=[
+    {'type': 'System Unlock', 'description': 'Military Hub, Shipyard at T1 surface ports, Outfitting at non-Military Outposts'}
+])
+REFINERY = facility('refinery', 'Refinery', is_support_facility=True)
+
+
+def catalogue() -> dict[str, FacilityTemplate]:
+    items = [PORT, OTHER_PORT, RELAY, PIRATE, MILITARY, REFINERY]
+    return {item.id: item for item in items}
+
+
+def ctx() -> PreviewContext:
+    return PreviewContext(
+        system_id64=4242,
+        estimated_orbital_slots=8,
+        estimated_ground_slots=8,
+        slot_confidence=0.9,
+        local_body_profiles={'1': {'body_name': 'Body 1', 'base_economies': ['Refinery']}},
+    )
+
+
+def run(plan: list[PreviewPlacement]):
+    return simulate_build_preview(
+        system_id64=4242,
+        target_archetype='refinery_industrial',
+        placements=plan,
+        catalogue=catalogue(),
+        context=ctx(),
+    )
+
+
+def state_for(result: dict, port_id: str) -> dict:
+    return next(state for state in result['port_service_states'] if state['port_id'] == port_id)
+
+
+def service_entries(result: dict, *, service: str | None = None, status: str | None = None, unlock_type: str | None = None) -> list[dict]:
+    entries = result['service_unlock_ledger']
+    if service is not None:
+        entries = [entry for entry in entries if entry['service'] == service]
+    if status is not None:
+        entries = [entry for entry in entries if entry['status'] == status]
+    if unlock_type is not None:
+        entries = [entry for entry in entries if entry['unlock_type'] == unlock_type]
+    return entries
+
+
+def test_main_port_gets_default_service_state_and_ledger_entry():
+    result = run([PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1)])
+
+    main = state_for(result, 'ocellus')
+    assert 'commodity_market' in main['active_services']
+    entry = main['active_services']['commodity_market']
+    assert entry['unlock_type'] == 'port_default'
+    assert entry['target_port_id'] == 'ocellus'
+
+
+def test_strong_link_unlock_activates_services_at_correct_port():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('relay_station', '1', build_order=2),
+        PreviewPlacement('orbis', '2', build_order=3),
+    ])
+
+    main = state_for(result, 'ocellus')
+    assert 'universal_cartographics' in main['active_services']
+    assert 'vista_genomics' in main['active_services']
+    assert main['active_services']['universal_cartographics']['source_id'] == 'relay_station'
+    assert main['active_services']['universal_cartographics']['link_type'] == 'strong'
+    other = state_for(result, 'orbis')
+    assert 'universal_cartographics' not in other['active_services']
+
+
+def test_unlinked_strong_link_unlock_is_locked_with_requirement():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('pirate_base', '2', build_order=2),
+    ])
+
+    entries = service_entries(result, service='black_market', status='locked')
+    assert entries
+    assert any(entry['unlock_type'] == 'strong_link_unlock' for entry in entries)
+    assert any(entry['requirements'] for entry in entries)
+
+
+def test_system_unlock_applies_to_each_main_port_without_removing_legacy_services():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('orbis', '2', build_order=2),
+        PreviewPlacement('military_installation', '2', build_order=3),
+    ])
+
+    assert result['services']['shipyard']['status'] == 'active'
+    assert all('shipyard' in state['active_services'] for state in result['port_service_states'])
+    assert all(state['active_services']['shipyard']['unlock_type'] == 'system_unlock' for state in result['port_service_states'])
+
+
+def test_unknown_and_locked_services_remain_explainable():
+    result = run([PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1)])
+    main = state_for(result, 'ocellus')
+
+    assert main['locked_services']
+    assert main['unknown_services']
+    assert any(entry['unlock_type'] == 'unknown_rule' for entry in result['service_unlock_ledger'])
+    assert any(entry['requirements'] for entry in result['service_unlock_ledger'] if entry['status'] == 'locked')
+
+
+def test_no_port_build_returns_empty_service_graph_outputs():
+    result = run([PreviewPlacement('refinery', '1', build_order=1)])
+
+    assert result['port_service_states'] == []
+    assert result['service_unlock_ledger'] == []
+
+
+def test_service_unlock_ledger_uses_standard_confidence_labels_and_trace_events():
+    result = run([
+        PreviewPlacement('ocellus', '1', is_primary_port=True, build_order=1),
+        PreviewPlacement('relay_station', '1', build_order=2),
+    ])
+
+    labels = {entry['confidence'] for entry in result['service_unlock_ledger']}
+    assert labels <= STANDARD_CONFIDENCE_LABELS
+    assert result['mechanics_trace']['port_service_effects']
+    assert result['mechanics_trace']['service_unlock_ledger_effects']
+    SimulateBuildResponse.model_validate(result)

--- a/tests/test_stage2_golden_scenario.py
+++ b/tests/test_stage2_golden_scenario.py
@@ -20,6 +20,11 @@ def test_stage2_refinery_industrial_golden_scenario_has_stage4a_outputs():
     assert any(entry['influence_type'] == 'weak_link' for entry in result['influence_ledger'])
     assert result['mechanics_trace']['port_economy_effects']
     assert result['mechanics_trace']['influence_ledger_effects']
+    assert result['port_service_states']
+    assert result['service_unlock_ledger']
+    assert result['mechanics_trace']['port_service_effects']
+    assert result['mechanics_trace']['service_unlock_ledger_effects']
+    assert any(entry['unlock_type'] == 'port_default' for entry in result['service_unlock_ledger'])
 
 
 def test_stage2_elw_golden_scenario_has_broad_body_inheritance_stage4a_outputs():
@@ -45,3 +50,5 @@ def test_stage2_elw_golden_scenario_has_broad_body_inheritance_stage4a_outputs()
     assert set(result['port_economy_states'][0]['inherited_economies']) == expected
     assert result['economy_composition']
     assert result['mechanics_trace']['port_economy_effects']
+    assert result['port_service_states']
+    assert result['service_unlock_ledger']


### PR DESCRIPTION
## Summary\n- Add Stage 4B per-port service dependency graph and service unlock ledger\n- Harden service unlock conservatism, qualifier handling, duplicate strong-link matching, and caveats\n- Add Stage 4C CP repair suggestions with structured actions, stable IDs, caps, and UI\n- Preserve existing services, cp, and cp_timeline fields\n\n## Validation\n- Backend compile + focused tests: 68 passed\n- npm run typecheck\n- npm run build\n- npm test -- CpRepairPanel.test.tsx\n- cd apps/api && pytest collected 0 tests from that directory/root config