### PR TITLE
Rename legacy Optimizer to Search Tuning

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -96,7 +96,9 @@ The preview pipeline is now documented as a sequence of internal stages: user pl
 
 ## Stage 5 - Optimiser V1
 
-Generate candidate plans rather than only previewing selected plans.
+Generate candidate plans rather than only previewing selected plans. This Stage 5 colony optimiser is separate from **Search Tuning**, the legacy Finder-result reranking tool that only adjusts weights and reorders the current Finder search results via the ratings rerank endpoint.
+
+Future Search Tuning work should add clearer presets, before/after rank movement, and better explanations, but that rework is separate from the Stage 5 colony optimiser and is not implemented in this pass.
 
 ### Stage 5A - Deterministic Candidate Generation
 

--- a/frontend-v2/README.md
+++ b/frontend-v2/README.md
@@ -27,7 +27,7 @@ root flip to `/v2/`. Now also:
 - ✅ **Watchlist tab** — sortable table backed by `/api/watchlist`. Optimistic add/remove with rollback. Renders via the shared `<SystemTable>`. Row-click opens the detail modal.
 - ✅ **Pinned tab** — localStorage-backed shortlist, schema-compatible with the vanilla `ed_pinned` key. Export-as-JSON, clear-all, cross-tab sync.
 - ✅ **Compare tab** — up to 6 systems, matrix view with per-row winner highlighting, CSV export. Snapshot-based localStorage (`ed_compare_v2`).
-- ✅ **Optimizer tab** — 6 weight sliders + economy preference selector. Reranks current Finder results in place via `/api/ratings/rerank`, with original→reranked deltas.
+- ✅ **Search Tuning tab** — legacy Finder-result reranking tool with 6 weight sliders + economy preference selector. It reorders current Finder results in place via `/api/ratings/rerank`, with original→reranked deltas, and is separate from the Stage 5 colony optimiser inside Simulation Preview.
 - ✅ **FC Planner tab** — Fleet Carrier route planner with autocomplete-driven waypoints, 4 config inputs (jump range, cargo, tritium/jump, tritium price), pure-client math (no backend call) for total LY / hops / tritium / cost / cargo trips. CSV export. localStorage persisted (`ed_fc_v2`).
 - ✅ **Colony Tracker tab** — localStorage-backed list of claimed systems (`ed_colony_v2`) with 4-state phase machine (planning / building / active / complete), per-row population progress bar, edit modal, CSV export, count badges per phase.
 - ✅ **System Detail Modal** — full-detail overlay (system info grid + 8 score bars + bodies table + stations table + exploration value + external links). Shares Watchlist / Pin / Compare hooks. **Deep-linkable**: `#tab/system/12345678`.
@@ -49,7 +49,7 @@ src/
     watchlist/                      server-backed
     pinned/                         localStorage (ed_pinned)
     compare/                        localStorage (ed_compare_v2)
-    optimizer/                      POST /api/ratings/rerank
+    optimizer/                      Search Tuning; POST /api/ratings/rerank
     fc-planner/                     localStorage (ed_fc_v2), pure-client math
     colony/                         localStorage (ed_colony_v2), phase state machine
     admin/                          sessionStorage token + ops actions
@@ -88,7 +88,7 @@ src/
     compare/                        compare (client-only, localStorage)
       CompareTab.tsx
       useCompare.ts
-    optimizer/                      optimizer (POST /api/ratings/rerank)
+    optimizer/                      Search Tuning reranker (POST /api/ratings/rerank)
       OptimizerTab.tsx
       useOptimizer.ts
     admin/                          admin (token-gated ops)
@@ -242,7 +242,7 @@ it's not worth the complexity.
 4. ✅ Watchlist / Pinned / Compare.
 5. ✅ Map.
 6. ✅ System Detail Modal — deep-linkable.
-7. ✅ Optimizer + Admin.
+7. ✅ Search Tuning + Admin. Future Search Tuning rework should add clearer presets, before/after rank movement, and stronger explanations without changing colony-build optimisation.
 8. ✅ FC Planner + Colony Tracker.
 9. ✅ Polish — Vitest tests + PWA + OpenAPI codegen wired + Profile sync (backend + frontend).
 10. **Parity flip → ready.** One-liner deploy:

--- a/frontend-v2/src/_redesign/README.md
+++ b/frontend-v2/src/_redesign/README.md
@@ -40,7 +40,7 @@ _redesign/
 │   ├── Plan/      ←  FC Planner workspace
 │   ├── Track/     ←  Colony Tracker workspace
 │   ├── Shell/     ←  TopBar + StatusStrip (top + bottom HUD)
-│   ├── Tabs/      ←  Watchlist/Pinned/Compare/Optimizer/Admin stubs
+│   ├── Tabs/      ←  Watchlist/Pinned/Compare/Search Tuning/Admin stubs
 │   └── UI/        ←  Hud primitives (Panel, HudButton, RatingBar, TierPill, etc.)
 └── lib/
     └── mockData.js          # single source of truth for the prototype

--- a/frontend-v2/src/_redesign/components/Shell/TopBar.jsx
+++ b/frontend-v2/src/_redesign/components/Shell/TopBar.jsx
@@ -10,7 +10,7 @@ const TABS = [
   { key: 'watchlist', label: 'Watchlist', icon: Eye,        badge: 7 },
   { key: 'pinned',    label: 'Pinned',    icon: Pin,        badge: 3 },
   { key: 'compare',   label: 'Compare',   icon: Scale,      badge: 2 },
-  { key: 'optimizer', label: 'Optimizer', icon: Sliders     },
+  { key: 'optimizer', label: 'Search Tuning', icon: Sliders     },
   { key: 'fc',        label: 'FC Route',  icon: Route,      badge: 4 },
   { key: 'colony',    label: 'Colony',    icon: Building2,  badge: 4 },
   { key: 'map',       label: 'Map',       icon: Map         },

--- a/frontend-v2/src/_redesign/components/Tabs/TabStubs.jsx
+++ b/frontend-v2/src/_redesign/components/Tabs/TabStubs.jsx
@@ -240,7 +240,7 @@ export function CompareTab() {
 }
 
 // ════════════════════════════════════════════════════════════════
-// OPTIMIZER  ·  weight-tuned re-rank with proper sliders
+// SEARCH TUNING  ·  weight-tuned Finder-result re-rank with proper sliders
 // ════════════════════════════════════════════════════════════════
 const WEIGHT_DEFS = [
   { key: 'economy',     label: 'Economy match',     def: 30 },
@@ -265,8 +265,8 @@ export function OptimizerTab() {
       <Panel className="overflow-hidden flex flex-col">
         <PanelHeader
           icon={<Sliders size={14} strokeWidth={1.6} />}
-          title="WEIGHTS"
-          sub={`Total ${total}% · re-ranks Finder results`}
+          title="SEARCH TUNING"
+          sub={`Total ${total}% · reorders Finder results only`}
           right={<HudButton size="sm" icon={Zap} active>RUN</HudButton>}
         />
         <div className="flex-1 overflow-y-auto p-3.5 space-y-3.5">
@@ -325,8 +325,8 @@ export function OptimizerTab() {
       <Panel className="overflow-hidden flex flex-col">
         <PanelHeader
           icon={<Activity size={14} strokeWidth={1.6} />}
-          title="RE-RANKED RESULTS"
-          sub="Tuned by your weights · live"
+          title="RE-RANKED FINDER RESULTS"
+          sub="Search Tuning does not generate colony build plans"
         />
         <div className="flex-1 overflow-y-auto divide-y divide-[hsla(232,22%,55%,0.15)]">
           {SYSTEMS.map((s, i) => (

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -53,7 +53,7 @@ export function NavBar({
           <Tab label="☁️ Watchlist"  active={current === 'watchlist'} onClick={() => onNavigate('watchlist')} testid="nav-watchlist" badge={watchlistCount ?? undefined} title="Watchlist — synced to your account, alerts on changes" />
           <Tab label="📌 Pins"       active={current === 'pinned'}    onClick={() => onNavigate('pinned')}    testid="nav-pinned"    badge={pinnedCount} title="Pins — quick local shortlist on this device only" />
           <Tab label="⚖️ Compare"    active={current === 'compare'}   onClick={() => onNavigate('compare')}   testid="nav-compare"   badge={compareCount} />
-          <Tab label="🎚️ Optimizer"  active={current === 'optimizer'} onClick={() => onNavigate('optimizer')} testid="nav-optimizer" />
+          <Tab label="🎚️ Search Tuning"  active={current === 'optimizer'} onClick={() => onNavigate('optimizer')} testid="nav-optimizer" />
           <Tab label="🚀 FC"         active={current === 'fc'}        onClick={() => onNavigate('fc')}        testid="nav-fc"        badge={fcCount} />
           <Tab label="🏗️ Colony"     active={current === 'colony'}    onClick={() => onNavigate('colony')}    testid="nav-colony"    badge={colonyCount} />
           <Tab label="🗺️ Map"        active={current === 'map'}       onClick={() => onNavigate('map')}       testid="nav-map" />

--- a/frontend-v2/src/features/optimizer/OptimizerTab.test.tsx
+++ b/frontend-v2/src/features/optimizer/OptimizerTab.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OptimizerTab } from './OptimizerTab';
+import type { UseOptimizer } from './useOptimizer';
+
+function makeOptimizer(overrides: Partial<UseOptimizer> = {}): UseOptimizer {
+  return {
+    weights: {
+      economy: 0.3,
+      slots: 0.2,
+      strategic: 0.15,
+      safety: 0.15,
+      terraforming: 0.1,
+      diversity: 0.1,
+    },
+    setWeight: vi.fn(),
+    resetWeights: vi.fn(),
+    weightSum: 1,
+    economy: null,
+    setEconomy: vi.fn(),
+    state: { kind: 'idle' },
+    run: vi.fn().mockResolvedValue(undefined),
+    resetState: vi.fn(),
+    ...overrides,
+  } as UseOptimizer;
+}
+
+function makeSearch(results: unknown[] = []) {
+  return { results } as never;
+}
+
+describe('OptimizerTab legacy Search Tuning rename', () => {
+  it('renders Search Tuning heading and explains Finder-result reranking scope', () => {
+    render(<OptimizerTab optimizer={makeOptimizer()} search={makeSearch()} />);
+
+    expect(screen.getByText('🎚️ Search Tuning')).toBeTruthy();
+    expect(screen.getByText('Re-weight and reorder your current Finder results.')).toBeTruthy();
+    expect(screen.getByText('This tunes Finder search results only. It does not generate colony build plans.')).toBeTruthy();
+    expect(screen.getByText(/Run a Finder search first/)).toBeTruthy();
+    expect(screen.getByText(/reorders the systems already in your Finder results/)).toBeTruthy();
+  });
+
+  it('shows ready-state copy when Finder results exist', () => {
+    render(<OptimizerTab optimizer={makeOptimizer()} search={makeSearch([{ id64: 123, name: 'Sol' }])} />);
+
+    expect(screen.getByText('Ready to tune search results')).toBeTruthy();
+    expect(screen.getByText('Adjust what matters most, then rerank the current Finder results.')).toBeTruthy();
+    expect(screen.getByText('Source: 1 system from current Finder results')).toBeTruthy();
+  });
+
+  it('keeps the rerank button behavior and test ids unchanged', () => {
+    const run = vi.fn().mockResolvedValue(undefined);
+    const optimizer = makeOptimizer({ run });
+    const source = [{ id64: 123, name: 'Sol' }];
+
+    render(<OptimizerTab optimizer={optimizer} search={makeSearch(source)} />);
+    fireEvent.click(screen.getByTestId('optimizer-run'));
+
+    expect(screen.getByText('▶ Rerank results')).toBeTruthy();
+    expect(run).toHaveBeenCalledWith(source);
+  });
+});

--- a/frontend-v2/src/features/optimizer/OptimizerTab.tsx
+++ b/frontend-v2/src/features/optimizer/OptimizerTab.tsx
@@ -10,7 +10,7 @@ export interface OptimizerTabProps {
 }
 
 const WEIGHT_LABELS: Array<{ key: keyof UseOptimizer['weights']; label: string; hint: string }> = [
-  { key: 'economy',      label: 'Economy',      hint: 'Per-economy match (Tourism, HighTech, …)' },
+  { key: 'economy',      label: 'Economy',      hint: 'Changes how strongly matching economies affect the rerank.' },
   { key: 'slots',        label: 'Slots',        hint: 'Build-slot capacity from body counts' },
   { key: 'strategic',    label: 'Strategic',    hint: 'Body-quality / system value' },
   { key: 'safety',       label: 'Safety',       hint: 'Orbital safety (no neutron / black hole)' },
@@ -19,8 +19,9 @@ const WEIGHT_LABELS: Array<{ key: keyof UseOptimizer['weights']; label: string; 
 ];
 
 /**
- * Optimizer = re-weight the score for the current Finder results.
+ * Legacy Search Tuning = re-weight the score for the current Finder results.
  *
+ * This legacy optimizer feature tunes Finder result ranking. The Stage 5 colony optimiser lives under Simulation Preview.
  * UX: 6 weight sliders + economy selector + Run button.
  * The "source" is whatever Finder last returned — no separate search here.
  * If Finder has no results, the Run button is disabled with a clear hint.
@@ -36,10 +37,11 @@ export function OptimizerTab({ optimizer, search, onOpenDetail }: OptimizerTabPr
   return (
     <section data-testid="optimizer-tab" className="space-y-5">
       <header className="panel flex flex-wrap items-center gap-3 px-5 py-3">
-        <h2 className="font-display text-orange tracking-[0.14em] text-lg">🎚️ Optimizer</h2>
-        <span className="font-mono text-xs text-silver-dk">
-          re-weight rating dimensions and rerank current Finder results
-        </span>
+        <h2 className="font-display text-orange tracking-[0.14em] text-lg">🎚️ Search Tuning</h2>
+        <div className="font-mono text-xs text-silver-dk">
+          <div>Re-weight and reorder your current Finder results.</div>
+          <div className="mt-1 text-[11px] text-gold">This tunes Finder search results only. It does not generate colony build plans.</div>
+        </div>
       </header>
 
       <div className="grid lg:grid-cols-[360px_1fr] gap-6">
@@ -63,7 +65,7 @@ export function OptimizerTab({ optimizer, search, onOpenDetail }: OptimizerTabPr
               ))}
             </select>
             <p className="text-[10px] text-silver-dk mt-1">
-              Drives the &ldquo;Economy&rdquo; weight column for every row.
+              Changes how strongly matching economies affect the rerank.
             </p>
           </div>
 
@@ -79,6 +81,9 @@ export function OptimizerTab({ optimizer, search, onOpenDetail }: OptimizerTabPr
                 ↺ Reset to v3.1 defaults
               </button>
             </div>
+            <p className="text-[10px] text-silver-dk">
+              Adjust how much each scoring dimension matters when reordering the current Finder results.
+            </p>
             {WEIGHT_LABELS.map(({ key, label, hint }) => (
               <WeightSlider
                 key={key}
@@ -113,7 +118,7 @@ export function OptimizerTab({ optimizer, search, onOpenDetail }: OptimizerTabPr
                 : 'btn-primary',
             ].join(' ')}
           >
-            {state.kind === 'busy' ? '⟳ Reranking…' : '▶ Rerank'}
+            {state.kind === 'busy' ? '⟳ Reranking…' : '▶ Rerank results'}
           </button>
 
           {state.kind === 'err' && (
@@ -129,10 +134,10 @@ export function OptimizerTab({ optimizer, search, onOpenDetail }: OptimizerTabPr
           {state.kind === 'idle' && (
             <EmptyState
               icon="🎚️"
-              title="Ready to rerank"
+              title="Ready to tune search results"
               hint={sourceCount === 0
-                ? 'Run a Finder search first to populate the source list.'
-                : `Tweak the weights and hit Rerank to reorder ${sourceCount} systems.`}
+                ? 'Run a Finder search first. Search Tuning reorders the systems already in your Finder results; it does not search or create colony build plans.'
+                : 'Adjust what matters most, then rerank the current Finder results.'}
             />
           )}
 
@@ -197,7 +202,7 @@ function ResultsList({
       <EmptyState
         icon="🤔"
         title="No results in source"
-        hint="The rerank service returned nothing — typically because the source IDs aren't in the ratings table."
+        hint="Search Tuning returned nothing — typically because the current Finder result IDs are not in the ratings table."
       />
     );
   }


### PR DESCRIPTION
## Summary\n- Rename the legacy Finder-result reranking UI from Optimizer to Search Tuning\n- Clarify that Search Tuning re-weights and reorders current Finder results only\n- Clarify that it does not generate colony build plans\n- Update navigation labels, docs, and focused frontend coverage\n\n## Validation\n- npm run typecheck\n- npm run build\n- npm test\n- git diff --check\n\nNo backend scoring, rerank algorithm, route path, or Stage 5 colony optimiser code was changed.