### PR TITLE
Implement Stage 5.9C Colony Planner layout

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -98,7 +98,9 @@ The preview pipeline is now documented as a sequence of internal stages: user pl
 
 Generate candidate plans rather than only previewing selected plans. This Stage 5 colony optimiser is separate from **Search Tuning**, the legacy Finder-result reranking tool that only adjusts weights and reorders the current Finder search results via the ratings rerank endpoint.
 
-Future Search Tuning work should add clearer presets, before/after rank movement, and better explanations, but that rework is separate from the Stage 5 colony optimiser and is not implemented in this pass.
+Stage 5.9C reframes the frontend planning surface as **Colony Planner**, with visible **Build Plan**, **Optimiser Candidates**, and **Preview Result** sections. Simulation Preview is now treated as the explicit preview action/result inside that workspace. Optimiser candidates show the generation parameters they were created with and warn when target archetype, max candidate count, or estimated-data controls have changed since generation.
+
+Future Search Tuning work should add clearer presets, before/after rank movement, and better explanations, but that rework is separate from the Stage 5 colony optimiser and is not implemented in this pass. Future Stage 5.9D should extract deeper planner state/hooks; future Stage 5.9E should harden end-to-end wiring tests before Stage 6 observed-vs-predicted validation work expands the planner surface again.
 
 ### Stage 5A - Deterministic Candidate Generation
 

--- a/docs/colonisation-redesign/optimiser-candidate-generator.md
+++ b/docs/colonisation-redesign/optimiser-candidate-generator.md
@@ -1,6 +1,6 @@
 # Stage 5A/5B Optimiser Candidate Generation And Ranking
 
-Stage 5A is a **bounded deterministic candidate-generation foundation** for ED-Finder colony planning. Stage 5B adds **deterministic candidate ranking** over those existing Stage 5A candidates. Together, they are still not a full optimiser, not an exhaustive search engine, not candidate comparison UI, and not an apply-candidate flow. **Simulation Preview remains the source of truth** for full mechanics explanation.
+Stage 5A is a **bounded deterministic candidate-generation foundation** for ED-Finder colony planning. Stage 5B adds **deterministic candidate ranking** over those existing Stage 5A candidates. Stages 5C–5F added candidate inspection, loading into the editable preview, and advisory comparison UI. Stage 5.9C now frames this surface as the **Colony Planner** workspace with **Build Plan**, **Optimiser Candidates**, and **Preview Result** sections. It is still not a full optimiser, not an exhaustive search engine, and not an in-game apply/save workflow. **Simulation Preview remains the explicit preview action/result for the editable Build Plan.**
 
 The optimiser package lives in `apps/api/src/optimiser/`. Core candidate generation is implemented in `candidate_generator.py`, ranking is implemented in `ranker.py`, optimiser dataclasses and serialization helpers live in `models.py`, archetype guidance lives in `archetype_rules.py`, and placement fingerprint deduplication lives in `dedupe.py`. No Stage 5A or Stage 5B optimiser logic lives under `apps/api/src/recommendations/`.
 
@@ -8,11 +8,12 @@ The optimiser package lives in `apps/api/src/optimiser/`. Core candidate generat
 |---|---|
 | Stage 5A scope | Generates bounded heuristic candidates only. |
 | Stage 5B scope | Ranks existing Stage 5A candidates using a deterministic heuristic. |
-| Non-scope | Does not perform Stage 5C comparison UI, Stage 5D candidate application, exhaustive search, or simulation mechanics changes. |
-| Simulation relationship | Simulation Preview remains the source of truth for detailed scoring, CP, economy, service, and explanation output. |
+| Non-scope | Does not perform exhaustive search, in-game save/apply, backend scoring changes, or simulation mechanics changes. |
+| Simulation relationship | Simulation Preview is now treated as the explicit preview/result mode inside Colony Planner and remains the source of truth for detailed scoring, CP, economy, service, and explanation output. |
 | Candidate strategies | `balanced`, `pure`, `services_aware`, `low_cp`, and `flexible_multirole`. |
 | Preview execution | `run_preview` controls whether a lightweight `preview_summary` is attached; full Simulation Preview responses are never embedded in candidates. |
 | Ranking execution | `include_ranking=true` adds a top-level ranking object that references candidates by `candidate_id`. |
+| Stage 5.9C UI framing | The frontend presents candidate generation under Colony Planner → Optimiser Candidates, stamps generated candidates with target archetype, max candidate count, and estimated-data setting, and warns when controls become stale. |
 | Candidate immutability | Ranking does not mutate candidate objects, add rank fields to candidates, reorder the `candidates` array, or duplicate full candidate payloads inside ranking. |
 | Failure handling | Preview failures are captured on the affected candidate and do not abort generation. |
 | Deduplication | Duplicate ordered placement fingerprints are deduped before returning results; the fingerprint is order-sensitive because build order affects CP timing and repair suggestions. |

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -10,7 +10,7 @@ The Simulation Preview UI now lives under `frontend-v2/src/features/system-detai
 
 | Path | Responsibility |
 |---|---|
-| `SimulationPreview.tsx` | Top-level orchestration and state for facility/template queries, build-plan state, target archetype, run action, and error/result selection. |
+| `SimulationPreview.tsx` | Top-level orchestration and state for facility/template queries, Build Plan state, target archetype, optimiser-candidate loading, run action, and error/result selection. Stage 5.9C also frames this surface as the Colony Planner workspace with Build Plan, Optimiser Candidates, and Preview Result sections. |
 | `SimulationResult.tsx` | Result layout and panel ordering for an already-returned `SimulateBuildResponse`. |
 | `BuildPlanEditor.tsx` | Placement editor for facility template, body, primary-port flag, sequence movement, and removal controls. |
 | `StartModes.tsx` | Start-mode cards, mode intro copy, and current plan badge. |
@@ -18,7 +18,7 @@ The Simulation Preview UI now lives under `frontend-v2/src/features/system-detai
 | `components/` | One file per shared UI atom, re-exported by `components/index.ts`. |
 | `panels/` | One file per major Simulation Preview result panel, re-exported by `panels/index.ts`. |
 | `utils/` | Formatting, tone, and placement helper functions shared by preview components. |
-| `optimiser/` | Stage 5C read-only optimiser candidate comparison UI, including candidate cards, details, ranking breakdown, placement list, and sorting utilities. |
+| `optimiser/` | Stage 5 optimiser candidate UI, including candidate cards, details, ranking breakdown, placement list, generated-parameter stamps, stale-control warnings, and comparison utilities. |
 
 ## Shared UI Atoms
 
@@ -73,8 +73,8 @@ The legacy wrapper `frontend-v2/src/features/system-detail/SimulationPreview.tsx
 
 ## Stage 5 Guidance
 
-Stage 5 optimiser UI should treat this structure as the boundary for existing Simulation Preview behaviour. Candidate lists, candidate comparison, optimiser warnings, and candidate explanation should be added as optimiser-specific components rather than folded into `SimulationPreview.tsx` or `SimulationResult.tsx`. Existing panels can be reused where they present the same response shape, but optimiser-specific state should remain separate.
+Stage 5 optimiser UI should treat this structure as the boundary for existing Simulation Preview behaviour. Stage 5.9C reframes the product surface as **Colony Planner** while keeping the implementation under `simulation-preview/` to avoid churn. Candidate lists, candidate comparison, optimiser warnings, generated-parameter stamps, stale-control warnings, and candidate explanation should remain optimiser-specific components rather than being folded into `SimulationResult.tsx`. The deeper hook/state extraction is deferred to Stage 5.9D.
 
 Stage 5C uses `simulation-preview/optimiser/` for candidate comparison. Stage 5D keeps the optimiser components grouped there and adds an opt-in load callback from `SimulationPreview.tsx`. Candidate details can show `Load into preview` only when that callback is present; otherwise the panel remains honestly read-only. Non-empty preview plans require confirmation before replacement, and loading copies placements into the existing editor without saving, committing in-game, or auto-running preview. The preview tracks optimiser-candidate origin and marks that origin as edited once the user manually changes placements.
 
-Stage 5E adds the comparison engine under `simulation-preview/optimiser/comparison/`. It intentionally exports serialisable types, source helpers, deterministic comparison logic, and pure formatter helpers without rendering the full comparison UI. Stage 5F consumes this engine in a focused show/hide comparison panel within optimiser candidate details. The comparison panel renders candidate-vs-current-preview deltas from the latest editable preview placements and target archetype while remaining advisory and read-only; it does not run preview, mutate placements, save builds, or replace the Stage 5D load confirmation flow. Candidate-vs-candidate comparison remains engine-supported, with selector UI deferred to avoid clutter.
+Stage 5E adds the comparison engine under `simulation-preview/optimiser/comparison/`. It intentionally exports serialisable types, source helpers, deterministic comparison logic, and pure formatter helpers without rendering the full comparison UI. Stage 5F consumes this engine in a focused show/hide comparison panel within optimiser candidate details. Stage 5.9C positions that panel inside the Colony Planner → Optimiser Candidates section and adds generated-request visibility so users can tell when target archetype, max candidate count, or estimated-data controls have changed since generation. The comparison panel remains advisory and read-only; it does not run preview, mutate placements, save builds, or replace the Stage 5D load confirmation flow. Candidate-vs-candidate comparison remains engine-supported, with selector UI deferred to avoid clutter.

--- a/docs/colonisation-redesign/stage-5-9-forensic-structural-ux-wiring-review.md
+++ b/docs/colonisation-redesign/stage-5-9-forensic-structural-ux-wiring-review.md
@@ -1,0 +1,211 @@
+# Stage 5.9B Forensic Structural, UX, and Wiring Review
+
+## 1. Executive Summary
+
+This review finds that ED-Finder’s post-Stage-5 implementation is **functionally coherent and technically safer than it looks at first glance**, but the product surface is now ahead of the navigation and workspace structure. The top-level app now distinguishes **Finder** and **Search Tuning** clearly: Finder searches systems, while Search Tuning reranks the current Finder result set. The Stage 5 colony optimiser/planner is also technically distinct from Search Tuning, but it is currently **buried too far down** inside the System Detail modal, inside the Colony Planning section, inside Simulation Preview, and finally below the manual preview editor/result grid.
+
+The backend Stage 5 structure is comparatively strong. The package `apps/api/src/optimiser/` contains separated generation, ranking, model, rule, dedupe, facility-selection, and preview-summary code. The FastAPI router `apps/api/src/routers/optimiser.py` is small and explicit: it normalises the target archetype, calls candidate generation, optionally attaches ranking, and validates the public response. This is a good foundation and should not be rewritten before Stage 6.
+
+The frontend structure is also better than a monolith, because Simulation Preview has already been decomposed under `frontend-v2/src/features/system-detail/simulation-preview/`. However, the orchestration component `SimulationPreview.tsx` now owns manual preview state, candidate-origin state, candidate loading, run-preview state, error state, target-archetype state, recommended-build loading, and the embedded optimiser panel. This is manageable now, but it is the next structural pressure point.
+
+> **Headline verdict:** ED-Finder is ready for a Stage 5.9 cleanup pass before Stage 6. It should not start observed-vs-predicted validation work until the planner surface is renamed, moved into a clearer workspace, and covered by one or two stronger end-to-end wiring tests.
+
+## 2. Overall Verdict
+
+The application now has two distinct concepts that are no longer both called “Optimizer”, which solves the immediate naming collision. Search Tuning is now clear enough to keep temporarily as a top-level route, but it should eventually move under Finder as an advanced reranking tool. The Stage 5 colony optimiser/planner should become a first-class workspace inside System Detail, preferably named **Colony Planner**, with Simulation Preview as one internal mode rather than the container for all planning activity.
+
+| Primary Question | Direct Answer |
+|---|---|
+| Does the app distinguish Finder, Search Tuning, System Detail, Simulation Preview, and the colony optimiser/planner? | **Partly.** Top-level Finder and Search Tuning are now distinct. System Detail and Simulation Preview are distinct in code. The colony optimiser is still visually nested under Simulation Preview, so the product distinction is not strong enough. |
+| Is Stage 5 buried too far down? | **Yes.** The route is Finder/Search Tuning/etc.; Stage 5 is only reached after opening a system, scrolling into Colony Planning, opening/using Simulation Preview, and then reaching the optimiser section at the bottom. |
+| Should Stage 5 get its own dedicated internal space? | **Yes.** It should become a System Detail-level or Colony Planner-level internal space, not a bottom section inside Simulation Preview. |
+| What should the user-facing term be? | **Colony Planner** for the broad workspace; **Optimiser Candidates** for the candidate-generation sub-panel; **Simulation Preview** for the explicit preview run/result sub-mode. |
+| Does the current Stage 5 UI explain generate/rank/compare/load semantics? | **Mostly.** The safety copy is good, especially “nothing is committed in-game” and comparison is advisory. The target-archetype and estimated-data controls still need stronger context. |
+| Are there stale optimizer references? | **Internally, yes, intentionally.** `frontend-v2/src/features/optimizer/` and route `optimizer` remain as low-risk compatibility names for Search Tuning. User-facing stale top-level “Optimizer” wording appears addressed. |
+| Does `SimulationPreview.tsx` own too much orchestration/state? | **Yes, next-stage concern.** It is not broken, but it is now the main frontend refactor candidate. |
+| Are tests sufficient? | **Good but not complete.** Backend optimiser and frontend panel tests are strong. Missing coverage remains around full generate → compare → load → edit → run, navigation labels, and target-archetype changes. |
+| Should Search Tuning stay? | **Yes, for now.** Keep it, but later demote it under Finder/Advanced Search Tuning and improve explanations/presets/rank movement. |
+| What should happen before Stage 6? | Stage 5.9C layout/naming cleanup, Stage 5.9D planner workspace refactor, and Stage 5.9E wiring test hardening. |
+
+## 3. Structural Findings
+
+| Severity | Evidence | Issue | Recommendation | Timing |
+|---|---|---|---|---|
+| Medium | `frontend-v2/src/features/system-detail/SystemDetailModal.tsx` renders one broad `Section title="Colony Planning"` containing Buildability, Regional, Recommended Builds, Simulation Preview, and Slot Prediction. | The System Detail modal has no internal planner navigation. Colony planning is a vertical stack, so the Stage 5 workflow is hard to discover. | Add internal System Detail/Colony Planning modes or tabs, with **Colony Planner** as the broad workspace. | Next stage |
+| High | `frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx` owns target archetype, placements, result, errors, recommended loading, candidate-origin state, candidate edit tracking, run-preview behavior, and embeds `OptimiserCandidatePanel`. | The file is not yet unmaintainable, but it is now the highest-risk frontend state owner. Future Stage 6 validation or saved builds will increase complexity sharply. | Extract planner state and optimiser-candidate orchestration into hooks such as `useSimulationPreviewPlan` and `useOptimiserCandidateLoading`, or move the optimiser into a sibling workspace. | Next stage |
+| Low | `apps/api/src/optimiser/` contains `candidate_generator.py`, `ranker.py`, `models.py`, `archetype_rules.py`, `facility_selection.py`, `dedupe.py`, and `preview_summary.py`. | Backend Stage 5 ownership is clean and does not need urgent structural change. | Keep backend package. Do not rename `apps/api/src/optimiser/` until there is a strong reason, because it is internally coherent and British spelling matches Stage 5 docs. | Do not fix now |
+| Medium | `frontend-v2/src/features/optimizer/OptimizerTab.tsx`, `useOptimizer.ts`, and route key `optimizer` now present as Search Tuning. | User-facing wording is fixed, but internal names remain “optimizer”. This is acceptable short-term, but it will confuse new contributors if left forever. | Later rename the folder to `search-tuning/` and keep a route alias if routing cleanup exists. Do this as a small migration, not during Stage 6. | Later |
+| Medium | `frontend-v2/src/lib/api.ts` contains both `/optimiser/candidates` and `/ratings/rerank` wrappers. | The API client correctly separates backend paths, but colocating both in one broad API file makes naming drift easy. | Add section comments that say “Colony planner optimiser” versus “Search Tuning rerank”, or later split API helpers by feature. | Next stage |
+| Low | `frontend-v2/src/features/system-detail/simulation-preview/optimiser/comparison/` is a separate comparison subfolder. | Comparison logic is well isolated from rendering and does not need a rewrite. | Keep this folder, but consider moving it under a future `colony-planner/` workspace if the optimiser becomes first-class. | Later |
+| Low | `docs/colonisation-redesign/optimiser-candidate-generator.md` starts with Stage 5A/5B scope caveats and later includes Stage 5C–5F. | The document is accurate in sections, but the first paragraph can read stale because it says Stage 5A/B are not comparison UI/apply flow before later describing Stage 5D–5F. | Add a current-status paragraph at the top explaining that Stage 5A–5F now exist, while the early section describes the original foundation. | Fix now or next stage |
+
+## 4. Stage 5 Wiring Findings
+
+The backend flow is clear and bounded. `OptimiserCandidatesRequest` reaches `apps/api/src/routers/optimiser.py`, where `target_archetype` is normalised from either `target_archetype` or `target_archetype_key`, catalogue data is loaded, and `generate_candidates(...)` is called. If `include_ranking` is true, `rank_candidates(...)` runs over the generated candidates and is attached as a top-level `ranking` object before Pydantic response validation.
+
+The candidate generator then resolves an archetype rule, loads preview context/body rows, selects body anchors, generates bounded candidates by strategy, deduplicates ordered placement fingerprints, optionally runs Simulation Preview to attach lightweight preview summaries, and captures preview failures as candidate warnings rather than aborting the full response. This is a robust flow for a v1 optimiser foundation.
+
+| Flow Step | Evidence | Assessment |
+|---|---|---|
+| Request model | `models.py` public `OptimiserCandidatesRequest`; internal `apps/api/src/optimiser/models.py` `CandidateGenerationRequest`. | Clear enough. Compatibility with `target_archetype_key` is preserved. |
+| Candidate generation | `apps/api/src/optimiser/candidate_generator.py`. | Bounded, deterministic, deduped, and non-exhaustive by design. Good. |
+| Preview summary | `candidate_generator.py` `_attach_preview_summary`; `apps/api/src/optimiser/preview_summary.py`. | Preview failures are isolated. Full preview payloads are not embedded. Good. |
+| Ranking | `apps/api/src/optimiser/ranker.py`; `apps/api/src/optimiser/models.py` ranking dataclasses. | Ranking is non-mutating and top-level by `candidate_id`. Good. |
+| Endpoint serialization | `apps/api/src/routers/optimiser.py`. | Small and explicit. Good. |
+| Frontend request | `OptimiserCandidatePanel.tsx` sends `run_preview: true` and `include_ranking: true`. | Correct for Stage 5C–5F UI. |
+| Candidate render | `OptimiserCandidatePanel.tsx`, `OptimiserCandidateCard.tsx`, `OptimiserCandidateDetails.tsx`. | Works, but the panel sits too low in the page. |
+| Comparison | `OptimiserCandidateDetails.tsx` uses `compareBuildSources(...)` from `comparison/`. | Good separation. Comparison does not auto-run preview. |
+| Load candidate | `SimulationPreview.tsx` `loadOptimiserCandidateIntoPreview(...)`; `OptimiserCandidateDetails.tsx` confirmation flow. | Safe and explicit. Existing plan confirmation exists. |
+| Manual edit after load | `SimulationPreview.tsx` `markOptimiserCandidateEdited()`. | Good safety signal, but this state belongs in a hook or planner controller later. |
+
+What is robust: the backend makes no hidden exhaustive-search claim, the frontend explicitly sends ranking/preview flags, candidate loading clears stale simulation result/error state, and comparison is advisory. The test `SimulationPreview.optimiser.test.tsx` verifies loading a candidate does **not** auto-run `simulateBuild`, which directly protects one of the highest-risk workflow semantics.
+
+What is fragile: selected candidate state can become stale if the target archetype changes after generation; the panel still shows the old response until the user generates again. The panel displays `Target: {targetArchetype}`, but it does not clearly say whether existing candidates were generated for the old target or current select value. Comparison uses current placements via props and recalculates with `useMemo`, which is good, but the UI does not visually stamp comparisons with “generated against target X” versus “current preview target Y” until the detailed comparison section notes a target change.
+
+| Fragility | Evidence | Recommended Fix | Timing |
+|---|---|---|---|
+| Candidate response can visually survive a target archetype change. | `OptimiserCandidatePanel.tsx` stores `response` and `selectedId`, while `targetArchetype` is a prop from `SimulationPreview.tsx`. | Add a generated-parameter stamp and a warning when current target differs from response target, or reset response on target change. | Next stage |
+| The optimiser panel is visually below the manual editor and result area. | `SimulationPreview.tsx` renders `OptimiserCandidatePanel` after the main preview grid at the bottom. | Move to an internal planner tab or a top “Generate Plans” mode. | Next stage |
+| Target archetype explanation is thin. | `SimulationPreview.tsx` label is just “Target archetype”; `OptimiserCandidatePanel.tsx` shows `Target: ...`. | Add copy: “This guides candidate generation and ranking; it does not overwrite in-game data.” | Fix now or next stage |
+| Estimated data checkbox lacks consequence explanation. | `OptimiserCandidatePanel.tsx` “Include estimated data”. | Add helper text explaining candidate breadth vs confidence risk. | Fix now |
+| Full workflow tests stop before edit → run. | `SimulationPreview.optimiser.test.tsx` verifies load/no-auto-run, not edit/run after load. | Add a second integration test for load → edit → run preview payload. | Next stage |
+
+## 5. UX Findings
+
+The main user journeys are now understandable in isolation. Finder is the search surface. Search Tuning is now labelled as a reranking tool. System Detail is the inspection modal. Simulation Preview lets users edit and run a build preview. Stage 5 adds candidate generation, ranking, comparison, and loading into preview. The problem is not functional incoherence; it is **spatial incoherence**. The planner workflow has grown into a multi-step product, but it still appears as a sub-panel under “Simulation Preview”.
+
+| Journey | What Works | What Is Confusing | Priority |
+|---|---|---|---|
+| Finder | Top-level route and search form are clear. | Finder-to-System-Detail-to-Planning handoff depends on modal discovery. | Low |
+| Search Tuning | Recent copy now clearly says it reranks current Finder results and does not generate colony builds. | It remains top-level even though it is dependent on Finder results. | Medium |
+| System Detail | Modal contains rating, bodies, stations, and Colony Planning. | Colony Planning is a long vertical stack without internal navigation. | High |
+| Manual Simulation Preview | “Run Preview” and editable placements are clear. | “Simulation Preview” now includes more than previewing; it contains candidate generation below it. | Medium |
+| Stage 5 Colony Optimiser | Safety copy is strong: load is preview-only, comparison is advisory, and nothing is committed in-game. | Candidate generation is hidden low, target archetype purpose is under-explained, and “Optimiser candidates” is a technical section name rather than a user journey. | High |
+
+The ED orange/brushed steel style is consistent. The UI feels visually coherent, but it now feels like a pile of panels because the System Detail modal has no internal information architecture. The strongest immediate UX improvement would be to convert Colony Planning from a vertical stack into an internal workspace with modes.
+
+Suggested user-facing copy changes are small and safe. “Optimiser candidates” should become **Plan Candidates** or **Optimiser Candidates** under a larger **Colony Planner** heading. The “Generate candidates” button should gain helper text such as: “Creates a few bounded build-plan candidates for this system using the selected archetype. It does not save or run anything in-game.” The “Target archetype” label should explain that it guides generation/ranking and may differ from the current preview target until a candidate is loaded.
+
+## 6. Stage 5 Layout Recommendation
+
+**Firm recommendation:** Do **Option 5** in product framing and **Option 3** in implementation sequence. Reframe the broader workspace as **Colony Planner**, then implement internal tabs/modes inside that workspace: **Build Plan**, **Optimiser Candidates**, and **Preview / Comparison**. Do not add another top-level app nav item yet. Do not leave the optimiser permanently at the bottom of Simulation Preview.
+
+| Option | Pros | Cons | Complexity | UX Clarity | Risk | Recommendation |
+|---|---|---|---|---|---|---|
+| 1. Keep optimiser at bottom of Simulation Preview | No code movement. Lowest risk. | Stage 5 remains buried; Simulation Preview name becomes misleading. | Low | Low | Low | Do not choose beyond short-term. |
+| 2. Move optimiser into collapsible section near top of Simulation Preview | Improves discoverability with modest change. | Still frames planner generation as a Simulation Preview sub-feature. | Low-Medium | Medium | Low | Acceptable quick win only. |
+| 3. Add internal tabs inside Simulation Preview: Build Plan, Optimiser Candidates, Results/Comparison | Clearer task separation; contained refactor. | “Simulation Preview” still names the whole workspace unless renamed. | Medium | High | Medium | Recommended implementation step. |
+| 4. Add System Detail-level tabs: Overview, Bodies, Simulation Preview, Colony Planner, Regional Context, Dependencies | Best long-term modal IA. | Larger refactor; touches more of System Detail. | High | Very high | Medium-High | Good later target after internal planner modes. |
+| 5. Rename/reframe Simulation Preview as broader Colony Planner workspace with internal modes | Best product language. Fits current capability. | Requires careful migration of headings/tests/docs. | Medium | Very high | Medium | **Firm recommendation.** |
+
+Stage 5.9C implemented the first low-risk version of this recommendation by reframing the existing planning surface as **Colony Planner**, adding visible **Build Plan**, **Optimiser Candidates**, and **Preview Result** structure, and moving the optimiser candidate area above the preview-result block without a broad state refactor. The deeper System Detail tab/workspace refactor remains deferred to Stage 5.9D.
+
+## 7. Naming Findings
+
+Search Tuning is the right name for the old Finder-result reranker. It is precise, low-drama, and does not imply build-plan generation. It should remain top-level temporarily because it already has a route and recent tests, but its best long-term home is under Finder as an **Advanced Search Tuning** panel.
+
+For Stage 5, the best broad user-facing name is **Colony Planner**. “Build Optimiser” is accurate but sounds more algorithmic and risks overclaiming optimality. “Colony Optimiser” is acceptable but carries the same overclaim risk. “Optimiser Candidates” is a good sub-section name, not a workspace name. “Candidate Planner” is less natural.
+
+| Name | Recommendation | Reason |
+|---|---|---|
+| Search Tuning | Keep for legacy reranker. | It accurately describes weighting/reordering Finder results. |
+| Colony Planner | Use as broad workspace name. | Covers manual plans, generated candidates, preview, comparison, and later validation. |
+| Optimiser Candidates | Use as sub-section. | Good for the generated-candidate panel. |
+| Simulation Preview | Keep as an action/result mode. | It should mean the explicit simulation run/result, not the whole planner workspace. |
+| Build Optimiser / Colony Optimiser | Avoid as top-level label for now. | It implies stronger optimality than bounded heuristic candidates provide. |
+
+Code naming should evolve later, not now. `apps/api/src/optimiser/` is acceptable because it is a backend package and British spelling is consistent with Stage 5 code. `frontend-v2/src/features/optimizer/` should eventually become `search-tuning/`. `frontend-v2/src/features/system-detail/simulation-preview/optimiser/` should eventually move under `colony-planner/optimiser/` if the workspace is renamed.
+
+## 8. Refactor Candidates
+
+| Item | File(s) | Problem | Suggested Refactor | Risk | Priority | Recommended Stage |
+|---|---|---|---|---|---|---|
+| Planner workspace shell | `SystemDetailModal.tsx`, `SimulationPreviewPanel.tsx`, `simulation-preview/SimulationPreview.tsx` | Colony Planning is a vertical stack and Stage 5 is buried. | Introduce a `ColonyPlannerPanel` wrapper with internal modes/tabs. | Medium | High | Stage 5.9C |
+| Simulation Preview state owner | `simulation-preview/SimulationPreview.tsx` | Manual plan, recommended-plan, optimiser-origin, preview result, and run state are all in one component. | Extract `useSimulationPreviewPlan` and `useOptimiserCandidateLoad` hooks. | Medium | High | Stage 5.9D |
+| Optimiser panel parameter lifecycle | `OptimiserCandidatePanel.tsx` | Stage 5.9C now stamps generated candidates with target archetype, max candidate count, and estimated-data setting, and warns when controls differ. | Keep the warning, then consider reset-on-change or stronger stale-load affordances later if user testing shows confusion. | Low-Medium | Medium | Stage 5.9E |
+| Search Tuning internal folder name | `frontend-v2/src/features/optimizer/` | Internal name conflicts with new user-facing Search Tuning terminology. | Rename to `search-tuning/` in a focused route-safe PR. | Medium | Medium | Stage 7 |
+| API client feature boundaries | `frontend-v2/src/lib/api.ts` | Broad API file contains both Search Tuning rerank and Stage 5 candidate generation. | Add clearer comments now; later split feature-specific API helpers. | Low | Medium | Stage 5.9C / Later |
+| Docs current-state framing | `docs/colonisation-redesign/optimiser-candidate-generator.md` | Early Stage 5A/B wording can read stale now that 5C–5F exist. | Add a current-state summary at top and a “scope by stage” table. | Low | Medium | Stage 5.9C |
+| System Detail internal IA | `SystemDetailModal.tsx` | Rating/profile/bodies/stations/planning all appear in one scroll. | Later add modal-level tabs: Overview, Bodies, Colony Planner, Regional Context, Dependencies. | High | Medium | Later |
+| Frontend API types breadth | `frontend-v2/src/types/api.ts` | API type file is growing with every simulation and optimiser field. | Split by domain or add generated-type guardrails after current work stabilises. | Medium | Low | Later |
+
+## 9. Test Coverage Findings
+
+Current test coverage is strong for many critical pieces. Backend `tests/test_optimiser.py` covers bounded candidate counts, deterministic candidate IDs, build-order sequencing, primary-port constraints, catalogue-only facilities, deduplication, fallback behavior, preview on/off, preview failure isolation, conversion helpers, endpoint response shape, and response cleanliness. Frontend `OptimiserCandidatePanel.test.tsx` covers candidate sorting, ranking display, comparison rendering, read-only mode, load confirmation, warning/reason separation, loading/error/empty states, and API request flags. `SimulationPreview.optimiser.test.tsx` verifies the most important safety behavior: loading a candidate into preview does **not** auto-run the simulation.
+
+| Coverage Area | Current Strength | Missing or Weak Test | Priority |
+|---|---|---|---|
+| Backend generation | Strong. `tests/test_optimiser.py` covers deterministic generator contracts. | No full database-backed integration test with real fixture DB. | Medium |
+| Backend ranking | Good heuristic coverage through backend tests. | Add explicit test that ranking IDs always refer to returned candidate IDs after all filters/dedupe. | Medium |
+| Frontend candidate panel | Strong component coverage. | Add stale-generated-target warning/reset test after implementing that UI. | High |
+| Load into preview | Good no-auto-run test. | Add load → edit → run preview test asserting edited placements are sent to `simulateBuild`. | High |
+| Comparison engine | Strong pure-function tests. | Add UI-level accessibility checks for show/hide comparison and keyboard navigation. | Medium |
+| Search Tuning | Rename tests exist. | Add nav-label test if a navigation test harness exists. | Medium |
+| Full happy path | Partial. | Add integration-style test: recommended/manual plan → generate → compare → load → edit → run. | High |
+| Route/nav regression | Thin. | Add tests that top-level `nav-optimizer` visibly says Search Tuning and that Stage 5 remains inside System Detail/Planner. | Medium |
+
+## 10. Docs Findings
+
+The docs are better than average for a fast-moving feature, but they now need a consolidation pass. `optimiser-candidate-generator.md` accurately documents Stages 5A–5F, but its opening language still frames Stage 5A/B as not including UI/load/comparison before later sections describe those stages. `engine-roadmap.md` now distinguishes Search Tuning from the Stage 5 colony optimiser, which is good. `frontend-v2/README.md` correctly identifies Search Tuning as legacy Finder-result reranking.
+
+| Severity | Evidence | Issue | Recommendation | Timing |
+|---|---|---|---|---|
+| Medium | `docs/colonisation-redesign/optimiser-candidate-generator.md` | Current-state framing should be updated so readers immediately understand Stage 5A–5F are implemented. | Add a top “Current status after Stage 5F” section. | Next stage |
+| Low | `docs/colonisation-redesign/simulation-preview-ui-architecture.md` | It documents decomposed Simulation Preview architecture, but the product has moved toward broader Colony Planner semantics. | Add note that Simulation Preview may become a sub-mode of Colony Planner. | Next stage |
+| Low | `frontend-v2/README.md` | Search Tuning distinction is now present. | Keep as is; update only after folder rename if that happens. | Do not fix now |
+| Medium | No dedicated “Colony Planner workspace” doc yet. | Stage 5 planner IA is not captured as a product architecture decision. | Add a short Stage 5.9C layout/naming doc before moving UI. | Next stage |
+| Low | Search Tuning future rework note exists in roadmap and README. | Adequate for now. | Do not implement rework now. | Do not fix |
+
+## 11. Recommended Next Stages
+
+| Stage | Goal | Why It Matters | Scope | Non-goals | Rough File Areas | Risk | Dependencies |
+|---|---|---|---|---|---|---|---|
+| Stage 5.9C — Navigation / Naming / Layout Cleanup | Reframe System Detail planning as **Colony Planner** with visible Build Plan, Optimiser Candidates, and Preview Result sections. | Solves immediate discoverability and terminology issues before Stage 6 adds validation complexity. | Product copy, headings, lightweight planner structure, generated-parameter stamp, stale-control warning, docs. | No generation/ranking/scoring changes. | `simulation-preview/SimulationPreview.tsx`, `OptimiserCandidatePanel.tsx`, docs. | Medium | Current Stage 5F + Search Tuning rename. |
+| Stage 5.9D — Simulation Preview / Colony Planner Workspace Refactor | Extract state ownership from `SimulationPreview.tsx`. | Reduces risk before saved builds or observed validation. | Hooks/controllers for plan state, candidate loading, and run state. | No visual redesign beyond moving logic. | `simulation-preview/SimulationPreview.tsx`, new hooks under `simulation-preview/`. | Medium | 5.9C layout decision. |
+| Stage 5.9E — Stage 5 Wiring Test Hardening | Add end-to-end-ish frontend tests for generate → compare → load → edit → run. | Protects the highest-risk user workflow. | Tests only, plus small testability helpers if required. | No feature changes. | `SimulationPreview.optimiser.test.tsx`, `OptimiserCandidatePanel.test.tsx`. | Low | Stable UI copy from 5.9C. |
+| Stage 5.9F — Candidate Parameter Staleness Guard | Make generated candidates visibly tied to request parameters. | Prevents users comparing/loading stale target-archetype results. | Generated request stamp, stale warning/reset behavior, tests. | No backend formula changes. | `OptimiserCandidatePanel.tsx`, tests. | Low-Medium | Can run before or after 5.9D. |
+| Stage 6 — Observed vs Predicted Validation Loop | Start actual observation validation after planner IA is clear. | Validation will add complexity; planner should be understandable first. | Observation ingestion/validation workflow as planned. | Do not mix with layout refactor. | Observations backend/frontend. | Medium-High | 5.9C–5.9E preferred. |
+| Stage 7 — Search Tuning Rework | Demote/refine Search Tuning with presets, rank movement, and explanations. | Search Tuning remains useful, but it is advanced Finder functionality. | Folder rename, Finder integration, before/after movement, presets. | No colony optimiser changes. | `features/optimizer` → `features/search-tuning`, Finder route. | Medium | After planner naming stabilizes. |
+
+## 12. Quick Wins
+
+The fastest safe improvement is a copy-only Stage 5.9C-lite change: rename the visible “Optimiser candidates” heading to “Plan Candidates” or “Optimiser Candidates” under a new “Colony Planner” wrapper, add helper text under Target Archetype, and add a generated-parameter summary in the candidate panel. These changes would improve user comprehension without touching backend logic.
+
+| Quick Win | File(s) | Benefit | Risk |
+|---|---|---|---|
+| Add target archetype helper text. | `SimulationPreview.tsx`, `OptimiserCandidatePanel.tsx` | Users understand why the selector matters. | Low |
+| Add generated-parameter stamp. | `OptimiserCandidatePanel.tsx` | Implemented in Stage 5.9C; candidates now show generated target, max count, estimated-data state, and stale-control warning. | Low |
+| Rename broad heading to Colony Planner while keeping Simulation Preview as subheading. | `SimulationPreviewPanel.tsx` or wrapper. | Clarifies workspace purpose. | Medium |
+| Add nav-label test for Search Tuning. | `NavBar` test or app-level test. | Prevents regression to old top-level label. | Low |
+| Update Stage 5 docs current-status intro. | `optimiser-candidate-generator.md` | Reduces docs drift. | Low |
+
+## 13. Risks if Ignored
+
+If the current structure remains unchanged, the main risk is not a code crash; it is user misunderstanding. Users may not find the candidate generator, may think Simulation Preview automatically applies plans, may compare stale generated candidates against a changed target, or may misunderstand Search Tuning as related to colony planning despite the recent rename.
+
+The engineering risk is that Stage 6 observed-vs-predicted validation would add another complex layer to an already crowded Simulation Preview workspace. If validation UI, observation facts, candidate generation, candidate comparison, manual plan editing, and preview results all live in the same vertical stack, future work will become slower and more brittle.
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Stage 5 remains undiscovered. | Medium | High | Give Colony Planner its own internal space. |
+| Stale candidate results are loaded after target changes. | Medium | Medium | Add generated-request stamp/reset warning. |
+| Simulation Preview becomes a state monolith again. | High | Medium | Extract plan and optimiser-loading hooks. |
+| Search Tuning confusion returns. | Low-Medium | Medium | Eventually move Search Tuning under Finder/Advanced. |
+| Stage 6 validation overwhelms planner UI. | High | High | Complete 5.9C–5.9E before Stage 6. |
+
+## 14. Do-Not-Do List
+
+Do not start Stage 6 until the planner surface has a clearer workspace name and at least one stronger end-to-end workflow test. Do not rewrite backend candidate generation or ranking, because the current bounded deterministic implementation is structurally sound. Do not rename backend `apps/api/src/optimiser/` during the UX cleanup. Do not remove Search Tuning. Do not move Search Tuning under Finder in the same PR that refactors Colony Planner, because that would mix two product moves. Do not introduce saved builds, commander accounts, journal upload, EDMC integration, or automatic observed-vs-predicted validation during the layout cleanup.
+
+## Review Evidence File Index
+
+| Area | Key Files Reviewed |
+|---|---|
+| App/nav structure | `frontend-v2/src/App.tsx`, `frontend-v2/src/components/NavBar.tsx` |
+| System Detail placement | `frontend-v2/src/features/system-detail/SystemDetailModal.tsx`, `SimulationPreviewPanel.tsx` |
+| Simulation Preview orchestration | `frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx` |
+| Stage 5 frontend | `frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx`, `OptimiserCandidateDetails.tsx`, `OptimiserComparisonPanel.tsx` |
+| Stage 5 backend | `apps/api/src/routers/optimiser.py`, `apps/api/src/optimiser/candidate_generator.py`, `ranker.py`, `models.py` |
+| Search Tuning | `frontend-v2/src/features/optimizer/OptimizerTab.tsx`, `useOptimizer.ts`, `OptimizerTab.test.tsx` |
+| Tests | `tests/test_optimiser.py`, `OptimiserCandidatePanel.test.tsx`, `SimulationPreview.optimiser.test.tsx`, `comparisonEngine.test.ts`, `OptimizerTab.test.tsx` |
+| Docs | `docs/colonisation-redesign/optimiser-candidate-generator.md`, `simulation-preview-ui-architecture.md`, `engine-roadmap.md`, `frontend-v2/README.md` |

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -118,6 +118,13 @@ describe('SimulationPreview optimiser candidate loading', () => {
 
     renderPreview();
 
+    expect(await screen.findByText('Colony Planner')).toBeTruthy();
+    expect(screen.getByText(/Plan a colony build for this system/)).toBeTruthy();
+    expect(screen.getAllByText('Build Plan').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Optimiser Candidates').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Preview Result').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Target archetype guides candidate generation, ranking, and preview scoring/)).toBeTruthy();
+
     fireEvent.click(await screen.findByRole('button', { name: 'Generate candidates' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Load into preview' }));
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -220,10 +220,10 @@ export function SimulationPreview({
         <div className="flex flex-wrap items-start gap-3">
           <div className="min-w-0 flex-1">
             <h3 className="text-orange text-sm font-bold tracking-[0.18em] uppercase">
-              Simulation Preview
+              Colony Planner
             </h3>
             <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">
-              This preview shows what your selected build would produce before you commit in-game.
+              Plan a colony build for this system. Generate candidate plans, compare them with your editable build plan, and run a preview before doing anything in-game.
             </p>
             {initialPlanLabel && (
               <p className="mt-1 text-[11px] text-orange font-mono">
@@ -275,11 +275,25 @@ export function SimulationPreview({
         )}
       </div>
 
-      <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(280px,0.9fr)]">
-        <div className="space-y-3">
+      <div className="border-b border-border/60 px-4 py-2">
+        <div className="flex flex-wrap gap-2 font-mono text-[10px] uppercase tracking-[0.14em]">
+          <span className="rounded border border-orange/35 bg-orange/10 px-2 py-1 text-orange">Build Plan</span>
+          <span className="rounded border border-cyan/35 bg-cyan/10 px-2 py-1 text-cyan">Optimiser Candidates</span>
+          <span className="rounded border border-border bg-bg3 px-2 py-1 text-silver-dk">Preview Result</span>
+        </div>
+      </div>
+
+      <div className="space-y-4 p-4">
+        <section aria-label="Build Plan" className="rounded-chunk-lg border border-border/60 bg-bg2/30 p-4">
+          <div className="mb-3">
+            <h4 className="font-mono text-[11px] uppercase tracking-[0.18em] text-orange">Build Plan</h4>
+            <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">
+              Edit the facility list, body assignments, and target archetype before running the Simulation Preview.
+            </p>
+          </div>
           <ModeIntro mode={startMode} hasRecommendedBuild={hasRecommendedBuild} />
 
-          <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+          <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
             <label className="space-y-1">
               <span className="block text-[10px] font-mono uppercase tracking-[0.16em] text-silver-dk">
                 Target archetype
@@ -293,6 +307,9 @@ export function SimulationPreview({
                   <option key={archetype.id} value={archetype.id}>{archetype.label}</option>
                 ))}
               </select>
+              <span className="block text-[10px] text-silver-dk font-mono leading-snug">
+                Target archetype guides candidate generation, ranking, and preview scoring. Changing it does not change anything in-game.
+              </span>
             </label>
             <button
               type="button"
@@ -306,73 +323,85 @@ export function SimulationPreview({
           </div>
 
           {templatesQuery.isLoading && (
-            <div className="rounded border border-border/60 bg-bg3/30 px-3 py-3 text-xs font-mono text-silver-dk">
+            <div className="mt-3 rounded border border-border/60 bg-bg3/30 px-3 py-3 text-xs font-mono text-silver-dk">
               Loading facility catalogue...
             </div>
           )}
 
           {templatesQuery.isError && (
-            <Message tone="warn" items={[templatesQuery.error?.message ?? 'Facility catalogue failed to load.']} />
+            <div className="mt-3"><Message tone="warn" items={[templatesQuery.error?.message ?? 'Facility catalogue failed to load.']} /></div>
           )}
 
-          {placements.length === 0 ? (
-            <div className="rounded-chunk-lg border border-dashed border-gold/45 bg-gold/5 px-4 py-6 text-center">
-              <div className="font-mono text-xs text-gold">
-                {startMode === 'blank_advanced' ? 'Blank advanced simulation' : 'No recommended build loaded yet'}
+          <div className="mt-3">
+            {placements.length === 0 ? (
+              <div className="rounded-chunk-lg border border-dashed border-gold/45 bg-gold/5 px-4 py-6 text-center">
+                <div className="font-mono text-xs text-gold">
+                  {startMode === 'blank_advanced' ? 'Blank advanced simulation' : 'No recommended build loaded yet'}
+                </div>
+                <div className="mt-1 text-[11px] text-silver-dk">
+                  {startMode === 'blank_advanced'
+                    ? 'Start with a primary port, then add support facilities and run the preview.'
+                    : 'Use a recommended build when available, or choose the advanced blank mode.'}
+                </div>
               </div>
-              <div className="mt-1 text-[11px] text-silver-dk">
-                {startMode === 'blank_advanced'
-                  ? 'Start with a primary port, then add support facilities and run the preview.'
-                  : 'Use a recommended build when available, or choose the advanced blank mode.'}
-              </div>
+            ) : (
+              <BuildPlanEditor
+                placements={placements}
+                templates={templates}
+                bodies={bodies}
+                onUpdate={updatePlacement}
+                onRemove={removePlacement}
+                onMove={movePlacement}
+              />
+            )}
+          </div>
+        </section>
+
+        <section aria-label="Optimiser Candidates">
+          <OptimiserCandidatePanel
+            systemId64={system.id64}
+            targetArchetype={targetArchetype}
+            hasExistingPreviewPlan={placements.length > 0}
+            onLoadCandidate={loadOptimiserCandidateIntoPreview}
+            currentPreviewPlacements={placements}
+            currentTargetArchetype={targetArchetype}
+            currentPreviewLabel="Current editable Build Plan"
+          />
+        </section>
+
+        <section aria-label="Preview Result" className="rounded-chunk-lg border border-border/60 bg-bg2/30 p-4">
+          <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h4 className="font-mono text-[11px] uppercase tracking-[0.18em] text-silver">Preview Result</h4>
+              <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">
+                Simulation Preview is the explicit action/result that scores the current editable Build Plan.
+              </p>
             </div>
-          ) : (
-            <BuildPlanEditor
-              placements={placements}
-              templates={templates}
-              bodies={bodies}
-              onUpdate={updatePlacement}
-              onRemove={removePlacement}
-              onMove={movePlacement}
-            />
-          )}
-        </div>
-
-        <div className="space-y-3">
-          <RegionalContextMini regional={regionalContext} loading={summaryQuery.isLoading} />
-          {error && <Message tone="danger" items={[error]} />}
-          {result ? (
-            <SimulationResult result={result} />
-          ) : (
-            <div className="h-full min-h-[260px] rounded-chunk-lg border border-border/60 bg-bg3/25 p-4">
-              <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-                Awaiting preview
+          </div>
+          <div className="space-y-3">
+            <RegionalContextMini regional={regionalContext} loading={summaryQuery.isLoading} />
+            {error && <Message tone="danger" items={[error]} />}
+            {result ? (
+              <SimulationResult result={result} />
+            ) : (
+              <div className="min-h-[260px] rounded-chunk-lg border border-border/60 bg-bg3/25 p-4">
+                <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+                  Awaiting preview
+                </div>
+                <div className="mt-4 grid grid-cols-3 gap-2">
+                  <GhostMetric label="Score" />
+                  <GhostMetric label="Build" />
+                  <GhostMetric label="Confidence" />
+                </div>
+                <div className="mt-5 space-y-2">
+                  <div className="h-3 w-4/5 rounded bg-bg4/70" />
+                  <div className="h-3 w-2/3 rounded bg-bg4/50" />
+                  <div className="h-3 w-1/2 rounded bg-bg4/40" />
+                </div>
               </div>
-              <div className="mt-4 grid grid-cols-3 gap-2">
-                <GhostMetric label="Score" />
-                <GhostMetric label="Build" />
-                <GhostMetric label="Confidence" />
-              </div>
-              <div className="mt-5 space-y-2">
-                <div className="h-3 w-4/5 rounded bg-bg4/70" />
-                <div className="h-3 w-2/3 rounded bg-bg4/50" />
-                <div className="h-3 w-1/2 rounded bg-bg4/40" />
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="border-t border-border/60 p-4">
-        <OptimiserCandidatePanel
-          systemId64={system.id64}
-          targetArchetype={targetArchetype}
-          hasExistingPreviewPlan={placements.length > 0}
-          onLoadCandidate={loadOptimiserCandidateIntoPreview}
-          currentPreviewPlacements={placements}
-          currentTargetArchetype={targetArchetype}
-          currentPreviewLabel="Current editable preview plan"
-        />
+            )}
+          </div>
+        </section>
       </div>
     </div>
   );

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
@@ -365,9 +365,16 @@ describe('optimiser candidate comparison UI', () => {
     expect(screen.getAllByText('Body: body1').length).toBeGreaterThan(0);
   });
 
-  it('renders initial read-only panel state with no apply button', () => {
+  it('renders initial read-only panel state with clear purpose copy and no apply button', () => {
     render(<OptimiserCandidatePanel systemId64={123} targetArchetype="agriculture_terraforming" />);
-    expect(screen.getByText('Optimiser candidates')).toBeTruthy();
+    expect(screen.getByText('Optimiser Candidates')).toBeTruthy();
+    expect(screen.getByText(/generates a small set of build-plan suggestions/i)).toBeTruthy();
+    expect(screen.getByText(/ranked and compared against your editable Build Plan/i)).toBeTruthy();
+    expect(screen.getByText(/Nothing is saved or committed in-game/i)).toBeTruthy();
+    expect(screen.getByText(/Generates bounded candidate build plans and lightweight preview summaries/i)).toBeTruthy();
+    expect(screen.getByText(/does not run the main Simulation Preview or change your current Build Plan/i)).toBeTruthy();
+    expect(screen.getByText(/Allows candidate generation to use inferred or incomplete data/i)).toBeTruthy();
+    expect(screen.getByText(/confidence and warnings should be reviewed/i)).toBeTruthy();
     expect(screen.getByText(/Read-only for now/i)).toBeTruthy();
     expect(screen.getByText('Generate candidates')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /load into preview/i })).toBeNull();
@@ -383,8 +390,8 @@ describe('optimiser candidate comparison UI', () => {
         onLoadCandidate={() => undefined}
       />,
     );
-    expect(screen.getByText(/load a selected candidate into the editable preview/i)).toBeTruthy();
-    expect(screen.getByText(/Nothing is committed in-game/i)).toBeTruthy();
+    expect(screen.getByText(/copy it into the editable Build Plan/i)).toBeTruthy();
+    expect(screen.getByText(/Nothing is saved or committed in-game/i)).toBeTruthy();
     expect(screen.queryByText(/Read-only for now/i)).toBeNull();
   });
 
@@ -396,9 +403,58 @@ describe('optimiser candidate comparison UI', () => {
     expect(mockedFetchOptimiserCandidates).toHaveBeenCalledWith(expect.objectContaining({
       system_id64: 123,
       target_archetype: 'agriculture_terraforming',
+      max_candidates: 5,
+      allow_estimated_data: true,
       run_preview: true,
       include_ranking: true,
     }));
+  });
+
+  it('renders generated-parameter stamp after successful generation', async () => {
+    mockedFetchOptimiserCandidates.mockResolvedValue(response());
+    render(<OptimiserCandidatePanel systemId64={123} targetArchetype="agriculture_terraforming" />);
+    fireEvent.click(screen.getByText('Generate candidates'));
+
+    expect(await screen.findByText('Generated for')).toBeTruthy();
+    expect(screen.getByText(/Target archetype:/)).toBeTruthy();
+    expect(screen.getAllByText(/agriculture_terraforming/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Max candidates:/)).toBeTruthy();
+    expect(screen.getAllByText('5').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Estimated data:/)).toBeTruthy();
+    expect(screen.getByText('on')).toBeTruthy();
+  });
+
+  it('warns when target archetype changes after generation', async () => {
+    mockedFetchOptimiserCandidates.mockResolvedValue(response());
+    const { rerender } = render(<OptimiserCandidatePanel systemId64={123} targetArchetype="agriculture_terraforming" />);
+    fireEvent.click(screen.getByText('Generate candidates'));
+    await screen.findByText('Generated for');
+
+    rerender(<OptimiserCandidatePanel systemId64={123} targetArchetype="refinery_industrial" />);
+
+    expect(screen.getByText(/Controls have changed since these candidates were generated/)).toBeTruthy();
+  });
+
+  it('warns when max candidates changes after generation', async () => {
+    mockedFetchOptimiserCandidates.mockResolvedValue(response());
+    render(<OptimiserCandidatePanel systemId64={123} targetArchetype="agriculture_terraforming" />);
+    fireEvent.click(screen.getByText('Generate candidates'));
+    await screen.findByText('Generated for');
+
+    fireEvent.change(screen.getByDisplayValue('5'), { target: { value: '8' } });
+
+    expect(screen.getByText(/Controls have changed since these candidates were generated/)).toBeTruthy();
+  });
+
+  it('warns when estimated-data toggle changes after generation', async () => {
+    mockedFetchOptimiserCandidates.mockResolvedValue(response());
+    render(<OptimiserCandidatePanel systemId64={123} targetArchetype="agriculture_terraforming" />);
+    fireEvent.click(screen.getByText('Generate candidates'));
+    await screen.findByText('Generated for');
+
+    fireEvent.click(screen.getByLabelText(/Include estimated data/i));
+
+    expect(screen.getByText(/Controls have changed since these candidates were generated/)).toBeTruthy();
   });
 
   it('renders loading state while candidates are being fetched', () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx
@@ -7,6 +7,12 @@ import { OptimiserEmptyState } from './OptimiserEmptyState';
 import { OptimiserErrorState } from './OptimiserErrorState';
 import { buildRankLookup, sortCandidatesForDisplay } from './optimiserUtils';
 
+type GeneratedCandidateParams = {
+  targetArchetype: string;
+  maxCandidates: number;
+  allowEstimatedData: boolean;
+};
+
 export function OptimiserCandidatePanel({
   systemId64,
   targetArchetype,
@@ -30,6 +36,7 @@ export function OptimiserCandidatePanel({
   const [error, setError] = useState<string | null>(null);
   const [response, setResponse] = useState<OptimiserCandidatesResponse | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [generatedParams, setGeneratedParams] = useState<GeneratedCandidateParams | null>(null);
 
   const rankLookup = useMemo(() => buildRankLookup(response?.ranking), [response]);
   const candidates = useMemo(
@@ -37,19 +44,27 @@ export function OptimiserCandidatePanel({
     [response],
   );
   const selectedCandidate = candidates.find((candidate) => candidate.candidate_id === selectedId) ?? candidates[0];
+  const currentParams: GeneratedCandidateParams = { targetArchetype, maxCandidates, allowEstimatedData };
+  const controlsChangedSinceGeneration = Boolean(generatedParams && (
+    generatedParams.targetArchetype !== currentParams.targetArchetype
+    || generatedParams.maxCandidates !== currentParams.maxCandidates
+    || generatedParams.allowEstimatedData !== currentParams.allowEstimatedData
+  ));
 
   const generateCandidates = async () => {
     setLoading(true);
     setError(null);
     try {
+      const requestParams = { ...currentParams };
       const data = await fetchOptimiserCandidates({
         system_id64: systemId64,
-        target_archetype: targetArchetype,
-        max_candidates: maxCandidates,
-        allow_estimated_data: allowEstimatedData,
+        target_archetype: requestParams.targetArchetype,
+        max_candidates: requestParams.maxCandidates,
+        allow_estimated_data: requestParams.allowEstimatedData,
         run_preview: true,
         include_ranking: true,
       });
+      setGeneratedParams(requestParams);
       setResponse(data);
       setSelectedId(data.ranking?.ranked_candidates[0]?.candidate_id ?? data.candidates[0]?.candidate_id ?? null);
     } catch (err) {
@@ -63,11 +78,14 @@ export function OptimiserCandidatePanel({
     <section className="rounded-chunk-lg border border-orange/20 bg-bg1/55 p-4" aria-label="Optimiser candidates">
       <div className="mb-3 flex flex-wrap items-start gap-3">
         <div className="min-w-0 flex-1">
-          <h3 className="text-orange text-sm font-bold tracking-[0.18em] uppercase">Optimiser candidates</h3>
+          <h3 className="text-orange text-sm font-bold tracking-[0.18em] uppercase">Optimiser Candidates</h3>
+          <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">
+            Optimiser Candidates generates a small set of build-plan suggestions for this system using the current target archetype. Candidates are ranked and compared against your editable Build Plan. Nothing is saved or committed in-game.
+          </p>
           <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">
             {onLoadCandidate
-              ? 'Generated and ranked suggestions. You can load a selected candidate into the editable preview. Nothing is committed in-game.'
-              : 'Generated and ranked suggestions. Read-only for now — applying a candidate comes in a later stage.'}
+              ? 'Load a selected candidate deliberately when you want to copy it into the editable Build Plan.'
+              : 'Read-only for now — applying a candidate comes in a later stage.'}
           </p>
         </div>
       </div>
@@ -86,17 +104,22 @@ export function OptimiserCandidatePanel({
             {[3, 5, 8, 10].map((value) => <option key={value} value={value}>{value}</option>)}
           </select>
         </label>
-        <button
-          type="button"
-          onClick={() => void generateCandidates()}
-          disabled={loading}
-          className="rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-2 font-mono text-xs font-bold text-orange hover:bg-orange/25 disabled:opacity-45"
-        >
-          {loading ? 'Generating' : 'Generate candidates'}
-        </button>
+        <div className="space-y-1">
+          <button
+            type="button"
+            onClick={() => void generateCandidates()}
+            disabled={loading}
+            className="rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-2 font-mono text-xs font-bold text-orange hover:bg-orange/25 disabled:opacity-45"
+          >
+            {loading ? 'Generating' : 'Generate candidates'}
+          </button>
+          <p className="max-w-xs font-mono text-[10px] leading-snug text-silver-dk">
+            Generates bounded candidate build plans and lightweight preview summaries. It does not run the main Simulation Preview or change your current Build Plan.
+          </p>
+        </div>
       </div>
 
-      <label className="mb-3 flex items-center gap-2 font-mono text-[11px] text-silver-dk">
+      <label className="mb-1 flex items-center gap-2 font-mono text-[11px] text-silver-dk">
         <input
           type="checkbox"
           checked={allowEstimatedData}
@@ -104,6 +127,26 @@ export function OptimiserCandidatePanel({
         />
         Include estimated data
       </label>
+      <p className="mb-3 max-w-2xl font-mono text-[10px] leading-snug text-silver-dk">
+        Allows candidate generation to use inferred or incomplete data when exact data is unavailable. This can produce more suggestions, but confidence and warnings should be reviewed.
+      </p>
+
+      {generatedParams && (
+        <div className="mb-3 rounded border border-cyan/35 bg-cyan/5 px-3 py-2 font-mono text-[10px] leading-snug text-silver-dk">
+          <div className="uppercase tracking-[0.16em] text-cyan">Generated for</div>
+          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+            <span>Target archetype: <span className="text-silver">{generatedParams.targetArchetype}</span></span>
+            <span>Max candidates: <span className="text-silver">{generatedParams.maxCandidates}</span></span>
+            <span>Estimated data: <span className="text-silver">{generatedParams.allowEstimatedData ? 'on' : 'off'}</span></span>
+          </div>
+        </div>
+      )}
+
+      {controlsChangedSinceGeneration && (
+        <div className="mb-3 rounded border border-gold/45 bg-gold/10 px-3 py-2 font-mono text-[11px] leading-snug text-gold">
+          Controls have changed since these candidates were generated. Generate again to refresh candidates before comparing or loading.
+        </div>
+      )}
 
       {loading && (
         <div className="rounded border border-border/60 bg-bg3/30 px-3 py-3 font-mono text-xs text-silver-dk">


### PR DESCRIPTION
## Summary\n- Reframe the planning surface as Colony Planner\n- Add visible Build Plan, Optimiser Candidates, and Preview Result sections\n- Clarify target archetype, candidate generation, and estimated-data copy\n- Add generated-parameter stamp and stale-control warning for optimiser candidates\n- Update frontend tests and Stage 5 docs\n\n## Validation\n- npm run typecheck\n- npm run build\n- npm test\n- git diff --check\n\nNo backend candidate generation, ranking, scoring, CP/economy/service mechanics, Search Tuning behavior, saved builds, or Stage 6 work was changed.