### PR TITLE
feat(frontend): Stage 6B — manual observed evidence UI

### DIFF
--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -204,3 +204,34 @@ Example response:
 The write models validate enum values, require positive `system_id64`, normalise/dedupe/cap tags, require object-shaped metadata, and require structured identifiers for the most common typed facts: `service_presence` needs `service_id`, `economy_presence` needs `economy`, and `facility_state` needs `facility_template_id`. These checks keep observations structured without claiming that one observed fact proves or disproves a mechanics rule.
 
 Observations do **not** change optimiser ranking, candidate generation, Simulation Preview scoring, CP/economy/service/buildability mechanics, or existing simulation response fields. They are stored evidence for future manual-entry UI and predicted-vs-observed comparison stages.
+
+## Stage 6B Frontend Observed Evidence Integration
+
+Stage 6B adds the frontend integration on top of the Stage 6A API. It introduces frontend types, central API helpers, and an Observed Evidence panel inside Colony Planner. It does **not** change any backend contract.
+
+Frontend types are declared in `frontend-v2/src/types/api.ts` and mirror the Stage 6A wire shapes:
+
+- `ObservationSource`
+- `ObservedFactType`
+- `ObservedSubjectType`
+- `ObservedStatus`
+- `ObservedConfidence`
+- `ObservedJsonValue`
+- `ObservedFact`
+- `ObservedFactCreateRequest`
+- `ObservedFactUpdateRequest`
+- `ObservationFactSummary`
+- `ObservedFactListResponse`
+- `ObservedFactDeleteResponse`
+- `ListObservedFactsParams`
+
+Central API client helpers in `frontend-v2/src/lib/api.ts` follow the existing `jsonFetch` style and target the Stage 6A endpoints:
+
+- `listObservedFacts(params)` → `GET /api/observations/facts?system_id64=...&fact_type=...&status=...`
+- `createObservedFact(request)` → `POST /api/observations/facts`
+- `updateObservedFact(observationId, request)` → `PATCH /api/observations/facts/{observation_id}`
+- `deleteObservedFact(observationId)` → `DELETE /api/observations/facts/{observation_id}`
+
+The Stage 6B UI only ever sends `source: 'manual'` in create requests. `imported` and `inferred` remain reserved Stage 6A enum values and are intentionally not exposed as create-form source options; the manual UI does not provide any control that could pick them.
+
+Stage 6B is a **passive** integration: the Observed Evidence panel does not feed observed facts back into `simulateBuild`, `fetchOptimiserCandidates`, optimiser ranking, candidate generation, or Simulation Preview scoring. The simulation and optimiser request payloads remain unchanged. Predicted-vs-observed comparison is reserved for Stage 6C, and validation rendering for Stage 6D.

--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -123,6 +123,26 @@ Stage 6A begins the validation layer as a backend-only observed facts foundation
 
 Stage 6B should add manual observation entry UI on top of this API. Stage 6C should add the predicted-vs-observed comparison engine that interprets stored observations against simulation output. Until those stages exist, observed facts are a trustworthy evidence shelf only.
 
+### Stage 6B - Manual Observed Evidence UI
+
+Stage 6B adds the frontend Observed Evidence panel that lets a user manually record, list, update, and delete observed evidence for the current system. The user-facing label is **Observed Evidence**; the backend wire vocabulary remains observed facts. The panel lives inside Colony Planner, after Preview Result, and is exposed as a fourth section label alongside Build Plan, Optimiser Candidates, and Preview Result.
+
+| Stage 6B Concern | Current Outcome |
+|---|---|
+| Frontend types | `frontend-v2/src/types/api.ts` adds `ObservationSource`, `ObservedFactType`, `ObservedSubjectType`, `ObservedStatus`, `ObservedConfidence`, `ObservedFact`, `ObservedFactCreateRequest`, `ObservedFactUpdateRequest`, `ObservationFactSummary`, `ObservedFactListResponse`, `ObservedFactDeleteResponse`, and `ListObservedFactsParams` matching the Stage 6A wire contract. |
+| API client | `frontend-v2/src/lib/api.ts` adds `listObservedFacts`, `createObservedFact`, `updateObservedFact`, and `deleteObservedFact` helpers calling the Stage 6A endpoints. |
+| Panel | `frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx` lists facts for the current `system_id64`, renders create/edit/delete UI, surfaces backend summary counts, and shows loading/error/empty states with a retry control. |
+| Create flow | `ObservedEvidenceForm.tsx` lets users record manual evidence with required Evidence type, Status, Confidence, and Notes fields. Conditional inputs for `service_id`, `economy`, `facility_template_id`, and observed value appear per fact type. Advanced fields (local body, target archetype, expected value, tags) are collapsible. The form hardcodes `source: 'manual'` — imported and inferred remain reserved for later stages. |
+| Update flow | Each card has an inline Edit form for status, confidence, notes, tags, and observed/expected values. Cancel preserves the original card; save calls `PATCH /api/observations/facts/{id}` and invalidates the list query. |
+| Delete flow | Delete requires explicit confirmation via a separate confirm panel with the exact non-mutation copy ("This removes the manually recorded evidence only. It does not change predictions, builds, or in-game state."). Cancel preserves the record. |
+| Filters | Fact-type and status filters call the backend list endpoint as query params. Confidence filter is applied client-side to the returned facts. A Clear filters control is exposed when at least one filter is active. |
+| Passivity copy | The panel renders the Stage 6B passive-evidence notice near the top: *"Observed Evidence is passive. It does not change Simulation Preview scoring, optimiser ranking, or generated candidates."* No proof, learning, or auto-correction wording is used. |
+| Integration | `SimulationPreview.tsx` renders `ObservedEvidencePanel` after `PreviewResultSection`, passes `system.id64` and `plan.targetArchetype`, and otherwise keeps the existing simulation/optimiser request payloads unchanged. `ColonyPlannerSectionNav.tsx` adds a neutral Observed Evidence section label. |
+| Tests | `ObservedEvidencePanel.test.tsx` covers passive copy, list/empty/loading/error states with retry, manual create for service/economy/facility/note evidence, 422 backend error display, client-side validation, edit save and cancel, delete confirm and cancel, fact-type/status filter calls, hidden imported/inferred sources, and absence of simulate/optimiser side effects during observation flows. `SimulationPreview.optimiser.test.tsx` adds Observed Evidence panel render checks and confirms the optimiser/simulation request paths remain unchanged. |
+| Boundaries | Stage 6B records evidence only. It does not classify predictions as correct/incorrect, run any comparison engine, change simulation/optimiser request payloads, alter scoring, ingest EDMC or journals, persist accounts/builds, or feed evidence back into mechanics. Stage 6C will add predicted-vs-observed comparison; Stage 6D will render validation results. |
+
+Stage 6C remains responsible for the predicted-vs-observed comparison engine. Stage 6D will render the validation/comparison results. Imported and inferred sources remain reserved for later ingestion stages; Stage 6B never exposes them in any create-form option.
+
 ### Stage 5A - Deterministic Candidate Generation
 
 Stage 5A is implemented as a bounded backend candidate generator rather than a full search optimiser. The hardened implementation lives in `apps/api/src/optimiser/`, with internal dataclasses, central archetype metadata, catalogue-driven facility selection, placement-fingerprint dedupe, and lightweight preview-summary extraction separated from the older recommendations package.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -96,3 +96,23 @@ Stage 6A is a **passive evidence shelf**: observations are recorded separately f
 The Stage 6A public API accepts only `manual` and `test_fixture` observation sources; `imported` and `inferred` are reserved enum values for later ingestion/comparison stages and are rejected by Stage 6A validation. The list endpoint's `summary` field describes the full filtered result set (matching `total`), not just the paginated page. `subject_id` may be null for system/build-level notes. Legacy Stage 4D columns on `observed_facts` (`area`, `source_type`, `observed_value`, `facility_id`, `body_id`) remain populated alongside the new Stage 6A columns until a later normalisation migration removes them.
 
 Stage 6A does **not** add frontend observation entry, automatic validation inside Simulation Preview, EDMC or journal ingestion, saved builds, account persistence, crowdsourcing, auto-learning, or mechanics mutation. Stage 6B can add manual observation entry UI, and Stage 6C can add predicted-vs-observed comparison on top of the stored facts.
+
+## Stage 6B Manual Observed Evidence UI
+
+Stage 6B adds a focused **Observed Evidence** panel inside Colony Planner. The panel lives under `frontend-v2/src/features/system-detail/simulation-preview/observations/` and is rendered by `SimulationPreview.tsx` after `PreviewResultSection`. `ColonyPlannerSectionNav.tsx` adds a neutral fourth section label so users can see Observed Evidence alongside Build Plan, Optimiser Candidates, and Preview Result without implying it feeds the predicted scoring chain.
+
+| Path | Responsibility |
+|---|---|
+| `observations/ObservedEvidencePanel.tsx` | Top-level panel: lists observed facts for the current `system_id64`, renders the create form, surfaces the backend summary, applies fact-type/status/confidence filters, and exposes loading/error/empty states with a retry control. |
+| `observations/ObservedEvidenceForm.tsx` | Manual create form with required Evidence type, Status, Confidence, and Notes inputs, conditional structured fields per fact type (`service_id`, `economy`, `facility_template_id`, observed value), and a collapsible advanced section for local body, target archetype, expected value, and tags. The form always sends `source: 'manual'`. |
+| `observations/ObservedEvidenceList.tsx` | Renders the list of cards or the Stage 6B empty-state copy when the backend returns no facts. |
+| `observations/ObservedEvidenceCard.tsx` | One evidence row with view, inline edit, and confirm-delete modes. Editable fields are status, confidence, notes, tags, and observed/expected values. |
+| `observations/observationLabels.ts` | User-facing labels, passive-evidence copy, empty-state copy, delete-confirm copy, and the curated `CREATABLE_FACT_TYPES` list. `prediction_match` and `prediction_mismatch` remain in the wire vocabulary but are not offered as create options. |
+| `observations/observationUtils.ts` | Pure helpers for tags parsing/formatting, observed-value JSON parsing, default form state, client-side validation, request building, and FastAPI Problem-Details error description. |
+| `observations/index.ts` | Barrel exports for the panel and its supporting helpers. |
+
+The Stage 6B panel is intentionally **passive**. It calls only the Stage 6A `/api/observations/facts` endpoints and never invokes `simulateBuild`, `fetchOptimiserCandidates`, or any prediction mechanics. Observed evidence created, edited, or deleted through the panel does not change `useSimulationPreviewRun`, `useSimulationPreviewPlan`, `OptimiserCandidatePanel`, optimiser ranking, candidate generation, or Preview Result scoring. The panel renders the visible safety copy *"Observed Evidence is passive. It does not change Simulation Preview scoring, optimiser ranking, or generated candidates."* near the top so users see the boundary without reading the docs.
+
+The create form intentionally never exposes `imported` or `inferred` as source options; both remain reserved enum values for later ingestion/comparison stages, and the Stage 6A request validation already rejects them server-side. Tests assert that no option element with those values exists in the form.
+
+Stage 6C will introduce the predicted-vs-observed comparison engine. Stage 6D will render validation/comparison results in the simulation surface. Stage 6B records evidence only; it does not decide what the evidence means.

--- a/frontend-v2/src/features/system-detail/simulation-preview/ColonyPlannerSectionNav.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/ColonyPlannerSectionNav.tsx
@@ -5,6 +5,10 @@ export function ColonyPlannerSectionNav() {
         <span className="rounded border border-orange/35 bg-orange/10 px-2 py-1 text-orange">Build Plan</span>
         <span className="rounded border border-cyan/35 bg-cyan/10 px-2 py-1 text-cyan">Optimiser Candidates</span>
         <span className="rounded border border-border bg-bg3 px-2 py-1 text-silver-dk">Preview Result</span>
+        {/* Stage 6B adds a fourth section label for the manual Observed
+            Evidence shelf. The label is intentionally neutral (silver) so
+            users do not read it as part of the predicted scoring chain. */}
+        <span className="rounded border border-border bg-bg3 px-2 py-1 text-silver-dk">Observed Evidence</span>
       </div>
     </div>
   );

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -1,7 +1,16 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchOptimiserCandidates, getFacilityTemplates, getSimulationSummary, simulateBuild } from '@/lib/api';
+import {
+  createObservedFact,
+  deleteObservedFact,
+  fetchOptimiserCandidates,
+  getFacilityTemplates,
+  getSimulationSummary,
+  listObservedFacts,
+  simulateBuild,
+  updateObservedFact,
+} from '@/lib/api';
 import type { FacilityTemplate, OptimiserCandidatesResponse, SimulateBuildResponse, SimulationSummary, SystemDetail } from '@/types/api';
 import { SimulationPreview } from './SimulationPreview';
 
@@ -10,12 +19,24 @@ vi.mock('@/lib/api', () => ({
   getFacilityTemplates: vi.fn(),
   getSimulationSummary: vi.fn(),
   simulateBuild: vi.fn(),
+  // Stage 6B observation helpers — the optimiser test does not exercise
+  // observation flows, but it does render the panel as part of the
+  // composed SimulationPreview, so list/create/update/delete must be
+  // mock-resolvable to keep the test deterministic.
+  listObservedFacts: vi.fn(),
+  createObservedFact: vi.fn(),
+  updateObservedFact: vi.fn(),
+  deleteObservedFact: vi.fn(),
 }));
 
 const mockedFetchOptimiserCandidates = vi.mocked(fetchOptimiserCandidates);
 const mockedGetFacilityTemplates = vi.mocked(getFacilityTemplates);
 const mockedGetSimulationSummary = vi.mocked(getSimulationSummary);
 const mockedSimulateBuild = vi.mocked(simulateBuild);
+const mockedListObservedFacts = vi.mocked(listObservedFacts);
+const mockedCreateObservedFact = vi.mocked(createObservedFact);
+const mockedUpdateObservedFact = vi.mocked(updateObservedFact);
+const mockedDeleteObservedFact = vi.mocked(deleteObservedFact);
 
 const templates: FacilityTemplate[] = [
   {
@@ -98,6 +119,22 @@ function renderPreview() {
   );
 }
 
+function emptyObservedFactsResponse() {
+  return {
+    facts: [],
+    total: 0,
+    limit: 100,
+    offset: 0,
+    summary: {
+      total_count: 0,
+      by_fact_type: {},
+      by_status: {},
+      by_confidence: {},
+      latest_observed_at: null,
+    },
+  };
+}
+
 function mockNoRecommendedBuild() {
   mockedGetFacilityTemplates.mockResolvedValue(templates);
   mockedGetSimulationSummary.mockResolvedValue({
@@ -106,6 +143,7 @@ function mockNoRecommendedBuild() {
     regional_context: null,
   } as unknown as SimulationSummary);
   mockedFetchOptimiserCandidates.mockResolvedValue(optimiserResponse);
+  mockedListObservedFacts.mockResolvedValue(emptyObservedFactsResponse());
 }
 
 function mockRecommendedBuild() {
@@ -121,6 +159,7 @@ function mockRecommendedBuild() {
     regional_context: null,
   } as unknown as SimulationSummary);
   mockedFetchOptimiserCandidates.mockResolvedValue(optimiserResponse);
+  mockedListObservedFacts.mockResolvedValue(emptyObservedFactsResponse());
 }
 
 function simulationResult(targetArchetype = 'agriculture_terraforming'): SimulateBuildResponse {
@@ -192,6 +231,46 @@ describe('SimulationPreview optimiser candidate loading', () => {
     mockedGetFacilityTemplates.mockReset();
     mockedGetSimulationSummary.mockReset();
     mockedSimulateBuild.mockReset();
+    mockedListObservedFacts.mockReset();
+    mockedCreateObservedFact.mockReset();
+    mockedUpdateObservedFact.mockReset();
+    mockedDeleteObservedFact.mockReset();
+  });
+
+  it('renders Observed Evidence panel and the passive evidence notice', async () => {
+    mockNoRecommendedBuild();
+    renderPreview();
+
+    // Observed Evidence label appears in both the section nav and the panel
+    // section region. getAllByText keeps this assertion robust.
+    const labels = await screen.findAllByText('Observed Evidence');
+    expect(labels.length).toBeGreaterThan(0);
+    // The region itself is exposed via aria-label so test code can scope
+    // assertions inside the Observed Evidence panel deterministically.
+    expect(screen.getByRole('region', { name: 'Observed Evidence' })).toBeTruthy();
+    // Passive copy is present so the user does not think evidence affects scoring.
+    expect(
+      screen.getByText(
+        /Observed Evidence is passive\. It does not change Simulation Preview scoring, optimiser ranking, or generated candidates\./,
+      ),
+    ).toBeTruthy();
+    // Section nav still renders predicted-side labels too.
+    expect(screen.getAllByText('Build Plan').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Optimiser Candidates').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Preview Result').length).toBeGreaterThan(0);
+  });
+
+  it('does not call simulateBuild or optimiser candidate generation when only the observed evidence panel renders', async () => {
+    mockNoRecommendedBuild();
+    renderPreview();
+
+    // Wait for the panel to settle.
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+    await waitFor(() => expect(mockedListObservedFacts).toHaveBeenCalled());
+
+    // No simulation or optimiser side effects from observed evidence flows.
+    expect(mockedSimulateBuild).not.toHaveBeenCalled();
+    expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
   });
 
   it('loads a selected optimiser candidate into the editable preview without auto-running simulation', async () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -12,6 +12,7 @@ import { BuildPlanSection } from './BuildPlanSection';
 import { ColonyPlannerHeader } from './ColonyPlannerHeader';
 import { ColonyPlannerSectionNav } from './ColonyPlannerSectionNav';
 import { PreviewResultSection } from './PreviewResultSection';
+import { ObservedEvidencePanel } from './observations';
 import { OptimiserCandidatePanel } from './optimiser';
 import { useSimulationPreviewPlan } from './hooks/useSimulationPreviewPlan';
 import { useSimulationPreviewRun } from './hooks/useSimulationPreviewRun';
@@ -137,6 +138,16 @@ export function SimulationPreview({
           error={runState.error}
           result={runState.result}
           isResultStale={runState.isResultStale}
+        />
+
+        {/* Stage 6B: Observed Evidence panel renders after Preview Result.
+            It is intentionally passive — see ObservedEvidencePanel for the
+            contract. The simulation and optimiser data above are NOT
+            re-derived from observations; Stage 6C will add predicted-vs-
+            observed comparison and Stage 6D will render validation. */}
+        <ObservedEvidencePanel
+          systemId64={system.id64}
+          suggestedArchetype={plan.targetArchetype}
         />
       </div>
     </div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceCard.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceCard.tsx
@@ -16,7 +16,6 @@ import {
   formatObservedValue,
   parseObservedValue,
   parseTagsInput,
-  tagsToInputValue,
 } from './observationUtils';
 
 interface ObservedEvidenceCardProps {
@@ -324,7 +323,7 @@ function KeyValue({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex gap-2">
       <dt className="shrink-0 text-silver-dk">{label}:</dt>
-      <dd className="min-w-0 break-words text-silver">{tagsToInputValue([value])}</dd>
+      <dd className="min-w-0 break-words text-silver">{value}</dd>
     </div>
   );
 }

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceCard.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceCard.tsx
@@ -1,0 +1,330 @@
+import { useState } from 'react';
+import type { ObservedFact, ObservedFactUpdateRequest } from '@/types/api';
+import {
+  CONFIDENCES,
+  DELETE_CONFIRM_BODY,
+  DELETE_CONFIRM_TITLE,
+  STATUSES,
+  confidenceLabel,
+  factTypeLabel,
+  sourceLabel,
+  statusLabel,
+  subjectTypeLabel,
+} from './observationLabels';
+import {
+  defaultEditFormState,
+  formatObservedValue,
+  parseObservedValue,
+  parseTagsInput,
+  tagsToInputValue,
+} from './observationUtils';
+
+interface ObservedEvidenceCardProps {
+  fact: ObservedFact;
+  saving: boolean;
+  deleting: boolean;
+  saveError: string | null;
+  deleteError: string | null;
+  onSave: (update: ObservedFactUpdateRequest) => Promise<void> | void;
+  onDelete: () => Promise<void> | void;
+  onClearErrors: () => void;
+}
+
+/**
+ * Single Observed Evidence row, with inline edit + confirm-delete behaviour.
+ *
+ * The card is intentionally compact so a system-detail user can scan many
+ * evidence rows without reading a wall of JSON. Detailed structured fields
+ * (facility ids, service ids, fingerprints) are still rendered so a user
+ * can verify they recorded the right thing, but they live below the
+ * primary status / confidence / fact-type chip row.
+ */
+export function ObservedEvidenceCard({
+  fact,
+  saving,
+  deleting,
+  saveError,
+  deleteError,
+  onSave,
+  onDelete,
+  onClearErrors,
+}: ObservedEvidenceCardProps) {
+  const [mode, setMode] = useState<'view' | 'edit' | 'confirm-delete'>('view');
+  const [editState, setEditState] = useState(() => defaultEditFormState(fact));
+
+  function startEdit() {
+    onClearErrors();
+    setEditState(defaultEditFormState(fact));
+    setMode('edit');
+  }
+
+  function cancelEdit() {
+    onClearErrors();
+    setEditState(defaultEditFormState(fact));
+    setMode('view');
+  }
+
+  async function submitEdit() {
+    const update: ObservedFactUpdateRequest = {
+      status: editState.status,
+      confidence: editState.confidence,
+      notes: editState.notes.trim() === '' ? null : editState.notes.trim(),
+      tags: parseTagsInput(editState.tags_input),
+    };
+    const observed = parseObservedValue(editState.observed_value_raw);
+    if (observed !== undefined) update.observed_value = observed;
+    const expected = parseObservedValue(editState.expected_value_raw);
+    if (expected !== undefined) update.expected_value = expected;
+    await onSave(update);
+    // Stay in view mode if the save succeeded — the caller will refetch
+    // and re-render with the updated fact. If it failed, the panel keeps
+    // saveError visible and we stay in edit mode so the user can retry.
+    if (!saveError) {
+      setMode('view');
+    }
+  }
+
+  async function confirmDelete() {
+    await onDelete();
+    // If delete succeeded the card unmounts. If it failed, deleteError is
+    // shown and the user can cancel or retry from the confirmation panel.
+  }
+
+  const tagList = fact.tags && fact.tags.length > 0 ? fact.tags : null;
+
+  return (
+    <li
+      className="rounded-chunk-lg border border-border/60 bg-bg2/40 p-3 font-mono text-[11px] text-silver-dk"
+      role="listitem"
+      aria-label="Observed evidence record"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.14em]">
+            <span className="rounded border border-orange/40 bg-orange/10 px-2 py-0.5 text-orange">
+              {factTypeLabel(fact.fact_type)}
+            </span>
+            <span className="rounded border border-cyan/35 bg-cyan/10 px-2 py-0.5 text-cyan">
+              {statusLabel(fact.status)}
+            </span>
+            <span className="rounded border border-border bg-bg3 px-2 py-0.5 text-silver">
+              {confidenceLabel(fact.confidence)} confidence
+            </span>
+            <span className="rounded border border-border bg-bg3/60 px-2 py-0.5 text-silver-dk">
+              {sourceLabel(fact.source)}
+            </span>
+          </div>
+          <div className="mt-1 text-[11px] text-silver">
+            {subjectTypeLabel(fact.subject_type)}
+            {fact.subject_id ? <span className="text-silver-dk"> · {fact.subject_id}</span> : null}
+          </div>
+        </div>
+        {mode === 'view' && (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={startEdit}
+              className="rounded-chunk-sm border border-border bg-bg2 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-silver hover:border-orange/40 hover:text-orange"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                onClearErrors();
+                setMode('confirm-delete');
+              }}
+              className="rounded-chunk-sm border border-red/40 bg-red/10 px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-red hover:bg-red/20"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {mode === 'view' && (
+        <div className="mt-3 space-y-2">
+          {fact.notes && (
+            <p className="whitespace-pre-wrap text-[11px] text-silver">{fact.notes}</p>
+          )}
+          <dl className="grid grid-cols-1 gap-1 sm:grid-cols-2 text-[10px] text-silver-dk">
+            {fact.service_id && (
+              <KeyValue label="Service" value={fact.service_id} />
+            )}
+            {fact.economy && (
+              <KeyValue label="Economy" value={fact.economy} />
+            )}
+            {fact.facility_template_id && (
+              <KeyValue label="Facility template" value={fact.facility_template_id} />
+            )}
+            {fact.local_body_id && (
+              <KeyValue label="Local body" value={fact.local_body_id} />
+            )}
+            {fact.target_archetype && (
+              <KeyValue label="Target archetype" value={fact.target_archetype} />
+            )}
+            {fact.observed_value !== undefined && fact.observed_value !== null && (
+              <KeyValue label="Observed value" value={formatObservedValue(fact.observed_value)} />
+            )}
+            {fact.expected_value !== undefined && fact.expected_value !== null && (
+              <KeyValue label="Expected value" value={formatObservedValue(fact.expected_value)} />
+            )}
+          </dl>
+          {tagList && (
+            <div className="flex flex-wrap gap-1">
+              {tagList.map((tag) => (
+                <span key={tag} className="rounded border border-border bg-bg3/40 px-1.5 py-0.5 text-[10px] text-silver-dk">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="text-[10px] text-silver-dk">
+            Recorded {fact.created_at}
+            {fact.updated_at ? <span> · Updated {fact.updated_at}</span> : null}
+            {' · ID '}
+            <span className="text-silver">{fact.observation_id}</span>
+          </div>
+        </div>
+      )}
+
+      {mode === 'edit' && (
+        <form
+          className="mt-3 space-y-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void submitEdit();
+          }}
+          aria-label="Edit observed evidence"
+        >
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Status
+              <select
+                value={editState.status}
+                onChange={(event) => setEditState({ ...editState, status: event.target.value as typeof editState.status })}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              >
+                {STATUSES.map((value) => (
+                  <option key={value} value={value}>{statusLabel(value)}</option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Confidence
+              <select
+                value={editState.confidence}
+                onChange={(event) => setEditState({ ...editState, confidence: event.target.value as typeof editState.confidence })}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              >
+                {CONFIDENCES.map((value) => (
+                  <option key={value} value={value}>{confidenceLabel(value)}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+            Notes
+            <textarea
+              value={editState.notes}
+              onChange={(event) => setEditState({ ...editState, notes: event.target.value })}
+              rows={3}
+              className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+            />
+          </label>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Observed value
+              <input
+                type="text"
+                value={editState.observed_value_raw}
+                onChange={(event) => setEditState({ ...editState, observed_value_raw: event.target.value })}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              />
+            </label>
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Expected value
+              <input
+                type="text"
+                value={editState.expected_value_raw}
+                onChange={(event) => setEditState({ ...editState, expected_value_raw: event.target.value })}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              />
+            </label>
+          </div>
+          <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+            Tags (comma separated)
+            <input
+              type="text"
+              value={editState.tags_input}
+              onChange={(event) => setEditState({ ...editState, tags_input: event.target.value })}
+              className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+            />
+          </label>
+          {saveError && (
+            <div role="alert" className="rounded border border-red/40 bg-red/10 px-2 py-1 text-[11px] text-red">
+              {saveError}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-1 text-[11px] font-bold text-orange hover:bg-orange/25 disabled:opacity-45"
+            >
+              {saving ? 'Saving' : 'Save changes'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              className="rounded-chunk-sm border border-border bg-bg2 px-3 py-1 text-[11px] text-silver hover:border-orange/40 hover:text-orange"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {mode === 'confirm-delete' && (
+        <div className="mt-3 rounded border border-red/40 bg-red/10 px-3 py-2" role="alertdialog" aria-label="Confirm delete observed evidence">
+          <div className="font-bold text-red">{DELETE_CONFIRM_TITLE}</div>
+          <p className="mt-1 text-[11px] leading-snug text-silver">{DELETE_CONFIRM_BODY}</p>
+          {deleteError && (
+            <div role="alert" className="mt-2 rounded border border-red/50 bg-red/15 px-2 py-1 text-[11px] text-red">
+              {deleteError}
+            </div>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void confirmDelete()}
+              disabled={deleting}
+              className="rounded-chunk-sm border border-red/60 bg-red/20 px-3 py-1 text-[11px] font-bold text-red hover:bg-red/30 disabled:opacity-45"
+            >
+              {deleting ? 'Deleting' : 'Confirm delete'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                onClearErrors();
+                setMode('view');
+              }}
+              className="rounded-chunk-sm border border-border bg-bg2 px-3 py-1 text-[11px] text-silver hover:border-orange/40 hover:text-orange"
+            >
+              Keep evidence
+            </button>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-2">
+      <dt className="shrink-0 text-silver-dk">{label}:</dt>
+      <dd className="min-w-0 break-words text-silver">{tagsToInputValue([value])}</dd>
+    </div>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceForm.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceForm.tsx
@@ -1,0 +1,307 @@
+import { useState } from 'react';
+import type { ObservedFactCreateRequest, ObservedFactType } from '@/types/api';
+import {
+  CONFIDENCES,
+  CREATABLE_FACT_TYPES,
+  STATUSES,
+  confidenceLabel,
+  factTypeLabel,
+  statusLabel,
+} from './observationLabels';
+import {
+  buildCreateRequest,
+  defaultCreateFormState,
+  validateCreateForm,
+  type CreateFormState,
+} from './observationUtils';
+
+interface ObservedEvidenceFormProps {
+  systemId64: number;
+  suggestedArchetype?: string | null;
+  submitting: boolean;
+  serverError: string | null;
+  onSubmit: (request: ObservedFactCreateRequest) => Promise<void> | void;
+  onClearError: () => void;
+}
+
+/**
+ * Manual create form for the Observed Evidence panel (Stage 6B).
+ *
+ * The form deliberately exposes only a compact subset of the Stage 6A
+ * backend contract:
+ *   - Evidence type, status, confidence, notes always visible.
+ *   - Subject fields shown conditionally based on evidence type.
+ *   - Optional structured advanced fields collapsed under a toggle so the
+ *     common case stays small.
+ *
+ * The form only sends `source: 'manual'`. Imported / inferred sources are
+ * reserved for later stages and are intentionally not exposed here.
+ */
+export function ObservedEvidenceForm({
+  systemId64,
+  suggestedArchetype,
+  submitting,
+  serverError,
+  onSubmit,
+  onClearError,
+}: ObservedEvidenceFormProps) {
+  const [state, setState] = useState<CreateFormState>(() => defaultCreateFormState(suggestedArchetype));
+  const [localErrors, setLocalErrors] = useState<string[]>([]);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+
+  function update<K extends keyof CreateFormState>(key: K, value: CreateFormState[K]) {
+    setState((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onClearError();
+    const validation = validateCreateForm(state);
+    if (!validation.ok) {
+      setLocalErrors(validation.errors);
+      return;
+    }
+    setLocalErrors([]);
+    const request = buildCreateRequest(state, systemId64);
+    try {
+      await onSubmit(request);
+    } catch {
+      // The parent's mutation `onError` already captures the failure and
+      // surfaces it via the `serverError` prop. We swallow the re-thrown
+      // rejection here so React/jest don't see it as an unhandled
+      // rejection. The user-visible error message remains controlled by
+      // the panel's mutation state. We don't know here whether the
+      // submit succeeded — the parent panel is the source of truth. If
+      // it set serverError we keep the form so the user can fix and
+      // retry; if it cleared serverError, ObservedEvidencePanel
+      // remounts the form via a `key` change for a clean reset.
+    }
+  }
+
+  function resetAfterSuccess() {
+    setState(defaultCreateFormState(suggestedArchetype));
+    setLocalErrors([]);
+    setAdvancedOpen(false);
+  }
+
+  // The parent panel calls this via an imperative-ish pattern: it passes
+  // a ref through `formInstance` if needed. To keep the API simple here
+  // we expose resetAfterSuccess on the function itself via a side-channel:
+  // we attach it to the form's onSubmit lifecycle by re-running the reset
+  // when `submitting` flips from true to false and there is no server
+  // error. That side-effect lives in the panel; the form's local form
+  // state is reset there by remounting via `key` changes.
+  void resetAfterSuccess;
+
+  return (
+    <form onSubmit={handleSubmit} aria-label="Record observed evidence" className="space-y-3">
+      <div className="grid gap-2 sm:grid-cols-3">
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Evidence type
+          <select
+            value={state.fact_type}
+            onChange={(event) => {
+              const next = event.target.value as ObservedFactType;
+              update('fact_type', next);
+              // Clear local validation when fact_type changes so the user
+              // doesn't see a stale "service_id required" error after
+              // switching to "Note".
+              setLocalErrors([]);
+            }}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          >
+            {CREATABLE_FACT_TYPES.map((value) => (
+              <option key={value} value={value}>{factTypeLabel(value)}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Status
+          <select
+            value={state.status}
+            onChange={(event) => update('status', event.target.value as CreateFormState['status'])}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          >
+            {STATUSES.map((value) => (
+              <option key={value} value={value}>{statusLabel(value)}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Confidence
+          <select
+            value={state.confidence}
+            onChange={(event) => update('confidence', event.target.value as CreateFormState['confidence'])}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          >
+            {CONFIDENCES.map((value) => (
+              <option key={value} value={value}>{confidenceLabel(value)}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {/* Conditional subject fields. Only render the structured input the
+          chosen evidence type needs so the form does not look intimidating
+          for a quick free-form note. */}
+      {state.fact_type === 'service_presence' && (
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Service ID
+          <input
+            type="text"
+            value={state.service_id}
+            onChange={(event) => update('service_id', event.target.value)}
+            placeholder="e.g. market, refuel, repair"
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          />
+        </label>
+      )}
+      {state.fact_type === 'economy_presence' && (
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Economy
+          <input
+            type="text"
+            value={state.economy}
+            onChange={(event) => update('economy', event.target.value)}
+            placeholder="e.g. Agriculture, Refinery"
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          />
+        </label>
+      )}
+      {state.fact_type === 'facility_state' && (
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Facility template ID
+          <input
+            type="text"
+            value={state.facility_template_id}
+            onChange={(event) => update('facility_template_id', event.target.value)}
+            placeholder="e.g. agri_support_a"
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          />
+        </label>
+      )}
+      {(state.fact_type === 'cp_value' || state.fact_type === 'build_outcome') && (
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Observed value
+          <input
+            type="text"
+            value={state.observed_value_raw}
+            onChange={(event) => update('observed_value_raw', event.target.value)}
+            placeholder={state.fact_type === 'cp_value' ? 'e.g. 12 or {"yellow":4,"green":2}' : 'e.g. completed'}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          />
+        </label>
+      )}
+
+      <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+        Notes
+        <textarea
+          value={state.notes}
+          onChange={(event) => update('notes', event.target.value)}
+          rows={2}
+          placeholder="What did you actually see in-game?"
+          className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+        />
+      </label>
+
+      <div>
+        <button
+          type="button"
+          onClick={() => setAdvancedOpen((v) => !v)}
+          className="text-[10px] uppercase tracking-[0.14em] text-silver-dk hover:text-orange"
+          aria-expanded={advancedOpen}
+        >
+          {advancedOpen ? 'Hide advanced details' : 'Show advanced details'}
+        </button>
+      </div>
+
+      {advancedOpen && (
+        <div className="space-y-2 rounded border border-border/60 bg-bg3/20 p-2">
+          <div className="grid gap-2 sm:grid-cols-2">
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Local body ID
+              <input
+                type="text"
+                value={state.local_body_id}
+                onChange={(event) => update('local_body_id', event.target.value)}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              />
+            </label>
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Target archetype
+              <input
+                type="text"
+                value={state.target_archetype}
+                onChange={(event) => update('target_archetype', event.target.value)}
+                placeholder={suggestedArchetype ?? ''}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              />
+            </label>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Observed value
+              <input
+                type="text"
+                value={state.observed_value_raw}
+                onChange={(event) => update('observed_value_raw', event.target.value)}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              />
+            </label>
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Expected value
+              <input
+                type="text"
+                value={state.expected_value_raw}
+                onChange={(event) => update('expected_value_raw', event.target.value)}
+                className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+              />
+            </label>
+          </div>
+          <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+            Tags (comma separated)
+            <input
+              type="text"
+              value={state.tags_input}
+              onChange={(event) => update('tags_input', event.target.value)}
+              className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+            />
+          </label>
+          <p className="text-[10px] text-silver-dk leading-snug">
+            These advanced fields are optional. Stage 6B records evidence only —
+            it does not interpret or compare it. Imported and inferred sources
+            are reserved for later stages and cannot be selected here.
+          </p>
+        </div>
+      )}
+
+      {localErrors.length > 0 && (
+        <div role="alert" className="rounded border border-gold/45 bg-gold/10 px-2 py-1 text-[11px] text-gold">
+          <ul className="list-disc space-y-1 pl-4">
+            {localErrors.map((message) => (
+              <li key={message}>{message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {serverError && (
+        <div role="alert" className="rounded border border-red/40 bg-red/10 px-2 py-1 text-[11px] text-red">
+          {serverError}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-1.5 text-[11px] font-bold text-orange hover:bg-orange/25 disabled:opacity-45"
+        >
+          {submitting ? 'Recording' : 'Record observed evidence'}
+        </button>
+        <span className="text-[10px] text-silver-dk">
+          Stage 6B records evidence only. It does not change predictions, scoring, or generated candidates.
+        </span>
+      </div>
+    </form>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceForm.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceForm.tsx
@@ -67,31 +67,13 @@ export function ObservedEvidenceForm({
       await onSubmit(request);
     } catch {
       // The parent's mutation `onError` already captures the failure and
-      // surfaces it via the `serverError` prop. We swallow the re-thrown
-      // rejection here so React/jest don't see it as an unhandled
-      // rejection. The user-visible error message remains controlled by
-      // the panel's mutation state. We don't know here whether the
-      // submit succeeded — the parent panel is the source of truth. If
-      // it set serverError we keep the form so the user can fix and
-      // retry; if it cleared serverError, ObservedEvidencePanel
-      // remounts the form via a `key` change for a clean reset.
+      // surfaces it via the `serverError` prop. Swallowing the re-thrown
+      // rejection here keeps React/jest from flagging it as unhandled.
+      // On success, the parent panel remounts this form via a `key`
+      // change, so local form state resets cleanly without any
+      // imperative reset call from the child.
     }
   }
-
-  function resetAfterSuccess() {
-    setState(defaultCreateFormState(suggestedArchetype));
-    setLocalErrors([]);
-    setAdvancedOpen(false);
-  }
-
-  // The parent panel calls this via an imperative-ish pattern: it passes
-  // a ref through `formInstance` if needed. To keep the API simple here
-  // we expose resetAfterSuccess on the function itself via a side-channel:
-  // we attach it to the form's onSubmit lifecycle by re-running the reset
-  // when `submitting` flips from true to false and there is no server
-  // error. That side-effect lives in the panel; the form's local form
-  // state is reset there by remounting via `key` changes.
-  void resetAfterSuccess;
 
   return (
     <form onSubmit={handleSubmit} aria-label="Record observed evidence" className="space-y-3">

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceList.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidenceList.tsx
@@ -1,0 +1,60 @@
+import type { ObservedFact, ObservedFactUpdateRequest } from '@/types/api';
+import { ObservedEvidenceCard } from './ObservedEvidenceCard';
+import { EMPTY_STATE_BODY, EMPTY_STATE_TITLE } from './observationLabels';
+
+interface ObservedEvidenceListProps {
+  facts: ObservedFact[];
+  savingId: string | null;
+  deletingId: string | null;
+  saveErrorById: Record<string, string | null>;
+  deleteErrorById: Record<string, string | null>;
+  onSave: (observationId: string, update: ObservedFactUpdateRequest) => Promise<void> | void;
+  onDelete: (observationId: string) => Promise<void> | void;
+  onClearErrors: (observationId: string) => void;
+}
+
+/**
+ * Renders the list of Observed Evidence cards (Stage 6B).
+ *
+ * The list itself is a passive display: it never calls the simulation
+ * or optimiser, never alters predictions, and only reads the observation
+ * shelf returned by the backend list endpoint. Empty/error/loading states
+ * live in the parent panel.
+ */
+export function ObservedEvidenceList({
+  facts,
+  savingId,
+  deletingId,
+  saveErrorById,
+  deleteErrorById,
+  onSave,
+  onDelete,
+  onClearErrors,
+}: ObservedEvidenceListProps) {
+  if (facts.length === 0) {
+    return (
+      <div className="rounded-chunk-lg border border-border/60 bg-bg3/25 p-4 font-mono text-[11px] text-silver-dk">
+        <div className="font-bold text-silver">{EMPTY_STATE_TITLE}</div>
+        <p className="mt-1 leading-snug">{EMPTY_STATE_BODY}</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-2" aria-label="Observed evidence list" role="list">
+      {facts.map((fact) => (
+        <ObservedEvidenceCard
+          key={fact.observation_id}
+          fact={fact}
+          saving={savingId === fact.observation_id}
+          deleting={deletingId === fact.observation_id}
+          saveError={saveErrorById[fact.observation_id] ?? null}
+          deleteError={deleteErrorById[fact.observation_id] ?? null}
+          onSave={(update) => onSave(fact.observation_id, update)}
+          onDelete={() => onDelete(fact.observation_id)}
+          onClearErrors={() => onClearErrors(fact.observation_id)}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
@@ -1,0 +1,547 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createObservedFact,
+  deleteObservedFact,
+  fetchOptimiserCandidates,
+  listObservedFacts,
+  simulateBuild,
+  updateObservedFact,
+} from '@/lib/api';
+import { ApiError } from '@/lib/api';
+import type {
+  ObservedFact,
+  ObservedFactCreateRequest,
+  ObservedFactListResponse,
+  ObservedFactUpdateRequest,
+} from '@/types/api';
+import { ObservedEvidencePanel } from './ObservedEvidencePanel';
+
+vi.mock('@/lib/api', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api')>('@/lib/api');
+  return {
+    ...actual,
+    listObservedFacts: vi.fn(),
+    createObservedFact: vi.fn(),
+    updateObservedFact: vi.fn(),
+    deleteObservedFact: vi.fn(),
+    fetchOptimiserCandidates: vi.fn(),
+    simulateBuild: vi.fn(),
+  };
+});
+
+const mockedList = vi.mocked(listObservedFacts);
+const mockedCreate = vi.mocked(createObservedFact);
+const mockedUpdate = vi.mocked(updateObservedFact);
+const mockedDelete = vi.mocked(deleteObservedFact);
+const mockedFetchOptimiser = vi.mocked(fetchOptimiserCandidates);
+const mockedSimulateBuild = vi.mocked(simulateBuild);
+
+function emptyResponse(): ObservedFactListResponse {
+  return {
+    facts: [],
+    total: 0,
+    limit: 100,
+    offset: 0,
+    summary: {
+      total_count: 0,
+      by_fact_type: {},
+      by_status: {},
+      by_confidence: {},
+      latest_observed_at: null,
+    },
+  };
+}
+
+function fact(overrides: Partial<ObservedFact> = {}): ObservedFact {
+  return {
+    observation_id: 'obs_a',
+    system_id64: 123,
+    created_at: '2026-05-14T13:00:00+00:00',
+    updated_at: null,
+    source: 'manual',
+    fact_type: 'note',
+    subject_type: 'system',
+    subject_id: null,
+    status: 'observed_present',
+    observed_value: undefined,
+    expected_value: undefined,
+    confidence: 'medium',
+    notes: 'A note about the system.',
+    build_fingerprint: null,
+    simulation_fingerprint: null,
+    target_archetype: null,
+    facility_template_id: null,
+    local_body_id: null,
+    service_id: null,
+    economy: null,
+    tags: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function listResponseWith(facts: ObservedFact[]): ObservedFactListResponse {
+  const by_fact_type: Record<string, number> = {};
+  const by_status: Record<string, number> = {};
+  const by_confidence: Record<string, number> = {};
+  for (const f of facts) {
+    by_fact_type[f.fact_type] = (by_fact_type[f.fact_type] ?? 0) + 1;
+    by_status[f.status] = (by_status[f.status] ?? 0) + 1;
+    by_confidence[f.confidence] = (by_confidence[f.confidence] ?? 0) + 1;
+  }
+  return {
+    facts,
+    total: facts.length,
+    limit: 100,
+    offset: 0,
+    summary: {
+      total_count: facts.length,
+      by_fact_type,
+      by_status,
+      by_confidence,
+      latest_observed_at: facts[0]?.created_at ?? null,
+    },
+  };
+}
+
+function renderPanel(systemId64 = 123, suggestedArchetype: string | null = 'agriculture_terraforming') {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ObservedEvidencePanel systemId64={systemId64} suggestedArchetype={suggestedArchetype} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () => {
+  beforeEach(() => {
+    mockedList.mockReset();
+    mockedCreate.mockReset();
+    mockedUpdate.mockReset();
+    mockedDelete.mockReset();
+    mockedFetchOptimiser.mockReset();
+    mockedSimulateBuild.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the passive evidence copy near the top of the panel', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    expect(await screen.findByRole('region', { name: 'Observed Evidence' })).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Observed Evidence is passive\. It does not change Simulation Preview scoring, optimiser ranking, or generated candidates\./,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Observed Evidence records what you actually saw in-game/),
+    ).toBeTruthy();
+  });
+
+  it('lists existing observations returned by the backend for the current system', async () => {
+    mockedList.mockResolvedValue(
+      listResponseWith([
+        fact({ observation_id: 'obs_one', notes: 'Saw a Market service after construction.' }),
+        fact({ observation_id: 'obs_two', fact_type: 'service_presence', service_id: 'market', notes: '' }),
+      ]),
+    );
+    renderPanel();
+
+    expect(await screen.findByText(/Saw a Market service after construction\./)).toBeTruthy();
+    // Service ID rendered for service_presence card.
+    expect(screen.getAllByText('market').length).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(mockedList).toHaveBeenCalledWith(
+        expect.objectContaining({ system_id64: 123 }),
+      ),
+    );
+  });
+
+  it('shows the empty state when no observations exist', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    expect(await screen.findByText('No observed evidence recorded yet.')).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Record what you actually saw in-game\. Evidence is passive and will not change predictions/,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('shows a loading state while the list query is pending', async () => {
+    let resolveList: (response: ObservedFactListResponse) => void = () => {};
+    mockedList.mockReturnValue(
+      new Promise<ObservedFactListResponse>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    renderPanel();
+
+    expect(await screen.findByText(/Loading observed evidence/)).toBeTruthy();
+
+    resolveList(emptyResponse());
+    await waitFor(() => expect(screen.queryByText(/Loading observed evidence/)).toBeNull());
+  });
+
+  it('shows an error state with a retry control when the list query fails', async () => {
+    // The panel sets retry: 1 by default, so the first failure call
+    // becomes a retry then a definitive failure. Reject both so React
+    // Query surfaces the error UI, then resolve subsequent calls so the
+    // user-triggered retry button can succeed.
+    mockedList.mockRejectedValueOnce(new Error('boom'));
+    mockedList.mockRejectedValueOnce(new Error('boom'));
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    // Wait for the visible error banner. We look for the user-facing
+    // copy rather than role=alert because the failure path renders the
+    // banner element with role=alert and additional descendants.
+    expect(
+      await screen.findByText(/Observed evidence failed to load/, undefined, { timeout: 3000 }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('No observed evidence recorded yet.')).toBeTruthy();
+    expect(mockedList.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('creates a manual service_presence observation with service_id', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedCreate.mockResolvedValue(fact({ fact_type: 'service_presence', service_id: 'market' }));
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    fireEvent.change(screen.getByLabelText(/Evidence type/i), {
+      target: { value: 'service_presence' },
+    });
+    fireEvent.change(screen.getByLabelText(/Service ID/i), {
+      target: { value: 'market' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Notes$/), {
+      target: { value: 'Market visible at primary port.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    const sentRequest = mockedCreate.mock.calls[0][0] as ObservedFactCreateRequest;
+    expect(sentRequest.source).toBe('manual');
+    expect(sentRequest.system_id64).toBe(123);
+    expect(sentRequest.fact_type).toBe('service_presence');
+    expect(sentRequest.subject_type).toBe('service');
+    expect(sentRequest.service_id).toBe('market');
+    expect(sentRequest.notes).toBe('Market visible at primary port.');
+  });
+
+  it('creates a manual economy_presence observation with economy', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedCreate.mockResolvedValue(fact({ fact_type: 'economy_presence', economy: 'Agriculture' }));
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    fireEvent.change(screen.getByLabelText(/Evidence type/i), {
+      target: { value: 'economy_presence' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Economy$/i), {
+      target: { value: 'Agriculture' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    const sentRequest = mockedCreate.mock.calls[0][0] as ObservedFactCreateRequest;
+    expect(sentRequest.fact_type).toBe('economy_presence');
+    expect(sentRequest.subject_type).toBe('economy');
+    expect(sentRequest.economy).toBe('Agriculture');
+  });
+
+  it('creates a manual facility_state observation with facility_template_id', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedCreate.mockResolvedValue(fact({ fact_type: 'facility_state', facility_template_id: 'agri_support_a' }));
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    fireEvent.change(screen.getByLabelText(/Evidence type/i), {
+      target: { value: 'facility_state' },
+    });
+    fireEvent.change(screen.getByLabelText(/Facility template ID/i), {
+      target: { value: 'agri_support_a' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    const sentRequest = mockedCreate.mock.calls[0][0] as ObservedFactCreateRequest;
+    expect(sentRequest.fact_type).toBe('facility_state');
+    expect(sentRequest.subject_type).toBe('facility');
+    expect(sentRequest.facility_template_id).toBe('agri_support_a');
+  });
+
+  it('creates a note/system observation without subject_id', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedCreate.mockResolvedValue(fact());
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    // Default fact_type is "note" so we can submit straight away.
+    fireEvent.change(screen.getByLabelText(/^Notes$/), {
+      target: { value: 'General note about the system.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    const sentRequest = mockedCreate.mock.calls[0][0] as ObservedFactCreateRequest;
+    expect(sentRequest.fact_type).toBe('note');
+    expect(sentRequest.subject_type).toBe('system');
+    expect(sentRequest.subject_id ?? null).toBeNull();
+    expect(sentRequest.source).toBe('manual');
+  });
+
+  it('shows backend validation errors clearly when create fails with 422', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedCreate.mockRejectedValue(
+      new ApiError(
+        422,
+        '/observations/facts',
+        JSON.stringify({ detail: [{ loc: ['body', 'service_id'], msg: 'service_id is required', type: 'value_error' }] }),
+      ),
+    );
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    fireEvent.change(screen.getByLabelText(/Evidence type/i), {
+      target: { value: 'service_presence' },
+    });
+    // Provide the field locally so client validation passes, but the
+    // backend will still reject — we use this to assert the error path.
+    fireEvent.change(screen.getByLabelText(/Service ID/i), {
+      target: { value: 'market' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(/service_id is required/)).toBeTruthy();
+  });
+
+  it('client-side validates that service_presence requires service_id before submit', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    fireEvent.change(screen.getByLabelText(/Evidence type/i), {
+      target: { value: 'service_presence' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    expect(
+      await screen.findByText(/Service ID is required for Service presence evidence/),
+    ).toBeTruthy();
+    expect(mockedCreate).not.toHaveBeenCalled();
+  });
+
+  it('edits an existing observation status, confidence, and notes', async () => {
+    mockedList.mockResolvedValueOnce(
+      listResponseWith([fact({ observation_id: 'obs_edit', notes: 'Original notes' })]),
+    );
+    mockedList.mockResolvedValue(
+      listResponseWith([
+        fact({
+          observation_id: 'obs_edit',
+          notes: 'Updated notes',
+          status: 'confirmed',
+          confidence: 'high',
+        }),
+      ]),
+    );
+    mockedUpdate.mockResolvedValue(
+      fact({
+        observation_id: 'obs_edit',
+        notes: 'Updated notes',
+        status: 'confirmed',
+        confidence: 'high',
+      }),
+    );
+    renderPanel();
+
+    await screen.findByText(/Original notes/);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    // Scope inside the edit form because the filter row also exposes
+    // "Status"/"Confidence" labels (as "Filter by status" / "Filter by
+    // confidence"). The edit-form is the only element with role=form
+    // and aria-label "Edit observed evidence", so scoping inside it
+    // disambiguates the controls cleanly.
+    const editForm = screen.getByRole('form', { name: /Edit observed evidence/i });
+    fireEvent.change(within(editForm).getByLabelText(/^Status$/), { target: { value: 'confirmed' } });
+    fireEvent.change(within(editForm).getByLabelText(/^Confidence$/), { target: { value: 'high' } });
+    fireEvent.change(within(editForm).getByLabelText(/^Notes$/), { target: { value: 'Updated notes' } });
+    fireEvent.click(within(editForm).getByRole('button', { name: /Save changes/ }));
+
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalledTimes(1));
+    const [observationId, request] = mockedUpdate.mock.calls[0] as [string, ObservedFactUpdateRequest];
+    expect(observationId).toBe('obs_edit');
+    expect(request.status).toBe('confirmed');
+    expect(request.confidence).toBe('high');
+    expect(request.notes).toBe('Updated notes');
+  });
+
+  it('cancels edit and preserves the original card without calling update', async () => {
+    mockedList.mockResolvedValue(
+      listResponseWith([fact({ observation_id: 'obs_cancel', notes: 'Untouched notes' })]),
+    );
+    renderPanel();
+
+    await screen.findByText(/Untouched notes/);
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    const editForm = screen.getByRole('form', { name: /Edit observed evidence/i });
+    fireEvent.change(within(editForm).getByLabelText(/^Notes$/), { target: { value: 'temp edit' } });
+    fireEvent.click(within(editForm).getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByText(/Untouched notes/)).toBeTruthy();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+  });
+
+  it('requires confirmation before delete and preserves the record on cancel', async () => {
+    mockedList.mockResolvedValue(
+      listResponseWith([fact({ observation_id: 'obs_del', notes: 'Will not be deleted' })]),
+    );
+    renderPanel();
+
+    await screen.findByText(/Will not be deleted/);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    // Confirm dialog appears, but no delete API call yet.
+    expect(screen.getByText(/Delete this observed evidence record\?/)).toBeTruthy();
+    expect(
+      screen.getByText(/This removes the manually recorded evidence only\. It does not change predictions/),
+    ).toBeTruthy();
+    expect(mockedDelete).not.toHaveBeenCalled();
+
+    // Cancel via "Keep evidence".
+    fireEvent.click(screen.getByRole('button', { name: 'Keep evidence' }));
+    expect(screen.queryByText(/Delete this observed evidence record\?/)).toBeNull();
+    expect(screen.getByText(/Will not be deleted/)).toBeTruthy();
+    expect(mockedDelete).not.toHaveBeenCalled();
+  });
+
+  it('deletes a record when the user confirms and refreshes the list', async () => {
+    mockedList.mockResolvedValueOnce(
+      listResponseWith([fact({ observation_id: 'obs_doomed', notes: 'Will be deleted' })]),
+    );
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedDelete.mockResolvedValue({ observation_id: 'obs_doomed', deleted: true });
+    renderPanel();
+
+    await screen.findByText(/Will be deleted/);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: /Confirm delete/ }));
+
+    await waitFor(() => expect(mockedDelete).toHaveBeenCalledWith('obs_doomed'));
+    await waitFor(() => expect(screen.queryByText(/Will be deleted/)).toBeNull());
+    expect(await screen.findByText('No observed evidence recorded yet.')).toBeTruthy();
+  });
+
+  it('applies fact_type and status filters via the list endpoint query params', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+    await waitFor(() => expect(mockedList).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByLabelText(/Filter by type/i), {
+      target: { value: 'service_presence' },
+    });
+    await waitFor(() =>
+      expect(mockedList).toHaveBeenLastCalledWith(
+        expect.objectContaining({ system_id64: 123, fact_type: 'service_presence' }),
+      ),
+    );
+
+    fireEvent.change(screen.getByLabelText(/Filter by status/i), {
+      target: { value: 'observed_present' },
+    });
+    await waitFor(() =>
+      expect(mockedList).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          system_id64: 123,
+          fact_type: 'service_presence',
+          status: 'observed_present',
+        }),
+      ),
+    );
+
+    // Clear filters button is exposed when at least one filter is active.
+    // After clearing, the button disappears and the call history must
+    // include at least one call with no fact_type / status filters. We
+    // assert via the full call history because React Query may serve the
+    // no-filter response from cache rather than refetching it.
+    fireEvent.click(screen.getByRole('button', { name: /Clear filters/ }));
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /Clear filters/ })).toBeNull(),
+    );
+    expect(
+      mockedList.mock.calls.some(([params]) =>
+        params.system_id64 === 123 && !params.fact_type && !params.status,
+      ),
+    ).toBe(true);
+  });
+
+  it('does not expose imported or inferred as create-form source options', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    // The create form has Evidence type / Status / Confidence selects but
+    // NO "Source" select. Imported/inferred never appear as option text in
+    // any select. We assert both by checking option DOM and by checking
+    // that submitting always sends source: 'manual'.
+    const options = Array.from(screen.queryAllByRole('option')) as HTMLOptionElement[];
+    for (const option of options) {
+      expect(option.value).not.toBe('imported');
+      expect(option.value).not.toBe('inferred');
+    }
+  });
+
+  it('does not call simulateBuild or fetchOptimiserCandidates during create/update/delete flows', async () => {
+    mockedList.mockResolvedValue(
+      listResponseWith([fact({ observation_id: 'obs_iso' })]),
+    );
+    mockedCreate.mockResolvedValue(fact({ observation_id: 'obs_new' }));
+    mockedUpdate.mockResolvedValue(fact({ observation_id: 'obs_iso', notes: 'edited' }));
+    mockedDelete.mockResolvedValue({ observation_id: 'obs_iso', deleted: true });
+    renderPanel();
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+
+    // Create
+    fireEvent.change(screen.getByLabelText(/^Notes$/), { target: { value: 'isolation note' } });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalled());
+
+    // Update — locate the inline edit button on the existing card.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Edit' })[0]);
+    const editForm = await screen.findByRole('form', { name: /Edit observed evidence/i });
+    fireEvent.change(within(editForm).getByLabelText(/^Notes$/), { target: { value: 'edited' } });
+    fireEvent.click(within(editForm).getByRole('button', { name: /Save changes/ }));
+    await waitFor(() => expect(mockedUpdate).toHaveBeenCalled());
+
+    // Delete
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: /Confirm delete/ }));
+    await waitFor(() => expect(mockedDelete).toHaveBeenCalled());
+
+    expect(mockedSimulateBuild).not.toHaveBeenCalled();
+    expect(mockedFetchOptimiser).not.toHaveBeenCalled();
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
@@ -82,10 +82,19 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
     retry: 1,
   });
 
-  // Confidence filtering happens client-side because the Stage 6A list
-  // endpoint does not expose a confidence query param yet. The backend
-  // summary still describes the full filtered result set; client-side
-  // confidence filtering is a UI-only refinement.
+  // Confidence filtering is applied locally because the Stage 6A list
+  // endpoint accepts `fact_type` and `status` query params but does not
+  // expose a `confidence` query param. As a result:
+  //   - The backend list query reflects only the type/status filters.
+  //   - The `summary` returned by the backend describes that backend
+  //     result set (type/status filters applied), NOT the
+  //     confidence-narrowed visible list below.
+  //   - The confidence filter is a UI-only refinement that hides rows
+  //     from view; it does not change the totals shown in summary.
+  // The UI surfaces this distinction explicitly via a "Showing X of Y
+  // records after confidence filter" line when the confidence filter is
+  // active. Adding backend confidence filtering is deferred until the
+  // backend list endpoint is extended in a later stage.
   const facts = useMemo(() => {
     const all = listQuery.data?.facts ?? [];
     if (!confidenceFilter) return all;
@@ -250,8 +259,15 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
         <div className="mb-3 rounded border border-border/60 bg-bg3/20 px-3 py-2 font-mono text-[10px] text-silver-dk">
           <div className="uppercase tracking-[0.16em] text-silver">
             Summary
-            {filtersActive && <span className="ml-2 text-cyan">(filtered)</span>}
+            {(factTypeFilter || statusFilter) && (
+              <span className="ml-2 text-cyan">(type / status filtered)</span>
+            )}
           </div>
+          <p className="mt-1 text-[10px] text-silver-dk">
+            Totals reflect the type and status filters only. Confidence
+            filtering is applied locally and narrows the visible list
+            below without changing these totals.
+          </p>
           <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1">
             <span>Total: <span className="text-silver">{summary.total_count}</span></span>
             {Object.entries(summary.by_fact_type ?? {}).map(([type, count]) => (
@@ -272,7 +288,7 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
           </div>
           {confidenceFilter && (
             <p className="mt-1 text-[10px] text-silver-dk">
-              Showing {filteredCount} of {summary.total_count} records after confidence filter.
+              Showing {filteredCount} of {summary.total_count} records after local confidence filter.
             </p>
           )}
         </div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
@@ -1,0 +1,321 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createObservedFact,
+  deleteObservedFact,
+  listObservedFacts,
+  updateObservedFact,
+} from '@/lib/api';
+import type {
+  ListObservedFactsParams,
+  ObservedConfidence,
+  ObservedFactCreateRequest,
+  ObservedFactListResponse,
+  ObservedFactType,
+  ObservedFactUpdateRequest,
+  ObservedStatus,
+} from '@/types/api';
+import { ObservedEvidenceForm } from './ObservedEvidenceForm';
+import { ObservedEvidenceList } from './ObservedEvidenceList';
+import {
+  CONFIDENCES,
+  CREATABLE_FACT_TYPES,
+  PANEL_INTRO_COPY,
+  PASSIVE_EVIDENCE_COPY,
+  STATUSES,
+  confidenceLabel,
+  factTypeLabel,
+  statusLabel,
+} from './observationLabels';
+import { describeApiError } from './observationUtils';
+
+interface ObservedEvidencePanelProps {
+  systemId64: number;
+  suggestedArchetype?: string | null;
+}
+
+/**
+ * Stage 6B Observed Evidence panel.
+ *
+ * Lists, creates, updates, and deletes manually recorded observed evidence
+ * for the current system. The panel is passive: nothing here calls
+ * `simulateBuild` or `fetchOptimiserCandidates`, and the data fetched here
+ * is NOT plumbed back into Simulation Preview scoring or optimiser ranking.
+ * Stage 6C will introduce predicted-vs-observed comparison; Stage 6D will
+ * render validation/comparison results.
+ *
+ * The query key includes the current filter set so changing a filter
+ * triggers a fresh backend list call with the filter applied (the
+ * backend list endpoint already returns `summary` over the full filtered
+ * result set).
+ */
+export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: ObservedEvidencePanelProps) {
+  const queryClient = useQueryClient();
+
+  const [factTypeFilter, setFactTypeFilter] = useState<ObservedFactType | ''>('');
+  const [statusFilter, setStatusFilter] = useState<ObservedStatus | ''>('');
+  const [confidenceFilter, setConfidenceFilter] = useState<ObservedConfidence | ''>('');
+
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createFormKey, setCreateFormKey] = useState(0);
+  const [saveErrorById, setSaveErrorById] = useState<Record<string, string | null>>({});
+  const [deleteErrorById, setDeleteErrorById] = useState<Record<string, string | null>>({});
+
+  const listParams: ListObservedFactsParams = useMemo(() => {
+    const params: ListObservedFactsParams = { system_id64: systemId64 };
+    if (factTypeFilter) params.fact_type = factTypeFilter;
+    if (statusFilter) params.status = statusFilter;
+    return params;
+  }, [systemId64, factTypeFilter, statusFilter]);
+
+  const queryKey = useMemo(
+    () => ['observed-facts', systemId64, factTypeFilter || null, statusFilter || null],
+    [systemId64, factTypeFilter, statusFilter],
+  );
+
+  const listQuery = useQuery<ObservedFactListResponse, Error>({
+    queryKey,
+    queryFn: () => listObservedFacts(listParams),
+    staleTime: 30 * 1000,
+    // Keep retries to 1 in production, but tests pass retry:false through
+    // the React Query client so failures surface immediately.
+    retry: 1,
+  });
+
+  // Confidence filtering happens client-side because the Stage 6A list
+  // endpoint does not expose a confidence query param yet. The backend
+  // summary still describes the full filtered result set; client-side
+  // confidence filtering is a UI-only refinement.
+  const facts = useMemo(() => {
+    const all = listQuery.data?.facts ?? [];
+    if (!confidenceFilter) return all;
+    return all.filter((fact) => fact.confidence === confidenceFilter);
+  }, [listQuery.data, confidenceFilter]);
+
+  const summary = listQuery.data?.summary;
+
+  const createMutation = useMutation({
+    mutationFn: (request: ObservedFactCreateRequest) => createObservedFact(request),
+    onSuccess: () => {
+      setCreateError(null);
+      // Force form remount to reset state on success.
+      setCreateFormKey((value) => value + 1);
+      void queryClient.invalidateQueries({ queryKey: ['observed-facts', systemId64] });
+    },
+    onError: (error: unknown) => {
+      setCreateError(describeApiError(error));
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ observationId, request }: { observationId: string; request: ObservedFactUpdateRequest }) =>
+      updateObservedFact(observationId, request),
+    onSuccess: (_data, variables) => {
+      setSaveErrorById((prev) => {
+        const next = { ...prev };
+        delete next[variables.observationId];
+        return next;
+      });
+      void queryClient.invalidateQueries({ queryKey: ['observed-facts', systemId64] });
+    },
+    onError: (error: unknown, variables) => {
+      setSaveErrorById((prev) => ({ ...prev, [variables.observationId]: describeApiError(error) }));
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (observationId: string) => deleteObservedFact(observationId),
+    onSuccess: (_data, observationId) => {
+      setDeleteErrorById((prev) => {
+        const next = { ...prev };
+        delete next[observationId];
+        return next;
+      });
+      void queryClient.invalidateQueries({ queryKey: ['observed-facts', systemId64] });
+    },
+    onError: (error: unknown, observationId) => {
+      setDeleteErrorById((prev) => ({ ...prev, [observationId]: describeApiError(error) }));
+    },
+  });
+
+  function clearCardErrors(observationId: string) {
+    setSaveErrorById((prev) => {
+      if (!prev[observationId]) return prev;
+      const next = { ...prev };
+      delete next[observationId];
+      return next;
+    });
+    setDeleteErrorById((prev) => {
+      if (!prev[observationId]) return prev;
+      const next = { ...prev };
+      delete next[observationId];
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(factTypeFilter || statusFilter || confidenceFilter);
+  const filteredCount = facts.length;
+
+  return (
+    <section
+      aria-label="Observed Evidence"
+      className="rounded-chunk-lg border border-orange/20 bg-bg1/55 p-4"
+    >
+      <header className="mb-3">
+        <h3 className="text-orange text-sm font-bold tracking-[0.18em] uppercase">Observed Evidence</h3>
+        <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">{PANEL_INTRO_COPY}</p>
+        <p
+          className="mt-1 rounded border border-cyan/30 bg-cyan/5 px-2 py-1 text-[10px] text-cyan font-mono"
+          role="note"
+          aria-label="Observed Evidence passivity notice"
+        >
+          {PASSIVE_EVIDENCE_COPY}
+        </p>
+      </header>
+
+      <div className="mb-4 rounded border border-border/60 bg-bg2/30 p-3">
+        <div className="mb-2 text-[10px] uppercase tracking-[0.14em] text-silver-dk">Record manually observed evidence</div>
+        <ObservedEvidenceForm
+          // Remount on success so internal form state resets cleanly.
+          key={createFormKey}
+          systemId64={systemId64}
+          suggestedArchetype={suggestedArchetype}
+          submitting={createMutation.isPending}
+          serverError={createError}
+          onSubmit={async (request) => {
+            await createMutation.mutateAsync(request);
+          }}
+          onClearError={() => setCreateError(null)}
+        />
+      </div>
+
+      <div className="mb-3 grid gap-2 sm:grid-cols-[auto_auto_auto_auto] sm:items-end">
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Filter by type
+          <select
+            value={factTypeFilter}
+            onChange={(event) => setFactTypeFilter(event.target.value as ObservedFactType | '')}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          >
+            <option value="">All types</option>
+            {CREATABLE_FACT_TYPES.map((value) => (
+              <option key={value} value={value}>{factTypeLabel(value)}</option>
+            ))}
+            <option value="prediction_match">{factTypeLabel('prediction_match')}</option>
+            <option value="prediction_mismatch">{factTypeLabel('prediction_mismatch')}</option>
+          </select>
+        </label>
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Filter by status
+          <select
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value as ObservedStatus | '')}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          >
+            <option value="">All statuses</option>
+            {STATUSES.map((value) => (
+              <option key={value} value={value}>{statusLabel(value)}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Filter by confidence
+          <select
+            value={confidenceFilter}
+            onChange={(event) => setConfidenceFilter(event.target.value as ObservedConfidence | '')}
+            className="mt-1 block w-full rounded border border-border bg-bg2 px-2 py-1 text-[11px] text-silver"
+          >
+            <option value="">All confidences</option>
+            {CONFIDENCES.map((value) => (
+              <option key={value} value={value}>{confidenceLabel(value)}</option>
+            ))}
+          </select>
+        </label>
+        {filtersActive && (
+          <button
+            type="button"
+            onClick={() => {
+              setFactTypeFilter('');
+              setStatusFilter('');
+              setConfidenceFilter('');
+            }}
+            className="rounded-chunk-sm border border-border bg-bg2 px-3 py-1.5 text-[11px] text-silver hover:border-orange/40 hover:text-orange"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {summary && (
+        <div className="mb-3 rounded border border-border/60 bg-bg3/20 px-3 py-2 font-mono text-[10px] text-silver-dk">
+          <div className="uppercase tracking-[0.16em] text-silver">
+            Summary
+            {filtersActive && <span className="ml-2 text-cyan">(filtered)</span>}
+          </div>
+          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1">
+            <span>Total: <span className="text-silver">{summary.total_count}</span></span>
+            {Object.entries(summary.by_fact_type ?? {}).map(([type, count]) => (
+              <span key={`ft-${type}`}>
+                {factTypeLabel(type)}: <span className="text-silver">{count}</span>
+              </span>
+            ))}
+            {Object.entries(summary.by_status ?? {}).map(([status, count]) => (
+              <span key={`st-${status}`}>
+                {statusLabel(status)}: <span className="text-silver">{count}</span>
+              </span>
+            ))}
+            {Object.entries(summary.by_confidence ?? {}).map(([confidence, count]) => (
+              <span key={`cf-${confidence}`}>
+                {confidenceLabel(confidence)}: <span className="text-silver">{count}</span>
+              </span>
+            ))}
+          </div>
+          {confidenceFilter && (
+            <p className="mt-1 text-[10px] text-silver-dk">
+              Showing {filteredCount} of {summary.total_count} records after confidence filter.
+            </p>
+          )}
+        </div>
+      )}
+
+      {listQuery.isLoading && (
+        <div className="rounded border border-border/60 bg-bg3/30 px-3 py-3 font-mono text-xs text-silver-dk">
+          Loading observed evidence&hellip;
+        </div>
+      )}
+
+      {listQuery.isError && (
+        <div
+          role="alert"
+          className="rounded border border-red/40 bg-red/10 px-3 py-2 font-mono text-[11px] text-red"
+        >
+          <div>Observed evidence failed to load: {describeApiError(listQuery.error)}</div>
+          <button
+            type="button"
+            onClick={() => void listQuery.refetch()}
+            className="mt-2 rounded-chunk-sm border border-red/50 bg-red/15 px-3 py-1 text-[11px] font-bold text-red hover:bg-red/25"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {!listQuery.isLoading && !listQuery.isError && (
+        <ObservedEvidenceList
+          facts={facts}
+          savingId={updateMutation.isPending ? updateMutation.variables?.observationId ?? null : null}
+          deletingId={deleteMutation.isPending ? deleteMutation.variables ?? null : null}
+          saveErrorById={saveErrorById}
+          deleteErrorById={deleteErrorById}
+          onSave={async (observationId, update) => {
+            await updateMutation.mutateAsync({ observationId, request: update });
+          }}
+          onDelete={async (observationId) => {
+            await deleteMutation.mutateAsync(observationId);
+          }}
+          onClearErrors={clearCardErrors}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/index.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/index.ts
@@ -1,0 +1,6 @@
+export { ObservedEvidencePanel } from './ObservedEvidencePanel';
+export { ObservedEvidenceForm } from './ObservedEvidenceForm';
+export { ObservedEvidenceList } from './ObservedEvidenceList';
+export { ObservedEvidenceCard } from './ObservedEvidenceCard';
+export * from './observationLabels';
+export * from './observationUtils';

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/observationLabels.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/observationLabels.ts
@@ -1,0 +1,142 @@
+/**
+ * User-facing labels for Observed Evidence (Stage 6B).
+ *
+ * The backend talks about "observed facts" because that maps to the persisted
+ * data contract. The user-facing product talks about "Observed Evidence" so
+ * the UI does not overclaim correctness — observations are recorded evidence,
+ * not proof. These labels keep both vocabularies aligned without leaking
+ * absolute wording ("verified", "proven", "rule update") into the UI.
+ *
+ * Stage 6B is intentionally passive: nothing here implies that an observation
+ * changes Simulation Preview scoring, optimiser ranking, or generated
+ * candidates. Comparison comes in Stage 6C, validation display in Stage 6D.
+ */
+import type {
+  ObservationSource,
+  ObservedConfidence,
+  ObservedFactType,
+  ObservedStatus,
+  ObservedSubjectType,
+} from '@/types/api';
+
+export const PASSIVE_EVIDENCE_COPY =
+  'Observed Evidence is passive. It does not change Simulation Preview scoring, optimiser ranking, or generated candidates.';
+
+export const PANEL_INTRO_COPY =
+  'Observed Evidence records what you actually saw in-game for this system or build. It is passive evidence: it does not change Simulation Preview scoring, optimiser ranking, or generated candidates.';
+
+export const EMPTY_STATE_TITLE = 'No observed evidence recorded yet.';
+export const EMPTY_STATE_BODY =
+  'Record what you actually saw in-game. Evidence is passive and will not change predictions until a later validation stage compares it.';
+
+export const DELETE_CONFIRM_TITLE = 'Delete this observed evidence record?';
+export const DELETE_CONFIRM_BODY =
+  'This removes the manually recorded evidence only. It does not change predictions, builds, or in-game state.';
+
+/**
+ * Fact types offered to manual users. The backend enum also includes
+ * `prediction_match` / `prediction_mismatch` which are reserved for Stage
+ * 6C predicted-vs-observed comparison; Stage 6B does not let the user
+ * manually create them because they would imply a comparison verdict that
+ * the Stage 6B UI does not produce.
+ */
+export const CREATABLE_FACT_TYPES: readonly ObservedFactType[] = [
+  'service_presence',
+  'economy_presence',
+  'facility_state',
+  'cp_value',
+  'build_outcome',
+  'note',
+];
+
+export const FACT_TYPE_LABELS: Record<ObservedFactType, string> = {
+  service_presence: 'Service presence',
+  economy_presence: 'Economy presence',
+  facility_state: 'Facility state',
+  cp_value: 'CP value',
+  build_outcome: 'Build outcome',
+  prediction_match: 'Prediction match',
+  prediction_mismatch: 'Prediction mismatch',
+  note: 'Note',
+};
+
+export const SUBJECT_TYPE_LABELS: Record<ObservedSubjectType, string> = {
+  system: 'System',
+  body: 'Body',
+  facility: 'Facility',
+  service: 'Service',
+  economy: 'Economy',
+  build: 'Build',
+  simulation: 'Simulation',
+  cp: 'CP',
+};
+
+export const STATUS_LABELS: Record<ObservedStatus, string> = {
+  observed_present: 'Observed present',
+  observed_absent: 'Observed absent',
+  confirmed: 'Confirmed',
+  contradicted: 'Contradicted',
+  unknown: 'Unknown',
+  unverified: 'Unverified',
+};
+
+export const STATUSES: readonly ObservedStatus[] = [
+  'observed_present',
+  'observed_absent',
+  'confirmed',
+  'contradicted',
+  'unknown',
+  'unverified',
+];
+
+export const CONFIDENCE_LABELS: Record<ObservedConfidence, string> = {
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+};
+
+export const CONFIDENCES: readonly ObservedConfidence[] = ['low', 'medium', 'high'];
+
+export const SOURCE_LABELS: Record<ObservationSource, string> = {
+  manual: 'Manual',
+  test_fixture: 'Test fixture',
+  imported: 'Imported',
+  inferred: 'Inferred',
+};
+
+/**
+ * Default subject_type the form uses for each fact_type. The backend
+ * doesn't strictly require these mappings (subject_id can be null for
+ * free-form notes), but using sensible defaults keeps the create form
+ * compact and matches how the panel cards describe each evidence row.
+ */
+export const DEFAULT_SUBJECT_TYPE_FOR_FACT_TYPE: Record<ObservedFactType, ObservedSubjectType> = {
+  service_presence: 'service',
+  economy_presence: 'economy',
+  facility_state: 'facility',
+  cp_value: 'cp',
+  build_outcome: 'build',
+  prediction_match: 'system',
+  prediction_mismatch: 'system',
+  note: 'system',
+};
+
+export function factTypeLabel(value: string): string {
+  return (FACT_TYPE_LABELS as Record<string, string>)[value] ?? value;
+}
+
+export function statusLabel(value: string): string {
+  return (STATUS_LABELS as Record<string, string>)[value] ?? value;
+}
+
+export function confidenceLabel(value: string): string {
+  return (CONFIDENCE_LABELS as Record<string, string>)[value] ?? value;
+}
+
+export function subjectTypeLabel(value: string): string {
+  return (SUBJECT_TYPE_LABELS as Record<string, string>)[value] ?? value;
+}
+
+export function sourceLabel(value: string): string {
+  return (SOURCE_LABELS as Record<string, string>)[value] ?? value;
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/observationUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/observationUtils.ts
@@ -1,0 +1,253 @@
+/**
+ * Pure helper utilities for the Stage 6B Observed Evidence panel.
+ *
+ * These helpers do NOT call the API. They format / parse strings that the
+ * manual-evidence form needs, and provide a small validator the form uses
+ * before POSTing to the backend. The backend remains the source of truth
+ * for validation; this validator only catches the most obvious mistakes so
+ * the user doesn't have to wait for a network round-trip to spot them.
+ */
+import type {
+  ApiError,
+} from '@/lib/api';
+import type {
+  ObservedConfidence,
+  ObservedFact,
+  ObservedFactCreateRequest,
+  ObservedFactType,
+  ObservedJsonValue,
+  ObservedStatus,
+  ObservedSubjectType,
+} from '@/types/api';
+import { DEFAULT_SUBJECT_TYPE_FOR_FACT_TYPE } from './observationLabels';
+
+export function parseTagsInput(raw: string): string[] {
+  if (!raw) return [];
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const piece of raw.split(',')) {
+    const value = piece.trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    tags.push(value);
+    if (tags.length >= 20) break;
+  }
+  return tags;
+}
+
+export function tagsToInputValue(tags: readonly string[] | undefined | null): string {
+  if (!tags || tags.length === 0) return '';
+  return tags.join(', ');
+}
+
+/**
+ * Parse the small "observed_value" / "expected_value" free-text fields.
+ *
+ * The backend column is JSONB, so users could in theory type any JSON
+ * value. We keep the UX small: blank → undefined, valid JSON → parsed,
+ * otherwise the raw string. This matches "type a number, type a JSON
+ * object, or just type a sentence" intuitions without forcing users to
+ * remember strict JSON quoting.
+ */
+export function parseObservedValue(raw: string): ObservedJsonValue | undefined {
+  if (raw == null) return undefined;
+  const trimmed = String(raw).trim();
+  if (trimmed === '') return undefined;
+  try {
+    return JSON.parse(trimmed) as ObservedJsonValue;
+  } catch {
+    return trimmed;
+  }
+}
+
+export function formatObservedValue(value: ObservedJsonValue | undefined | null): string {
+  if (value === undefined || value === null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Map a fact_type the user picked to the sensible default subject_type
+ * the panel/form uses behind the scenes. The user can still leave the
+ * structured subject blank for note-style entries.
+ */
+export function subjectTypeForFactType(factType: ObservedFactType): ObservedSubjectType {
+  return DEFAULT_SUBJECT_TYPE_FOR_FACT_TYPE[factType] ?? 'system';
+}
+
+export interface CreateFormState {
+  fact_type: ObservedFactType;
+  status: ObservedStatus;
+  confidence: ObservedConfidence;
+  notes: string;
+  service_id: string;
+  economy: string;
+  facility_template_id: string;
+  local_body_id: string;
+  observed_value_raw: string;
+  expected_value_raw: string;
+  target_archetype: string;
+  tags_input: string;
+}
+
+export function defaultCreateFormState(suggestedArchetype?: string | null): CreateFormState {
+  return {
+    fact_type: 'note',
+    status: 'observed_present',
+    confidence: 'medium',
+    notes: '',
+    service_id: '',
+    economy: '',
+    facility_template_id: '',
+    local_body_id: '',
+    observed_value_raw: '',
+    expected_value_raw: '',
+    target_archetype: suggestedArchetype ?? '',
+    tags_input: '',
+  };
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/**
+ * Lightweight client-side validation. The Stage 6A backend still validates
+ * authoritatively (and rejects e.g. `service_presence` without `service_id`),
+ * but flagging the most common mistakes locally avoids a round-trip.
+ */
+export function validateCreateForm(state: CreateFormState): ValidationResult {
+  const errors: string[] = [];
+  if (state.fact_type === 'service_presence' && !state.service_id.trim()) {
+    errors.push('Service ID is required for Service presence evidence.');
+  }
+  if (state.fact_type === 'economy_presence' && !state.economy.trim()) {
+    errors.push('Economy is required for Economy presence evidence.');
+  }
+  if (state.fact_type === 'facility_state' && !state.facility_template_id.trim()) {
+    errors.push('Facility template ID is required for Facility state evidence.');
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+export function buildCreateRequest(
+  state: CreateFormState,
+  systemId64: number,
+): ObservedFactCreateRequest {
+  const subject_type = subjectTypeForFactType(state.fact_type);
+  let subject_id: string | null = null;
+  switch (state.fact_type) {
+    case 'service_presence':
+      subject_id = state.service_id.trim() || null;
+      break;
+    case 'economy_presence':
+      subject_id = state.economy.trim() || null;
+      break;
+    case 'facility_state':
+      subject_id = state.facility_template_id.trim() || null;
+      break;
+    case 'cp_value':
+      subject_id = 'cp';
+      break;
+    case 'build_outcome':
+      subject_id = null;
+      break;
+    case 'note':
+    default:
+      subject_id = null;
+      break;
+  }
+
+  const request: ObservedFactCreateRequest = {
+    system_id64: systemId64,
+    source: 'manual',
+    fact_type: state.fact_type,
+    subject_type,
+    subject_id,
+    status: state.status,
+    confidence: state.confidence,
+  };
+
+  const notes = state.notes.trim();
+  if (notes) request.notes = notes;
+
+  const observed = parseObservedValue(state.observed_value_raw);
+  if (observed !== undefined) request.observed_value = observed;
+
+  const expected = parseObservedValue(state.expected_value_raw);
+  if (expected !== undefined) request.expected_value = expected;
+
+  if (state.service_id.trim())          request.service_id          = state.service_id.trim();
+  if (state.economy.trim())             request.economy             = state.economy.trim();
+  if (state.facility_template_id.trim()) request.facility_template_id = state.facility_template_id.trim();
+  if (state.local_body_id.trim())       request.local_body_id       = state.local_body_id.trim();
+  if (state.target_archetype.trim())    request.target_archetype    = state.target_archetype.trim();
+
+  const tags = parseTagsInput(state.tags_input);
+  if (tags.length > 0) request.tags = tags;
+
+  return request;
+}
+
+export interface EditFormState {
+  status: ObservedStatus;
+  confidence: ObservedConfidence;
+  notes: string;
+  tags_input: string;
+  observed_value_raw: string;
+  expected_value_raw: string;
+}
+
+export function defaultEditFormState(fact: ObservedFact): EditFormState {
+  return {
+    status: (fact.status as ObservedStatus) ?? 'observed_present',
+    confidence: (fact.confidence as ObservedConfidence) ?? 'medium',
+    notes: fact.notes ?? '',
+    tags_input: tagsToInputValue(fact.tags),
+    observed_value_raw: formatObservedValue(fact.observed_value),
+    expected_value_raw: formatObservedValue(fact.expected_value),
+  };
+}
+
+/**
+ * Surface FastAPI / Problem-Details validation messages in a human form.
+ *
+ * The backend returns either a plain text message or a JSON body shaped
+ * like `{ detail: [ { loc, msg, type } ] }` for 422 validation errors.
+ * We try the JSON shape first so the user sees the real reason a request
+ * was rejected, but fall back to the raw text rather than swallowing it.
+ */
+export function describeApiError(err: unknown): string {
+  if (err instanceof Error) {
+    const apiErr = err as unknown as ApiError;
+    const body = (apiErr.body ?? '').trim();
+    if (body.startsWith('{') || body.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(body) as { detail?: unknown };
+        const detail = parsed?.detail;
+        if (Array.isArray(detail)) {
+          const messages = detail
+            .map((d) => {
+              if (d && typeof d === 'object' && 'msg' in (d as Record<string, unknown>)) {
+                return String((d as Record<string, unknown>).msg ?? '');
+              }
+              return '';
+            })
+            .filter((s) => s.length > 0);
+          if (messages.length > 0) return messages.join('; ');
+        }
+        if (typeof detail === 'string') return detail;
+      } catch {
+        /* fall through to raw body */
+      }
+    }
+    if (body) return body;
+    return err.message;
+  }
+  return 'Unexpected error';
+}

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -15,6 +15,12 @@ import type {
   AutocompleteResponse,
   CacheStats,
   FacilityTemplate,
+  ListObservedFactsParams,
+  ObservedFact,
+  ObservedFactCreateRequest,
+  ObservedFactDeleteResponse,
+  ObservedFactListResponse,
+  ObservedFactUpdateRequest,
   OptimiserCandidatesRequest,
   OptimiserCandidatesResponse,
   RecommendedBuildsResponse,
@@ -253,6 +259,46 @@ export const api = {
       headers: { 'X-Admin-Token': token },
     });
   },
+
+  // ── Stage 6B Observed Evidence (Observed Facts) ────────────────────────
+  // Passive evidence: records what a user actually saw in-game for a system
+  // or build. These calls do NOT change Simulation Preview scoring, optimiser
+  // ranking, or generated candidates. They are also not consumed by the
+  // simulation/optimiser modules — see api-contracts.md "Stage 6A Observed
+  // Facts API" for the contract details.
+  listObservedFacts(params: ListObservedFactsParams): Promise<ObservedFactListResponse> {
+    const usp = new URLSearchParams();
+    usp.set('system_id64', String(params.system_id64));
+    if (params.fact_type)              usp.set('fact_type',              params.fact_type);
+    if (params.subject_type)           usp.set('subject_type',           params.subject_type);
+    if (params.status)                 usp.set('status',                 params.status);
+    if (params.target_archetype)       usp.set('target_archetype',       params.target_archetype);
+    if (params.build_fingerprint)      usp.set('build_fingerprint',      params.build_fingerprint);
+    if (params.simulation_fingerprint) usp.set('simulation_fingerprint', params.simulation_fingerprint);
+    if (params.limit  !== undefined)   usp.set('limit',  String(params.limit));
+    if (params.offset !== undefined)   usp.set('offset', String(params.offset));
+    return jsonFetch(`/observations/facts?${usp.toString()}`);
+  },
+
+  createObservedFact(request: ObservedFactCreateRequest): Promise<ObservedFact> {
+    return jsonFetch('/observations/facts', {
+      method: 'POST',
+      body:   JSON.stringify(request),
+    });
+  },
+
+  updateObservedFact(observationId: string, request: ObservedFactUpdateRequest): Promise<ObservedFact> {
+    return jsonFetch(`/observations/facts/${encodeURIComponent(observationId)}`, {
+      method: 'PATCH',
+      body:   JSON.stringify(request),
+    });
+  },
+
+  deleteObservedFact(observationId: string): Promise<ObservedFactDeleteResponse> {
+    return jsonFetch(`/observations/facts/${encodeURIComponent(observationId)}`, {
+      method: 'DELETE',
+    });
+  },
 };
 
 export function getSlotPredictions(id64: number): Promise<SlotPredictionResponse> {
@@ -285,6 +331,37 @@ export function getFacilityTemplates(): Promise<FacilityTemplate[]> {
 
 export function simulateBuild(request: SimulateBuildRequest): Promise<SimulateBuildResponse> {
   return api.simulateBuild(request);
+}
+
+// ── Stage 6B Observed Evidence helpers ──────────────────────────────────
+//
+// These are thin re-exports so feature modules can import named helpers
+// rather than passing the whole `api` object around. The same passivity
+// note applies: observed evidence does NOT affect predictions, optimiser
+// ranking, candidate generation, or Simulation Preview scoring.
+export function listObservedFacts(
+  params: ListObservedFactsParams,
+): Promise<ObservedFactListResponse> {
+  return api.listObservedFacts(params);
+}
+
+export function createObservedFact(
+  request: ObservedFactCreateRequest,
+): Promise<ObservedFact> {
+  return api.createObservedFact(request);
+}
+
+export function updateObservedFact(
+  observationId: string,
+  request: ObservedFactUpdateRequest,
+): Promise<ObservedFact> {
+  return api.updateObservedFact(observationId, request);
+}
+
+export function deleteObservedFact(
+  observationId: string,
+): Promise<ObservedFactDeleteResponse> {
+  return api.deleteObservedFact(observationId);
 }
 
 /** Shape of one row from /api/watchlist. */

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -994,6 +994,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/optimiser/candidates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post Optimiser Candidates */
+        post: operations["post_optimiser_candidates_api_optimiser_candidates_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/observations/facts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Observed Facts */
+        get: operations["list_observed_facts_api_observations_facts_get"];
+        put?: never;
+        /** Create Observed Fact */
+        post: operations["create_observed_fact_api_observations_facts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/observations/facts/{observation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Observed Fact */
+        get: operations["get_observed_fact_api_observations_facts__observation_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Observed Fact */
+        delete: operations["delete_observed_fact_api_observations_facts__observation_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Observed Fact */
+        patch: operations["update_observed_fact_api_observations_facts__observation_id__patch"];
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1803,6 +1857,393 @@ export interface components {
         NoteBody: {
             /** Note */
             note: string;
+        };
+        /** ObservationFactSummaryResponse */
+        ObservationFactSummaryResponse: {
+            /** Total Count */
+            total_count: number;
+            /** By Fact Type */
+            by_fact_type: {
+                [key: string]: number;
+            };
+            /** By Status */
+            by_status: {
+                [key: string]: number;
+            };
+            /** By Confidence */
+            by_confidence: {
+                [key: string]: number;
+            };
+            /** Latest Observed At */
+            latest_observed_at: string | null;
+        };
+        /**
+         * ObservationSource
+         * @enum {string}
+         */
+        ObservationSource: "manual" | "imported" | "inferred" | "test_fixture";
+        /**
+         * ObservedConfidence
+         * @enum {string}
+         */
+        ObservedConfidence: "low" | "medium" | "high";
+        /** ObservedFactCreateRequest */
+        ObservedFactCreateRequest: {
+            /** @default manual */
+            source: components["schemas"]["ObservationSource"];
+            fact_type: components["schemas"]["ObservedFactType"];
+            subject_type: components["schemas"]["ObservedSubjectType"];
+            /** Subject Id */
+            subject_id?: string | null;
+            status: components["schemas"]["ObservedStatus"];
+            /** Observed Value */
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Expected Value */
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** @default medium */
+            confidence: components["schemas"]["ObservedConfidence"];
+            /** Notes */
+            notes?: string | null;
+            /** Build Fingerprint */
+            build_fingerprint?: string | null;
+            /** Simulation Fingerprint */
+            simulation_fingerprint?: string | null;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Facility Template Id */
+            facility_template_id?: string | null;
+            /** Local Body Id */
+            local_body_id?: string | null;
+            /** Service Id */
+            service_id?: string | null;
+            /** Economy */
+            economy?: string | null;
+            /** Tags */
+            tags?: string[];
+            /** Metadata */
+            metadata?: Record<string, never>;
+            /** System Id64 */
+            system_id64: number;
+        };
+        /** ObservedFactDeleteResponse */
+        ObservedFactDeleteResponse: {
+            /** Observation Id */
+            observation_id: string;
+            /** Deleted */
+            deleted: boolean;
+        };
+        /** ObservedFactListResponse */
+        ObservedFactListResponse: {
+            /** Facts */
+            facts: components["schemas"]["ObservedFactResponse"][];
+            /** Total */
+            total: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            summary: components["schemas"]["ObservationFactSummaryResponse"];
+        };
+        /** ObservedFactResponse */
+        ObservedFactResponse: {
+            /** Observation Id */
+            observation_id: string;
+            /** System Id64 */
+            system_id64: number;
+            /** Created At */
+            created_at: string;
+            /** Updated At */
+            updated_at: string | null;
+            /** Source */
+            source: string;
+            /** Fact Type */
+            fact_type: string;
+            /** Subject Type */
+            subject_type: string;
+            /** Subject Id */
+            subject_id: string | null;
+            /** Status */
+            status: string;
+            /** Observed Value */
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Expected Value */
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Confidence */
+            confidence: string;
+            /** Notes */
+            notes?: string | null;
+            /** Build Fingerprint */
+            build_fingerprint?: string | null;
+            /** Simulation Fingerprint */
+            simulation_fingerprint?: string | null;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Facility Template Id */
+            facility_template_id?: string | null;
+            /** Local Body Id */
+            local_body_id?: string | null;
+            /** Service Id */
+            service_id?: string | null;
+            /** Economy */
+            economy?: string | null;
+            /** Tags */
+            tags?: string[];
+            /** Metadata */
+            metadata?: Record<string, never>;
+        };
+        /**
+         * ObservedFactType
+         * @enum {string}
+         */
+        ObservedFactType: "service_presence" | "economy_presence" | "facility_state" | "cp_value" | "build_outcome" | "prediction_match" | "prediction_mismatch" | "note";
+        /** ObservedFactUpdateRequest */
+        ObservedFactUpdateRequest: {
+            source?: components["schemas"]["ObservationSource"] | null;
+            fact_type?: components["schemas"]["ObservedFactType"] | null;
+            subject_type?: components["schemas"]["ObservedSubjectType"] | null;
+            /** Subject Id */
+            subject_id?: string | null;
+            status?: components["schemas"]["ObservedStatus"] | null;
+            /** Observed Value */
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Expected Value */
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            confidence?: components["schemas"]["ObservedConfidence"] | null;
+            /** Notes */
+            notes?: string | null;
+            /** Build Fingerprint */
+            build_fingerprint?: string | null;
+            /** Simulation Fingerprint */
+            simulation_fingerprint?: string | null;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Facility Template Id */
+            facility_template_id?: string | null;
+            /** Local Body Id */
+            local_body_id?: string | null;
+            /** Service Id */
+            service_id?: string | null;
+            /** Economy */
+            economy?: string | null;
+            /** Tags */
+            tags?: string[] | null;
+            /** Metadata */
+            metadata?: Record<string, never> | null;
+        };
+        /**
+         * ObservedStatus
+         * @enum {string}
+         */
+        ObservedStatus: "observed_present" | "observed_absent" | "confirmed" | "contradicted" | "unknown" | "unverified";
+        /**
+         * ObservedSubjectType
+         * @enum {string}
+         */
+        ObservedSubjectType: "system" | "body" | "facility" | "service" | "economy" | "build" | "simulation" | "cp";
+        /**
+         * OptimiserCandidate
+         * @description A single bounded Stage 5A candidate plan.
+         */
+        OptimiserCandidate: {
+            /** Candidate Id */
+            candidate_id: string;
+            /** Label */
+            label: string;
+            /** Target Archetype */
+            target_archetype: string;
+            /** Strategy */
+            strategy: string;
+            /** Placements */
+            placements: components["schemas"]["OptimiserCandidatePlacement"][];
+            /** Rationale */
+            rationale?: string[];
+            /** Warnings */
+            warnings?: string[];
+            /** Assumptions */
+            assumptions?: string[];
+            /** Tags */
+            tags?: string[];
+            preview_summary?: components["schemas"]["OptimiserCandidatePreviewSummary"] | null;
+        };
+        /**
+         * OptimiserCandidatePlacement
+         * @description One facility placement in an optimiser candidate.
+         */
+        OptimiserCandidatePlacement: {
+            /** Facility Template Id */
+            facility_template_id: string;
+            /** Local Body Id */
+            local_body_id?: string | null;
+            /**
+             * Is Primary Port
+             * @default false
+             */
+            is_primary_port: boolean;
+            /**
+             * Build Order
+             * @default 1
+             */
+            build_order: number;
+        };
+        /**
+         * OptimiserCandidatePreviewSummary
+         * @description Lightweight optimiser-specific summary of Simulation Preview output.
+         */
+        OptimiserCandidatePreviewSummary: {
+            /** Final Score */
+            final_score?: number | null;
+            /** Composition Score */
+            composition_score?: number | null;
+            /** Buildability Score */
+            buildability_score?: number | null;
+            /** Confidence */
+            confidence?: number | null;
+            /** Build Complexity */
+            build_complexity?: string | null;
+            /**
+             * Warnings Count
+             * @default 0
+             */
+            warnings_count: number;
+            /** Cp Negative */
+            cp_negative?: boolean | null;
+            /** Top Two Alignment */
+            top_two_alignment?: string | null;
+        };
+        /**
+         * OptimiserCandidatesRequest
+         * @description Request for bounded deterministic Stage 5A candidate generation.
+         */
+        OptimiserCandidatesRequest: {
+            /** System Id64 */
+            system_id64: number;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Target Archetype Key */
+            target_archetype_key?: string | null;
+            /**
+             * Max Candidates
+             * @default 5
+             */
+            max_candidates: number;
+            /** Preferred Body Ids */
+            preferred_body_ids?: string[];
+            /**
+             * Allow Estimated Data
+             * @default true
+             */
+            allow_estimated_data: boolean;
+            /**
+             * Run Preview
+             * @default true
+             */
+            run_preview: boolean;
+            /**
+             * Include Ranking
+             * @default false
+             */
+            include_ranking: boolean;
+        };
+        /**
+         * OptimiserCandidatesResponse
+         * @description Response envelope for bounded deterministic Stage 5A candidates.
+         */
+        OptimiserCandidatesResponse: {
+            /** System Id64 */
+            system_id64: number;
+            /** Target Archetype */
+            target_archetype: string;
+            /** Candidate Count */
+            candidate_count: number;
+            /** Candidates */
+            candidates: components["schemas"]["OptimiserCandidate"][];
+            /** Warnings */
+            warnings?: string[];
+            /** Assumptions */
+            assumptions?: string[];
+            ranking?: components["schemas"]["OptimiserRankingResponse"] | null;
+        };
+        /**
+         * OptimiserRankBreakdown
+         * @description Structured explanation for a ranked optimiser candidate.
+         */
+        OptimiserRankBreakdown: {
+            /**
+             * Preview Score Component
+             * @default 0
+             */
+            preview_score_component: number;
+            /**
+             * Composition Component
+             * @default 0
+             */
+            composition_component: number;
+            /**
+             * Buildability Component
+             * @default 0
+             */
+            buildability_component: number;
+            /**
+             * Confidence Component
+             * @default 0
+             */
+            confidence_component: number;
+            /**
+             * Alignment Component
+             * @default 0
+             */
+            alignment_component: number;
+            /**
+             * Warning Penalty
+             * @default 0
+             */
+            warning_penalty: number;
+            /**
+             * Cp Penalty
+             * @default 0
+             */
+            cp_penalty: number;
+            /**
+             * Strategy Modifier
+             * @default 0
+             */
+            strategy_modifier: number;
+            /**
+             * Total Score
+             * @default 0
+             */
+            total_score: number;
+            /** Reasons */
+            reasons?: string[];
+        };
+        /**
+         * OptimiserRankedCandidate
+         * @description Ranking entry that references a candidate by ID without duplicating it.
+         */
+        OptimiserRankedCandidate: {
+            /** Candidate Id */
+            candidate_id: string;
+            /** Rank */
+            rank: number;
+            /** Rank Score */
+            rank_score: number;
+            /** Rank Tier */
+            rank_tier: string;
+            rank_breakdown: components["schemas"]["OptimiserRankBreakdown"];
+        };
+        /**
+         * OptimiserRankingResponse
+         * @description Top-level optional Stage 5B ranking result.
+         */
+        OptimiserRankingResponse: {
+            /** Target Archetype */
+            target_archetype: string;
+            /** Ranked Candidates */
+            ranked_candidates: components["schemas"]["OptimiserRankedCandidate"][];
+            /** Warnings */
+            warnings?: string[];
+            /** Assumptions */
+            assumptions?: string[];
         };
         /**
          * PlannedFacility
@@ -4596,6 +5037,208 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SimulationSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    post_optimiser_candidates_api_optimiser_candidates_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OptimiserCandidatesRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OptimiserCandidatesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_observed_facts_api_observations_facts_get: {
+        parameters: {
+            query: {
+                system_id64: number;
+                fact_type?: string | null;
+                subject_type?: string | null;
+                status?: string | null;
+                target_archetype?: string | null;
+                build_fingerprint?: string | null;
+                simulation_fingerprint?: string | null;
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ObservedFactListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_observed_fact_api_observations_facts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ObservedFactCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ObservedFactResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_observed_fact_api_observations_facts__observation_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                observation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ObservedFactResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_observed_fact_api_observations_facts__observation_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                observation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ObservedFactDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_observed_fact_api_observations_facts__observation_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                observation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ObservedFactUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ObservedFactResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -500,3 +500,164 @@ export interface OptimiserCandidatesResponse {
   assumptions: string[];
   ranking?: OptimiserRanking | null;
 }
+
+// ─── Stage 6B Observed Evidence (Observed Facts) ──────────────────────────
+//
+// Wire types matching the Stage 6A backend observed-facts CRUD API. These
+// model passive evidence — what a user actually saw in-game — and are
+// recorded entirely separately from predictions. They MUST NOT change
+// optimiser ranking, candidate generation, Simulation Preview scoring,
+// or any simulation mechanics. See `apps/api/src/observations/api_models.py`
+// for the source of truth.
+//
+// The full backend vocabulary for `ObservationSource` includes `imported`
+// and `inferred`, but they are reserved for later stages. The Stage 6B
+// manual-entry UI only creates observations with `source: 'manual'`.
+export type ObservationSource =
+  | 'manual'
+  | 'test_fixture'
+  | 'imported'
+  | 'inferred';
+
+export type ObservedFactType =
+  | 'service_presence'
+  | 'economy_presence'
+  | 'facility_state'
+  | 'cp_value'
+  | 'build_outcome'
+  | 'prediction_match'
+  | 'prediction_mismatch'
+  | 'note';
+
+export type ObservedSubjectType =
+  | 'system'
+  | 'body'
+  | 'facility'
+  | 'service'
+  | 'economy'
+  | 'build'
+  | 'simulation'
+  | 'cp';
+
+export type ObservedStatus =
+  | 'observed_present'
+  | 'observed_absent'
+  | 'confirmed'
+  | 'contradicted'
+  | 'unknown'
+  | 'unverified';
+
+export type ObservedConfidence = 'low' | 'medium' | 'high';
+
+/** Any JSON value (matches backend `JsonValue`). */
+export type ObservedJsonValue =
+  | string
+  | number
+  | boolean
+  | { [key: string]: ObservedJsonValue }
+  | ObservedJsonValue[]
+  | null;
+
+export interface ObservedFact {
+  observation_id: string;
+  system_id64: number;
+  created_at: string;
+  updated_at: string | null;
+  source: ObservationSource | string;
+  fact_type: ObservedFactType | string;
+  subject_type: ObservedSubjectType | string;
+  subject_id: string | null;
+  status: ObservedStatus | string;
+  observed_value?: ObservedJsonValue;
+  expected_value?: ObservedJsonValue;
+  confidence: ObservedConfidence | string;
+  notes?: string | null;
+  build_fingerprint?: string | null;
+  simulation_fingerprint?: string | null;
+  target_archetype?: string | null;
+  facility_template_id?: string | null;
+  local_body_id?: string | null;
+  service_id?: string | null;
+  economy?: string | null;
+  tags: string[];
+  metadata: Record<string, unknown>;
+}
+
+export interface ObservedFactCreateRequest {
+  system_id64: number;
+  // The UI only ever sends 'manual', but the backend accepts 'test_fixture'
+  // for tests. 'imported' and 'inferred' are intentionally not part of the
+  // create-form options exposed in Stage 6B.
+  source: 'manual' | 'test_fixture';
+  fact_type: ObservedFactType;
+  subject_type: ObservedSubjectType;
+  subject_id?: string | null;
+  status: ObservedStatus;
+  observed_value?: ObservedJsonValue;
+  expected_value?: ObservedJsonValue;
+  confidence?: ObservedConfidence;
+  notes?: string | null;
+  build_fingerprint?: string | null;
+  simulation_fingerprint?: string | null;
+  target_archetype?: string | null;
+  facility_template_id?: string | null;
+  local_body_id?: string | null;
+  service_id?: string | null;
+  economy?: string | null;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ObservedFactUpdateRequest {
+  source?: 'manual' | 'test_fixture';
+  fact_type?: ObservedFactType;
+  subject_type?: ObservedSubjectType;
+  subject_id?: string | null;
+  status?: ObservedStatus;
+  observed_value?: ObservedJsonValue;
+  expected_value?: ObservedJsonValue;
+  confidence?: ObservedConfidence;
+  notes?: string | null;
+  build_fingerprint?: string | null;
+  simulation_fingerprint?: string | null;
+  target_archetype?: string | null;
+  facility_template_id?: string | null;
+  local_body_id?: string | null;
+  service_id?: string | null;
+  economy?: string | null;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface ObservationFactSummary {
+  total_count: number;
+  by_fact_type: Record<string, number>;
+  by_status: Record<string, number>;
+  by_confidence: Record<string, number>;
+  latest_observed_at: string | null;
+}
+
+export interface ObservedFactListResponse {
+  facts: ObservedFact[];
+  total: number;
+  limit: number;
+  offset: number;
+  summary: ObservationFactSummary;
+}
+
+export interface ObservedFactDeleteResponse {
+  observation_id: string;
+  deleted: boolean;
+}
+
+export interface ListObservedFactsParams {
+  system_id64: number;
+  fact_type?: ObservedFactType | string;
+  subject_type?: ObservedSubjectType | string;
+  status?: ObservedStatus | string;
+  target_archetype?: string;
+  build_fingerprint?: string;
+  simulation_fingerprint?: string;
+  limit?: number;
+  offset?: number;
+}


### PR DESCRIPTION
## Summary

Implements **Stage 6B — Manual Observed Evidence UI** on top of the Stage 6A backend observed-facts evidence shelf. Adds a new "Observed Evidence" panel to the Colony Planner inside the system detail view so users can manually create, list, edit, and delete observed evidence for the current system.

This is strictly **passive evidence capture** — no comparison/validation engine, no scoring/optimiser changes, no ingestion, and no learning/auto-correction wording.

## Scope

### Types & API client (`frontend-v2/src/`)
- `types/api.ts`: Stage 6B wire types — `ObservationSource`, `ObservedFactType`, `ObservedSubjectType`, `ObservedStatus`, `ObservedConfidence`, `ObservedFact`, `ObservedFactCreateRequest` (source restricted to `manual` | `test_fixture`), `ObservedFactUpdateRequest`, `ObservationFactSummary`, `ObservedFactListResponse`, `ObservedFactDeleteResponse`, `ListObservedFactsParams`, `ObservedJsonValue`.
- `lib/api.ts`: `listObservedFacts`, `createObservedFact`, `updateObservedFact`, `deleteObservedFact` wired to `GET/POST/PATCH/DELETE /api/observations/facts`.

### Observed Evidence panel
New folder `frontend-v2/src/features/system-detail/simulation-preview/observations/`:
- `observationLabels.ts` — user-facing labels, passive-evidence copy, empty/delete-confirm copy, `CREATABLE_FACT_TYPES` (excludes `prediction_match`/`prediction_mismatch`).
- `observationUtils.ts` — pure helpers (`parseTagsInput`, `parseObservedValue`, `buildCreateRequest`, `validateCreateForm`, `describeApiError` parsing FastAPI 422 detail arrays).
- `ObservedEvidenceForm.tsx` — manual create form, conditional structured inputs per fact_type, collapsible advanced details, always sends `source: 'manual'`.
- `ObservedEvidenceCard.tsx` — row with view/edit/confirm-delete modes; confirm-delete renders `role="alertdialog"` with exact non-mutation copy.
- `ObservedEvidenceList.tsx` — cards or empty state.
- `ObservedEvidencePanel.tsx` — top-level `role="region"` panel with React Query (`useQuery` + 3 `useMutation`), filters (fact_type/status server-side, confidence client-side), loading/error/retry, passive-evidence notice as `role="note"`.
- `index.ts` — barrel exports.

### Colony Planner integration
- `SimulationPreview.tsx` renders `ObservedEvidencePanel` after `PreviewResultSection` (`system.id64` + `plan.targetArchetype` passed through). Simulation/optimiser payloads untouched.
- `ColonyPlannerSectionNav.tsx` adds the fourth section label "Observed Evidence".

### Tests
- `ObservedEvidencePanel.test.tsx` — 18 tests covering passive copy, list rendering, empty/loading/error+retry (uses two `mockRejectedValueOnce` because panel `retry: 1`), create per fact_type with `subject_type`/`subject_id` assertions, 422 backend error via `ApiError`, client validation, edit save (scoped via `within(editForm)` to disambiguate filter labels), edit cancel, delete confirm/cancel, fact_type+status filter API calls, no `imported`/`inferred` options exposed, and no `simulateBuild`/`fetchOptimiserCandidates` during observation flows.
- `SimulationPreview.optimiser.test.tsx` — extends `vi.mock('@/lib/api', ...)` with observation helpers, adds `emptyObservedFactsResponse` helper, adds 2 tests (panel renders with passive notice; observation flows do not trigger simulate/optimiser).

### Docs
- `docs/api-contracts.md` — Stage 6B Frontend Observed Evidence Integration section.
- `docs/colonisation-redesign/engine-roadmap.md` — Stage 6B subsection with concern/outcome table.
- `docs/colonisation-redesign/simulation-preview-ui-architecture.md` — file/responsibility table for the new observations subfolder.

## Non-goals (verified)

- ❌ No backend changes
- ❌ No comparison/validation engine
- ❌ No scoring / optimiser / ranking changes
- ❌ No EDMC ingestion
- ❌ No `imported` / `inferred` create options exposed in UI
- ❌ No "proof" / "learning" / "auto-correction" wording

## Verification

- `npm run typecheck` — clean
- `npm run build` — success (2382 modules transformed)
- `npm test` — 18 test files, **112/112 tests passed**, 0 unhandled errors
- `git diff --check` — clean

## Branch

`stage-6b-manual-observed-evidence-ui` → `main` (based on `main` at the Stage 6A merge `ff081df`; fast-forward, no conflicts).
