### PR TITLE
Stage 11F: colony planner micro-polish and workflow wording alignment

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -715,3 +715,25 @@ Deferred beyond Stage 11E:
 - Additional body-map style spatial rendering beyond the current card layout.
 - Saved build persistence and external ingestion loops.
 - Commodity/material/commodity/trip planning features, which remain outside ED-Finder's planning layer.
+
+## Stage 11F - Micro-Polish and QA Guardrails
+
+Stage 11F is a narrow UX polish and wording alignment pass over the existing Colony Planner visual workflow before deeper planning interaction work resumes.
+
+Current Stage 11F status:
+
+- Clarified the Build Plan workflow chips in `BuildPlanSection` so the primary flow remains `Suggested Builds -> Build Plan -> Preview Result` and later sections are clearly separated as `Observed Evidence` and `Validation`.
+- Updated workflow labeling in the plan section to avoid abbreviated "Evidence / Validation later" phrasing, while retaining existing non-side-effect behavior.
+- Kept `List view` as the canonical editable surface and `Layout view` as planning readout-only.
+- Preserved keyboard/accessibility behavior for body and placement selection controls introduced in Stage 11D/11E.
+- Reaffirmed no automatic preview execution, no Suggested Build auto-generation, and no automatic build mutation during navigation, view toggling, or layout interactions.
+
+No backend mechanics, backend scoring, normal search scoring, Simulation Preview scoring, CP formulas, economy mechanics, service unlock mechanics, buildability mechanics, optimiser generation/ranking, candidate comparison logic, Search Tuning behaviour, Observed Evidence behavior, Validation behavior, saved-build persistence, auto-run, auto-generate, auto-load behavior, or hauling/material workflow changed in Stage 11F.
+
+Deferred beyond Stage 11F:
+
+- Full structure picker/table enhancements.
+- Variant-aware placement comparison workflows.
+- Deeper planner map topology and import-review UX beyond the current layout cards.
+- Saved build lifecycle and external ingestion loops.
+- Commodity/material/commodity/trip planning features.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -61,6 +61,15 @@ Stage 11E is a micro-polish and interaction hardening pass:
 - Confirm user-visible copy avoids non-goal logistics wording and unsafe claims while remaining planning/conservative.
 - Reinforce no interaction side effects: no `simulateBuild` auto-run, no Suggested Build mutation, and no automatic persistence from layout interactions.
 
+Stage 11F is the Stage 11E follow-up micro-polish:
+
+- `BuildPlanSection` workflow chips now surface `Suggested Builds`, `Build Plan`, `Preview Result`, `Observed Evidence`, and `Validation` with explicit step numbering and no abbreviated later-step label.
+- Keep `List view` as the canonical editable surface and `Layout view` as read-only planning readout; all layout interactions remain non-mutating for preview execution and suggested-build generation.
+- Copy across the planner workflow remains conservative (`Use List view to edit`, `Read-only planning readout` framing), with `Observed Evidence` and `Validation` consistently represented as later planning steps.
+- Preserve separate interactive targets for body and placement selection in `BuildPlanBodyView` / `BuildPlanLayoutDetailPanel`, including keyboard-friendly selection state.
+- Keep explicit no-side-effect behavior for planning interactions and no mechanics changes.
+- This pass remains frontend visual/copy/accessibility hardening for planner clarity before broader picker/table work resumes.
+
 ## Shared UI Atoms
 
 Shared visual atoms are intentionally small and boring. Each atom lives in its own file so future optimiser components can reuse them without importing an unrelated grouped implementation file.

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanSection.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanSection.tsx
@@ -95,7 +95,8 @@ export function BuildPlanSection({
           <BuildFlowChip step="1" label="Suggested Builds" tone="primary" />
           <BuildFlowChip step="2" label="Build Plan" tone="primary" />
           <BuildFlowChip step="3" label="Preview Result" tone="primary" />
-          <BuildFlowChip step="4" label="Evidence / Validation later" tone="later" />
+          <BuildFlowChip step="4" label="Observed Evidence" tone="later" />
+          <BuildFlowChip step="5" label="Validation" tone="later" />
         </div>
       </div>
       <BuildPlanStatus

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -183,7 +183,7 @@ export function SimulationPreview({
 
         <section className="rounded-chunk-lg border border-border/60 bg-bg2/25 p-3">
           <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">
-            Later step: Evidence and Validation
+            Later step: Observed Evidence and Validation
           </div>
           {/* Stage 6B: Observed Evidence panel renders after Preview Result.
               It is intentionally passive - see ObservedEvidencePanel for the


### PR DESCRIPTION
## Summary
- Stage 11F micro-polish for planner workflow copy and wording alignment.
- `BuildPlanSection.tsx` now labels workflow chips as `Suggested Builds -> Build Plan -> Preview Result -> Observed Evidence -> Validation` to keep a clearer primary-vs-later-step hierarchy.
- `SimulationPreview.tsx` now uses `Later step: Observed Evidence and Validation` for consistency with planner naming.
- Roadmap and architecture docs updated to capture Stage 11F scope, non-changes, and mechanics-safe boundaries.

## Safety
- No backend mechanics/scoring changes.
- No simulation logic or optimiser/validation pipeline changes.
- Layout/editor interaction behavior unchanged.
- No auto-run/generation persistence side effects introduced.