### PR TITLE
Stage 12A: Structure Picker / Table Foundation for Colony Planner List View

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -782,3 +782,32 @@ Deferred beyond Stage 11H:
 - Additional layout-import UX refinements (history, retry queueing, conflict messaging).
 - Saved build persistence and external ingestion loops.
 - Commodity/material/commodity/trip planning features.
+
+## Stage 12A - Structure Picker / Table Foundation
+
+Stage 12A adds the first safe structure-picker surface in the Colony Planner List view so users can compare facility templates before selecting one for a placement.
+
+Current Stage 12A status:
+
+- Added a dedicated `StructurePickerTable` component integrated into `BuildPlanEditor` via an explicit `Browse structures` control per placement.
+- Preserved List view as the canonical edit path. The existing template `<select>` remains available and authoritative.
+- Added conservative search/filter controls (`All`, `Orbital`, `Surface`, `Both`) and facility comparison columns: structure, location, tier, pad, economy, role, CP gives/needs, confidence, validity, and explicit select action.
+- Added body-context-aware planning hints: selected body context, no-body state, unknown-body state, and conservative warnings for likely risky combinations.
+- Reused existing planning warning semantics for high-signal checks:
+  - surface facility on water world
+  - surface facility on non-landable body
+  - sparse body metadata
+  - orbital suitability unclear
+  - estimated template data
+- Kept selection explicit and local. Choosing `Select structure` only updates the current placement template via existing `onUpdate`; no preview/generation/load side effects are introduced.
+- Added focused tests for picker rendering, search/filter behavior, warning/validity labels, explicit selection callback behavior, and composed no-side-effect behavior from `SimulationPreview`.
+
+No backend mechanics, backend scoring, normal search scoring, Simulation Preview scoring, CP formulas, economy mechanics, service unlock mechanics, buildability mechanics, optimiser generation/ranking, candidate comparison logic, Search Tuning behaviour, Observed Evidence behavior, Validation behavior, saved-build persistence, auto-run, auto-generate, auto-load behavior, or hauling/material workflow changed in Stage 12A.
+
+Deferred to Stage 12B:
+
+- Variant/family grouping and richer picker presentation modes.
+- Placement replacement workflows beyond explicit per-row template selection.
+- Layout-view-side picker actions (Layout remains read-only).
+- Any backend catalogue enrichment or new mechanics fields.
+- Saved-build and logistics workflows.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -250,3 +250,35 @@ Stage 11H is a narrow follow-up to keep the planner readout state coherent durin
 Chronology note:
 
 - Stage 11F happened before Stage 11G, and Stage 11H follows Stage 11G on this branch.
+
+## Stage 12A - Structure Picker / Table Foundation
+
+Stage 12A introduces a focused picker surface in List view without changing planner mechanics or introducing automatic actions.
+
+- `BuildPlanEditor.tsx` now exposes an explicit `Browse structures` control per placement.
+- `StructurePickerTable.tsx` is a dedicated presentational component for template comparison, search, location filtering, conservative validity hints, and explicit row selection.
+- `structurePickerUtils.ts` owns pure helper logic for:
+  - location-kind normalization (`orbital`, `surface`, `both`, `unknown`)
+  - filter matching
+  - selected/no-body/unknown-body context resolution
+  - conservative warning and validity-label derivation
+
+Safety boundaries in Stage 12A:
+
+- List view remains the canonical editable path.
+- Layout view remains read-only planning output.
+- Picker selection updates only the current placement template through the existing `onUpdate` callback.
+- No automatic preview execution, no Suggested Build generation/load, no persistence, and no backend mutation are introduced.
+- No scoring, mechanics, optimiser ranking/generation, Search Tuning, Observed Evidence, or Validation behavior changes are introduced.
+
+Test coverage added in Stage 12A:
+
+- `StructurePickerTable.test.tsx` for rendering, search/filter behavior, context/warning labels, and explicit selection callback behavior.
+- `structurePickerUtils.test.ts` for deterministic helper behavior and conservative warning labels.
+- `SimulationPreview.optimiser.test.tsx` coverage for opening/using picker controls without preview or suggested-build side effects.
+
+Deferred to Stage 12B:
+
+- Variant/family grouping, richer compare layouts, and broader replacement flows.
+- Any layout-view-side picker action (Layout remains read-only).
+- Backend catalogue enrichment and non-frontend planner mechanics work.

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { ArrowDown, ArrowUp, Trash2 } from 'lucide-react';
 import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
 import { Chip, IconButton } from './components';
+import { StructurePickerTable } from './StructurePickerTable';
 import { formatLocation } from './utils/formatters';
 
 export function BuildPlanEditor({
@@ -18,10 +20,14 @@ export function BuildPlanEditor({
   onRemove: (index: number) => void;
   onMove: (index: number, direction: -1 | 1) => void;
 }) {
+  const [pickerIndex, setPickerIndex] = useState<number | null>(null);
+
   return (
     <div className="space-y-2">
       {placements.map((placement, index) => {
         const template = templates.find((item) => item.id === placement.facility_template_id);
+        const hasMissingTemplate = !template && Boolean(placement.facility_template_id);
+        const pickerOpen = pickerIndex === index;
         return (
           <div key={`${placement.build_order}-${index}`} className="rounded-chunk-lg border border-border/70 bg-bg2/70 p-3">
             <div className="mb-2 flex items-center justify-between gap-2">
@@ -45,6 +51,11 @@ export function BuildPlanEditor({
                 }}
                 className="min-w-0 flex-1"
               >
+                {hasMissingTemplate && (
+                  <option value={placement.facility_template_id} disabled>
+                    Missing template - {placement.facility_template_id}
+                  </option>
+                )}
                 {templates.map((item) => (
                   <option key={item.id} value={item.id}>
                     T{item.tier} - {item.name}{item.economy ? ` - ${item.economy}` : ''}
@@ -60,6 +71,24 @@ export function BuildPlanEditor({
               <IconButton label="Remove" onClick={() => onRemove(index)}>
                 <Trash2 size={14} />
               </IconButton>
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+              <p className="font-mono text-[10px] text-silver-dk">Use List view to edit. Compare options with Browse structures.</p>
+              <button
+                type="button"
+                onClick={() => setPickerIndex((current) => current === index ? null : index)}
+                className={[
+                  'rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] transition',
+                  pickerOpen
+                    ? 'border-cyan/60 bg-cyan/10 text-cyan'
+                    : 'border-border/65 bg-bg3/45 text-silver-dk hover:border-cyan/60 hover:text-cyan',
+                ].join(' ')}
+                aria-expanded={pickerOpen}
+                aria-controls={`structure-picker-panel-${index}`}
+              >
+                Browse structures
+              </button>
             </div>
 
             {!template && (
@@ -103,6 +132,24 @@ export function BuildPlanEditor({
                 <Chip>{formatLocation(template.allowed_location)}</Chip>
                 <Chip>Y+{template.yellow_cp_generated} G+{template.green_cp_generated}</Chip>
                 {template.confidence === 'estimated' && <Chip tone="warn">Estimated data</Chip>}
+              </div>
+            )}
+
+            {pickerOpen && (
+              <div id={`structure-picker-panel-${index}`}>
+                <StructurePickerTable
+                  templates={templates}
+                  bodies={bodies}
+                  selectedBodyId={placement.local_body_id ?? null}
+                  selectedTemplateId={placement.facility_template_id}
+                  onSelectTemplate={(templateId) => {
+                    const nextTemplate = templates.find((item) => item.id === templateId);
+                    onUpdate(index, {
+                      facility_template_id: templateId,
+                      is_primary_port: Boolean(placement.is_primary_port && nextTemplate?.is_port),
+                    });
+                  }}
+                />
               </div>
             )}
           </div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -459,6 +459,30 @@ describe('SimulationPreview optimiser candidate loading', () => {
     expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
   });
 
+  it('opens structure picker, filters/selects templates, and keeps preview/generation explicit', async () => {
+    mockNoRecommendedBuild();
+    renderPreview();
+
+    await screen.findByText(/0 placements in Build Plan/);
+    fireEvent.click(screen.getByRole('button', { name: /Start blank/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Add Facility/i }));
+    expect(screen.getByDisplayValue('T1 - Generic Port Alpha')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /Browse structures/i }));
+    await screen.findByTestId('structure-picker');
+    expect(screen.getByText(/Uses current facility catalogue/)).toBeTruthy();
+    expect(screen.getByText(/Evaluating against: Test Body/)).toBeTruthy();
+    expect(screen.getByRole('searchbox', { name: /Search structures/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Surface' }));
+    fireEvent.change(screen.getByRole('searchbox', { name: /Search structures/i }), { target: { value: 'Agriculture' } });
+    fireEvent.click(screen.getByRole('button', { name: /Select structure Agriculture Support A/i }));
+
+    expect(screen.getByDisplayValue('T1 - Agriculture Support A - Agriculture')).toBeTruthy();
+    expect(mockedSimulateBuild).not.toHaveBeenCalled();
+    expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
+  });
+
   it('manually imports system layout and shows success status without planner side effects', async () => {
     mockNoRecommendedBuild();
     let resolveImport: (value: LayoutImportResponse) => void = () => {};

--- a/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { FacilityTemplate, SystemBody } from '@/types/api';
+import { StructurePickerTable } from './StructurePickerTable';
+
+const templates: FacilityTemplate[] = [
+  {
+    id: 'orbital_port',
+    name: 'Orbital Port',
+    category: 'port',
+    tier: 3,
+    economy: 'Industrial',
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'orbital',
+    pad_size: 'large',
+    confidence: 'observed',
+    notes: null,
+    yellow_cp_generated: 0,
+    green_cp_generated: 0,
+    yellow_cp_cost: 20,
+    green_cp_cost: 40,
+  },
+  {
+    id: 'surface_hub',
+    name: 'Surface Hub',
+    category: 'support',
+    tier: 2,
+    economy: 'Extraction',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface',
+    pad_size: null,
+    confidence: 'estimated',
+    notes: null,
+    yellow_cp_generated: 8,
+    green_cp_generated: 2,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+];
+
+const bodies = [
+  { id: 1, name: 'A 1', is_landable: true },
+  { id: 2, name: 'A 2', is_water_world: true, is_landable: true },
+] as SystemBody[];
+
+function renderPicker(overrides: Partial<Parameters<typeof StructurePickerTable>[0]> = {}) {
+  const onSelectTemplate = vi.fn();
+  render(
+    <StructurePickerTable
+      templates={templates}
+      bodies={bodies}
+      selectedBodyId="1"
+      selectedTemplateId="orbital_port"
+      onSelectTemplate={onSelectTemplate}
+      {...overrides}
+    />,
+  );
+  return { onSelectTemplate };
+}
+
+describe('StructurePickerTable', () => {
+  it('renders template rows with planning fields and selection control', () => {
+    renderPicker();
+
+    const panel = screen.getByTestId('structure-picker');
+    expect(within(panel).getByText('Compare structures')).toBeTruthy();
+    expect(within(panel).getByText('Evaluating against: A 1')).toBeTruthy();
+    expect(screen.getByTestId('structure-picker-row-orbital_port')).toBeTruthy();
+    expect(screen.getByTestId('structure-picker-row-surface_hub')).toBeTruthy();
+    expect(screen.getAllByText('Orbital Port').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('surface').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CP gives').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('CP needs').length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Select structure Surface Hub' })).toBeTruthy();
+  });
+
+  it('filters by search and location', () => {
+    renderPicker();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search structures' }), { target: { value: 'Surface' } });
+    expect(screen.queryByTestId('structure-picker-row-orbital_port')).toBeNull();
+    expect(screen.getByTestId('structure-picker-row-surface_hub')).toBeTruthy();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search structures' }), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Orbital' }));
+    expect(screen.getByTestId('structure-picker-row-orbital_port')).toBeTruthy();
+    expect(screen.queryByTestId('structure-picker-row-surface_hub')).toBeNull();
+  });
+
+  it('renders conservative warnings for body suitability and confidence', () => {
+    renderPicker({ selectedBodyId: '2' });
+
+    expect(screen.getByText('May be invalid: surface facility on water world')).toBeTruthy();
+    expect(screen.getByText('Needs review: template uses estimated data')).toBeTruthy();
+    expect(screen.getByText('Check location')).toBeTruthy();
+  });
+
+  it('handles no-body and unknown-body context labels', () => {
+    renderPicker({ selectedBodyId: null });
+    expect(screen.getByText('No body selected yet')).toBeTruthy();
+    expect(screen.getAllByText('Needs body').length).toBeGreaterThan(0);
+
+    renderPicker({ selectedBodyId: '404' });
+    expect(screen.getByText('Unknown body: 404')).toBeTruthy();
+    expect(screen.getAllByText('Unknown body').length).toBeGreaterThan(0);
+  });
+
+  it('invokes onSelectTemplate only when user explicitly selects a row', () => {
+    const { onSelectTemplate } = renderPicker();
+    expect(onSelectTemplate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select structure Surface Hub' }));
+    expect(onSelectTemplate).toHaveBeenCalledTimes(1);
+    expect(onSelectTemplate).toHaveBeenCalledWith('surface_hub');
+  });
+
+  it('shows empty catalogue and empty-filter states', () => {
+    const emptyRender = render(
+      <StructurePickerTable
+        templates={[]}
+        bodies={bodies}
+        selectedBodyId="1"
+        selectedTemplateId="orbital_port"
+        onSelectTemplate={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('No structures available yet.')).toBeTruthy();
+    emptyRender.unmount();
+
+    renderPicker();
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search structures' }), { target: { value: 'zzzz' } });
+    expect(screen.getByText('No structures match the current filters.')).toBeTruthy();
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import type { FacilityTemplate, SystemBody } from '@/types/api';
+import { bodyDisplayName } from './buildPlanLayoutUtils';
+import { Chip } from './components';
+import { formatLocation } from './utils/formatters';
+import {
+  getStructurePickerValidityLabel,
+  getStructurePickerWarnings,
+  locationMatchesFilter,
+  resolveBodyContext,
+  type StructurePickerLocationFilter,
+} from './structurePickerUtils';
+
+export function StructurePickerTable({
+  templates,
+  bodies,
+  selectedBodyId,
+  selectedTemplateId,
+  onSelectTemplate,
+}: {
+  templates: FacilityTemplate[];
+  bodies: SystemBody[];
+  selectedBodyId?: string | null;
+  selectedTemplateId?: string | null;
+  onSelectTemplate: (templateId: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [locationFilter, setLocationFilter] = useState<StructurePickerLocationFilter>('all');
+  const bodyContext = useMemo(
+    () => resolveBodyContext(bodies, selectedBodyId),
+    [bodies, selectedBodyId],
+  );
+  const filteredTemplates = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return templates.filter((template) => {
+      if (!locationMatchesFilter(template, locationFilter)) return false;
+      if (!normalizedQuery) return true;
+      return `${template.name} ${template.category} ${template.economy ?? ''}`.toLowerCase().includes(normalizedQuery);
+    });
+  }, [templates, query, locationFilter]);
+
+  return (
+    <section
+      aria-label="Structure picker"
+      data-testid="structure-picker"
+      className="mt-3 rounded-chunk-lg border border-border/65 bg-bg3/35 p-3"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-2">
+        <div>
+          <h6 className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">Compare structures</h6>
+          <p className="mt-1 text-[11px] text-silver-dk">Uses current facility catalogue. Validity hints are planning checks; run Preview for full prediction.</p>
+        </div>
+        <div className="rounded border border-border/60 bg-bg2/60 px-2 py-1 font-mono text-[10px] text-silver-dk">
+          {bodyContext.status === 'selected'
+            ? `Evaluating against: ${bodyDisplayName(bodyContext.body as SystemBody)}`
+            : bodyContext.status === 'unknown'
+              ? `Unknown body: ${bodyContext.bodyId}`
+              : 'No body selected yet'}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+        <label className="relative">
+          <Search size={13} className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-silver-dk" />
+          <input
+            aria-label="Search structures"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search structures"
+            className="w-full rounded border border-border/70 bg-bg2 px-8 py-2 font-mono text-xs text-silver outline-none focus:border-cyan/60"
+          />
+        </label>
+        <div className="inline-flex rounded border border-border/70 bg-bg2/60 p-1" role="group" aria-label="Location filter">
+          {([
+            ['all', 'All'],
+            ['orbital', 'Orbital'],
+            ['surface', 'Surface'],
+            ['both', 'Both'],
+          ] as const).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setLocationFilter(value)}
+              aria-pressed={locationFilter === value}
+              className={[
+                'rounded px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em]',
+                locationFilter === value ? 'bg-orange/15 text-orange' : 'text-silver-dk hover:text-silver',
+              ].join(' ')}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {templates.length === 0 ? (
+        <p className="mt-3 rounded border border-gold/35 bg-gold/10 px-3 py-2 font-mono text-[11px] text-gold">
+          No structures available yet.
+        </p>
+      ) : filteredTemplates.length === 0 ? (
+        <p className="mt-3 rounded border border-border/60 bg-bg2/45 px-3 py-2 font-mono text-[11px] text-silver-dk">
+          No structures match the current filters.
+        </p>
+      ) : (
+        <div className="mt-3 overflow-x-auto">
+          <table className="min-w-full border-collapse text-left font-mono text-[10px]">
+            <thead>
+              <tr className="border-b border-border/60 text-silver-dk">
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Structure</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Location</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Tier</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Pad</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Economy</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Role</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">CP gives</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">CP needs</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Confidence</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Validity</th>
+                <th className="px-2 py-1 uppercase tracking-[0.14em]">Select</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTemplates.map((template) => {
+                const warnings = getStructurePickerWarnings(template, bodyContext);
+                const validity = getStructurePickerValidityLabel(template, bodyContext);
+                const isSelected = selectedTemplateId === template.id;
+                const validityTone = validity === 'Looks valid' ? 'good' : validity === 'Needs body' || validity === 'Unknown body' ? 'default' : 'warn';
+                return (
+                  <tr
+                    key={template.id}
+                    data-testid={`structure-picker-row-${template.id}`}
+                    className={[
+                      'border-b border-border/35 align-top',
+                      isSelected ? 'bg-cyan/10' : 'bg-transparent',
+                    ].join(' ')}
+                  >
+                    <td className="px-2 py-2 text-silver">
+                      <div className="font-semibold">{template.name}</div>
+                      {template.is_port ? (
+                        <div className="mt-1"><Chip>Port</Chip></div>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-2 text-silver-dk">{formatLocation(template.allowed_location)}</td>
+                    <td className="px-2 py-2 text-silver-dk">{template.tier}</td>
+                    <td className="px-2 py-2 text-silver-dk">{template.pad_size ?? 'Unknown'}</td>
+                    <td className="px-2 py-2 text-silver-dk">{template.economy ?? 'Unknown'}</td>
+                    <td className="px-2 py-2 text-silver-dk">{template.category}</td>
+                    <td className="px-2 py-2 text-silver-dk">Y+{template.yellow_cp_generated} G+{template.green_cp_generated}</td>
+                    <td className="px-2 py-2 text-silver-dk">Y{template.yellow_cp_cost} G{template.green_cp_cost}</td>
+                    <td className="px-2 py-2 text-silver-dk">{template.confidence ?? 'missing'}</td>
+                    <td className="px-2 py-2">
+                      <div className="flex max-w-[14rem] flex-wrap gap-1">
+                        <Chip tone={validityTone}>{validity}</Chip>
+                        {warnings.map((warning) => (
+                          <Chip key={`${template.id}-${warning}`} tone="warn">{warning}</Chip>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-2 py-2">
+                      <button
+                        type="button"
+                        aria-label={`Select structure ${template.name}`}
+                        onClick={() => onSelectTemplate(template.id)}
+                        className={[
+                          'rounded border px-2 py-1 text-[10px] uppercase tracking-[0.12em] transition',
+                          isSelected
+                            ? 'border-cyan/65 bg-cyan/15 text-cyan'
+                            : 'border-border/60 bg-bg2 text-silver-dk hover:border-cyan/55 hover:text-cyan',
+                        ].join(' ')}
+                      >
+                        {isSelected ? 'Selected' : 'Select structure'}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/structurePickerUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/structurePickerUtils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { FacilityTemplate, SystemBody } from '@/types/api';
+import {
+  getStructurePickerValidityLabel,
+  getStructurePickerWarnings,
+  locationMatchesFilter,
+  resolveBodyContext,
+  templateLocationKind,
+} from './structurePickerUtils';
+
+const baseTemplate: FacilityTemplate = {
+  id: 'template-a',
+  name: 'Template A',
+  category: 'support',
+  tier: 1,
+  economy: 'Industrial',
+  is_port: false,
+  is_support_facility: true,
+  allowed_location: 'surface',
+  pad_size: 'medium',
+  confidence: 'observed',
+  notes: null,
+  yellow_cp_generated: 1,
+  green_cp_generated: 0,
+  yellow_cp_cost: 0,
+  green_cp_cost: 0,
+};
+
+describe('structurePickerUtils', () => {
+  it('classifies location and filters templates', () => {
+    const orbital = { ...baseTemplate, id: 'o', allowed_location: 'orbital' };
+    const surface = { ...baseTemplate, id: 's', allowed_location: 'surface' };
+    const both = { ...baseTemplate, id: 'b', allowed_location: 'surface_or_orbit' };
+
+    expect(templateLocationKind(orbital)).toBe('orbital');
+    expect(templateLocationKind(surface)).toBe('surface');
+    expect(templateLocationKind(both)).toBe('both');
+    expect(locationMatchesFilter(orbital, 'orbital')).toBe(true);
+    expect(locationMatchesFilter(orbital, 'surface')).toBe(false);
+    expect(locationMatchesFilter(both, 'both')).toBe(true);
+    expect(locationMatchesFilter(surface, 'all')).toBe(true);
+  });
+
+  it('resolves body context for selected, none, and unknown body ids', () => {
+    const bodies = [{ id: 42, name: 'A 42' }] as SystemBody[];
+    expect(resolveBodyContext(bodies, null).status).toBe('none');
+    expect(resolveBodyContext(bodies, '').status).toBe('none');
+    const selected = resolveBodyContext(bodies, '42');
+    expect(selected.status).toBe('selected');
+    expect(selected.body?.name).toBe('A 42');
+    const unknown = resolveBodyContext(bodies, '404');
+    expect(unknown.status).toBe('unknown');
+    expect(unknown.bodyId).toBe('404');
+  });
+
+  it('emits conservative body suitability warnings and validity labels', () => {
+    const waterWorld = { id: 1, name: 'A 1', is_water_world: true, is_landable: true } as SystemBody;
+    const nonLandable = { id: 2, name: 'A 2', is_landable: false } as SystemBody;
+    const unknownMetadata = { id: 3 } as SystemBody;
+    const surfaceTemplate = { ...baseTemplate, allowed_location: 'surface' };
+    const orbitalTemplate = { ...baseTemplate, allowed_location: 'orbital' };
+    const estimatedTemplate = { ...baseTemplate, confidence: 'estimated' };
+
+    const noBodyWarnings = getStructurePickerWarnings(surfaceTemplate, { status: 'none', body: null, bodyId: null });
+    expect(noBodyWarnings).toContain('Needs body: body-specific checks are unavailable');
+    expect(getStructurePickerValidityLabel(surfaceTemplate, { status: 'none', body: null, bodyId: null })).toBe('Needs body');
+
+    const unknownBodyWarnings = getStructurePickerWarnings(surfaceTemplate, { status: 'unknown', body: null, bodyId: '404' });
+    expect(unknownBodyWarnings).toContain('Unknown body: body-specific checks are unavailable');
+    expect(getStructurePickerValidityLabel(surfaceTemplate, { status: 'unknown', body: null, bodyId: '404' })).toBe('Unknown body');
+
+    const waterWarnings = getStructurePickerWarnings(surfaceTemplate, { status: 'selected', body: waterWorld, bodyId: '1' });
+    expect(waterWarnings).toContain('May be invalid: surface facility on water world');
+    expect(getStructurePickerValidityLabel(surfaceTemplate, { status: 'selected', body: waterWorld, bodyId: '1' })).toBe('Check location');
+
+    const landableWarnings = getStructurePickerWarnings(surfaceTemplate, { status: 'selected', body: nonLandable, bodyId: '2' });
+    expect(landableWarnings).toContain('May be invalid: surface facility on non-landable body');
+
+    const orbitalWarnings = getStructurePickerWarnings(orbitalTemplate, { status: 'selected', body: unknownMetadata, bodyId: '3' });
+    expect(orbitalWarnings).toContain('Data incomplete: orbital suitability unclear');
+
+    const estimatedWarnings = getStructurePickerWarnings(estimatedTemplate, { status: 'selected', body: waterWorld, bodyId: '1' });
+    expect(estimatedWarnings).toContain('Needs review: template uses estimated data');
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/structurePickerUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/structurePickerUtils.ts
@@ -1,0 +1,96 @@
+import type { FacilityTemplate, SystemBody } from '@/types/api';
+import { bodyTags } from './buildPlanLayoutUtils';
+
+export type StructurePickerLocationKind = 'orbital' | 'surface' | 'both' | 'unknown';
+export type StructurePickerLocationFilter = 'all' | 'orbital' | 'surface' | 'both';
+
+export interface StructurePickerBodyContext {
+  status: 'selected' | 'none' | 'unknown';
+  body: SystemBody | null;
+  bodyId: string | null;
+}
+
+export function templateLocationKind(template: FacilityTemplate): StructurePickerLocationKind {
+  const value = (template.allowed_location ?? '').toLowerCase();
+  if (value.includes('surface') && value.includes('orbit')) return 'both';
+  if (value.includes('surface')) return 'surface';
+  if (value.includes('orbit')) return 'orbital';
+  return 'unknown';
+}
+
+export function locationMatchesFilter(
+  template: FacilityTemplate,
+  filter: StructurePickerLocationFilter,
+): boolean {
+  if (filter === 'all') return true;
+  return templateLocationKind(template) === filter;
+}
+
+export function resolveBodyContext(
+  bodies: SystemBody[],
+  selectedBodyId?: string | null,
+): StructurePickerBodyContext {
+  const bodyId = selectedBodyId != null && selectedBodyId !== '' ? String(selectedBodyId) : null;
+  if (!bodyId) {
+    return { status: 'none', body: null, bodyId: null };
+  }
+  const body = bodies.find((item) => item.id != null && String(item.id) === bodyId) ?? null;
+  if (!body) {
+    return { status: 'unknown', body: null, bodyId };
+  }
+  return { status: 'selected', body, bodyId };
+}
+
+export function getStructurePickerWarnings(
+  template: FacilityTemplate,
+  context: StructurePickerBodyContext,
+): string[] {
+  const warnings = new Set<string>();
+  const location = templateLocationKind(template);
+  if (template.confidence === 'estimated') {
+    warnings.add('Needs review: template uses estimated data');
+  }
+
+  if (context.status === 'none') {
+    warnings.add('Needs body: body-specific checks are unavailable');
+    return Array.from(warnings);
+  }
+
+  if (context.status === 'unknown') {
+    warnings.add('Unknown body: body-specific checks are unavailable');
+    return Array.from(warnings);
+  }
+
+  const body = context.body;
+  if (!body) {
+    warnings.add('Unknown body: body-specific checks are unavailable');
+    return Array.from(warnings);
+  }
+
+  if (bodyTags(body).includes('Unknown body data')) {
+    warnings.add('Data incomplete: body metadata is sparse');
+  }
+  if (location === 'surface' && body.is_water_world) {
+    warnings.add('May be invalid: surface facility on water world');
+  }
+  if (location === 'surface' && body.is_landable === false) {
+    warnings.add('May be invalid: surface facility on non-landable body');
+  }
+  if (location === 'orbital' && !body.body_type && !body.subtype) {
+    warnings.add('Data incomplete: orbital suitability unclear');
+  }
+
+  return Array.from(warnings);
+}
+
+export function getStructurePickerValidityLabel(
+  template: FacilityTemplate,
+  context: StructurePickerBodyContext,
+): string {
+  const warnings = getStructurePickerWarnings(template, context);
+  if (context.status === 'none') return 'Needs body';
+  if (context.status === 'unknown') return 'Unknown body';
+  if (warnings.some((item) => item.startsWith('May be invalid'))) return 'Check location';
+  if (warnings.length > 0) return 'Needs review';
+  return 'Looks valid';
+}


### PR DESCRIPTION
## Summary
Stage 12A adds the first safe Structure Picker / Table foundation inside Colony Planner List view so users can inspect facility templates before selecting one for a Build Plan placement.

## What changed
- Added `StructurePickerTable` with:
  - search
  - location filters (`All`, `Orbital`, `Surface`, `Both`)
  - template comparison fields (structure, location, tier, pad, economy, role, CP gives/needs, confidence, validity)
  - explicit `Select structure` action
- Added pure helper module `structurePickerUtils` for:
  - location-kind derivation
  - filter matching
  - body-context resolution (`selected` / `none` / `unknown`)
  - conservative compatibility/warning labels
- Integrated picker into `BuildPlanEditor` as explicit per-placement `Browse structures` panel.
- Preserved existing template dropdown as canonical edit control.
- Preserved missing-template visibility in List view with labeled disabled option.

## Conservative warning coverage
- surface facility on water world
- surface facility on non-landable body
- sparse body metadata
- orbital suitability unclear
- estimated template data
- no/unknown selected body context

## Safety boundaries (unchanged)
- No backend mechanics/scoring/CP/economy/service/buildability changes.
- No optimiser generation/ranking/comparison changes.
- No Observed Evidence / Validation behavior changes.
- No Search Tuning changes.
- No persistence/saved-build changes.
- No auto-run Preview, auto-generate, auto-load, auto-save, polling, or silent mutation.
- Layout view remains read-only; List view remains canonical editor.

## Tests
Added:
- `StructurePickerTable.test.tsx`
- `structurePickerUtils.test.ts`

Updated:
- `SimulationPreview.optimiser.test.tsx` with no-side-effect picker interaction coverage

## Checks run
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `cd frontend-v2 && npm test`
- `git diff --check`

All passed.

## Deferred to Stage 12B
- Variant/family grouping and richer picker comparison modes
- Expanded replacement workflows beyond explicit per-row select
- Any picker action from Layout view (Layout remains read-only)
- Any backend catalogue enrichment for new fields