### PR TITLE
Stage 12D: planner intelligence guidance foundation

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -865,3 +865,33 @@ Deferred to Stage 12D:
 - Architect Slot Survey data entry/import surfaces for confirmed in-game primary-port slot evidence.
 - Better body/orbit recommendation context once confirmed Architect-slot data exists.
 - Any backend catalogue enrichment, saved-build persistence, logistics/material planning, or layout-view action surface.
+
+## Stage 12D - Planner Intelligence Guidance Foundation
+
+Stage 12D adds a frontend-only guidance layer on top of existing planner data and warning strings. It explains what a warning means, how severe it is, and what the user should confirm in game without changing optimiser output, scoring, preview semantics, or Build Plan mutation rules.
+
+Current Stage 12D status:
+
+- Added deterministic guidance severity levels: `info`, `advisory`, `caution`, `high-risk`, and `incompatible`.
+- Added compact guidance rows in List view and read-only Layout view. These rows explain existing facts such as estimated template data, sparse body metadata, unknown body assignments, and potentially invalid surface placements.
+- Surface structures planned on water worlds or non-landable bodies are explained as incompatible placement risks. Estimated template data stays advisory and does not block explicit user actions.
+- Water-world orbital context can surface a conservative tourism/agriculture planning hint when the existing body/template data supports it.
+- Architect primary-port guidance remains read-only. Users are reminded to check System Map -> Architect Mode before final major station placement, and inconvenient flagged primary-port slots are framed as possible outpost placements rather than reasons to reject a system.
+
+Safety boundaries in Stage 12D:
+
+- No backend mechanics, backend scoring, CP formulas, economy mechanics, service unlock mechanics, buildability mechanics, optimiser generation/ranking, Simulation Preview scoring, Search Tuning, Observed Evidence semantics, Validation semantics, persistence, imports, EDMC ingestion, hauling/material workflows, or map topology rendering changed.
+- Guidance is explanatory only. It does not block Apply/Cancel actions, does not auto-run Preview, does not auto-generate/load/save, and does not mutate the Build Plan silently.
+- Primary-port location remains planning guidance only and is not treated as a Build Point source or user-editable truth.
+
+Test coverage added in Stage 12D:
+
+- `plannerGuidanceUtils.test.ts` for severity mapping, placement guidance, read-only Architect guidance, and body-level guidance.
+- `BuildPlanEditor.test.tsx` coverage for advisory guidance rendering while preserving explicit cancel/apply behavior.
+- `BuildPlanBodyView.test.tsx` coverage for Layout guidance rendering and continued absence of primary-port editing controls.
+
+Deferred to Stage 13:
+
+- Architect observation concepts, unknown-vs-observed status, and future storage/import decisions.
+- Topology-aware readout beyond conservative body/placement guidance.
+- Full Architect Slot Survey and primary-port observation workflows.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -341,3 +341,31 @@ Deferred to Stage 12D:
 - Architect Slot Survey data entry/import and confirmed primary-port slot evidence handling.
 - Better body/orbit recommendation context once confirmed Architect-slot data exists.
 - Backend catalogue enrichment, saved-build persistence, logistics/material planning, and any Layout-view action surface.
+
+## Stage 12D - Planner Guidance Foundation
+
+Stage 12D keeps the planner deterministic and frontend-only while making existing placement risks easier to interpret.
+
+- `plannerGuidanceUtils.ts` maps existing warning strings and body/template facts into `info`, `advisory`, `caution`, `high-risk`, and `incompatible` guidance. The helper does not alter warnings, scoring, preview results, or optimiser ranking.
+- `PlannerGuidanceList.tsx` renders compact guidance rows in the List editor and read-only Layout surfaces.
+- List view guidance explains estimated template data, sparse body metadata, unknown or missing body context, and Architect primary-port checks without blocking replacement Apply/Cancel.
+- Layout view guidance repeats only high-signal body/placement context so the readout advises without becoming an editing surface.
+- Architect copy remains read-only: primary-port location should be checked in System Map -> Architect Mode before final major station placement, it is not a Build Point source, and an inconvenient flagged slot can be treated as an outpost candidate while the main station goes elsewhere.
+
+Safety boundaries in Stage 12D:
+
+- No backend mutation, persistence, import/storage, auto-preview, auto-generation, auto-load/save, polling, or silent mutation is introduced.
+- No scoring, CP formulas, economy mechanics, buildability rules, service unlock logic, optimiser ranking/generation, Search Tuning, Observed Evidence, or Validation behavior changes are introduced.
+- No primary-port editing controls, make/remove primary actions, arbitrary slot assignment, or Architect Slot Survey storage are introduced.
+
+Test coverage added in Stage 12D:
+
+- `plannerGuidanceUtils.test.ts` covers severity mapping and deterministic guidance generation.
+- `BuildPlanEditor.test.tsx` covers guidance rendering while preserving explicit replacement cancel/apply behavior.
+- `BuildPlanBodyView.test.tsx` covers Layout guidance rendering and confirms primary-port guidance remains read-only.
+
+Deferred to Stage 13:
+
+- Architect observation status and unknown/observed survey concepts.
+- Topology-aware Layout readout beyond guidance rows.
+- Any persistent Architect survey data, imports, or primary-port observation workflows.

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
@@ -143,6 +143,8 @@ describe('BuildPlanBodyView', () => {
     expect(within(secondBody).getByText('Confidence: estimated')).toBeTruthy();
     expect(within(secondBody).getByText('Needs review: template uses estimated data')).toBeTruthy();
     expect(within(secondBody).getAllByText('May be invalid: surface facility on water world').length).toBeGreaterThan(0);
+    expect(within(secondBody).getAllByText('Surface structure may be invalid on this body.').length).toBeGreaterThan(0);
+    expect(within(secondBody).getAllByText('Estimated template data: review before relying on the plan.').length).toBeGreaterThan(0);
 
     const unassigned = screen.getByTestId('layout-body-group-unassigned');
     expect(within(unassigned).getAllByText('Unassigned / needs body').length).toBeGreaterThan(0);
@@ -180,6 +182,7 @@ describe('BuildPlanBodyView', () => {
     expect(screen.getByRole('button', { name: 'Select body Body 9' })).toBeTruthy();
     expect(screen.getAllByText('Data incomplete: body metadata is sparse').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Data incomplete: orbital suitability unclear').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Sparse body metadata: confirm in game before relying on this placement.').length).toBeGreaterThan(0);
   });
 
   it('handles helper fallbacks and sparse body metadata without crashing', () => {
@@ -221,6 +224,7 @@ describe('BuildPlanBodyView', () => {
     const panel = screen.getByTestId('layout-detail-panel');
     expect(within(panel).getAllByText('A 2').length).toBeGreaterThan(0);
     expect(within(panel).getByText('Water world')).toBeTruthy();
+    expect(within(panel).getByText('Surface structure may be invalid on this body.')).toBeTruthy();
     expect(within(panel).getByText('Placements')).toBeTruthy();
     expect(within(panel).getByText('1')).toBeTruthy();
     expect(within(panel).getByText('Primary port here')).toBeTruthy();
@@ -248,6 +252,9 @@ describe('BuildPlanBodyView', () => {
     expect(within(panel).getByText('Y+0/20 G+0/40')).toBeTruthy();
     expect(within(panel).getByText('observed')).toBeTruthy();
     expect(within(panel).getByText('Use List view to edit this placement.')).toBeTruthy();
+    expect(within(panel).getByText('Architect primary-port location should be checked before final major station placement.')).toBeTruthy();
+    expect(within(panel).queryByRole('button', { name: /make primary/i })).toBeNull();
+    expect(within(panel).queryByRole('button', { name: /remove primary/i })).toBeNull();
   });
 
   it('handles missing templates, unassigned placements, and summary reset safely', () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
@@ -16,6 +16,8 @@ import {
 } from './buildPlanLayoutUtils';
 import { BuildPlanLayoutDetailPanel, type LayoutSelection } from './BuildPlanLayoutDetailPanel';
 import { Chip } from './components';
+import { PlannerGuidanceList } from './PlannerGuidanceList';
+import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
 import { formatLocation } from './utils/formatters';
 
 interface BuildPlanBodyViewProps {
@@ -178,6 +180,13 @@ function BodyGroupCard({
   onSelectPlacement: (placementIndex: number) => void;
 }) {
   const bodyWarnings = getBodyGroupWarnings(group);
+  const bodyGuidance = buildPlannerGuidanceForBody(group.body, group.placements.map((item) => ({
+    placement: item.placement,
+    template: item.template,
+    body: group.body,
+    hasUnknownBody: item.hasUnknownBody,
+    warnings: getPlacementWarnings(item, group.body),
+  })));
   const summary = getBodyGroupSummary(group);
   const isUnassigned = group.body === null;
   const body = group.body;
@@ -242,6 +251,7 @@ function BodyGroupCard({
             {bodyWarnings.map((warning) => <Chip key={warning} tone="warn">{warning}</Chip>)}
           </div>
         )}
+        <PlannerGuidanceList items={bodyGuidance} limit={2} title="Body guidance" />
       </div>
 
       <div className="mt-3 grid gap-2">
@@ -275,6 +285,13 @@ function PlacementCard({
 }) {
   const { placement, template, index } = item;
   const warnings = getPlacementWarnings(item, body);
+  const guidance = buildPlannerGuidanceForPlacement({
+    placement,
+    template,
+    body,
+    hasUnknownBody: item.hasUnknownBody,
+    warnings,
+  });
   const status = getPlacementStatus(item, body);
   const confidence = template?.confidence ?? 'missing';
   const hasNotes = template?.notes != null && template.notes.trim().length > 0;
@@ -342,6 +359,9 @@ function PlacementCard({
       <p className="mt-2 font-mono text-[10px] text-silver-dk">
         Body assignment: {body ? bodyDisplayName(body) : item.hasUnknownBody ? `Unknown body ${item.bodyId}` : 'Unassigned'}
       </p>
+      <div className="mt-2">
+        <PlannerGuidanceList items={guidance} limit={2} />
+      </div>
     </button>
   );
 }

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
@@ -48,11 +48,11 @@ const placements: SimulateBuildPlacement[] = [
   { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
 ];
 
-function renderEditor() {
+function renderEditor(customPlacements = placements) {
   const onUpdate = vi.fn();
   render(
     <BuildPlanEditor
-      placements={placements}
+      placements={customPlacements}
       templates={templates}
       bodies={bodies}
       onUpdate={onUpdate}
@@ -113,11 +113,28 @@ describe('BuildPlanEditor structure replacement review', () => {
     expect(screen.getAllByText(/Check the primary-port location in-game through System Map and Architect Mode/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Primary-port location is placement guidance, not a Build Point source/).length).toBeGreaterThan(0);
     expect(screen.getByText(/If the flagged slot is inconvenient, consider placing an outpost there/)).toBeTruthy();
+    expect(screen.getByText('Architect primary-port location should be checked before final major station placement.')).toBeTruthy();
+    expect(screen.getByText('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /make primary/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /remove primary/i })).toBeNull();
     expect(screen.queryByRole('checkbox', { name: /primary/i })).toBeNull();
     expect(screen.queryByText(/unsafe to invest/i)).toBeNull();
     expect(screen.queryByText(/system is poor/i)).toBeNull();
     expect(screen.queryByText(/do not build here/i)).toBeNull();
+  });
+
+  it('renders advisory guidance without changing apply or cancel behavior', () => {
+    const { onUpdate } = renderEditor([
+      { facility_template_id: 'surface_outpost', local_body_id: '1', is_primary_port: false, build_order: 1 },
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: /Browse structures/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Select structure Orbital Port/i }));
+
+    expect(screen.getAllByText('Estimated template data: review before relying on the plan.').length).toBeGreaterThan(0);
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel replacement/i }));
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 });

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
@@ -2,8 +2,11 @@ import { useState } from 'react';
 import { ArrowDown, ArrowUp, Trash2 } from 'lucide-react';
 import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
 import { Chip, IconButton } from './components';
+import { PlannerGuidanceList } from './PlannerGuidanceList';
+import { buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
 import { StructureReplacementComparison } from './StructureReplacementComparison';
 import { StructurePickerTable } from './StructurePickerTable';
+import { getStructurePickerWarnings, resolveBodyContext } from './structurePickerUtils';
 import { formatLocation } from './utils/formatters';
 
 export function BuildPlanEditor({
@@ -33,6 +36,14 @@ export function BuildPlanEditor({
         const proposedTemplate = pendingReplacement?.index === index
           ? templates.find((item) => item.id === pendingReplacement.templateId)
           : undefined;
+        const bodyContext = resolveBodyContext(bodies, placement.local_body_id ?? null);
+        const guidance = buildPlannerGuidanceForPlacement({
+          placement,
+          template,
+          body: bodyContext.body,
+          hasUnknownBody: bodyContext.status === 'unknown',
+          warnings: template ? getStructurePickerWarnings(template, bodyContext) : [],
+        });
         return (
           <div key={`${placement.build_order}-${index}`} className="rounded-chunk-lg border border-border/70 bg-bg2/70 p-3">
             <div className="mb-2 flex items-center justify-between gap-2">
@@ -142,6 +153,10 @@ export function BuildPlanEditor({
                 {template.confidence === 'estimated' && <Chip tone="warn">Estimated data</Chip>}
               </div>
             )}
+
+            <div className="mt-2">
+              <PlannerGuidanceList items={guidance} />
+            </div>
 
             {pickerOpen && (
               <div id={`structure-picker-panel-${index}`}>

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
@@ -13,6 +13,8 @@ import {
   type PlanSummary,
 } from './buildPlanLayoutUtils';
 import { Chip } from './components';
+import { PlannerGuidanceList } from './PlannerGuidanceList';
+import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
 import { formatLocation } from './utils/formatters';
 
 export type LayoutSelection =
@@ -114,6 +116,13 @@ function SummaryDetail({ summary }: { summary: PlanSummary }) {
 function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary }) {
   const bodySummary = getBodyGroupSummary(group);
   const warnings = getBodyGroupWarnings(group);
+  const guidance = buildPlannerGuidanceForBody(group.body, group.placements.map((item) => ({
+    placement: item.placement,
+    template: item.template,
+    body: group.body,
+    hasUnknownBody: item.hasUnknownBody,
+    warnings: getPlacementWarnings(item, group.body),
+  })));
   const name = group.body ? bodyDisplayName(group.body) : 'Unassigned / needs body';
 
   return (
@@ -131,6 +140,7 @@ function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary
       </DetailGrid>
       <TagList body={group.body} />
       <WarningList warnings={warnings} emptyLabel="No body-level warnings from current layout data." />
+      <PlannerGuidanceList items={guidance} title="Body guidance" />
       <div>
         <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">Placements on this body</div>
         <ul className="mt-2 space-y-1 font-mono text-[11px] text-silver-dk">
@@ -150,6 +160,13 @@ function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary
 function PlacementDetail({ group, item, summary }: { group: BodyGroup; item: GroupedPlacement; summary: PlanSummary }) {
   const { placement, template } = item;
   const warnings = getPlacementWarnings(item, group.body);
+  const guidance = buildPlannerGuidanceForPlacement({
+    placement,
+    template,
+    body: group.body,
+    hasUnknownBody: item.hasUnknownBody,
+    warnings,
+  });
   const bodyLabel = placementBodyLabel(group.body, item);
   const status = getPlacementStatus(item, group.body);
 
@@ -175,6 +192,7 @@ function PlacementDetail({ group, item, summary }: { group: BodyGroup; item: Gro
         <DetailItem label="Confidence" value={template?.confidence ?? 'missing'} tone={template?.confidence === 'estimated' || !template ? 'warn' : 'default'} />
       </DetailGrid>
       <WarningList warnings={warnings} emptyLabel="No placement warnings from current layout data." />
+      <PlannerGuidanceList items={guidance} />
       <p className="rounded border border-border/50 bg-bg3/35 px-3 py-2 font-mono text-[11px] leading-snug text-silver-dk">
         Use List view to edit this placement.
       </p>

--- a/frontend-v2/src/features/system-detail/simulation-preview/PlannerGuidanceList.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/PlannerGuidanceList.tsx
@@ -1,0 +1,45 @@
+import type { PlannerGuidanceItem } from './plannerGuidanceUtils';
+import { guidanceTone } from './plannerGuidanceUtils';
+
+export function PlannerGuidanceList({
+  items,
+  limit = 3,
+  title = 'Planner guidance',
+}: {
+  items: PlannerGuidanceItem[];
+  limit?: number;
+  title?: string;
+}) {
+  if (items.length === 0) return null;
+  const visible = items.slice(0, limit);
+  const extra = items.length - visible.length;
+
+  return (
+    <div className="rounded border border-border/50 bg-bg3/30 px-2 py-2" data-testid="planner-guidance">
+      <div className="font-mono text-[9px] uppercase tracking-[0.14em] text-cyan">{title}</div>
+      <div className="mt-1.5 space-y-1">
+        {visible.map((item) => (
+          <div key={item.id} className="flex flex-wrap items-center gap-1.5 font-mono text-[10px] leading-snug text-silver-dk">
+            <span className={severityClass(item.severity)}>{item.severity}</span>
+            <span>{item.text}</span>
+          </div>
+        ))}
+        {extra > 0 && (
+          <div className="font-mono text-[10px] text-silver-dk">+{extra} more guidance item{extra === 1 ? '' : 's'}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function severityClass(severity: PlannerGuidanceItem['severity']): string {
+  const tone = guidanceTone(severity);
+  const cls = tone === 'risk'
+    ? 'border-red-400/40 bg-red-400/10 text-red-200'
+    : tone === 'caution'
+      ? 'border-gold/35 bg-gold/10 text-gold'
+      : tone === 'advisory'
+        ? 'border-orange/35 bg-orange/10 text-orange'
+        : 'border-cyan/30 bg-cyan/10 text-cyan';
+  return `inline-flex rounded border px-1.5 py-0.5 uppercase tracking-[0.12em] ${cls}`;
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/plannerGuidanceUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/plannerGuidanceUtils.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import {
+  buildPlannerGuidanceForBody,
+  buildPlannerGuidanceForPlacement,
+  plannerSeverityForWarning,
+} from './plannerGuidanceUtils';
+
+const orbitalPort: FacilityTemplate = {
+  id: 'orbital_port',
+  name: 'Orbital Port',
+  category: 'port',
+  tier: 3,
+  economy: 'Industrial',
+  is_port: true,
+  is_support_facility: false,
+  allowed_location: 'orbital',
+  pad_size: 'large',
+  confidence: 'observed',
+  notes: null,
+  yellow_cp_generated: 0,
+  green_cp_generated: 0,
+  yellow_cp_cost: 20,
+  green_cp_cost: 40,
+};
+
+const surfaceSupport: FacilityTemplate = {
+  id: 'surface_support',
+  name: 'Surface Support',
+  category: 'support',
+  tier: 1,
+  economy: 'Extraction',
+  is_port: false,
+  is_support_facility: true,
+  allowed_location: 'surface',
+  pad_size: 'small',
+  confidence: 'estimated',
+  notes: null,
+  yellow_cp_generated: 8,
+  green_cp_generated: 2,
+  yellow_cp_cost: 0,
+  green_cp_cost: 0,
+};
+
+const placement: SimulateBuildPlacement = {
+  facility_template_id: 'surface_support',
+  local_body_id: '2',
+  build_order: 1,
+};
+
+describe('plannerGuidanceUtils', () => {
+  it('maps warning strings to conservative severity levels', () => {
+    expect(plannerSeverityForWarning('May be invalid: surface facility on water world')).toBe('incompatible');
+    expect(plannerSeverityForWarning('Needs review: template uses estimated data')).toBe('advisory');
+    expect(plannerSeverityForWarning('Data incomplete: body metadata is sparse')).toBe('caution');
+    expect(plannerSeverityForWarning('Unknown planner note')).toBe('advisory');
+  });
+
+  it('builds high-risk placement guidance without blocking explicit actions', () => {
+    const guidance = buildPlannerGuidanceForPlacement({
+      placement,
+      template: surfaceSupport,
+      body: { id: 2, name: 'A 2', is_water_world: true } as SystemBody,
+      warnings: [
+        'May be invalid: surface facility on water world',
+        'Needs review: template uses estimated data',
+      ],
+    });
+
+    expect(guidance.map((item) => item.severity)).toContain('incompatible');
+    expect(guidance.map((item) => item.text)).toContain('Surface structure may be invalid on this body.');
+    expect(guidance.map((item) => item.text)).toContain('Estimated template data: review before relying on the plan.');
+  });
+
+  it('keeps Architect guidance read-only and informational', () => {
+    const guidance = buildPlannerGuidanceForPlacement({
+      placement: { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
+      template: orbitalPort,
+      body: { id: 1, name: 'A 1', body_type: 'Planet' } as SystemBody,
+      warnings: [],
+    });
+
+    expect(guidance).toContainEqual(expect.objectContaining({
+      severity: 'info',
+      text: 'Architect primary-port location should be checked before final major station placement.',
+    }));
+    expect(guidance).toContainEqual(expect.objectContaining({
+      severity: 'advisory',
+      text: 'If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.',
+    }));
+  });
+
+  it('derives body guidance from existing body and placement data only', () => {
+    const guidance = buildPlannerGuidanceForBody(
+      { id: 2, name: 'A 2', is_water_world: true } as SystemBody,
+      [{
+        placement: { facility_template_id: 'orbital_port', local_body_id: '2', build_order: 1 },
+        template: orbitalPort,
+        body: { id: 2, name: 'A 2', is_water_world: true } as SystemBody,
+        warnings: [],
+      }],
+    );
+
+    expect(guidance.map((item) => item.text)).toContain('Water-world orbital planning may favour tourism/agriculture.');
+    expect(guidance.map((item) => item.text)).toContain('Architect primary-port location should be checked before final major station placement.');
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/plannerGuidanceUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/plannerGuidanceUtils.ts
@@ -1,0 +1,256 @@
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+
+export type PlannerGuidanceSeverity = 'info' | 'advisory' | 'caution' | 'high-risk' | 'incompatible';
+
+export interface PlannerGuidanceItem {
+  id: string;
+  severity: PlannerGuidanceSeverity;
+  text: string;
+}
+
+export interface PlannerGuidancePlacementInput {
+  placement: SimulateBuildPlacement;
+  template?: FacilityTemplate;
+  body: SystemBody | null;
+  hasUnknownBody?: boolean;
+  warnings?: string[];
+}
+
+const severityByWarning: Array<[RegExp, PlannerGuidanceSeverity]> = [
+  [/surface facility on water world/i, 'incompatible'],
+  [/surface facility on non-landable body/i, 'incompatible'],
+  [/template uses estimated data/i, 'advisory'],
+  [/metadata is sparse|orbital suitability unclear|body-specific checks are unavailable/i, 'caution'],
+  [/body id does not match known body|placement has no body|placement has no known body|facility template missing/i, 'caution'],
+];
+
+export function plannerSeverityForWarning(warning: string): PlannerGuidanceSeverity {
+  return severityByWarning.find(([pattern]) => pattern.test(warning))?.[1] ?? 'advisory';
+}
+
+export function buildPlannerGuidanceForPlacement({
+  placement,
+  template,
+  body,
+  hasUnknownBody = false,
+  warnings = [],
+}: PlannerGuidancePlacementInput): PlannerGuidanceItem[] {
+  const guidance = new Map<string, PlannerGuidanceItem>();
+  const add = (item: PlannerGuidanceItem) => {
+    const existing = guidance.get(item.text);
+    if (!existing || severityRank(item.severity) > severityRank(existing.severity)) {
+      guidance.set(item.text, item);
+    }
+  };
+
+  for (const warning of warnings) {
+    add({
+      id: `warning:${warning}`,
+      severity: plannerSeverityForWarning(warning),
+      text: guidanceTextForWarning(warning),
+    });
+  }
+
+  if (!template) {
+    add({
+      id: 'missing-template',
+      severity: 'caution',
+      text: 'Facility template is missing; confirm the plan before relying on this placement.',
+    });
+  }
+
+  if (!body) {
+    add({
+      id: hasUnknownBody ? 'unknown-body' : 'unassigned-body',
+      severity: 'caution',
+      text: hasUnknownBody
+        ? 'Unknown body assignment: confirm the body in game before relying on this placement.'
+        : 'No body is assigned yet; body-specific checks are unavailable.',
+    });
+  }
+
+  if (body && isSparseBody(body)) {
+    add({
+      id: 'sparse-body',
+      severity: 'caution',
+      text: 'Sparse body metadata: confirm in game before relying on this placement.',
+    });
+  }
+
+  if (template?.confidence === 'estimated') {
+    add({
+      id: 'estimated-template',
+      severity: 'advisory',
+      text: 'Estimated template data: review before relying on the plan.',
+    });
+  }
+
+  if (template && body?.is_water_world && isSurfaceTemplate(template)) {
+    add({
+      id: 'surface-water-world',
+      severity: 'incompatible',
+      text: 'Surface structure may be invalid on this body.',
+    });
+  }
+
+  if (template && body?.is_landable === false && isSurfaceTemplate(template)) {
+    add({
+      id: 'surface-non-landable',
+      severity: 'incompatible',
+      text: 'Surface structure may be invalid on this body.',
+    });
+  }
+
+  if (template && body?.is_water_world && isOrbitalTemplate(template)) {
+    add({
+      id: 'water-world-orbital',
+      severity: 'advisory',
+      text: 'Water-world orbital planning may favour tourism/agriculture.',
+    });
+  }
+
+  if (shouldShowArchitectGuidance(placement, template)) {
+    add({
+      id: 'architect-check',
+      severity: 'info',
+      text: 'Architect primary-port location should be checked before final major station placement.',
+    });
+  }
+
+  if (placement.is_primary_port) {
+    add({
+      id: 'primary-port-outpost-option',
+      severity: 'advisory',
+      text: 'If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.',
+    });
+  }
+
+  return Array.from(guidance.values()).sort((a, b) => (
+    severityRank(b.severity) - severityRank(a.severity) || a.text.localeCompare(b.text)
+  ));
+}
+
+export function buildPlannerGuidanceForBody(
+  body: SystemBody | null,
+  placements: PlannerGuidancePlacementInput[],
+): PlannerGuidanceItem[] {
+  const guidance = new Map<string, PlannerGuidanceItem>();
+  const add = (item: PlannerGuidanceItem) => {
+    const existing = guidance.get(item.text);
+    if (!existing || severityRank(item.severity) > severityRank(existing.severity)) {
+      guidance.set(item.text, item);
+    }
+  };
+
+  for (const { warnings = [] } of placements) {
+    for (const warning of warnings) {
+      add({
+        id: `body-warning:${warning}`,
+        severity: plannerSeverityForWarning(warning),
+        text: guidanceTextForWarning(warning),
+      });
+    }
+  }
+
+  if (!body) {
+    add({
+      id: 'body-unassigned',
+      severity: 'caution',
+      text: 'No known body context yet; confirm assignments before relying on Preview.',
+    });
+  } else if (isSparseBody(body)) {
+    add({
+      id: 'body-sparse',
+      severity: 'caution',
+      text: 'Sparse body metadata: confirm in game.',
+    });
+  }
+
+  if (body?.is_water_world && placements.some(({ template }) => template && isOrbitalTemplate(template))) {
+    add({
+      id: 'body-water-world-orbital',
+      severity: 'advisory',
+      text: 'Water-world orbital planning may favour tourism/agriculture.',
+    });
+  }
+
+  if (placements.some(({ placement, template }) => shouldShowArchitectGuidance(placement, template))) {
+    add({
+      id: 'body-architect-check',
+      severity: 'info',
+      text: 'Architect primary-port location should be checked before final major station placement.',
+    });
+  }
+
+  if (placements.some(({ placement }) => placement.is_primary_port)) {
+    add({
+      id: 'body-primary-outpost-option',
+      severity: 'advisory',
+      text: 'If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.',
+    });
+  }
+
+  return Array.from(guidance.values()).sort((a, b) => (
+    severityRank(b.severity) - severityRank(a.severity) || a.text.localeCompare(b.text)
+  ));
+}
+
+export function guidanceTone(severity: PlannerGuidanceSeverity): 'info' | 'advisory' | 'caution' | 'risk' {
+  if (severity === 'incompatible' || severity === 'high-risk') return 'risk';
+  if (severity === 'caution') return 'caution';
+  return severity;
+}
+
+function guidanceTextForWarning(warning: string): string {
+  if (/surface facility on water world|surface facility on non-landable body/i.test(warning)) {
+    return 'Surface structure may be invalid on this body.';
+  }
+  if (/template uses estimated data/i.test(warning)) {
+    return 'Estimated template data: review before relying on the plan.';
+  }
+  if (/metadata is sparse|orbital suitability unclear/i.test(warning)) {
+    return 'Sparse body metadata: confirm in game before relying on this placement.';
+  }
+  if (/body id does not match known body/i.test(warning)) {
+    return 'Unknown body assignment: confirm the body in game before relying on this placement.';
+  }
+  if (/placement has no body|placement has no known body/i.test(warning)) {
+    return 'No body is assigned yet; body-specific checks are unavailable.';
+  }
+  if (/facility template missing/i.test(warning)) {
+    return 'Facility template is missing; confirm the plan before relying on this placement.';
+  }
+  return warning;
+}
+
+function shouldShowArchitectGuidance(placement: SimulateBuildPlacement, template?: FacilityTemplate): boolean {
+  return Boolean(placement.is_primary_port || template?.is_port || (template?.tier ?? 0) >= 3);
+}
+
+function isSurfaceTemplate(template: FacilityTemplate): boolean {
+  return template.allowed_location.toLowerCase().includes('surface');
+}
+
+function isOrbitalTemplate(template: FacilityTemplate): boolean {
+  return template.allowed_location.toLowerCase().includes('orbital');
+}
+
+function isSparseBody(body: SystemBody): boolean {
+  return !body.body_type && !body.subtype;
+}
+
+function severityRank(severity: PlannerGuidanceSeverity): number {
+  switch (severity) {
+    case 'incompatible':
+      return 4;
+    case 'high-risk':
+      return 3;
+    case 'caution':
+      return 2;
+    case 'advisory':
+      return 1;
+    case 'info':
+    default:
+      return 0;
+  }
+}

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -1048,6 +1048,103 @@ export interface paths {
         patch: operations["update_observed_fact_api_observations_facts__observation_id__patch"];
         trace?: never;
     };
+    "/api/observations/compare": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Compare Prediction Against Observations
+         * @description Run the Stage 6C deterministic comparison engine.
+         *
+         *     Two modes:
+         *
+         *     * **Mode A** — ``observed_facts`` omitted from the request. The
+         *       router loads up to ``fact_load_limit`` persisted facts for
+         *       ``system_id64`` via ``store.list_observed_facts_for_comparison``
+         *       and passes them to the engine.
+         *
+         *       Fact-loading semantics (Stage 6C hardening):
+         *         * If ``target_archetype`` is omitted/null in the request, all
+         *           facts for the system are loaded.
+         *         * If ``target_archetype`` is supplied, facts are included when
+         *           their ``target_archetype`` matches the requested value **or**
+         *           is ``NULL`` — i.e. system-level general evidence (notes,
+         *           service evidence, economy evidence, CP observations not tied
+         *           to a specific target) is included alongside target-specific
+         *           evidence. Facts targeting a *different* explicit archetype
+         *           are excluded.
+         *     * **Mode B** — ``observed_facts`` provided. The supplied list is
+         *       converted to ``PersistedObservedFact`` objects and passed to the
+         *       engine verbatim. The database is NOT queried for facts in this
+         *       mode.
+         *
+         *       Source semantics (Stage 6C hardening): Mode B supplied facts may
+         *       carry any ``ObservationSource`` value including ``imported`` and
+         *       ``inferred``. This is deliberate — Mode B is read-only and the
+         *       supplied facts are never persisted, so Stage 6A's reserved-source
+         *       restriction (manual/test_fixture only on create/update) does not
+         *       apply. Persistence still goes exclusively through Stage 6A's
+         *       ``POST /api/observations/facts`` endpoint and remains restricted.
+         *
+         *     The handler is **passive**: it never invokes simulation, optimiser,
+         *     or ranking code, and never mutates persisted observations. It only
+         *     reads observations (Mode A) and runs the pure comparison engine.
+         */
+        post: operations["compare_prediction_against_observations_api_observations_compare_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/observations/review": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Review Prediction Validation
+         * @description Run Stage 6C comparison and Stage 6E review guidance.
+         *
+         *     The handler mirrors compare-endpoint input semantics for caller
+         *     convenience, then passes the comparison result into the pure Stage
+         *     6E review engine. It does not run Simulation Preview, optimiser
+         *     generation, optimiser ranking, or any mechanics module, and it does
+         *     not mutate observations or predictions.
+         */
+        post: operations["review_prediction_validation_api_observations_review_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/colony-planner/system/{id64}/import-layout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Import System Layout */
+        post: operations["import_system_layout_api_colony_planner_system__id64__import_layout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1817,6 +1914,55 @@ export interface components {
             /** Version */
             version: string;
         };
+        /** LayoutImportRequest */
+        LayoutImportRequest: {
+            /**
+             * Source
+             * @default spansh
+             * @constant
+             * @enum {string}
+             */
+            source: "spansh";
+        };
+        /** LayoutImportResponse */
+        LayoutImportResponse: {
+            /** System Id64 */
+            system_id64: number;
+            /**
+             * Source
+             * @constant
+             * @enum {string}
+             */
+            source: "spansh";
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "success" | "partial" | "failed";
+            /**
+             * Fetched At
+             * Format: date-time
+             */
+            fetched_at: string;
+            summary: components["schemas"]["LayoutImportSummary"];
+            /** Warnings */
+            warnings: string[];
+            /** Errors */
+            errors: string[];
+        };
+        /** LayoutImportSummary */
+        LayoutImportSummary: {
+            /** Bodies Found */
+            bodies_found: number;
+            /** Stations Found */
+            stations_found: number;
+            /** Bodies Upserted */
+            bodies_upserted: number;
+            /** Stations Upserted */
+            stations_upserted: number;
+            /** Warnings Count */
+            warnings_count: number;
+        };
         /** LocalSearchRequest */
         LocalSearchRequest: {
             filters?: components["schemas"]["SearchFilters"] | null;
@@ -1857,6 +2003,27 @@ export interface components {
         NoteBody: {
             /** Note */
             note: string;
+        };
+        /** ObservationEvidenceMatchResponse */
+        ObservationEvidenceMatchResponse: {
+            /** Observation Id */
+            observation_id: string;
+            /** Fact Type */
+            fact_type: string;
+            /** Subject Type */
+            subject_type: string;
+            /** Subject Id */
+            subject_id: string | null;
+            /** Status */
+            status: string;
+            /** Confidence */
+            confidence: string;
+            /** Observed Value */
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Expected Value */
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Notes */
+            notes?: string | null;
         };
         /** ObservationFactSummaryResponse */
         ObservationFactSummaryResponse: {
@@ -1931,6 +2098,53 @@ export interface components {
             observation_id: string;
             /** Deleted */
             deleted: boolean;
+        };
+        /**
+         * ObservedFactInput
+         * @description Fact-shaped object accepted by the Stage 6C compare endpoint.
+         */
+        ObservedFactInput: {
+            /** Observation Id */
+            observation_id: string;
+            /** System Id64 */
+            system_id64: number;
+            /** Created At */
+            created_at: string;
+            /** Updated At */
+            updated_at?: string | null;
+            /** @default manual */
+            source: components["schemas"]["ObservationSource"];
+            fact_type: components["schemas"]["ObservedFactType"];
+            subject_type: components["schemas"]["ObservedSubjectType"];
+            /** Subject Id */
+            subject_id?: string | null;
+            status: components["schemas"]["ObservedStatus"];
+            /** Observed Value */
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Expected Value */
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** @default medium */
+            confidence: components["schemas"]["ObservedConfidence"];
+            /** Notes */
+            notes?: string | null;
+            /** Build Fingerprint */
+            build_fingerprint?: string | null;
+            /** Simulation Fingerprint */
+            simulation_fingerprint?: string | null;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Facility Template Id */
+            facility_template_id?: string | null;
+            /** Local Body Id */
+            local_body_id?: string | null;
+            /** Service Id */
+            service_id?: string | null;
+            /** Economy */
+            economy?: string | null;
+            /** Tags */
+            tags?: string[];
+            /** Metadata */
+            metadata?: Record<string, never>;
         };
         /** ObservedFactListResponse */
         ObservedFactListResponse: {
@@ -2260,6 +2474,104 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * PredictionObservationCompareRequest
+         * @description Request payload for ``POST /api/observations/compare``.
+         *
+         *     Two modes:
+         *
+         *     * **Mode A** — supply only ``system_id64``, ``target_archetype`` and
+         *       ``prediction``. The router loads observed facts for the system
+         *       from the persisted Stage 6A store.
+         *     * **Mode B** — supply ``observed_facts`` explicitly (in addition to
+         *       the other fields). The router will NOT hit the database for facts
+         *       and will use the supplied list verbatim.
+         */
+        PredictionObservationCompareRequest: {
+            /** System Id64 */
+            system_id64: number;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Prediction */
+            prediction: Record<string, never>;
+            /** Observed Facts */
+            observed_facts?: components["schemas"]["ObservedFactInput"][] | null;
+            /**
+             * Fact Load Limit
+             * @default 500
+             */
+            fact_load_limit: number;
+        };
+        /** PredictionObservationCompareResponse */
+        PredictionObservationCompareResponse: {
+            /** System Id64 */
+            system_id64: number;
+            /** Target Archetype */
+            target_archetype: string | null;
+            /** Generated At */
+            generated_at: string;
+            summary: components["schemas"]["PredictionObservationComparisonSummaryResponse"];
+            /** Comparisons */
+            comparisons?: components["schemas"]["PredictionObservationComparisonResponse"][];
+            /** Warnings */
+            warnings?: string[];
+            /** Assumptions */
+            assumptions?: string[];
+        };
+        /** PredictionObservationComparisonResponse */
+        PredictionObservationComparisonResponse: {
+            /** Comparison Id */
+            comparison_id: string;
+            /** Area */
+            area: string;
+            /** Subject Type */
+            subject_type: string;
+            /** Subject Id */
+            subject_id: string | null;
+            /** Predicted Value */
+            predicted_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Observed Value */
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            /** Status */
+            status: string;
+            /** Severity */
+            severity: string;
+            /** Confidence */
+            confidence: string;
+            /** Reason */
+            reason: string;
+            /** Recommended Action */
+            recommended_action?: string | null;
+            /** Evidence */
+            evidence?: components["schemas"]["ObservationEvidenceMatchResponse"][];
+            /** Prediction Source */
+            prediction_source?: string | null;
+        };
+        /** PredictionObservationComparisonSummaryResponse */
+        PredictionObservationComparisonSummaryResponse: {
+            /** Status */
+            status: string;
+            /** Observed Facts Count */
+            observed_facts_count: number;
+            /** Compared Predictions Count */
+            compared_predictions_count: number;
+            /** Confirmed Count */
+            confirmed_count: number;
+            /** Contradicted Count */
+            contradicted_count: number;
+            /** Observed Only Count */
+            observed_only_count: number;
+            /** Predicted Only Count */
+            predicted_only_count: number;
+            /** Unknown Count */
+            unknown_count: number;
+            /** Unverified Count */
+            unverified_count: number;
+            /** Confidence Impact */
+            confidence_impact: string;
+            /** Summary */
+            summary: string;
+        };
+        /**
          * ProfileSyncBlob
          * @description The shape is intentionally `Any` — the frontend owns the schema.
          *
@@ -2481,6 +2793,21 @@ export interface components {
             /** Computed At */
             computed_at?: unknown | null;
         };
+        /** RerankContributions */
+        RerankContributions: {
+            /** Economy */
+            economy: number;
+            /** Slots */
+            slots: number;
+            /** Strategic */
+            strategic: number;
+            /** Safety */
+            safety: number;
+            /** Terraforming */
+            terraforming: number;
+            /** Diversity */
+            diversity: number;
+        };
         /** RerankRequest */
         RerankRequest: {
             /** Id64S */
@@ -2516,23 +2843,21 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** RerankContributions */
-        RerankContributions: {
-            economy: number;
-            slots: number;
-            strategic: number;
-            safety: number;
-            terraforming: number;
-            diversity: number;
-        };
         /** RerankSignals */
         RerankSignals: {
+            /** Economy Score */
             economy_score?: number | null;
+            /** Slots */
             slots?: number | null;
+            /** Body Quality */
             body_quality?: number | null;
+            /** Orbital Safety */
             orbital_safety?: number | null;
+            /** Terraforming Potential */
             terraforming_potential?: number | null;
+            /** Body Diversity */
             body_diversity?: number | null;
+            /** Confidence */
             confidence?: number | null;
         };
         /** RerankWeights */
@@ -3386,6 +3711,85 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+        };
+        /**
+         * ValidationReviewRequest
+         * @description Request payload for ``POST /api/observations/review``.
+         *
+         *     Shape intentionally matches ``PredictionObservationCompareRequest``:
+         *     callers supply a system, optional target archetype, and current
+         *     prediction object. ``observed_facts`` remains an optional Mode B
+         *     override for tests/offline tools; when omitted the router loads
+         *     persisted facts with the same semantics as Stage 6C compare.
+         */
+        ValidationReviewRequest: {
+            /** System Id64 */
+            system_id64: number;
+            /** Target Archetype */
+            target_archetype?: string | null;
+            /** Prediction */
+            prediction: Record<string, never>;
+            /** Observed Facts */
+            observed_facts?: components["schemas"]["ObservedFactInput"][] | null;
+            /**
+             * Fact Load Limit
+             * @default 500
+             */
+            fact_load_limit: number;
+        };
+        /** ValidationReviewResponse */
+        ValidationReviewResponse: {
+            /** System Id64 */
+            system_id64: number;
+            /** Target Archetype */
+            target_archetype: string | null;
+            /** Generated At */
+            generated_at: string;
+            summary: components["schemas"]["ValidationReviewSummaryResponse"];
+            /** Signals */
+            signals?: components["schemas"]["ValidationReviewSignalResponse"][];
+            /** Warnings */
+            warnings?: string[];
+            /** Assumptions */
+            assumptions?: string[];
+        };
+        /** ValidationReviewSignalResponse */
+        ValidationReviewSignalResponse: {
+            /** Signal Id */
+            signal_id: string;
+            /** Area */
+            area: string;
+            /** Severity */
+            severity: string;
+            /** Confidence */
+            confidence: string;
+            /** Status */
+            status: string;
+            /** Title */
+            title: string;
+            /** Message */
+            message: string;
+            /** Recommended Action */
+            recommended_action?: string | null;
+            /** Comparison Ids */
+            comparison_ids?: string[];
+        };
+        /** ValidationReviewSummaryResponse */
+        ValidationReviewSummaryResponse: {
+            /** Overall Review Status */
+            overall_review_status: string;
+            /** Confidence Impact */
+            confidence_impact: string;
+            /** Highest Severity */
+            highest_severity: string;
+            /** Review Needed Count */
+            review_needed_count: number;
+            /** Evidence Strength */
+            evidence_strength: string;
+            /** Primary Review Areas */
+            primary_review_areas?: string[];
+            /** Summary */
+            summary: string;
         };
         /** WatchlistAlert */
         WatchlistAlert: {
@@ -5260,6 +5664,107 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ObservedFactResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    compare_prediction_against_observations_api_observations_compare_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PredictionObservationCompareRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PredictionObservationCompareResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    review_prediction_validation_api_observations_review_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ValidationReviewRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationReviewResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    import_system_layout_api_colony_planner_system__id64__import_layout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id64: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["LayoutImportRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LayoutImportResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- Adds a frontend-only planner guidance layer with conservative severity labels.
- Renders compact guidance in Build Plan List and read-only Layout views.
- Keeps Architect primary-port guidance read-only and non-mutating.
- Updates Stage 12D roadmap and UI architecture docs.

## Verification
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `cd frontend-v2 && npm test`
- `git diff --check`

## Safety
- No backend mechanics, scoring, CP formulas, economy logic, optimiser ranking/generation, Search Tuning, Simulation Preview scoring, Observed Evidence semantics, Validation semantics, persistence, imports, or hauling/material workflows changed.
- No auto-preview, auto-generate, auto-save, polling, silent mutation, or primary-port editing controls added.