### PR TITLE
Stage 13A: Architect observation foundation

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -895,3 +895,31 @@ Deferred to Stage 13:
 - Architect observation concepts, unknown-vs-observed status, and future storage/import decisions.
 - Topology-aware readout beyond conservative body/placement guidance.
 - Full Architect Slot Survey and primary-port observation workflows.
+
+## Stage 13A - Architect Observation Foundation
+
+Stage 13A introduces frontend-only Architect observation concepts so the planner can distinguish unknown planning context from user-observed in-game Architect context without adding storage, imports, or primary-port editing.
+
+Current Stage 13A status:
+
+- Added read-only Architect observation status helpers for `not_observed` vs `observed` survey state, observed orbital/ground slot counts when supplied, and unknown vs observed primary-port flag context.
+- Added a compact Architect observation panel in the List editor and read-only Layout detail surfaces. By default it reports `Architect survey: not observed`, `Primary-port flag: unknown`, and unknown slot counts.
+- Preserved the conservative guidance that System Map -> Architect Mode should be checked before final major station placement, primary-port location is placement guidance rather than a Build Point source, and inconvenient flagged primary-port slots can be handled with an outpost while the main station goes elsewhere.
+
+Safety boundaries in Stage 13A:
+
+- No backend persistence, import, EDMC ingestion, Architect Slot Survey storage, scoring, CP formulas, economy mechanics, buildability mechanics, service unlock mechanics, optimiser behavior, Simulation Preview scoring, Observed Evidence semantics, or Validation semantics changed.
+- The Architect observation panel is display-only. It has no make-primary/remove-primary controls, no set/unset primary-port controls, no slot editing, and no automatic mutation.
+- Unknown Architect context is never presented as confirmed. Observed state is only rendered when explicitly supplied to the frontend helper/component.
+
+Test coverage added in Stage 13A:
+
+- `architectObservationUtils.test.ts` covers default unknown state, observed mock state, slot-count normalization, and guidance copy.
+- `ArchitectObservationPanel.test.tsx` covers unknown and observed rendering plus absence of primary-port editing controls.
+- Existing planner/List/Layout tests continue to confirm read-only Architect wording and no primary-port controls.
+
+Deferred to Stage 13B/13C:
+
+- Persistent Architect survey records, import/storage design, manual observation entry workflows, and EDMC/journal ingestion.
+- Full Architect Slot Survey UI and exact slot topology capture.
+- Topology-aware Layout readout that groups bodies, orbital-capable context, ground-capable context, and observed/unknown Architect status.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -369,3 +369,30 @@ Deferred to Stage 13:
 - Architect observation status and unknown/observed survey concepts.
 - Topology-aware Layout readout beyond guidance rows.
 - Any persistent Architect survey data, imports, or primary-port observation workflows.
+
+## Stage 13A - Architect Observation Foundation
+
+Stage 13A adds a display-only Architect observation layer to the planner UI. It does not add persistence, imports, scoring, or editing flows.
+
+- `architectObservationUtils.ts` normalizes optional frontend Architect observation context into `not_observed`/`observed` survey state, unknown/observed primary-port flag state, and optional orbital/ground slot counts.
+- `ArchitectObservationPanel.tsx` renders the status in the List editor and read-only Layout detail panel. The default state is deliberately unknown: `Architect survey: not observed`, `Primary-port flag: unknown`, and unknown slot counts.
+- When tests or future callers provide observed mock context, the panel can render `Architect survey: observed` and `Primary-port flag: observed on ...` without treating it as backend-confirmed truth.
+- Existing primary-port guidance remains conservative: check System Map -> Architect Mode before final major station placement, primary-port location is placement guidance rather than a Build Point source, and an inconvenient flagged primary-port slot can be used for an outpost while the main station is placed elsewhere.
+
+Safety boundaries in Stage 13A:
+
+- No primary-port editing controls, make/remove primary actions, arbitrary slot assignment, Architect Slot Survey storage, backend imports, EDMC ingestion, auto-preview, auto-generation, auto-load/save, polling, or silent mutation are introduced.
+- No Simulation Preview scoring, optimiser ranking/generation, CP formulas, economy mechanics, service unlock logic, buildability rules, Observed Evidence, or Validation behavior changes are introduced.
+- Unknown Architect context remains unknown unless explicit observed context is supplied to the frontend component.
+
+Test coverage added in Stage 13A:
+
+- `architectObservationUtils.test.ts` covers unknown defaults and observed mock context.
+- `ArchitectObservationPanel.test.tsx` covers read-only unknown/observed rendering and absence of primary-port controls.
+- Existing Build Plan tests cover the integrated read-only wording in List/Layout surfaces.
+
+Deferred to later Stage 13 work:
+
+- Storage/import decisions for Architect surveys.
+- Full Architect Slot Survey UI and exact topology capture.
+- Topology-aware Layout grouping beyond the current read-only observation panel.

--- a/frontend-v2/src/features/system-detail/simulation-preview/ArchitectObservationPanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/ArchitectObservationPanel.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ArchitectObservationPanel } from './ArchitectObservationPanel';
+
+describe('ArchitectObservationPanel', () => {
+  it('renders unknown Architect survey state as read-only guidance', () => {
+    render(<ArchitectObservationPanel />);
+
+    expect(screen.getByRole('region', { name: 'Architect observation status' })).toBeTruthy();
+    expect(screen.getByText('Architect survey: not observed')).toBeTruthy();
+    expect(screen.getByText('Primary-port flag: unknown')).toBeTruthy();
+    expect(screen.getByText('Orbital slots: unknown')).toBeTruthy();
+    expect(screen.getByText('Ground slots: unknown')).toBeTruthy();
+    expect(screen.getByText('Primary-port flag is unknown until observed in Architect Mode.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /primary/i })).toBeNull();
+    expect(screen.queryByRole('checkbox', { name: /primary/i })).toBeNull();
+  });
+
+  it('renders provided observed Architect context without edit controls', () => {
+    render(
+      <ArchitectObservationPanel
+        observation={{
+          surveyState: 'observed',
+          orbitalSlotCount: 3,
+          groundSlotCount: 2,
+          primaryPortFlag: { state: 'observed', bodyName: 'A 1', slotLabel: 'Orbital slot 2' },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Architect survey: observed')).toBeTruthy();
+    expect(screen.getByText('Primary-port flag: observed on A 1 / Orbital slot 2')).toBeTruthy();
+    expect(screen.getByText('Orbital slots: 3')).toBeTruthy();
+    expect(screen.getByText('Ground slots: 2')).toBeTruthy();
+    expect(screen.getByText('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /make primary/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /remove primary/i })).toBeNull();
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/ArchitectObservationPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/ArchitectObservationPanel.tsx
@@ -1,0 +1,53 @@
+import { Telescope } from 'lucide-react';
+import type { ArchitectObservationInput } from './architectObservationUtils';
+import {
+  architectObservationGuidance,
+  architectPrimaryPortFlagLabel,
+  architectSlotCountLabel,
+  architectSurveyLabel,
+  normalizeArchitectObservation,
+} from './architectObservationUtils';
+import { Chip } from './components';
+
+export function ArchitectObservationPanel({
+  observation,
+  compact = false,
+  showPrimaryPortPlacementReminder = false,
+}: {
+  observation?: ArchitectObservationInput | null;
+  compact?: boolean;
+  showPrimaryPortPlacementReminder?: boolean;
+}) {
+  const status = normalizeArchitectObservation(observation);
+  const guidance = architectObservationGuidance(status, { showPrimaryPortPlacementReminder });
+
+  return (
+    <section
+      aria-label="Architect observation status"
+      data-testid="architect-observation-panel"
+      className={[
+        'rounded border border-cyan/25 bg-cyan/5 text-[11px] leading-snug text-silver-dk',
+        compact ? 'px-2 py-1.5' : 'px-3 py-2',
+      ].join(' ')}
+    >
+      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">
+        <Telescope size={13} />
+        Architect observation
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5 font-mono text-[10px]">
+        <Chip tone={status.surveyState === 'observed' ? 'good' : 'default'}>{architectSurveyLabel(status)}</Chip>
+        <Chip tone={status.primaryPortFlag.state === 'observed' ? 'good' : 'warn'}>
+          {architectPrimaryPortFlagLabel(status)}
+        </Chip>
+        <Chip>{architectSlotCountLabel('Orbital slots', status.orbitalSlotCount)}</Chip>
+        <Chip>{architectSlotCountLabel('Ground slots', status.groundSlotCount)}</Chip>
+        <Chip>Read-only</Chip>
+      </div>
+      <ul className="mt-2 space-y-1">
+        {guidance.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
@@ -252,6 +252,9 @@ describe('BuildPlanBodyView', () => {
     expect(within(panel).getByText('Y+0/20 G+0/40')).toBeTruthy();
     expect(within(panel).getByText('observed')).toBeTruthy();
     expect(within(panel).getByText('Use List view to edit this placement.')).toBeTruthy();
+    expect(within(panel).getByText('Architect survey: not observed')).toBeTruthy();
+    expect(within(panel).getByText('Primary-port flag: unknown')).toBeTruthy();
+    expect(within(panel).getByText('Primary-port location is placement guidance, not a Build Point source.')).toBeTruthy();
     expect(within(panel).getByText('Architect primary-port location should be checked before final major station placement.')).toBeTruthy();
     expect(within(panel).queryByRole('button', { name: /make primary/i })).toBeNull();
     expect(within(panel).queryByRole('button', { name: /remove primary/i })).toBeNull();

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
@@ -116,7 +116,7 @@ describe('BuildPlanEditor structure replacement review', () => {
     expect(screen.getByText('Primary-port flag: unknown')).toBeTruthy();
     expect(screen.getAllByText(/If the flagged primary-port slot is inconvenient, consider an outpost there/).length).toBeGreaterThan(0);
     expect(screen.getByText('Architect primary-port location should be checked before final major station placement.')).toBeTruthy();
-    expect(screen.getByText('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.')).toBeTruthy();
+    expect(screen.getAllByText('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.').length).toBeGreaterThan(0);
     expect(screen.queryByRole('button', { name: /make primary/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /remove primary/i })).toBeNull();
     expect(screen.queryByRole('checkbox', { name: /primary/i })).toBeNull();

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
@@ -110,9 +110,11 @@ describe('BuildPlanEditor structure replacement review', () => {
   it('shows read-only Architect primary-port context without primary controls', () => {
     renderEditor();
 
-    expect(screen.getAllByText(/Check the primary-port location in-game through System Map and Architect Mode/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Check System Map > Architect Mode before final major station placement/).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Primary-port location is placement guidance, not a Build Point source/).length).toBeGreaterThan(0);
-    expect(screen.getByText(/If the flagged slot is inconvenient, consider placing an outpost there/)).toBeTruthy();
+    expect(screen.getByText('Architect survey: not observed')).toBeTruthy();
+    expect(screen.getByText('Primary-port flag: unknown')).toBeTruthy();
+    expect(screen.getByText(/If the flagged primary-port slot is inconvenient, consider an outpost there/)).toBeTruthy();
     expect(screen.getByText('Architect primary-port location should be checked before final major station placement.')).toBeTruthy();
     expect(screen.getByText('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /make primary/i })).toBeNull();

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
@@ -114,7 +114,7 @@ describe('BuildPlanEditor structure replacement review', () => {
     expect(screen.getAllByText(/Primary-port location is placement guidance, not a Build Point source/).length).toBeGreaterThan(0);
     expect(screen.getByText('Architect survey: not observed')).toBeTruthy();
     expect(screen.getByText('Primary-port flag: unknown')).toBeTruthy();
-    expect(screen.getByText(/If the flagged primary-port slot is inconvenient, consider an outpost there/)).toBeTruthy();
+    expect(screen.getAllByText(/If the flagged primary-port slot is inconvenient, consider an outpost there/).length).toBeGreaterThan(0);
     expect(screen.getByText('Architect primary-port location should be checked before final major station placement.')).toBeTruthy();
     expect(screen.getByText('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: /make primary/i })).toBeNull();

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ArrowDown, ArrowUp, Trash2 } from 'lucide-react';
 import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import { ArchitectObservationPanel } from './ArchitectObservationPanel';
 import { Chip, IconButton } from './components';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
 import { buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
@@ -132,16 +133,8 @@ export function BuildPlanEditor({
               </div>
             </div>
 
-            <div className="mt-2 rounded border border-cyan/25 bg-cyan/5 px-3 py-2 text-[11px] leading-snug text-silver-dk">
-              <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">Architect planning context</div>
-              <p className="mt-1">
-                Check the primary-port location in-game through System Map and Architect Mode before final major station placement. Primary-port location is placement guidance, not a Build Point source.
-              </p>
-              {placement.is_primary_port && (
-                <p className="mt-1">
-                  If the flagged slot is inconvenient, consider placing an outpost there and using a better body/orbit for the main station.
-                </p>
-              )}
+            <div className="mt-2">
+              <ArchitectObservationPanel showPrimaryPortPlacementReminder={Boolean(placement.is_primary_port)} />
             </div>
 
             {template && (

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
@@ -12,6 +12,7 @@ import {
   type GroupedPlacement,
   type PlanSummary,
 } from './buildPlanLayoutUtils';
+import { ArchitectObservationPanel } from './ArchitectObservationPanel';
 import { Chip } from './components';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
 import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
@@ -109,6 +110,7 @@ function SummaryDetail({ summary }: { summary: PlanSummary }) {
         <DetailItem label="CP visible" value={`Y+${summary.yellowGenerated}/${summary.yellowNeeded} G+${summary.greenGenerated}/${summary.greenNeeded}`} />
       </DetailGrid>
       <NextAction summary={summary} />
+      <ArchitectObservationPanel compact />
     </div>
   );
 }
@@ -193,6 +195,7 @@ function PlacementDetail({ group, item, summary }: { group: BodyGroup; item: Gro
       </DetailGrid>
       <WarningList warnings={warnings} emptyLabel="No placement warnings from current layout data." />
       <PlannerGuidanceList items={guidance} />
+      <ArchitectObservationPanel compact showPrimaryPortPlacementReminder={Boolean(placement.is_primary_port)} />
       <p className="rounded border border-border/50 bg-bg3/35 px-3 py-2 font-mono text-[11px] leading-snug text-silver-dk">
         Use List view to edit this placement.
       </p>

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -415,7 +415,9 @@ describe('SimulationPreview optimiser candidate loading', () => {
 
     expect(screen.getByText(/1 placement in Build Plan/)).toBeTruthy();
     expect(screen.getByText(/Target archetype affects predicted economy, service, and buildability outcomes/)).toBeTruthy();
-    expect(screen.getAllByText(/Check the primary-port location in-game through System Map and Architect Mode/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Check System Map > Architect Mode before final major station placement/).length).toBeGreaterThan(0);
+    expect(screen.getByText('Architect survey: not observed')).toBeTruthy();
+    expect(screen.getByText('Primary-port flag: unknown')).toBeTruthy();
     expect(screen.getByText(/Yellow CP supports Tier 2 construction/)).toBeTruthy();
     expect(screen.getByText(/Green CP supports Tier 3 construction/)).toBeTruthy();
     expect(screen.getByText(/Build order can affect CP timing and port escalation/)).toBeTruthy();

--- a/frontend-v2/src/features/system-detail/simulation-preview/architectObservationUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/architectObservationUtils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  architectObservationGuidance,
+  architectPrimaryPortFlagLabel,
+  architectSlotCountLabel,
+  architectSurveyLabel,
+  normalizeArchitectObservation,
+} from './architectObservationUtils';
+
+describe('architectObservationUtils', () => {
+  it('defaults Architect survey and primary-port flag to unknown planning context', () => {
+    const status = normalizeArchitectObservation();
+
+    expect(status.surveyState).toBe('not_observed');
+    expect(status.primaryPortFlag.state).toBe('unknown');
+    expect(architectSurveyLabel(status)).toBe('Architect survey: not observed');
+    expect(architectPrimaryPortFlagLabel(status)).toBe('Primary-port flag: unknown');
+    expect(architectSlotCountLabel('Orbital slots', status.orbitalSlotCount)).toBe('Orbital slots: unknown');
+    expect(architectObservationGuidance(status)).toContain('Primary-port flag is unknown until observed in Architect Mode.');
+  });
+
+  it('renders observed Architect survey status without inventing slot data', () => {
+    const status = normalizeArchitectObservation({
+      surveyState: 'observed',
+      orbitalSlotCount: 4.8,
+      groundSlotCount: -1,
+      primaryPortFlag: {
+        state: 'observed',
+        bodyName: 'A 2',
+        slotLabel: 'Orbital slot 1',
+      },
+    });
+
+    expect(status.surveyState).toBe('observed');
+    expect(status.orbitalSlotCount).toBe(4);
+    expect(status.groundSlotCount).toBeNull();
+    expect(architectSurveyLabel(status)).toBe('Architect survey: observed');
+    expect(architectPrimaryPortFlagLabel(status)).toBe('Primary-port flag: observed on A 2 / Orbital slot 1');
+    expect(architectObservationGuidance(status)).toContain('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.');
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/architectObservationUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/architectObservationUtils.ts
@@ -1,0 +1,81 @@
+export type ArchitectSurveyState = 'not_observed' | 'observed';
+export type ArchitectPrimaryPortFlagState = 'unknown' | 'observed';
+
+export interface ArchitectPrimaryPortFlag {
+  state: ArchitectPrimaryPortFlagState;
+  bodyName?: string | null;
+  slotLabel?: string | null;
+}
+
+export interface ArchitectObservationInput {
+  surveyState?: ArchitectSurveyState | null;
+  orbitalSlotCount?: number | null;
+  groundSlotCount?: number | null;
+  primaryPortFlag?: ArchitectPrimaryPortFlag | null;
+}
+
+export interface ArchitectObservationStatus {
+  surveyState: ArchitectSurveyState;
+  orbitalSlotCount: number | null;
+  groundSlotCount: number | null;
+  primaryPortFlag: ArchitectPrimaryPortFlag;
+}
+
+export function normalizeArchitectObservation(input?: ArchitectObservationInput | null): ArchitectObservationStatus {
+  return {
+    surveyState: input?.surveyState === 'observed' ? 'observed' : 'not_observed',
+    orbitalSlotCount: normalizeSlotCount(input?.orbitalSlotCount),
+    groundSlotCount: normalizeSlotCount(input?.groundSlotCount),
+    primaryPortFlag: normalizePrimaryPortFlag(input?.primaryPortFlag),
+  };
+}
+
+export function architectSurveyLabel(status: ArchitectObservationStatus): string {
+  return status.surveyState === 'observed' ? 'Architect survey: observed' : 'Architect survey: not observed';
+}
+
+export function architectPrimaryPortFlagLabel(status: ArchitectObservationStatus): string {
+  if (status.primaryPortFlag.state !== 'observed') return 'Primary-port flag: unknown';
+
+  const location = [status.primaryPortFlag.bodyName, status.primaryPortFlag.slotLabel]
+    .filter((part): part is string => Boolean(part && part.trim()))
+    .join(' / ');
+
+  return location ? `Primary-port flag: observed on ${location}` : 'Primary-port flag: observed';
+}
+
+export function architectSlotCountLabel(label: 'Orbital slots' | 'Ground slots', count: number | null): string {
+  return `${label}: ${count == null ? 'unknown' : count}`;
+}
+
+export function architectObservationGuidance(
+  status: ArchitectObservationStatus,
+  options: { showPrimaryPortPlacementReminder?: boolean } = {},
+): string[] {
+  const guidance = [
+    'Check System Map > Architect Mode before final major station placement.',
+    'Primary-port location is placement guidance, not a Build Point source.',
+  ];
+
+  if (status.primaryPortFlag.state === 'observed' || options.showPrimaryPortPlacementReminder) {
+    guidance.push('If the flagged primary-port slot is inconvenient, consider an outpost there and place the main station elsewhere.');
+  } else {
+    guidance.push('Primary-port flag is unknown until observed in Architect Mode.');
+  }
+
+  return guidance;
+}
+
+function normalizeSlotCount(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? Math.floor(value) : null;
+}
+
+function normalizePrimaryPortFlag(value: ArchitectPrimaryPortFlag | null | undefined): ArchitectPrimaryPortFlag {
+  if (value?.state !== 'observed') return { state: 'unknown' };
+
+  return {
+    state: 'observed',
+    bodyName: value.bodyName?.trim() || null,
+    slotLabel: value.slotLabel?.trim() || null,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds frontend-only Architect observation helpers for unknown vs observed survey context.
- Renders a read-only Architect observation panel in Build Plan List and Layout detail surfaces.
- Keeps primary-port guidance conservative: no primary editing, no storage/import, and no Build Point claims.
- Updates roadmap and Simulation Preview architecture docs for Stage 13A.

## Verification
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `git diff --check`
- Local `npm test` was blocked by the Windows node_modules junction/sandbox path issue; CI runs tests from a clean install.

## Safety
- No backend mechanics, scoring, CP formulas, economy logic, service unlock logic, buildability rules, optimiser ranking/generation, Simulation Preview scoring, Observed Evidence semantics, Validation semantics, persistence, imports, EDMC ingestion, hauling/material workflows, or map topology rendering changed.
- No primary-port editing controls, make/remove primary actions, Architect Slot Survey storage, auto-preview, auto-generation, auto-save, polling, or silent mutation added.