### PR TITLE
Stage 13B: topology-aware layout readout

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -923,3 +923,30 @@ Deferred to Stage 13B/13C:
 - Persistent Architect survey records, import/storage design, manual observation entry workflows, and EDMC/journal ingestion.
 - Full Architect Slot Survey UI and exact slot topology capture.
 - Topology-aware Layout readout that groups bodies, orbital-capable context, ground-capable context, and observed/unknown Architect status.
+
+## Stage 13B - Layout Topology Readout
+
+Stage 13B improves the read-only Layout view into a more topology-aware planning readout while staying conservative about unknown Architect data.
+
+Current Stage 13B status:
+
+- Added frontend-only topology readout helpers that count current planned orbital, ground, and unknown-location placements per body group using existing placement templates only.
+- Added compact read-only topology sections to Layout body cards and selected-body detail so users can distinguish known bodies, unknown body references, unassigned placements, ground-capable context, and unknown Architect slot counts.
+- Preserved the Stage 13A Architect boundary: slot counts and primary-port flags remain unknown unless explicit observed context is supplied to frontend helpers; no exact slot locations are invented.
+
+Safety boundaries in Stage 13B:
+
+- Layout view remains read-only. No placement editing, primary-port editing, make/remove primary actions, slot editing, persistence, imports, polling, auto-preview, auto-generation, or silent mutation are introduced.
+- No backend mechanics, scoring, CP formulas, economy mechanics, service unlock logic, buildability rules, optimiser generation/ranking, Search Tuning, Simulation Preview scoring, Observed Evidence semantics, Validation semantics, EDMC ingestion, hauling/material workflows, or map topology rendering changed.
+- Ground/orbital readouts are planning context only. They do not assert confirmed Architect capacity and do not change buildability or planner scoring.
+
+Test coverage added in Stage 13B:
+
+- `layoutTopologyUtils.test.ts` covers topology grouping, orbital/ground/unknown counts, known/unknown/unassigned body states, conservative ground-capability labels, observed mock Architect labels, and template-location formatting.
+- `BuildPlanBodyView.test.tsx` covers topology readout rendering in Layout cards/detail while preserving read-only selection behavior.
+
+Deferred to Stage 13C:
+
+- Strategic topology labels such as main-station candidate and support-body guidance.
+- Persistent Architect survey records, manual observation entry, imports, and EDMC/journal ingestion.
+- Full Architect Slot Survey UI, exact slot topology capture, and any map-like spatial rendering.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -396,3 +396,23 @@ Deferred to later Stage 13 work:
 - Storage/import decisions for Architect surveys.
 - Full Architect Slot Survey UI and exact topology capture.
 - Topology-aware Layout grouping beyond the current read-only observation panel.
+
+## Stage 13B - Layout Topology Readout
+
+Stage 13B adds read-only topology readouts to Layout view without turning Layout into an editor or map engine.
+
+- `layoutTopologyUtils.ts` derives per-body topology context from existing Build Plan placements, facility templates, body metadata, and optional frontend Architect observation context. It counts planned orbital, ground, and unknown-location structures without inventing slot capacity.
+- `LayoutTopologyReadout.tsx` renders compact chips for body state, planned orbital/ground counts, conservative ground capability, Architect survey status, unknown/observed slot counts, and primary-port context.
+- `BuildPlanBodyView.tsx` shows compact topology context on each body group. `BuildPlanLayoutDetailPanel.tsx` shows the fuller readout for a selected body and keeps placement detail read-only.
+
+Safety boundaries in Stage 13B:
+
+- Layout view remains read-only. No placement mutation, primary-port setting/unsetting, slot editing, import/storage, polling, auto-preview, auto-generation, or silent mutation is introduced.
+- Unknown Architect slot counts stay unknown by default. Observed slot labels render only when explicit frontend observation context is supplied to helpers/components.
+- The readout does not change Simulation Preview scoring, optimiser ranking/generation, CP formulas, economy mechanics, service unlock logic, buildability rules, Observed Evidence behavior, Validation behavior, or persistence.
+
+Deferred to later Stage 13 work:
+
+- Strategic body relationship guidance and candidate labels.
+- Persistent Architect survey capture and import/storage decisions.
+- Full Architect Slot Survey UI and exact map/topology rendering.

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
@@ -135,6 +135,13 @@ describe('BuildPlanBodyView', () => {
     expect(within(firstBody).getAllByText('Needs: Y20 G40').length).toBeGreaterThan(0);
     expect(within(firstBody).getByText('Landable')).toBeTruthy();
     expect(within(firstBody).getByText('Terraformable')).toBeTruthy();
+    expect(within(firstBody).getByText('Topology readout')).toBeTruthy();
+    expect(within(firstBody).getByText('Body: known')).toBeTruthy();
+    expect(within(firstBody).getByText('Orbital planned: 1')).toBeTruthy();
+    expect(within(firstBody).getByText('Ground planned: 0')).toBeTruthy();
+    expect(within(firstBody).getByText('Ground capability: landable')).toBeTruthy();
+    expect(within(firstBody).getByText('Architect survey: not observed')).toBeTruthy();
+    expect(within(firstBody).getByText('Orbital slots: unknown')).toBeTruthy();
 
     const secondBody = screen.getByTestId('layout-body-group-2');
     expect(within(secondBody).getByText('Extraction Hub')).toBeTruthy();
@@ -152,6 +159,8 @@ describe('BuildPlanBodyView', () => {
     expect(within(unassigned).getByText('missing_template')).toBeTruthy();
     expect(within(unassigned).getByText('Needs review: facility template missing')).toBeTruthy();
     expect(within(unassigned).getByText('Needs review: placement has no body')).toBeTruthy();
+    expect(within(unassigned).getByText('Body: unassigned')).toBeTruthy();
+    expect(within(unassigned).getByText('Location unknown: 1')).toBeTruthy();
   });
 
   it('reports primary port states for none, one, and multiple primary ports', () => {
@@ -231,6 +240,10 @@ describe('BuildPlanBodyView', () => {
     expect(within(panel).getByText('No')).toBeTruthy();
     expect(within(panel).getByText((content) => content.includes('#2') && content.includes('Extraction Hub'))).toBeTruthy();
     expect(within(panel).getByText('May be invalid: surface facility on water world')).toBeTruthy();
+    expect(within(panel).getByText('Topology readout')).toBeTruthy();
+    expect(within(panel).getByText('Ground capability: review water world')).toBeTruthy();
+    expect(within(panel).getByText('Ground planned: 1')).toBeTruthy();
+    expect(within(panel).getByText(/Slot counts stay unknown until Architect Mode observations are recorded/)).toBeTruthy();
   });
 
   it('selects a placement and shows read-only placement details', () => {
@@ -246,7 +259,8 @@ describe('BuildPlanBodyView', () => {
     expect(within(panel).getByText('A 1')).toBeTruthy();
     expect(within(panel).getByText('planned')).toBeTruthy();
     expect(within(panel).getByText('Yes')).toBeTruthy();
-    expect(within(panel).getByText('orbital')).toBeTruthy();
+    expect(within(panel).getAllByText('orbital').length).toBeGreaterThan(0);
+    expect(within(panel).getByText('Topology')).toBeTruthy();
     expect(within(panel).getByText('Industrial')).toBeTruthy();
     expect(within(panel).getByText('port')).toBeTruthy();
     expect(within(panel).getByText('Y+0/20 G+0/40')).toBeTruthy();

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
@@ -16,6 +16,8 @@ import {
 } from './buildPlanLayoutUtils';
 import { BuildPlanLayoutDetailPanel, type LayoutSelection } from './BuildPlanLayoutDetailPanel';
 import { Chip } from './components';
+import { LayoutTopologyReadout } from './LayoutTopologyReadout';
+import { buildLayoutTopologyReadout, topologyPlacementLocationLabel } from './layoutTopologyUtils';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
 import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
 import { formatLocation } from './utils/formatters';
@@ -188,6 +190,7 @@ function BodyGroupCard({
     warnings: getPlacementWarnings(item, group.body),
   })));
   const summary = getBodyGroupSummary(group);
+  const topology = buildLayoutTopologyReadout(group);
   const isUnassigned = group.body === null;
   const body = group.body;
   const title = isUnassigned || !body ? 'Unassigned / needs body' : bodyDisplayName(body);
@@ -246,6 +249,7 @@ function BodyGroupCard({
           <span className="text-silver-dk">Body CP</span>
           <span className="ml-1 text-silver">Y+{summary.yellowGenerated}/{summary.yellowNeeded} G+{summary.greenGenerated}/{summary.greenNeeded}</span>
         </div>
+        <LayoutTopologyReadout readout={topology} compact />
         {bodyWarnings.length > 0 && (
           <div className="flex max-w-md flex-wrap gap-1.5 font-mono text-[10px]">
             {bodyWarnings.map((warning) => <Chip key={warning} tone="warn">{warning}</Chip>)}
@@ -341,6 +345,7 @@ function PlacementCard({
           <div className="mt-2 flex flex-wrap gap-1.5 font-mono text-[10px]">
             {placement.is_primary_port && <Chip tone="good">Primary port</Chip>}
             {template ? <Chip>{formatLocation(template.allowed_location)}</Chip> : 'Unknown location'}
+            <Chip>{topologyPlacementLocationLabel(template)}</Chip>
             {template?.tier != null && <Chip>Tier {template.tier}</Chip>}
             {template?.pad_size && <Chip>Pad: {template.pad_size}</Chip>}
             {template?.economy && <Chip>Economy: {template.economy}</Chip>}

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
@@ -14,6 +14,8 @@ import {
 } from './buildPlanLayoutUtils';
 import { ArchitectObservationPanel } from './ArchitectObservationPanel';
 import { Chip } from './components';
+import { LayoutTopologyReadout } from './LayoutTopologyReadout';
+import { buildLayoutTopologyReadout, topologyPlacementLocationLabel } from './layoutTopologyUtils';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
 import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
 import { formatLocation } from './utils/formatters';
@@ -118,6 +120,7 @@ function SummaryDetail({ summary }: { summary: PlanSummary }) {
 function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary }) {
   const bodySummary = getBodyGroupSummary(group);
   const warnings = getBodyGroupWarnings(group);
+  const topology = buildLayoutTopologyReadout(group);
   const guidance = buildPlannerGuidanceForBody(group.body, group.placements.map((item) => ({
     placement: item.placement,
     template: item.template,
@@ -140,6 +143,7 @@ function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary
         <DetailItem label="Primary port here" value={bodySummary.hasPrimaryPort ? 'Yes' : 'No'} tone={bodySummary.hasPrimaryPort ? 'default' : 'warn'} />
         <DetailItem label="CP visible" value={`Y+${bodySummary.yellowGenerated}/${bodySummary.yellowNeeded} G+${bodySummary.greenGenerated}/${bodySummary.greenNeeded}`} />
       </DetailGrid>
+      <LayoutTopologyReadout readout={topology} />
       <TagList body={group.body} />
       <WarningList warnings={warnings} emptyLabel="No body-level warnings from current layout data." />
       <PlannerGuidanceList items={guidance} title="Body guidance" />
@@ -186,6 +190,7 @@ function PlacementDetail({ group, item, summary }: { group: BodyGroup; item: Gro
         <DetailItem label="Status" value={status} tone={status === 'planned' ? 'default' : 'warn'} />
         <DetailItem label="Primary port" value={placement.is_primary_port ? 'Yes' : 'No'} tone={placement.is_primary_port ? 'default' : 'warn'} />
         <DetailItem label="Location" value={template ? formatLocation(template.allowed_location) : 'Unknown'} tone={template ? 'default' : 'warn'} />
+        <DetailItem label="Topology" value={topologyPlacementLocationLabel(template).replace('Topology location: ', '')} tone={template ? 'default' : 'warn'} />
         <DetailItem label="Tier" value={template?.tier != null ? String(template.tier) : 'Unknown'} tone={template ? 'default' : 'warn'} />
         <DetailItem label="Pad" value={template?.pad_size ?? 'Unknown'} tone={template?.pad_size ? 'default' : 'warn'} />
         <DetailItem label="Economy" value={template?.economy ?? 'Unknown'} tone={template?.economy ? 'default' : 'warn'} />

--- a/frontend-v2/src/features/system-detail/simulation-preview/LayoutTopologyReadout.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/LayoutTopologyReadout.tsx
@@ -1,0 +1,41 @@
+import { Network } from 'lucide-react';
+import { Chip } from './components';
+import type { LayoutTopologyReadout as LayoutTopologyReadoutModel } from './layoutTopologyUtils';
+
+export function LayoutTopologyReadout({
+  readout,
+  compact = false,
+}: {
+  readout: LayoutTopologyReadoutModel;
+  compact?: boolean;
+}) {
+  const visibleChips = compact ? readout.chips.slice(0, 6) : readout.chips;
+
+  return (
+    <section
+      aria-label={`Topology readout for ${readout.bodyLabel}`}
+      data-testid="layout-topology-readout"
+      className={[
+        'rounded border border-cyan/25 bg-cyan/5 px-2 py-2',
+        compact ? 'mt-2' : '',
+      ].join(' ')}
+    >
+      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.14em] text-cyan">
+        <Network size={12} />
+        Topology readout
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5 font-mono text-[10px]">
+        {visibleChips.map((chip) => (
+          <Chip key={chip.key} tone={chip.tone === 'good' ? 'good' : chip.tone === 'warn' ? 'warn' : 'default'}>
+            {chip.label}
+          </Chip>
+        ))}
+      </div>
+      {!compact && (
+        <p className="mt-2 font-mono text-[10px] leading-snug text-silver-dk">
+          Slot counts stay unknown until Architect Mode observations are recorded; this readout only groups the current plan.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/layoutTopologyUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/layoutTopologyUtils.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import { groupPlacementsByBody } from './buildPlanLayoutUtils';
+import { buildLayoutTopologyReadout, topologyPlacementLocationLabel } from './layoutTopologyUtils';
+
+const templates: FacilityTemplate[] = [
+  {
+    id: 'orbital_port',
+    name: 'Orbital Port',
+    category: 'port',
+    tier: 3,
+    economy: 'Industrial',
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'orbital',
+    pad_size: 'large',
+    confidence: 'observed',
+    notes: null,
+    yellow_cp_generated: 0,
+    green_cp_generated: 0,
+    yellow_cp_cost: 20,
+    green_cp_cost: 40,
+  },
+  {
+    id: 'surface_hub',
+    name: 'Surface Hub',
+    category: 'support',
+    tier: 2,
+    economy: 'Extraction',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface',
+    pad_size: 'small',
+    confidence: 'estimated',
+    notes: null,
+    yellow_cp_generated: 5,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+];
+
+const bodies = [
+  { id: 1, name: 'A 1', is_landable: true, body_type: 'Planet' },
+  { id: 2, name: 'A 2', is_landable: false, body_type: 'Planet' },
+  { id: 3, name: 'A 3', is_water_world: true, body_type: 'Planet' },
+] as SystemBody[];
+
+function groupFor(placements: SimulateBuildPlacement[], key: string) {
+  const group = groupPlacementsByBody(placements, templates, bodies).find((item) => item.key === key);
+  if (!group) throw new Error(`Missing group ${key}`);
+  return group;
+}
+
+describe('layoutTopologyUtils', () => {
+  it('counts orbital and ground planned placements without inventing slot capacity', () => {
+    const group = groupFor([
+      { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
+      { facility_template_id: 'surface_hub', local_body_id: '1', build_order: 2 },
+    ], '1');
+
+    const readout = buildLayoutTopologyReadout(group);
+
+    expect(readout.bodyLabel).toBe('A 1');
+    expect(readout.bodyState).toBe('known');
+    expect(readout.orbitalPlanned).toBe(1);
+    expect(readout.groundPlanned).toBe(1);
+    expect(readout.groundCapabilityLabel).toBe('Ground capability: landable');
+    expect(readout.orbitalSlotLabel).toBe('Orbital slots: unknown');
+    expect(readout.groundSlotLabel).toBe('Ground slots: unknown');
+    expect(readout.primaryPortContextLabel).toBe('Primary-port plan: on this body');
+  });
+
+  it('flags non-landable, water-world, unknown body, and unassigned contexts conservatively', () => {
+    const nonLandable = buildLayoutTopologyReadout(groupFor([
+      { facility_template_id: 'surface_hub', local_body_id: '2', build_order: 1 },
+    ], '2'));
+    expect(nonLandable.groundCapabilityLabel).toBe('Ground capability: not landable');
+    expect(nonLandable.groundCapabilityTone).toBe('warn');
+
+    const waterWorld = buildLayoutTopologyReadout(groupFor([
+      { facility_template_id: 'surface_hub', local_body_id: '3', build_order: 1 },
+    ], '3'));
+    expect(waterWorld.groundCapabilityLabel).toBe('Ground capability: review water world');
+
+    const unknown = buildLayoutTopologyReadout(groupFor([
+      { facility_template_id: 'surface_hub', local_body_id: '404', build_order: 1 },
+    ], 'unassigned'));
+    expect(unknown.bodyState).toBe('unknown');
+    expect(unknown.bodyLabel).toBe('Unknown body reference');
+    expect(unknown.groundCapabilityLabel).toBe('Ground capability: unknown');
+
+    const unassigned = buildLayoutTopologyReadout(groupFor([
+      { facility_template_id: 'surface_hub', local_body_id: null, build_order: 1 },
+    ], 'unassigned'));
+    expect(unassigned.bodyState).toBe('unassigned');
+    expect(unassigned.bodyLabel).toBe('Unassigned / needs body');
+  });
+
+  it('renders observed Architect mock context as read-only labels when supplied', () => {
+    const readout = buildLayoutTopologyReadout(groupFor([
+      { facility_template_id: 'orbital_port', local_body_id: '1', build_order: 1 },
+    ], '1'), {
+      surveyState: 'observed',
+      orbitalSlotCount: 4,
+      groundSlotCount: 2,
+      primaryPortFlag: { state: 'observed', bodyName: 'A 1', slotLabel: 'Orbital slot 2' },
+    });
+
+    expect(readout.architectSurveyLabel).toBe('Architect survey: observed');
+    expect(readout.orbitalSlotLabel).toBe('Orbital slots: 4');
+    expect(readout.groundSlotLabel).toBe('Ground slots: 2');
+    expect(readout.primaryPortContextLabel).toBe('Primary-port flag: observed on A 1 / Orbital slot 2');
+  });
+
+  it('formats placement topology labels from existing template location only', () => {
+    expect(topologyPlacementLocationLabel(templates[0])).toBe('Topology location: orbital');
+    expect(topologyPlacementLocationLabel(undefined)).toBe('Topology location: unknown');
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/layoutTopologyUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/layoutTopologyUtils.ts
@@ -1,0 +1,122 @@
+import type { FacilityTemplate } from '@/types/api';
+import {
+  architectPrimaryPortFlagLabel,
+  architectSlotCountLabel,
+  architectSurveyLabel,
+  normalizeArchitectObservation,
+  type ArchitectObservationInput,
+} from './architectObservationUtils';
+import { bodyDisplayName, type BodyGroup } from './buildPlanLayoutUtils';
+import { formatLocation } from './utils/formatters';
+
+export type TopologyTone = 'default' | 'good' | 'warn';
+
+export interface TopologyChip {
+  key: string;
+  label: string;
+  tone: TopologyTone;
+}
+
+export interface LayoutTopologyReadout {
+  bodyLabel: string;
+  bodyState: 'known' | 'unknown' | 'unassigned';
+  orbitalPlanned: number;
+  groundPlanned: number;
+  unknownLocationPlanned: number;
+  groundCapabilityLabel: string;
+  groundCapabilityTone: TopologyTone;
+  architectSurveyLabel: string;
+  orbitalSlotLabel: string;
+  groundSlotLabel: string;
+  primaryPortContextLabel: string;
+  primaryPortContextTone: TopologyTone;
+  chips: TopologyChip[];
+}
+
+export function buildLayoutTopologyReadout(
+  group: BodyGroup,
+  architectInput?: ArchitectObservationInput | null,
+): LayoutTopologyReadout {
+  const status = normalizeArchitectObservation(architectInput);
+  const counts = countPlacementLocations(group);
+  const bodyState = getBodyState(group);
+  const groundCapability = getGroundCapability(group);
+  const primaryContext = getPrimaryPortContext(group, status.primaryPortFlag.state === 'observed'
+    ? architectPrimaryPortFlagLabel(status)
+    : null);
+
+  const chips: TopologyChip[] = [
+    {
+      key: 'body-state',
+      label: bodyState === 'known' ? 'Body: known' : bodyState === 'unknown' ? 'Body: unknown' : 'Body: unassigned',
+      tone: bodyState === 'known' ? 'good' : 'warn',
+    },
+    { key: 'orbital-planned', label: `Orbital planned: ${counts.orbital}`, tone: counts.orbital > 0 ? 'good' : 'default' },
+    { key: 'ground-planned', label: `Ground planned: ${counts.ground}`, tone: counts.ground > 0 ? groundCapability.tone : 'default' },
+    { key: 'ground-capability', label: groundCapability.label, tone: groundCapability.tone },
+    ...(counts.unknown > 0 ? [{ key: 'unknown-location', label: `Location unknown: ${counts.unknown}`, tone: 'warn' as const }] : []),
+    { key: 'architect-survey', label: architectSurveyLabel(status), tone: status.surveyState === 'observed' ? 'good' : 'default' },
+    { key: 'orbital-slots', label: architectSlotCountLabel('Orbital slots', status.orbitalSlotCount), tone: status.orbitalSlotCount == null ? 'default' : 'good' },
+    { key: 'ground-slots', label: architectSlotCountLabel('Ground slots', status.groundSlotCount), tone: status.groundSlotCount == null ? 'default' : 'good' },
+    { key: 'primary-context', label: primaryContext.label, tone: primaryContext.tone },
+  ];
+
+  return {
+    bodyLabel: group.body ? bodyDisplayName(group.body) : bodyState === 'unknown' ? 'Unknown body reference' : 'Unassigned / needs body',
+    bodyState,
+    orbitalPlanned: counts.orbital,
+    groundPlanned: counts.ground,
+    unknownLocationPlanned: counts.unknown,
+    groundCapabilityLabel: groundCapability.label,
+    groundCapabilityTone: groundCapability.tone,
+    architectSurveyLabel: architectSurveyLabel(status),
+    orbitalSlotLabel: architectSlotCountLabel('Orbital slots', status.orbitalSlotCount),
+    groundSlotLabel: architectSlotCountLabel('Ground slots', status.groundSlotCount),
+    primaryPortContextLabel: primaryContext.label,
+    primaryPortContextTone: primaryContext.tone,
+    chips,
+  };
+}
+
+function countPlacementLocations(group: BodyGroup): { orbital: number; ground: number; unknown: number } {
+  return group.placements.reduce((counts, item) => {
+    const location = normalizeTemplateLocation(item.template);
+    if (location === 'orbital') counts.orbital += 1;
+    else if (location === 'ground') counts.ground += 1;
+    else counts.unknown += 1;
+    return counts;
+  }, { orbital: 0, ground: 0, unknown: 0 });
+}
+
+function normalizeTemplateLocation(template: FacilityTemplate | undefined): 'orbital' | 'ground' | 'unknown' {
+  const value = template?.allowed_location?.toLowerCase() ?? '';
+  if (value.includes('orbital')) return 'orbital';
+  if (value.includes('surface') || value.includes('ground')) return 'ground';
+  return 'unknown';
+}
+
+function getBodyState(group: BodyGroup): LayoutTopologyReadout['bodyState'] {
+  if (group.body) return 'known';
+  return group.placements.some((item) => item.hasUnknownBody) ? 'unknown' : 'unassigned';
+}
+
+function getGroundCapability(group: BodyGroup): { label: string; tone: TopologyTone } {
+  if (!group.body) return { label: 'Ground capability: unknown', tone: 'warn' };
+  if (group.body.is_water_world) return { label: 'Ground capability: review water world', tone: 'warn' };
+  if (group.body.is_landable === false) return { label: 'Ground capability: not landable', tone: 'warn' };
+  if (group.body.is_landable === true) return { label: 'Ground capability: landable', tone: 'good' };
+  return { label: 'Ground capability: unknown', tone: 'default' };
+}
+
+function getPrimaryPortContext(group: BodyGroup, observedLabel: string | null): { label: string; tone: TopologyTone } {
+  if (group.placements.some((item) => item.placement.is_primary_port)) {
+    return { label: 'Primary-port plan: on this body', tone: 'good' };
+  }
+  if (observedLabel) return { label: observedLabel, tone: 'good' };
+  return { label: 'Primary-port flag: unknown', tone: 'default' };
+}
+
+export function topologyPlacementLocationLabel(template: FacilityTemplate | undefined): string {
+  if (!template) return 'Topology location: unknown';
+  return `Topology location: ${formatLocation(template.allowed_location)}`;
+}


### PR DESCRIPTION
## Summary
- Adds frontend-only layout topology helpers for body state, planned orbital/ground counts, unknown locations, conservative ground capability, and Architect status labels.
- Renders compact read-only topology readouts in Layout body cards and selected-body detail.
- Updates planner architecture docs and roadmap for Stage 13B scope, safety boundaries, and deferred work.

## Verification
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `git diff --check`
- Local `npm test` is still blocked by the Windows/Codex Vite/Vitest access-denied issue; CI runs tests from a clean install.

## Safety
- Layout remains read-only.
- No backend mechanics, scoring, CP formulas, economy mechanics, buildability rules, service unlock logic, optimiser ranking/generation, Search Tuning, Simulation Preview scoring, Observed Evidence semantics, Validation semantics, persistence, imports, EDMC ingestion, hauling/material workflows, or map topology rendering changed.
- No primary-port editing, slot editing, auto-preview, auto-generation, auto-save, polling, or silent mutation added.