### PR TITLE
Stage 13C: strategic topology guidance

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -950,3 +950,31 @@ Deferred to Stage 13C:
 - Strategic topology labels such as main-station candidate and support-body guidance.
 - Persistent Architect survey records, manual observation entry, imports, and EDMC/journal ingestion.
 - Full Architect Slot Survey UI, exact slot topology capture, and any map-like spatial rendering.
+
+## Stage 13C - Strategic Topology Guidance
+
+Stage 13C adds conservative strategic labels to the read-only Layout topology surface. It uses only existing Build Plan placements, facility-template fields, body metadata, and optional frontend Architect observation context.
+
+Current Stage 13C status:
+
+- Added frontend-only strategic topology guidance helpers for body groups.
+- Layout body cards and selected-body detail can now label main-station candidates, support-focused bodies, sparse metadata, likely tourism/agriculture review pressure, unknown Architect primary-port flag context, and the outpost-on-inconvenient-flag option.
+- The guidance is advisory copy only. It does not create or modify scoring signals, optimiser ranking, travel-time calculations, Build Plan placement state, Preview state, Observed Evidence, or Validation state.
+- Primary-port guidance remains conservative: unknown Architect primary-port flag context is labelled unknown, users are told to check Architect Mode before final station placement, and inconvenient flagged slots are framed as possible outpost placements rather than reasons to reject a system.
+
+Safety boundaries in Stage 13C:
+
+- No backend mechanics, scoring, CP formulas, economy mechanics, buildability rules, service unlock logic, optimiser generation/ranking, Search Tuning, Simulation Preview scoring, Observed Evidence semantics, Validation semantics, persistence, imports, EDMC ingestion, hauling/material workflows, or map topology rendering changed.
+- No primary-port editing controls, make/remove primary actions, arbitrary slot assignment, Architect Slot Survey storage, auto-preview, auto-generation, auto-load/save, polling, or silent mutation are introduced.
+- Strategic labels are deterministic UI guidance from existing facts only. They do not invent body relationships, exact travel times, confirmed slot capacity, or primary-port truth.
+
+Test coverage added in Stage 13C:
+
+- `strategicTopologyGuidanceUtils.test.ts` covers main-station candidate labels, support-body labels, tourism/agriculture pressure labels, observed-vs-unknown Architect primary-port flag handling, and sparse/unknown body copy.
+- `BuildPlanBodyView.test.tsx` covers strategic topology rendering in Layout cards and selected-body detail while preserving read-only layout behavior.
+
+Deferred beyond Stage 13C:
+
+- Persistent Architect survey records, manual observation entry, imports, and EDMC/journal ingestion.
+- Full Architect Slot Survey UI, exact slot topology capture, and any map-like spatial rendering.
+- Travel-time or adjacency calculations unless future data supports them.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -416,3 +416,17 @@ Deferred to later Stage 13 work:
 - Strategic body relationship guidance and candidate labels.
 - Persistent Architect survey capture and import/storage decisions.
 - Full Architect Slot Survey UI and exact map/topology rendering.
+
+## Stage 13C - Strategic Topology Guidance
+
+Stage 13C layers conservative strategic guidance onto the Stage 13B Layout readout without changing planner mechanics.
+
+- `strategicTopologyGuidanceUtils.ts` derives deterministic body-group guidance from existing placements, templates, body metadata, and optional frontend Architect observation context.
+- `BuildPlanBodyView.tsx` and `BuildPlanLayoutDetailPanel.tsx` render this guidance under a compact **Strategic topology** heading on read-only Layout body surfaces.
+- Labels include main-station candidate, good support body, likely tourism/agriculture pressure, sparse metadata confirmation, unknown Architect primary-port flag checks, and the outpost option for inconvenient flagged primary-port slots.
+
+Safety boundaries:
+
+- The guidance does not call `simulateBuild`, optimiser generation, validation compare/review, observation mutation, persistence, import, polling, or any backend endpoint.
+- It does not change scoring, CP formulas, economy mechanics, service unlock logic, buildability checks, optimiser ranking, Simulation Preview scoring, Observed Evidence, or Validation behavior.
+- It does not add primary-port editing, slot editing, Architect Slot Survey storage, or map-like spatial rendering. Unknown Architect context remains unknown until future stages provide observed data.

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
@@ -142,6 +142,9 @@ describe('BuildPlanBodyView', () => {
     expect(within(firstBody).getByText('Ground capability: landable')).toBeTruthy();
     expect(within(firstBody).getByText('Architect survey: not observed')).toBeTruthy();
     expect(within(firstBody).getByText('Orbital slots: unknown')).toBeTruthy();
+    expect(within(firstBody).getByText('Strategic topology')).toBeTruthy();
+    expect(within(firstBody).getByText('Main station candidate: current plan places a primary or major port here.')).toBeTruthy();
+    expect(within(firstBody).getByText('Primary-port flag unknown: check Architect Mode before final station placement.')).toBeTruthy();
 
     const secondBody = screen.getByTestId('layout-body-group-2');
     expect(within(secondBody).getByText('Extraction Hub')).toBeTruthy();
@@ -152,6 +155,7 @@ describe('BuildPlanBodyView', () => {
     expect(within(secondBody).getAllByText('May be invalid: surface facility on water world').length).toBeGreaterThan(0);
     expect(within(secondBody).getAllByText('Surface structure may be invalid on this body.').length).toBeGreaterThan(0);
     expect(within(secondBody).getAllByText('Estimated template data: review before relying on the plan.').length).toBeGreaterThan(0);
+    expect(within(secondBody).getByText('Good support body: current plan keeps this body support-focused away from the main station candidate.')).toBeTruthy();
 
     const unassigned = screen.getByTestId('layout-body-group-unassigned');
     expect(within(unassigned).getAllByText('Unassigned / needs body').length).toBeGreaterThan(0);
@@ -243,6 +247,8 @@ describe('BuildPlanBodyView', () => {
     expect(within(panel).getByText('Topology readout')).toBeTruthy();
     expect(within(panel).getByText('Ground capability: review water world')).toBeTruthy();
     expect(within(panel).getByText('Ground planned: 1')).toBeTruthy();
+    expect(within(panel).getByText('Strategic topology')).toBeTruthy();
+    expect(within(panel).getByText('Good support body: current plan keeps this body support-focused away from the main station candidate.')).toBeTruthy();
     expect(within(panel).getByText(/Slot counts stay unknown until Architect Mode observations are recorded/)).toBeTruthy();
   });
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
@@ -260,7 +260,7 @@ function BodyGroupCard({
             {bodyWarnings.map((warning) => <Chip key={warning} tone="warn">{warning}</Chip>)}
           </div>
         )}
-        <PlannerGuidanceList items={strategicGuidance} limit={3} title="Strategic topology" />
+        <PlannerGuidanceList items={strategicGuidance} limit={4} title="Strategic topology" />
         <PlannerGuidanceList items={bodyGuidance} limit={2} title="Body guidance" />
       </div>
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
@@ -20,6 +20,7 @@ import { LayoutTopologyReadout } from './LayoutTopologyReadout';
 import { buildLayoutTopologyReadout, topologyPlacementLocationLabel } from './layoutTopologyUtils';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
 import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
+import { buildStrategicTopologyGuidanceForGroup } from './strategicTopologyGuidanceUtils';
 import { formatLocation } from './utils/formatters';
 
 interface BuildPlanBodyViewProps {
@@ -97,6 +98,7 @@ export function BuildPlanBodyView({
               placements={placements}
               selected={selection.kind === 'body' && selection.groupKey === group.key}
               selectedPlacementIndex={selection.kind === 'placement' && selection.groupKey === group.key ? selection.placementIndex : null}
+              allGroups={groups}
               onSelectBody={() => selectBody(group.key)}
               onSelectPlacement={(placementIndex) => selectPlacement(group.key, placementIndex)}
             />
@@ -171,6 +173,7 @@ function BodyGroupCard({
   placements,
   selected,
   selectedPlacementIndex,
+  allGroups,
   onSelectBody,
   onSelectPlacement,
 }: {
@@ -178,6 +181,7 @@ function BodyGroupCard({
   placements: SimulateBuildPlacement[];
   selected: boolean;
   selectedPlacementIndex: number | null;
+  allGroups: BodyGroup[];
   onSelectBody: () => void;
   onSelectPlacement: (placementIndex: number) => void;
 }) {
@@ -189,6 +193,7 @@ function BodyGroupCard({
     hasUnknownBody: item.hasUnknownBody,
     warnings: getPlacementWarnings(item, group.body),
   })));
+  const strategicGuidance = buildStrategicTopologyGuidanceForGroup(group, allGroups);
   const summary = getBodyGroupSummary(group);
   const topology = buildLayoutTopologyReadout(group);
   const isUnassigned = group.body === null;
@@ -255,6 +260,7 @@ function BodyGroupCard({
             {bodyWarnings.map((warning) => <Chip key={warning} tone="warn">{warning}</Chip>)}
           </div>
         )}
+        <PlannerGuidanceList items={strategicGuidance} limit={3} title="Strategic topology" />
         <PlannerGuidanceList items={bodyGuidance} limit={2} title="Body guidance" />
       </div>
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
@@ -148,7 +148,7 @@ function BodyDetail({ group, groups, summary }: { group: BodyGroup; groups: Body
       <LayoutTopologyReadout readout={topology} />
       <TagList body={group.body} />
       <WarningList warnings={warnings} emptyLabel="No body-level warnings from current layout data." />
-      <PlannerGuidanceList items={strategicGuidance} title="Strategic topology" />
+      <PlannerGuidanceList items={strategicGuidance} limit={4} title="Strategic topology" />
       <PlannerGuidanceList items={guidance} title="Body guidance" />
       <div>
         <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">Placements on this body</div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
@@ -18,6 +18,7 @@ import { LayoutTopologyReadout } from './LayoutTopologyReadout';
 import { buildLayoutTopologyReadout, topologyPlacementLocationLabel } from './layoutTopologyUtils';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
 import { buildPlannerGuidanceForBody, buildPlannerGuidanceForPlacement } from './plannerGuidanceUtils';
+import { buildStrategicTopologyGuidanceForGroup } from './strategicTopologyGuidanceUtils';
 import { formatLocation } from './utils/formatters';
 
 export type LayoutSelection =
@@ -77,7 +78,7 @@ export function BuildPlanLayoutDetailPanel({
       </div>
 
       {selection.kind === 'summary' && <SummaryDetail summary={summary} />}
-      {selection.kind === 'body' && selectedGroup && <BodyDetail group={selectedGroup} summary={summary} />}
+      {selection.kind === 'body' && selectedGroup && <BodyDetail group={selectedGroup} groups={groups} summary={summary} />}
       {selection.kind === 'placement' && selectedGroup && selectedPlacement && (
         <PlacementDetail group={selectedGroup} item={selectedPlacement} summary={summary} />
       )}
@@ -117,10 +118,11 @@ function SummaryDetail({ summary }: { summary: PlanSummary }) {
   );
 }
 
-function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary }) {
+function BodyDetail({ group, groups, summary }: { group: BodyGroup; groups: BodyGroup[]; summary: PlanSummary }) {
   const bodySummary = getBodyGroupSummary(group);
   const warnings = getBodyGroupWarnings(group);
   const topology = buildLayoutTopologyReadout(group);
+  const strategicGuidance = buildStrategicTopologyGuidanceForGroup(group, groups);
   const guidance = buildPlannerGuidanceForBody(group.body, group.placements.map((item) => ({
     placement: item.placement,
     template: item.template,
@@ -146,6 +148,7 @@ function BodyDetail({ group, summary }: { group: BodyGroup; summary: PlanSummary
       <LayoutTopologyReadout readout={topology} />
       <TagList body={group.body} />
       <WarningList warnings={warnings} emptyLabel="No body-level warnings from current layout data." />
+      <PlannerGuidanceList items={strategicGuidance} title="Strategic topology" />
       <PlannerGuidanceList items={guidance} title="Body guidance" />
       <div>
         <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">Placements on this body</div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/strategicTopologyGuidanceUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/strategicTopologyGuidanceUtils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import { groupPlacementsByBody } from './buildPlanLayoutUtils';
+import { buildStrategicTopologyGuidanceForGroup } from './strategicTopologyGuidanceUtils';
+
+const templates: FacilityTemplate[] = [
+  {
+    id: 'orbital_port',
+    name: 'Orbital Port',
+    category: 'port',
+    tier: 3,
+    economy: 'Industrial',
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'orbital',
+    pad_size: 'large',
+    confidence: 'observed',
+    notes: null,
+    yellow_cp_generated: 0,
+    green_cp_generated: 0,
+    yellow_cp_cost: 20,
+    green_cp_cost: 40,
+  },
+  {
+    id: 'tourism_outpost',
+    name: 'Tourism Outpost',
+    category: 'support',
+    tier: 1,
+    economy: 'Tourism',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'orbital',
+    pad_size: 'medium',
+    confidence: 'observed',
+    notes: null,
+    yellow_cp_generated: 4,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'surface_hub',
+    name: 'Surface Hub',
+    category: 'support',
+    tier: 1,
+    economy: 'Extraction',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface',
+    pad_size: 'small',
+    confidence: 'estimated',
+    notes: null,
+    yellow_cp_generated: 5,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+];
+
+const bodies = [
+  { id: 1, name: 'A 1', body_type: 'Planet', subtype: 'High metal content world', is_landable: true },
+  { id: 2, name: 'A 2', body_type: 'Planet', subtype: 'Water world', is_water_world: true },
+  { id: 3, name: 'A 3' },
+] as SystemBody[];
+
+function groupsFor(placements: SimulateBuildPlacement[]) {
+  return groupPlacementsByBody(placements, templates, bodies);
+}
+
+describe('strategicTopologyGuidanceUtils', () => {
+  it('labels a planned primary or major port as a main station candidate without changing scoring', () => {
+    const groups = groupsFor([
+      { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
+    ]);
+
+    const guidance = buildStrategicTopologyGuidanceForGroup(groups[0], groups);
+    const text = guidance.map((item) => item.text);
+
+    expect(text).toContain('Main station candidate: current plan places a primary or major port here.');
+    expect(text).toContain('Primary-port flag unknown: check Architect Mode before final station placement.');
+    expect(text).toContain('Consider outpost on inconvenient primary-port slot and main station elsewhere.');
+    expect(guidance.some((item) => item.id === 'strategic-main-station-candidate' && item.severity === 'advisory')).toBe(true);
+  });
+
+  it('labels support-focused bodies and likely tourism/agriculture pressure from existing body facts only', () => {
+    const groups = groupsFor([
+      { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
+      { facility_template_id: 'tourism_outpost', local_body_id: '2', build_order: 2 },
+    ]);
+
+    const supportGroup = groups.find((group) => group.key === '2');
+    if (!supportGroup) throw new Error('Missing support group');
+
+    const guidance = buildStrategicTopologyGuidanceForGroup(supportGroup, groups);
+    const text = guidance.map((item) => item.text);
+
+    expect(text).toContain('Good support body: current plan keeps this body support-focused away from the main station candidate.');
+    expect(text).toContain('Likely tourism/agriculture pressure: body context may favour reviewing tourism or agriculture support.');
+  });
+
+  it('keeps observed Architect primary-port context from showing the unknown-flag guidance', () => {
+    const groups = groupsFor([
+      { facility_template_id: 'orbital_port', local_body_id: '1', build_order: 1 },
+    ]);
+
+    const guidance = buildStrategicTopologyGuidanceForGroup(groups[0], groups, {
+      surveyState: 'observed',
+      primaryPortFlag: { state: 'observed', bodyName: 'A 1', slotLabel: 'Orbital slot 1' },
+    });
+
+    expect(guidance.map((item) => item.text)).not.toContain('Primary-port flag unknown: check Architect Mode before final station placement.');
+    expect(guidance.map((item) => item.text)).toContain('Main station candidate: current plan places a primary or major port here.');
+  });
+
+  it('uses caution copy for sparse or unknown bodies without inventing relationships', () => {
+    const sparseGroup = groupsFor([
+      { facility_template_id: 'surface_hub', local_body_id: '3', build_order: 1 },
+    ])[0];
+    const unknownGroup = groupsFor([
+      { facility_template_id: 'surface_hub', local_body_id: '404', build_order: 1 },
+    ])[0];
+
+    expect(buildStrategicTopologyGuidanceForGroup(sparseGroup).map((item) => item.text)).toContain('Sparse metadata: confirm in game.');
+    expect(buildStrategicTopologyGuidanceForGroup(unknownGroup).map((item) => item.text)).toContain('Sparse metadata: confirm in game before treating this as a strategic body.');
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/strategicTopologyGuidanceUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/strategicTopologyGuidanceUtils.ts
@@ -1,0 +1,132 @@
+import type { FacilityTemplate } from '@/types/api';
+import {
+  normalizeArchitectObservation,
+  type ArchitectObservationInput,
+} from './architectObservationUtils';
+import type { BodyGroup, GroupedPlacement } from './buildPlanLayoutUtils';
+import type { PlannerGuidanceItem, PlannerGuidanceSeverity } from './plannerGuidanceUtils';
+
+export function buildStrategicTopologyGuidanceForGroup(
+  group: BodyGroup,
+  allGroups: BodyGroup[] = [group],
+  architectInput?: ArchitectObservationInput | null,
+): PlannerGuidanceItem[] {
+  const guidance = new Map<string, PlannerGuidanceItem>();
+  const status = normalizeArchitectObservation(architectInput);
+  const hasMainCandidate = groupHasMainStationCandidate(group);
+  const hasPrimaryPlan = group.placements.some((item) => item.placement.is_primary_port);
+  const hasSupport = group.placements.some((item) => isSupportPlacement(item));
+  const hasOrbitalPlan = group.placements.some((item) => isOrbitalTemplate(item.template));
+  const otherGroupsHaveMainCandidate = allGroups.some((item) => item.key !== group.key && groupHasMainStationCandidate(item));
+
+  const add = (item: PlannerGuidanceItem) => addGuidance(guidance, item);
+
+  if (!group.body) {
+    add({
+      id: 'strategic-body-unknown',
+      severity: 'caution',
+      text: 'Sparse metadata: confirm in game before treating this as a strategic body.',
+    });
+  } else if (isSparseBody(group.body)) {
+    add({
+      id: 'strategic-body-sparse',
+      severity: 'caution',
+      text: 'Sparse metadata: confirm in game.',
+    });
+  }
+
+  if (hasMainCandidate) {
+    add({
+      id: 'strategic-main-station-candidate',
+      severity: 'advisory',
+      text: 'Main station candidate: current plan places a primary or major port here.',
+    });
+  }
+
+  if (hasSupport && !hasMainCandidate && group.body) {
+    add({
+      id: 'strategic-support-body',
+      severity: 'info',
+      text: otherGroupsHaveMainCandidate
+        ? 'Good support body: current plan keeps this body support-focused away from the main station candidate.'
+        : 'Good support body: current placements are support-focused.',
+    });
+  }
+
+  if (group.body && hasOrbitalPlan && hasTourismAgriculturePressure(group.body)) {
+    add({
+      id: 'strategic-tourism-agriculture-pressure',
+      severity: 'advisory',
+      text: 'Likely tourism/agriculture pressure: body context may favour reviewing tourism or agriculture support.',
+    });
+  }
+
+  if (hasMainCandidate && status.primaryPortFlag.state !== 'observed') {
+    add({
+      id: 'strategic-primary-unknown',
+      severity: 'info',
+      text: 'Primary-port flag unknown: check Architect Mode before final station placement.',
+    });
+  }
+
+  if (hasPrimaryPlan) {
+    add({
+      id: 'strategic-outpost-option',
+      severity: 'advisory',
+      text: 'Consider outpost on inconvenient primary-port slot and main station elsewhere.',
+    });
+  }
+
+  return Array.from(guidance.values()).sort((a, b) => (
+    severityRank(b.severity) - severityRank(a.severity) || a.text.localeCompare(b.text)
+  ));
+}
+
+function groupHasMainStationCandidate(group: BodyGroup): boolean {
+  return group.placements.some((item) => (
+    item.placement.is_primary_port
+    || Boolean(item.template?.is_port)
+    || (item.template?.tier ?? 0) >= 3
+  ));
+}
+
+function isSupportPlacement(item: GroupedPlacement): boolean {
+  const template = item.template;
+  if (!template) return false;
+  return Boolean(template.is_support_facility || !template.is_port);
+}
+
+function isOrbitalTemplate(template: FacilityTemplate | undefined): boolean {
+  return template?.allowed_location.toLowerCase().includes('orbital') ?? false;
+}
+
+function hasTourismAgriculturePressure(body: NonNullable<BodyGroup['body']>): boolean {
+  return Boolean(body.is_water_world || body.is_earth_like || body.is_terraformable);
+}
+
+function isSparseBody(body: NonNullable<BodyGroup['body']>): boolean {
+  return !body.body_type && !body.subtype;
+}
+
+function addGuidance(guidance: Map<string, PlannerGuidanceItem>, item: PlannerGuidanceItem) {
+  const existing = guidance.get(item.text);
+  if (!existing || severityRank(item.severity) > severityRank(existing.severity)) {
+    guidance.set(item.text, item);
+  }
+}
+
+function severityRank(severity: PlannerGuidanceSeverity): number {
+  switch (severity) {
+    case 'incompatible':
+      return 4;
+    case 'high-risk':
+      return 3;
+    case 'caution':
+      return 2;
+    case 'advisory':
+      return 1;
+    case 'info':
+    default:
+      return 0;
+  }
+}


### PR DESCRIPTION
## Summary
- Add frontend-only strategic topology guidance derived from existing body, placement, template, and optional Architect observation context
- Render conservative strategic labels in read-only Layout body cards and selected-body detail
- Document Stage 13C safety boundaries and deferred Architect/storage/map work

## Safety boundaries
- No backend mechanics, scoring, CP formulas, economy/service/buildability logic, optimiser generation/ranking, Search Tuning, Simulation Preview scoring, Observed Evidence, Validation, persistence, imports, EDMC, hauling/material, or map topology behavior changed
- No primary-port editing, slot editing, Architect Slot Survey storage, auto-preview, auto-generation, polling, or silent mutation

## Local checks
- `cd frontend-v2 && npm run typecheck` passed
- `cd frontend-v2 && npm run build` passed
- `git diff --check` passed
- `cd frontend-v2 && npm test` could not start locally because the Windows/Codex Vitest config loader hit a host filesystem access-denied error before discovering tests; GitHub CI is expected to run the suite as the gate