### PR TITLE
Stage 14A: observed evidence planning expansion

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -978,3 +978,29 @@ Deferred beyond Stage 13C:
 - Persistent Architect survey records, manual observation entry, imports, and EDMC/journal ingestion.
 - Full Architect Slot Survey UI, exact slot topology capture, and any map-like spatial rendering.
 - Travel-time or adjacency calculations unless future data supports them.
+
+## Stage 14A - Observed Evidence Planning Expansion
+
+Stage 14A strengthens Observed Evidence as the place where real in-game observations are organized against the plan. It remains a passive evidence surface and uses the existing observed-facts API only.
+
+Current Stage 14A status:
+
+- Added frontend-only evidence category helpers for primary-port / Architect notes, structures actually built, body or slot observations, economy observations, service / population / security observations, and general notes.
+- Added an Observed vs planned framing readout to the Observed Evidence panel so Planned, Observed, and Unknown / not checked states remain visibly distinct.
+- Category counts are derived from the visible evidence list and stay clearly labelled as evidence organization, not validation verdicts.
+
+Safety boundaries in Stage 14A:
+
+- No backend persistence contract, imports, EDMC ingestion, scoring, CP formulas, economy mechanics, buildability rules, service unlock logic, optimiser behavior, Simulation Preview scoring, Validation semantics, or planner mutation changed.
+- Viewing Observed Evidence does not auto-run Preview, generation, Validation compare/review, polling, or silent mutation.
+- Primary-port / Architect evidence is categorized only when existing manual evidence text/tags/fields mention it. Stage 14A does not add Architect survey storage, slot editing, or primary-port editing controls.
+
+Test coverage added in Stage 14A:
+
+- `observedEvidencePlanningUtils.test.ts` covers category derivation and zero-count category summaries.
+- `ObservedEvidencePanel.test.tsx` covers planned/observed/unknown framing, category rendering, and passivity against preview, generation, validation compare/review, and observed-fact mutations while viewing.
+
+Deferred beyond Stage 14A:
+
+- Richer manual evidence types for Architect survey records, slot observations, service/population/security-specific fields, and future persistence/import work.
+- Validation mismatch copy and review-category refinements for Stage 14B.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -430,3 +430,21 @@ Safety boundaries:
 - The guidance does not call `simulateBuild`, optimiser generation, validation compare/review, observation mutation, persistence, import, polling, or any backend endpoint.
 - It does not change scoring, CP formulas, economy mechanics, service unlock logic, buildability checks, optimiser ranking, Simulation Preview scoring, Observed Evidence, or Validation behavior.
 - It does not add primary-port editing, slot editing, Architect Slot Survey storage, or map-like spatial rendering. Unknown Architect context remains unknown until future stages provide observed data.
+
+## Stage 14A - Observed Evidence Planning Expansion
+
+Stage 14A improves the existing Observed Evidence panel as a planning review surface without changing the observed-facts backend contract.
+
+- `observedEvidencePlanningUtils.ts` derives conservative frontend-only categories from existing observed-fact fields: primary-port / Architect observation, structure actually built, body / slot observation, economy observation, service / population / security observation, and general note.
+- `ObservedEvidencePlanningSummary.tsx` renders the planned / observed / unknown distinction above the manual entry form and shows category counts for the visible evidence list.
+- `ObservedEvidencePanel.tsx` keeps the existing manual create/edit/delete flows and inserts the summary as passive context only.
+
+Safety boundaries:
+
+- The panel still calls only observed-facts list/create/update/delete endpoints through explicit user actions already present in the UI.
+- Viewing Observed Evidence does not call `simulateBuild`, optimiser generation, Validation compare/review, persistence/import, polling, auto-preview, or any planner mutation.
+- The new primary-port / Architect category is a label for manually recorded evidence only. It does not add primary-port editing, Architect Slot Survey storage, slot editing, or confirmed primary-port truth.
+
+Deferred:
+
+- Dedicated Architect survey evidence input/storage, richer slot evidence fields, import/EDMC ingestion, and Stage 14B validation mismatch copy.

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
@@ -219,7 +219,9 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
     expect(within(categories).getByText('Primary-port / Architect observation')).toBeTruthy();
     expect(within(categories).getByText('Structure actually built')).toBeTruthy();
     expect(within(categories).getByText('Economy observation')).toBeTruthy();
-    expect(screen.getByLabelText('Visible observed evidence count').textContent).toMatch(/3\s+visible\s+\/\s+3\s+recorded/);
+    await waitFor(() =>
+      expect(screen.getByLabelText('Visible observed evidence count').textContent).toMatch(/3\s+visible\s+\/\s+3\s+recorded/),
+    );
   });
 
   it('shows a loading state while the list query is pending', async () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
@@ -191,7 +191,6 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
     expect(screen.getByText(/Build Plan and Preview Result are planning context/)).toBeTruthy();
     expect(screen.getByText('Observed')).toBeTruthy();
     expect(screen.getByText(/Manual evidence is what was checked in-game/)).toBeTruthy();
-    expect(screen.getByText('Unknown')).toBeTruthy();
     expect(screen.getByText(/Missing evidence stays not checked, not contradicted/)).toBeTruthy();
   });
 
@@ -220,7 +219,13 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
     expect(within(categories).getByText('Primary-port / Architect observation')).toBeTruthy();
     expect(within(categories).getByText('Structure actually built')).toBeTruthy();
     expect(within(categories).getByText('Economy observation')).toBeTruthy();
-    expect(screen.getByText('3 visible / 3 recorded')).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        screen.getByText((_content, element) =>
+          Boolean(element?.textContent?.replace(/\s+/g, ' ').includes('3 visible / 3 recorded')),
+        ),
+      ).toBeTruthy(),
+    );
   });
 
   it('shows a loading state while the list query is pending', async () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
@@ -2,10 +2,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  comparePredictionToObservations,
   createObservedFact,
   deleteObservedFact,
   fetchOptimiserCandidates,
   listObservedFacts,
+  reviewPredictionValidation,
   simulateBuild,
   updateObservedFact,
 } from '@/lib/api';
@@ -26,6 +28,8 @@ vi.mock('@/lib/api', async () => {
     createObservedFact: vi.fn(),
     updateObservedFact: vi.fn(),
     deleteObservedFact: vi.fn(),
+    comparePredictionToObservations: vi.fn(),
+    reviewPredictionValidation: vi.fn(),
     fetchOptimiserCandidates: vi.fn(),
     simulateBuild: vi.fn(),
   };
@@ -35,6 +39,8 @@ const mockedList = vi.mocked(listObservedFacts);
 const mockedCreate = vi.mocked(createObservedFact);
 const mockedUpdate = vi.mocked(updateObservedFact);
 const mockedDelete = vi.mocked(deleteObservedFact);
+const mockedCompare = vi.mocked(comparePredictionToObservations);
+const mockedReview = vi.mocked(reviewPredictionValidation);
 const mockedFetchOptimiser = vi.mocked(fetchOptimiserCandidates);
 const mockedSimulateBuild = vi.mocked(simulateBuild);
 
@@ -122,6 +128,8 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
     mockedCreate.mockReset();
     mockedUpdate.mockReset();
     mockedDelete.mockReset();
+    mockedCompare.mockReset();
+    mockedReview.mockReset();
     mockedFetchOptimiser.mockReset();
     mockedSimulateBuild.mockReset();
   });
@@ -172,6 +180,47 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
         /Record what you actually saw in-game\. Evidence is passive; Validation can compare it with predictions without changing scoring or mechanics/,
       ),
     ).toBeTruthy();
+  });
+
+  it('renders Stage 14A observed-vs-planned framing and keeps unknown state distinct', async () => {
+    mockedList.mockResolvedValue(emptyResponse());
+    renderPanel();
+
+    expect(await screen.findByText('Observed vs planned framing')).toBeTruthy();
+    expect(screen.getByText('Planned')).toBeTruthy();
+    expect(screen.getByText(/Build Plan and Preview Result are planning context/)).toBeTruthy();
+    expect(screen.getByText('Observed')).toBeTruthy();
+    expect(screen.getByText(/Manual evidence is what was checked in-game/)).toBeTruthy();
+    expect(screen.getByText('Unknown')).toBeTruthy();
+    expect(screen.getByText(/Missing evidence stays not checked, not contradicted/)).toBeTruthy();
+  });
+
+  it('renders Stage 14A evidence categories from the visible observed facts', async () => {
+    mockedList.mockResolvedValue(
+      listResponseWith([
+        fact({
+          observation_id: 'obs_architect',
+          notes: 'Architect Mode primary-port flag observed on A 1.',
+        }),
+        fact({
+          observation_id: 'obs_build',
+          fact_type: 'facility_state',
+          facility_template_id: 'outpost_support_a',
+        }),
+        fact({
+          observation_id: 'obs_economy',
+          fact_type: 'economy_presence',
+          economy: 'Agriculture',
+        }),
+      ]),
+    );
+    renderPanel();
+
+    const categories = await screen.findByLabelText('Observed evidence categories');
+    expect(within(categories).getByText('Primary-port / Architect observation')).toBeTruthy();
+    expect(within(categories).getByText('Structure actually built')).toBeTruthy();
+    expect(within(categories).getByText('Economy observation')).toBeTruthy();
+    expect(screen.getByText('3 visible / 3 recorded')).toBeTruthy();
   });
 
   it('shows a loading state while the list query is pending', async () => {
@@ -559,5 +608,23 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
 
     expect(mockedSimulateBuild).not.toHaveBeenCalled();
     expect(mockedFetchOptimiser).not.toHaveBeenCalled();
+    expect(mockedCompare).not.toHaveBeenCalled();
+    expect(mockedReview).not.toHaveBeenCalled();
+  });
+
+  it('viewing observed evidence does not run preview, generation, validation, or planner mutation', async () => {
+    mockedList.mockResolvedValue(
+      listResponseWith([fact({ observation_id: 'obs_view', notes: 'Passive viewing only.' })]),
+    );
+    renderPanel();
+
+    expect(await screen.findByText(/Passive viewing only/)).toBeTruthy();
+    expect(mockedSimulateBuild).not.toHaveBeenCalled();
+    expect(mockedFetchOptimiser).not.toHaveBeenCalled();
+    expect(mockedCompare).not.toHaveBeenCalled();
+    expect(mockedReview).not.toHaveBeenCalled();
+    expect(mockedCreate).not.toHaveBeenCalled();
+    expect(mockedUpdate).not.toHaveBeenCalled();
+    expect(mockedDelete).not.toHaveBeenCalled();
   });
 });

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
@@ -219,13 +219,7 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
     expect(within(categories).getByText('Primary-port / Architect observation')).toBeTruthy();
     expect(within(categories).getByText('Structure actually built')).toBeTruthy();
     expect(within(categories).getByText('Economy observation')).toBeTruthy();
-    await waitFor(() =>
-      expect(
-        screen.getByText((_content, element) =>
-          Boolean(element?.textContent?.replace(/\s+/g, ' ').includes('3 visible / 3 recorded')),
-        ),
-      ).toBeTruthy(),
-    );
+    expect(screen.getByLabelText('Visible observed evidence count').textContent).toMatch(/3\s+visible\s+\/\s+3\s+recorded/);
   });
 
   it('shows a loading state while the list query is pending', async () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
@@ -17,6 +17,7 @@ import type {
 } from '@/types/api';
 import { ObservedEvidenceForm } from './ObservedEvidenceForm';
 import { ObservedEvidenceList } from './ObservedEvidenceList';
+import { ObservedEvidencePlanningSummary } from './ObservedEvidencePlanningSummary';
 import {
   CONFIDENCES,
   CREATABLE_FACT_TYPES,
@@ -191,6 +192,12 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
           {PASSIVE_EVIDENCE_COPY}
         </p>
       </header>
+
+      <ObservedEvidencePlanningSummary
+        facts={facts}
+        totalCount={summary?.total_count ?? facts.length}
+        filtered={filtersActive}
+      />
 
       <div className="mb-4 rounded border border-border/60 bg-bg2/30 p-3">
         <div className="mb-2 text-[10px] uppercase tracking-[0.14em] text-silver-dk">Record manually observed evidence</div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePlanningSummary.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePlanningSummary.tsx
@@ -1,0 +1,74 @@
+import type { ObservedFact } from '@/types/api';
+import { summarizeObservedEvidenceCategories } from './observedEvidencePlanningUtils';
+
+interface ObservedEvidencePlanningSummaryProps {
+  facts: readonly ObservedFact[];
+  totalCount: number;
+  filtered: boolean;
+}
+
+export function ObservedEvidencePlanningSummary({
+  facts,
+  totalCount,
+  filtered,
+}: ObservedEvidencePlanningSummaryProps) {
+  const categories = summarizeObservedEvidenceCategories(facts);
+  const visibleCount = facts.length;
+
+  return (
+    <div className="mb-4 rounded border border-border/60 bg-bg2/25 p-3 font-mono text-[10px] text-silver-dk">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+        <div className="uppercase tracking-[0.16em] text-silver">Observed vs planned framing</div>
+        <div className="text-cyan">
+          {visibleCount} visible / {totalCount} recorded
+        </div>
+      </div>
+
+      <div className="grid gap-2 md:grid-cols-3">
+        <EvidenceState label="Planned" value="Build Plan and Preview Result are planning context." />
+        <EvidenceState label="Observed" value="Manual evidence is what was checked in-game." />
+        <EvidenceState label="Unknown" value="Missing evidence stays not checked, not contradicted." />
+      </div>
+
+      <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3" aria-label="Observed evidence categories">
+        {categories.map((category) => (
+          <div
+            key={category.id}
+            className={[
+              'rounded border px-2 py-2',
+              category.count > 0
+                ? 'border-orange/30 bg-orange/10 text-silver'
+                : 'border-border/50 bg-bg3/20 text-silver-dk',
+            ].join(' ')}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="uppercase tracking-[0.12em]">{category.label}</span>
+              <span className={category.count > 0 ? 'text-orange' : 'text-silver-dk'}>
+                {category.count}
+              </span>
+            </div>
+            <p className="mt-1 leading-snug">{category.description}</p>
+          </div>
+        ))}
+      </div>
+
+      {filtered && (
+        <p className="mt-2 text-cyan">
+          Category counts reflect the visible filtered evidence list.
+        </p>
+      )}
+      <p className="mt-2 leading-snug">
+        Viewing evidence does not run Preview, Validation, generation, or planner mutation. Use Validation when you want a manual comparison against the current Preview Result.
+      </p>
+    </div>
+  );
+}
+
+function EvidenceState({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-border/50 bg-bg3/25 px-2 py-2">
+      <div className="uppercase tracking-[0.14em] text-silver">{label}</div>
+      <div className="mt-1 leading-snug">{value}</div>
+    </div>
+  );
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePlanningSummary.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/ObservedEvidencePlanningSummary.tsx
@@ -19,7 +19,7 @@ export function ObservedEvidencePlanningSummary({
     <div className="mb-4 rounded border border-border/60 bg-bg2/25 p-3 font-mono text-[10px] text-silver-dk">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
         <div className="uppercase tracking-[0.16em] text-silver">Observed vs planned framing</div>
-        <div className="text-cyan">
+        <div className="text-cyan" aria-label="Visible observed evidence count">
           {visibleCount} visible / {totalCount} recorded
         </div>
       </div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/observedEvidencePlanningUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/observedEvidencePlanningUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { ObservedFact } from '@/types/api';
+import {
+  categorizeObservedEvidence,
+  summarizeObservedEvidenceCategories,
+} from './observedEvidencePlanningUtils';
+
+function fact(overrides: Partial<ObservedFact> = {}): ObservedFact {
+  return {
+    observation_id: 'obs_a',
+    system_id64: 123,
+    created_at: '2026-05-14T13:00:00+00:00',
+    updated_at: null,
+    source: 'manual',
+    fact_type: 'note',
+    subject_type: 'system',
+    subject_id: null,
+    status: 'observed_present',
+    observed_value: undefined,
+    expected_value: undefined,
+    confidence: 'medium',
+    notes: null,
+    build_fingerprint: null,
+    simulation_fingerprint: null,
+    target_archetype: null,
+    facility_template_id: null,
+    local_body_id: null,
+    service_id: null,
+    economy: null,
+    tags: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('observedEvidencePlanningUtils', () => {
+  it('categorizes Architect and primary-port notes without a backend taxonomy', () => {
+    expect(
+      categorizeObservedEvidence(
+        fact({ notes: 'Architect Mode shows the primary-port flag on the inner orbital slot.' }),
+      ),
+    ).toBe('architect_primary_port');
+  });
+
+  it('categorizes existing observed fact types into planning categories', () => {
+    expect(categorizeObservedEvidence(fact({ fact_type: 'facility_state', facility_template_id: 'orbital_port_a' }))).toBe('structure_built');
+    expect(categorizeObservedEvidence(fact({ fact_type: 'build_outcome', observed_value: 'completed' }))).toBe('structure_built');
+    expect(categorizeObservedEvidence(fact({ fact_type: 'economy_presence', economy: 'Agriculture' }))).toBe('economy');
+    expect(categorizeObservedEvidence(fact({ fact_type: 'service_presence', service_id: 'market' }))).toBe('service_population_security');
+    expect(categorizeObservedEvidence(fact({ subject_type: 'body', local_body_id: 'A 2' }))).toBe('body_slot');
+  });
+
+  it('summarizes category counts while keeping zero-count categories visible', () => {
+    const summary = summarizeObservedEvidenceCategories([
+      fact({ notes: 'Primary port flag observed in Architect Mode.' }),
+      fact({ fact_type: 'facility_state', facility_template_id: 'tourism_support_a' }),
+      fact({ fact_type: 'economy_presence', economy: 'Tourism' }),
+    ]);
+
+    expect(summary.find((item) => item.id === 'architect_primary_port')?.count).toBe(1);
+    expect(summary.find((item) => item.id === 'structure_built')?.count).toBe(1);
+    expect(summary.find((item) => item.id === 'economy')?.count).toBe(1);
+    expect(summary.find((item) => item.id === 'service_population_security')?.count).toBe(0);
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/observations/observedEvidencePlanningUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/observations/observedEvidencePlanningUtils.ts
@@ -1,0 +1,104 @@
+import type { ObservedFact } from '@/types/api';
+
+export type ObservedEvidenceCategoryId =
+  | 'architect_primary_port'
+  | 'structure_built'
+  | 'body_slot'
+  | 'economy'
+  | 'service_population_security'
+  | 'general';
+
+export interface ObservedEvidenceCategorySummary {
+  id: ObservedEvidenceCategoryId;
+  label: string;
+  description: string;
+  count: number;
+}
+
+export const OBSERVED_EVIDENCE_CATEGORIES: readonly Omit<ObservedEvidenceCategorySummary, 'count'>[] = [
+  {
+    id: 'architect_primary_port',
+    label: 'Primary-port / Architect observation',
+    description: 'Manual notes about the in-game Architect primary-port flag or slot context.',
+  },
+  {
+    id: 'structure_built',
+    label: 'Structure actually built',
+    description: 'Facility state and build outcome records that describe what was constructed.',
+  },
+  {
+    id: 'body_slot',
+    label: 'Body / slot observation',
+    description: 'Evidence tied to a body, orbital slot, ground slot, or local placement context.',
+  },
+  {
+    id: 'economy',
+    label: 'Economy observation',
+    description: 'Observed economy records for planned or built structures.',
+  },
+  {
+    id: 'service_population_security',
+    label: 'Service / population / security observation',
+    description: 'Service observations and notes about population or security state.',
+  },
+  {
+    id: 'general',
+    label: 'General note',
+    description: 'Other manual evidence that should stay distinct from planned assumptions.',
+  },
+];
+
+const ARCHITECT_TERMS = ['architect', 'primary port', 'primary-port', 'flagged slot', 'flag icon'];
+const BODY_SLOT_TERMS = ['body', 'orbital slot', 'ground slot', 'surface slot', 'slot'];
+const SERVICE_TERMS = ['service', 'population', 'security'];
+
+export function categorizeObservedEvidence(fact: ObservedFact): ObservedEvidenceCategoryId {
+  const haystack = [
+    fact.fact_type,
+    fact.subject_type,
+    fact.subject_id,
+    fact.notes,
+    fact.local_body_id,
+    fact.service_id,
+    fact.economy,
+    ...(fact.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+
+  if (ARCHITECT_TERMS.some((term) => haystack.includes(term))) {
+    return 'architect_primary_port';
+  }
+
+  if (fact.fact_type === 'economy_presence' || fact.subject_type === 'economy' || Boolean(fact.economy)) {
+    return 'economy';
+  }
+
+  if (fact.fact_type === 'service_presence' || fact.subject_type === 'service' || SERVICE_TERMS.some((term) => haystack.includes(term))) {
+    return 'service_population_security';
+  }
+
+  if (fact.fact_type === 'facility_state' || fact.fact_type === 'build_outcome' || Boolean(fact.facility_template_id)) {
+    return 'structure_built';
+  }
+
+  if (Boolean(fact.local_body_id) || fact.subject_type === 'body' || BODY_SLOT_TERMS.some((term) => haystack.includes(term))) {
+    return 'body_slot';
+  }
+
+  return 'general';
+}
+
+export function summarizeObservedEvidenceCategories(facts: readonly ObservedFact[]): ObservedEvidenceCategorySummary[] {
+  const counts = new Map<ObservedEvidenceCategoryId, number>();
+  for (const fact of facts) {
+    const category = categorizeObservedEvidence(fact);
+    counts.set(category, (counts.get(category) ?? 0) + 1);
+  }
+
+  return OBSERVED_EVIDENCE_CATEGORIES.map((category) => ({
+    ...category,
+    count: counts.get(category.id) ?? 0,
+  }));
+}


### PR DESCRIPTION
## Summary
- Add frontend-only Observed Evidence planning categories for Architect/primary-port notes, built structures, body/slot observations, economy, service/population/security, and general notes
- Add planned / observed / unknown framing above the existing manual evidence form
- Update Stage 14A docs with safety boundaries and deferred work

## Safety boundaries
- No backend mechanics, scoring, CP formulas, economy/service/buildability logic, optimiser generation/ranking, Search Tuning, Simulation Preview scoring, Validation semantics, persistence/imports, EDMC, hauling/material, or planner mutation changed
- Viewing Observed Evidence does not auto-run Preview, generation, Validation compare/review, polling, or silent mutation
- Primary-port / Architect evidence is categorized only from existing manual evidence text/tags/fields; no primary-port editing, slot editing, or Architect survey storage added

## Local checks
- `cd frontend-v2 && npm run typecheck` passed via `npm.cmd run typecheck`
- `cd frontend-v2 && npm run build` passed via `npm.cmd run build`
- `git diff --check` passed
- `cd frontend-v2 && npm test` could not start locally because the Windows/Codex Vitest config loader hit a host filesystem access-denied error before discovering tests; GitHub CI is expected to run the suite as the gate