### PR TITLE
Stage 14B: validation review clarity

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1003,4 +1003,30 @@ Test coverage added in Stage 14A:
 Deferred beyond Stage 14A:
 
 - Richer manual evidence types for Architect survey records, slot observations, service/population/security-specific fields, and future persistence/import work.
-- Validation mismatch copy and review-category refinements for Stage 14B.
+
+## Stage 14B - Validation Review Clarity
+
+Stage 14B improves how Validation explains mismatches between the current Preview Result and Observed Evidence. It remains a frontend clarity stage layered over the existing Stage 6C compare response and Stage 6E review response.
+
+Current Stage 14B status:
+
+- Added a frontend-only validation review category layer for comparison rows: Matches plan, Differs from plan, Missing observation, Unknown / not checked, and Needs manual review.
+- Comparison cards now show the category alongside the existing backend status/severity/confidence labels. Backend statuses are preserved; the new category is explanatory copy only.
+- Differing rows use explicit mismatch wording: `Observed value differs from preview.` Missing and unknown rows distinguish unrecorded evidence from unchecked/uncertain comparison state.
+- Validation now includes conservative review reminders: Preview assumes the current plan and should be confirmed in-game; Architect primary-port context is not a dedicated validation field and should be checked in System Map -> Architect Mode before final major station placement.
+
+Safety boundaries in Stage 14B:
+
+- No backend compare/review engine, API contract, persistence, observed-facts semantics, Validation semantics, Simulation Preview scoring, optimiser behavior, CP/economy/buildability/service mechanics, Search Tuning, imports, EDMC ingestion, or planner mutation changed.
+- Validation still does not auto-run Preview, generation, evidence mutation, compare/review outside the existing Validation queries, polling, auto-save, or auto-load.
+- Primary-port wording remains read-only guidance. Stage 14B does not add Architect survey storage, primary-port editing, slot editing, or any make/remove primary control.
+
+Test coverage added in Stage 14B:
+
+- `validationReviewCategoryUtils.test.ts` covers category mapping, fallback behavior for future statuses, and explicit mismatch copy.
+- `ValidationPanel.test.tsx` covers review reminders, comparison category rendering for matches/differs/missing/manual-review/unknown states, Architect primary-port unknown copy, and existing passivity against preview/generation/observed-fact mutation.
+
+Deferred beyond Stage 14B:
+
+- Dedicated Architect survey validation fields once Stage 13 storage/input work exists.
+- Richer mismatch grouping, bulk review workflows, and any auto-resolution remain deferred.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -447,4 +447,24 @@ Safety boundaries:
 
 Deferred:
 
-- Dedicated Architect survey evidence input/storage, richer slot evidence fields, import/EDMC ingestion, and Stage 14B validation mismatch copy.
+- Dedicated Architect survey evidence input/storage, richer slot evidence fields, and import/EDMC ingestion.
+
+## Stage 14B - Validation Review Clarity
+
+Stage 14B keeps the existing Validation data flow and improves the readout language around mismatches.
+
+- `validationReviewCategoryUtils.ts` maps existing comparison row statuses into frontend-only review categories: Matches plan, Differs from plan, Missing observation, Unknown / not checked, and Needs manual review.
+- `ValidationComparisonCard.tsx` renders the category chip and short category explanation beside the existing status, severity, and confidence labels. The raw compare status is still preserved for filters and tests.
+- `ValidationPanel.tsx` adds a compact reminder strip: Preview assumes the current plan and should be confirmed in-game; Architect primary-port context is not a dedicated validation field and should be checked in System Map -> Architect Mode before final major station placement.
+- Copy remains conservative: differing rows say `Observed value differs from preview.` Unknown or missing rows do not imply the plan is wrong, and no row auto-resolves a mismatch.
+
+Safety boundaries:
+
+- No compare/review endpoint, backend validation engine, Observed Evidence semantics, Simulation Preview scoring, optimiser behavior, CP/economy/buildability/service mechanics, persistence, imports, EDMC ingestion, or planner state mutation changed.
+- Validation remains an explicit review surface. It does not auto-run Preview, auto-generate, auto-save, poll, mutate evidence, or write back to the Build Plan.
+- Architect/primary-port wording is read-only. Stage 14B does not add Architect survey storage, slot editing, or primary-port editing controls.
+
+Deferred:
+
+- Dedicated Architect survey validation once a later stage adds observed Architect data storage/input.
+- Higher-level mismatch grouping, review workflows, and any automatic resolution.

--- a/frontend-v2/src/features/system-detail/simulation-preview/validation/ValidationComparisonCard.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/validation/ValidationComparisonCard.tsx
@@ -5,6 +5,11 @@ import {
   comparisonSeverityLabel,
   comparisonStatusLabel,
 } from './validationLabels';
+import {
+  validationMismatchCategory,
+  validationMismatchCategoryClassName,
+  validationMismatchCategoryCopy,
+} from './validationReviewCategoryUtils';
 import { formatComparisonValue } from './validationUtils';
 
 interface ValidationComparisonCardProps {
@@ -25,6 +30,8 @@ export function ValidationComparisonCard({ comparison }: ValidationComparisonCar
   const statusLabel = comparisonStatusLabel(comparison.status);
   const severityLabel = comparisonSeverityLabel(comparison.severity);
   const conservativeNote = conservativeStatusNote(comparison.status);
+  const mismatchCategory = validationMismatchCategory(comparison);
+  const mismatchCategoryCopy = validationMismatchCategoryCopy(mismatchCategory);
 
   return (
     <article
@@ -44,6 +51,15 @@ export function ValidationComparisonCard({ comparison }: ValidationComparisonCar
           data-testid="validation-card-severity"
         >
           Severity: <span className="text-silver">{severityLabel}</span>
+        </span>
+        <span
+          className={[
+            'rounded border px-2 py-0.5 text-[10px] uppercase tracking-[0.14em]',
+            validationMismatchCategoryClassName(mismatchCategory),
+          ].join(' ')}
+          data-testid="validation-card-review-category"
+        >
+          {mismatchCategoryCopy.label}
         </span>
         <span className="text-[10px] uppercase tracking-[0.14em] text-silver-dk">
           Confidence:{' '}
@@ -78,6 +94,13 @@ export function ValidationComparisonCard({ comparison }: ValidationComparisonCar
           {formatComparisonValue(comparison.observed_value)}
         </span>
       </div>
+
+      <p
+        className="mt-2 text-[11px] text-silver leading-snug"
+        data-testid="validation-card-review-category-note"
+      >
+        {mismatchCategoryCopy.description}
+      </p>
 
       {conservativeNote && (
         <p

--- a/frontend-v2/src/features/system-detail/simulation-preview/validation/ValidationPanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/validation/ValidationPanel.test.tsx
@@ -368,6 +368,16 @@ describe('ValidationPanel - Stage 6D validation display', () => {
     ).toBeTruthy();
   });
 
+  it('renders validation review reminders without requiring a preview run', () => {
+    renderPanel({ preview: null });
+    expect(screen.getByTestId('validation-review-reminders').textContent).toMatch(
+      /Preview assumes current plan; confirm in game\./,
+    );
+    expect(screen.getByTestId('validation-review-reminders').textContent).toMatch(
+      /Architect primary-port flag has not been recorded as a dedicated validation field/,
+    );
+  });
+
   it('shows the no-preview empty state and does not call compare API when there is no preview result', async () => {
     renderPanel({ preview: null });
     expect(
@@ -451,6 +461,7 @@ describe('ValidationPanel - Stage 6D validation display', () => {
     const confirmedCard = cards.find((card) => card.getAttribute('data-status') === 'confirmed');
     expect(confirmedCard).toBeTruthy();
     expect(within(confirmedCard!).getByTestId('validation-card-status').textContent).toBe('Confirmed');
+    expect(within(confirmedCard!).getByTestId('validation-card-review-category').textContent).toBe('Matches plan');
   });
 
   it('renders a contradicted row as "Needs review" and avoids high-certainty wording', async () => {
@@ -460,6 +471,10 @@ describe('ValidationPanel - Stage 6D validation display', () => {
     const contradicted = cards.find((card) => card.getAttribute('data-status') === 'contradicted');
     expect(contradicted).toBeTruthy();
     expect(within(contradicted!).getByTestId('validation-card-status').textContent).toBe('Needs review');
+    expect(within(contradicted!).getByTestId('validation-card-review-category').textContent).toBe('Differs from plan');
+    expect(within(contradicted!).getByTestId('validation-card-review-category-note').textContent).toBe(
+      'Observed value differs from preview.',
+    );
     expect(screen.getByTestId('validation-panel').textContent ?? '').not.toMatch(/wrong/i);
     expect(screen.getByTestId('validation-panel').textContent ?? '').not.toMatch(/proof/i);
   });
@@ -473,6 +488,7 @@ describe('ValidationPanel - Stage 6D validation display', () => {
     expect(
       within(predOnly!).getByTestId('validation-card-conservative-note').textContent,
     ).toMatch(/Predicted, but no matching observation has been recorded yet\./);
+    expect(within(predOnly!).getByTestId('validation-card-review-category').textContent).toBe('Missing observation');
   });
 
   it('renders the conservative copy for observed_only rows', async () => {
@@ -484,6 +500,71 @@ describe('ValidationPanel - Stage 6D validation display', () => {
     expect(
       within(obsOnly!).getByTestId('validation-card-conservative-note').textContent,
     ).toMatch(/Observed evidence exists, but the current prediction has no matching item\./);
+    expect(within(obsOnly!).getByTestId('validation-card-review-category').textContent).toBe('Needs manual review');
+  });
+
+  it('renders unknown and unverified rows as not-checked/manual-review categories', async () => {
+    const base = compareResponse();
+    mockedCompare.mockResolvedValue(
+      compareResponse({
+        summary: {
+          ...base.summary,
+          compared_predictions_count: 2,
+          confirmed_count: 0,
+          contradicted_count: 0,
+          observed_only_count: 0,
+          predicted_only_count: 0,
+          unknown_count: 1,
+          unverified_count: 1,
+        },
+        comparisons: [
+          {
+            comparison_id: 'architect:primary-port',
+            area: 'architect',
+            subject_type: 'primary_port_flag',
+            subject_id: null,
+            predicted_value: null,
+            observed_value: null,
+            status: 'unknown',
+            severity: 'info',
+            confidence: 'unknown',
+            reason: 'Architect primary-port flag has not been recorded.',
+            recommended_action: 'Check System Map -> Architect Mode before final station placement.',
+            evidence: [],
+            prediction_source: null,
+          },
+          {
+            comparison_id: 'economy:pending-review',
+            area: 'economy',
+            subject_type: 'economy',
+            subject_id: 'industrial',
+            predicted_value: 'industrial',
+            observed_value: { economy: 'industrial' },
+            status: 'unverified',
+            severity: 'low',
+            confidence: 'low',
+            reason: 'Evidence needs manual review.',
+            recommended_action: null,
+            evidence: [],
+            prediction_source: 'economy_composition',
+          },
+        ],
+      }),
+    );
+    renderPanel();
+    const cards = await screen.findAllByTestId('validation-comparison-card');
+    const unknown = cards.find((card) => card.getAttribute('data-status') === 'unknown');
+    const unverified = cards.find((card) => card.getAttribute('data-status') === 'unverified');
+
+    expect(unknown).toBeTruthy();
+    expect(within(unknown!).getByTestId('validation-card-review-category').textContent).toBe(
+      'Unknown / not checked',
+    );
+    expect(within(unknown!).getByText(/Architect primary-port flag has not been recorded/)).toBeTruthy();
+    expect(unverified).toBeTruthy();
+    expect(within(unverified!).getByTestId('validation-card-review-category').textContent).toBe(
+      'Needs manual review',
+    );
   });
 
   it('renders evidence observation_id, fact_type, status, confidence, and notes inside the evidence list', async () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/validation/ValidationPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/validation/ValidationPanel.tsx
@@ -14,6 +14,7 @@ import {
   ADVISORY_COPY,
   NO_PREVIEW_COPY,
   STALE_PREVIEW_COPY,
+  VALIDATION_REVIEW_REMINDERS,
 } from './validationLabels';
 import { previewResultFingerprint } from './validationUtils';
 
@@ -156,6 +157,14 @@ export function ValidationPanel({
         >
           {ADVISORY_COPY}
         </p>
+        <ul
+          className="mt-2 grid gap-1 rounded border border-border/60 bg-bg3/30 px-3 py-2 font-mono text-[10px] leading-snug text-silver-dk sm:grid-cols-2"
+          data-testid="validation-review-reminders"
+        >
+          {VALIDATION_REVIEW_REMINDERS.map((reminder) => (
+            <li key={reminder}>{reminder}</li>
+          ))}
+        </ul>
       </header>
 
       {isPreviewResultStale && previewResult && (

--- a/frontend-v2/src/features/system-detail/simulation-preview/validation/validationLabels.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/validation/validationLabels.ts
@@ -39,6 +39,11 @@ export const EMPTY_COMPARISONS_COPY =
 export const REVIEW_ADVISORY_COPY =
   'Review guidance is advisory. This does not change mechanics or scoring. Use this to decide what to investigate next.';
 
+export const VALIDATION_REVIEW_REMINDERS = [
+  'Preview assumes current plan; confirm in game.',
+  'Architect primary-port flag has not been recorded as a dedicated validation field; check System Map -> Architect Mode before final major station placement.',
+] as const;
+
 export const PREDICTED_ONLY_COPY =
   'Predicted, but no matching observation has been recorded yet.';
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/validation/validationReviewCategoryUtils.test.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/validation/validationReviewCategoryUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  validationMismatchCategory,
+  validationMismatchCategoryCopy,
+} from './validationReviewCategoryUtils';
+
+describe('validationReviewCategoryUtils', () => {
+  it.each([
+    ['confirmed', 'matches_plan', 'Matches plan'],
+    ['contradicted', 'differs_from_plan', 'Differs from plan'],
+    ['predicted_only', 'missing_observation', 'Missing observation'],
+    ['unknown', 'unknown_not_checked', 'Unknown / not checked'],
+    ['observed_only', 'needs_manual_review', 'Needs manual review'],
+    ['unverified', 'needs_manual_review', 'Needs manual review'],
+    ['future_status', 'needs_manual_review', 'Needs manual review'],
+  ])('maps %s into the Stage 14B review category', (status, category, label) => {
+    const mapped = validationMismatchCategory({ status });
+    expect(mapped).toBe(category);
+    expect(validationMismatchCategoryCopy(mapped).label).toBe(label);
+  });
+
+  it('uses explicit mismatch copy for differs-from-plan rows', () => {
+    const category = validationMismatchCategory({ status: 'contradicted' });
+    expect(validationMismatchCategoryCopy(category).description).toBe(
+      'Observed value differs from preview.',
+    );
+  });
+});

--- a/frontend-v2/src/features/system-detail/simulation-preview/validation/validationReviewCategoryUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/validation/validationReviewCategoryUtils.ts
@@ -1,0 +1,87 @@
+import type { PredictionObservationComparison } from '@/types/api';
+
+export type ValidationMismatchCategory =
+  | 'matches_plan'
+  | 'differs_from_plan'
+  | 'missing_observation'
+  | 'unknown_not_checked'
+  | 'needs_manual_review';
+
+interface ValidationMismatchCategoryCopy {
+  label: string;
+  description: string;
+  tone: 'confirmed' | 'warning' | 'missing' | 'unknown' | 'review';
+}
+
+const CATEGORY_COPY: Record<ValidationMismatchCategory, ValidationMismatchCategoryCopy> = {
+  matches_plan: {
+    label: 'Matches plan',
+    description: 'Observed evidence matches the Preview Result for this row.',
+    tone: 'confirmed',
+  },
+  differs_from_plan: {
+    label: 'Differs from plan',
+    description: 'Observed value differs from preview.',
+    tone: 'warning',
+  },
+  missing_observation: {
+    label: 'Missing observation',
+    description: 'Preview expects this value, but no matching observation has been recorded.',
+    tone: 'missing',
+  },
+  unknown_not_checked: {
+    label: 'Unknown / not checked',
+    description: 'Validation cannot compare this row yet; confirm it in-game when it matters.',
+    tone: 'unknown',
+  },
+  needs_manual_review: {
+    label: 'Needs manual review',
+    description: 'Evidence and preview do not line up cleanly enough for automatic review.',
+    tone: 'review',
+  },
+};
+
+export function validationMismatchCategory(
+  comparison: Pick<PredictionObservationComparison, 'status'>,
+): ValidationMismatchCategory {
+  switch (comparison.status) {
+    case 'confirmed':
+      return 'matches_plan';
+    case 'contradicted':
+      return 'differs_from_plan';
+    case 'predicted_only':
+      return 'missing_observation';
+    case 'unknown':
+      return 'unknown_not_checked';
+    case 'observed_only':
+    case 'unverified':
+      return 'needs_manual_review';
+    default:
+      return 'needs_manual_review';
+  }
+}
+
+export function validationMismatchCategoryCopy(
+  category: ValidationMismatchCategory,
+): ValidationMismatchCategoryCopy {
+  return CATEGORY_COPY[category];
+}
+
+export function validationMismatchCategoryClassName(
+  category: ValidationMismatchCategory,
+): string {
+  const tone = CATEGORY_COPY[category].tone;
+  if (tone === 'confirmed') {
+    return 'border-green/30 bg-green/10 text-green';
+  }
+  if (tone === 'warning') {
+    return 'border-orange/35 bg-orange/10 text-orange';
+  }
+  if (tone === 'missing') {
+    return 'border-cyan/30 bg-cyan/10 text-cyan';
+  }
+  if (tone === 'unknown') {
+    return 'border-border bg-bg3 text-silver-dk';
+  }
+  return 'border-orange/25 bg-bg3/60 text-silver';
+}


### PR DESCRIPTION
## Summary
- Add frontend-only validation review categories for matches, differences, missing observations, unknown/not-checked rows, and manual-review rows.
- Add compact Validation reminders for current-preview assumptions and read-only Architect primary-port checks.
- Update Validation tests and roadmap/architecture docs for the Stage 14B scope and safety boundaries.

## Safety
- No backend compare/review mechanics, scoring, optimiser, CP/economy/service logic, persistence, imports, or planner mutation changed.
- No primary-port editing or Architect slot storage added.
- Validation remains explicit and passive; no auto-preview, auto-generation, polling, or silent mutation.

## Checks
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `git diff --check`
- `cd frontend-v2 && npm test` attempted locally but Windows access denied while loading `vite.config.ts`; GitHub CI is the full test gate.