### PR TITLE
Stage 15E: topology-aware planner coordination

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1127,3 +1127,31 @@ Deferred to Stage 15E:
 
 - Move editing toward selected body/slot context while preserving explicit Apply/Preview behavior.
 - Keep saved projects, Suggested Builds quality gates, and drawer-mode Evidence/Validation for later scoped stages.
+
+### Stage 15E - Topology-Aware Planner Coordination
+
+Stage 15E keeps topology selection read-only while allowing it to coordinate with the central Build Plan editor.
+
+Current Stage 15E status:
+
+- The workspace passes the selected topology body or placement into the existing central planner through a narrow prop chain.
+- Selecting a body in the topology rail updates a compact `Currently viewing` context in Build Plan and highlights matching placement rows in List view.
+- Selecting a placement in the topology rail highlights and focuses the corresponding placement editor row in List view.
+- The central planner exposes an explicit `Add to selected body` action when a known topology body is selected. It reuses the existing placement-add path and assigns only the selected body id.
+- Structure picker context can evaluate an unassigned placement against the selected topology body without mutating the placement.
+
+Safety boundaries in Stage 15E:
+
+- Rail clicks do not mutate the Build Plan, run Preview, generate Suggested Builds, import layout, save state, mutate Observed Evidence, or run Validation.
+- Editing remains in the central planner. No drag/drop, slot editing, topology-local editor, primary-port truth editing, persistence, backend mechanics, scoring, CP formulas, economy logic, optimiser behavior, or validation/evidence semantics changed.
+
+Test coverage added/updated in Stage 15E:
+
+- Workspace tests cover selection propagation from topology rail to the planner adapter.
+- Build Plan tests cover selected-body context, explicit add-to-selected-body behavior, placement-row highlighting/focus targeting, and no mutation from selection alone.
+
+Deferred after Stage 15E:
+
+- Stage 15F should improve Suggested Builds quality and workspace loading.
+- Stage 15G should add saved Colony Project persistence.
+- Stage 15H should move Evidence and Validation into drawers/modes.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -516,3 +516,11 @@ Stage 15D implementation note:
 - `SimulationPreviewPanel` and `SimulationPreview` now accept an optional `onPlanSnapshotChange` callback. This is a narrow read-only bridge from the existing central planner state back to the workspace shell; it does not move editing ownership out of `simulation-preview/`.
 - `ColonyPlannerWorkspace` owns only local read-only selection state for topology navigation. Selection updates the rail highlight and right summary context, but never mutates placements, never runs Preview, never generates Suggested Builds, never imports layout, and never touches Observed Evidence or Validation.
 - Stage 15E should build on this by moving add/replace/move interactions toward selected body/slot context. Stage 15D deliberately leaves all editing inside the central planner content.
+
+Stage 15E implementation note:
+
+- `ColonyPlannerWorkspace` now passes topology selection into `SimulationPreviewPanel` as coordination context. This remains local workspace UI state, not persisted project state.
+- `SimulationPreviewPanel`, `SimulationPreview`, and `BuildPlanSection` forward that context to the central Build Plan editor through narrow optional props.
+- `BuildPlanSection` renders compact `Currently viewing` context for selected topology bodies/placements and adds an explicit `Add to selected body` control when the selected body exists in the loaded body list.
+- `BuildPlanEditor` highlights placement rows related to the selected topology body and focuses/highlights a selected topology placement. Structure picker receives selected topology body context for unassigned rows so warnings can be evaluated without changing the placement.
+- The ownership line remains unchanged: topology rail selection is navigation/context only, while placement mutation still happens through central planner buttons/selects and the existing placement editor hook.

--- a/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
+++ b/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
@@ -1125,3 +1125,26 @@ No implementation changes should be made in Stage 15A.
 3. Should the planner route expose project IDs in the hash immediately, or keep project selection local until saved projects are proven?
 4. Should Suggested Builds quality gates live in the backend response, frontend display layer, or both?
 5. Should Architect observation capture be a subtype of Observed Evidence first, or a separate project survey record first?
+
+## Stage 15E Implementation Note
+
+Stage 15E implemented topology-aware coordination without moving editing into the rail.
+
+Delivered:
+
+- Topology selection is passed from the workspace into the existing central planner as optional context.
+- Body selection shows a compact `Currently viewing` context in Build Plan and highlights matching placement rows in List view.
+- Placement selection highlights and focuses the matching placement editor row in List view.
+- The central planner can explicitly add a new placement to the selected topology body through the existing placement-add path.
+- Structure picker can evaluate an unassigned placement against the selected topology body context without changing the placement assignment.
+
+Safety boundaries preserved:
+
+- Rail clicks remain non-mutating.
+- No drag/drop, slot editing, topology-local placement editor, auto-preview, auto-generation, auto-import, auto-validation, persistence, backend mechanics, scoring, CP/economy/buildability/service logic, observed-evidence semantics, validation behavior, optimiser behavior, or primary-port truth handling changed.
+
+Deferred:
+
+- Suggested Builds quality/load workflow remains Stage 15F.
+- Saved Colony Project persistence remains Stage 15G.
+- Evidence/Validation drawers remain Stage 15H.

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -206,11 +206,18 @@ describe('ColonyPlannerWorkspace', () => {
         system,
         selectedPlan: null,
         onPlanSnapshotChange: expect.any(Function),
+        topologySelection: { type: 'system' },
       }),
       undefined,
     );
 
     fireEvent.click(screen.getByText('Workspace System A 1'));
+    expect(mockedSimulationPreviewPanel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        topologySelection: { type: 'body', bodyId: 'body1' },
+      }),
+      undefined,
+    );
     expect(screen.getByText('Read-only topology selection')).toBeTruthy();
     expect(screen.getByText(/Build Plan editing stays in the central planner/i)).toBeTruthy();
 

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -290,6 +290,7 @@ function WorkspaceGrid({ system }: { system: SystemDetail }) {
           system={system}
           selectedPlan={null}
           onPlanSnapshotChange={handlePlanSnapshotChange}
+          topologySelection={selection}
         />
       </main>
       <SummaryPanel

--- a/frontend-v2/src/features/system-detail/SimulationPreviewPanel.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreviewPanel.tsx
@@ -1,15 +1,17 @@
 import type { RecommendedBuildPlan, SystemDetail } from '@/types/api';
 import { SimulationPreview } from './SimulationPreview';
-import type { TopologyPlanSnapshot } from '@/features/colony-planner/ColonyTopologyRail';
+import type { TopologyPlanSnapshot, TopologySelection } from '@/features/colony-planner/ColonyTopologyRail';
 
 export function SimulationPreviewPanel({
   system,
   selectedPlan,
   onPlanSnapshotChange,
+  topologySelection,
 }: {
   system: SystemDetail;
   selectedPlan: RecommendedBuildPlan | null;
   onPlanSnapshotChange?: (snapshot: TopologyPlanSnapshot) => void;
+  topologySelection?: TopologySelection;
 }) {
   return (
     <SimulationPreview
@@ -18,6 +20,7 @@ export function SimulationPreviewPanel({
       initialPlanLabel={selectedPlan?.label ?? null}
       initialAssumptions={selectedPlan?.assumptions ?? []}
       onPlanSnapshotChange={onPlanSnapshotChange}
+      topologySelection={topologySelection}
     />
   );
 }

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.test.tsx
@@ -139,4 +139,48 @@ describe('BuildPlanEditor structure replacement review', () => {
     fireEvent.click(screen.getByRole('button', { name: /Cancel replacement/i }));
     expect(onUpdate).not.toHaveBeenCalled();
   });
+
+  it('highlights placements related to the selected topology body without mutating the plan', () => {
+    const onUpdate = vi.fn();
+    render(
+      <BuildPlanEditor
+        placements={[
+          { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
+          { facility_template_id: 'surface_outpost', local_body_id: null, is_primary_port: false, build_order: 2 },
+        ]}
+        templates={templates}
+        bodies={bodies}
+        topologySelection={{ type: 'body', bodyId: '1' }}
+        onUpdate={onUpdate}
+        onRemove={vi.fn()}
+        onMove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('build-plan-placement-0').getAttribute('data-topology-highlight')).toBe('body');
+    expect(screen.getByTestId('build-plan-placement-1').getAttribute('data-topology-highlight')).toBe('none');
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('highlights the selected topology placement and keeps editing in the central planner', () => {
+    const onUpdate = vi.fn();
+    render(
+      <BuildPlanEditor
+        placements={[
+          { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: true, build_order: 1 },
+          { facility_template_id: 'surface_outpost', local_body_id: null, is_primary_port: false, build_order: 2 },
+        ]}
+        templates={templates}
+        bodies={bodies}
+        topologySelection={{ type: 'placement', placementIndex: 1 }}
+        onUpdate={onUpdate}
+        onRemove={vi.fn()}
+        onMove={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('build-plan-placement-1').getAttribute('data-topology-highlight')).toBe('placement');
+    expect(screen.getByText('Topology selected')).toBeTruthy();
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
 });

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanEditor.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ArrowDown, ArrowUp, Trash2 } from 'lucide-react';
 import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import type { TopologySelection } from '@/features/colony-planner/ColonyTopologyRail';
 import { ArchitectObservationPanel } from './ArchitectObservationPanel';
 import { Chip, IconButton } from './components';
 import { PlannerGuidanceList } from './PlannerGuidanceList';
@@ -17,6 +18,7 @@ export function BuildPlanEditor({
   onUpdate,
   onRemove,
   onMove,
+  topologySelection,
 }: {
   placements: SimulateBuildPlacement[];
   templates: FacilityTemplate[];
@@ -24,9 +26,21 @@ export function BuildPlanEditor({
   onUpdate: (index: number, patch: Partial<SimulateBuildPlacement>) => void;
   onRemove: (index: number) => void;
   onMove: (index: number, direction: -1 | 1) => void;
+  topologySelection?: TopologySelection;
 }) {
   const [pickerIndex, setPickerIndex] = useState<number | null>(null);
   const [pendingReplacement, setPendingReplacement] = useState<{ index: number; templateId: string } | null>(null);
+  const rowRefs = useRef(new Map<number, HTMLDivElement>());
+  const selectedBodyId = topologySelection?.type === 'body' ? topologySelection.bodyId : null;
+  const selectedPlacementIndex = topologySelection?.type === 'placement' ? topologySelection.placementIndex : null;
+
+  useEffect(() => {
+    if (selectedPlacementIndex == null) return;
+    const node = rowRefs.current.get(selectedPlacementIndex);
+    if (!node) return;
+    node.scrollIntoView?.({ behavior: 'smooth', block: 'center' });
+    node.focus({ preventScroll: true });
+  }, [selectedPlacementIndex]);
 
   return (
     <div className="space-y-2">
@@ -38,6 +52,9 @@ export function BuildPlanEditor({
           ? templates.find((item) => item.id === pendingReplacement.templateId)
           : undefined;
         const bodyContext = resolveBodyContext(bodies, placement.local_body_id ?? null);
+        const selectedByTopology = selectedPlacementIndex === index;
+        const relatedToSelectedBody = Boolean(selectedBodyId && String(placement.local_body_id ?? '') === selectedBodyId);
+        const pickerBodyContextId = placement.local_body_id ?? selectedBodyId ?? null;
         const guidance = buildPlannerGuidanceForPlacement({
           placement,
           template,
@@ -46,12 +63,41 @@ export function BuildPlanEditor({
           warnings: template ? getStructurePickerWarnings(template, bodyContext) : [],
         });
         return (
-          <div key={`${placement.build_order}-${index}`} className="rounded-chunk-lg border border-border/70 bg-bg2/70 p-3">
+          <div
+            key={`${placement.build_order}-${index}`}
+            ref={(node) => {
+              if (node) rowRefs.current.set(index, node);
+              else rowRefs.current.delete(index);
+            }}
+            tabIndex={selectedByTopology ? -1 : undefined}
+            data-testid={`build-plan-placement-${index}`}
+            data-topology-highlight={selectedByTopology ? 'placement' : relatedToSelectedBody ? 'body' : 'none'}
+            className={[
+              'rounded-chunk-lg border p-3 outline-none transition-[border-color,box-shadow,background-color]',
+              selectedByTopology
+                ? 'border-orange/70 bg-orange/10 shadow-[0_0_18px_rgba(255,125,32,0.16)]'
+                : relatedToSelectedBody
+                  ? 'border-cyan/55 bg-cyan/5'
+                  : 'border-border/70 bg-bg2/70',
+            ].join(' ')}
+          >
             <div className="mb-2 flex items-center justify-between gap-2">
               <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">Placement</span>
-              <span className="rounded border border-border/60 bg-bg3/45 px-2 py-0.5 font-mono text-[10px] text-silver-dk">
-                List view editor
-              </span>
+              <div className="flex flex-wrap justify-end gap-1.5">
+                {selectedByTopology && (
+                  <span className="rounded border border-orange/50 bg-orange/10 px-2 py-0.5 font-mono text-[10px] text-orange">
+                    Topology selected
+                  </span>
+                )}
+                {relatedToSelectedBody && !selectedByTopology && (
+                  <span className="rounded border border-cyan/45 bg-cyan/10 px-2 py-0.5 font-mono text-[10px] text-cyan">
+                    Selected body
+                  </span>
+                )}
+                <span className="rounded border border-border/60 bg-bg3/45 px-2 py-0.5 font-mono text-[10px] text-silver-dk">
+                  List view editor
+                </span>
+              </div>
             </div>
             <div className="flex items-center gap-2">
               <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full border border-orange/40 bg-orange/10 text-[11px] font-mono font-bold text-orange">
@@ -156,7 +202,8 @@ export function BuildPlanEditor({
                 <StructurePickerTable
                   templates={templates}
                   bodies={bodies}
-                  selectedBodyId={placement.local_body_id ?? null}
+                  selectedBodyId={pickerBodyContextId}
+                  topologyBodyId={selectedBodyId}
                   selectedTemplateId={placement.facility_template_id}
                   proposedTemplateId={pendingReplacement?.index === index ? pendingReplacement.templateId : null}
                   onSelectTemplate={(templateId) => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanSection.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanSection.test.tsx
@@ -199,4 +199,48 @@ describe('BuildPlanSection layout import state', () => {
     expect(await screen.findByText(/Status/)).toBeTruthy();
     expect(await screen.findByText('success')).toBeTruthy();
   });
+
+  it('shows selected topology body context and adds placement only through explicit action', () => {
+    const onAddPlacement = vi.fn();
+
+    render(
+      <BuildPlanSection
+        systemId64={123}
+        systemName="Test System"
+        startMode={'blank_advanced' as StartMode}
+        hasRecommendedBuild={false}
+        loadingRecommended={false}
+        targetArchetype="refinery_industrial"
+        onTargetArchetypeChange={vi.fn()}
+        placements={[{ facility_template_id: 'generic_port_alpha', local_body_id: '1', is_primary_port: false, build_order: 1 }]}
+        templates={[templateMinimal]}
+        bodies={bodies}
+        templatesLoading={false}
+        templatesErrorMessage={null}
+        optimiserCandidateOriginLabel={null}
+        optimiserCandidateWasEdited={false}
+        initialAssumptions={[]}
+        previewResult={previewResult}
+        isPreviewResultStale={false}
+        runningPreview={false}
+        onUseRecommended={vi.fn()}
+        onBlank={vi.fn()}
+        onShowSuggestedBuilds={vi.fn()}
+        onAddPlacement={onAddPlacement}
+        onUpdatePlacement={vi.fn()}
+        onRemovePlacement={vi.fn()}
+        onMovePlacement={vi.fn()}
+        topologySelection={{ type: 'body', bodyId: '1' }}
+      />,
+    );
+
+    expect(screen.getByTestId('topology-planner-context')).toBeTruthy();
+    expect(screen.getByText(/Body 1 - 1 matching placement/)).toBeTruthy();
+    expect(onAddPlacement).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Add to selected body/i }));
+
+    expect(onAddPlacement).toHaveBeenCalledTimes(1);
+    expect(onAddPlacement).toHaveBeenCalledWith('1');
+  });
 });

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanSection.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanSection.tsx
@@ -7,6 +7,8 @@ import { BuildPlanEditor } from './BuildPlanEditor';
 import { ModeIntro, StartModes } from './StartModes';
 import { Message } from './components';
 import { ARCHETYPES, type StartMode } from './types';
+import type { TopologySelection } from '@/features/colony-planner/ColonyTopologyRail';
+import { bodyDisplayName } from './buildPlanLayoutUtils';
 
 type BuildPlanViewMode = 'list' | 'body';
 
@@ -36,6 +38,7 @@ export function BuildPlanSection({
   onUpdatePlacement,
   onRemovePlacement,
   onMovePlacement,
+  topologySelection,
 }: {
   systemId64: number;
   systemName: string;
@@ -58,10 +61,11 @@ export function BuildPlanSection({
   onUseRecommended: () => void;
   onBlank: () => void;
   onShowSuggestedBuilds?: () => void;
-  onAddPlacement: () => void;
+  onAddPlacement: (bodyId?: string | null) => void;
   onUpdatePlacement: (index: number, patch: Partial<SimulateBuildPlacement>) => void;
   onRemovePlacement: (index: number) => void;
   onMovePlacement: (index: number, direction: -1 | 1) => void;
+  topologySelection?: TopologySelection;
 }) {
   const [viewMode, setViewMode] = useState<BuildPlanViewMode>('list');
   const [layoutImportResult, setLayoutImportResult] = useState<LayoutImportResponse | null>(null);
@@ -74,6 +78,14 @@ export function BuildPlanSection({
   }, [systemId64]);
   const assignedUnknownBodyIds = getAssignedUnknownBodyIds(placements, bodies);
   const templateCatalogueEmpty = !templatesLoading && !templatesErrorMessage && templates.length === 0;
+  const selectedBodyId = topologySelection?.type === 'body' ? topologySelection.bodyId : null;
+  const selectedPlacementIndex = topologySelection?.type === 'placement' ? topologySelection.placementIndex : null;
+  const selectedBody = selectedBodyId
+    ? bodies.find((body) => body.id != null && String(body.id) === selectedBodyId) ?? null
+    : null;
+  const selectedBodyPlacementCount = selectedBodyId
+    ? placements.filter((placement) => String(placement.local_body_id ?? '') === selectedBodyId).length
+    : 0;
 
   const handleImportLayout = async () => {
     setLayoutImportRunning(true);
@@ -171,7 +183,7 @@ export function BuildPlanSection({
           </label>
           <button
             type="button"
-            onClick={onAddPlacement}
+            onClick={() => onAddPlacement()}
             disabled={templates.length === 0}
             className="self-end inline-flex items-center justify-center gap-2 rounded-chunk-sm border border-border bg-bg3 px-3 py-2 text-xs font-mono text-silver hover:border-orange/60 hover:text-orange disabled:opacity-45"
           >
@@ -179,6 +191,38 @@ export function BuildPlanSection({
             Add Facility
           </button>
         </div>
+        {selectedBodyId && (
+          <div
+            data-testid="topology-planner-context"
+            className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded border border-cyan/30 bg-cyan/5 px-3 py-2"
+          >
+            <div className="min-w-0">
+              <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">
+                Currently viewing
+              </div>
+              <p className="mt-0.5 truncate text-[11px] font-mono text-silver-dk">
+                {selectedBody ? bodyDisplayName(selectedBody) : 'Selected topology body'} - {selectedBodyPlacementCount} matching placement{selectedBodyPlacementCount === 1 ? '' : 's'}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onAddPlacement(selectedBodyId)}
+              disabled={templates.length === 0 || !selectedBody}
+              className="inline-flex items-center justify-center gap-2 rounded-chunk-sm border border-cyan/45 bg-cyan/10 px-3 py-2 text-xs font-mono text-cyan hover:bg-cyan/20 disabled:opacity-45"
+            >
+              <Plus size={14} />
+              Add to selected body
+            </button>
+          </div>
+        )}
+        {selectedPlacementIndex != null && (
+          <div
+            data-testid="topology-placement-context"
+            className="mt-3 rounded border border-orange/30 bg-orange/5 px-3 py-2 font-mono text-[11px] text-silver-dk"
+          >
+            Currently viewing placement {selectedPlacementIndex + 1}. The matching editor row is highlighted in List view.
+          </div>
+        )}
       </div>
 
       {templatesLoading && (
@@ -261,6 +305,7 @@ export function BuildPlanSection({
               placements={placements}
               templates={templates}
               bodies={bodies}
+              topologySelection={topologySelection}
               onUpdate={onUpdatePlacement}
               onRemove={onRemovePlacement}
               onMove={onMovePlacement}

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -8,7 +8,7 @@ import type {
   SimulationSummary,
   SystemDetail,
 } from '@/types/api';
-import type { TopologyPlanSnapshot } from '@/features/colony-planner/ColonyTopologyRail';
+import type { TopologyPlanSnapshot, TopologySelection } from '@/features/colony-planner/ColonyTopologyRail';
 import { BuildPlanSection } from './BuildPlanSection';
 import { ColonyPlannerHeader } from './ColonyPlannerHeader';
 import { ColonyPlannerSectionNav } from './ColonyPlannerSectionNav';
@@ -30,12 +30,14 @@ export function SimulationPreview({
   initialPlanLabel,
   initialAssumptions = [],
   onPlanSnapshotChange,
+  topologySelection,
 }: {
   system: SystemDetail;
   initialRequest?: SimulateBuildRequest | null;
   initialPlanLabel?: string | null;
   initialAssumptions?: string[];
   onPlanSnapshotChange?: (snapshot: TopologyPlanSnapshot) => void;
+  topologySelection?: TopologySelection;
 }) {
   const templatesQuery = useQuery<FacilityTemplate[], Error>({
     queryKey: ['facility-templates'],
@@ -160,6 +162,7 @@ export function SimulationPreview({
           onUpdatePlacement={plan.updatePlacement}
           onRemovePlacement={plan.removePlacement}
           onMovePlacement={plan.movePlacement}
+          topologySelection={topologySelection}
         />
 
         <div

--- a/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
@@ -20,6 +20,7 @@ export function StructurePickerTable({
   templates,
   bodies,
   selectedBodyId,
+  topologyBodyId,
   selectedTemplateId,
   proposedTemplateId,
   onSelectTemplate,
@@ -27,6 +28,7 @@ export function StructurePickerTable({
   templates: FacilityTemplate[];
   bodies: SystemBody[];
   selectedBodyId?: string | null;
+  topologyBodyId?: string | null;
   selectedTemplateId?: string | null;
   proposedTemplateId?: string | null;
   onSelectTemplate: (templateId: string) => void;
@@ -73,6 +75,9 @@ export function StructurePickerTable({
             : bodyContext.status === 'unknown'
               ? `Unknown body: ${bodyContext.bodyId}`
               : 'No body selected yet'}
+          {topologyBodyId && topologyBodyId === selectedBodyId && (
+            <span className="ml-2 text-cyan">Topology context</span>
+          )}
         </div>
       </div>
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/hooks/usePlacementEditor.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/hooks/usePlacementEditor.ts
@@ -16,7 +16,7 @@ export interface UsePlacementEditorResult {
   setPlacements: Dispatch<SetStateAction<SimulateBuildPlacement[]>>;
   replacePlacements: (nextPlacements: SimulateBuildPlacement[]) => void;
   clearPlacements: () => void;
-  addPlacement: () => void;
+  addPlacement: (bodyId?: string | null) => void;
   updatePlacement: (index: number, patch: Partial<SimulateBuildPlacement>) => void;
   removePlacement: (index: number) => void;
   movePlacement: (index: number, direction: -1 | 1) => void;
@@ -39,7 +39,7 @@ export function usePlacementEditor({
     setPlacements([]);
   };
 
-  const addPlacement = () => {
+  const addPlacement = (bodyId?: string | null) => {
     const firstTemplate = preferredTemplate(templates);
     if (!firstTemplate) return;
     onManualEdit();
@@ -50,7 +50,7 @@ export function usePlacementEditor({
       ...current,
       {
         facility_template_id: firstTemplate.id,
-        local_body_id: bodies[0]?.id != null ? String(bodies[0].id) : null,
+        local_body_id: bodyId ?? (bodies[0]?.id != null ? String(bodies[0].id) : null),
         is_primary_port: current.length === 0 && firstTemplate.is_port,
         build_order: current.length + 1,
       },

--- a/frontend-v2/src/features/system-detail/simulation-preview/hooks/useSimulationPreviewPlan.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/hooks/useSimulationPreviewPlan.ts
@@ -31,7 +31,7 @@ export interface UseSimulationPreviewPlanResult {
   loadRecommendedPlan: (mode: StartMode) => void;
   loadOptimiserCandidateIntoPreview: (candidate: OptimiserCandidate) => void;
   startBlankAdvanced: () => void;
-  addPlacement: () => void;
+  addPlacement: (bodyId?: string | null) => void;
   updatePlacement: (index: number, patch: Partial<SimulateBuildPlacement>) => void;
   removePlacement: (index: number) => void;
   movePlacement: (index: number, direction: -1 | 1) => void;


### PR DESCRIPTION
## Summary
- Pass topology selection into the central planner as read-only coordination context
- Highlight/focus matching Build Plan rows from topology body/placement selection
- Add explicit Add to selected body action using the existing placement add path
- Update Stage 15 documentation and roadmap

## Checks
- cd frontend-v2 && npm run typecheck
- cd frontend-v2 && npm run build
- cd frontend-v2 && npm test
- git diff --check