### PR TITLE
Stage 15F: suggested build quality gate and workspace loading

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1155,3 +1155,29 @@ Deferred after Stage 15E:
 - Stage 15F should improve Suggested Builds quality and workspace loading.
 - Stage 15G should add saved Colony Project persistence.
 - Stage 15H should move Evidence and Validation into drawers/modes.
+
+### Stage 15F - Suggested Builds Quality Gate + Workspace Loading
+
+Stage 15F makes Suggested Builds a workspace-first review surface without changing optimiser generation, ranking, scoring, or backend mechanics.
+
+Current Stage 15F status:
+
+- Suggested Build display now applies a frontend quality gate over the existing optimiser response. Trivial one-placement plans, Colony Ship-only plans, Colony Ship plus generic-station plans, duplicate near-identical placement sets, and candidates with no clear purpose are hidden from the visible list.
+- If generation returns only trivial/duplicate candidates, the workspace shows: `No useful suggested builds are available yet. Add more system data or start a manual Build Plan.`
+- Candidate cards/details now surface player-facing category, purpose, reason, tradeoff, and next action copy.
+- Raw optimiser tags such as `body_diversity` are translated into readable labels like `Uses multiple bodies`.
+- The explicit load action is now framed as `Load into Planner Workspace`; it still uses the existing candidate-to-Build-Plan path and still requires confirmation when replacing an existing plan or loading stale candidates.
+
+Safety boundaries in Stage 15F:
+
+- No optimiser backend scoring/ranking/generation, Simulation Preview scoring, CP/economy/buildability/service mechanics, Search Tuning, imports, persistence, Observed Evidence, Validation, or primary-port truth handling changed.
+- Suggested Builds still require explicit generation and explicit load. They do not auto-copy into the Build Plan, auto-run Preview, auto-save, auto-import, auto-generate on page load, mutate evidence, or run validation.
+
+Test coverage added/updated in Stage 15F:
+
+- Optimiser UI tests cover trivial build filtering, duplicate filtering, useful-build empty state, purpose/reason/tradeoff/action rendering, tag translation, explicit workspace loading, and existing no-auto-side-effect behavior.
+
+Deferred after Stage 15F:
+
+- Stage 15G should add saved Colony Project persistence.
+- Stage 15H should move Evidence and Validation into drawers/modes.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -524,3 +524,11 @@ Stage 15E implementation note:
 - `BuildPlanSection` renders compact `Currently viewing` context for selected topology bodies/placements and adds an explicit `Add to selected body` control when the selected body exists in the loaded body list.
 - `BuildPlanEditor` highlights placement rows related to the selected topology body and focuses/highlights a selected topology placement. Structure picker receives selected topology body context for unassigned rows so warnings can be evaluated without changing the placement.
 - The ownership line remains unchanged: topology rail selection is navigation/context only, while placement mutation still happens through central planner buttons/selects and the existing placement editor hook.
+
+Stage 15F implementation note:
+
+- `optimiserQualityUtils.ts` adds a frontend display gate for Suggested Builds. It filters trivial and duplicate candidates after the existing optimiser response is sorted for display, so backend generation/ranking remains unchanged.
+- `OptimiserCandidatePanel` renders the useful-build empty state when all returned candidates are filtered out.
+- `OptimiserCandidateCard` and `OptimiserCandidateDetails` now present a player-facing category, purpose, reason, tradeoff, and next action for each visible candidate.
+- Raw optimiser tags are translated before display. Internal tags remain available in the response/comparison data, but the UI avoids exposing raw labels like `body_diversity`.
+- Loading a suggested build remains an explicit workspace action through the existing candidate load path. It still does not run the main Preview, save, import, validate, or mutate observed evidence.

--- a/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
+++ b/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
@@ -1148,3 +1148,31 @@ Deferred:
 - Suggested Builds quality/load workflow remains Stage 15F.
 - Saved Colony Project persistence remains Stage 15G.
 - Evidence/Validation drawers remain Stage 15H.
+
+## Stage 15F Implementation Note
+
+Stage 15F implemented a frontend Suggested Builds quality gate and workspace loading copy.
+
+Delivered:
+
+- Trivial or unhelpful candidates are hidden from the visible Suggested Builds list:
+  - one-placement builds
+  - Colony Ship-only builds
+  - Colony Ship plus generic-station/outpost builds
+  - duplicate near-identical placement sets
+  - candidates with no clear role/purpose
+- If all returned candidates are filtered out, the workspace shows the useful-build empty state instead of presenting low-value cards.
+- Suggested Build cards/details now explain category, purpose, reason, tradeoff, and next action.
+- Raw tags are translated into player-facing labels.
+- The explicit load action is labelled `Load into Planner Workspace` and continues to use the existing candidate-to-Build-Plan path with replacement/stale confirmations.
+
+Safety boundaries preserved:
+
+- No optimiser backend scoring/ranking/generation changes.
+- No Simulation Preview scoring, CP/economy/buildability/service logic, Search Tuning, imports, persistence, Observed Evidence, Validation, primary-port truth handling, auto-preview, auto-generation, or auto-copy behavior changed.
+
+Deferred:
+
+- Saved Colony Project persistence remains Stage 15G.
+- Evidence/Validation drawers remain Stage 15H.
+- Broader Stage 15 QA/accessibility hardening remains Stage 15I.

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -369,7 +369,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     expect(screen.getAllByText(/Preview not run yet/).length).toBeGreaterThan(0);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
 
     await waitFor(() => expect(screen.getByText(/Copied suggested build:/)).toBeTruthy());
     expect(screen.getAllByText(/Balanced Agriculture candidate/).length).toBeGreaterThan(0);
@@ -569,7 +569,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
 
     fireEvent.click(screen.getByRole('button', { name: /Add Facility/i }));
@@ -583,7 +583,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
 
     fireEvent.click(screen.getByRole('button', { name: /Start blank/i }));
@@ -598,7 +598,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     const replaceButton = screen.queryByRole('button', { name: /Replace Build Plan/i });
     if (replaceButton) {
       fireEvent.click(replaceButton);
@@ -618,7 +618,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
     fireEvent.click(screen.getAllByRole('button', { name: /Move down/i })[0]);
     expect(mockedSimulateBuild).not.toHaveBeenCalled();
@@ -641,7 +641,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
     fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
     await screen.findByText(/Final Score/i);
@@ -666,7 +666,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
     fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
     await screen.findByText(/Final Score/i);
@@ -692,7 +692,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     expect(await screen.findByText(/Compare with current plan/i)).toBeTruthy();
     expect(screen.getByText(/advisory and preview-only/i)).toBeTruthy();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
     fireEvent.click(await screen.findByRole('button', { name: /Replace Build Plan/i }));
     await screen.findByText(/Copied suggested build:/);
     expect(mockedSimulateBuild).not.toHaveBeenCalled();
@@ -723,7 +723,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     renderPreview();
 
     fireEvent.click(await screen.findByTestId('generate-suggested-builds'));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
     fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
 
@@ -789,7 +789,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
 
     renderPreview();
     fireEvent.click(await screen.findByRole('button', { name: 'Generate Suggested Builds' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Load into Planner Workspace' }));
     await screen.findByText(/Copied suggested build:/);
     fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateCard.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateCard.tsx
@@ -1,5 +1,6 @@
 import type { OptimiserCandidate, RankedOptimiserCandidate } from '@/types/api';
 import { formatPercent, formatScore, rankTone, strategyLabel } from './optimiserUtils';
+import { suggestedBuildPresentation } from './optimiserQualityUtils';
 
 export function OptimiserCandidateCard({
   candidate,
@@ -14,6 +15,7 @@ export function OptimiserCandidateCard({
 }) {
   const summary = candidate.preview_summary;
   const warningCount = candidate.warnings.length + (summary?.warnings_count ?? 0);
+  const presentation = suggestedBuildPresentation(candidate);
   return (
     <button
       type="button"
@@ -39,6 +41,9 @@ export function OptimiserCandidateCard({
           <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
             {strategyLabel(candidate.strategy)}
           </div>
+          <div className="mt-1 font-mono text-[10px] text-cyan">
+            {presentation.category}
+          </div>
         </div>
         {ranking && (
           <div className="shrink-0 text-right">
@@ -60,9 +65,7 @@ export function OptimiserCandidateCard({
         {!summary && <span className="rounded border border-border bg-bg3 px-1.5 py-0.5 text-silver-dk">No preview summary</span>}
       </div>
 
-      {candidate.rationale[0] && (
-        <p className="mt-3 line-clamp-2 text-[11px] leading-snug text-silver-dk">{candidate.rationale[0]}</p>
-      )}
+      <p className="mt-3 line-clamp-2 text-[11px] leading-snug text-silver-dk">{presentation.purpose}</p>
     </button>
   );
 }

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateDetails.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateDetails.tsx
@@ -4,6 +4,7 @@ import { OptimiserPlacementList } from './OptimiserPlacementList';
 import { OptimiserRankingBreakdown } from './OptimiserRankingBreakdown';
 import { OptimiserComparisonPanel, compareBuildSources, sourceFromCurrentPreview, sourceFromOptimiserCandidate } from './comparison';
 import { formatScore, rankTone, strategyLabel } from './optimiserUtils';
+import { suggestedBuildPresentation } from './optimiserQualityUtils';
 
 export function OptimiserCandidateDetails({
   candidate,
@@ -55,6 +56,7 @@ export function OptimiserCandidateDetails({
 
   const rankingReasons = ranking?.rank_breakdown.reasons ?? [];
   const responseAssumptions = response?.assumptions ?? [];
+  const presentation = suggestedBuildPresentation(candidate);
 
   const requestLoad = () => {
     if (!onLoadCandidate) return;
@@ -98,13 +100,20 @@ export function OptimiserCandidateDetails({
 
       {candidate.tags.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
-          {candidate.tags.map((tag) => (
+          {presentation.tags.map((tag) => (
             <span key={tag} className="rounded border border-border/50 bg-bg3/30 px-1.5 py-0.5 font-mono text-[10px] text-silver-dk">
               {tag}
             </span>
           ))}
         </div>
       )}
+
+      <div className="grid gap-2 md:grid-cols-2">
+        <SummaryBox title="What this build is for" body={presentation.purpose} />
+        <SummaryBox title="Why suggested" body={presentation.reason} />
+        <SummaryBox title="Tradeoff" body={presentation.tradeoff} />
+        <SummaryBox title="Next action" body={presentation.nextAction} />
+      </div>
 
       <Section title="Rationale" items={candidate.rationale} empty="No rationale was returned for this suggested build." />
       <Section
@@ -144,9 +153,9 @@ export function OptimiserCandidateDetails({
 
       {onLoadCandidate && (
         <div className="rounded-chunk-lg border border-orange/30 bg-orange/8 p-3">
-          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">Copy to Build Plan</div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">Load into Planner Workspace</div>
           <p className="mt-1 text-[11px] text-silver-dk">
-            Copies this suggested build into the editable Build Plan. Nothing is committed in-game.
+            Loads this suggested build into the editable Build Plan for review. Nothing is committed in-game.
           </p>
           {controlsChangedSinceGeneration && (
             <p className="mt-2 text-[11px] text-gold">
@@ -165,7 +174,7 @@ export function OptimiserCandidateDetails({
               onClick={requestLoad}
               className="mt-3 rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-2 font-mono text-xs font-bold text-orange hover:bg-orange/25"
             >
-              Copy to Build Plan
+              Load into Planner Workspace
             </button>
           )}
         </div>
@@ -224,6 +233,15 @@ function LoadConfirmation({
           {confirmLabel}
         </button>
       </div>
+    </div>
+  );
+}
+
+function SummaryBox({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded border border-cyan/25 bg-cyan/5 px-3 py-2">
+      <h5 className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">{title}</h5>
+      <p className="mt-1 text-[11px] leading-snug text-silver-dk">{body}</p>
     </div>
   );
 }

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
@@ -8,6 +8,7 @@ import { OptimiserCandidatePanel } from './OptimiserCandidatePanel';
 import { OptimiserPlacementList } from './OptimiserPlacementList';
 import { OptimiserRankingBreakdown } from './OptimiserRankingBreakdown';
 import { candidatePlacementsToPreviewPlacements, sortCandidatesForDisplay } from './optimiserUtils';
+import { filterUsefulSuggestedBuilds, suggestedBuildPresentation } from './optimiserQualityUtils';
 
 vi.mock('@/lib/api', () => ({
   fetchOptimiserCandidates: vi.fn(),
@@ -91,7 +92,16 @@ function response(overrides: Partial<OptimiserCandidatesResponse> = {}): Optimis
     system_id64: 123,
     target_archetype: 'agriculture_terraforming',
     candidate_count: 2,
-    candidates: [candidate('candidate-a', 'Candidate A'), candidate('candidate-b', 'Candidate B')],
+    candidates: [
+      {
+        ...candidate('candidate-a', 'Candidate A'),
+        placements: [
+          { facility_template_id: 'generic_port_alpha', local_body_id: 'body1', is_primary_port: true, build_order: 1 },
+          { facility_template_id: 'agri_support_b', local_body_id: 'body2', is_primary_port: false, build_order: 2 },
+        ],
+      },
+      candidate('candidate-b', 'Candidate B'),
+    ],
     warnings: [],
     assumptions: ['Stage 5C is read-only.'],
     ranking,
@@ -132,6 +142,35 @@ describe('optimiser candidate comparison UI', () => {
     expect(sorted).not.toBe(original);
   });
 
+  it('filters trivial and duplicate suggested builds without mutating optimiser results', () => {
+    const useful = candidate('useful', 'Useful plan');
+    const duplicate = { ...candidate('duplicate', 'Duplicate plan'), placements: structuredClone(useful.placements) };
+    const portOnly = {
+      ...candidate('port-only', 'Port only'),
+      placements: [{ facility_template_id: 'generic_port_alpha', local_body_id: 'body1', is_primary_port: true, build_order: 1 }],
+    };
+    const original = [portOnly, useful, duplicate];
+    const before = structuredClone(original);
+
+    expect(filterUsefulSuggestedBuilds(original).map((item) => item.candidate_id)).toEqual(['useful']);
+    expect(original).toEqual(before);
+  });
+
+  it('translates raw optimiser tags into player-facing suggested build language', () => {
+    const presentation = suggestedBuildPresentation({
+      ...candidate('tagged', 'Tagged plan'),
+      tags: ['body_diversity', 'refinery'],
+    });
+
+    expect(presentation.tags).toContain('Uses multiple bodies');
+    expect(presentation.tags).toContain('Refinery pressure');
+    expect(presentation.tags).not.toContain('body_diversity');
+    expect(presentation.purpose).toBeTruthy();
+    expect(presentation.reason).toBeTruthy();
+    expect(presentation.tradeoff).toBeTruthy();
+    expect(presentation.nextAction).toMatch(/Review in Workspace/i);
+  });
+
   it('renders selected suggested build comparison against current Build Plan and supports hide/show', () => {
     const load = vi.fn();
     const currentPlacements: SimulateBuildPlacement[] = [
@@ -151,6 +190,10 @@ describe('optimiser candidate comparison UI', () => {
     );
 
     expect(screen.getByText('Compare with current plan')).toBeTruthy();
+    expect(screen.getByText('What this build is for')).toBeTruthy();
+    expect(screen.getByText('Why suggested')).toBeTruthy();
+    expect(screen.getByText('Tradeoff')).toBeTruthy();
+    expect(screen.getByText('Next action')).toBeTruthy();
     expect(screen.getByText(/advisory and preview-only/i)).toBeTruthy();
     expect(screen.getAllByText('Prefer before').length).toBeGreaterThan(0);
     expect(screen.getByText('Tradeoff summary')).toBeTruthy();
@@ -241,7 +284,7 @@ describe('optimiser candidate comparison UI', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Copy to Build Plan' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Load into Planner Workspace' })).toBeTruthy();
     expect(screen.getByText(/Nothing is committed in-game/)).toBeTruthy();
     expect(screen.getByText(/does not run Simulation Preview, save a build, or commit anything in-game/)).toBeTruthy();
     expect(container.textContent).not.toMatch(/\bApply candidate\b/i);
@@ -285,18 +328,18 @@ describe('optimiser candidate comparison UI', () => {
     expect(screen.getByText('No preview summary')).toBeTruthy();
   });
 
-  it('does not render Copy to Build Plan when no load callback is provided', () => {
+  it('does not render Load into Planner Workspace when no load callback is provided', () => {
     render(<OptimiserCandidateDetails candidate={candidate('candidate-a', 'Candidate A')} />);
-    expect(screen.queryByRole('button', { name: 'Copy to Build Plan' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Load into Planner Workspace' })).toBeNull();
   });
 
-  it('renders Copy to Build Plan with callback and loads immediately when no Build Plan exists', () => {
+  it('renders Load into Planner Workspace with callback and loads immediately when no Build Plan exists', () => {
     const onLoadCandidate = vi.fn();
     const selected = candidate('candidate-a', 'Candidate A');
     render(<OptimiserCandidateDetails candidate={selected} onLoadCandidate={onLoadCandidate} />);
 
     expect(screen.getByText(/Nothing is committed in-game/)).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
 
     expect(onLoadCandidate).toHaveBeenCalledTimes(1);
     expect(onLoadCandidate).toHaveBeenCalledWith(selected);
@@ -313,7 +356,7 @@ describe('optimiser candidate comparison UI', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
     expect(screen.getByText('Replace current Build Plan with this suggested build?')).toBeTruthy();
     expect(screen.getByText(/This will replace your current Build Plan with this suggested build/)).toBeTruthy();
     expect(onLoadCandidate).not.toHaveBeenCalled();
@@ -322,7 +365,7 @@ describe('optimiser candidate comparison UI', () => {
     expect(screen.queryByText('Replace current Build Plan with this suggested build?')).toBeNull();
     expect(onLoadCandidate).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
     fireEvent.click(screen.getByRole('button', { name: 'Replace Build Plan' }));
     expect(onLoadCandidate).toHaveBeenCalledTimes(1);
     expect(onLoadCandidate).toHaveBeenCalledWith(selected);
@@ -342,7 +385,7 @@ describe('optimiser candidate comparison UI', () => {
     );
 
     expect(screen.getAllByText(/Copying is still possible, but requires confirmation/).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
     expect(onLoadCandidate).not.toHaveBeenCalled();
     expect(screen.getByText('These suggested builds were generated with older controls')).toBeTruthy();
     expect(screen.getByText(/Generate again for the safest comparison/)).toBeTruthy();
@@ -366,7 +409,7 @@ describe('optimiser candidate comparison UI', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
     expect(onLoadCandidate).not.toHaveBeenCalled();
     expect(screen.getByText('Replace current Build Plan with older suggested build?')).toBeTruthy();
     expect(screen.getByText(/generated with older controls/)).toBeTruthy();
@@ -376,7 +419,7 @@ describe('optimiser candidate comparison UI', () => {
     expect(onLoadCandidate).not.toHaveBeenCalled();
     expect(screen.queryByText('Replace current Build Plan with older suggested build?')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy to Build Plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
     fireEvent.click(screen.getByRole('button', { name: 'Replace with older suggested build' }));
     expect(onLoadCandidate).toHaveBeenCalledTimes(1);
     expect(onLoadCandidate).toHaveBeenCalledWith(selected);
@@ -432,7 +475,7 @@ describe('optimiser candidate comparison UI', () => {
     expect(screen.getByText(/confidence and warnings should be reviewed/i)).toBeTruthy();
     expect(screen.getByText(/Read-only for now/i)).toBeTruthy();
     expect(screen.getByText('Generate Suggested Builds')).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /Copy to Build Plan/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Load into Planner Workspace/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /apply/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /use this build/i })).toBeNull();
     expect(screen.queryByText('Optimiser Candidates')).toBeNull();
@@ -446,7 +489,7 @@ describe('optimiser candidate comparison UI', () => {
         onLoadCandidate={() => undefined}
       />,
     );
-    expect(screen.getByText(/use it as the editable Build Plan/i)).toBeTruthy();
+    expect(screen.getByText(/review it as the editable Build Plan/i)).toBeTruthy();
     expect(screen.getByText(/Nothing is saved or committed in-game/i)).toBeTruthy();
     expect(screen.queryByText(/Read-only for now/i)).toBeNull();
   });
@@ -541,6 +584,23 @@ describe('optimiser candidate comparison UI', () => {
     expect(await screen.findByText('No Suggested Builds generated yet.')).toBeTruthy();
     expect(screen.getByText('Warning: No candidate anchors found.')).toBeTruthy();
     expect(screen.getByText('Assumption: Generated no plans.')).toBeTruthy();
+  });
+
+  it('replaces trivial generated builds with the useful-build empty state', async () => {
+    mockedFetchOptimiserCandidates.mockResolvedValue(response({
+      candidate_count: 1,
+      candidates: [{
+        ...candidate('port-only', 'Port only'),
+        placements: [{ facility_template_id: 'generic_port_alpha', local_body_id: 'body1', is_primary_port: true, build_order: 1 }],
+      }],
+      ranking: null,
+    }));
+
+    render(<OptimiserCandidatePanel systemId64={123} targetArchetype="agriculture_terraforming" />);
+    fireEvent.click(screen.getByText('Generate Suggested Builds'));
+
+    expect(await screen.findByText('No useful suggested builds are available yet. Add more system data or start a manual Build Plan.')).toBeTruthy();
+    expect(screen.queryByText('Port only')).toBeNull();
   });
 
   it('displays ranked candidates in ranking order and details for the selected candidate', async () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx
@@ -6,6 +6,7 @@ import { OptimiserCandidateDetails } from './OptimiserCandidateDetails';
 import { OptimiserEmptyState } from './OptimiserEmptyState';
 import { OptimiserErrorState } from './OptimiserErrorState';
 import { buildRankLookup, sortCandidatesForDisplay } from './optimiserUtils';
+import { filterUsefulSuggestedBuilds } from './optimiserQualityUtils';
 
 type GeneratedCandidateParams = {
   targetArchetype: string;
@@ -40,7 +41,7 @@ export function OptimiserCandidatePanel({
 
   const rankLookup = useMemo(() => buildRankLookup(response?.ranking), [response]);
   const candidates = useMemo(
-    () => sortCandidatesForDisplay(response?.candidates ?? [], response?.ranking),
+    () => filterUsefulSuggestedBuilds(sortCandidatesForDisplay(response?.candidates ?? [], response?.ranking)),
     [response],
   );
   const selectedCandidate = candidates.find((candidate) => candidate.candidate_id === selectedId) ?? candidates[0];
@@ -84,8 +85,8 @@ export function OptimiserCandidatePanel({
           </p>
           <p className="mt-1 text-[11px] text-silver-dk font-mono leading-snug">
             {onLoadCandidate
-              ? 'Copy a suggested build deliberately when you want to use it as the editable Build Plan.'
-              : 'Read-only for now - copying a suggested build comes in a later stage.'}
+              ? 'Load a useful suggested build deliberately when you want to review it as the editable Build Plan.'
+              : 'Read-only for now - workspace loading comes in a later stage.'}
           </p>
         </div>
       </div>
@@ -169,8 +170,13 @@ export function OptimiserCandidatePanel({
       {!loading && !error && response && response.candidates.length === 0 && (
         <OptimiserEmptyState warnings={response.warnings} assumptions={response.assumptions} />
       )}
+      {!loading && !error && response && response.candidates.length > 0 && candidates.length === 0 && (
+        <div className="rounded border border-border/60 bg-bg3/30 px-3 py-3 font-mono text-xs text-silver-dk">
+          No useful suggested builds are available yet. Add more system data or start a manual Build Plan.
+        </div>
+      )}
 
-      {!loading && !error && response && response.candidates.length > 0 && (
+      {!loading && !error && response && response.candidates.length > 0 && candidates.length > 0 && (
         <div className="grid gap-3 xl:grid-cols-[minmax(220px,0.85fr)_minmax(0,1.15fr)]">
           <div className="space-y-2">
             {candidates.map((candidate) => (

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/optimiserQualityUtils.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/optimiserQualityUtils.ts
@@ -1,0 +1,179 @@
+import type { OptimiserCandidate } from '@/types/api';
+import { strategyLabel } from './optimiserUtils';
+
+export interface SuggestedBuildPresentation {
+  category: string;
+  purpose: string;
+  reason: string;
+  tradeoff: string;
+  nextAction: string;
+  tags: string[];
+}
+
+const TAG_LABELS: Record<string, string> = {
+  balanced: 'Balanced spread',
+  body_diversity: 'Uses multiple bodies',
+  primary_port: 'Includes a port anchor',
+  main_station: 'Main station candidate',
+  industrial: 'Industrial pressure',
+  refinery: 'Refinery pressure',
+  extraction: 'Extraction support',
+  tourism: 'Tourism pressure',
+  agriculture: 'Agriculture pressure',
+  military: 'Security pressure',
+  security: 'Security pressure',
+  support_body: 'Support body coverage',
+};
+
+export function filterUsefulSuggestedBuilds(candidates: OptimiserCandidate[]): OptimiserCandidate[] {
+  const seen = new Set<string>();
+  const useful: OptimiserCandidate[] = [];
+
+  for (const candidate of candidates) {
+    if (isTrivialSuggestedBuild(candidate)) continue;
+    const signature = candidateSignature(candidate);
+    if (seen.has(signature)) continue;
+    seen.add(signature);
+    useful.push(candidate);
+  }
+
+  return useful;
+}
+
+export function isTrivialSuggestedBuild(candidate: OptimiserCandidate): boolean {
+  if (candidate.placements.length <= 1) return true;
+  if (isColonyShipOnly(candidate)) return true;
+  if (isColonyShipAndGenericStation(candidate)) return true;
+  return !hasClearSuggestedBuildPurpose(candidate);
+}
+
+export function suggestedBuildPresentation(candidate: OptimiserCandidate): SuggestedBuildPresentation {
+  const text = candidateText(candidate);
+  const category = suggestedBuildCategory(candidate);
+  const reason = candidate.rationale[0]
+    ?? `This ${strategyLabel(candidate.strategy).toLowerCase()} plan matches the current target better than a blank plan.`;
+  const warningCount = candidate.warnings.length + (candidate.preview_summary?.warnings_count ?? 0);
+  const tradeoff = warningCount > 0
+    ? `Review ${warningCount} warning${warningCount === 1 ? '' : 's'} before relying on this plan.`
+    : candidate.placements.length >= 5
+      ? 'Broader coverage means more placements to validate before committing materials.'
+      : 'Focused starter plan; it may need support bodies after more system data is available.';
+
+  return {
+    category,
+    purpose: purposeForCategory(category),
+    reason,
+    tradeoff,
+    nextAction: 'Review in Workspace, then load deliberately if it fits the current Build Plan.',
+    tags: translateSuggestedBuildTags(candidate.tags, text),
+  };
+}
+
+export function translateSuggestedBuildTags(tags: string[], text = ''): string[] {
+  const translated = tags
+    .map((tag) => TAG_LABELS[tag] ?? humanizeTag(tag))
+    .filter((tag) => tag.length > 0);
+  const unique = Array.from(new Set(translated));
+  if (unique.length > 0) return unique;
+  if (text.includes('agriculture')) return ['Agriculture pressure'];
+  if (text.includes('tourism')) return ['Tourism pressure'];
+  if (text.includes('industrial') || text.includes('refinery')) return ['Industrial pressure'];
+  if (text.includes('military') || text.includes('security')) return ['Security pressure'];
+  return ['Workspace candidate'];
+}
+
+function isColonyShipOnly(candidate: OptimiserCandidate) {
+  return candidate.placements.length > 0
+    && candidate.placements.every((placement) => placement.facility_template_id.toLowerCase().includes('colony_ship'));
+}
+
+function isColonyShipAndGenericStation(candidate: OptimiserCandidate) {
+  if (candidate.placements.length !== 2) return false;
+  const ids = candidate.placements.map((placement) => placement.facility_template_id.toLowerCase());
+  return ids.some((id) => id.includes('colony_ship'))
+    && ids.some((id) => id.includes('generic') || id.includes('station') || id.includes('outpost'));
+}
+
+function hasClearSuggestedBuildPurpose(candidate: OptimiserCandidate) {
+  const text = candidateText(candidate);
+  if (candidate.rationale.some((item) => item.trim().length > 0)) return true;
+  return [
+    'primary',
+    'port',
+    'main',
+    'industrial',
+    'refinery',
+    'tourism',
+    'agriculture',
+    'military',
+    'security',
+    'balanced',
+    'support',
+    'body',
+  ].some((term) => text.includes(term));
+}
+
+function suggestedBuildCategory(candidate: OptimiserCandidate) {
+  const text = candidateText(candidate);
+  const hasPrimaryPort = candidate.placements.some((placement) => placement.is_primary_port);
+  const bodyCount = new Set(candidate.placements.map((placement) => placement.local_body_id ?? 'unassigned')).size;
+
+  if (text.includes('primary') || (hasPrimaryPort && candidate.placements.length <= 3)) return 'Primary-port starter';
+  if (text.includes('main station') || (hasPrimaryPort && candidate.placements.length > 3)) return 'Main station candidate';
+  if (text.includes('industrial') || text.includes('refinery') || text.includes('extraction')) return 'Industrial/refinery starter';
+  if (text.includes('tourism') || text.includes('agriculture')) return 'Tourism/agriculture starter';
+  if (text.includes('military') || text.includes('security')) return 'Military/security stabiliser';
+  if (text.includes('support') || bodyCount > 1) return 'Support-body plan';
+  return 'Balanced expansion';
+}
+
+function purposeForCategory(category: string) {
+  switch (category) {
+    case 'Primary-port starter':
+      return 'Establish a conservative port anchor before expanding the plan.';
+    case 'Main station candidate':
+      return 'Evaluate whether this body can carry the main station role.';
+    case 'Industrial/refinery starter':
+      return 'Seed industrial, refinery, or extraction pressure with supporting placements.';
+    case 'Tourism/agriculture starter':
+      return 'Start a lighter civilian economy plan around tourism or agriculture pressure.';
+    case 'Military/security stabiliser':
+      return 'Add security-oriented support without claiming a final colony role.';
+    case 'Support-body plan':
+      return 'Use additional bodies to support the main colony plan.';
+    default:
+      return 'Build a balanced starter plan that can be adjusted in the workspace.';
+  }
+}
+
+function candidateText(candidate: OptimiserCandidate) {
+  return [
+    candidate.label,
+    candidate.target_archetype,
+    candidate.strategy,
+    ...candidate.tags,
+    ...candidate.rationale,
+    ...candidate.warnings,
+    ...candidate.assumptions,
+    ...candidate.placements.map((placement) => placement.facility_template_id),
+  ].join(' ').toLowerCase();
+}
+
+function candidateSignature(candidate: OptimiserCandidate) {
+  return candidate.placements
+    .map((placement) => [
+      placement.facility_template_id,
+      placement.local_body_id ?? '',
+      placement.is_primary_port ? 'primary' : '',
+    ].join('@'))
+    .sort()
+    .join('|');
+}
+
+function humanizeTag(tag: string) {
+  return tag
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- Add a frontend Suggested Builds quality gate for trivial and duplicate optimiser candidates
- Add useful-build empty state when only trivial suggestions return
- Add player-facing purpose/reason/tradeoff/next-action copy and translated tags
- Rename explicit load action to Load into Planner Workspace while keeping existing confirmations
- Update Stage 15 documentation and roadmap

## Checks
- cd frontend-v2 && npm run typecheck
- cd frontend-v2 && npm run build
- cd frontend-v2 && npm test
- git diff --check