### PR TITLE
Stage 15G: colony project persistence MVP

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1181,3 +1181,30 @@ Deferred after Stage 15F:
 
 - Stage 15G should add saved Colony Project persistence.
 - Stage 15H should move Evidence and Validation into drawers/modes.
+
+### Stage 15G - Saved Colony Project Persistence MVP
+
+Stage 15G adds a local-only saved Colony Project MVP so users can return to a plan later without committing to backend schema too early.
+
+Current Stage 15G status:
+
+- Added a Zustand/localStorage project store under `ed_colony_projects_v1`.
+- The minimum project model includes project id, system id64/name, project name, build plan placements, selected body assignments derived from placements, notes, status, created/updated timestamps, and archive timestamp.
+- The workspace summary rail now includes local project controls: save, rename, load, duplicate, and delete/archive with confirmation.
+- The summary rail shows `Unsaved changes` / `Saved` and a `Last saved` timestamp.
+- Reloading the planner workspace for a system restores the latest active local project into the editable Build Plan through the existing `initialRequest` path.
+
+Safety boundaries in Stage 15G:
+
+- Persistence is local-only. No backend schema, account sync, collaboration, cloud sync, imports, EDMC ingestion, hauling/material execution, scoring, CP/economy/buildability/service mechanics, optimiser behavior, Search Tuning, Observed Evidence, Validation, or primary-port truth handling changed.
+- Saving/loading projects does not auto-run Preview, auto-generate Suggested Builds, auto-import layout, mutate evidence, or run validation.
+
+Test coverage added/updated in Stage 15G:
+
+- Store tests cover save/load shape, rename, duplicate, archive, active project filtering, selected body assignments, and unsaved snapshot matching.
+- Workspace tests cover save, rename, duplicate, archive confirmation, unsaved/saved indicator, and reload restoring a saved plan through the planner adapter.
+
+Deferred after Stage 15G:
+
+- Backend persistence and migration remain future work after the project model stabilises.
+- Stage 15H should move Evidence and Validation into drawers/modes.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -532,3 +532,11 @@ Stage 15F implementation note:
 - `OptimiserCandidateCard` and `OptimiserCandidateDetails` now present a player-facing category, purpose, reason, tradeoff, and next action for each visible candidate.
 - Raw optimiser tags are translated before display. Internal tags remain available in the response/comparison data, but the UI avoids exposing raw labels like `body_diversity`.
 - Loading a suggested build remains an explicit workspace action through the existing candidate load path. It still does not run the main Preview, save, import, validate, or mutate observed evidence.
+
+Stage 15G implementation note:
+
+- Saved Colony Projects use localStorage through `features/colony-planner/colonyProjectStore.ts`. This matches existing frontend persistence patterns while avoiding premature backend schema work.
+- `ColonyPlannerWorkspace` owns project selection and notes state in the workspace shell. It passes a saved project into `SimulationPreviewPanel` as an `initialRequest`, reusing the existing plan replacement path rather than adding a second editor.
+- Project save captures the current one-way planner snapshot: placements, selected body assignments derived from placement body IDs, target archetype, notes, and local status.
+- Project load/restore does not run Preview, generation, import, evidence, or validation. It only replaces the editable Build Plan through the same request shape already used for selected recommended plans.
+- Delete is implemented as local archive with confirmation so the MVP can hide projects without destructive backend semantics.

--- a/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
+++ b/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
@@ -1176,3 +1176,39 @@ Deferred:
 - Saved Colony Project persistence remains Stage 15G.
 - Evidence/Validation drawers remain Stage 15H.
 - Broader Stage 15 QA/accessibility hardening remains Stage 15I.
+
+## Stage 15G Implementation Note
+
+Stage 15G implemented local-only saved Colony Project persistence.
+
+Delivered:
+
+- Local project storage with:
+  - project id
+  - system id64
+  - system name
+  - project name
+  - build plan placements
+  - selected body assignments
+  - notes
+  - status
+  - created_at
+  - updated_at
+  - archived_at for local archive/delete
+- Workspace controls for Save project, Rename project, Load project, Duplicate project, and Delete/archive project with confirmation.
+- Unsaved changes indicator and Last saved timestamp in the persistent summary rail.
+- Reload restore of the latest active saved project for the current system.
+- Local-only copy so users understand this is not cloud/account sync.
+
+Safety boundaries preserved:
+
+- No backend persistence, account model, collaboration, cloud sync, imports, EDMC ingestion, hauling/material execution, optimiser scoring/ranking/generation, Simulation Preview scoring, CP/economy/buildability/service logic, Observed Evidence, Validation, Search Tuning, or primary-port truth handling changed.
+- No silent autosave. Project save/load/duplicate/archive are explicit user actions, except reload restore of the latest local project for the same system.
+- Loading a project does not auto-run Preview, auto-generate Suggested Builds, auto-import layout, mutate evidence, or run validation.
+
+Deferred:
+
+- Backend project persistence and migration.
+- Preview/evidence/validation snapshots.
+- Project routes and sharable project IDs.
+- Evidence/Validation drawers remain Stage 15H.

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -4,6 +4,7 @@ import type { SystemDetail } from '@/types/api';
 import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { SimulationPreviewPanel } from '@/features/system-detail/SimulationPreviewPanel';
 import { ColonyPlannerWorkspace } from './ColonyPlannerWorkspace';
+import { useColonyProjectStore } from './colonyProjectStore';
 
 vi.mock('@/features/system-detail/useSystemDetail', () => ({
   useSystemDetail: vi.fn(),
@@ -86,6 +87,8 @@ const system = {
 
 describe('ColonyPlannerWorkspace', () => {
   beforeEach(() => {
+    localStorage.clear();
+    useColonyProjectStore.setState({ projects: [] });
     mockedUseSystemDetail.mockReturnValue({
       data: null,
       loading: false,
@@ -97,6 +100,8 @@ describe('ColonyPlannerWorkspace', () => {
   afterEach(() => {
     mockedUseSystemDetail.mockReset();
     mockedSimulationPreviewPanel.mockClear();
+    localStorage.clear();
+    useColonyProjectStore.setState({ projects: [] });
   });
 
   it('renders a no-system state for direct #colony-planner visits', () => {
@@ -207,6 +212,7 @@ describe('ColonyPlannerWorkspace', () => {
         selectedPlan: null,
         onPlanSnapshotChange: expect.any(Function),
         topologySelection: { type: 'system' },
+        initialRequest: null,
       }),
       undefined,
     );
@@ -224,5 +230,86 @@ describe('ColonyPlannerWorkspace', () => {
     fireEvent.click(screen.getByRole('button', { name: /Back to system detail/i }));
     expect(onOpenSystemDetail).toHaveBeenCalledTimes(1);
     expect(onOpenSystemDetail).toHaveBeenCalledWith(123);
+  });
+
+  it('saves, renames, duplicates, and archives a local Colony Project with confirmation', async () => {
+    mockedUseSystemDetail.mockReturnValue({
+      data: system,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <ColonyPlannerWorkspace
+        id64={123}
+        onBackToFinder={vi.fn()}
+        onOpenSystemDetail={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId('colony-project-panel')).toBeTruthy();
+    expect(screen.getByTestId('project-unsaved-indicator').textContent).toContain('Unsaved changes');
+
+    fireEvent.change(screen.getByLabelText('Project name'), { target: { value: 'Local starter' } });
+    fireEvent.change(screen.getByLabelText('Project notes'), { target: { value: 'Check Architect mode before final placement.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save project' }));
+
+    expect(screen.getByTestId('project-unsaved-indicator').textContent).toContain('Saved');
+    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Local starter');
+    expect(useColonyProjectStore.getState().projects[0].build_plan_placements).toHaveLength(3);
+
+    fireEvent.change(screen.getByLabelText('Project name'), { target: { value: 'Renamed local starter' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
+    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Renamed local starter');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate project' }));
+    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Renamed local starter copy');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete / archive project' }));
+    expect(screen.getByText(/Archive this local project/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Archive project' }));
+    expect(useColonyProjectStore.getState().projects[0].archived_at).toBeTruthy();
+  });
+
+  it('restores the latest saved local project into the workspace on reload', async () => {
+    useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 123,
+      system_name: 'Workspace System',
+      project_name: 'Reloaded project',
+      build_plan_placements: [
+        { facility_template_id: 'surface_hub', local_body_id: 'body1', is_primary_port: false, build_order: 1 },
+      ],
+      target_archetype: 'tourism_agriculture',
+      notes: 'Reload me.',
+    });
+    mockedUseSystemDetail.mockReturnValue({
+      data: system,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <ColonyPlannerWorkspace
+        id64={123}
+        onBackToFinder={vi.fn()}
+        onOpenSystemDetail={vi.fn()}
+      />,
+    );
+
+    expect((await screen.findAllByText('Reloaded project')).length).toBeGreaterThan(0);
+    expect(mockedSimulationPreviewPanel).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        initialRequest: {
+          system_id64: 123,
+          target_archetype: 'tourism_agriculture',
+          placements: [
+            { facility_template_id: 'surface_hub', local_body_id: 'body1', is_primary_port: false, build_order: 1 },
+          ],
+        },
+      }),
+      undefined,
+    );
   });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -1,7 +1,7 @@
 import { ArrowLeft, ExternalLink, PanelRight, Rocket } from 'lucide-react';
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
 import { formatPopulation } from '@/lib/format';
-import type { SystemDetail } from '@/types/api';
+import type { SimulateBuildRequest, SystemDetail } from '@/types/api';
 import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { SimulationPreviewPanel } from '@/features/system-detail/SimulationPreviewPanel';
 import {
@@ -10,6 +10,12 @@ import {
   type TopologyPlanSnapshot,
   type TopologySelection,
 } from './ColonyTopologyRail';
+import {
+  activeProjectsForSystem,
+  projectMatchesSnapshot,
+  useColonyProjectStore,
+  type ColonyProject,
+} from './colonyProjectStore';
 
 export interface ColonyPlannerWorkspaceProps {
   id64: number | null;
@@ -248,13 +254,81 @@ function WorkspaceGrid({ system }: { system: SystemDetail }) {
     templates: [],
     targetArchetype: 'refinery_industrial',
   });
+  const projects = useColonyProjectStore((state) => state.projects);
+  const saveProject = useColonyProjectStore((state) => state.saveProject);
+  const renameProject = useColonyProjectStore((state) => state.renameProject);
+  const duplicateProject = useColonyProjectStore((state) => state.duplicateProject);
+  const archiveProject = useColonyProjectStore((state) => state.archiveProject);
+  const systemProjects = useMemo(() => activeProjectsForSystem(projects, system.id64), [projects, system.id64]);
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(() => systemProjects[0]?.id ?? null);
+  const [pendingProjectId, setPendingProjectId] = useState<string>('');
+  const [projectName, setProjectName] = useState(`${system.name || 'Colony'} project`);
+  const [projectNotes, setProjectNotes] = useState('');
+  const [confirmArchive, setConfirmArchive] = useState(false);
+  const activeProject = systemProjects.find((project) => project.id === activeProjectId) ?? null;
+
+  useEffect(() => {
+    if (activeProjectId && systemProjects.some((project) => project.id === activeProjectId)) return;
+    const next = systemProjects[0] ?? null;
+    setActiveProjectId(next?.id ?? null);
+  }, [activeProjectId, systemProjects]);
+
+  useEffect(() => {
+    setPendingProjectId(activeProjectId ?? '');
+    setProjectName(activeProject?.project_name ?? `${system.name || 'Colony'} project`);
+    setProjectNotes(activeProject?.notes ?? '');
+    setConfirmArchive(false);
+  }, [activeProject, activeProjectId, system.name]);
+
   const handlePlanSnapshotChange = useCallback((snapshot: TopologyPlanSnapshot) => {
     setPlanSnapshot(snapshot);
   }, []);
+  const projectRequest = useMemo<SimulateBuildRequest | null>(() => {
+    if (!activeProject) return null;
+    return {
+      system_id64: activeProject.system_id64,
+      target_archetype: activeProject.target_archetype,
+      placements: activeProject.build_plan_placements,
+    };
+  }, [activeProject]);
   const selectedContext = useMemo(
     () => describeTopologySelection(selection, system, planSnapshot),
     [planSnapshot, selection, system],
   );
+  const unsavedChanges = !projectMatchesSnapshot(
+    activeProject,
+    planSnapshot.placements,
+    planSnapshot.targetArchetype,
+    projectNotes,
+    projectName,
+  );
+  const handleSaveProject = () => {
+    const saved = saveProject(activeProject?.id ?? null, {
+      system_id64: system.id64,
+      system_name: system.name || 'Unknown system',
+      project_name: projectName,
+      build_plan_placements: planSnapshot.placements,
+      target_archetype: planSnapshot.targetArchetype,
+      notes: projectNotes,
+      status: 'draft',
+    });
+    setActiveProjectId(saved.id);
+  };
+  const handleRenameProject = () => {
+    if (!activeProject) return;
+    renameProject(activeProject.id, projectName);
+  };
+  const handleDuplicateProject = () => {
+    if (!activeProject) return;
+    const duplicate = duplicateProject(activeProject.id);
+    if (duplicate) setActiveProjectId(duplicate.id);
+  };
+  const handleArchiveProject = () => {
+    if (!activeProject) return;
+    archiveProject(activeProject.id);
+    setConfirmArchive(false);
+    setActiveProjectId(null);
+  };
 
   return (
     <section
@@ -291,12 +365,29 @@ function WorkspaceGrid({ system }: { system: SystemDetail }) {
           selectedPlan={null}
           onPlanSnapshotChange={handlePlanSnapshotChange}
           topologySelection={selection}
+          initialRequest={projectRequest}
         />
       </main>
       <SummaryPanel
         system={system}
         snapshot={planSnapshot}
         selectedContext={selectedContext}
+        projects={systemProjects}
+        activeProject={activeProject}
+        pendingProjectId={pendingProjectId}
+        projectName={projectName}
+        projectNotes={projectNotes}
+        unsavedChanges={unsavedChanges}
+        confirmArchive={confirmArchive}
+        onPendingProjectChange={setPendingProjectId}
+        onLoadProject={() => setActiveProjectId(pendingProjectId || null)}
+        onProjectNameChange={setProjectName}
+        onProjectNotesChange={setProjectNotes}
+        onSaveProject={handleSaveProject}
+        onRenameProject={handleRenameProject}
+        onDuplicateProject={handleDuplicateProject}
+        onArchiveProject={handleArchiveProject}
+        onConfirmArchiveChange={setConfirmArchive}
       />
     </section>
   );
@@ -306,14 +397,48 @@ function SummaryPanel({
   system,
   snapshot,
   selectedContext,
+  projects,
+  activeProject,
+  pendingProjectId,
+  projectName,
+  projectNotes,
+  unsavedChanges,
+  confirmArchive,
+  onPendingProjectChange,
+  onLoadProject,
+  onProjectNameChange,
+  onProjectNotesChange,
+  onSaveProject,
+  onRenameProject,
+  onDuplicateProject,
+  onArchiveProject,
+  onConfirmArchiveChange,
 }: {
   system: SystemDetail;
   snapshot: TopologyPlanSnapshot;
   selectedContext: ReturnType<typeof describeTopologySelection>;
+  projects: ColonyProject[];
+  activeProject: ColonyProject | null;
+  pendingProjectId: string;
+  projectName: string;
+  projectNotes: string;
+  unsavedChanges: boolean;
+  confirmArchive: boolean;
+  onPendingProjectChange: (projectId: string) => void;
+  onLoadProject: () => void;
+  onProjectNameChange: (name: string) => void;
+  onProjectNotesChange: (notes: string) => void;
+  onSaveProject: () => void;
+  onRenameProject: () => void;
+  onDuplicateProject: () => void;
+  onArchiveProject: () => void;
+  onConfirmArchiveChange: (confirming: boolean) => void;
 }) {
   const bodyCount = system.bodies?.length ?? 0;
   const stationCount = system.stations?.length ?? 0;
-  const projectState = 'Unsaved workspace';
+  const projectState = activeProject
+    ? activeProject.project_name
+    : 'Unsaved workspace';
   const architectState = 'Architect flag not observed';
   const plannerState = 'Preview remains explicit';
 
@@ -328,11 +453,13 @@ function SummaryPanel({
         Planner summary
       </div>
       <p className="mt-2 text-[11px] leading-snug text-silver-dk">
-        Persistent project context lives here first; saved projects and validation drawers remain deferred.
+        Local saved project context lives here first; evidence and validation drawers remain deferred.
       </p>
 
       <dl className="mt-3 space-y-2 font-mono text-[10px]">
-        <SummaryRow label="Project" value={projectState} tone="gold" />
+        <SummaryRow label="Project" value={projectState} tone={unsavedChanges ? 'gold' : 'green'} />
+        <SummaryRow label="Changes" value={unsavedChanges ? 'Unsaved changes' : 'Saved'} tone={unsavedChanges ? 'gold' : 'green'} />
+        <SummaryRow label="Last saved" value={formatProjectTimestamp(activeProject?.updated_at)} />
         <SummaryRow label="Planner" value={plannerState} tone="cyan" />
         <SummaryRow label="Bodies loaded" value={String(bodyCount)} />
         <SummaryRow label="Stations loaded" value={String(stationCount)} />
@@ -357,6 +484,25 @@ function SummaryPanel({
         </p>
       </section>
 
+      <ProjectPanel
+        projects={projects}
+        activeProject={activeProject}
+        pendingProjectId={pendingProjectId}
+        projectName={projectName}
+        projectNotes={projectNotes}
+        unsavedChanges={unsavedChanges}
+        confirmArchive={confirmArchive}
+        onPendingProjectChange={onPendingProjectChange}
+        onLoadProject={onLoadProject}
+        onProjectNameChange={onProjectNameChange}
+        onProjectNotesChange={onProjectNotesChange}
+        onSaveProject={onSaveProject}
+        onRenameProject={onRenameProject}
+        onDuplicateProject={onDuplicateProject}
+        onArchiveProject={onArchiveProject}
+        onConfirmArchiveChange={onConfirmArchiveChange}
+      />
+
       <section className="mt-4 rounded border border-cyan/25 bg-cyan/5 p-2">
         <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">
           Workspace modes
@@ -374,11 +520,149 @@ function SummaryPanel({
           Deferred to next stages
         </h3>
         <ul className="mt-2 space-y-1 font-mono text-[10px] text-silver-dk">
-          <li>15E: topology-based editing</li>
-          <li>15G: saved colony projects</li>
+          <li>15H: evidence and validation drawers</li>
+          <li>15I: workspace QA hardening</li>
         </ul>
       </section>
     </aside>
+  );
+}
+
+function ProjectPanel({
+  projects,
+  activeProject,
+  pendingProjectId,
+  projectName,
+  projectNotes,
+  unsavedChanges,
+  confirmArchive,
+  onPendingProjectChange,
+  onLoadProject,
+  onProjectNameChange,
+  onProjectNotesChange,
+  onSaveProject,
+  onRenameProject,
+  onDuplicateProject,
+  onArchiveProject,
+  onConfirmArchiveChange,
+}: {
+  projects: ColonyProject[];
+  activeProject: ColonyProject | null;
+  pendingProjectId: string;
+  projectName: string;
+  projectNotes: string;
+  unsavedChanges: boolean;
+  confirmArchive: boolean;
+  onPendingProjectChange: (projectId: string) => void;
+  onLoadProject: () => void;
+  onProjectNameChange: (name: string) => void;
+  onProjectNotesChange: (notes: string) => void;
+  onSaveProject: () => void;
+  onRenameProject: () => void;
+  onDuplicateProject: () => void;
+  onArchiveProject: () => void;
+  onConfirmArchiveChange: (confirming: boolean) => void;
+}) {
+  return (
+    <section className="mt-4 rounded border border-cyan/25 bg-cyan/5 p-2" data-testid="colony-project-panel">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">
+          Saved project
+        </h3>
+        <span
+          data-testid="project-unsaved-indicator"
+          className={[
+            'rounded border px-1.5 py-0.5 font-mono text-[10px]',
+            unsavedChanges ? 'border-gold/45 bg-gold/10 text-gold' : 'border-green/35 bg-green/10 text-green',
+          ].join(' ')}
+        >
+          {unsavedChanges ? 'Unsaved changes' : 'Saved'}
+        </span>
+      </div>
+
+      <label className="mt-2 block space-y-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Project name</span>
+        <input
+          aria-label="Project name"
+          value={projectName}
+          onChange={(event) => onProjectNameChange(event.target.value)}
+          className="w-full rounded border border-border/70 bg-bg2 px-2 py-1.5 font-mono text-xs text-silver"
+        />
+      </label>
+
+      <label className="mt-2 block space-y-1">
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Notes</span>
+        <textarea
+          aria-label="Project notes"
+          value={projectNotes}
+          onChange={(event) => onProjectNotesChange(event.target.value)}
+          rows={3}
+          className="w-full resize-y rounded border border-border/70 bg-bg2 px-2 py-1.5 font-mono text-xs text-silver"
+        />
+      </label>
+
+      <div className="mt-2 grid gap-2">
+        <button type="button" onClick={onSaveProject} className="rounded border border-orange/45 bg-orange/10 px-2 py-1.5 font-mono text-[11px] font-bold text-orange hover:bg-orange/20">
+          Save project
+        </button>
+        <button type="button" onClick={onRenameProject} disabled={!activeProject} className="rounded border border-border/70 bg-bg3 px-2 py-1.5 font-mono text-[11px] text-silver hover:border-cyan/50 disabled:opacity-45">
+          Rename project
+        </button>
+      </div>
+
+      <div className="mt-3 rounded border border-border/55 bg-bg3/30 p-2">
+        <label className="block space-y-1">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Load project</span>
+          <select
+            aria-label="Load project"
+            value={pendingProjectId}
+            onChange={(event) => onPendingProjectChange(event.target.value)}
+            className="w-full"
+          >
+            <option value="">No saved project selected</option>
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.project_name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="mt-2 grid gap-2">
+          <button type="button" onClick={onLoadProject} disabled={!pendingProjectId} className="rounded border border-cyan/45 bg-cyan/10 px-2 py-1.5 font-mono text-[11px] text-cyan hover:bg-cyan/20 disabled:opacity-45">
+            Load project
+          </button>
+          <button type="button" onClick={onDuplicateProject} disabled={!activeProject} className="rounded border border-border/70 bg-bg3 px-2 py-1.5 font-mono text-[11px] text-silver hover:border-cyan/50 disabled:opacity-45">
+            Duplicate project
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-3 rounded border border-gold/30 bg-gold/5 p-2">
+        {confirmArchive ? (
+          <div>
+            <p className="font-mono text-[10px] leading-snug text-gold">
+              Archive this local project? The current workspace remains open, but the saved project is removed from this system list.
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <button type="button" onClick={() => onConfirmArchiveChange(false)} className="rounded border border-border bg-bg3 px-2 py-1 font-mono text-[10px] text-silver">
+                Cancel
+              </button>
+              <button type="button" onClick={onArchiveProject} className="rounded border border-gold/45 bg-gold/10 px-2 py-1 font-mono text-[10px] font-bold text-gold">
+                Archive project
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button type="button" onClick={() => onConfirmArchiveChange(true)} disabled={!activeProject} className="w-full rounded border border-gold/40 bg-gold/10 px-2 py-1.5 font-mono text-[11px] text-gold hover:bg-gold/20 disabled:opacity-45">
+            Delete / archive project
+          </button>
+        )}
+      </div>
+
+      <p className="mt-2 font-mono text-[10px] leading-snug text-silver-dk">
+        Local-only MVP. No account sync or backend persistence is used.
+      </p>
+    </section>
   );
 }
 
@@ -389,7 +673,7 @@ function SummaryRow({
 }: {
   label: string;
   value: ReactNode;
-  tone?: 'orange' | 'cyan' | 'gold';
+  tone?: 'orange' | 'cyan' | 'gold' | 'green';
 }) {
   const toneClass = tone === 'orange'
     ? 'text-orange'
@@ -397,13 +681,25 @@ function SummaryRow({
       ? 'text-gold'
       : tone === 'cyan'
         ? 'text-cyan'
-        : 'text-silver';
+        : tone === 'green'
+          ? 'text-green'
+          : 'text-silver';
   return (
     <div className="rounded border border-border/55 bg-bg3/35 px-2 py-1.5">
       <dt className="uppercase tracking-[0.14em] text-silver-dk">{label}</dt>
       <dd className={['mt-0.5 break-words text-[11px]', toneClass].join(' ')}>{value}</dd>
     </div>
   );
+}
+
+function formatProjectTimestamp(value?: string | null) {
+  if (!value) return 'Not saved';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown';
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
 }
 
 function ModeChip({ label, active = false }: { label: string; active?: boolean }) {

--- a/frontend-v2/src/features/colony-planner/colonyProjectStore.test.ts
+++ b/frontend-v2/src/features/colony-planner/colonyProjectStore.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  activeProjectsForSystem,
+  projectMatchesSnapshot,
+  useColonyProjectStore,
+} from './colonyProjectStore';
+
+const placement = { facility_template_id: 'orbital_port', local_body_id: 'body1', is_primary_port: true, build_order: 1 };
+
+describe('colonyProjectStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useColonyProjectStore.setState({ projects: [] });
+  });
+
+  it('saves and matches a local colony project snapshot', () => {
+    const saved = useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 123,
+      system_name: 'Workspace System',
+      project_name: 'Starter project',
+      build_plan_placements: [placement],
+      target_archetype: 'refinery_industrial',
+      notes: 'Check Architect mode.',
+    });
+
+    expect(saved.id).toMatch(/^colony-123-/);
+    expect(saved.status).toBe('draft');
+    expect(saved.selected_body_assignments).toEqual({ 0: 'body1' });
+    expect(useColonyProjectStore.getState().projects).toHaveLength(1);
+    expect(projectMatchesSnapshot(saved, [placement], 'refinery_industrial', 'Check Architect mode.', 'Starter project')).toBe(true);
+    expect(projectMatchesSnapshot(saved, [placement], 'refinery_industrial', 'Changed notes.', 'Starter project')).toBe(false);
+  });
+
+  it('renames, duplicates, and archives projects without deleting the source data shape', () => {
+    const saved = useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 123,
+      system_name: 'Workspace System',
+      project_name: 'Starter project',
+      build_plan_placements: [placement],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+    });
+
+    useColonyProjectStore.getState().renameProject(saved.id, 'Renamed project');
+    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Renamed project');
+
+    const duplicate = useColonyProjectStore.getState().duplicateProject(saved.id);
+    expect(duplicate?.project_name).toBe('Renamed project copy');
+    expect(duplicate?.id).not.toBe(saved.id);
+    expect(duplicate?.build_plan_placements).toEqual([placement]);
+
+    useColonyProjectStore.getState().archiveProject(saved.id);
+    const projects = useColonyProjectStore.getState().projects;
+    expect(projects.find((project) => project.id === saved.id)?.archived_at).toBeTruthy();
+    expect(activeProjectsForSystem(projects, 123).map((project) => project.id)).toEqual([duplicate?.id]);
+  });
+});

--- a/frontend-v2/src/features/colony-planner/colonyProjectStore.ts
+++ b/frontend-v2/src/features/colony-planner/colonyProjectStore.ts
@@ -1,0 +1,151 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import type { SimulateBuildPlacement } from '@/types/api';
+
+export type ColonyProjectStatus = 'draft' | 'previewed' | 'validated';
+
+export interface ColonyProject {
+  id: string;
+  system_id64: number;
+  system_name: string;
+  project_name: string;
+  build_plan_placements: SimulateBuildPlacement[];
+  selected_body_assignments: Record<number, string | null>;
+  target_archetype: string;
+  notes: string;
+  status: ColonyProjectStatus;
+  created_at: string;
+  updated_at: string;
+  archived_at?: string | null;
+}
+
+export interface ColonyProjectInput {
+  system_id64: number;
+  system_name: string;
+  project_name: string;
+  build_plan_placements: SimulateBuildPlacement[];
+  target_archetype: string;
+  notes: string;
+  status?: ColonyProjectStatus;
+}
+
+interface ColonyProjectState {
+  projects: ColonyProject[];
+  saveProject: (projectId: string | null, input: ColonyProjectInput) => ColonyProject;
+  renameProject: (projectId: string, name: string) => void;
+  duplicateProject: (projectId: string) => ColonyProject | null;
+  archiveProject: (projectId: string) => void;
+}
+
+const STORAGE_KEY = 'ed_colony_projects_v1';
+
+export const useColonyProjectStore = create<ColonyProjectState>()(
+  persist(
+    (set, get) => ({
+      projects: [],
+      saveProject: (projectId, input) => {
+        const now = new Date().toISOString();
+        const existing = projectId ? get().projects.find((project) => project.id === projectId) ?? null : null;
+        const project: ColonyProject = {
+          id: existing?.id ?? createProjectId(input.system_id64),
+          system_id64: input.system_id64,
+          system_name: input.system_name,
+          project_name: input.project_name.trim() || `${input.system_name || 'Colony'} project`,
+          build_plan_placements: clonePlacements(input.build_plan_placements),
+          selected_body_assignments: bodyAssignments(input.build_plan_placements),
+          target_archetype: input.target_archetype,
+          notes: input.notes,
+          status: input.status ?? existing?.status ?? 'draft',
+          created_at: existing?.created_at ?? now,
+          updated_at: now,
+          archived_at: null,
+        };
+        set({
+          projects: [
+            project,
+            ...get().projects.filter((item) => item.id !== project.id),
+          ],
+        });
+        return project;
+      },
+      renameProject: (projectId, name) => {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        const now = new Date().toISOString();
+        set({
+          projects: get().projects.map((project) => (
+            project.id === projectId ? { ...project, project_name: trimmed, updated_at: now } : project
+          )),
+        });
+      },
+      duplicateProject: (projectId) => {
+        const source = get().projects.find((project) => project.id === projectId);
+        if (!source) return null;
+        const now = new Date().toISOString();
+        const duplicate: ColonyProject = {
+          ...source,
+          id: createProjectId(source.system_id64),
+          project_name: `${source.project_name} copy`,
+          build_plan_placements: clonePlacements(source.build_plan_placements),
+          selected_body_assignments: { ...source.selected_body_assignments },
+          status: 'draft',
+          created_at: now,
+          updated_at: now,
+          archived_at: null,
+        };
+        set({ projects: [duplicate, ...get().projects] });
+        return duplicate;
+      },
+      archiveProject: (projectId) => {
+        const now = new Date().toISOString();
+        set({
+          projects: get().projects.map((project) => (
+            project.id === projectId ? { ...project, archived_at: now, updated_at: now } : project
+          )),
+        });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
+
+export function activeProjectsForSystem(projects: ColonyProject[], systemId64: number) {
+  return projects
+    .filter((project) => project.system_id64 === systemId64 && !project.archived_at)
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+}
+
+export function projectMatchesSnapshot(
+  project: ColonyProject | null,
+  placements: SimulateBuildPlacement[],
+  targetArchetype: string,
+  notes: string,
+  name: string,
+) {
+  if (!project) return placements.length === 0 && notes.trim() === '';
+  return project.project_name === name
+    && project.target_archetype === targetArchetype
+    && project.notes === notes
+    && JSON.stringify(project.build_plan_placements) === JSON.stringify(clonePlacements(placements));
+}
+
+function clonePlacements(placements: SimulateBuildPlacement[]) {
+  return placements.map((placement) => ({ ...placement }));
+}
+
+function bodyAssignments(placements: SimulateBuildPlacement[]) {
+  return placements.reduce<Record<number, string | null>>((assignments, placement, index) => {
+    assignments[index] = placement.local_body_id ?? null;
+    return assignments;
+  }, {});
+}
+
+function createProjectId(systemId64: number) {
+  const random = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return `colony-${systemId64}-${random}`;
+}

--- a/frontend-v2/src/features/system-detail/SimulationPreviewPanel.tsx
+++ b/frontend-v2/src/features/system-detail/SimulationPreviewPanel.tsx
@@ -1,4 +1,4 @@
-import type { RecommendedBuildPlan, SystemDetail } from '@/types/api';
+import type { RecommendedBuildPlan, SimulateBuildRequest, SystemDetail } from '@/types/api';
 import { SimulationPreview } from './SimulationPreview';
 import type { TopologyPlanSnapshot, TopologySelection } from '@/features/colony-planner/ColonyTopologyRail';
 
@@ -7,16 +7,18 @@ export function SimulationPreviewPanel({
   selectedPlan,
   onPlanSnapshotChange,
   topologySelection,
+  initialRequest,
 }: {
   system: SystemDetail;
   selectedPlan: RecommendedBuildPlan | null;
   onPlanSnapshotChange?: (snapshot: TopologyPlanSnapshot) => void;
   topologySelection?: TopologySelection;
+  initialRequest?: SimulateBuildRequest | null;
 }) {
   return (
     <SimulationPreview
       system={system}
-      initialRequest={selectedPlan?.simulation_request ?? null}
+      initialRequest={initialRequest ?? selectedPlan?.simulation_request ?? null}
       initialPlanLabel={selectedPlan?.label ?? null}
       initialAssumptions={selectedPlan?.assumptions ?? []}
       onPlanSnapshotChange={onPlanSnapshotChange}


### PR DESCRIPTION
## Summary
- Add local-only Colony Project persistence with localStorage/Zustand
- Add workspace controls for save, rename, load, duplicate, and archive with confirmation
- Add unsaved changes and last saved status in the planner summary rail
- Restore latest local project into the workspace through the existing initialRequest path
- Update Stage 15 documentation and roadmap

## Checks
- cd frontend-v2 && npm run typecheck
- cd frontend-v2 && npm run build
- cd frontend-v2 && npm test
- git diff --check