### PR TITLE
Stage 15H: evidence and validation workspace drawers

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1208,3 +1208,29 @@ Deferred after Stage 15G:
 
 - Backend persistence and migration remain future work after the project model stabilises.
 - Stage 15H should move Evidence and Validation into drawers/modes.
+
+### Stage 15H - Evidence / Validation Drawers
+
+Stage 15H moves Observed Evidence and Validation out of the always-visible planner stack and into explicit workspace drawers.
+
+Current Stage 15H status:
+
+- `SimulationPreview` now renders compact Evidence / Validation drawer controls after Preview Result.
+- Observed Evidence and Validation panels mount only when their drawer is opened.
+- Compact status badges show Evidence as manual and Validation as needing preview, preview ready, or preview stale.
+- Each drawer includes a short mismatch / needs-observation summary in a collapsed details block before the existing panel.
+- The existing Observed Evidence and Validation components are reused unchanged inside drawers.
+
+Safety boundaries in Stage 15H:
+
+- Opening/closing drawers does not run Preview, generate Suggested Builds, import layout, save projects, mutate the Build Plan, or change backend mechanics.
+- Validation still does not auto-run without an explicit preview result; the compare query only mounts when the Validation drawer is opened.
+- Observed Evidence CRUD semantics and Validation compare/review semantics remain unchanged.
+
+Test coverage added/updated in Stage 15H:
+
+- Simulation Preview tests cover drawer buttons, evidence drawer open/close, validation drawer open/close, existing Evidence/Validation panel accessibility, no-preview validation empty state, and no compare call until the Validation drawer is explicitly opened.
+
+Deferred after Stage 15H:
+
+- Stage 15I should finish QA, accessibility, copy cleanup, and responsive hardening.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -540,3 +540,10 @@ Stage 15G implementation note:
 - Project save captures the current one-way planner snapshot: placements, selected body assignments derived from placement body IDs, target archetype, notes, and local status.
 - Project load/restore does not run Preview, generation, import, evidence, or validation. It only replaces the editable Build Plan through the same request shape already used for selected recommended plans.
 - Delete is implemented as local archive with confirmation so the MVP can hide projects without destructive backend semantics.
+
+Stage 15H implementation note:
+
+- `SimulationPreview` now owns a small `workspaceDrawer` state for Evidence and Validation drawers.
+- Observed Evidence and Validation remain existing components; Stage 15H changes presentation and mount timing, not evidence/compare/review behavior.
+- Drawer status badges live near the central planner flow. They are intentionally compact until Stage 15I decides whether any status should move into the right workspace summary rail.
+- Validation is not mounted until the user opens the Validation drawer. This keeps compare/review advisory and explicit, and avoids the old always-visible stacked panel behavior.

--- a/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
+++ b/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
@@ -1212,3 +1212,30 @@ Deferred:
 - Preview/evidence/validation snapshots.
 - Project routes and sharable project IDs.
 - Evidence/Validation drawers remain Stage 15H.
+
+## Stage 15H Implementation Note
+
+Stage 15H moved Evidence and Validation into compact workspace drawers.
+
+Delivered:
+
+- Evidence drawer button and panel.
+- Validation drawer button and panel.
+- Compact Evidence/Validation status badges in the planner flow.
+- Short mismatch / needs-observation summaries inside collapsed details blocks.
+- Existing Observed Evidence and Validation panels remain accessible inside their drawers.
+- Validation compare mounts only when the Validation drawer is opened.
+
+Safety boundaries preserved:
+
+- No auto-validation.
+- No auto-preview.
+- No auto-generation.
+- No Build Plan mutation.
+- No project save/load mutation.
+- No changes to Observed Evidence CRUD semantics or Validation compare/review semantics.
+
+Deferred:
+
+- Summary-rail Evidence/Validation badge consolidation.
+- Focus polish and responsive QA remain Stage 15I.

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -317,32 +317,33 @@ describe('SimulationPreview optimiser candidate loading', () => {
     mockedReview.mockReset();
   });
 
-  it('renders Observed Evidence panel and the passive evidence notice', async () => {
+  it('renders Evidence and Validation drawer controls without mounting the panels by default', async () => {
     mockNoRecommendedBuild();
     renderPreview();
 
-    // Observed Evidence label appears in both the section nav and the panel
-    // section region. getAllByText keeps this assertion robust.
     const labels = await screen.findAllByText('Observed Evidence');
     expect(labels.length).toBeGreaterThan(0);
-    // The region itself is exposed via aria-label so test code can scope
-    // assertions inside the Observed Evidence panel deterministically.
+    expect(screen.getByRole('button', { name: 'Evidence drawer' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Validation drawer' })).toBeTruthy();
+    expect(screen.queryByRole('region', { name: 'Observed Evidence' })).toBeNull();
+    expect(screen.queryByRole('region', { name: 'Validation' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Evidence drawer' }));
+    expect(await screen.findByTestId('evidence-drawer')).toBeTruthy();
     expect(screen.getByRole('region', { name: 'Observed Evidence' })).toBeTruthy();
-    // Passive copy is present so the user does not think evidence affects scoring.
     expect(
       screen.getByText(/Later step: Observed Evidence records what you see in-game after planning/),
     ).toBeTruthy();
-    // Section nav still renders predicted-side labels too.
     expect(screen.getAllByText('Build Plan').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Suggested Builds').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Preview Result').length).toBeGreaterThan(0);
   });
 
-  it('does not call simulateBuild or optimiser candidate generation when only the observed evidence panel renders', async () => {
+  it('does not call simulateBuild or optimiser candidate generation when the evidence drawer opens', async () => {
     mockNoRecommendedBuild();
     renderPreview();
 
-    // Wait for the panel to settle.
+    fireEvent.click(await screen.findByRole('button', { name: 'Evidence drawer' }));
     await screen.findByRole('region', { name: 'Observed Evidence' });
     await waitFor(() => expect(mockedListObservedFacts).toHaveBeenCalled());
 
@@ -734,26 +735,29 @@ describe('SimulationPreview optimiser candidate loading', () => {
   });
 
   // ── Stage 6D integration ────────────────────────────────────────────────
-  it('renders the Validation section after Observed Evidence and the section nav exposes a Validation label', async () => {
+  it('opens and closes Evidence and Validation drawers explicitly', async () => {
     mockNoRecommendedBuild();
     renderPreview();
 
-    // Validation chip appears in the section nav.
     expect((await screen.findAllByText('Validation')).length).toBeGreaterThan(0);
-    // Validation panel renders as a separate aria region.
-    const validation = await screen.findByRole('region', { name: 'Validation' });
-    const observed = await screen.findByRole('region', { name: 'Observed Evidence' });
 
-    // The Validation region must appear *after* the Observed Evidence
-    // region in DOM order (Colony Planner section ordering rule).
-    const order = observed.compareDocumentPosition(validation);
-    expect(order & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Evidence drawer' }));
+    expect(await screen.findByTestId('evidence-drawer')).toBeTruthy();
+    expect(screen.queryByTestId('validation-drawer')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Validation drawer' }));
+    expect(await screen.findByTestId('validation-drawer')).toBeTruthy();
+    expect(screen.queryByTestId('evidence-drawer')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(screen.queryByTestId('validation-drawer')).toBeNull();
   });
 
   it('shows the no-preview empty state in Validation when no preview has been run', async () => {
     mockNoRecommendedBuild();
     renderPreview();
 
+    fireEvent.click(await screen.findByRole('button', { name: 'Validation drawer' }));
     await screen.findByRole('region', { name: 'Validation' });
     expect(
       screen.getByText(/Run Preview first, then record Observed Evidence after checking in-game/),
@@ -793,6 +797,9 @@ describe('SimulationPreview optimiser candidate loading', () => {
     await screen.findByText(/Copied suggested build:/);
     fireEvent.click(screen.getByRole('button', { name: /Run Preview/i }));
 
+    await screen.findByText(/Final Score/i);
+    expect(mockedCompare).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Validation drawer' }));
     await waitFor(() => expect(mockedCompare).toHaveBeenCalledTimes(1));
     const sent = mockedCompare.mock.calls[0][0];
     expect(sent.system_id64).toBe(123);

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -39,6 +39,7 @@ export function SimulationPreview({
   onPlanSnapshotChange?: (snapshot: TopologyPlanSnapshot) => void;
   topologySelection?: TopologySelection;
 }) {
+  const [workspaceDrawer, setWorkspaceDrawer] = useState<'evidence' | 'validation' | null>(null);
   const templatesQuery = useQuery<FacilityTemplate[], Error>({
     queryKey: ['facility-templates'],
     queryFn: getFacilityTemplates,
@@ -195,39 +196,150 @@ export function SimulationPreview({
           isResultStale={runState.isResultStale}
         />
 
-        <section className="rounded-chunk-lg border border-border/60 bg-bg2/25 p-3">
-          <div className="mb-3 font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">
-            Later step: Observed Evidence and Validation
-          </div>
-          {/* Stage 6B: Observed Evidence panel renders after Preview Result.
-              It is intentionally passive - see ObservedEvidencePanel for the
-              contract. The simulation and optimiser data above are NOT
-              re-derived from observations; Stage 6C added the predicted-vs-
-              observed comparison engine and Stage 6D renders that result
-              below in the Validation section. */}
-          <ObservedEvidencePanel
-            systemId64={system.id64}
-            suggestedArchetype={plan.targetArchetype}
-          />
-
-          {/* Stage 6D: Validation section renders the Stage 6C
-              `/api/observations/compare` response in-page (no popout, no
-              top-level tab). The panel is passive: it never runs
-              simulation, never invokes the optimiser, never mutates
-              observed evidence, and never feeds confidence back into
-              scoring or ranking. */}
-          <div className="mt-4">
-            <ValidationPanel
-              systemId64={system.id64}
-              targetArchetype={plan.targetArchetype}
-              previewResult={runState.result}
-              isPreviewResultStale={runState.isResultStale}
-            />
-          </div>
-        </section>
+        <WorkspaceReviewDrawers
+          openDrawer={workspaceDrawer}
+          onOpenDrawer={setWorkspaceDrawer}
+          systemId64={system.id64}
+          targetArchetype={plan.targetArchetype}
+          previewResult={runState.result}
+          isPreviewResultStale={runState.isResultStale}
+        />
       </div>
     </div>
   );
 }
 
 export type { RecommendedBuildPlan };
+
+function WorkspaceReviewDrawers({
+  openDrawer,
+  onOpenDrawer,
+  systemId64,
+  targetArchetype,
+  previewResult,
+  isPreviewResultStale,
+}: {
+  openDrawer: 'evidence' | 'validation' | null;
+  onOpenDrawer: (drawer: 'evidence' | 'validation' | null) => void;
+  systemId64: number;
+  targetArchetype: string;
+  previewResult: ReturnType<typeof useSimulationPreviewRun>['result'];
+  isPreviewResultStale: boolean;
+}) {
+  return (
+    <section className="rounded-chunk-lg border border-border/60 bg-bg2/25 p-3" aria-label="Evidence and validation workspace drawers">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-silver-dk">
+            Evidence / Validation
+          </div>
+          <p className="mt-1 text-[11px] leading-snug text-silver-dk">
+            Review evidence or validation when needed. Opening a drawer does not run Preview.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-1.5 font-mono text-[10px]">
+          <StatusBadge label="Evidence" value="Manual" />
+          <StatusBadge
+            label="Validation"
+            value={previewResult ? (isPreviewResultStale ? 'Preview stale' : 'Preview ready') : 'Needs preview'}
+            warn={!previewResult || isPreviewResultStale}
+          />
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        <DrawerButton
+          label="Evidence drawer"
+          active={openDrawer === 'evidence'}
+          onClick={() => onOpenDrawer(openDrawer === 'evidence' ? null : 'evidence')}
+        />
+        <DrawerButton
+          label="Validation drawer"
+          active={openDrawer === 'validation'}
+          onClick={() => onOpenDrawer(openDrawer === 'validation' ? null : 'validation')}
+        />
+      </div>
+
+      {!openDrawer && (
+        <div className="mt-3 rounded border border-border/55 bg-bg3/30 px-3 py-2 font-mono text-[11px] text-silver-dk">
+          Evidence and validation are available as drawers so they do not dominate the planning workspace.
+        </div>
+      )}
+
+      {openDrawer === 'evidence' && (
+        <div className="mt-3 rounded-chunk-lg border border-cyan/30 bg-bg1/50 p-3" data-testid="evidence-drawer">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <h4 className="font-mono text-[11px] uppercase tracking-[0.16em] text-cyan">Evidence drawer</h4>
+            <button type="button" onClick={() => onOpenDrawer(null)} className="rounded border border-border bg-bg3 px-2 py-1 font-mono text-[10px] text-silver hover:border-cyan/50">
+              Close
+            </button>
+          </div>
+          <details className="mb-3 rounded border border-border/55 bg-bg3/25 px-3 py-2">
+            <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Mismatch / needs-observation summary
+            </summary>
+            <p className="mt-2 text-[11px] leading-snug text-silver-dk">
+              Add manual observations here when in-game facts need to be compared with the current preview.
+            </p>
+          </details>
+          <ObservedEvidencePanel
+            systemId64={systemId64}
+            suggestedArchetype={targetArchetype}
+          />
+        </div>
+      )}
+
+      {openDrawer === 'validation' && (
+        <div className="mt-3 rounded-chunk-lg border border-orange/30 bg-bg1/50 p-3" data-testid="validation-drawer">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <h4 className="font-mono text-[11px] uppercase tracking-[0.16em] text-orange">Validation drawer</h4>
+            <button type="button" onClick={() => onOpenDrawer(null)} className="rounded border border-border bg-bg3 px-2 py-1 font-mono text-[10px] text-silver hover:border-orange/50">
+              Close
+            </button>
+          </div>
+          <details className="mb-3 rounded border border-border/55 bg-bg3/25 px-3 py-2">
+            <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+              Mismatch / needs-observation summary
+            </summary>
+            <p className="mt-2 text-[11px] leading-snug text-silver-dk">
+              Validation compares the current preview with manual evidence only after this drawer is opened.
+            </p>
+          </details>
+          <ValidationPanel
+            systemId64={systemId64}
+            targetArchetype={targetArchetype}
+            previewResult={previewResult}
+            isPreviewResultStale={isPreviewResultStale}
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StatusBadge({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <span className={[
+      'rounded border px-1.5 py-0.5',
+      warn ? 'border-gold/40 bg-gold/10 text-gold' : 'border-cyan/35 bg-cyan/10 text-cyan',
+    ].join(' ')}>
+      {label}: {value}
+    </span>
+  );
+}
+
+function DrawerButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      aria-expanded={active}
+      onClick={onClick}
+      className={[
+        'rounded border px-3 py-2 font-mono text-xs font-bold transition',
+        active ? 'border-orange/60 bg-orange/15 text-orange' : 'border-border bg-bg3 text-silver hover:border-cyan/50',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Move Observed Evidence and Validation into explicit workspace drawers
- Add compact Evidence/Validation status badges and short details summaries
- Mount Validation only when its drawer is opened, preserving explicit review behavior
- Update Simulation Preview tests and Stage 15 docs

## Checks
- cd frontend-v2 && npm run typecheck
- cd frontend-v2 && npm run build
- cd frontend-v2 && npm test
- git diff --check