### PR TITLE
Stage 15I: workspace QA and regression hardening

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1234,3 +1234,32 @@ Test coverage added/updated in Stage 15H:
 Deferred after Stage 15H:
 
 - Stage 15I should finish QA, accessibility, copy cleanup, and responsive hardening.
+
+### Stage 15I - Workspace QA / Accessibility / Regression Hardening
+
+Stage 15I closes the topology-first planner workspace pass with focused QA and copy hardening.
+
+Current Stage 15I status:
+
+- The dedicated planner route header now describes the surface as the Stage 15 workspace instead of the earlier topology-only milestone.
+- User-facing planner copy no longer exposes raw body IDs by default when body metadata is missing.
+- Structure picker, body layout summaries, optimiser placement summaries, and optimiser comparison deltas use compact body-reference fallback copy.
+- Existing component tests cover the updated fallback labels.
+
+Safety boundaries in Stage 15I:
+
+- Stage 15I does not change backend mechanics, scoring, CP/economy/buildability/service logic, optimiser generation/ranking, Simulation Preview scoring, Observed Evidence semantics, Validation behavior, imports, persistence semantics, EDMC ingestion, hauling/material execution, or primary-port truth handling.
+- No auto-preview, auto-generation, auto-validation, auto-import, or autosave behavior is introduced.
+
+Test coverage added/updated in Stage 15I:
+
+- Structure picker fallback copy.
+- Body layout fallback copy.
+- Optimiser placement fallback copy.
+- Existing workspace route tests remain in place for project controls and planner navigation.
+
+Deferred after Stage 15I:
+
+- Backend saved-project persistence and migration.
+- Stage 16 colony role and colony planet modelling.
+- Additional visual regression and responsive screenshot coverage after the role model surfaces are designed.

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -547,3 +547,10 @@ Stage 15H implementation note:
 - Observed Evidence and Validation remain existing components; Stage 15H changes presentation and mount timing, not evidence/compare/review behavior.
 - Drawer status badges live near the central planner flow. They are intentionally compact until Stage 15I decides whether any status should move into the right workspace summary rail.
 - Validation is not mounted until the user opens the Validation drawer. This keeps compare/review advisory and explicit, and avoids the old always-visible stacked panel behavior.
+
+Stage 15I implementation note:
+
+- Stage 15I does not move ownership boundaries again. `features/colony-planner/` remains the workspace shell, and `simulation-preview/` remains the existing planner/editor/preview implementation boundary.
+- The hardening pass focused on copy and default visibility: missing body metadata should produce compact fallback labels, not raw body IDs, unless a future technical-details surface explicitly asks for those IDs.
+- Optimiser comparison copy now describes body assignment changes in player-facing terms. It still compares only the existing frontend candidate data and does not change optimiser generation, ranking, or scoring.
+- The next architecture step is Stage 16A documentation for colony roles and colony planet modelling, not another broad Stage 15 UI rewrite.

--- a/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
+++ b/docs/colonisation-redesign/stage-15-planner-workspace-redesign-plan.md
@@ -1239,3 +1239,26 @@ Deferred:
 
 - Summary-rail Evidence/Validation badge consolidation.
 - Focus polish and responsive QA remain Stage 15I.
+
+## Stage 15I Implementation Note
+
+Stage 15I closed the Stage 15 workspace pass with focused QA, copy, and regression hardening.
+
+Delivered:
+
+- Workspace copy now refers to the dedicated route as the Stage 15 workspace rather than an earlier topology-only milestone.
+- User-facing planner surfaces avoid exposing raw body IDs by default when a placement references a missing body record.
+- Structure picker, body layout views, optimiser placement summaries, and optimiser comparison deltas now use compact fallback copy such as `Unknown body reference`, `Body assignment present`, and `body assignment changed`.
+- Existing tests were updated to lock the user-facing fallback copy.
+
+Safety boundaries preserved:
+
+- No backend mechanics, scoring, CP/economy/buildability/service logic, optimiser generation/ranking, Search Tuning, Simulation Preview scoring, Observed Evidence semantics, Validation behavior, imports, persistence semantics, EDMC ingestion, hauling/material execution, or primary-port truth handling changed.
+- No auto-preview, auto-generation, auto-validation, auto-import, or autosave behavior added.
+- The topology rail remains a coordination surface; editing remains in the central planner.
+
+Deferred:
+
+- Backend saved-project persistence and migration remain future work.
+- Colony roles, role confidence, and role-aware topology guidance are Stage 16 concerns.
+- Further end-to-end visual/responsive screenshot coverage can be added once Stage 16 role surfaces settle.

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -179,7 +179,7 @@ function WorkspaceHeader({
           <div className="flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
             <span>Colony Planner Workspace</span>
             <span className="rounded border border-orange/35 bg-orange/10 px-1.5 py-0.5 text-orange">
-              Stage 15D topology
+              Stage 15 workspace
             </span>
             <span className="rounded border border-cyan/30 bg-cyan/5 px-1.5 py-0.5 text-cyan">
               {status}

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.test.tsx
@@ -189,7 +189,7 @@ describe('BuildPlanBodyView', () => {
     });
 
     expect(screen.getByText('Preview is stale')).toBeTruthy();
-    expect(screen.getByText((content) => content.includes('Unknown body 404'))).toBeTruthy();
+    expect(screen.getByText((content) => content.includes('Unknown body reference'))).toBeTruthy();
     expect(screen.getByText('Check placement: body ID does not match known body')).toBeTruthy();
     expect(screen.getAllByText('May be invalid: surface facility on non-landable body').length).toBeGreaterThan(0);
     expect(screen.getByRole('button', { name: 'Select body Body 9' })).toBeTruthy();
@@ -313,7 +313,7 @@ describe('BuildPlanBodyView', () => {
     fireEvent.click(placement);
 
     const panel = screen.getByTestId('layout-detail-panel');
-    expect(within(panel).getByText('Unknown body 404')).toBeTruthy();
+    expect(within(panel).getByText('Unknown body reference')).toBeTruthy();
     expect(within(panel).getByText('Check placement: body ID does not match known body')).toBeTruthy();
     expect(within(panel).getByText('Build Plan changed. Run Preview again before relying on this result.')).toBeTruthy();
   });

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanBodyView.tsx
@@ -368,7 +368,7 @@ function PlacementCard({
         </div>
       </div>
       <p className="mt-2 font-mono text-[10px] text-silver-dk">
-        Body assignment: {body ? bodyDisplayName(body) : item.hasUnknownBody ? `Unknown body ${item.bodyId}` : 'Unassigned'}
+        Body assignment: {body ? bodyDisplayName(body) : item.hasUnknownBody ? 'Unknown body reference' : 'Unassigned'}
       </p>
       <div className="mt-2">
         <PlannerGuidanceList items={guidance} limit={2} />

--- a/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/BuildPlanLayoutDetailPanel.tsx
@@ -291,7 +291,7 @@ function WarningList({ warnings, emptyLabel }: { warnings: string[]; emptyLabel:
 
 function placementBodyLabel(body: SystemBody | null, item: GroupedPlacement): string {
   if (body) return bodyDisplayName(body);
-  if (item.hasUnknownBody) return `Unknown body ${item.bodyId}`;
+  if (item.hasUnknownBody) return 'Unknown body reference';
   return 'Unassigned';
 }
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.test.tsx
@@ -106,7 +106,7 @@ describe('StructurePickerTable', () => {
     expect(screen.getAllByText('Needs body').length).toBeGreaterThan(0);
 
     renderPicker({ selectedBodyId: '404' });
-    expect(screen.getByText('Unknown body: 404')).toBeTruthy();
+    expect(screen.getByText('Unknown body reference')).toBeTruthy();
     expect(screen.getAllByText('Unknown body').length).toBeGreaterThan(0);
   });
 

--- a/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
@@ -73,7 +73,7 @@ export function StructurePickerTable({
           {bodyContext.status === 'selected'
             ? `Evaluating against: ${bodyDisplayName(bodyContext.body as SystemBody)}`
             : bodyContext.status === 'unknown'
-              ? `Unknown body: ${bodyContext.bodyId}`
+              ? 'Unknown body reference'
               : 'No body selected yet'}
           {topologyBodyId && topologyBodyId === selectedBodyId && (
             <span className="ml-2 text-cyan">Topology context</span>

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
@@ -460,7 +460,7 @@ describe('optimiser candidate comparison UI', () => {
     expect(screen.getByText('#1')).toBeTruthy();
     expect(screen.getByText('Primary port')).toBeTruthy();
     expect(screen.getByText('generic_port_alpha')).toBeTruthy();
-    expect(screen.getAllByText('Body: body1').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Body assignment present').length).toBeGreaterThan(0);
   });
 
   it('renders initial read-only panel state with clear purpose copy and no apply button', () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserPlacementList.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserPlacementList.tsx
@@ -26,7 +26,7 @@ export function OptimiserPlacementList({ placements }: { placements: OptimiserCa
             <span>{placement.facility_template_id}</span>
           </div>
           <div className="mt-1 text-[10px] text-silver-dk">
-            Body: {placement.local_body_id ?? 'system-level / unassigned'}
+            {placement.local_body_id ? 'Body assignment present' : 'System-level / unassigned'}
           </div>
         </li>
       ))}

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/comparison/OptimiserComparisonPanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/comparison/OptimiserComparisonPanel.tsx
@@ -169,8 +169,10 @@ function ListSection({ title, items, empty }: { title: string; items: string[]; 
 
 function placementText(change: PlacementChange): string {
   const body = change.before_body_id !== change.after_body_id
-    ? ` body ${change.before_body_id ?? 'none'} → ${change.after_body_id ?? 'none'}`
-    : ` body ${change.after_body_id ?? change.before_body_id ?? 'none'}`;
+    ? ' body assignment changed'
+    : change.after_body_id || change.before_body_id
+      ? ' body assigned'
+      : ' unassigned';
   const order = change.before_build_order !== change.after_build_order
     ? ` order ${change.before_build_order ?? 'none'} → ${change.after_build_order ?? 'none'}`
     : '';


### PR DESCRIPTION
## Summary
- close the Stage 15 workspace docs with the QA hardening phase
- update planner workspace copy away from the earlier topology-only milestone
- hide raw body IDs from default planner fallback copy and adjust related tests

## Checks
- cd frontend-v2 && npm run typecheck
- cd frontend-v2 && npm run build
- cd frontend-v2 && npm test
- git diff --check