### PR TITLE
Stage 17G: validated slot algorithm everywhere + system-wide slot map

### DIFF
--- a/apps/api/src/ingest/slot_prediction.py
+++ b/apps/api/src/ingest/slot_prediction.py
@@ -1,345 +1,461 @@
-"""
-ED Finder — Ingest: Slot Prediction Engine
-============================================
-Predicts orbital and surface slot counts per body from scan facts.
+"""Canonical validated slot prediction for colony planning.
 
-Design rules:
-  • Pure functions — no DB, no asyncio.
-  • Every prediction carries confidence + reasons (explainability).
-  • Predictions are ESTIMATES. ED does not expose slot counts via any API.
-    All values are derived from observed colonisation behaviour.
-  • Versionable: PREDICTION_VERSION bumped when logic changes.
-
-Slot count heuristics (community-derived, confidence: observed):
-  Surface slots:
-    • Radius-based primary driver (larger body → more slots)
-    • Landable required for any surface slots
-    • High-metal / rocky bodies favour more slots
-    • Terraformable gets a bonus
-
-  Orbital slots:
-    • Presence of body in system = 1 base orbital slot
-    • Ringed body = +1 bonus orbital slot (ring anchor)
-    • Large gas giants = +1 bonus (multiple orbital insertion points)
-    • Binary pairs may share orbital budget — penalised slightly
-
-IMPORTANT:
-  These heuristics are derived from limited community observations.
-  Real slot counts are only visible in-game when placing facilities.
-  Treat all predictions as guidance, not authoritative values.
+This module is the only runtime source for predicted slot counts.
+It intentionally does not fall back to legacy radius/class heuristics.
+When required inputs are missing, it returns unknown with reasons.
 """
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field
-from typing import Any, Optional
+import re
+from typing import Any, Literal, Optional
 
-log = logging.getLogger('ed_finder')
+PREDICTION_VERSION = 'validated-slot-v1'
+PREDICTION_DISCLAIMER = (
+    'Predicted slots — high-accuracy algorithm, not guaranteed. '
+    'Verify in Architect Mode.'
+)
+VALIDATION_NOTE = (
+    'Validated against the supplied evidence set with only 2 true mismatches '
+    'after data-entry corrections.'
+)
+INSUFFICIENT_DATA_REASON = 'insufficient data for validated prediction algorithm'
 
-PREDICTION_VERSION = '1.0.0'
-
-# Radius thresholds for surface slot estimation (in km, converted from metres)
-# Source: community colonisation spreadsheets — confidence: observed
-_RADIUS_SURFACE_TIERS = [
-    (8_000_000,  5),   # >8000 km → 5 surface slots
-    (6_000_000,  4),   # >6000 km → 4 surface slots
-    (4_000_000,  3),   # >4000 km → 3 surface slots
-    (2_500_000,  2),   # >2500 km → 2 surface slots
-    (1_000_000,  1),   # >1000 km → 1 surface slot
-    (0,          0),   # tiny / very small → 0 surface slots
-]
-
-# Planet class bonuses/overrides for surface slots
-_CLASS_SURFACE_MODIFIERS: dict[str, int] = {
-    'High metal content body':     +1,
-    'Metal rich body':             +1,
-    'Rocky body':                   0,
-    'Rocky ice body':              -1,
-    'Icy body':                    -1,
-    'Water world':                 +1,
-    'Ammonia world':                0,
-    'Earth-like world':            +2,   # ELWs are always prime real estate
-    'Gas giant with water based life':  0,
-    'Class I gas giant':            0,
-    'Class II gas giant':           0,
-    'Class III gas giant':          0,
-    'Class IV gas giant':           0,
-    'Class V gas giant':            0,
-    'Helium rich gas giant':        0,
-    'Helium gas giant':             0,
-}
-
-# Planet classes that cannot have surface slots (not landable)
-_NON_LANDABLE_CLASSES = {
-    'Class I gas giant', 'Class II gas giant', 'Class III gas giant',
-    'Class IV gas giant', 'Class V gas giant', 'Helium rich gas giant',
-    'Helium gas giant', 'Gas giant with water based life',
-    'Gas giant with ammonia based life',
-    'Sudarsky class I gas giant', 'Sudarsky class II gas giant',
-    'Sudarsky class III gas giant', 'Sudarsky class IV gas giant',
-    'Sudarsky class V gas giant',
-}
-
-_GAS_GIANT_CLASSES = _NON_LANDABLE_CLASSES
+PredictionStatus = Literal['predicted', 'unknown', 'observed']
 
 
 @dataclass
 class SlotPrediction:
-    """
-    Slot prediction result for a single body.
+    system_address: int
+    body_id: int
+    body_name: Optional[str]
+    predicted_orbital_slots: Optional[int]
+    predicted_ground_slots: Optional[int]
+    prediction_status: PredictionStatus
+    confidence_label: str
+    prediction_version: str
+    reasons: list[dict[str, Any]] = field(default_factory=list)
+    validation_note: str = VALIDATION_NOTE
+    required_input_missing: list[str] = field(default_factory=list)
 
-    surface_slots:  estimated buildable surface slots
-    orbital_slots:  estimated orbital slots this body contributes
-    confidence:     0.0–1.0 prediction confidence
-    slot_source:    'journal', 'predicted', 'estimated'
-    reasons:        explainability chain
-    """
-    system_address:  int
-    body_id:         int
-    surface_slots:   int
-    orbital_slots:   int
-    confidence:      float
-    slot_source:     str
-    reasons:         list[dict] = field(default_factory=list)
+    # Backward-compatible aliases used by existing call-sites/tests.
+    @property
+    def orbital_slots(self) -> int:
+        return int(self.predicted_orbital_slots or 0)
 
-    def to_dict(self) -> dict:
+    @property
+    def surface_slots(self) -> int:
+        return int(self.predicted_ground_slots or 0)
+
+    @property
+    def confidence(self) -> float:
+        return 0.96 if self.prediction_status == 'predicted' else 0.0
+
+    @property
+    def slot_source(self) -> str:
+        if self.prediction_status == 'observed':
+            return 'observed'
+        if self.prediction_status == 'predicted':
+            return 'validated_prediction'
+        return 'unknown'
+
+    def to_dict(self) -> dict[str, Any]:
         return {
-            'system_address':          self.system_address,
-            'body_id':                 self.body_id,
-            'estimated_surface_slots': self.surface_slots,
-            'estimated_orbital_slots': self.orbital_slots,
-            'slot_confidence':         round(self.confidence, 3),
-            'slot_source':             self.slot_source,
-            'reasons':                 self.reasons,
-            'prediction_version':      PREDICTION_VERSION,
+            'system_address': self.system_address,
+            'body_id': self.body_id,
+            'body_name': self.body_name,
+            'predicted_orbital_slots': self.predicted_orbital_slots,
+            'predicted_ground_slots': self.predicted_ground_slots,
+            'prediction_status': self.prediction_status,
+            'confidence_label': self.confidence_label,
+            'prediction_version': self.prediction_version,
+            'reasons': self.reasons,
+            'validation_note': self.validation_note,
+            'required_input_missing': self.required_input_missing,
+            # Back-compat mirrors
+            'estimated_orbital_slots': self.predicted_orbital_slots,
+            'estimated_surface_slots': self.predicted_ground_slots,
+            'slot_confidence': self.confidence,
+            'slot_source': self.slot_source,
         }
 
 
-def predict_body_slots(scan_fact: dict) -> SlotPrediction:
-    """
-    Predict surface and orbital slot counts for a single body
-    from its body_scan_facts row.
+def predict_body_slots(scan_fact: dict[str, Any]) -> SlotPrediction:
+    """Predict orbital/ground slots for a single body using validated rules."""
+    system_address = _coerce_identifier(scan_fact.get('system_address'))
+    body_id = _coerce_identifier(scan_fact.get('body_id'))
+    body_name = _clean_text(scan_fact.get('body_name'))
 
-    This is the primary prediction function. All other functions
-    in this module are helpers called from here.
-    """
-    system_address = scan_fact['system_address']
-    body_id        = scan_fact['body_id']
-    planet_class   = (scan_fact.get('planet_class') or '').strip()
-    radius         = scan_fact.get('radius')            # metres
-    is_landable    = scan_fact.get('is_landable', False)
-    is_terraformable = scan_fact.get('is_terraformable', False)
-    is_ringed      = scan_fact.get('is_ringed', False)
-    terraform_state = (scan_fact.get('terraform_state') or '').strip()
-    data_sources   = scan_fact.get('data_sources', [])
-    input_confidence = float(scan_fact.get('confidence', 0.4))
-
-    reasons: list[dict] = []
-
-    # ── Gas giants: no surface slots, 1-2 orbital slots ──────────────────
-    is_gas_giant = planet_class in _GAS_GIANT_CLASSES
-    if is_gas_giant:
-        orbital = 1
-        reasons.append({
-            'factor': 'planet_class',
-            'value':  planet_class,
-            'contribution': '+1 orbital (gas giant)',
-        })
-        if is_ringed:
-            orbital += 1
-            reasons.append({
-                'factor': 'ringed',
-                'value':  True,
-                'contribution': '+1 orbital (ringed body — orbital anchor)',
-            })
+    observed_orbital = _coerce_int(scan_fact.get('observed_orbital_slots'))
+    observed_ground = _coerce_int(scan_fact.get('observed_ground_slots'))
+    if observed_orbital is not None or observed_ground is not None:
         return SlotPrediction(
             system_address=system_address,
             body_id=body_id,
-            surface_slots=0,
-            orbital_slots=orbital,
-            confidence=min(input_confidence, 0.80),
-            slot_source=_source_from_data(data_sources),
-            reasons=reasons,
+            body_name=body_name,
+            predicted_orbital_slots=observed_orbital,
+            predicted_ground_slots=observed_ground,
+            prediction_status='observed',
+            confidence_label='architect_observed',
+            prediction_version=PREDICTION_VERSION,
+            reasons=[
+                {
+                    'factor': 'observed_slots',
+                    'note': 'Using architect-observed slot values.',
+                }
+            ],
+            required_input_missing=[],
         )
 
-    # ── Non-landable rocky/icy bodies: orbital only ───────────────────────
-    if not is_landable and planet_class not in ('', None):
-        orbital = 1
+    reasons: list[dict[str, Any]] = []
+    missing: list[str] = []
+
+    is_landable = _coerce_bool(scan_fact.get('is_landable'))
+    radius_m = _coerce_float(scan_fact.get('radius'))
+    surface_temp = _coerce_float(scan_fact.get('surface_temp'))
+    gravity = _coerce_float(scan_fact.get('gravity'))
+    atmosphere = _clean_text(scan_fact.get('atmosphere'))
+
+    # Required inputs for validated algorithm.
+    if is_landable is None:
+        missing.append('is_landable')
+    if radius_m is None:
+        missing.append('radius')
+    if surface_temp is None and is_landable is True:
+        missing.append('surface_temp')
+    if gravity is None and is_landable is True:
+        missing.append('gravity')
+    if atmosphere is None and is_landable is True:
+        missing.append('atmosphere')
+
+    # Orbital prediction can still be emitted when radius exists.
+    orbital_slots = _predict_orbital_slots(scan_fact, radius_m, reasons) if radius_m is not None else None
+
+    if missing:
+        return SlotPrediction(
+            system_address=system_address,
+            body_id=body_id,
+            body_name=body_name,
+            predicted_orbital_slots=orbital_slots,
+            predicted_ground_slots=None,
+            prediction_status='unknown',
+            confidence_label='insufficient_prediction_data',
+            prediction_version=PREDICTION_VERSION,
+            reasons=[
+                *reasons,
+                {
+                    'factor': 'missing_input',
+                    'note': INSUFFICIENT_DATA_REASON,
+                },
+                {
+                    'factor': 'guidance',
+                    'note': 'Verify in Architect Mode.',
+                },
+            ],
+            required_input_missing=sorted(set(missing)),
+        )
+
+    if is_landable is False:
         reasons.append({
             'factor': 'is_landable',
-            'value':  False,
-            'contribution': '0 surface slots (not landable), +1 orbital',
+            'value': False,
+            'note': 'Non-landable body: 0 predicted ground slots.',
         })
-        if is_ringed:
-            orbital += 1
-            reasons.append({
-                'factor': 'ringed',
-                'value':  True,
-                'contribution': '+1 orbital (ring anchor)',
-            })
         return SlotPrediction(
             system_address=system_address,
             body_id=body_id,
-            surface_slots=0,
-            orbital_slots=orbital,
-            confidence=min(input_confidence, 0.75),
-            slot_source=_source_from_data(data_sources),
+            body_name=body_name,
+            predicted_orbital_slots=orbital_slots,
+            predicted_ground_slots=0,
+            prediction_status='predicted' if orbital_slots is not None else 'unknown',
+            confidence_label='validated_high_accuracy',
+            prediction_version=PREDICTION_VERSION,
             reasons=reasons,
+            required_input_missing=[],
         )
 
-    # ── Landable bodies: radius-based surface slots ───────────────────────
-    surface_slots = 0
-    if radius is not None:
-        for threshold, slots in _RADIUS_SURFACE_TIERS:
-            if radius >= threshold:
-                surface_slots = slots
-                reasons.append({
-                    'factor':       'radius',
-                    'value':        round(radius / 1000, 1),
-                    'unit':         'km',
-                    'contribution': f'+{slots} surface slots (radius tier)',
-                })
-                break
-    else:
-        # No radius data — very low confidence estimate
-        surface_slots = 1
-        reasons.append({
-            'factor':       'radius',
-            'value':        None,
-            'contribution': '+1 surface (no radius data — minimum estimate)',
-        })
+    # Landable and required inputs present.
+    assert radius_m is not None
+    assert surface_temp is not None
+    assert gravity is not None
+    assert atmosphere is not None
 
-    # Planet class modifier
-    class_mod = _CLASS_SURFACE_MODIFIERS.get(planet_class, 0)
-    if class_mod != 0:
-        surface_slots = max(0, surface_slots + class_mod)
+    if surface_temp > 700:
         reasons.append({
-            'factor':       'planet_class',
-            'value':        planet_class,
-            'contribution': f'{class_mod:+d} surface (class modifier)',
+            'factor': 'surface_temp',
+            'value': surface_temp,
+            'note': 'Surface temp > 700K: 0 predicted ground slots.',
         })
+        return SlotPrediction(
+            system_address=system_address,
+            body_id=body_id,
+            body_name=body_name,
+            predicted_orbital_slots=orbital_slots,
+            predicted_ground_slots=0,
+            prediction_status='predicted' if orbital_slots is not None else 'unknown',
+            confidence_label='validated_high_accuracy',
+            prediction_version=PREDICTION_VERSION,
+            reasons=reasons,
+            required_input_missing=[],
+        )
 
-    # Terraformable bonus
-    if is_terraformable or terraform_state == 'Terraformable':
-        surface_slots += 1
+    if gravity > 2.7:
         reasons.append({
-            'factor':       'terraformable',
-            'value':        True,
-            'contribution': '+1 surface (terraformable bonus)',
+            'factor': 'gravity',
+            'value': gravity,
+            'note': 'Gravity > 2.7g: 0 predicted ground slots.',
         })
+        return SlotPrediction(
+            system_address=system_address,
+            body_id=body_id,
+            body_name=body_name,
+            predicted_orbital_slots=orbital_slots,
+            predicted_ground_slots=0,
+            prediction_status='predicted' if orbital_slots is not None else 'unknown',
+            confidence_label='validated_high_accuracy',
+            prediction_version=PREDICTION_VERSION,
+            reasons=reasons,
+            required_input_missing=[],
+        )
 
-    # Orbital slots for landable body: body itself + ring bonus
-    orbital_slots = 1
+    radius_km = radius_m / 1000.0
+    base_ground = _ground_base_from_radius_km(radius_km)
     reasons.append({
-        'factor':       'body_present',
-        'value':        True,
-        'contribution': '+1 orbital (body in system)',
+        'factor': 'radius',
+        'value': round(radius_km, 2),
+        'note': f'Radius tier base ground slots = {base_ground}.',
     })
-    if is_ringed:
-        orbital_slots += 1
+
+    bonus = 0
+    planet_class = _clean_text(scan_fact.get('planet_class')) or _clean_text(scan_fact.get('subtype')) or ''
+    if _is_hmc(planet_class):
+        bonus += 1
+        reasons.append({'factor': 'planet_class', 'value': planet_class, 'note': 'High metal content bonus +1.'})
+
+    terraformable = _coerce_bool(scan_fact.get('is_terraformable'))
+    terraform_state = _clean_text(scan_fact.get('terraform_state'))
+    if terraformable is True or (terraform_state or '').lower() == 'terraformable':
+        bonus += 1
+        reasons.append({'factor': 'terraformable', 'value': True, 'note': 'Terraformable bonus +1.'})
+
+    has_geo = _has_geo_or_volcanism(scan_fact)
+    if has_geo:
+        bonus += 1
+        reasons.append({'factor': 'geo_or_volcanism', 'value': True, 'note': 'Geo/volcanism bonus +1.'})
+
+    has_bio = _has_bio(scan_fact)
+    if has_bio:
+        bonus += 1
+        reasons.append({'factor': 'bio', 'value': True, 'note': 'Biological signal bonus +1.'})
+
+    atmosphere_bonus = _atmosphere_bonus(atmosphere)
+    if atmosphere_bonus:
+        bonus += atmosphere_bonus
         reasons.append({
-            'factor':       'ringed',
-            'value':        True,
-            'contribution': '+1 orbital (ring anchor point)',
+            'factor': 'atmosphere',
+            'value': atmosphere,
+            'note': f'Atmosphere bonus +{atmosphere_bonus}.',
         })
 
-    # Confidence: journal scan data is higher confidence than estimates
-    confidence = _calculate_confidence(input_confidence, radius, planet_class)
+    bonus = min(bonus, 3)
+    ground_slots = min(base_ground + bonus, 7)
 
     return SlotPrediction(
         system_address=system_address,
         body_id=body_id,
-        surface_slots=max(0, surface_slots),
-        orbital_slots=max(0, orbital_slots),
-        confidence=confidence,
-        slot_source=_source_from_data(data_sources),
+        body_name=body_name,
+        predicted_orbital_slots=orbital_slots,
+        predicted_ground_slots=ground_slots,
+        prediction_status='predicted' if orbital_slots is not None else 'unknown',
+        confidence_label='validated_high_accuracy',
+        prediction_version=PREDICTION_VERSION,
         reasons=reasons,
+        required_input_missing=[] if orbital_slots is not None else ['radius'],
     )
 
 
-def predict_system_slots(scan_facts: list[dict]) -> dict:
-    """
-    Aggregate slot predictions across all bodies in a system.
-
-    Returns a dict suitable for upserting into buildability_analysis:
-      {
-        estimated_orbital_slots: int,
-        estimated_ground_slots:  int,
-        slot_confidence:         float,
-        body_predictions:        list[SlotPrediction],
-      }
-    """
+def predict_system_slots(scan_facts: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate canonical predictions for a system."""
     if not scan_facts:
         return {
-            'estimated_orbital_slots': 0,
-            'estimated_ground_slots':  0,
-            'slot_confidence':         0.0,
-            'body_predictions':        [],
+            'predicted_orbital_slots_total': None,
+            'predicted_ground_slots_total': None,
+            'slot_confidence': None,
+            'body_predictions': [],
+            'prediction_status': 'unknown',
+            'prediction_version': PREDICTION_VERSION,
+            'validation_note': VALIDATION_NOTE,
+            'required_input_missing': ['body_scan_facts'],
         }
 
-    predictions = [predict_body_slots(f) for f in scan_facts]
+    predictions = [predict_body_slots(fact) for fact in scan_facts]
+    known_orbital = [p.predicted_orbital_slots for p in predictions if p.predicted_orbital_slots is not None]
+    known_ground = [p.predicted_ground_slots for p in predictions if p.predicted_ground_slots is not None]
 
-    total_orbital  = sum(p.orbital_slots  for p in predictions)
-    total_surface  = sum(p.surface_slots  for p in predictions)
-
-    # System confidence = mean of body confidences, weighted by slot count
-    total_slots = total_orbital + total_surface
-    if total_slots > 0:
-        weighted_conf = sum(
-            p.confidence * (p.orbital_slots + p.surface_slots)
-            for p in predictions
-        ) / total_slots
+    has_unknown = any(p.prediction_status == 'unknown' for p in predictions)
+    status: str
+    if all(p.prediction_status == 'observed' for p in predictions):
+        status = 'observed'
+    elif has_unknown:
+        status = 'unknown'
     else:
-        weighted_conf = 0.0
+        status = 'predicted'
+
+    required_missing = sorted({
+        missing
+        for prediction in predictions
+        for missing in prediction.required_input_missing
+    })
 
     return {
-        'estimated_orbital_slots': total_orbital,
-        'estimated_ground_slots':  total_surface,
-        'slot_confidence':         round(weighted_conf, 3),
-        'body_predictions':        predictions,
+        'predicted_orbital_slots_total': sum(known_orbital) if known_orbital else None,
+        'predicted_ground_slots_total': sum(known_ground) if known_ground else None,
+        'slot_confidence': 0.96 if status == 'predicted' else None,
+        'body_predictions': predictions,
+        'prediction_status': status,
+        'prediction_version': PREDICTION_VERSION,
+        'validation_note': VALIDATION_NOTE,
+        'required_input_missing': required_missing,
+        # Back-compat fields
+        'estimated_orbital_slots': sum(known_orbital) if known_orbital else None,
+        'estimated_ground_slots': sum(known_ground) if known_ground else None,
     }
 
 
-def confidence_label(confidence: float) -> str:
-    """Human-readable confidence label for UI display."""
-    if confidence >= 0.90:
+def confidence_label(confidence: Optional[float]) -> str:
+    """Backward-compatible helper for legacy call sites."""
+    if confidence is None:
+        return 'Unknown'
+    if confidence >= 0.9:
         return 'High'
-    if confidence >= 0.70:
+    if confidence >= 0.7:
         return 'Moderate'
-    if confidence >= 0.50:
+    if confidence >= 0.5:
         return 'Low'
     return 'Estimated'
 
 
-# ---------------------------------------------------------------------------
-# Private helpers
-# ---------------------------------------------------------------------------
+def _predict_orbital_slots(
+    scan_fact: dict[str, Any],
+    radius_m: Optional[float],
+    reasons: list[dict[str, Any]],
+) -> Optional[int]:
+    if radius_m is None:
+        return None
+    radius_km = radius_m / 1000.0
+    orbital = _orbital_base_from_radius_km(radius_km)
 
-def _source_from_data(data_sources: list[str]) -> str:
-    """Map data sources to a slot_source label."""
-    if 'eddn_saasignals' in data_sources:
-        return 'journal'
-    if 'eddn_scan' in data_sources:
-        return 'journal'
-    if 'eddn_fssbodysignals' in data_sources:
-        return 'predicted'
-    return 'estimated'
+    is_ringed = _coerce_bool(scan_fact.get('is_ringed'))
+    if is_ringed:
+        orbital = min(4, orbital + 1)
+        reasons.append({'factor': 'is_ringed', 'value': True, 'note': 'Ringed body orbital bonus +1.'})
+
+    return min(max(orbital, 1), 4)
 
 
-def _calculate_confidence(
-    input_confidence: float,
-    radius: Optional[float],
-    planet_class: Optional[str],
-) -> float:
-    """
-    Derive final slot prediction confidence.
+def _ground_base_from_radius_km(radius_km: float) -> int:
+    if radius_km < 1500:
+        return 1
+    if radius_km < 3750:
+        return 2
+    if radius_km < 5500:
+        return 3
+    return 4
 
-    Higher input_confidence (from scan facts) propagates through.
-    Missing radius or planet_class reduces confidence.
-    """
-    conf = input_confidence
-    if radius is None:
-        conf -= 0.15
-    if not planet_class:
-        conf -= 0.10
-    return round(max(0.0, min(1.0, conf)), 3)
+
+def _orbital_base_from_radius_km(radius_km: float) -> int:
+    if radius_km < 1500:
+        return 1
+    if radius_km < 3750:
+        return 2
+    if radius_km < 5500:
+        return 3
+    return 4
+
+
+def _atmosphere_bonus(atmosphere: str) -> int:
+    normalised = atmosphere.strip().lower()
+    if not normalised or normalised == 'no atmosphere':
+        return 0
+    if 'thin' in normalised:
+        return 1
+    return 2
+
+
+def _is_hmc(planet_class: str) -> bool:
+    normalised = planet_class.strip().lower()
+    return normalised in {
+        'high metal content world',
+        'high metal content body',
+    }
+
+
+def _has_geo_or_volcanism(scan_fact: dict[str, Any]) -> bool:
+    has_geo = _coerce_bool(scan_fact.get('has_geo'))
+    geo_count = _coerce_int(scan_fact.get('geo_signal_count'))
+    volcanism = _clean_text(scan_fact.get('volcanism')) or ''
+    volcanism_norm = volcanism.strip().lower()
+    has_volcanism = bool(volcanism_norm and volcanism_norm not in {'no volcanism', 'none'})
+    return bool(has_geo or (geo_count is not None and geo_count > 0) or has_volcanism)
+
+
+def _has_bio(scan_fact: dict[str, Any]) -> bool:
+    has_bio = _coerce_bool(scan_fact.get('has_bio'))
+    bio_count = _coerce_int(scan_fact.get('bio_signal_count'))
+    return bool(has_bio or (bio_count is not None and bio_count > 0))
+
+
+def _clean_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    if text in {'true', 't', '1', 'yes', 'y'}:
+        return True
+    if text in {'false', 'f', '0', 'no', 'n'}:
+        return False
+    return None
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_identifier(value: Any) -> int:
+    parsed = _coerce_int(value)
+    if parsed is not None:
+        return parsed
+    if value is None:
+        return 0
+    text = str(value).strip()
+    if not text:
+        return 0
+    # Some legacy rows/tests use ids like "body1"; extract the numeric suffix.
+    match = re.search(r'(\d+)(?!.*\d)', text)
+    if match:
+        return int(match.group(1))
+    return 0

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -1073,6 +1073,7 @@ class FacilityTemplateResponse(BaseModel):
 
 SimulationSource = Literal['precomputed', 'computed', 'insufficient_data']
 SlotDataSource = Literal['eddn', 'spansh', 'none']
+SlotPredictionStatus = Literal['predicted', 'unknown', 'observed']
 
 
 class SlotReason(BaseModel):
@@ -1092,10 +1093,17 @@ class BodySlotPrediction(BaseModel):
     body_id:        int
     body_name:      Optional[str]   = None
     planet_class:   Optional[str]   = None
-    estimated_surface_slots: int    = 0
-    estimated_orbital_slots: int    = 0
-    slot_confidence: float          = 0.0
-    slot_source:    str             = 'estimated'
+    predicted_ground_slots: Optional[int] = None
+    predicted_orbital_slots: Optional[int] = None
+    prediction_status: SlotPredictionStatus = 'unknown'
+    confidence_label: Optional[str] = None
+    prediction_version: Optional[str] = None
+    validation_note: Optional[str] = None
+    required_input_missing: list[str] = Field(default_factory=list)
+    estimated_surface_slots: Optional[int] = None
+    estimated_orbital_slots: Optional[int] = None
+    slot_confidence: Optional[float] = None
+    slot_source:    Optional[str] = None
     reasons:        list[SlotReason]= Field(default_factory=list)
     is_ringed:      Optional[bool]  = None
     is_landable:    Optional[bool]  = None
@@ -1108,10 +1116,18 @@ class SlotPredictionResponse(BaseModel):
     system_id64:             int
     data_source:             SlotDataSource
     body_count:              int
-    estimated_orbital_slots: int
-    estimated_ground_slots:  int
-    slot_confidence:         float
-    slot_confidence_label:   str
+    predicted_orbital_slots_total: Optional[int] = None
+    predicted_ground_slots_total:  Optional[int] = None
+    prediction_status: SlotPredictionStatus = 'unknown'
+    prediction_version: str
+    confidence_label: Optional[str] = None
+    disclaimer: str
+    validation_note: str
+    required_input_missing: list[str] = Field(default_factory=list)
+    estimated_orbital_slots: Optional[int] = None
+    estimated_ground_slots:  Optional[int] = None
+    slot_confidence:         Optional[float] = None
+    slot_confidence_label:   Optional[str] = None
     predictions:             list[BodySlotPrediction] = Field(default_factory=list)
     note:                    Optional[str] = None
 

--- a/apps/api/src/optimiser/candidate_generator.py
+++ b/apps/api/src/optimiser/candidate_generator.py
@@ -10,6 +10,7 @@ import asyncpg
 
 from domain.colonisation_rules import BodyEconomyProfile, profile_body
 from domain.facilities import FacilityTemplate
+from ingest.slot_prediction import INSUFFICIENT_DATA_REASON, PREDICTION_DISCLAIMER, predict_system_slots
 from optimiser.archetype_rules import ArchetypeRule, resolve_archetype_rule
 from optimiser.dedupe import dedupe_candidates, placement_fingerprint
 from optimiser.facility_selection import (
@@ -181,19 +182,51 @@ async def _get_preview_context_and_body_rows(pool: asyncpg.Pool, system_id64: in
 
     local_body_profiles: dict[str, dict[str, Any]] = {}
     clean_rows = [dict(row) for row in body_rows]
+    slot_input_rows: list[dict[str, Any]] = []
     for row in clean_rows:
         profile = profile_body(row)
         if profile.body_id:
             local_body_profiles[profile.body_id] = profile.to_context_profile()
+        slot_input_rows.append({
+            'system_address': system_id64,
+            'body_id': row.get('body_id') or row.get('id'),
+            'body_name': row.get('body_name') or row.get('name'),
+            'radius': row.get('radius'),
+            'gravity': row.get('gravity'),
+            'surface_temp': row.get('surface_temp'),
+            'planet_class': row.get('planet_class') or row.get('subtype'),
+            'terraform_state': row.get('terraform_state'),
+            'atmosphere': row.get('atmosphere') or row.get('atmosphere_type'),
+            'volcanism': row.get('volcanism') or row.get('volcanism_type'),
+            'has_geo': row.get('has_geo'),
+            'has_bio': row.get('has_bio'),
+            'geo_signal_count': row.get('geo_signal_count'),
+            'bio_signal_count': row.get('bio_signal_count'),
+            'is_landable': row.get('is_landable'),
+            'is_terraformable': row.get('is_terraformable'),
+            'is_ringed': row.get('is_ringed'),
+        })
+
+    slot_prediction = predict_system_slots(slot_input_rows) if slot_input_rows else {
+        'predicted_orbital_slots_total': None,
+        'predicted_ground_slots_total': None,
+        'slot_confidence': None,
+        'prediction_status': 'unknown',
+    }
+
+    notes: list[str] = []
+    notes.append(PREDICTION_DISCLAIMER)
+    if slot_prediction.get('prediction_status') == 'unknown':
+        notes.append(f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.')
 
     return PreviewContext(
         system_id64=system_id64,
-        estimated_orbital_slots=system_row.get('estimated_orbital_slots'),
-        estimated_ground_slots=system_row.get('estimated_ground_slots'),
-        slot_confidence=system_row.get('slot_confidence'),
-        has_ringed_body=system_row.get('has_ringed_body'),
+        estimated_orbital_slots=slot_prediction.get('predicted_orbital_slots_total'),
+        estimated_ground_slots=slot_prediction.get('predicted_ground_slots_total'),
+        slot_confidence=slot_prediction.get('slot_confidence'),
+        has_ringed_body=any(bool(row.get('is_ringed')) for row in clean_rows),
         local_body_profiles=local_body_profiles,
-        mechanics_notes=[],
+        mechanics_notes=notes,
         observed_facts=[],
     ), clean_rows
 

--- a/apps/api/src/routers/archetypes.py
+++ b/apps/api/src/routers/archetypes.py
@@ -35,6 +35,7 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 
 from config import log, limiter
+from ingest.slot_prediction import INSUFFICIENT_DATA_REASON, predict_system_slots
 from models import (
     ArchetypeRankingsResponse,
     ArchetypeRerankRequest,
@@ -528,6 +529,62 @@ async def get_system_archetypes(request: Request, id64: int):
                 FROM system_archetype_traits WHERE system_id64 = $1
             """, id64)
 
+            slot_fact_rows = await conn.fetch("""
+                SELECT
+                    system_address,
+                    body_id,
+                    body_name,
+                    radius,
+                    gravity,
+                    surface_temp,
+                    planet_class,
+                    terraform_state,
+                    atmosphere,
+                    volcanism,
+                    has_geo,
+                    has_bio,
+                    geo_signal_count,
+                    bio_signal_count,
+                    is_landable,
+                    is_terraformable,
+                    is_ringed
+                FROM body_scan_facts
+                WHERE system_address = $1
+                ORDER BY body_id
+            """, id64)
+            if slot_fact_rows:
+                slot_facts = [dict(r) for r in slot_fact_rows]
+            else:
+                slot_facts = [
+                    {
+                        'system_address': id64,
+                        'body_id': r['id'],
+                        'body_name': r['name'],
+                        'radius': r['radius'],
+                        'gravity': r['gravity'],
+                        'surface_temp': r['surface_temp'],
+                        'planet_class': r['subtype'],
+                        'terraform_state': None,
+                        'atmosphere': None,
+                        'volcanism': None,
+                        'has_geo': (r['geo_signal_count'] or 0) > 0,
+                        'has_bio': (r['bio_signal_count'] or 0) > 0,
+                        'geo_signal_count': r['geo_signal_count'],
+                        'bio_signal_count': r['bio_signal_count'],
+                        'is_landable': r['is_landable'],
+                        'is_terraformable': r['is_terraformable'],
+                        'is_ringed': False,
+                    }
+                    for r in await conn.fetch("""
+                        SELECT id, name, subtype, radius, gravity, surface_temp,
+                               geo_signal_count, bio_signal_count,
+                               is_landable, is_terraformable
+                        FROM bodies
+                        WHERE system_id64 = $1 AND body_type != 'Star'
+                        ORDER BY id
+                    """, id64)
+                ]
+
     except asyncpg.PostgresError as e:
         log.error('archetypes.system DB error: %s', e)
         raise HTTPException(
@@ -537,6 +594,11 @@ async def get_system_archetypes(request: Request, id64: int):
         )
 
     query_ms = int((time.monotonic() - t0) * 1000)
+    slot_prediction = predict_system_slots(slot_facts) if slot_facts else {
+        'predicted_orbital_slots_total': None,
+        'predicted_ground_slots_total': None,
+        'prediction_status': 'unknown',
+    }
 
     # Build per-archetype score dict
     archetypes_out = {}
@@ -555,9 +617,15 @@ async def get_system_archetypes(request: Request, id64: int):
     topology_out = None
     if topo_row:
         topology_out = {
-            'estimated_orbital_slots': topo_row['estimated_orbital_slots'],
-            'estimated_ground_slots':  topo_row['estimated_ground_slots'],
-            'estimated_total_slots':   topo_row['estimated_total_slots'],
+            'estimated_orbital_slots': slot_prediction.get('predicted_orbital_slots_total'),
+            'estimated_ground_slots':  slot_prediction.get('predicted_ground_slots_total'),
+            'estimated_total_slots': (
+                (slot_prediction.get('predicted_orbital_slots_total') or 0)
+                + (slot_prediction.get('predicted_ground_slots_total') or 0)
+                if slot_prediction.get('predicted_orbital_slots_total') is not None
+                and slot_prediction.get('predicted_ground_slots_total') is not None
+                else None
+            ),
             'strong_link_potential':   topo_row['strong_link_potential'],
             'weak_link_stability':     topo_row['weak_link_stability'],
             'contamination_risk':      topo_row['topo_contamination'],
@@ -567,6 +635,11 @@ async def get_system_archetypes(request: Request, id64: int):
             'build_flexibility':       topo_row['build_flexibility'],
             'has_viable_surface_port': topo_row['has_viable_surface_port'],
             'has_deep_orbital_anchor': topo_row['has_deep_orbital_anchor'],
+            'prediction_status':       slot_prediction.get('prediction_status', 'unknown'),
+            'slot_prediction_note': (
+                None if slot_prediction.get('prediction_status') != 'unknown'
+                else f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.'
+            ),
         }
 
     economy_pairs_out = [

--- a/apps/api/src/routers/simulate.py
+++ b/apps/api/src/routers/simulate.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, Query
 from deps import get_pool
 from domain.colonisation_rules import get_target_profile, profile_body
 from domain.facilities import FacilityTemplate, get_catalogue, load_bundled_catalogue, load_catalogue_from_rows
+from ingest.slot_prediction import INSUFFICIENT_DATA_REASON, PREDICTION_DISCLAIMER, predict_system_slots
 from mechanics.scoring_rules import REGIONAL_RECOMMENDATION_WEIGHT, SIMULATION_RECOMMENDATION_WEIGHT
 from mechanics.versions import MECHANICS_VERSION
 from models import (
@@ -252,30 +253,14 @@ async def _catalogue_or_db(pool: asyncpg.Pool) -> dict[str, FacilityTemplate]:
 
 async def _preview_context(pool: asyncpg.Pool, system_id64: int) -> tuple[PreviewContext, list[dict]]:
     async with pool.acquire() as conn:
-        topology = await conn.fetchrow(
-            """
-            SELECT estimated_orbital_slots, estimated_ground_slots,
-                   has_ringed_gas_giant, has_viable_surface_port, body_slots
-            FROM system_slot_topology
-            WHERE system_id64 = $1
-            """,
-            system_id64,
-        )
-        buildability = await conn.fetchrow(
-            """
-            SELECT estimated_orbital_slots, estimated_ground_slots, slot_confidence
-            FROM buildability_analysis
-            WHERE system_id64 = $1
-            """,
-            system_id64,
-        )
         body_rows = await conn.fetch(
             """
-            SELECT body_id, body_name, 'Planet' AS body_type,
+            SELECT system_address, body_id, body_name, 'Planet' AS body_type,
                    planet_class AS subtype, planet_class,
                    is_landable, is_terraformable, is_ringed,
                    has_geo, has_bio, geo_signal_count, bio_signal_count,
-                   terraform_state, volcanism, confidence
+                   terraform_state, volcanism, atmosphere,
+                   radius, gravity, surface_temp, confidence
             FROM body_scan_facts
             WHERE system_address = $1
             ORDER BY body_id
@@ -285,10 +270,18 @@ async def _preview_context(pool: asyncpg.Pool, system_id64: int) -> tuple[Previe
         if not body_rows:
             body_rows = await conn.fetch(
                 """
-                SELECT id AS body_id, name AS body_name, body_type, subtype,
+                SELECT $1::bigint AS system_address,
+                       id AS body_id, name AS body_name, body_type, subtype,
+                       subtype AS planet_class,
                        is_landable, is_terraformable,
                        (LOWER(COALESCE(subtype, '')) LIKE '%ring%') AS is_ringed,
+                       (geo_signal_count > 0) AS has_geo,
+                       (bio_signal_count > 0) AS has_bio,
                        bio_signal_count, geo_signal_count,
+                       NULL AS terraform_state,
+                       NULL AS volcanism,
+                       NULL AS atmosphere,
+                       radius, gravity, surface_temp,
                        is_earth_like, is_water_world, is_ammonia_world,
                        0.45::numeric AS confidence
                 FROM bodies
@@ -298,19 +291,16 @@ async def _preview_context(pool: asyncpg.Pool, system_id64: int) -> tuple[Previe
                 system_id64,
             )
 
-    topology_dict = dict(topology) if topology else None
-    buildability_dict = dict(buildability) if buildability else None
-
-    orbital = _maybe_int(buildability_dict, 'estimated_orbital_slots')
-    ground = _maybe_int(buildability_dict, 'estimated_ground_slots')
-    slot_confidence = _maybe_float(buildability_dict, 'slot_confidence')
-
-    if topology_dict:
-        orbital = orbital if orbital is not None else _maybe_int(topology_dict, 'estimated_orbital_slots')
-        ground = ground if ground is not None else _maybe_int(topology_dict, 'estimated_ground_slots')
-        slot_confidence = slot_confidence if slot_confidence is not None else 0.65
-
     body_dicts = [dict(row) for row in body_rows]
+    slot_prediction = predict_system_slots(body_dicts) if body_dicts else {
+        'predicted_orbital_slots_total': None,
+        'predicted_ground_slots_total': None,
+        'slot_confidence': None,
+        'prediction_status': 'unknown',
+    }
+    orbital = slot_prediction.get('predicted_orbital_slots_total')
+    ground = slot_prediction.get('predicted_ground_slots_total')
+    slot_confidence = slot_prediction.get('slot_confidence')
     body_profiles = {}
     for body in body_dicts:
         if body.get('body_id') is None:
@@ -321,13 +311,16 @@ async def _preview_context(pool: asyncpg.Pool, system_id64: int) -> tuple[Previe
     mechanics_notes = ['Body economy inheritance follows the repo Mega Guide table in frontend-v2/public/ratings.html.']
     if body_profiles:
         mechanics_notes.append('Body economy is estimated from scan facts; confirm unusual cases in-game.')
+    mechanics_notes.append(PREDICTION_DISCLAIMER)
+    if slot_prediction.get('prediction_status') == 'unknown':
+        mechanics_notes.append(f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.')
 
     return PreviewContext(
         system_id64=system_id64,
         estimated_orbital_slots=orbital,
         estimated_ground_slots=ground,
         slot_confidence=slot_confidence,
-        has_ringed_body=bool(topology_dict and topology_dict['has_ringed_gas_giant']),
+        has_ringed_body=any(bool(body.get('is_ringed')) for body in body_dicts),
         local_body_profiles=body_profiles,
         mechanics_notes=mechanics_notes,
     ), body_dicts
@@ -344,18 +337,6 @@ async def _suggested_archetype(pool: asyncpg.Pool, system_id64: int) -> Optional
             system_id64,
         )
     return str(row['primary_archetype']) if row and row['primary_archetype'] else None
-
-
-def _maybe_int(row: Optional[dict], key: str) -> Optional[int]:
-    if not row or row.get(key) is None:
-        return None
-    return int(row[key])
-
-
-def _maybe_float(row: Optional[dict], key: str) -> Optional[float]:
-    if not row or row.get(key) is None:
-        return None
-    return float(row[key])
 
 
 def _decision_explanation(

--- a/apps/api/src/routers/simulation.py
+++ b/apps/api/src/routers/simulation.py
@@ -34,7 +34,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 
 from config import log
 from deps import get_pool, get_redis, cache_get, cache_set
-from ingest.slot_prediction import predict_system_slots, confidence_label
+from ingest.slot_prediction import (
+    INSUFFICIENT_DATA_REASON,
+    PREDICTION_DISCLAIMER,
+    PREDICTION_VERSION,
+    VALIDATION_NOTE,
+    confidence_label,
+    predict_system_slots,
+)
 from mechanics.versions import MECHANICS_VERSION
 from models import (
     BuildabilityResponse,
@@ -45,7 +52,7 @@ from models import (
 from regional.regional_analysis import response_from_row
 from simulation.buildability import analyse_buildability
 from simulation.topology_simulator import (
-    topology_from_row, topology_from_traits, summarise_topology,
+    topology_from_row, summarise_topology,
 )
 
 router = APIRouter(prefix='/api/systems', tags=['simulation'])
@@ -109,95 +116,66 @@ async def get_slot_predictions(
         return cached
 
     async with pool.acquire() as conn:
-        # Try body_scan_facts first (EDDN-derived, better confidence)
-        scan_facts = await conn.fetch("""
-            SELECT system_address, body_id, body_name,
-                   radius, mass_em, gravity,
-                   planet_class, terraform_state, atmosphere,
-                   has_geo, has_bio, geo_signal_count, bio_signal_count,
-                   is_landable, is_terraformable, is_ringed,
-                   data_sources, confidence
-            FROM body_scan_facts
-            WHERE system_address = $1
-            ORDER BY body_id
-        """, id64)
-
-        # Fall back to bodies table (Spansh import)
-        if not scan_facts:
-            bodies = await conn.fetch("""
-                SELECT
-                    $1::bigint AS system_address,
-                    id AS body_id,
-                    name AS body_name,
-                    radius,
-                    NULL::float AS mass_em,
-                    gravity,
-                    subtype AS planet_class,
-                    NULL AS terraform_state,
-                    NULL AS atmosphere,
-                    (geo_signal_count > 0) AS has_geo,
-                    (bio_signal_count > 0) AS has_bio,
-                    geo_signal_count,
-                    bio_signal_count,
-                    is_landable,
-                    is_terraformable,
-                    (LOWER(subtype) LIKE '%%ring%%') AS is_ringed,
-                    ARRAY['spansh_import'] AS data_sources,
-                    0.55::numeric AS confidence
-                FROM bodies
-                WHERE system_id64 = $1
-                  AND body_type != 'Star'
-                ORDER BY id
-            """, id64)
-            scan_facts = bodies
-
-        # System exists check
-        system_exists = await conn.fetchval(
-            'SELECT 1 FROM systems WHERE id64 = $1', id64
-        )
+        system_exists = await conn.fetchval('SELECT 1 FROM systems WHERE id64 = $1', id64)
         if not system_exists:
             raise HTTPException(404, f'System {id64} not found')
+        scan_facts, data_source = await _fetch_slot_scan_facts(conn, id64)
 
     if not scan_facts:
         result = {
-            'system_id64':             id64,
-            'data_source':             'none',
-            'body_count':              0,
-            'estimated_orbital_slots': 0,
-            'estimated_ground_slots':  0,
-            'slot_confidence':         0.0,
-            'slot_confidence_label':   'No Data',
-            'predictions':             [],
+            'system_id64': id64,
+            'data_source': 'none',
+            'body_count': 0,
+            'predicted_orbital_slots_total': None,
+            'predicted_ground_slots_total': None,
+            'prediction_status': 'unknown',
+            'prediction_version': PREDICTION_VERSION,
+            'confidence_label': 'insufficient_prediction_data',
+            'disclaimer': PREDICTION_DISCLAIMER,
+            'validation_note': VALIDATION_NOTE,
+            'required_input_missing': ['body_scan_facts'],
+            'estimated_orbital_slots': None,
+            'estimated_ground_slots': None,
+            'slot_confidence': None,
+            'slot_confidence_label': 'Unknown',
+            'predictions': [],
             'note': (
                 'No body scan data available for this system. '
-                'Slot predictions require at least FSS scan data via EDDN. '
-                'Visit this system and use the Full Spectrum Scanner to contribute data.'
+                f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.'
             ),
         }
         await cache_set(cache_key, result, _CACHE_TTL, redis)
         return result
 
-    facts = [dict(r) for r in scan_facts]
-    prediction = predict_system_slots(facts)
-
-    data_source = (
-        'eddn' if facts and 'eddn_scan' in (facts[0].get('data_sources') or [])
-        else 'spansh'
-    )
+    prediction = predict_system_slots(scan_facts)
+    slot_confidence = prediction.get('slot_confidence')
 
     result = {
-        'system_id64':             id64,
-        'data_source':             data_source,
-        'body_count':              len(facts),
-        'estimated_orbital_slots': prediction['estimated_orbital_slots'],
-        'estimated_ground_slots':  prediction['estimated_ground_slots'],
-        'slot_confidence':         round(prediction['slot_confidence'], 3),
-        'slot_confidence_label':   confidence_label(prediction['slot_confidence']),
-        'predictions': [
-            _slot_prediction_to_api(p, fact)
-            for p, fact in zip(prediction['body_predictions'], facts)
-            if p.orbital_slots > 0 or p.surface_slots > 0
-        ],
+        'system_id64': id64,
+        'data_source': data_source,
+        'body_count': len(scan_facts),
+        'predicted_orbital_slots_total': prediction.get('predicted_orbital_slots_total'),
+        'predicted_ground_slots_total': prediction.get('predicted_ground_slots_total'),
+        'prediction_status': prediction.get('prediction_status', 'unknown'),
+        'prediction_version': prediction.get('prediction_version', PREDICTION_VERSION),
+        'confidence_label': (
+            'validated_high_accuracy'
+            if prediction.get('prediction_status') == 'predicted'
+            else 'architect_observed'
+            if prediction.get('prediction_status') == 'observed'
+            else 'insufficient_prediction_data'
+        ),
+        'disclaimer': PREDICTION_DISCLAIMER,
+        'validation_note': prediction.get('validation_note', VALIDATION_NOTE),
+        'required_input_missing': prediction.get('required_input_missing') or [],
+        'estimated_orbital_slots': prediction.get('predicted_orbital_slots_total'),
+        'estimated_ground_slots': prediction.get('predicted_ground_slots_total'),
+        'slot_confidence': round(float(slot_confidence), 3) if slot_confidence is not None else None,
+        'slot_confidence_label': confidence_label(slot_confidence),
+        'predictions': [_slot_prediction_to_api(p, fact) for p, fact in zip(prediction['body_predictions'], scan_facts)],
+        'note': None if prediction.get('prediction_status') != 'unknown' else (
+            f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.'
+        ),
     }
 
     await cache_set(cache_key, result, _CACHE_TTL, redis)
@@ -229,8 +207,8 @@ async def get_buildability(
 
     Data source priority:
       1. buildability_analysis (pre-computed, fastest)
-      2. system_slot_topology + body_scan_facts (compute on demand)
-      3. system_archetype_traits (fallback, lower confidence)
+      2. canonical slot prediction + topology traits (compute on demand)
+      3. insufficient data response (no slot fallback estimates)
     """
     cache_key = f'sim:v3:build:{id64}:{archetype or "auto"}'
     cached = await cache_get(cache_key, redis)
@@ -267,28 +245,45 @@ async def get_buildability(
                    has_ringed_gas_giant
             FROM system_slot_topology WHERE system_id64 = $1
         """, id64)
+        slot_facts, _slot_source = await _fetch_slot_scan_facts(conn, id64)
 
-        # Traits row (fallback)
-        traits_row = await conn.fetchrow("""
-            SELECT est_orbital_slots, est_ground_slots,
-                   has_ringed_body, total_body_count
-            FROM system_archetype_traits WHERE system_id64 = $1
-        """, id64)
+    topo_dict = dict(topo_row) if topo_row else None
+    slot_prediction = predict_system_slots(slot_facts) if slot_facts else {
+        'predicted_orbital_slots_total': None,
+        'predicted_ground_slots_total': None,
+        'slot_confidence': None,
+        'prediction_status': 'unknown',
+        'required_input_missing': ['body_scan_facts'],
+    }
 
-    topo_dict   = dict(topo_row)  if topo_row   else None
-    traits_dict = dict(traits_row) if traits_row else None
-
-    # Determine slot inputs
-    if topo_dict:
-        ctx = topology_from_row(topo_dict)
-    elif traits_dict:
-        ctx = topology_from_traits(traits_dict)
+    predicted_orbital = slot_prediction.get('predicted_orbital_slots_total')
+    predicted_ground = slot_prediction.get('predicted_ground_slots_total')
+    if predicted_orbital is not None and predicted_ground is not None:
+        topo_for_ctx = dict(topo_dict) if topo_dict else {
+            'has_ringed_gas_giant': any(bool(f.get('is_ringed')) for f in slot_facts),
+            'has_viable_surface_port': True,
+            'has_deep_orbital_anchor': False,
+            'orbital_synergy': 0.0,
+            'ground_synergy': 0.0,
+            'build_flexibility': 0.0,
+            'contamination_risk': 0.0,
+            'strong_link_potential': 0.0,
+            'weak_link_stability': 0.0,
+            'nesting_potential': 0.0,
+        }
+        topo_for_ctx['estimated_orbital_slots'] = predicted_orbital
+        topo_for_ctx['estimated_ground_slots'] = predicted_ground
+        ctx = topology_from_row(topo_for_ctx)
+        ctx.slot_confidence = float(slot_prediction.get('slot_confidence') or 0.0)
     else:
         ctx = None
 
     # If we have pre-computed buildability AND no archetype override, use it
-    if ba_row and not archetype:
+    if ba_row and not archetype and ctx:
         ba_dict = dict(ba_row)
+        ba_dict['estimated_orbital_slots'] = ctx.orbital_slots
+        ba_dict['estimated_ground_slots'] = ctx.surface_slots
+        ba_dict['slot_confidence'] = slot_prediction.get('slot_confidence')
         topology_summary = summarise_topology(ctx) if ctx else []
         result = {
             'system_id64':             id64,
@@ -318,9 +313,8 @@ async def get_buildability(
             'system_name':   system_row['name'],
             'archetype':     effective_archetype,
             **_normalise_buildability({}, source='insufficient_data', note=(
-                'Insufficient topology data to compute buildability. '
-                'Run build_topology.py to generate slot estimates for this system, '
-                'or scan bodies in-game to contribute data via EDDN.'
+                f'{INSUFFICIENT_DATA_REASON}. '
+                'Predicted slots are unknown. Verify in Architect Mode.'
             )),
         }
         await cache_set(cache_key, result, 60, redis)
@@ -443,6 +437,18 @@ async def get_simulation_summary(
             )
         except asyncpg.UndefinedTableError:
             regional_row = None
+        slot_facts, _slot_source = await _fetch_slot_scan_facts(conn, id64)
+
+    slot_prediction = predict_system_slots(slot_facts) if slot_facts else {
+        'predicted_orbital_slots_total': None,
+        'predicted_ground_slots_total': None,
+        'slot_confidence': None,
+        'prediction_status': 'unknown',
+        'required_input_missing': ['body_scan_facts'],
+    }
+    predicted_orbital = slot_prediction.get('predicted_orbital_slots_total')
+    predicted_ground = slot_prediction.get('predicted_ground_slots_total')
+    predicted_slot_confidence = slot_prediction.get('slot_confidence')
 
     effective_archetype = archetype or (
         mv_row['primary_archetype'] if mv_row else None
@@ -497,29 +503,33 @@ async def get_simulation_summary(
         }
 
     # Buildability
-    if ba_row:
+    if ba_row and predicted_orbital is not None and predicted_ground is not None:
         ba = dict(ba_row)
+        ba['estimated_orbital_slots'] = predicted_orbital
+        ba['estimated_ground_slots'] = predicted_ground
+        ba['slot_confidence'] = predicted_slot_confidence
         response['buildability'] = _normalise_buildability(ba, source='precomputed')
-    elif mv_row and (mv_row['topo_orbital_slots'] or mv_row['est_orbital_slots']):
-        # Compute on demand from MV data
-        orbital = int(mv_row['topo_orbital_slots'] or mv_row['est_orbital_slots'] or 0)
-        surface = int(mv_row['topo_ground_slots']  or mv_row['est_ground_slots']  or 0)
+    elif predicted_orbital is not None and predicted_ground is not None:
+        # Compute on demand from canonical predicted slots + topology traits.
         topo_dict = {
-            'estimated_orbital_slots':  orbital,
-            'estimated_ground_slots':   surface,
-            'orbital_synergy':          mv_row['orbital_synergy'],
-            'ground_synergy':           mv_row['ground_synergy'],
-            'build_flexibility':        mv_row['build_flexibility'],
-            'contamination_risk':       mv_row['topo_contamination_risk'],
-            'strong_link_potential':    mv_row['strong_link_potential'],
-            'weak_link_stability':      mv_row['weak_link_stability'],
-            'nesting_potential':        mv_row['nesting_potential'],
-            'has_viable_surface_port':  mv_row['has_viable_surface_port'],
-            'has_deep_orbital_anchor':  mv_row['has_deep_orbital_anchor'],
-            'has_ringed_gas_giant':     mv_row['has_ringed_body'],
+            'estimated_orbital_slots': predicted_orbital,
+            'estimated_ground_slots': predicted_ground,
+            'orbital_synergy': mv_row['orbital_synergy'] if mv_row else 0.0,
+            'ground_synergy': mv_row['ground_synergy'] if mv_row else 0.0,
+            'build_flexibility': mv_row['build_flexibility'] if mv_row else 0.0,
+            'contamination_risk': mv_row['topo_contamination_risk'] if mv_row else 0.0,
+            'strong_link_potential': mv_row['strong_link_potential'] if mv_row else 0.0,
+            'weak_link_stability': mv_row['weak_link_stability'] if mv_row else 0.0,
+            'nesting_potential': mv_row['nesting_potential'] if mv_row else 0.0,
+            'has_viable_surface_port': mv_row['has_viable_surface_port'] if mv_row else True,
+            'has_deep_orbital_anchor': mv_row['has_deep_orbital_anchor'] if mv_row else False,
+            'has_ringed_gas_giant': (
+                mv_row['has_ringed_body'] if mv_row else any(bool(f.get('is_ringed')) for f in slot_facts)
+            ),
         }
         from simulation.topology_simulator import topology_from_row
         ctx = topology_from_row(topo_dict)
+        ctx.slot_confidence = float(predicted_slot_confidence or 0.0)
         ba = analyse_buildability(
             system_id64=id64,
             orbital_slots=ctx.orbital_slots,
@@ -536,33 +546,111 @@ async def get_simulation_summary(
         response['buildability'] = _normalise_buildability(
             {},
             source='insufficient_data',
-            note='Run build_topology.py to generate slot estimates, or scan bodies in-game.',
+            note=f'{INSUFFICIENT_DATA_REASON}. Predicted slots are unknown. Verify in Architect Mode.',
         )
 
     # Topology summary narrative
-    if mv_row:
+    if predicted_orbital is not None and predicted_ground is not None:
         topo_dict_for_ctx = {
-            'estimated_orbital_slots': mv_row['topo_orbital_slots'] or mv_row['est_orbital_slots'] or 0,
-            'estimated_ground_slots':  mv_row['topo_ground_slots']  or mv_row['est_ground_slots']  or 0,
-            'orbital_synergy':         mv_row['orbital_synergy'],
-            'ground_synergy':          mv_row['ground_synergy'],
-            'build_flexibility':       mv_row['build_flexibility'],
-            'contamination_risk':      mv_row['topo_contamination_risk'],
-            'strong_link_potential':   mv_row['strong_link_potential'],
-            'weak_link_stability':     mv_row['weak_link_stability'],
-            'nesting_potential':       mv_row['nesting_potential'],
-            'has_viable_surface_port': mv_row['has_viable_surface_port'],
-            'has_deep_orbital_anchor': mv_row['has_deep_orbital_anchor'],
-            'has_ringed_gas_giant':    mv_row['has_ringed_body'],
+            'estimated_orbital_slots': predicted_orbital,
+            'estimated_ground_slots': predicted_ground,
+            'orbital_synergy': mv_row['orbital_synergy'] if mv_row else 0.0,
+            'ground_synergy': mv_row['ground_synergy'] if mv_row else 0.0,
+            'build_flexibility': mv_row['build_flexibility'] if mv_row else 0.0,
+            'contamination_risk': mv_row['topo_contamination_risk'] if mv_row else 0.0,
+            'strong_link_potential': mv_row['strong_link_potential'] if mv_row else 0.0,
+            'weak_link_stability': mv_row['weak_link_stability'] if mv_row else 0.0,
+            'nesting_potential': mv_row['nesting_potential'] if mv_row else 0.0,
+            'has_viable_surface_port': mv_row['has_viable_surface_port'] if mv_row else True,
+            'has_deep_orbital_anchor': mv_row['has_deep_orbital_anchor'] if mv_row else False,
+            'has_ringed_gas_giant': (
+                mv_row['has_ringed_body'] if mv_row else any(bool(f.get('is_ringed')) for f in slot_facts)
+            ),
         }
         from simulation.topology_simulator import topology_from_row
         ctx = topology_from_row(topo_dict_for_ctx)
+        ctx.slot_confidence = float(predicted_slot_confidence or 0.0)
         response['topology_summary'] = summarise_topology(ctx)
-        response['distance_to_sol']  = float(mv_row['distance_to_sol'] or 0)
-        response['main_star_type']   = mv_row['main_star_type']
+    elif slot_prediction.get('prediction_status') == 'unknown':
+        response['topology_summary'] = [
+            f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.',
+        ]
+
+    if mv_row:
+        response['distance_to_sol'] = float(mv_row['distance_to_sol'] or 0)
+        response['main_star_type'] = mv_row['main_star_type']
 
     await cache_set(cache_key, response, _CACHE_TTL, redis)
     return response
+
+
+async def _fetch_slot_scan_facts(
+    conn: asyncpg.Connection,
+    id64: int,
+) -> tuple[list[dict[str, Any]], str]:
+    scan_facts = await conn.fetch(
+        """
+        SELECT
+            system_address,
+            body_id,
+            body_name,
+            radius,
+            gravity,
+            surface_temp,
+            planet_class,
+            terraform_state,
+            atmosphere,
+            volcanism,
+            has_geo,
+            has_bio,
+            geo_signal_count,
+            bio_signal_count,
+            is_landable,
+            is_terraformable,
+            is_ringed,
+            data_sources,
+            confidence
+        FROM body_scan_facts
+        WHERE system_address = $1
+        ORDER BY body_id
+        """,
+        id64,
+    )
+    if scan_facts:
+        return [dict(row) for row in scan_facts], 'eddn'
+
+    bodies = await conn.fetch(
+        """
+        SELECT
+            $1::bigint AS system_address,
+            id AS body_id,
+            name AS body_name,
+            radius,
+            gravity,
+            surface_temp,
+            subtype AS planet_class,
+            NULL AS terraform_state,
+            NULL AS atmosphere,
+            NULL AS volcanism,
+            (geo_signal_count > 0) AS has_geo,
+            (bio_signal_count > 0) AS has_bio,
+            geo_signal_count,
+            bio_signal_count,
+            is_landable,
+            is_terraformable,
+            (LOWER(COALESCE(subtype, '')) LIKE '%%ring%%') AS is_ringed,
+            ARRAY['spansh_import'] AS data_sources,
+            0.55::numeric AS confidence
+        FROM bodies
+        WHERE system_id64 = $1
+          AND body_type != 'Star'
+        ORDER BY id
+        """,
+        id64,
+    )
+    if bodies:
+        return [dict(row) for row in bodies], 'spansh'
+    return [], 'none'
 
 
 def _conf_label(v: float) -> str:
@@ -579,10 +667,17 @@ def _slot_prediction_to_api(pred: Any, fact: dict[str, Any]) -> dict[str, Any]:
         'body_id':        pred.body_id,
         'body_name':      fact.get('body_name'),
         'planet_class':   fact.get('planet_class'),
-        'estimated_surface_slots': pred.surface_slots,
-        'estimated_orbital_slots': pred.orbital_slots,
-        'slot_confidence': round(float(pred.confidence or 0), 3),
-        'slot_source':    pred.slot_source,
+        'predicted_ground_slots': pred.predicted_ground_slots,
+        'predicted_orbital_slots': pred.predicted_orbital_slots,
+        'prediction_status': pred.prediction_status,
+        'confidence_label': pred.confidence_label,
+        'prediction_version': pred.prediction_version,
+        'validation_note': pred.validation_note,
+        'required_input_missing': list(pred.required_input_missing or []),
+        'estimated_surface_slots': pred.predicted_ground_slots,
+        'estimated_orbital_slots': pred.predicted_orbital_slots,
+        'slot_confidence': round(float(pred.confidence or 0), 3) if pred.prediction_status == 'predicted' else None,
+        'slot_source': pred.slot_source,
         'reasons':        [_normalise_slot_reason(r) for r in pred.reasons],
         'is_ringed':      _maybe_bool(fact.get('is_ringed')),
         'is_landable':    _maybe_bool(fact.get('is_landable')),

--- a/docs/api-contracts.md
+++ b/docs/api-contracts.md
@@ -18,6 +18,10 @@ For the simulation and optimiser endpoints, the important response models are:
 - `OptimiserCandidate`
 - `OptimiserCandidatesResponse`
 
+Stage 17G slot-prediction mechanics and safety boundaries are documented in:
+
+- `docs/colonisation-redesign/validated-slot-prediction-algorithm.md`
+
 Frontend code should not manually guess these response shapes. When backend fields change, regenerate the frontend OpenAPI types and update the central API client if needed.
 
 ## Frontend Types
@@ -83,20 +87,52 @@ Stage 7D added explicit row actions to open system detail and evaluate in Colony
 
 ## Canonical Field Names
 
-The frontend should consume the backend field names exactly:
+Stage 17G defines canonical slot-prediction fields.
 
-- `estimated_surface_slots`
+Top-level slot-prediction response fields:
+
+- `predicted_orbital_slots_total`
+- `predicted_ground_slots_total`
+- `prediction_status` (`predicted|unknown|observed`)
+- `prediction_version`
+- `confidence_label`
+- `disclaimer`
+- `validation_note`
+- `required_input_missing`
+
+Per-body slot-prediction fields:
+
+- `predicted_orbital_slots`
+- `predicted_ground_slots`
+- `prediction_status`
+- `prediction_version`
+- `confidence_label`
+- `validation_note`
+- `required_input_missing`
+- `reasons`
+
+Unknown handling rule:
+
+- if required canonical inputs are missing, return `prediction_status=unknown`
+- include `required_input_missing` and user guidance (`Verify in Architect Mode`)
+- do not return fallback heuristic slot estimates
+
+Compatibility note:
+
+- `estimated_*` and `slot_confidence*` fields may still appear for legacy clients, but they mirror canonical predictor output; they are not an alternate slot source.
+
+Buildability/simulation summary fields still use:
+
 - `estimated_orbital_slots`
 - `estimated_ground_slots`
 - `slot_confidence`
 - `slot_confidence_label`
-- `slot_source`
 - `build_complexity`
 - `bottlenecks`
 - `opportunities`
 - `recommended_build_order`
 
-Do not introduce frontend-only names such as `surface_slots`, `orbital_slots`, or `confidence` for these API responses unless they are deliberately mapped in one central API adapter.
+Do not introduce frontend-only alias names such as `surface_slots`, `orbital_slots`, or `confidence` unless mapped once in the central API adapter.
 
 For optimiser candidates, clients should consume the backend field names exactly:
 

--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1540,6 +1540,38 @@ Remaining non-RavenColonial gaps (intentional in Stage 17F):
 - no automatic planner synthesis or AI-driven plan mutation
 - no durable cloud project persistence (local project model remains)
 
+## Stage 17G - Validated Slot Algorithm Everywhere + System-Wide Slot Map (Implemented)
+
+Stage 17G makes one canonical slot predictor authoritative across backend and frontend planner surfaces.
+
+Delivered:
+
+- canonical predictor module: `apps/api/src/ingest/slot_prediction.py`
+- prediction version and metadata: `validated-slot-v1`, `prediction_status`, `validation_note`, `required_input_missing`
+- strict no-fallback behavior for slot predictions when required data is missing
+- canonical slot totals/body rows wired into:
+  - `/api/systems/{id64}/slot-predictions`
+  - `/api/systems/{id64}/buildability`
+  - `/api/systems/{id64}/simulation-summary`
+  - preview/recommended-build contexts
+  - optimiser preview context
+  - archetype system topology slot output
+- dense whole-system slot map lanes in the planner left rail and matching selected-body lanes in the centre
+- projected Suggested Build ghost occupancy and overflow labelling (`+N overflow / unconfirmed`)
+
+Required prediction copy:
+
+- `Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.`
+- `Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.`
+
+Stage 17G safety boundaries preserved:
+
+- no CP/economy/service/scoring mechanics changes
+- no Search Tuning changes
+- no import/EDMC changes
+- no auto-generation/auto-load/auto-preview changes
+- no Architect-observed slot persistence (future work)
+
 ## Stage 18 - Colony Architect Assistant Foundation (Planned)
 
 Stage 18 should add an assistant foundation while keeping deterministic planner authority:

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -860,6 +860,26 @@ Stage 17F boundaries remain unchanged:
 - no backend Architect slot survey persistence
 - no automatic plan mutation actions
 
+## Stage 17G Canonical Slot Prediction + System-Wide Slot Map
+
+Stage 17G keeps the Stage 17E workspace ownership model and upgrades slot visibility/data trust boundaries:
+
+- slot-count prediction now comes from one canonical backend algorithm (`validated-slot-v1`)
+- planner slot lanes consume canonical `predicted_orbital_slots` / `predicted_ground_slots` values
+- when canonical prediction data is missing, UI lanes render unknown (`[?]`) rather than fallback estimates
+- left topology rail now shows dense per-body orbital/ground slot lanes with:
+  - planned occupancy
+  - projected Suggested Build ghost occupancy
+  - explicit overflow (`+N overflow / unconfirmed`)
+- centre selected-body planner lane counts match left rail counts from the same snapshot payload
+
+Stage 17G copy boundary:
+
+- `Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.`
+- optional detail note: `Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.`
+
+Stage 17G does not add Architect-observed slot persistence. Predicted and observed slot states remain distinct.
+
 ## Stage 18 Assistant Foundation Boundary
 
 Planned assistant layer should sit above this architecture:

--- a/docs/colonisation-redesign/stage-17a-colony-architect-report.md
+++ b/docs/colonisation-redesign/stage-17a-colony-architect-report.md
@@ -187,6 +187,34 @@ Stage 17E is a functional rebuild pass, not a visual polish pass. It targets the
 - candidate scale still depends on catalogue breadth and body coverage; sparse systems can still produce starter-level output
 - LLM advisor remains foundation-only (schema/docs), not active UI generation
 
+## Stage 17G Validated Slot Algorithm Everywhere + System-Wide Slot Map
+
+Stage 17G standardises slot prediction on one canonical backend algorithm and removes active heuristic fallback paths for slot counts.
+
+Delivered:
+
+- canonical runtime predictor in `apps/api/src/ingest/slot_prediction.py` (`validated-slot-v1`)
+- strict unknown behavior for missing required inputs (`insufficient prediction data`, `Verify in Architect Mode`)
+- no active radius/class/body-type fallback slot estimates when canonical prediction cannot be produced
+- canonical slot metadata in API responses (`prediction_status`, `prediction_version`, `validation_note`, `required_input_missing`)
+- frontend slot-map surfaces now consume canonical `predicted_*` fields directly and render unknown lanes when unavailable
+- planner left rail now shows dense whole-system per-body slot lanes (orbital + ground), planned occupancy, projected ghost occupancy, and overflow labels
+- central selected-body planner lane counts now match left-rail canonical counts
+
+Prediction wording is explicit and conservative:
+
+- `Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.`
+- `Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.`
+
+Boundaries kept:
+
+- no CP formula changes
+- no economy/service scoring changes
+- no Search Tuning changes
+- no import/EDMC/persistence model changes
+- no auto-generation/auto-load/auto-preview behavior changes
+- no Architect-observed slot storage in this stage
+
 ## Stage 18 direction
 
 Stage 18 should build a constrained Colony Architect assistant shell on top of Stage 17E:

--- a/docs/colonisation-redesign/validated-slot-prediction-algorithm.md
+++ b/docs/colonisation-redesign/validated-slot-prediction-algorithm.md
@@ -1,0 +1,121 @@
+# Validated Slot Prediction Algorithm (Stage 17G)
+
+## Purpose
+
+Stage 17G sets one canonical predictor for colony slot counts across backend and frontend.
+
+Required product wording:
+
+`Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.`
+
+Validation note used in UI/tooltips:
+
+`Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.`
+
+Predicted slots are not architect-observed truth.
+
+## No-Fallback Rule
+
+The old heuristic is not used on active execution paths.
+
+If required inputs are missing, the system must return/show `unknown` and:
+
+- `insufficient prediction data`
+- `verify in Architect Mode`
+- no radius/class fallback estimate
+- no body-type-only slot guess
+
+## Canonical Module
+
+Runtime canonical source:
+
+- `apps/api/src/ingest/slot_prediction.py`
+
+Prediction version:
+
+- `validated-slot-v1`
+
+## Algorithm Rules (validated-slot-v1)
+
+Per body:
+
+1. If architect-observed slot values exist, return `prediction_status=observed`.
+2. Required prediction inputs:
+   - always: `is_landable`, `radius`
+   - for landable bodies: `surface_temp`, `gravity`, `atmosphere`
+3. If required inputs are missing:
+   - return `prediction_status=unknown`
+   - return `required_input_missing`
+   - do not emit fallback counts
+4. Orbital base from radius (`km`):
+   - `<1500 => 1`, `<3750 => 2`, `<5500 => 3`, else `4`
+   - ring bonus `+1`, capped at `4`
+5. Ground hard gates:
+   - non-landable => `0`
+   - `surface_temp > 700` => `0`
+   - `gravity > 2.7` => `0`
+6. Ground base from radius (`km`):
+   - `<1500 => 1`, `<3750 => 2`, `<5500 => 3`, else `4`
+7. Ground bonuses:
+   - high metal content body/world `+1`
+   - terraformable `+1`
+   - geo/volcanism `+1`
+   - bio `+1`
+   - atmosphere `+1` if thin, `+2` if non-thin and non-empty
+8. Bonus cap `+3`; final ground cap `7`.
+
+## API Output Contract
+
+Per body canonical fields:
+
+- `body_id`
+- `body_name`
+- `predicted_orbital_slots`
+- `predicted_ground_slots`
+- `prediction_status` (`predicted|unknown|observed`)
+- `confidence_label`
+- `prediction_version`
+- `reasons`
+- `validation_note`
+- `required_input_missing`
+
+System aggregates:
+
+- `predicted_orbital_slots_total`
+- `predicted_ground_slots_total`
+- `prediction_status`
+- `prediction_version`
+- `disclaimer`
+- `validation_note`
+- `required_input_missing`
+
+Compatibility fields (`estimated_*`, `slot_confidence*`) remain mirrored for legacy consumers but are populated from the canonical predictor only.
+
+## Audited Slot Surfaces
+
+Backend slot-count producers/consumers audited:
+
+- `apps/api/src/ingest/slot_prediction.py`
+- `apps/api/src/routers/simulation.py`
+  - `GET /api/systems/{id64}/slot-predictions`
+  - `GET /api/systems/{id64}/buildability`
+  - `GET /api/systems/{id64}/simulation-summary`
+- `apps/api/src/routers/simulate.py`
+  - preview context for `POST /api/simulate/build`
+  - preview context for `GET /api/systems/{id64}/recommended-builds`
+- `apps/api/src/optimiser/candidate_generator.py`
+  - optimiser preview context used by `/api/optimiser/candidates`
+- `apps/api/src/routers/archetypes.py`
+  - `GET /api/archetypes/system/{id64}` topology slot fields
+
+Frontend slot displays audited:
+
+- `frontend-v2/src/features/system-detail/SlotPredictionPanel.tsx`
+- `frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx`
+- `frontend-v2/src/features/colony-planner/WorkspaceGrid.tsx`
+- `frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx` (slot-prediction fetch + snapshot propagation)
+
+## Remaining Future Work
+
+- Architect-observed slot survey storage and persistence are still future work.
+- Predicted and observed slots remain explicitly distinct in status and copy.

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
@@ -1,4 +1,4 @@
-import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import type { BodySlotPrediction, FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
 import {
   bodyDisplayName,
   bodyTags,
@@ -27,6 +27,7 @@ export interface BodyPlannerProjectedPlacementItem {
 
 export function BodySlotPlanner({
   body,
+  slotPrediction,
   placements,
   projectedPlacements,
   selectedPlacementIndex,
@@ -35,6 +36,7 @@ export function BodySlotPlanner({
   onAddLaneStructure,
 }: {
   body: SystemBody;
+  slotPrediction: BodySlotPrediction | null;
   placements: BodyPlannerPlacementItem[];
   projectedPlacements: BodyPlannerProjectedPlacementItem[];
   selectedPlacementIndex: number | null;
@@ -53,8 +55,8 @@ export function BodySlotPlanner({
   const surfaceProjected = projectedPlacements.filter((item) => laneForTemplate(item.template) === 'surface');
   const flexProjected = projectedPlacements.filter((item) => laneForTemplate(item.template) === 'flex');
 
-  const orbitalSlots = readLaneSlotCount(body, 'orbital');
-  const surfaceSlots = readLaneSlotCount(body, 'surface');
+  const orbitalSlots = readLaneSlotCount(slotPrediction, 'orbital');
+  const surfaceSlots = readLaneSlotCount(slotPrediction, 'surface');
   const surfaceBlocked = body.is_water_world === true || body.is_landable === false;
   const surfaceBlockedReason = body.is_water_world
     ? 'Surface lane limited: water world.'
@@ -484,42 +486,17 @@ function laneForTemplate(template: FacilityTemplate | undefined): BodyPlannerLan
   return 'flex';
 }
 
-function readLaneSlotCount(body: SystemBody, lane: 'orbital' | 'surface'): number | null {
-  const paths = lane === 'orbital'
-    ? [
-      'orbital_slot_count',
-      'orbital_slots',
-      'estimated_orbital_slots',
-      'architect_observation.orbitalSlotCount',
-      'architectObservation.orbitalSlotCount',
-      'slot_counts.orbital',
-      'slots.orbital',
-    ]
-    : [
-      'ground_slot_count',
-      'ground_slots',
-      'surface_slot_count',
-      'surface_slots',
-      'estimated_surface_slots',
-      'architect_observation.groundSlotCount',
-      'architectObservation.groundSlotCount',
-      'slot_counts.surface',
-      'slots.surface',
-    ];
-  for (const path of paths) {
-    const value = readPath(body as Record<string, unknown>, path);
-    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
-      return Math.floor(value);
-    }
+function readLaneSlotCount(
+  prediction: BodySlotPrediction | null,
+  lane: 'orbital' | 'surface',
+): number | null {
+  const raw = lane === 'orbital'
+    ? prediction?.predicted_orbital_slots
+    : prediction?.predicted_ground_slots;
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0) {
+    return null;
   }
-  return null;
-}
-
-function readPath(obj: Record<string, unknown>, path: string): unknown {
-  return path.split('.').reduce<unknown>((current, part) => {
-    if (!current || typeof current !== 'object') return null;
-    return (current as Record<string, unknown>)[part];
-  }, obj);
+  return Math.floor(raw);
 }
 
 function laneSlotStatusLabel(slotCount: number | null, plannedCount: number, projectedCount: number) {

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   api,
@@ -290,24 +290,28 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     });
 
     fireEvent.click(screen.getByTestId('topology-body-button-1'));
-    await screen.findByText('Planning on body');
+    await screen.findByText(/Planning focus:/i);
     await waitFor(() => {
-      expect(screen.getByTestId('body-1-orbital-slot-3')).toBeTruthy();
-      expect(screen.getByTestId('body-1-ground-slot-4')).toBeTruthy();
+      expect(screen.getByTestId('slot-lane-orbital')).toBeTruthy();
+      expect(screen.getByTestId('slot-lane-surface')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-orbital')).getByText('0/4 planned')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-surface')).getByText('0/5 planned')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add structure here' })[0]);
+    fireEvent.click(screen.getByTestId('slot-lane-add-orbital'));
     fireEvent.click(await screen.findByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
       expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
-      expect((screen.getByTestId('body-1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+      expect(within(screen.getByTestId('slot-lane-orbital')).getByText('1/4 planned')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-orbital')).getByText(/Orbital Port/i)).toBeTruthy();
     });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Add structure here' })[0]);
+    fireEvent.click(screen.getByTestId('slot-lane-add-surface'));
     fireEvent.click(await screen.findByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
-      expect((screen.getByTestId('body-1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+      expect(within(screen.getByTestId('slot-lane-surface')).getByText('1/5 planned')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-surface')).getByText(/Surface Hub/i)).toBeTruthy();
     });
   });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -9,6 +9,7 @@ import {
   fetchOptimiserCandidates,
   getFacilityTemplates,
   getSimulationSummary,
+  getSlotPredictions,
   importSystemLayout,
   reviewPredictionValidation,
   simulateBuild,
@@ -24,6 +25,7 @@ vi.mock('@/lib/api', () => ({
   fetchOptimiserCandidates: vi.fn(),
   getFacilityTemplates: vi.fn(),
   getSimulationSummary: vi.fn(),
+  getSlotPredictions: vi.fn(),
   importSystemLayout: vi.fn(),
   simulateBuild: vi.fn(),
   listObservedFacts: vi.fn().mockResolvedValue({
@@ -49,6 +51,7 @@ vi.mock('@/lib/api', () => ({
 const mockedApiSystem = vi.mocked(api.system);
 const mockedGetFacilityTemplates = vi.mocked(getFacilityTemplates);
 const mockedGetSimulationSummary = vi.mocked(getSimulationSummary);
+const mockedGetSlotPredictions = vi.mocked(getSlotPredictions);
 const mockedImportSystemLayout = vi.mocked(importSystemLayout);
 const mockedFetchOptimiserCandidates = vi.mocked(fetchOptimiserCandidates);
 const mockedSimulateBuild = vi.mocked(simulateBuild);
@@ -74,14 +77,14 @@ const system = {
 
 const templates: FacilityTemplate[] = [
   {
-    id: 'generic_port_alpha',
-    name: 'Generic Port Alpha',
+    id: 'orbital_port',
+    name: 'Orbital Port',
     category: 'port',
     tier: 1,
     economy: null,
     is_port: true,
     is_support_facility: false,
-    allowed_location: 'surface_or_orbit',
+    allowed_location: 'orbital',
     pad_size: 'large',
     confidence: 'inferred',
     notes: null,
@@ -90,7 +93,29 @@ const templates: FacilityTemplate[] = [
     yellow_cp_cost: 0,
     green_cp_cost: 0,
   },
+  {
+    id: 'surface_hub',
+    name: 'Surface Hub',
+    category: 'support',
+    tier: 1,
+    economy: 'Agriculture',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface',
+    pad_size: 'medium',
+    confidence: 'inferred',
+    notes: null,
+    yellow_cp_generated: 0,
+    green_cp_generated: 0,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
 ];
+
+const slotMapSystem = {
+  ...system,
+  bodies: [{ id: 1, name: 'Body 1', body_type: 'Planet', is_landable: true }],
+} as unknown as SystemDetail;
 
 function renderWorkspace() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -110,6 +135,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     mockedApiSystem.mockReset();
     mockedGetFacilityTemplates.mockReset();
     mockedGetSimulationSummary.mockReset();
+    mockedGetSlotPredictions.mockReset();
     mockedImportSystemLayout.mockReset();
     mockedFetchOptimiserCandidates.mockReset();
     mockedSimulateBuild.mockReset();
@@ -128,6 +154,30 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       buildability: { recommended_build_order: [] },
       regional_context: null,
     } as unknown as SimulationSummary);
+    mockedGetSlotPredictions.mockResolvedValue({
+      system_id64: 123,
+      data_source: 'eddn',
+      body_count: 1,
+      predicted_orbital_slots_total: 4,
+      predicted_ground_slots_total: 5,
+      prediction_status: 'predicted',
+      prediction_version: 'validated-slot-v1',
+      confidence_label: 'validated_high_accuracy',
+      disclaimer: 'Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.',
+      validation_note: 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+      required_input_missing: [],
+      predictions: [
+        {
+          system_address: 123,
+          body_id: 1,
+          body_name: 'Body 1',
+          predicted_orbital_slots: 4,
+          predicted_ground_slots: 5,
+          prediction_status: 'predicted',
+          reasons: [],
+        },
+      ],
+    } as any);
     mockedImportSystemLayout.mockResolvedValue({
       system_id64: 123,
       source: 'spansh',
@@ -181,5 +231,83 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(mockedCompare).not.toHaveBeenCalled();
     expect(mockedReview).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /Copy to Build Plan/i })).toBeNull();
+  });
+
+  it('keeps left and centre slot lanes aligned and updates both after explicit structure adds', async () => {
+    mockedApiSystem.mockResolvedValue(slotMapSystem);
+    mockedGetFacilityTemplates.mockResolvedValue(templates);
+    mockedGetSimulationSummary.mockResolvedValue({
+      classification: { primary_archetype: 'refinery_industrial' },
+      buildability: { recommended_build_order: [] },
+      regional_context: null,
+    } as unknown as SimulationSummary);
+    mockedGetSlotPredictions.mockResolvedValue({
+      system_id64: 123,
+      data_source: 'eddn',
+      body_count: 1,
+      predicted_orbital_slots_total: 4,
+      predicted_ground_slots_total: 5,
+      prediction_status: 'predicted',
+      prediction_version: 'validated-slot-v1',
+      confidence_label: 'validated_high_accuracy',
+      disclaimer: 'Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.',
+      validation_note: 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+      required_input_missing: [],
+      predictions: [
+        {
+          system_address: 123,
+          body_id: 1,
+          body_name: 'Body 1',
+          predicted_orbital_slots: 4,
+          predicted_ground_slots: 5,
+          prediction_status: 'predicted',
+          reasons: [],
+        },
+      ],
+    } as any);
+    mockedImportSystemLayout.mockResolvedValue({
+      system_id64: 123,
+      source: 'spansh',
+      status: 'success',
+      fetched_at: '2026-05-16T00:00:00Z',
+      summary: {
+        bodies_found: 0,
+        stations_found: 0,
+        bodies_upserted: 0,
+        stations_upserted: 0,
+        warnings_count: 0,
+      },
+      warnings: [],
+      errors: [],
+    });
+
+    renderWorkspace();
+
+    await screen.findByTestId('topology-body-1');
+    await waitFor(() => {
+      expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
+      expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('topology-body-button-1'));
+    await screen.findByText('Planning on body');
+    await waitFor(() => {
+      expect(screen.getByTestId('body-1-orbital-slot-3')).toBeTruthy();
+      expect(screen.getByTestId('body-1-ground-slot-4')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add structure here' })[0]);
+    fireEvent.click(await screen.findByTestId('body-structure-template-orbital_port'));
+    await waitFor(() => {
+      expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+      expect((screen.getByTestId('body-1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add structure here' })[0]);
+    fireEvent.click(await screen.findByTestId('body-structure-template-surface_hub'));
+    await waitFor(() => {
+      expect((screen.getByTestId('1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+      expect((screen.getByTestId('body-1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+    });
   });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import type { FacilityTemplate, SimulateBuildPlacement, SystemDetail } from '@/types/api';
+import type { FacilityTemplate, SimulateBuildPlacement, SlotPredictionResponse, SystemDetail } from '@/types/api';
 import {
   ColonyTopologyRail,
   describeTopologySelection,
@@ -52,6 +52,43 @@ const placements: SimulateBuildPlacement[] = [
   { facility_template_id: 'surface_hub', local_body_id: null, build_order: 4 },
 ];
 
+const slotPredictions: SlotPredictionResponse = {
+  system_id64: 123,
+  data_source: 'eddn',
+  body_count: 2,
+  predicted_orbital_slots_total: 4,
+  predicted_ground_slots_total: 5,
+  prediction_status: 'predicted',
+  prediction_version: 'validated-slot-v1',
+  confidence_label: 'validated_high_accuracy',
+  disclaimer: 'Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.',
+  validation_note: 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+  required_input_missing: [],
+  predictions: [
+    {
+      system_address: 123,
+      body_id: 1,
+      body_name: 'Tree System A 1',
+      planet_class: 'High metal content world',
+      predicted_orbital_slots: 4,
+      predicted_ground_slots: 5,
+      prediction_status: 'predicted',
+      reasons: [],
+    },
+    {
+      system_address: 123,
+      body_id: 2,
+      body_name: 'Tree System A 1 a',
+      planet_class: 'Rocky body',
+      predicted_orbital_slots: null,
+      predicted_ground_slots: null,
+      prediction_status: 'unknown',
+      required_input_missing: ['atmosphere'],
+      reasons: [],
+    },
+  ],
+};
+
 const system = {
   id64: 123,
   name: 'Tree System',
@@ -80,7 +117,7 @@ function RailHarness({
     <>
       <ColonyTopologyRail
         system={customSystem}
-        snapshot={{ placements, templates, targetArchetype: 'refinery_industrial', projection }}
+        snapshot={{ placements, templates, targetArchetype: 'refinery_industrial', slotPredictions, projection }}
         selection={selection}
         onSelect={(next) => {
           onSelectSpy?.(next);
@@ -92,6 +129,7 @@ function RailHarness({
           placements,
           templates,
           targetArchetype: 'refinery_industrial',
+          slotPredictions,
         }).label}
       </output>
     </>
@@ -172,5 +210,41 @@ describe('ColonyTopologyRail', () => {
     expect(screen.getByTestId('topology-projected-group-2')).toBeTruthy();
     expect(within(screen.getByTestId('topology-projected-group-2')).getByText('Projected')).toBeTruthy();
     expect(screen.getByTestId('topology-projected-placement-0')).toBeTruthy();
+  });
+
+  it('renders canonical slot lane counts and occupancy for a 4 orbital / 5 ground body', () => {
+    render(<RailHarness />);
+
+    expect(screen.getByText(/Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode./)).toBeTruthy();
+    expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
+    expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
+
+    const firstBody = screen.getByTestId('topology-body-1');
+    expect(within(firstBody).getByTestId('1-orbital-slot-0').textContent?.trim().length).toBeGreaterThan(0);
+  });
+
+  it('shows unknown slot lane when canonical prediction is unknown', () => {
+    render(<RailHarness />);
+    expect(screen.getByTestId('slot-lane-unknown-2-orbital')).toBeTruthy();
+    expect(screen.getByTestId('slot-lane-unknown-2-ground')).toBeTruthy();
+  });
+
+  it('shows overflow when structures exceed predicted capacity', () => {
+    render(
+      <RailHarness
+        projection={{
+          candidateId: 'candidate-overflow',
+          label: 'Overflow candidate',
+          placements: [
+            { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: false, build_order: 5 },
+            { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: false, build_order: 6 },
+            { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: false, build_order: 7 },
+            { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: false, build_order: 8 },
+            { facility_template_id: 'orbital_port', local_body_id: '1', is_primary_port: false, build_order: 9 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByTestId('topology-overflow-1').textContent).toContain('overflow / unconfirmed');
   });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
@@ -2,6 +2,7 @@ import { Network } from 'lucide-react';
 import type {
   FacilityTemplate,
   SimulateBuildPlacement,
+  SlotPredictionResponse,
   SystemBody,
   SystemDetail,
 } from '@/types/api';
@@ -25,6 +26,7 @@ export interface TopologyPlanSnapshot {
   placements: SimulateBuildPlacement[];
   templates: FacilityTemplate[];
   targetArchetype: string;
+  slotPredictions?: SlotPredictionResponse | null;
   projection?: {
     candidateId: string;
     label: string;
@@ -66,6 +68,8 @@ interface ProjectedPlacementItem {
   template?: FacilityTemplate;
 }
 
+type SlotLaneKind = 'orbital' | 'ground' | 'unknown';
+
 export function ColonyTopologyRail({
   system,
   snapshot,
@@ -98,6 +102,13 @@ export function ColonyTopologyRail({
         <Network size={13} />
         System topology
       </div>
+      {snapshot.slotPredictions && (
+        <div className="mt-2 rounded border border-cyan/25 bg-cyan/5 px-2 py-1.5 font-mono text-[10px] text-silver-dk">
+          <div className="text-cyan">Predicted slots</div>
+          <div className="mt-0.5">{snapshot.slotPredictions.disclaimer}</div>
+          <div className="mt-0.5 italic">{snapshot.slotPredictions.validation_note}</div>
+        </div>
+      )}
 
       <button
         type="button"
@@ -130,6 +141,7 @@ export function ColonyTopologyRail({
               key={node.id}
               node={node}
               systemName={system.name}
+              slotPrediction={snapshot.slotPredictions?.predictions?.find((item) => String(item.body_id) === node.id) ?? null}
               placements={buckets.knownByBody.get(node.id) ?? []}
               projectedPlacements={projectedByBody.get(node.id) ?? []}
               selected={selection.type === 'body' && selection.bodyId === node.id}
@@ -190,6 +202,7 @@ export function ColonyTopologyRail({
 function BodyTreeRow({
   node,
   systemName,
+  slotPrediction,
   placements,
   projectedPlacements,
   selected,
@@ -199,6 +212,7 @@ function BodyTreeRow({
 }: {
   node: BodyNode;
   systemName?: string | null;
+  slotPrediction: NonNullable<TopologyPlanSnapshot['slotPredictions']>['predictions'][number] | null;
   placements: GroupedPlacement[];
   projectedPlacements: ProjectedPlacementItem[];
   selected: boolean;
@@ -214,6 +228,18 @@ function BodyTreeRow({
   const compactName = compactBodyDisplayName(node.body, systemName);
   const projectedCount = projectedPlacements.length;
   const depthIndent = node.depth > 0 ? `${node.depth * 0.75}rem` : '0rem';
+  const plannedOrbital = placements.filter((item) => placementLaneKind(item.template) === 'orbital');
+  const plannedGround = placements.filter((item) => placementLaneKind(item.template) === 'ground');
+  const plannedUnknown = placements.filter((item) => placementLaneKind(item.template) === 'unknown');
+  const projectedOrbital = projectedPlacements.filter((item) => placementLaneKind(item.template) === 'orbital');
+  const projectedGround = projectedPlacements.filter((item) => placementLaneKind(item.template) === 'ground');
+  const projectedUnknown = projectedPlacements.filter((item) => placementLaneKind(item.template) === 'unknown');
+  const orbitalCapacity = slotPrediction?.predicted_orbital_slots ?? null;
+  const groundCapacity = slotPrediction?.predicted_ground_slots ?? null;
+  const orbitalOverflow = orbitalCapacity == null ? 0 : Math.max(0, plannedOrbital.length + projectedOrbital.length - orbitalCapacity);
+  const groundOverflow = groundCapacity == null ? 0 : Math.max(0, plannedGround.length + projectedGround.length - groundCapacity);
+  const unknownOverflow = plannedUnknown.length + projectedUnknown.length;
+  const totalOverflow = orbitalOverflow + groundOverflow + unknownOverflow;
 
   return (
     <div data-testid={`topology-body-${node.id}`}>
@@ -263,6 +289,30 @@ function BodyTreeRow({
           ))}
         </div>
       )}
+      <div className="ml-3 mt-1 rounded border border-border/45 bg-bg3/35 px-2 py-1.5">
+        <SlotLaneRow
+          laneKey={`${node.id}-orbital`}
+          label="Orbital"
+          capacity={orbitalCapacity}
+          planned={plannedOrbital.map((item) => item.template?.name ?? item.placement.facility_template_id)}
+          projected={projectedOrbital.map((item) => item.template?.name ?? item.placement.facility_template_id)}
+        />
+        <SlotLaneRow
+          laneKey={`${node.id}-ground`}
+          label="Ground"
+          capacity={groundCapacity}
+          planned={plannedGround.map((item) => item.template?.name ?? item.placement.facility_template_id)}
+          projected={projectedGround.map((item) => item.template?.name ?? item.placement.facility_template_id)}
+        />
+        {totalOverflow > 0 && (
+          <div
+            data-testid={`topology-overflow-${node.id}`}
+            className="mt-1 font-mono text-[9px] text-gold"
+          >
+            +{totalOverflow} overflow / unconfirmed
+          </div>
+        )}
+      </div>
       {projectedPlacements.length > 0 && (
         <div
           data-testid={`topology-projected-group-${node.id}`}
@@ -348,6 +398,96 @@ function PlacementButton({
       {item.placement.is_primary_port && <span className="shrink-0 text-gold">primary</span>}
     </button>
   );
+}
+
+function placementLaneKind(template?: FacilityTemplate): SlotLaneKind {
+  const value = (template?.allowed_location ?? '').toLowerCase();
+  const hasOrbital = value.includes('orbit');
+  const hasGround = value.includes('surface') || value.includes('ground');
+  if (hasOrbital && !hasGround) return 'orbital';
+  if (hasGround && !hasOrbital) return 'ground';
+  return 'unknown';
+}
+
+function SlotLaneRow({
+  laneKey,
+  label,
+  capacity,
+  planned,
+  projected,
+}: {
+  laneKey: string;
+  label: string;
+  capacity: number | null | undefined;
+  planned: string[];
+  projected: string[];
+}) {
+  if (capacity == null) {
+    return (
+      <div className="flex items-center gap-1.5 font-mono text-[9px] text-silver-dk">
+        <span className="w-10 uppercase tracking-[0.12em]">{label}</span>
+        <span className="rounded border border-gold/35 bg-gold/10 px-1 text-gold" data-testid={`slot-lane-unknown-${laneKey}`}>[?]</span>
+      </div>
+    );
+  }
+
+  const cells = Array.from({ length: Math.max(0, capacity) }, (_unused, index) => {
+    if (index < planned.length) {
+      const value = planned[index] ?? '';
+      return {
+        key: `planned-${laneKey}-${index}`,
+        label: compactFacilityName(value),
+        tone: 'planned' as const,
+      };
+    }
+    const projectedIndex = index - planned.length;
+    if (projectedIndex >= 0 && projectedIndex < projected.length) {
+      const value = projected[projectedIndex] ?? '';
+      return {
+        key: `projected-${laneKey}-${index}`,
+        label: compactFacilityName(value),
+        tone: 'projected' as const,
+      };
+    }
+    return {
+      key: `empty-${laneKey}-${index}`,
+      label: '',
+      tone: 'empty' as const,
+    };
+  });
+
+  return (
+    <div className="flex items-center gap-1.5 font-mono text-[9px] text-silver-dk">
+      <span className="w-10 uppercase tracking-[0.12em]">{label}</span>
+      <div className="flex min-w-0 flex-wrap gap-1">
+        {cells.map((cell, index) => (
+          <span
+            key={cell.key}
+            data-testid={`${laneKey}-slot-${index}`}
+            className={[
+              'inline-flex h-5 min-w-5 max-w-[4.6rem] items-center justify-center rounded border px-1 text-[8px] leading-none',
+              cell.tone === 'planned'
+                ? 'border-orange/55 bg-orange/15 text-orange'
+                : cell.tone === 'projected'
+                  ? 'border-cyan/45 bg-cyan/10 text-cyan'
+                  : 'border-border/60 bg-bg2/45 text-silver-dk',
+            ].join(' ')}
+            title={cell.label || 'Empty slot'}
+          >
+            {cell.label ? cell.label : ' '}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function compactFacilityName(value: string): string {
+  const clean = value.trim();
+  if (!clean) return '';
+  const parts = clean.split(/\s+/);
+  if (parts.length === 1) return parts[0].slice(0, 6);
+  return parts[0].slice(0, 5);
 }
 
 function ProjectedPlacementRow({ item }: { item: ProjectedPlacementItem }) {

--- a/frontend-v2/src/features/colony-planner/WorkspaceGrid.tsx
+++ b/frontend-v2/src/features/colony-planner/WorkspaceGrid.tsx
@@ -39,6 +39,7 @@ export function WorkspaceGrid({ system }: { system: SystemDetail }) {
     placements: [],
     templates: [],
     targetArchetype: 'refinery_industrial',
+    slotPredictions: null,
     projection: null,
   });
   const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
@@ -293,6 +294,7 @@ function BodyPlanningSurface({
       template: templatesById.get(placement.facility_template_id),
     }))
     .filter((item) => item.placement.local_body_id != null && String(item.placement.local_body_id) === bodyId);
+  const slotPrediction = snapshot.slotPredictions?.predictions?.find((item) => String(item.body_id) === bodyId) ?? null;
 
   const reviewBodyStructures = () => {
     onReviewStructures(bodyId);
@@ -302,6 +304,7 @@ function BodyPlanningSurface({
     <div data-testid="body-planning-surface">
       <BodySlotPlanner
         body={body}
+        slotPrediction={slotPrediction}
         placements={placements}
         projectedPlacements={projectedPlacements}
         selectedPlacementIndex={selectedPlacementIndex}

--- a/frontend-v2/src/features/system-detail/SlotPredictionPanel.tsx
+++ b/frontend-v2/src/features/system-detail/SlotPredictionPanel.tsx
@@ -1,36 +1,18 @@
-/**
- * SlotPredictionPanel — Per-body slot prediction table
- * ======================================================
- * Renders inside the "Colony Build Analysis" section of SystemDetailModal.
- *
- * Data source: GET /api/systems/{id64}/slot-predictions
- * Shows predicted orbital + surface slots per body, confidence badges,
- * and expandable reason tooltips for each prediction.
- *
- * Design language: ED orange / brushed-steel (matches SystemDetailModal).
- */
-
 import { Fragment, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import type { BodySlotPrediction, SlotPredictionResponse, SlotReason } from '@/types/api';
 
-// ─── Types ──────────────────────────────────────────────────────────────────
-
 type BodyPrediction = BodySlotPrediction;
-
-// ─── Fetch hook ─────────────────────────────────────────────────────────────
 
 function useSlotPredictions(id64: number) {
   return useQuery<SlotPredictionResponse, Error>({
     queryKey: ['slot-predictions', id64],
-    queryFn:  () => api.slotPredictions(id64),
+    queryFn: () => api.slotPredictions(id64),
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });
 }
-
-// ─── Public component ───────────────────────────────────────────────────────
 
 export interface SlotPredictionPanelProps {
   id64: number;
@@ -41,45 +23,41 @@ export function SlotPredictionPanel({ id64 }: SlotPredictionPanelProps) {
   const { data, isLoading, isError, refetch } = useSlotPredictions(id64);
   const predictions = data?.predictions ?? [];
 
-  // Collapsed header — always show, even before expand
+  const orbitalTotal = data?.predicted_orbital_slots_total ?? null;
+  const groundTotal = data?.predicted_ground_slots_total ?? null;
+
   const headerContent = () => {
     if (isLoading) {
-      return (
-        <span className="font-mono text-silver-dk text-[11px] animate-pulse">
-          Loading slot data…
-        </span>
-      );
+      return <span className="font-mono text-silver-dk text-[11px] animate-pulse">Loading slot data…</span>;
     }
     if (isError || !data) {
       return (
         <span className="font-mono text-red text-[11px]">
-          Failed to load · <button
+          Failed to load ·{' '}
+          <button
             type="button"
-            onClick={(e) => { e.stopPropagation(); void refetch(); }}
+            onClick={(event) => {
+              event.stopPropagation();
+              void refetch();
+            }}
             className="underline hover:text-orange"
-          >retry</button>
-        </span>
-      );
-    }
-    if (data.data_source === 'none' || predictions.length === 0) {
-      return (
-        <span className="font-mono text-silver-dk text-[11px] italic">
-          No body scan data available
+          >
+            retry
+          </button>
         </span>
       );
     }
     return (
       <div className="flex flex-wrap items-center gap-2">
         <span className="font-mono text-silver text-[11px]">
-          <span className="tabular-nums text-cyan font-bold">{data.estimated_orbital_slots}</span>
+          <span className="tabular-nums text-cyan font-bold">{slotLabel(orbitalTotal)}</span>
           <span className="text-silver-dk"> orbital · </span>
-          <span className="tabular-nums text-gold font-bold">{data.estimated_ground_slots}</span>
-          <span className="text-silver-dk"> surface · </span>
+          <span className="tabular-nums text-gold font-bold">{slotLabel(groundTotal)}</span>
+          <span className="text-silver-dk"> ground · </span>
           <span className="tabular-nums text-silver">{data.body_count}</span>
-          <span className="text-silver-dk"> bodies scanned</span>
+          <span className="text-silver-dk"> bodies</span>
         </span>
-        <ConfidenceBadge label={data.slot_confidence_label} />
-        <DataSourceBadge source={data.data_source} />
+        <StatusBadge status={data.prediction_status} />
       </div>
     );
   };
@@ -89,13 +67,12 @@ export function SlotPredictionPanel({ id64 }: SlotPredictionPanelProps) {
       className="rounded-chunk-lg border border-border/60 overflow-hidden"
       style={{
         background: 'linear-gradient(180deg, rgba(20,22,26,0.85), rgba(14,16,20,0.85))',
-        boxShadow:  'inset 0 1px 0 rgba(255,255,255,0.04), 0 8px 24px -16px rgba(0,0,0,0.6)',
+        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.04), 0 8px 24px -16px rgba(0,0,0,0.6)',
       }}
     >
-      {/* ── Collapsible header ────────────────────────────────────────── */}
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen((value) => !value)}
         disabled={!data || predictions.length === 0}
         className="w-full flex items-center justify-between px-3 py-2.5 text-left hover:bg-orange/5 disabled:cursor-default transition-colors"
       >
@@ -106,112 +83,75 @@ export function SlotPredictionPanel({ id64 }: SlotPredictionPanelProps) {
           {headerContent()}
         </div>
         {data && predictions.length > 0 && (
-          <span
-            className={[
-              'font-mono text-orange text-sm transition-transform duration-200 ml-3 shrink-0',
-              open ? 'rotate-180' : '',
-            ].join(' ')}
-          >
+          <span className={['font-mono text-orange text-sm transition-transform duration-200 ml-3 shrink-0', open ? 'rotate-180' : ''].join(' ')}>
             ▾
           </span>
         )}
       </button>
 
-      {/* ── Expanded table ────────────────────────────────────────────── */}
       {open && data && predictions.length > 0 && (
         <div className="border-t border-border/50">
+          <div className="px-3 py-2 border-b border-border/40 font-mono text-[10px] text-silver-dk">
+            <div className="text-silver">{data.disclaimer}</div>
+            <div className="mt-1 italic">{data.validation_note}</div>
+            {data.prediction_status === 'unknown' && (
+              <div className="mt-1 text-gold">{data.note ?? 'insufficient prediction data. verify in Architect Mode.'}</div>
+            )}
+          </div>
           <PredictionTable predictions={predictions} />
-          {data.note && (
-            <div className="px-3 py-2 font-mono text-[10px] text-silver-dk border-t border-border/40 italic leading-snug">
-              {data.note}
-            </div>
-          )}
         </div>
       )}
     </div>
   );
 }
 
-// ─── PredictionTable ────────────────────────────────────────────────────────
-
 function PredictionTable({ predictions }: { predictions: BodyPrediction[] }) {
   const [expandedId, setExpandedId] = useState<number | null>(null);
 
   return (
     <table className="w-full text-xs font-mono">
-      <thead
-        className="text-silver-dk uppercase tracking-[0.14em] text-[9px]"
-        style={{
-          background:   'linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))',
-          borderBottom: '1px solid hsl(216 10% 22%)',
-        }}
-      >
+      <thead className="text-silver-dk uppercase tracking-[0.14em] text-[9px]" style={{ background: 'linear-gradient(180deg, rgba(255,255,255,0.04), rgba(255,255,255,0.01))', borderBottom: '1px solid hsl(216 10% 22%)' }}>
         <tr>
           <th className="px-3 py-2 text-left">Body</th>
           <th className="px-3 py-2 text-left">Class</th>
-          <th className="px-3 py-2 text-center">Tags</th>
           <th className="px-3 py-2 text-right text-cyan">Orbital</th>
-          <th className="px-3 py-2 text-right text-gold">Surface</th>
-          <th className="px-3 py-2 text-center">Conf.</th>
+          <th className="px-3 py-2 text-right text-gold">Ground</th>
+          <th className="px-3 py-2 text-center">Status</th>
           <th className="px-3 py-2 text-center">Reasons</th>
         </tr>
       </thead>
       <tbody>
-        {predictions.map((p) => {
-          const isExpanded = expandedId === p.body_id;
+        {predictions.map((prediction) => {
+          const isExpanded = expandedId === prediction.body_id;
           return (
-            <Fragment key={p.body_id}>
+            <Fragment key={prediction.body_id}>
               <tr
                 className="border-t border-border/40 hover:bg-orange/5 transition-colors cursor-pointer"
-                onClick={() => setExpandedId(isExpanded ? null : p.body_id)}
+                onClick={() => setExpandedId(isExpanded ? null : prediction.body_id)}
               >
-                {/* Body name */}
                 <td className="px-3 py-2 text-orange-lt font-semibold max-w-[140px] truncate">
-                  {shortBodyName(p.body_name)}
+                  {shortBodyName(prediction.body_name)}
                 </td>
-
-                {/* Planet class */}
-                <td className="px-3 py-2 text-silver max-w-[120px]">
-                  <span className="truncate block">{abbreviateClass(p.planet_class)}</span>
+                <td className="px-3 py-2 text-silver max-w-[140px]">
+                  <span className="truncate block">{abbreviateClass(prediction.planet_class)}</span>
                 </td>
-
-                {/* Body tags */}
+                <td className="px-3 py-2 text-right tabular-nums text-cyan font-bold">{slotLabel(prediction.predicted_orbital_slots ?? null)}</td>
+                <td className="px-3 py-2 text-right tabular-nums text-gold font-bold">{slotLabel(prediction.predicted_ground_slots ?? null)}</td>
                 <td className="px-3 py-2 text-center">
-                  <BodyTagRow pred={p} />
+                  <StatusBadge status={prediction.prediction_status} compact />
                 </td>
-
-                {/* Orbital slots */}
-                <td className="px-3 py-2 text-right tabular-nums text-cyan font-bold">
-                  {p.estimated_orbital_slots > 0 ? p.estimated_orbital_slots : <span className="text-text-dim font-normal">—</span>}
-                </td>
-
-                {/* Surface slots */}
-                <td className="px-3 py-2 text-right tabular-nums text-gold font-bold">
-                  {p.estimated_surface_slots > 0 ? p.estimated_surface_slots : <span className="text-text-dim font-normal">—</span>}
-                </td>
-
-                {/* Confidence */}
                 <td className="px-3 py-2 text-center">
-                  <ConfidencePip value={p.slot_confidence} />
-                </td>
-
-                {/* Reasons toggle */}
-                <td className="px-3 py-2 text-center">
-                  {p.reasons && p.reasons.length > 0 ? (
-                    <span className={['text-[10px]', isExpanded ? 'text-orange' : 'text-silver-dk'].join(' ')}>
-                      {isExpanded ? '▲' : `▾ ${p.reasons.length}`}
-                    </span>
+                  {(prediction.reasons?.length ?? 0) > 0 ? (
+                    <span className={['text-[10px]', isExpanded ? 'text-orange' : 'text-silver-dk'].join(' ')}>{isExpanded ? '▲' : `▾ ${prediction.reasons?.length ?? 0}`}</span>
                   ) : (
                     <span className="text-border">—</span>
                   )}
                 </td>
               </tr>
-
-              {/* Expanded reasons row */}
-              {isExpanded && p.reasons && p.reasons.length > 0 && (
-                <tr key={`${p.body_id}-reasons`} className="border-t border-orange/10 bg-orange/5">
-                  <td colSpan={7} className="px-4 py-2">
-                    <ReasonList reasons={p.reasons} />
+              {isExpanded && (prediction.reasons?.length ?? 0) > 0 && (
+                <tr className="border-t border-orange/10 bg-orange/5">
+                  <td colSpan={6} className="px-4 py-2">
+                    <ReasonList reasons={prediction.reasons ?? []} missingInputs={prediction.required_input_missing ?? []} />
                   </td>
                 </tr>
               )}
@@ -223,140 +163,61 @@ function PredictionTable({ predictions }: { predictions: BodyPrediction[] }) {
   );
 }
 
-// ─── ReasonList ─────────────────────────────────────────────────────────────
-
-function ReasonList({ reasons }: { reasons: SlotReason[] }) {
+function ReasonList({ reasons, missingInputs }: { reasons: SlotReason[]; missingInputs: string[] }) {
   return (
     <ul className="space-y-1">
-      {reasons.map((r, i) => (
-        <li key={i} className="flex items-start gap-2 font-mono text-[10px]">
+      {reasons.map((reason, index) => (
+        <li key={index} className="flex items-start gap-2 font-mono text-[10px]">
           <span className="text-orange shrink-0 mt-0.5">›</span>
-          <span className="text-silver-dk uppercase tracking-wide shrink-0">{r.factor}</span>
-          {r.delta != null && r.delta !== 0 && (
-            <span
-              className={['tabular-nums font-bold shrink-0', r.delta > 0 ? 'text-green' : 'text-red'].join(' ')}
-            >
-              {r.delta > 0 ? `+${r.delta}` : r.delta}
+          <span className="text-silver-dk uppercase tracking-wide shrink-0">{reason.factor}</span>
+          {reason.delta != null && reason.delta !== 0 && (
+            <span className={['tabular-nums font-bold shrink-0', reason.delta > 0 ? 'text-green' : 'text-red'].join(' ')}>
+              {reason.delta > 0 ? `+${reason.delta}` : reason.delta}
             </span>
           )}
-          {r.note && <span className="text-silver italic leading-tight">{r.note}</span>}
+          {reason.note && <span className="text-silver italic leading-tight">{reason.note}</span>}
         </li>
       ))}
+      {missingInputs.length > 0 && (
+        <li className="flex items-start gap-2 font-mono text-[10px] text-gold">
+          <span className="shrink-0 mt-0.5">!</span>
+          <span>Missing inputs: {missingInputs.join(', ')}</span>
+        </li>
+      )}
     </ul>
   );
 }
 
-// ─── BodyTagRow ─────────────────────────────────────────────────────────────
-
-function BodyTagRow({ pred }: { pred: BodyPrediction }) {
-  const tags: string[] = [];
-  if (pred.is_ringed)   tags.push('⊙');   // ringed
-  if (pred.is_landable) tags.push('⬇');   // landable
-  if (tags.length === 0) return <span className="text-border">—</span>;
+function StatusBadge({ status, compact = false }: { status: 'predicted' | 'unknown' | 'observed'; compact?: boolean }) {
+  const style = status === 'predicted'
+    ? { border: 'border-green/40', bg: 'bg-green/15', text: 'text-green', label: compact ? 'P' : 'predicted' }
+    : status === 'observed'
+      ? { border: 'border-cyan/40', bg: 'bg-cyan/15', text: 'text-cyan', label: compact ? 'O' : 'observed' }
+      : { border: 'border-gold/40', bg: 'bg-gold/15', text: 'text-gold', label: compact ? '?' : 'unknown' };
   return (
-    <span className="text-silver-dk text-[10px] tracking-widest">{tags.join(' ')}</span>
-  );
-}
-
-// ─── ConfidenceBadge ────────────────────────────────────────────────────────
-
-function ConfidenceBadge({ label }: { label: string }) {
-  const colour = confidenceColour(label);
-  return (
-    <span
-      className="px-1.5 py-0.5 rounded border font-mono text-[9px] font-bold uppercase tracking-wide"
-      style={{ borderColor: `${colour}60`, color: colour, backgroundColor: `${colour}18` }}
-    >
-      {label}
+    <span className={['rounded border px-1.5 py-0.5 text-[9px] uppercase tracking-[0.12em]', style.border, style.bg, style.text].join(' ')}>
+      {style.label}
     </span>
   );
 }
 
-// ─── ConfidencePip ──────────────────────────────────────────────────────────
-
-function ConfidencePip({ value }: { value: number }) {
-  const pct   = Math.round(value * 100);
-  const colour = value >= 0.85 ? '#4caf50' : value >= 0.65 ? '#f5c518' : value >= 0.45 ? '#ff9800' : '#8c9bab';
-  return (
-    <span
-      className="inline-block px-1.5 py-0.5 rounded font-mono text-[9px] tabular-nums font-bold border"
-      style={{ borderColor: `${colour}50`, color: colour, backgroundColor: `${colour}15` }}
-      title={`${pct}% confidence`}
-    >
-      {pct}%
-    </span>
-  );
+function slotLabel(value: number | null | undefined): string {
+  return value == null ? '?' : String(value);
 }
 
-// ─── DataSourceBadge ────────────────────────────────────────────────────────
-
-function DataSourceBadge({ source }: { source: 'eddn' | 'spansh' | 'none' }) {
-  const map: Record<string, { label: string; colour: string }> = {
-    eddn:   { label: 'EDDN', colour: '#4caf50' },
-    spansh: { label: 'Spansh', colour: '#f5c518' },
-    none:   { label: 'No data', colour: '#8c9bab' },
-  };
-  const { label, colour } = map[source] ?? map.none;
-  return (
-    <span
-      className="px-1.5 py-0.5 rounded border font-mono text-[9px] uppercase tracking-wide"
-      style={{ borderColor: `${colour}50`, color: colour, backgroundColor: `${colour}12` }}
-    >
-      {label}
-    </span>
-  );
-}
-
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
-function confidenceColour(label: string): string {
-  switch (label) {
-    case 'High':      return '#4caf50';
-    case 'Moderate':  return '#f5c518';
-    case 'Low':       return '#ff9800';
-    default:          return '#8c9bab';
-  }
-}
-
-/** Strip the system name prefix from body names (e.g. "Colonia 1 a" → "1 a") */
 function shortBodyName(name?: string | null): string {
-  if (!name) return '—';
-  // Body names in ED follow pattern "<System> <body designator>"
-  // We show the full name but truncate long system-name prefixes
+  if (!name) return 'Unknown body';
   const parts = name.trim().split(' ');
-  // If ≤3 words it's already short
   if (parts.length <= 3) return name;
-  // Return last 2 tokens (body designator usually 1-2 tokens)
-  return parts.slice(-2).join(' ');
+  return parts.slice(-3).join(' ');
 }
 
-const CLASS_ABBREV: Record<string, string> = {
-  'High metal content body':         'HMC',
-  'Rocky body':                      'Rocky',
-  'Rocky ice body':                  'Rocky Ice',
-  'Icy body':                        'Icy',
-  'Metal rich body':                 'Metal Rich',
-  'Earth-like world':                'ELW',
-  'Water world':                     'Water World',
-  'Ammonia world':                   'Ammonia',
-  'Gas giant with water-based life': 'GG Water',
-  'Gas giant with ammonia-based life':'GG Ammonia',
-  'Class I gas giant':               'GG-I',
-  'Class II gas giant':              'GG-II',
-  'Class III gas giant':             'GG-III',
-  'Class IV gas giant':              'GG-IV',
-  'Class V gas giant':               'GG-V',
-  'Sudarsky class I gas giant':      'GG-I',
-  'Sudarsky class II gas giant':     'GG-II',
-  'Sudarsky class III gas giant':    'GG-III',
-  'Sudarsky class IV gas giant':     'GG-IV',
-  'Sudarsky class V gas giant':      'GG-V',
-  'Helium-rich gas giant':           'GG He',
-  'Helium gas giant':                'GG He',
-  'Water giant':                     'Water GG',
-};
-
-function abbreviateClass(cls?: string | null): string {
-  if (!cls) return '—';
-  return CLASS_ABBREV[cls] ?? cls;
+function abbreviateClass(planetClass?: string | null): string {
+  if (!planetClass) return '—';
+  return planetClass
+    .replace('High metal content body', 'HMC')
+    .replace('High metal content world', 'HMC')
+    .replace('Rocky ice body', 'Rocky-Ice')
+    .replace('Earth-like world', 'ELW')
+    .replace('Water world', 'WW');
 }

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.optimiser.test.tsx
@@ -8,6 +8,7 @@ import {
   fetchOptimiserCandidates,
   getFacilityTemplates,
   getSimulationSummary,
+  getSlotPredictions,
   importSystemLayout,
   listObservedFacts,
   reviewPredictionValidation,
@@ -21,6 +22,7 @@ vi.mock('@/lib/api', () => ({
   fetchOptimiserCandidates: vi.fn(),
   getFacilityTemplates: vi.fn(),
   getSimulationSummary: vi.fn(),
+  getSlotPredictions: vi.fn(),
   importSystemLayout: vi.fn(),
   simulateBuild: vi.fn(),
   // Stage 6B observation helpers — the optimiser test does not exercise
@@ -40,6 +42,7 @@ vi.mock('@/lib/api', () => ({
 const mockedFetchOptimiserCandidates = vi.mocked(fetchOptimiserCandidates);
 const mockedGetFacilityTemplates = vi.mocked(getFacilityTemplates);
 const mockedGetSimulationSummary = vi.mocked(getSimulationSummary);
+const mockedGetSlotPredictions = vi.mocked(getSlotPredictions);
 const mockedImportSystemLayout = vi.mocked(importSystemLayout);
 const mockedSimulateBuild = vi.mocked(simulateBuild);
 const mockedListObservedFacts = vi.mocked(listObservedFacts);
@@ -120,6 +123,31 @@ const system = {
     { id: 'body1', name: 'Test Body', body_type: 'Planet', is_landable: true },
   ],
 } as unknown as SystemDetail;
+
+const slotPredictionResponse = {
+  system_id64: 123,
+  data_source: 'eddn',
+  body_count: 1,
+  predicted_orbital_slots_total: 4,
+  predicted_ground_slots_total: 5,
+  prediction_status: 'predicted',
+  prediction_version: 'validated-slot-v1',
+  confidence_label: 'validated_high_accuracy',
+  disclaimer: 'Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.',
+  validation_note: 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+  required_input_missing: [],
+  predictions: [
+    {
+      system_address: 123,
+      body_id: 1,
+      body_name: 'Test Body',
+      predicted_orbital_slots: 4,
+      predicted_ground_slots: 5,
+      prediction_status: 'predicted',
+      reasons: [],
+    },
+  ],
+};
 
 const layoutImportSuccess: LayoutImportResponse = {
   system_id64: 123,
@@ -238,6 +266,7 @@ function mockNoRecommendedBuild() {
     regional_context: null,
   } as unknown as SimulationSummary);
   mockedFetchOptimiserCandidates.mockResolvedValue(optimiserResponse);
+  mockedGetSlotPredictions.mockResolvedValue(slotPredictionResponse as any);
   mockedImportSystemLayout.mockResolvedValue(layoutImportSuccess);
   mockedListObservedFacts.mockResolvedValue(emptyObservedFactsResponse());
   mockedCompare.mockResolvedValue(emptyCompareResponse());
@@ -257,6 +286,7 @@ function mockRecommendedBuild() {
     regional_context: null,
   } as unknown as SimulationSummary);
   mockedFetchOptimiserCandidates.mockResolvedValue(optimiserResponse);
+  mockedGetSlotPredictions.mockResolvedValue(slotPredictionResponse as any);
   mockedImportSystemLayout.mockResolvedValue(layoutImportSuccess);
   mockedListObservedFacts.mockResolvedValue(emptyObservedFactsResponse());
   mockedCompare.mockResolvedValue(emptyCompareResponse());
@@ -331,6 +361,7 @@ describe('SimulationPreview optimiser candidate loading', () => {
     mockedFetchOptimiserCandidates.mockReset();
     mockedGetFacilityTemplates.mockReset();
     mockedGetSimulationSummary.mockReset();
+    mockedGetSlotPredictions.mockReset();
     mockedImportSystemLayout.mockReset();
     mockedSimulateBuild.mockReset();
     mockedListObservedFacts.mockReset();

--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getFacilityTemplates, getSimulationSummary, listObservedFacts } from '@/lib/api';
+import { getFacilityTemplates, getSimulationSummary, getSlotPredictions, listObservedFacts } from '@/lib/api';
 import type {
   FacilityTemplate,
   OptimiserCandidate,
@@ -83,6 +83,12 @@ export function SimulationPreview({
     staleTime: 5 * 60 * 1000,
     retry: 1,
   });
+  const slotPredictionsQuery = useQuery({
+    queryKey: ['slot-predictions-preview', system.id64],
+    queryFn: () => getSlotPredictions(system.id64),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
   const observedFactsQuery = useQuery({
     queryKey: ['role-review-observed-facts', system.id64],
     queryFn: () => listObservedFacts({ system_id64: system.id64, limit: 100 }),
@@ -160,6 +166,7 @@ export function SimulationPreview({
       placements: plan.placements,
       templates,
       targetArchetype: plan.targetArchetype,
+      slotPredictions: slotPredictionsQuery.data ?? null,
       projection: projectedCandidate ? {
         candidateId: projectedCandidate.candidate_id,
         label: projectedCandidate.label,
@@ -171,7 +178,7 @@ export function SimulationPreview({
         })),
       } : null,
     });
-  }, [onPlanSnapshotChange, plan.placements, plan.targetArchetype, projectedCandidate, templates]);
+  }, [onPlanSnapshotChange, plan.placements, plan.targetArchetype, projectedCandidate, slotPredictionsQuery.data, templates]);
 
   useEffect(() => {
     clearPreviewState();

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -60,12 +60,57 @@ export type RerankResponse        = Schemas['RerankResponse'];
 export type RerankRow             = Schemas['RerankRow'];
 export type RerankWeights         = Schemas['RerankWeights'];
 export type BuildabilityData      = Schemas['BuildabilityData'];
-export type BodySlotPrediction    = Schemas['BodySlotPrediction'];
 export type SimulationSummary     = Schemas['SimulationSummaryResponse'] & { regional_context?: RegionalAnalysisResponse | null };
-export type SlotPredictionResponse = Schemas['SlotPredictionResponse'];
-export type SlotReason            = Schemas['SlotReason'];
 export type BuildabilityResponse  = Schemas['BuildabilityResponse'];
 export type SystemBuildability    = BuildabilityResponse;
+
+export interface SlotReason {
+  factor: string;
+  delta?: number | null;
+  note?: string | null;
+}
+
+export interface BodySlotPrediction {
+  system_address: number;
+  body_id: number;
+  body_name?: string | null;
+  planet_class?: string | null;
+  predicted_orbital_slots?: number | null;
+  predicted_ground_slots?: number | null;
+  prediction_status: 'predicted' | 'unknown' | 'observed';
+  confidence_label?: string | null;
+  prediction_version?: string | null;
+  validation_note?: string | null;
+  required_input_missing?: string[];
+  estimated_orbital_slots?: number | null;
+  estimated_surface_slots?: number | null;
+  slot_confidence?: number | null;
+  slot_source?: string | null;
+  reasons?: SlotReason[];
+  is_ringed?: boolean | null;
+  is_landable?: boolean | null;
+  radius?: number | null;
+}
+
+export interface SlotPredictionResponse {
+  system_id64: number;
+  data_source: 'eddn' | 'spansh' | 'none';
+  body_count: number;
+  predicted_orbital_slots_total?: number | null;
+  predicted_ground_slots_total?: number | null;
+  prediction_status: 'predicted' | 'unknown' | 'observed';
+  prediction_version: string;
+  confidence_label?: string | null;
+  disclaimer: string;
+  validation_note: string;
+  required_input_missing?: string[];
+  estimated_orbital_slots?: number | null;
+  estimated_ground_slots?: number | null;
+  slot_confidence?: number | null;
+  slot_confidence_label?: string | null;
+  predictions: BodySlotPrediction[];
+  note?: string | null;
+}
 
 export interface FacilityTemplate {
   id: string;

--- a/tests/test_simulation_contracts.py
+++ b/tests/test_simulation_contracts.py
@@ -16,46 +16,53 @@ from routers.simulation import _normalise_buildability, _slot_prediction_to_api
 
 
 class TestSimulationContracts(unittest.TestCase):
-    def test_slot_prediction_response_uses_frontend_field_names(self):
+    def test_slot_prediction_response_uses_canonical_prediction_fields(self):
         prediction = SlotPrediction(
             system_address=123,
             body_id=4,
-            surface_slots=2,
-            orbital_slots=1,
-            confidence=0.75,
-            slot_source='journal',
+            body_name='Test System 4 a',
+            predicted_orbital_slots=1,
+            predicted_ground_slots=2,
+            prediction_status='predicted',
+            confidence_label='validated_high_accuracy',
+            prediction_version='validated-slot-v1',
             reasons=[{
                 'factor': 'radius',
                 'value': 5000.0,
-                'contribution': '+2 surface slots',
+                'note': 'Radius tier base ground slots = 3.',
             }],
         )
         fact = {
             'body_name': 'Test System 4 a',
-            'planet_class': 'High metal content body',
+            'planet_class': 'High metal content world',
             'is_ringed': False,
             'is_landable': True,
             'radius': 5_000_000,
         }
 
         body = _slot_prediction_to_api(prediction, fact)
-        self.assertEqual(body['estimated_surface_slots'], 2)
-        self.assertEqual(body['estimated_orbital_slots'], 1)
-        self.assertEqual(body['slot_confidence'], 0.75)
+        self.assertEqual(body['predicted_ground_slots'], 2)
+        self.assertEqual(body['predicted_orbital_slots'], 1)
+        self.assertEqual(body['prediction_status'], 'predicted')
         self.assertEqual(body['body_name'], 'Test System 4 a')
-        self.assertEqual(body['reasons'][0]['note'], '+2 surface slots')
-        self.assertNotIn('surface_slots', body)
-        self.assertNotIn('orbital_slots', body)
-        self.assertNotIn('confidence', body)
+        self.assertEqual(body['reasons'][0]['note'], 'Radius tier base ground slots = 3.')
 
         SlotPredictionResponse.model_validate({
             'system_id64': 123,
             'data_source': 'eddn',
             'body_count': 1,
+            'predicted_orbital_slots_total': 1,
+            'predicted_ground_slots_total': 2,
+            'prediction_status': 'predicted',
+            'prediction_version': 'validated-slot-v1',
+            'confidence_label': 'validated_high_accuracy',
+            'disclaimer': 'Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.',
+            'validation_note': 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+            'required_input_missing': [],
             'estimated_orbital_slots': 1,
             'estimated_ground_slots': 2,
-            'slot_confidence': 0.75,
-            'slot_confidence_label': 'Moderate',
+            'slot_confidence': 0.96,
+            'slot_confidence_label': 'High',
             'predictions': [body],
         })
 

--- a/tests/test_slot_prediction_algorithm.py
+++ b/tests/test_slot_prediction_algorithm.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+
+from ingest.slot_prediction import INSUFFICIENT_DATA_REASON, predict_body_slots, predict_system_slots
+
+
+def fact(**overrides):
+    row = {
+        'system_address': 42,
+        'body_id': 7,
+        'body_name': 'Test 7',
+        'radius': 5_600_000,
+        'gravity': 1.1,
+        'surface_temp': 290,
+        'planet_class': 'Rocky body',
+        'terraform_state': None,
+        'atmosphere': 'Carbon dioxide atmosphere',
+        'volcanism': 'No volcanism',
+        'has_geo': False,
+        'has_bio': False,
+        'geo_signal_count': 0,
+        'bio_signal_count': 0,
+        'is_landable': True,
+        'is_terraformable': False,
+        'is_ringed': False,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_temperature_gate_above_700_returns_zero_ground_slots():
+    prediction = predict_body_slots(fact(surface_temp=701))
+    assert prediction.predicted_ground_slots == 0
+    assert prediction.prediction_status == 'predicted'
+
+
+def test_gravity_gate_above_2_7_returns_zero_ground_slots():
+    prediction = predict_body_slots(fact(gravity=2.71))
+    assert prediction.predicted_ground_slots == 0
+    assert prediction.prediction_status == 'predicted'
+
+
+def test_non_landable_returns_zero_ground_slots():
+    prediction = predict_body_slots(fact(is_landable=False))
+    assert prediction.predicted_ground_slots == 0
+
+
+def test_radius_cutoffs_match_validated_boundaries():
+    args = {'atmosphere': 'No atmosphere', 'planet_class': 'Rocky body'}
+    assert predict_body_slots(fact(radius=1_499_000, **args)).predicted_ground_slots == 1
+    assert predict_body_slots(fact(radius=1_500_000, **args)).predicted_ground_slots == 2
+    assert predict_body_slots(fact(radius=3_749_000, **args)).predicted_ground_slots == 2
+    assert predict_body_slots(fact(radius=3_750_000, **args)).predicted_ground_slots == 3
+    assert predict_body_slots(fact(radius=5_499_000, **args)).predicted_ground_slots == 3
+    assert predict_body_slots(fact(radius=5_500_000, **args)).predicted_ground_slots == 4
+
+
+def test_hmc_terraform_geo_bio_and_atmosphere_bonuses_apply_and_cap():
+    prediction = predict_body_slots(fact(
+        planet_class='High metal content world',
+        is_terraformable=True,
+        has_geo=True,
+        has_bio=True,
+        atmosphere='Methane atmosphere',
+        radius=5_900_000,
+    ))
+    # Base 4 + HMC 1 + modifiers capped to +3 => 7
+    assert prediction.predicted_ground_slots == 7
+
+
+def test_atmosphere_bonus_plus_one_for_thin_plus_two_for_standard():
+    thin = predict_body_slots(fact(atmosphere='Thin methane atmosphere', radius=3_750_000, planet_class='Rocky body'))
+    thick = predict_body_slots(fact(atmosphere='Methane atmosphere', radius=3_750_000, planet_class='Rocky body'))
+    assert thin.predicted_ground_slots == 4
+    assert thick.predicted_ground_slots == 5
+
+
+def test_cap_at_seven_even_with_multiple_bonuses():
+    prediction = predict_body_slots(fact(
+        radius=10_000_000,
+        planet_class='High metal content world',
+        is_terraformable=True,
+        has_geo=True,
+        has_bio=True,
+        atmosphere='Ammonia atmosphere',
+        volcanism='Major rocky magma',
+    ))
+    assert prediction.predicted_ground_slots == 7
+
+
+def test_missing_required_input_returns_unknown_not_fallback_estimate():
+    prediction = predict_body_slots(fact(radius=None))
+    assert prediction.prediction_status == 'unknown'
+    assert prediction.predicted_ground_slots is None
+    assert 'radius' in prediction.required_input_missing
+    assert any((reason.get('note') or '').find(INSUFFICIENT_DATA_REASON) >= 0 for reason in prediction.reasons)
+
+
+def test_system_prediction_unknown_when_required_data_missing():
+    result = predict_system_slots([fact(radius=None)])
+    assert result['prediction_status'] == 'unknown'
+    assert result['predicted_ground_slots_total'] is None
+
+
+def test_example_body_supports_four_orbital_and_five_ground():
+    prediction = predict_body_slots(fact(radius=5_600_000, atmosphere='Thin methane atmosphere'))
+    assert prediction.predicted_orbital_slots == 4
+    assert prediction.predicted_ground_slots == 5
+
+
+def test_non_landable_bodies_do_not_produce_ground_slots():
+    prediction = predict_body_slots(fact(is_landable=False, radius=5_600_000))
+    assert prediction.predicted_ground_slots == 0

--- a/tests/test_slot_prediction_endpoint.py
+++ b/tests/test_slot_prediction_endpoint.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+os.environ.setdefault('CORS_ORIGINS', 'http://test')
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+
+from ingest.slot_prediction import SlotPrediction
+from routers import simulation as simulation_router
+
+
+class MockConnection:
+    async def fetch(self, query, *args):
+        if 'FROM body_scan_facts' in query:
+            return [{
+                'system_address': 123,
+                'body_id': 1,
+                'body_name': 'Test A 1',
+                'radius': 5_600_000,
+                'gravity': 1.1,
+                'surface_temp': 290,
+                'planet_class': 'Rocky body',
+                'terraform_state': None,
+                'atmosphere': 'Methane atmosphere',
+                'volcanism': 'No volcanism',
+                'has_geo': False,
+                'has_bio': False,
+                'geo_signal_count': 0,
+                'bio_signal_count': 0,
+                'is_landable': True,
+                'is_terraformable': False,
+                'is_ringed': False,
+                'data_sources': ['eddn_scan'],
+                'confidence': 0.9,
+            }]
+        if 'FROM bodies' in query:
+            return []
+        return []
+
+    async def fetchval(self, query, *args):
+        if 'SELECT 1 FROM systems' in query:
+            return 1
+        return None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class MockPool:
+    def acquire(self):
+        return MockConnection()
+
+
+@pytest.mark.asyncio
+async def test_slot_prediction_endpoint_uses_canonical_predictor(monkeypatch):
+    prediction_row = SlotPrediction(
+        system_address=123,
+        body_id=1,
+        body_name='Test A 1',
+        predicted_orbital_slots=4,
+        predicted_ground_slots=5,
+        prediction_status='predicted',
+        confidence_label='validated_high_accuracy',
+        prediction_version='validated-slot-v1',
+        reasons=[],
+    )
+
+    def fake_predict_system_slots(_facts):
+        return {
+            'predicted_orbital_slots_total': 4,
+            'predicted_ground_slots_total': 5,
+            'slot_confidence': 0.96,
+            'body_predictions': [prediction_row],
+            'prediction_status': 'predicted',
+            'prediction_version': 'validated-slot-v1',
+            'validation_note': 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+            'required_input_missing': [],
+        }
+
+    monkeypatch.setattr(simulation_router, 'predict_system_slots', fake_predict_system_slots)
+
+    result = await simulation_router.get_slot_predictions(
+        id64=123,
+        pool=MockPool(),
+        redis=None,
+    )
+
+    assert result['predicted_orbital_slots_total'] == 4
+    assert result['predicted_ground_slots_total'] == 5
+    assert result['prediction_status'] == 'predicted'
+    assert result['prediction_version'] == 'validated-slot-v1'
+    assert result['disclaimer'].startswith('Predicted slots — high-accuracy algorithm')
+    assert result['predictions'][0]['predicted_orbital_slots'] == 4
+    assert result['predictions'][0]['predicted_ground_slots'] == 5
+
+
+@pytest.mark.asyncio
+async def test_slot_prediction_endpoint_reports_unknown_without_fallback(monkeypatch):
+    def fake_predict_system_slots(_facts):
+        return {
+            'predicted_orbital_slots_total': None,
+            'predicted_ground_slots_total': None,
+            'slot_confidence': None,
+            'body_predictions': [
+                SlotPrediction(
+                    system_address=123,
+                    body_id=1,
+                    body_name='Test A 1',
+                    predicted_orbital_slots=None,
+                    predicted_ground_slots=None,
+                    prediction_status='unknown',
+                    confidence_label='insufficient_prediction_data',
+                    prediction_version='validated-slot-v1',
+                    reasons=[{'factor': 'missing_input', 'note': 'insufficient data for validated prediction algorithm'}],
+                    required_input_missing=['radius'],
+                ),
+            ],
+            'prediction_status': 'unknown',
+            'prediction_version': 'validated-slot-v1',
+            'validation_note': 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+            'required_input_missing': ['radius'],
+        }
+
+    monkeypatch.setattr(simulation_router, 'predict_system_slots', fake_predict_system_slots)
+
+    result = await simulation_router.get_slot_predictions(
+        id64=123,
+        pool=MockPool(),
+        redis=None,
+    )
+
+    assert result['prediction_status'] == 'unknown'
+    assert result['predicted_orbital_slots_total'] is None
+    assert result['predicted_ground_slots_total'] is None
+    assert result['predictions'][0]['prediction_status'] == 'unknown'
+    assert result['predictions'][0]['predicted_ground_slots'] is None


### PR DESCRIPTION
## Summary
- enforce canonical validated slot prediction algorithm across backend and frontend slot surfaces
- remove active heuristic slot fallback paths and return unknown with validation guidance when prediction inputs are insufficient
- add system-wide left panel slot map visibility and keep center body planner aligned with canonical slot predictions
- update suggested build capacity handling to consume canonical slot constraints/overflow signalling
- add Stage 17G docs and slot prediction contract updates
- add backend slot predictor and endpoint coverage tests
- update planner integration tests to validate left/center slot alignment under canonical predictions

## Validation
- backend: `pytest tests/test_slot_prediction_algorithm.py tests/test_slot_prediction_endpoint.py tests/test_simulation_contracts.py tests/test_optimiser.py`
- frontend: `npm run typecheck`
- frontend: `npm run build`
- frontend: `npm test`
- repo hygiene: `git diff --check`