### PR TITLE
[codex] Fix slot fallback and modal interactions

### DIFF
--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
@@ -10,6 +10,7 @@ import { BodyStructureSlot, type BodyStructureSlotItem } from './BodyStructureSl
 import { ProjectedStructureSlot } from './ProjectedStructureSlot';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import { buildPlanningEconomyLedger } from './planningEconomy';
+import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity } from './slotCapacityFallback';
 
 export type BodyPlannerLane = 'orbital' | 'surface';
 
@@ -59,8 +60,11 @@ export function BodySlotPlanner({
   const orbitalProjected = projectedPlacements.filter((item) => laneForTemplate(item.template, body) === 'orbital');
   const surfaceProjected = projectedPlacements.filter((item) => laneForTemplate(item.template, body) === 'surface');
 
-  const orbitalSlots = readLaneSlotCount(slotPrediction, 'orbital');
-  const surfaceSlots = readLaneSlotCount(slotPrediction, 'surface');
+  const orbitalCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital');
+  const surfaceCapacity = resolveSlotCapacity(body, slotPrediction, 'surface');
+  const orbitalSlots = orbitalCapacity.value;
+  const surfaceSlots = surfaceCapacity.value;
+  const hasEstimatedSlots = orbitalCapacity.estimated || surfaceCapacity.estimated;
   const surfaceBlocked = body.is_water_world === true || body.is_landable === false;
   const surfaceBlockedReason = body.is_water_world
     ? 'Surface limited: water world.'
@@ -100,6 +104,11 @@ export function BodySlotPlanner({
                 testId="selected-body-slot-indicators"
               />
             </div>
+            {hasEstimatedSlots && (
+              <p data-testid="body-slot-estimated-disclaimer" className="mt-1 font-mono text-[10px] italic text-gold">
+                {ESTIMATED_SLOT_LAYOUT_DISCLAIMER}
+              </p>
+            )}
             <div className="mt-1 flex flex-wrap gap-1.5">
               <FactChip label={body.subtype ?? body.body_type ?? 'Body'} />
               {tags.map((tag) => <FactChip key={tag} label={tag} />)}
@@ -148,6 +157,7 @@ export function BodySlotPlanner({
             selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
             onSelectPlacement={onSelectPlacement}
             onSelectProjectedPlacement={onSelectProjectedPlacement}
+            onAddEmptySlot={hasTemplates ? () => onAddLaneStructure('orbital') : undefined}
           />
           <LaneSlots
             body={body}
@@ -180,6 +190,7 @@ export function BodySlotPlanner({
             selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
             onSelectPlacement={onSelectPlacement}
             onSelectProjectedPlacement={onSelectProjectedPlacement}
+            onAddEmptySlot={hasTemplates && !surfaceBlocked ? () => onAddLaneStructure('surface') : undefined}
           />
           <LaneSlots
             body={body}
@@ -239,11 +250,17 @@ function BodyRingMap({
   return (
     <section data-testid="body-slot-graph" className="mb-3 rounded border border-border/60 bg-bg3/35 px-2 py-3">
       <div className="relative mx-auto min-h-[18.5rem] max-w-[56rem]">
-        <div className="absolute left-1/2 top-[8.9rem] h-[16rem] w-[16rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-cyan/35" />
-        <div className="absolute left-1/2 top-[8.9rem] h-[11.4rem] w-[11.4rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-green/35" />
-        <div className="absolute left-1/2 top-[8.9rem] h-[6.4rem] w-[6.4rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-orange/45 bg-orange/10 shadow-[0_0_30px_rgba(255,122,20,0.2)]" />
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 320 320"
+          className="pointer-events-none absolute left-1/2 top-[8.9rem] h-[16rem] w-[16rem] -translate-x-1/2 -translate-y-1/2 overflow-visible"
+        >
+          <circle cx="160" cy="160" r="130" fill="none" stroke="#9bdcff" strokeWidth="24" strokeOpacity="0.18" />
+          <circle cx="160" cy="160" r="92" fill="none" stroke="#d9aa72" strokeWidth="16" strokeOpacity="0.18" />
+        </svg>
+        <div className="pointer-events-none absolute left-1/2 top-[8.9rem] h-[6.4rem] w-[6.4rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-orange/45 bg-orange/10 shadow-[0_0_30px_rgba(255,122,20,0.2)]" />
 
-        <div className="absolute left-1/2 top-[8.9rem] -translate-x-1/2 -translate-y-1/2 text-center">
+        <div className="pointer-events-none absolute left-1/2 top-[8.9rem] -translate-x-1/2 -translate-y-1/2 text-center">
           <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Body core</div>
         </div>
 
@@ -290,8 +307,8 @@ function BodyRingMap({
           onAdd={() => onAddLaneStructure('surface')}
         />
 
-        <div className="absolute left-2 top-2 rounded border border-cyan/35 bg-cyan/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-cyan">Orbit ring</div>
-        <div className="absolute left-2 top-8 rounded border border-green/35 bg-green/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-green">Surface ring</div>
+        <div className="pointer-events-none absolute left-2 top-2 rounded border border-cyan/35 bg-cyan/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-cyan">Orbit band</div>
+        <div className="pointer-events-none absolute left-2 top-8 rounded border border-gold/35 bg-gold/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-gold">Surface band</div>
       </div>
     </section>
   );
@@ -354,7 +371,7 @@ function RingPlacementToken({
         onClick={onClick}
         style={{ left, top, transform: 'translate(-50%, -50%)' }}
         className={[
-          'absolute z-10 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em] transition-transform hover:scale-105',
+          'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em] transition-transform hover:scale-105',
           toneClass,
           selectedClass,
         ].join(' ')}
@@ -368,7 +385,7 @@ function RingPlacementToken({
     <div
       style={{ left, top, transform: 'translate(-50%, -50%)' }}
       className={[
-        'absolute z-10 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em]',
+        'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em]',
         toneClass,
       ].join(' ')}
     >
@@ -404,7 +421,7 @@ function LaneAddNode({
       onClick={onAdd}
       style={{ left, top, transform: 'translate(-50%, -50%)' }}
       className={[
-        'absolute z-20 grid h-8 w-8 place-items-center rounded-full border text-sm font-bold transition-transform',
+        'absolute z-40 grid h-8 w-8 place-items-center rounded-full border text-sm font-bold transition-transform',
         enabled
           ? 'border-orange/55 bg-orange/18 text-orange hover:scale-110'
           : 'cursor-not-allowed border-gold/35 bg-gold/10 text-gold/70',
@@ -424,6 +441,7 @@ function LaneCapacityMap({
   selectedProjectedPlacementIndex,
   onSelectPlacement,
   onSelectProjectedPlacement,
+  onAddEmptySlot,
 }: {
   laneKey: BodyPlannerLane;
   capacity: number | null;
@@ -433,6 +451,7 @@ function LaneCapacityMap({
   selectedProjectedPlacementIndex: number | null;
   onSelectPlacement: (index: number) => void;
   onSelectProjectedPlacement: (index: number) => void;
+  onAddEmptySlot?: () => void;
 }) {
   const used = planned.length + projected.length;
   if (capacity == null) {
@@ -496,10 +515,12 @@ function LaneCapacityMap({
     return {
       key: `empty-${laneKey}-${index}`,
       label: '',
-      fullLabel: 'Empty slot',
+      fullLabel: onAddEmptySlot
+        ? `Add ${laneKey === 'orbital' ? 'orbit' : 'surface'} structure to empty slot`
+        : 'Empty slot',
       projected: false,
       selected: false,
-      onClick: undefined,
+      onClick: onAddEmptySlot,
     };
   });
   const overflow = Math.max(0, used - capacity);
@@ -657,19 +678,6 @@ function laneForTemplate(template: FacilityTemplate | undefined, body: SystemBod
 
 function fallbackLaneForBody(body: SystemBody): BodyPlannerLane {
   return body.is_landable === true && body.is_water_world !== true ? 'surface' : 'orbital';
-}
-
-function readLaneSlotCount(
-  prediction: BodySlotPrediction | null,
-  lane: 'orbital' | 'surface',
-): number | null {
-  const raw = lane === 'orbital'
-    ? prediction?.predicted_orbital_slots
-    : prediction?.predicted_ground_slots;
-  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0) {
-    return null;
-  }
-  return Math.floor(raw);
 }
 
 function laneSlotStatusLabel(slotCount: number | null, plannedCount: number, projectedCount: number) {

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -304,7 +304,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       expect(screen.getByTestId('center-surface-slot-4')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByTestId('slot-lane-add-orbital'));
+    fireEvent.click(screen.getByTestId('center-orbital-slot-3'));
     fireEvent.click(await screen.findByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
       expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
@@ -313,7 +313,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       expect((screen.getByTestId('center-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getByTestId('slot-lane-add-surface'));
+    fireEvent.click(screen.getByTestId('center-surface-slot-4'));
     fireEvent.click(await screen.findByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
@@ -232,6 +232,39 @@ describe('ColonyTopologyRail', () => {
     expect(screen.getByTestId('slot-lane-unknown-2-ground')).toBeTruthy();
   });
 
+  it('falls back to estimated slots from body data when canonical prediction is unknown', () => {
+    render(
+      <RailHarness
+        customSystem={{
+          ...system,
+          bodies: [
+            ...(system.bodies ?? []).slice(0, 2),
+            {
+              id: 2,
+              name: 'Tree System A 1 a',
+              body_type: 'Planet',
+              subtype: 'High metal content world',
+              parent_body_id: 1,
+              is_landable: true,
+              is_terraformable: true,
+              radius: 2_500_000,
+              geo_signal_count: 1,
+              bio_signal_count: 1,
+            },
+          ],
+        } as unknown as SystemDetail}
+      />,
+    );
+
+    expect(screen.getByTestId('topology-slot-estimate-disclaimer').textContent).toContain(
+      'Slot layout estimated from body data',
+    );
+    expect(screen.queryByTestId('slot-lane-unknown-2-orbital')).toBeNull();
+    expect(screen.queryByTestId('slot-lane-unknown-2-ground')).toBeNull();
+    expect(screen.getByTestId('2-orbital-slot-1')).toBeTruthy();
+    expect(screen.getByTestId('2-ground-slot-4')).toBeTruthy();
+  });
+
   it('shows overflow when structures exceed predicted capacity', () => {
     render(
       <RailHarness

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
@@ -18,6 +18,7 @@ import {
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import { buildPlanningEconomyLedger } from './planningEconomy';
+import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, hasEstimatedSlotFallback, resolveSlotCapacity } from './slotCapacityFallback';
 
 export type TopologySelection =
   | { type: 'system' }
@@ -85,6 +86,7 @@ export function ColonyTopologyRail({
   const buckets = bucketPlacements(snapshot.placements, snapshot.templates, bodies);
   const totalPlacements = snapshot.placements.length;
   const selectedIsSystem = selection.type === 'system';
+  const hasEstimatedSlots = hasEstimatedSlotFallback(system, snapshot);
   const projectedByBody = bucketProjectedPlacements(snapshot.projection?.placements ?? [], snapshot.templates, bodies);
   const projectedBodyIds = new Set(
     (snapshot.projection?.placements ?? [])
@@ -111,6 +113,14 @@ export function ColonyTopologyRail({
           <div className="text-cyan">Predicted slots</div>
           <div className="mt-0.5">{snapshot.slotPredictions.disclaimer}</div>
           <div className="mt-0.5 italic">{snapshot.slotPredictions.validation_note}</div>
+        </div>
+      )}
+      {hasEstimatedSlots && (
+        <div
+          data-testid="topology-slot-estimate-disclaimer"
+          className="mt-2 rounded border border-gold/30 bg-gold/10 px-2 py-1.5 font-mono text-[10px] italic text-gold"
+        >
+          {ESTIMATED_SLOT_LAYOUT_DISCLAIMER}
         </div>
       )}
 
@@ -246,8 +256,10 @@ function BodyTreeRow({
       ...projectedPlacements.map((item) => item.template).filter((template): template is FacilityTemplate => Boolean(template)),
     ],
   });
-  const orbitalCapacity = slotPrediction?.predicted_orbital_slots ?? null;
-  const groundCapacity = slotPrediction?.predicted_ground_slots ?? null;
+  const orbitalSlotCapacity = resolveSlotCapacity(node.body, slotPrediction, 'orbital');
+  const groundSlotCapacity = resolveSlotCapacity(node.body, slotPrediction, 'surface');
+  const orbitalCapacity = orbitalSlotCapacity.value;
+  const groundCapacity = groundSlotCapacity.value;
   const orbitalOverflow = orbitalCapacity == null ? 0 : Math.max(0, plannedOrbital.length + projectedOrbital.length - orbitalCapacity);
   const groundOverflow = groundCapacity == null ? 0 : Math.max(0, plannedGround.length + projectedGround.length - groundCapacity);
   const unknownOverflow = plannedUnknown.length + projectedUnknown.length;

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -13,6 +13,7 @@ import { templateLocationKind } from '@/features/system-detail/simulation-previe
 import type { TopologyPlanSnapshot, TopologySelection, TopologySelectionContext } from './ColonyTopologyRail';
 import { SlotCapacityDots } from './BodySlotPlanner';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
+import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity } from './slotCapacityFallback';
 import {
   buildPlanningEconomyLedger,
   normalisePlanningEconomy,
@@ -74,6 +75,8 @@ export interface RavenPlannerRow {
   bodyTags: string[];
   orbitalCapacity: number | null;
   groundCapacity: number | null;
+  orbitalCapacityEstimated: boolean;
+  groundCapacityEstimated: boolean;
   orbitalSlots: RavenStructureSlot[];
   groundSlots: RavenStructureSlot[];
   bodyEconomy: PlanningEconomyLedger;
@@ -142,6 +145,7 @@ export function RavenStylePlannerCanvas({
         ? placementBodyId(snapshot.projection?.placements[selection.placementIndex])
         : null;
   const selectedProjectedPlacementIndex = selection.type === 'projected-placement' ? selection.placementIndex : null;
+  const hasEstimatedSlots = rows.some((row) => row.orbitalCapacityEstimated || row.groundCapacityEstimated);
   const gridStyle: CSSProperties = {
     gridTemplateColumns: '280px minmax(300px,1fr) minmax(320px,1.05fr)',
   };
@@ -169,9 +173,14 @@ export function RavenStylePlannerCanvas({
           <CanvasPill label={`${rows.length} bodies`} tone="silver" />
           <CanvasPill label={`${snapshot.placements.length} planned`} tone={snapshot.placements.length > 0 ? 'orange' : 'silver'} />
           {snapshot.projection && <CanvasPill label={`${snapshot.projection.placements.length} projected`} tone="cyan" />}
-          <CanvasPill label={snapshot.slotPredictions ? 'slots loaded' : 'slots unknown'} tone={snapshot.slotPredictions ? 'green' : 'gold'} />
+          <CanvasPill label={hasEstimatedSlots ? 'slots estimated' : snapshot.slotPredictions ? 'slots loaded' : 'slots unknown'} tone={hasEstimatedSlots ? 'gold' : snapshot.slotPredictions ? 'green' : 'gold'} />
         </div>
       </header>
+      {hasEstimatedSlots && (
+        <div data-testid="raven-slot-estimate-disclaimer" className="border-b border-gold/25 bg-gold/8 px-3 py-2 font-mono text-[10px] italic text-gold">
+          {ESTIMATED_SLOT_LAYOUT_DISCLAIMER}
+        </div>
+      )}
 
       <div className="overflow-x-auto">
         <div className="min-w-[860px]">
@@ -1032,6 +1041,10 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
     const projected = projectedByBody.get(node.id) ?? emptyStructureBuckets();
     const orbitalStructures = [...planned.orbital, ...projected.orbital];
     const groundStructures = [...planned.ground, ...projected.ground];
+    const orbitalSlotCapacity = resolveSlotCapacity(node.body, prediction, 'orbital');
+    const groundSlotCapacity = resolveSlotCapacity(node.body, prediction, 'surface');
+    const orbitalCapacity = orbitalSlotCapacity.value;
+    const groundCapacity = groundSlotCapacity.value;
     const bodyLedger = buildPlanningEconomyLedger({
       placements: [...planned.orbital, ...planned.ground].map((item) => item.placement),
       projectedPlacements: [...projected.orbital, ...projected.ground].map((item) => item.placement),
@@ -1048,10 +1061,12 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
       compactName: compactBodyDisplayName(node.body, system.name),
       bodyKind: bodyKind(node.body),
       bodyTags: bodyTags(node.body),
-      orbitalCapacity: readSlotCount(prediction, 'orbital'),
-      groundCapacity: readSlotCount(prediction, 'ground'),
-      orbitalSlots: buildLaneSlots(node.id, 'orbital', readSlotCount(prediction, 'orbital'), orbitalStructures),
-      groundSlots: buildLaneSlots(node.id, 'ground', readSlotCount(prediction, 'ground'), groundStructures),
+      orbitalCapacity,
+      groundCapacity,
+      orbitalCapacityEstimated: orbitalSlotCapacity.estimated,
+      groundCapacityEstimated: groundSlotCapacity.estimated,
+      orbitalSlots: buildLaneSlots(node.id, 'orbital', orbitalCapacity, orbitalStructures),
+      groundSlots: buildLaneSlots(node.id, 'ground', groundCapacity, groundStructures),
       bodyEconomy: bodyLedger,
       projected: projectedBodyIds.has(node.id),
       warningCount: countRowWarnings(node.body, prediction, bodyLedger),
@@ -1353,12 +1368,6 @@ function laneForPlacement(template: FacilityTemplate | undefined, body: SystemBo
 
 function fallbackRavenLane(body: SystemBody | undefined): 'orbital' | 'ground' {
   return body?.is_landable === true && body.is_water_world !== true ? 'ground' : 'orbital';
-}
-
-function readSlotCount(prediction: BodySlotPrediction | null, lane: RavenLane): number | null {
-  const value = lane === 'orbital' ? prediction?.predicted_orbital_slots : prediction?.predicted_ground_slots;
-  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
-  return Math.floor(value);
 }
 
 function placementBodyId(placement: SimulateBuildPlacement | undefined): string | null {

--- a/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
@@ -1,6 +1,6 @@
 import { PanelTopOpen, Sparkles, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import type { BodySlotPrediction, FacilityTemplate, SimulateBuildPlacement, SystemBody, SystemDetail } from '@/types/api';
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody, SystemDetail } from '@/types/api';
 import {
   bodyDisplayName,
   bodyTags,
@@ -12,6 +12,7 @@ import { templateLocationKind } from '@/features/system-detail/simulation-previe
 import type { SimulationWorkspaceMode } from '@/features/system-detail/simulation-preview/WorkspaceModeTabs';
 import { BodySlotPlanner, type BodyPlannerLane } from './BodySlotPlanner';
 import type { TopologyPlanSnapshot, TopologySelection } from './ColonyTopologyRail';
+import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity } from './slotCapacityFallback';
 
 interface PlacementViewItem {
   placement: SimulateBuildPlacement;
@@ -196,6 +197,7 @@ interface SystemOverviewItem {
   plannedSurface: number;
   projectedOrbital: number;
   projectedSurface: number;
+  slotLayoutEstimated: boolean;
   score: number;
 }
 
@@ -217,6 +219,7 @@ function SystemOverviewPlannerCanvas({
   const knownOrbitalCapacity = sumKnownCapacity(overviewItems, 'orbital');
   const knownSurfaceCapacity = sumKnownCapacity(overviewItems, 'surface');
   const unknownSurfaceCount = overviewItems.filter((item) => item.surfaceCapacity == null).length;
+  const hasEstimatedSlots = overviewItems.some((item) => item.slotLayoutEstimated);
   const plannedCount = snapshot.placements.length;
   const projectedCount = snapshot.projection?.placements.length ?? 0;
 
@@ -240,6 +243,11 @@ function SystemOverviewPlannerCanvas({
           <OverviewStat label="Surface cap" value={knownSurfaceCapacity > 0 ? String(knownSurfaceCapacity) : 'unknown'} tone="gold" />
         </div>
       </div>
+      {hasEstimatedSlots && (
+        <p data-testid="system-overview-slot-estimate-disclaimer" className="mt-2 font-mono text-[10px] italic text-gold">
+          {ESTIMATED_SLOT_LAYOUT_DISCLAIMER}
+        </p>
+      )}
 
       <div className="mt-4 rounded border border-border/60 bg-bg3/30 p-3" data-testid="system-overview-map">
         <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
@@ -488,8 +496,10 @@ function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSn
       const slotPrediction = predictionsByBodyId.get(bodyId) ?? null;
       const planned = plannedCounts.get(bodyId) ?? emptyLaneCounts();
       const projected = projectedCounts.get(bodyId) ?? emptyLaneCounts();
-      const orbitalCapacity = readOverviewSlotCount(slotPrediction, 'orbital');
-      const surfaceCapacity = readOverviewSlotCount(slotPrediction, 'surface');
+      const orbitalSlotCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital');
+      const surfaceSlotCapacity = resolveSlotCapacity(body, slotPrediction, 'surface');
+      const orbitalCapacity = orbitalSlotCapacity.value;
+      const surfaceCapacity = surfaceSlotCapacity.value;
       const tags = bodyTags(body);
       const score = overviewBodyScore(body, planned, projected, orbitalCapacity, surfaceCapacity, tags);
       return {
@@ -505,6 +515,7 @@ function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSn
         plannedSurface: planned.surface,
         projectedOrbital: projected.orbital,
         projectedSurface: projected.surface,
+        slotLayoutEstimated: orbitalSlotCapacity.estimated || surfaceSlotCapacity.estimated,
         score,
       };
     })
@@ -555,19 +566,6 @@ function overviewLaneForTemplate(template: FacilityTemplate | undefined, body: S
 
 function fallbackOverviewLane(body: SystemBody | undefined): BodyPlannerLane {
   return body?.is_landable === true && body.is_water_world !== true ? 'surface' : 'orbital';
-}
-
-function readOverviewSlotCount(
-  prediction: BodySlotPrediction | null,
-  lane: 'orbital' | 'surface',
-): number | null {
-  const raw = lane === 'orbital'
-    ? prediction?.predicted_orbital_slots
-    : prediction?.predicted_ground_slots;
-  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 0) {
-    return null;
-  }
-  return Math.floor(raw);
 }
 
 function overviewBodyScore(

--- a/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
+++ b/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
@@ -1,0 +1,153 @@
+import type { BodySlotPrediction, SystemBody, SystemDetail } from '@/types/api';
+import { bodyIdKey } from '@/features/system-detail/simulation-preview/bodyIdUtils';
+import type { TopologyPlanSnapshot } from './ColonyTopologyRail';
+
+export type SlotCapacityLane = 'orbital' | 'surface';
+
+export interface ResolvedSlotCapacity {
+  value: number | null;
+  estimated: boolean;
+}
+
+export const ESTIMATED_SLOT_LAYOUT_DISCLAIMER = 'Slot layout estimated from body data (Not 100% verified).';
+
+export function resolveSlotCapacity(
+  body: SystemBody,
+  prediction: BodySlotPrediction | null,
+  lane: SlotCapacityLane,
+): ResolvedSlotCapacity {
+  const predicted = normaliseSlotCount(lane === 'orbital'
+    ? prediction?.predicted_orbital_slots
+    : prediction?.predicted_ground_slots);
+
+  if (prediction?.prediction_status === 'observed') {
+    return { value: predicted, estimated: false };
+  }
+
+  if (predicted != null && predicted > 0) {
+    return { value: predicted, estimated: false };
+  }
+
+  const fallback = estimateBodySlots(body);
+  const estimatedValue = lane === 'orbital' ? fallback?.orbital : fallback?.surface;
+  if (estimatedValue != null && (predicted == null || estimatedValue > predicted)) {
+    return { value: estimatedValue, estimated: true };
+  }
+
+  return { value: predicted, estimated: false };
+}
+
+export function hasEstimatedSlotFallback(system: SystemDetail, snapshot: TopologyPlanSnapshot): boolean {
+  const predictionsByBodyId = new Map(
+    (snapshot.slotPredictions?.predictions ?? []).map((prediction) => [bodyIdKey(prediction.body_id), prediction]),
+  );
+
+  return (system.bodies ?? []).some((body) => {
+    if (body.id == null) return false;
+    const prediction = predictionsByBodyId.get(bodyIdKey(body.id)) ?? null;
+    return resolveSlotCapacity(body, prediction, 'orbital').estimated
+      || resolveSlotCapacity(body, prediction, 'surface').estimated;
+  });
+}
+
+function estimateBodySlots(body: SystemBody): { orbital: number; surface: number | null } | null {
+  if (!isBuildableBodyCandidate(body)) return null;
+
+  const radiusKm = readRadiusKm(body);
+  if (radiusKm == null) return null;
+
+  const orbitalBase = radiusBaseSlots(radiusKm);
+  const orbital = clampSlotCount(orbitalBase + (readBoolean(body, 'is_ringed') ? 1 : 0), 1, 4);
+
+  if (body.is_landable !== true || body.is_water_world === true) {
+    return { orbital, surface: 0 };
+  }
+
+  const surfaceTemp = readNumber(body, 'surface_temp');
+  if (surfaceTemp != null && surfaceTemp > 700) {
+    return { orbital, surface: 0 };
+  }
+
+  const gravity = readNumber(body, 'gravity');
+  if (gravity != null && gravity > 2.7) {
+    return { orbital, surface: 0 };
+  }
+
+  let bonus = 0;
+  const planetClass = String(body.subtype ?? '').trim().toLowerCase();
+  if (planetClass === 'high metal content world' || planetClass === 'high metal content body') bonus += 1;
+  if (body.is_terraformable === true) bonus += 1;
+  if ((body.geo_signal_count ?? 0) > 0 || hasVolcanism(body)) bonus += 1;
+  if ((body.bio_signal_count ?? 0) > 0) bonus += 1;
+  bonus += atmosphereBonus(body);
+
+  const surface = Math.min(radiusBaseSlots(radiusKm) + Math.min(bonus, 3), 7);
+  return { orbital, surface };
+}
+
+function isBuildableBodyCandidate(body: SystemBody): boolean {
+  const type = `${body.body_type ?? ''} ${body.subtype ?? ''}`.toLowerCase();
+  return !type.includes('star') && !type.includes('barycentre');
+}
+
+function readRadiusKm(body: SystemBody): number | null {
+  const radius = readNumber(body, 'radius');
+  if (radius == null || radius <= 0) return null;
+  return radius > 50_000 ? radius / 1000 : radius;
+}
+
+function radiusBaseSlots(radiusKm: number): number {
+  if (radiusKm < 1500) return 1;
+  if (radiusKm < 3750) return 2;
+  if (radiusKm < 5500) return 3;
+  return 4;
+}
+
+function atmosphereBonus(body: SystemBody): number {
+  const atmosphere = readString(body, 'atmosphere') ?? readString(body, 'atmosphere_type');
+  if (!atmosphere) return 0;
+  const normalised = atmosphere.toLowerCase();
+  if (normalised === 'no atmosphere') return 0;
+  return normalised.includes('thin') ? 1 : 2;
+}
+
+function hasVolcanism(body: SystemBody): boolean {
+  const volcanism = readString(body, 'volcanism');
+  if (!volcanism) return false;
+  const normalised = volcanism.toLowerCase();
+  return normalised !== 'no volcanism' && normalised !== 'none';
+}
+
+function normaliseSlotCount(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return null;
+  return Math.floor(value);
+}
+
+function readNumber(body: SystemBody, key: string): number | null {
+  const value = (body as Record<string, unknown>)[key];
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function readBoolean(body: SystemBody, key: string): boolean {
+  const value = (body as Record<string, unknown>)[key];
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') return ['true', 't', '1', 'yes', 'y'].includes(value.trim().toLowerCase());
+  return false;
+}
+
+function readString(body: SystemBody, key: string): string | null {
+  const value = (body as Record<string, unknown>)[key];
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text || null;
+}
+
+function clampSlotCount(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/frontend-v2/src/features/system-detail/SystemDetailModal.tsx
+++ b/frontend-v2/src/features/system-detail/SystemDetailModal.tsx
@@ -62,11 +62,19 @@ export function SystemDetailModal({
         className="panel relative w-full max-w-6xl animate-fade-up"
         onClick={(e) => e.stopPropagation()}
       >
+        <button
+          type="button"
+          onClick={onClose}
+          data-testid="system-detail-close"
+          aria-label="Close system details"
+          className="absolute right-4 top-4 z-50 grid h-10 w-10 place-items-center rounded-full border border-white/20 bg-bg1/95 text-white shadow-[0_10px_30px_rgba(0,0,0,0.45)] transition-colors hover:border-orange/70 hover:bg-orange hover:text-bg1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80"
+        >
+          <X size={19} strokeWidth={3} />
+        </button>
         <ModalHeader
           name={data?.name}
           id64={id64}
           loading={loading}
-          onClose={onClose}
         />
 
         <div className="px-5 sm:px-6 py-5 space-y-5 text-sm">
@@ -180,10 +188,10 @@ function ColonyPlannerEntryPoint({
 // ─── Header ────────────────────────────────────────────────────────────────
 
 function ModalHeader({
-  name, id64, loading, onClose,
-}: { name?: string; id64: number; loading: boolean; onClose: () => void }) {
+  name, id64, loading,
+}: { name?: string; id64: number; loading: boolean }) {
   return (
-    <header className="sticky top-0 z-10 flex items-start gap-3 px-5 sm:px-7 py-4 border-b border-border bg-bg2/85 backdrop-blur-md rounded-t-chunk-lg">
+    <header className="sticky top-0 z-10 flex items-start gap-3 px-5 py-4 pr-16 sm:px-7 sm:pr-20 border-b border-border bg-bg2/85 backdrop-blur-md rounded-t-chunk-lg">
       <div className="min-w-0 flex-1">
         <h2
           id="system-detail-title"
@@ -195,15 +203,6 @@ function ModalHeader({
           ID64 · <span className="tabular-nums text-silver">{id64}</span>
         </div>
       </div>
-      <button
-        type="button"
-        onClick={onClose}
-        data-testid="system-detail-close"
-        aria-label="Close"
-        className="shrink-0 grid place-items-center w-9 h-9 rounded-full text-silver-dk hover:text-orange-lt hover:bg-orange/10 border border-border hover:border-orange/45 transition-colors"
-      >
-        <X size={16} />
-      </button>
     </header>
   );
 }

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -947,8 +947,8 @@ export interface paths {
          *
          *     Data source priority:
          *       1. buildability_analysis (pre-computed, fastest)
-         *       2. system_slot_topology + body_scan_facts (compute on demand)
-         *       3. system_archetype_traits (fallback, lower confidence)
+         *       2. canonical slot prediction + topology traits (compute on demand)
+         *       3. insufficient data response (no slot fallback estimates)
          */
         get: operations["get_buildability_api_systems__id64__buildability_get"];
         put?: never;
@@ -1542,8 +1542,9 @@ export interface components {
             /**
              * Prediction Status
              * @default unknown
+             * @enum {string}
              */
-            prediction_status?: "predicted" | "unknown" | "observed";
+            prediction_status: "predicted" | "unknown" | "observed";
             /** Confidence Label */
             confidence_label?: string | null;
             /** Prediction Version */
@@ -1556,26 +1557,14 @@ export interface components {
             missing_inputs?: string[];
             /** Source Label */
             source_label?: string | null;
-            /**
-             * Estimated Surface Slots
-             * @default 0
-             */
-            estimated_surface_slots: number;
-            /**
-             * Estimated Orbital Slots
-             * @default 0
-             */
-            estimated_orbital_slots: number;
-            /**
-             * Slot Confidence
-             * @default 0
-             */
-            slot_confidence: number;
-            /**
-             * Slot Source
-             * @default estimated
-             */
-            slot_source: string;
+            /** Estimated Surface Slots */
+            estimated_surface_slots?: number | null;
+            /** Estimated Orbital Slots */
+            estimated_orbital_slots?: number | null;
+            /** Slot Confidence */
+            slot_confidence?: number | null;
+            /** Slot Source */
+            slot_source?: string | null;
             /** Reasons */
             reasons?: components["schemas"]["SlotReason"][];
             /** Is Ringed */
@@ -1897,13 +1886,8 @@ export interface components {
              * @default 0
              */
             green_cp_cost: number;
-            /**
-             * Stat Effects
-             * @default
-             */
-            stat_effects: {
-                [key: string]: unknown;
-            };
+            /** Stat Effects */
+            stat_effects?: Record<string, never>;
         };
         /** GalaxySearchRequest */
         GalaxySearchRequest: {
@@ -3250,16 +3234,17 @@ export interface components {
             /**
              * Prediction Status
              * @default unknown
+             * @enum {string}
              */
-            prediction_status?: "predicted" | "unknown" | "observed";
+            prediction_status: "predicted" | "unknown" | "observed";
             /** Prediction Version */
-            prediction_version?: string;
+            prediction_version: string;
             /** Confidence Label */
             confidence_label?: string | null;
             /** Disclaimer */
-            disclaimer?: string;
+            disclaimer: string;
             /** Validation Note */
-            validation_note?: string;
+            validation_note: string;
             /** Required Input Missing */
             required_input_missing?: string[];
             /** Missing Inputs */
@@ -3267,13 +3252,13 @@ export interface components {
             /** Source Label */
             source_label?: string | null;
             /** Estimated Orbital Slots */
-            estimated_orbital_slots: number;
+            estimated_orbital_slots?: number | null;
             /** Estimated Ground Slots */
-            estimated_ground_slots: number;
+            estimated_ground_slots?: number | null;
             /** Slot Confidence */
-            slot_confidence: number;
+            slot_confidence?: number | null;
             /** Slot Confidence Label */
-            slot_confidence_label: string;
+            slot_confidence_label?: string | null;
             /** Predictions */
             predictions?: components["schemas"]["BodySlotPrediction"][];
             /** Note */


### PR DESCRIPTION
## Summary
- Add display-only body-data fallback slot estimates with estimated-layout disclaimers.
- Restyle the system detail modal close button and convert body planner rings to translucent orbit/surface bands.
- Wire empty orbit/surface capacity cells to open the structure picker and cover the flow in tests.

## Validation
- npm run typecheck
- npm run build
- npm test