### PR TITLE
[codex] Refine slot fallback and band positioning

### DIFF
--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.test.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { BodySlotPrediction, SystemBody } from '@/types/api';
+import { BodySlotPlanner } from './BodySlotPlanner';
+
+const body = {
+  id: 2,
+  name: 'Band Test A 1',
+  body_type: 'Planet',
+  subtype: 'High metal content world',
+  is_landable: true,
+} as SystemBody;
+
+const slotPrediction: BodySlotPrediction = {
+  system_address: 123,
+  body_id: 2,
+  body_name: 'Band Test A 1',
+  predicted_orbital_slots: 4,
+  predicted_ground_slots: 5,
+  prediction_status: 'predicted',
+  reasons: [],
+};
+
+describe('BodySlotPlanner', () => {
+  it('renders vivid orbit/surface bands with slot tokens centered from polar coordinates', () => {
+    const { container } = render(
+      <BodySlotPlanner
+        body={body}
+        slotPrediction={slotPrediction}
+        placements={[]}
+        projectedPlacements={[]}
+        selectedPlacementIndex={null}
+        selectedProjectedPlacementIndex={null}
+        hasTemplates
+        onSelectPlacement={vi.fn()}
+        onSelectProjectedPlacement={vi.fn()}
+        onAddLaneStructure={vi.fn()}
+      />,
+    );
+
+    const orbitBand = container.querySelector('circle[stroke="#00c8ff"]');
+    const surfaceBand = container.querySelector('circle[stroke="#ff9f1a"]');
+    expect(orbitBand?.getAttribute('stroke-width')).toBe('24');
+    expect(orbitBand?.getAttribute('stroke-opacity')).toBe('0.46');
+    expect(surfaceBand?.getAttribute('stroke-width')).toBe('16');
+    expect(surfaceBand?.getAttribute('stroke-opacity')).toBe('0.48');
+
+    const orbitSlot = screen.getByTestId('ring-orbital-slot-0') as HTMLElement;
+    const surfaceSlot = screen.getByTestId('ring-surface-slot-0') as HTMLElement;
+    expect(orbitSlot.style.left).toContain('calc(50%');
+    expect(orbitSlot.style.left).toContain('px');
+    expect(orbitSlot.style.top).toContain('8.9rem');
+    expect(orbitSlot.style.top).toContain('px');
+    expect(orbitSlot.style.left).not.toContain('130px');
+    expect(surfaceSlot.style.left).toContain('calc(50%');
+    expect(surfaceSlot.style.left).toContain('px');
+    expect(surfaceSlot.style.top).toContain('8.9rem');
+    expect(surfaceSlot.style.top).toContain('px');
+    expect(surfaceSlot.style.left).not.toContain('92px');
+    expect(screen.getByTestId('ring-orbital-slot-3')).toBeTruthy();
+    expect(screen.getByTestId('ring-surface-slot-4')).toBeTruthy();
+  });
+});

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
@@ -10,7 +10,7 @@ import { BodyStructureSlot, type BodyStructureSlotItem } from './BodyStructureSl
 import { ProjectedStructureSlot } from './ProjectedStructureSlot';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import { buildPlanningEconomyLedger } from './planningEconomy';
-import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity } from './slotCapacityFallback';
+import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity, type BodyDataSlotEstimate } from './slotCapacityFallback';
 
 export type BodyPlannerLane = 'orbital' | 'surface';
 
@@ -31,6 +31,7 @@ export interface BodyPlannerProjectedPlacementItem {
 export function BodySlotPlanner({
   body,
   slotPrediction,
+  bodyDataSlotEstimate,
   placements,
   projectedPlacements,
   selectedPlacementIndex,
@@ -42,6 +43,7 @@ export function BodySlotPlanner({
 }: {
   body: SystemBody;
   slotPrediction: BodySlotPrediction | null;
+  bodyDataSlotEstimate?: BodyDataSlotEstimate | null;
   placements: BodyPlannerPlacementItem[];
   projectedPlacements: BodyPlannerProjectedPlacementItem[];
   selectedPlacementIndex: number | null;
@@ -60,8 +62,8 @@ export function BodySlotPlanner({
   const orbitalProjected = projectedPlacements.filter((item) => laneForTemplate(item.template, body) === 'orbital');
   const surfaceProjected = projectedPlacements.filter((item) => laneForTemplate(item.template, body) === 'surface');
 
-  const orbitalCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital');
-  const surfaceCapacity = resolveSlotCapacity(body, slotPrediction, 'surface');
+  const orbitalCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital', bodyDataSlotEstimate);
+  const surfaceCapacity = resolveSlotCapacity(body, slotPrediction, 'surface', bodyDataSlotEstimate);
   const orbitalSlots = orbitalCapacity.value;
   const surfaceSlots = surfaceCapacity.value;
   const hasEstimatedSlots = orbitalCapacity.estimated || surfaceCapacity.estimated;
@@ -121,6 +123,8 @@ export function BodySlotPlanner({
       </header>
 
       <BodyRingMap
+        orbitalCapacity={orbitalSlots}
+        surfaceCapacity={surfaceSlots}
         orbitalPlanned={orbitalPlanned}
         surfacePlanned={surfacePlanned}
         orbitalProjected={orbitalProjected}
@@ -211,6 +215,8 @@ export function BodySlotPlanner({
 }
 
 function BodyRingMap({
+  orbitalCapacity,
+  surfaceCapacity,
   orbitalPlanned,
   surfacePlanned,
   orbitalProjected,
@@ -223,6 +229,8 @@ function BodyRingMap({
   onSelectProjectedPlacement,
   onAddLaneStructure,
 }: {
+  orbitalCapacity: number | null;
+  surfaceCapacity: number | null;
   orbitalPlanned: BodyPlannerPlacementItem[];
   surfacePlanned: BodyPlannerPlacementItem[];
   orbitalProjected: BodyPlannerProjectedPlacementItem[];
@@ -235,17 +243,36 @@ function BodyRingMap({
   onSelectProjectedPlacement: (index: number) => void;
   onAddLaneStructure: (lane: BodyPlannerLane) => void;
 }) {
-  const orbitalNodes = [
-    ...orbitalPlanned.map((item) => ({ kind: 'planned' as const, id: `p-${item.index}`, item })),
-    ...orbitalProjected.map((item, i) => ({ kind: 'projected' as const, id: `g-${i}-${item.placement.facility_template_id}`, item })),
-  ];
-  const surfaceNodes = [
-    ...surfacePlanned.map((item) => ({ kind: 'planned' as const, id: `p-${item.index}`, item })),
-    ...surfaceProjected.map((item, i) => ({ kind: 'projected' as const, id: `g-${i}-${item.placement.facility_template_id}`, item })),
-  ];
-
-  const orbitalSlots = ringSlots(orbitalNodes.length, 130);
-  const surfaceSlots = ringSlots(surfaceNodes.length, 92);
+  const orbitRadius = scaledBandRadius(ORBIT_BAND_RADIUS);
+  const surfaceRadius = scaledBandRadius(SURFACE_BAND_RADIUS);
+  const orbitalNodes = buildRingNodes({
+    lane: 'orbital',
+    capacity: orbitalCapacity,
+    planned: orbitalPlanned,
+    projected: orbitalProjected,
+    selectedPlacementIndex,
+    selectedProjectedPlacementIndex,
+    canAdd: hasTemplates,
+    onAdd: () => onAddLaneStructure('orbital'),
+    onSelectPlacement,
+    onSelectProjectedPlacement,
+  });
+  const surfaceNodes = buildRingNodes({
+    lane: 'surface',
+    capacity: surfaceCapacity,
+    planned: surfacePlanned,
+    projected: surfaceProjected,
+    selectedPlacementIndex,
+    selectedProjectedPlacementIndex,
+    canAdd: hasTemplates && !surfaceBlocked,
+    onAdd: () => onAddLaneStructure('surface'),
+    onSelectPlacement,
+    onSelectProjectedPlacement,
+  });
+  const orbitalSlots = ringSlots(orbitalNodes.length, orbitRadius);
+  const surfaceSlots = ringSlots(surfaceNodes.length, surfaceRadius);
+  const orbitAddPoint = polarPoint(orbitRadius, -90);
+  const surfaceAddPoint = polarPoint(surfaceRadius, 0);
 
   return (
     <section data-testid="body-slot-graph" className="mb-3 rounded border border-border/60 bg-bg3/35 px-2 py-3">
@@ -255,8 +282,8 @@ function BodyRingMap({
           viewBox="0 0 320 320"
           className="pointer-events-none absolute left-1/2 top-[8.9rem] h-[16rem] w-[16rem] -translate-x-1/2 -translate-y-1/2 overflow-visible"
         >
-          <circle cx="160" cy="160" r="130" fill="none" stroke="#9bdcff" strokeWidth="24" strokeOpacity="0.18" />
-          <circle cx="160" cy="160" r="92" fill="none" stroke="#d9aa72" strokeWidth="16" strokeOpacity="0.18" />
+          <circle cx="160" cy="160" r={ORBIT_BAND_RADIUS} fill="none" stroke="#00c8ff" strokeWidth="24" strokeOpacity="0.46" />
+          <circle cx="160" cy="160" r={SURFACE_BAND_RADIUS} fill="none" stroke="#ff9f1a" strokeWidth="16" strokeOpacity="0.48" />
         </svg>
         <div className="pointer-events-none absolute left-1/2 top-[8.9rem] h-[6.4rem] w-[6.4rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-orange/45 bg-orange/10 shadow-[0_0_30px_rgba(255,122,20,0.2)]" />
 
@@ -268,12 +295,14 @@ function BodyRingMap({
           <RingPlacementToken
             key={`orb-${node.id}`}
             lane="orbital"
-            left={`calc(50% + ${orbitalSlots[index].x}px)`}
-            top={`calc(8.9rem + ${orbitalSlots[index].y}px)`}
-            label={slotLabel(node.item)}
-            projected={node.kind === 'projected'}
-            selected={node.kind === 'planned' ? selectedPlacementIndex === node.item.index : selectedProjectedPlacementIndex === node.item.index}
-            onClick={node.kind === 'planned' ? () => onSelectPlacement(node.item.index) : () => onSelectProjectedPlacement(node.item.index)}
+            left={ringLeft(orbitalSlots[index].x)}
+            top={ringTop(orbitalSlots[index].y)}
+            label={node.label}
+            title={node.title}
+            kind={node.kind}
+            selected={node.selected}
+            testId={`ring-orbital-slot-${index}`}
+            onClick={node.onClick}
           />
         ))}
 
@@ -281,31 +310,37 @@ function BodyRingMap({
           <RingPlacementToken
             key={`surf-${node.id}`}
             lane="surface"
-            left={`calc(50% + ${surfaceSlots[index].x}px)`}
-            top={`calc(8.9rem + ${surfaceSlots[index].y}px)`}
-            label={slotLabel(node.item)}
-            projected={node.kind === 'projected'}
-            selected={node.kind === 'planned' ? selectedPlacementIndex === node.item.index : selectedProjectedPlacementIndex === node.item.index}
-            onClick={node.kind === 'planned' ? () => onSelectPlacement(node.item.index) : () => onSelectProjectedPlacement(node.item.index)}
+            left={ringLeft(surfaceSlots[index].x)}
+            top={ringTop(surfaceSlots[index].y)}
+            label={node.label}
+            title={node.title}
+            kind={node.kind}
+            selected={node.selected}
+            testId={`ring-surface-slot-${index}`}
+            onClick={node.onClick}
           />
         ))}
 
-        <LaneAddNode
-          lane="orbital"
-          left="50%"
-          top="0.9rem"
-          enabled={hasTemplates}
-          disabledReason={!hasTemplates ? 'Facility catalogue loading.' : undefined}
-          onAdd={() => onAddLaneStructure('orbital')}
-        />
-        <LaneAddNode
-          lane="surface"
-          left="calc(50% + 5.7rem)"
-          top="8.9rem"
-          enabled={hasTemplates && !surfaceBlocked}
-          disabledReason={surfaceBlocked ? 'Surface blocked for this body.' : (!hasTemplates ? 'Facility catalogue loading.' : undefined)}
-          onAdd={() => onAddLaneStructure('surface')}
-        />
+        {orbitalNodes.length === 0 && (
+          <LaneAddNode
+            lane="orbital"
+            left={ringLeft(orbitAddPoint.x)}
+            top={ringTop(orbitAddPoint.y)}
+            enabled={hasTemplates}
+            disabledReason={!hasTemplates ? 'Facility catalogue loading.' : undefined}
+            onAdd={() => onAddLaneStructure('orbital')}
+          />
+        )}
+        {surfaceNodes.length === 0 && (
+          <LaneAddNode
+            lane="surface"
+            left={ringLeft(surfaceAddPoint.x)}
+            top={ringTop(surfaceAddPoint.y)}
+            enabled={hasTemplates && !surfaceBlocked}
+            disabledReason={surfaceBlocked ? 'Surface blocked for this body.' : (!hasTemplates ? 'Facility catalogue loading.' : undefined)}
+            onAdd={() => onAddLaneStructure('surface')}
+          />
+        )}
 
         <div className="pointer-events-none absolute left-2 top-2 rounded border border-cyan/35 bg-cyan/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-cyan">Orbit band</div>
         <div className="pointer-events-none absolute left-2 top-8 rounded border border-gold/35 bg-gold/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-gold">Surface band</div>
@@ -314,18 +349,121 @@ function BodyRingMap({
   );
 }
 
-function ringSlots(count: number, radius: number) {
-  if (count <= 0) return [];
-  const spread = Math.min(320, Math.max(140, 50 * count));
-  const start = -90 - spread / 2;
-  const step = count === 1 ? 0 : spread / (count - 1);
-  return new Array(count).fill(null).map((_, index) => {
-    const angle = (start + step * index) * (Math.PI / 180);
+const RING_CENTER_TOP = '8.9rem';
+const RING_VIEWBOX_SIZE = 320;
+const RING_RENDER_SIZE_PX = 256;
+const ORBIT_BAND_RADIUS = 130;
+const SURFACE_BAND_RADIUS = 92;
+
+type RingNodeKind = 'planned' | 'projected' | 'empty';
+
+interface RingNode {
+  id: string;
+  kind: RingNodeKind;
+  label: string;
+  title: string;
+  selected: boolean;
+  onClick?: () => void;
+}
+
+function buildRingNodes({
+  lane,
+  capacity,
+  planned,
+  projected,
+  selectedPlacementIndex,
+  selectedProjectedPlacementIndex,
+  canAdd,
+  onAdd,
+  onSelectPlacement,
+  onSelectProjectedPlacement,
+}: {
+  lane: BodyPlannerLane;
+  capacity: number | null;
+  planned: BodyPlannerPlacementItem[];
+  projected: BodyPlannerProjectedPlacementItem[];
+  selectedPlacementIndex: number | null;
+  selectedProjectedPlacementIndex: number | null;
+  canAdd: boolean;
+  onAdd: () => void;
+  onSelectPlacement: (index: number) => void;
+  onSelectProjectedPlacement: (index: number) => void;
+}): RingNode[] {
+  const structures = [
+    ...planned.map((item) => structureRingNode(lane, item, selectedPlacementIndex === item.index, () => onSelectPlacement(item.index))),
+    ...projected.map((item) => structureRingNode(lane, item, selectedProjectedPlacementIndex === item.index, () => onSelectProjectedPlacement(item.index), true)),
+  ];
+
+  if (capacity == null) return structures;
+  if (capacity <= 0) return structures;
+
+  const nodes = Array.from({ length: capacity }, (_unused, index) => {
+    if (index < structures.length) return structures[index];
     return {
-      x: Math.cos(angle) * radius,
-      y: Math.sin(angle) * radius,
+      id: `${lane}-empty-${index}`,
+      kind: 'empty' as const,
+      label: '+',
+      title: canAdd
+        ? `Add ${lane === 'orbital' ? 'orbit' : 'surface'} structure to empty slot`
+        : 'Empty slot',
+      selected: false,
+      onClick: canAdd ? onAdd : undefined,
     };
   });
+
+  return structures.length > capacity
+    ? [...nodes, ...structures.slice(capacity)]
+    : nodes;
+}
+
+function structureRingNode(
+  lane: BodyPlannerLane,
+  item: BodyPlannerPlacementItem | BodyPlannerProjectedPlacementItem,
+  selected: boolean,
+  onClick: () => void,
+  projected = false,
+): RingNode {
+  return {
+    id: `${lane}-${projected ? 'projected' : 'planned'}-${item.index}-${item.placement.facility_template_id}`,
+    kind: projected ? 'projected' : 'planned',
+    label: slotLabel(item),
+    title: item.template?.name ?? item.placement.facility_template_id,
+    selected,
+    onClick,
+  };
+}
+
+function scaledBandRadius(viewBoxRadius: number) {
+  return viewBoxRadius * (RING_RENDER_SIZE_PX / RING_VIEWBOX_SIZE);
+}
+
+function polarPoint(radius: number, angleDegrees: number) {
+  const angle = angleDegrees * (Math.PI / 180);
+  return {
+    x: Math.cos(angle) * radius,
+    y: Math.sin(angle) * radius,
+  };
+}
+
+function ringSlots(count: number, radius: number) {
+  if (count <= 0) return [];
+  if (count === 1) return [polarPoint(radius, -90)];
+  const spread = Math.min(320, Math.max(140, 50 * count));
+  const start = -90 - spread / 2;
+  const step = spread / (count - 1);
+  return new Array(count).fill(null).map((_, index) => polarPoint(radius, start + step * index));
+}
+
+function ringLeft(x: number) {
+  return `calc(50% + ${formatCoordinate(x)})`;
+}
+
+function ringTop(y: number) {
+  return `calc(${RING_CENTER_TOP} + ${formatCoordinate(y)})`;
+}
+
+function formatCoordinate(value: number) {
+  return `${Math.round(value * 10) / 10}px`;
 }
 
 function slotLabel(item: BodyPlannerPlacementItem | BodyPlannerProjectedPlacementItem) {
@@ -342,23 +480,31 @@ function RingPlacementToken({
   left,
   top,
   label,
-  projected,
+  title,
+  kind,
   selected,
+  testId,
   onClick,
 }: {
   lane: BodyPlannerLane;
   left: string;
   top: string;
   label: string;
-  projected: boolean;
+  title: string;
+  kind: RingNodeKind;
   selected: boolean;
+  testId: string;
   onClick?: () => void;
 }) {
-  const toneClass = projected
+  const toneClass = kind === 'projected'
     ? 'border-cyan/45 bg-cyan/14 text-cyan'
+    : kind === 'empty'
+      ? lane === 'orbital'
+        ? 'border-cyan/70 bg-cyan/18 text-cyan'
+        : 'border-orange/70 bg-orange/18 text-orange-lt'
     : lane === 'orbital'
-      ? 'border-cyan/45 bg-cyan/8 text-cyan'
-      : 'border-green/45 bg-green/10 text-green';
+      ? 'border-cyan/70 bg-cyan/14 text-cyan'
+      : 'border-orange/75 bg-orange/20 text-orange-lt';
 
   const selectedClass = selected
     ? 'shadow-[0_0_20px_rgba(255,122,20,0.3)] ring-2 ring-orange/70'
@@ -368,6 +514,9 @@ function RingPlacementToken({
     return (
       <button
         type="button"
+        data-testid={testId}
+        title={title}
+        aria-label={title}
         onClick={onClick}
         style={{ left, top, transform: 'translate(-50%, -50%)' }}
         className={[
@@ -383,6 +532,8 @@ function RingPlacementToken({
 
   return (
     <div
+      data-testid={testId}
+      title={title}
       style={{ left, top, transform: 'translate(-50%, -50%)' }}
       className={[
         'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em]',

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
@@ -265,6 +265,49 @@ describe('ColonyTopologyRail', () => {
     expect(screen.getByTestId('2-ground-slot-4')).toBeTruthy();
   });
 
+  it('forces calculated body-data slots when confirmed slot predictions are empty', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const customSystem = {
+      ...system,
+      bodies: [
+        { id: 0, name: 'Tree System A', body_type: 'Star', subtype: 'K' },
+        {
+          id: 2,
+          name: 'Tree System A 1 a',
+          body_type: 'Planet',
+          subtype: 'Rocky body',
+          parent_body_id: 1,
+          is_landable: true,
+        },
+      ],
+    } as unknown as SystemDetail;
+
+    try {
+      render(
+        <ColonyTopologyRail
+          system={customSystem}
+          snapshot={{ placements: [], templates, targetArchetype: 'refinery_industrial', slotPredictions: null }}
+          selection={{ type: 'system' }}
+          onSelect={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('topology-slot-estimate-disclaimer').textContent).toContain(
+        'Slot layout estimated from body data',
+      );
+      expect(screen.getByTestId('2-orbital-slot-0')).toBeTruthy();
+      expect(screen.getByTestId('2-ground-slot-0')).toBeTruthy();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Calculated Slots:',
+        expect.arrayContaining([
+          expect.objectContaining({ bodyId: '2', orbital: 1, surface: 1 }),
+        ]),
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('shows overflow when structures exceed predicted capacity', () => {
     render(
       <RailHarness

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
@@ -18,7 +18,14 @@ import {
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import { buildPlanningEconomyLedger } from './planningEconomy';
-import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, hasEstimatedSlotFallback, resolveSlotCapacity } from './slotCapacityFallback';
+import {
+  ESTIMATED_SLOT_LAYOUT_DISCLAIMER,
+  buildBodyDataSlotEstimateMap,
+  hasEstimatedSlotFallback,
+  resolveSlotCapacity,
+  systemBodyData,
+  type BodyDataSlotEstimate,
+} from './slotCapacityFallback';
 
 export type TopologySelection =
   | { type: 'system' }
@@ -81,12 +88,13 @@ export function ColonyTopologyRail({
   selection,
   onSelect,
 }: ColonyTopologyRailProps) {
-  const bodies = system.bodies ?? [];
+  const bodies = systemBodyData(system);
+  const bodyDataSlotEstimates = buildBodyDataSlotEstimateMap(system, snapshot.slotPredictions?.predictions);
   const bodyNodes = buildBodyNodes(bodies);
   const buckets = bucketPlacements(snapshot.placements, snapshot.templates, bodies);
   const totalPlacements = snapshot.placements.length;
   const selectedIsSystem = selection.type === 'system';
-  const hasEstimatedSlots = hasEstimatedSlotFallback(system, snapshot);
+  const hasEstimatedSlots = bodyDataSlotEstimates.size > 0 || hasEstimatedSlotFallback(system, snapshot);
   const projectedByBody = bucketProjectedPlacements(snapshot.projection?.placements ?? [], snapshot.templates, bodies);
   const projectedBodyIds = new Set(
     (snapshot.projection?.placements ?? [])
@@ -156,6 +164,7 @@ export function ColonyTopologyRail({
               node={node}
               systemName={system.name}
               slotPrediction={snapshot.slotPredictions?.predictions?.find((item) => sameBodyId(item.body_id, node.id)) ?? null}
+              bodyDataSlotEstimate={bodyDataSlotEstimates.get(node.id) ?? null}
               placements={buckets.knownByBody.get(node.id) ?? []}
               projectedPlacements={projectedByBody.get(node.id) ?? []}
               selected={selection.type === 'body' && sameBodyId(selection.bodyId, node.id)}
@@ -217,6 +226,7 @@ function BodyTreeRow({
   node,
   systemName,
   slotPrediction,
+  bodyDataSlotEstimate,
   placements,
   projectedPlacements,
   selected,
@@ -227,6 +237,7 @@ function BodyTreeRow({
   node: BodyNode;
   systemName?: string | null;
   slotPrediction: NonNullable<TopologyPlanSnapshot['slotPredictions']>['predictions'][number] | null;
+  bodyDataSlotEstimate?: BodyDataSlotEstimate | null;
   placements: GroupedPlacement[];
   projectedPlacements: ProjectedPlacementItem[];
   selected: boolean;
@@ -256,8 +267,8 @@ function BodyTreeRow({
       ...projectedPlacements.map((item) => item.template).filter((template): template is FacilityTemplate => Boolean(template)),
     ],
   });
-  const orbitalSlotCapacity = resolveSlotCapacity(node.body, slotPrediction, 'orbital');
-  const groundSlotCapacity = resolveSlotCapacity(node.body, slotPrediction, 'surface');
+  const orbitalSlotCapacity = resolveSlotCapacity(node.body, slotPrediction, 'orbital', bodyDataSlotEstimate);
+  const groundSlotCapacity = resolveSlotCapacity(node.body, slotPrediction, 'surface', bodyDataSlotEstimate);
   const orbitalCapacity = orbitalSlotCapacity.value;
   const groundCapacity = groundSlotCapacity.value;
   const orbitalOverflow = orbitalCapacity == null ? 0 : Math.max(0, plannedOrbital.length + projectedOrbital.length - orbitalCapacity);
@@ -548,7 +559,7 @@ export function describeTopologySelection(
   system: SystemDetail,
   snapshot: TopologyPlanSnapshot,
 ): TopologySelectionContext {
-  const bodies = system.bodies ?? [];
+  const bodies = systemBodyData(system);
   const buckets = bucketPlacements(snapshot.placements, snapshot.templates, bodies);
   const bodyById = new Map(
     bodies

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -13,7 +13,12 @@ import { templateLocationKind } from '@/features/system-detail/simulation-previe
 import type { TopologyPlanSnapshot, TopologySelection, TopologySelectionContext } from './ColonyTopologyRail';
 import { SlotCapacityDots } from './BodySlotPlanner';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
-import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity } from './slotCapacityFallback';
+import {
+  ESTIMATED_SLOT_LAYOUT_DISCLAIMER,
+  buildBodyDataSlotEstimateMap,
+  resolveSlotCapacity,
+  systemBodyData,
+} from './slotCapacityFallback';
 import {
   buildPlanningEconomyLedger,
   normalisePlanningEconomy,
@@ -906,7 +911,7 @@ function buildSelectedStructureTelemetryDetail(
   const template = snapshot.templates.find((candidate) => candidate.id === placement.facility_template_id);
   const bodyId = placement.local_body_id != null ? bodyIdKey(placement.local_body_id) : null;
   const body = bodyId
-    ? (system.bodies ?? []).find((candidate) => sameBodyId(candidate.id, bodyId))
+    ? systemBodyData(system).find((candidate) => sameBodyId(candidate.id, bodyId))
     : null;
   const lane = laneForPlacement(template, body ?? undefined);
   const strength = template ? Math.max(0, (template.yellow_cp_generated ?? 0) + (template.green_cp_generated ?? 0)) : null;
@@ -929,13 +934,14 @@ function buildTelemetryWarningItems(
   economyLedger: PlanningEconomyLedger,
   selectedContext: TopologySelectionContext,
 ): string[] {
-  const bodyIds = new Set((system.bodies ?? []).filter((body) => body.id != null).map((body) => bodyIdKey(body.id)));
+  const bodies = systemBodyData(system);
+  const bodyIds = new Set(bodies.filter((body) => body.id != null).map((body) => bodyIdKey(body.id)));
   const unassigned = snapshot.placements.filter((placement) => placement.local_body_id == null).length;
   const unknownBodies = snapshot.placements.filter((placement) => {
     const bodyId = placement.local_body_id != null ? bodyIdKey(placement.local_body_id) : '';
     return Boolean(bodyId && !bodyIds.has(bodyId));
   }).length;
-  const slotGaps = (system.bodies ?? []).filter((body) => body.id != null && !snapshot.slotPredictions?.predictions?.some((prediction) => sameBodyId(prediction.body_id, body.id))).length;
+  const slotGaps = bodies.filter((body) => body.id != null && !snapshot.slotPredictions?.predictions?.some((prediction) => sameBodyId(prediction.body_id, body.id))).length;
   return [
     selectedContext.warningCount > 0 ? `${selectedContext.warningCount} selected warning${selectedContext.warningCount === 1 ? '' : 's'}` : null,
     unassigned > 0 ? `${unassigned} unassigned` : null,
@@ -1021,7 +1027,8 @@ function CanvasPill({ label, tone }: { label: string; tone: 'silver' | 'orange' 
 }
 
 export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPlanSnapshot): RavenPlannerRow[] {
-  const bodies = system.bodies ?? [];
+  const bodies = systemBodyData(system);
+  const bodyDataSlotEstimates = buildBodyDataSlotEstimateMap(system, snapshot.slotPredictions?.predictions);
   const predictionsByBodyId = new Map(
     (snapshot.slotPredictions?.predictions ?? []).map((prediction) => [bodyIdKey(prediction.body_id), prediction]),
   );
@@ -1037,12 +1044,13 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
 
   return flattenBodyNodes(bodies).map((node) => {
     const prediction = predictionsByBodyId.get(node.id) ?? null;
+    const bodyDataSlotEstimate = bodyDataSlotEstimates.get(node.id) ?? null;
     const planned = plannedByBody.get(node.id) ?? emptyStructureBuckets();
     const projected = projectedByBody.get(node.id) ?? emptyStructureBuckets();
     const orbitalStructures = [...planned.orbital, ...projected.orbital];
     const groundStructures = [...planned.ground, ...projected.ground];
-    const orbitalSlotCapacity = resolveSlotCapacity(node.body, prediction, 'orbital');
-    const groundSlotCapacity = resolveSlotCapacity(node.body, prediction, 'surface');
+    const orbitalSlotCapacity = resolveSlotCapacity(node.body, prediction, 'orbital', bodyDataSlotEstimate);
+    const groundSlotCapacity = resolveSlotCapacity(node.body, prediction, 'surface', bodyDataSlotEstimate);
     const orbitalCapacity = orbitalSlotCapacity.value;
     const groundCapacity = groundSlotCapacity.value;
     const bodyLedger = buildPlanningEconomyLedger({
@@ -1108,7 +1116,7 @@ export function buildProjectionComparison(
   economyLedger: PlanningEconomyLedger,
   rows = buildRavenPlannerRows(system, snapshot),
 ): ProjectionComparisonSummary {
-  const bodies = system.bodies ?? [];
+  const bodies = systemBodyData(system);
   const bodyById = new Map(
     bodies
       .filter((body) => body.id != null)

--- a/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
@@ -12,7 +12,12 @@ import { templateLocationKind } from '@/features/system-detail/simulation-previe
 import type { SimulationWorkspaceMode } from '@/features/system-detail/simulation-preview/WorkspaceModeTabs';
 import { BodySlotPlanner, type BodyPlannerLane } from './BodySlotPlanner';
 import type { TopologyPlanSnapshot, TopologySelection } from './ColonyTopologyRail';
-import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity } from './slotCapacityFallback';
+import {
+  ESTIMATED_SLOT_LAYOUT_DISCLAIMER,
+  buildBodyDataSlotEstimateMap,
+  resolveSlotCapacity,
+  systemBodyData,
+} from './slotCapacityFallback';
 
 interface PlacementViewItem {
   placement: SimulateBuildPlacement;
@@ -99,6 +104,8 @@ export function SelectedBodyPlannerCanvas({
   }
 
   const bodyId = bodyIdKey(body.id);
+  const bodyDataSlotEstimates = buildBodyDataSlotEstimateMap(system, snapshot.slotPredictions?.predictions);
+  const bodyDataSlotEstimate = bodyDataSlotEstimates.get(bodyId) ?? null;
   const templatesById = new Map(snapshot.templates.map((template) => [template.id, template]));
   const placements: PlacementViewItem[] = snapshot.placements
     .map((placement, index) => ({
@@ -135,6 +142,7 @@ export function SelectedBodyPlannerCanvas({
       <BodySlotPlanner
         body={body}
         slotPrediction={slotPrediction}
+        bodyDataSlotEstimate={bodyDataSlotEstimate}
         placements={placements}
         projectedPlacements={projectedPlacements}
         selectedPlacementIndex={selectedPlacementIndex}
@@ -214,7 +222,7 @@ function SystemOverviewPlannerCanvas({
 }) {
   const overviewItems = buildSystemOverviewItems(system, snapshot);
   const featuredItems = overviewItems.slice(0, 18);
-  const bodies = system.bodies ?? [];
+  const bodies = systemBodyData(system);
   const landableCount = bodies.filter((candidate) => candidate.is_landable === true).length;
   const knownOrbitalCapacity = sumKnownCapacity(overviewItems, 'orbital');
   const knownSurfaceCapacity = sumKnownCapacity(overviewItems, 'surface');
@@ -480,7 +488,8 @@ function MiniLegend({
 }
 
 function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSnapshot): SystemOverviewItem[] {
-  const bodies = system.bodies ?? [];
+  const bodies = systemBodyData(system);
+  const bodyDataSlotEstimates = buildBodyDataSlotEstimateMap(system, snapshot.slotPredictions?.predictions);
   const predictionsByBodyId = new Map(
     (snapshot.slotPredictions?.predictions ?? []).map((prediction) => [bodyIdKey(prediction.body_id), prediction]),
   );
@@ -494,10 +503,11 @@ function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSn
     .map((body) => {
       const bodyId = bodyIdKey(body.id);
       const slotPrediction = predictionsByBodyId.get(bodyId) ?? null;
+      const bodyDataSlotEstimate = bodyDataSlotEstimates.get(bodyId) ?? null;
       const planned = plannedCounts.get(bodyId) ?? emptyLaneCounts();
       const projected = projectedCounts.get(bodyId) ?? emptyLaneCounts();
-      const orbitalSlotCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital');
-      const surfaceSlotCapacity = resolveSlotCapacity(body, slotPrediction, 'surface');
+      const orbitalSlotCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital', bodyDataSlotEstimate);
+      const surfaceSlotCapacity = resolveSlotCapacity(body, slotPrediction, 'surface', bodyDataSlotEstimate);
       const orbitalCapacity = orbitalSlotCapacity.value;
       const surfaceCapacity = surfaceSlotCapacity.value;
       const tags = bodyTags(body);

--- a/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
+++ b/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
@@ -9,16 +9,31 @@ export interface ResolvedSlotCapacity {
   estimated: boolean;
 }
 
+export interface BodyDataSlotEstimate {
+  bodyId: string;
+  bodyName: string | null;
+  orbital: number;
+  surface: number | null;
+}
+
 export const ESTIMATED_SLOT_LAYOUT_DISCLAIMER = 'Slot layout estimated from body data (Not 100% verified).';
 
 export function resolveSlotCapacity(
   body: SystemBody,
   prediction: BodySlotPrediction | null,
   lane: SlotCapacityLane,
+  bodyDataEstimate?: BodyDataSlotEstimate | null,
 ): ResolvedSlotCapacity {
+  if (bodyDataEstimate) {
+    return {
+      value: lane === 'orbital' ? bodyDataEstimate.orbital : bodyDataEstimate.surface,
+      estimated: true,
+    };
+  }
+
   const predicted = normaliseSlotCount(lane === 'orbital'
-    ? prediction?.predicted_orbital_slots
-    : prediction?.predicted_ground_slots);
+    ? prediction?.predicted_orbital_slots ?? prediction?.estimated_orbital_slots
+    : prediction?.predicted_ground_slots ?? prediction?.estimated_surface_slots);
 
   if (prediction?.prediction_status === 'observed') {
     return { value: predicted, estimated: false };
@@ -37,12 +52,58 @@ export function resolveSlotCapacity(
   return { value: predicted, estimated: false };
 }
 
+export function buildBodyDataSlotEstimateMap(
+  system: SystemDetail,
+  confirmedSlots: BodySlotPrediction[] | null | undefined,
+): Map<string, BodyDataSlotEstimate> {
+  const bodyData = systemBodyData(system);
+  if (!shouldUseBodyDataSlotFallback(system, confirmedSlots)) return new Map();
+
+  const calculatedArray = bodyData
+    .filter((body) => body.id != null)
+    .map((body) => {
+      const slots = estimateBodySlots(body, { allowMinimalBodyDataEstimate: true });
+      if (!slots) return null;
+      return {
+        bodyId: bodyIdKey(body.id),
+        bodyName: body.name ?? null,
+        orbital: slots.orbital,
+        surface: slots.surface,
+      };
+    })
+    .filter((estimate): estimate is BodyDataSlotEstimate => estimate != null);
+
+  console.log('Calculated Slots:', calculatedArray);
+
+  return new Map(calculatedArray.map((estimate) => [estimate.bodyId, estimate]));
+}
+
+export function shouldUseBodyDataSlotFallback(
+  system: SystemDetail,
+  confirmedSlots: BodySlotPrediction[] | null | undefined,
+): boolean {
+  const bodyData = systemBodyData(system);
+  return (!confirmedSlots || confirmedSlots.length === 0) && bodyData.length > 0;
+}
+
+export function systemBodyData(system: SystemDetail): SystemBody[] {
+  const directBodies = system.bodies;
+  if (Array.isArray(directBodies)) return directBodies;
+
+  const bodyData = (system as { bodyData?: unknown }).bodyData
+    ?? (system as { body_data?: unknown }).body_data;
+  return Array.isArray(bodyData) ? (bodyData as SystemBody[]) : [];
+}
+
 export function hasEstimatedSlotFallback(system: SystemDetail, snapshot: TopologyPlanSnapshot): boolean {
+  const bodyDataSlotEstimates = buildBodyDataSlotEstimateMap(system, snapshot.slotPredictions?.predictions);
+  if (bodyDataSlotEstimates.size > 0) return true;
+
   const predictionsByBodyId = new Map(
     (snapshot.slotPredictions?.predictions ?? []).map((prediction) => [bodyIdKey(prediction.body_id), prediction]),
   );
 
-  return (system.bodies ?? []).some((body) => {
+  return systemBodyData(system).some((body) => {
     if (body.id == null) return false;
     const prediction = predictionsByBodyId.get(bodyIdKey(body.id)) ?? null;
     return resolveSlotCapacity(body, prediction, 'orbital').estimated
@@ -50,13 +111,16 @@ export function hasEstimatedSlotFallback(system: SystemDetail, snapshot: Topolog
   });
 }
 
-function estimateBodySlots(body: SystemBody): { orbital: number; surface: number | null } | null {
+function estimateBodySlots(
+  body: SystemBody,
+  options: { allowMinimalBodyDataEstimate?: boolean } = {},
+): { orbital: number; surface: number | null } | null {
   if (!isBuildableBodyCandidate(body)) return null;
 
   const radiusKm = readRadiusKm(body);
-  if (radiusKm == null) return null;
+  if (radiusKm == null && !options.allowMinimalBodyDataEstimate) return null;
 
-  const orbitalBase = radiusBaseSlots(radiusKm);
+  const orbitalBase = radiusKm == null ? 1 : radiusBaseSlots(radiusKm);
   const orbital = clampSlotCount(orbitalBase + (readBoolean(body, 'is_ringed') ? 1 : 0), 1, 4);
 
   if (body.is_landable !== true || body.is_water_world === true) {
@@ -81,7 +145,8 @@ function estimateBodySlots(body: SystemBody): { orbital: number; surface: number
   if ((body.bio_signal_count ?? 0) > 0) bonus += 1;
   bonus += atmosphereBonus(body);
 
-  const surface = Math.min(radiusBaseSlots(radiusKm) + Math.min(bonus, 3), 7);
+  const surfaceBase = radiusKm == null ? 1 : radiusBaseSlots(radiusKm);
+  const surface = Math.min(surfaceBase + Math.min(bonus, 3), 7);
   return { orbital, surface };
 }
 


### PR DESCRIPTION
Summary:
- Force body-data slot fallback when confirmed slot predictions are missing or empty, with the requested temporary Calculated Slots console log.
- Brighten orbit and surface SVG bands and align slot/add icons on those bands using scaled polar coordinates.
- Add regression coverage for empty confirmed slot fallback and body band slot positioning.

Validation:
- npm run typecheck
- npm run build
- npm test

Notes: build still reports the existing Vite chunk-size warning; tests still print the existing jsdom navigation / React act warnings plus the requested temporary slot calculation logs.