### PR TITLE
[codex] Polish system modal and tree slots

### DIFF
--- a/frontend-v2/src/features/colony-planner/BodySlotLane.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotLane.tsx
@@ -48,11 +48,11 @@ export function BodySlotLane({
       />
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <div className="font-mono text-[11px] uppercase tracking-[0.1em] text-silver">{label}</div>
-          <p className="mt-0.5 text-xs leading-relaxed text-silver-dk">{helper}</p>
+          <div className="mb-4 font-mono text-2xl font-bold uppercase tracking-wide text-silver">{label}</div>
+          <p className="mt-0.5 text-xs leading-relaxed text-silver">{helper}</p>
         </div>
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="rounded border border-border/55 bg-bg2/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-silver-dk">
+          <span className="rounded border border-border/55 bg-bg2/60 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.1em] text-silver">
             {slotStatus}
           </span>
           <button

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.test.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.test.tsx
@@ -22,7 +22,7 @@ const slotPrediction: BodySlotPrediction = {
 };
 
 describe('BodySlotPlanner', () => {
-  it('renders vivid orbit/surface bands with slot tokens centered from polar coordinates', () => {
+  it('renders vivid orbit/surface bands with one token per calculated slot', () => {
     const { container } = render(
       <BodySlotPlanner
         body={body}
@@ -40,24 +40,52 @@ describe('BodySlotPlanner', () => {
 
     const orbitBand = container.querySelector('circle[stroke="#00c8ff"]');
     const surfaceBand = container.querySelector('circle[stroke="#ff9f1a"]');
-    expect(orbitBand?.getAttribute('stroke-width')).toBe('24');
+    expect(orbitBand?.getAttribute('stroke-width')).toBe('40');
     expect(orbitBand?.getAttribute('stroke-opacity')).toBe('0.46');
-    expect(surfaceBand?.getAttribute('stroke-width')).toBe('16');
+    expect(surfaceBand?.getAttribute('stroke-width')).toBe('40');
     expect(surfaceBand?.getAttribute('stroke-opacity')).toBe('0.48');
 
+    expect(screen.getAllByTestId(/^ring-orbital-slot-/)).toHaveLength(4);
+    expect(screen.getAllByTestId(/^ring-surface-slot-/)).toHaveLength(5);
     const orbitSlot = screen.getByTestId('ring-orbital-slot-0') as HTMLElement;
     const surfaceSlot = screen.getByTestId('ring-surface-slot-0') as HTMLElement;
     expect(orbitSlot.style.left).toContain('calc(50%');
     expect(orbitSlot.style.left).toContain('px');
     expect(orbitSlot.style.top).toContain('8.9rem');
-    expect(orbitSlot.style.top).toContain('px');
     expect(orbitSlot.style.left).not.toContain('130px');
+    expect(orbitSlot.textContent).toBe('1');
     expect(surfaceSlot.style.left).toContain('calc(50%');
     expect(surfaceSlot.style.left).toContain('px');
     expect(surfaceSlot.style.top).toContain('8.9rem');
-    expect(surfaceSlot.style.top).toContain('px');
     expect(surfaceSlot.style.left).not.toContain('92px');
+    expect(surfaceSlot.textContent).toBe('1');
     expect(screen.getByTestId('ring-orbital-slot-3')).toBeTruthy();
     expect(screen.getByTestId('ring-surface-slot-4')).toBeTruthy();
+  });
+
+  it('keeps both bands visible but draws no slot icons when calculated counts are zero', () => {
+    const { container } = render(
+      <BodySlotPlanner
+        body={body}
+        slotPrediction={{
+          ...slotPrediction,
+          predicted_orbital_slots: 0,
+          predicted_ground_slots: 0,
+        }}
+        placements={[]}
+        projectedPlacements={[]}
+        selectedPlacementIndex={null}
+        selectedProjectedPlacementIndex={null}
+        hasTemplates
+        onSelectPlacement={vi.fn()}
+        onSelectProjectedPlacement={vi.fn()}
+        onAddLaneStructure={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('circle[stroke="#00c8ff"]')).toBeTruthy();
+    expect(container.querySelector('circle[stroke="#ff9f1a"]')).toBeTruthy();
+    expect(screen.queryByTestId('ring-orbital-slot-0')).toBeNull();
+    expect(screen.queryByTestId('ring-surface-slot-0')).toBeNull();
   });
 });

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
@@ -245,9 +245,11 @@ function BodyRingMap({
 }) {
   const orbitRadius = scaledBandRadius(ORBIT_BAND_RADIUS);
   const surfaceRadius = scaledBandRadius(SURFACE_BAND_RADIUS);
+  const orbitalSlotCount = slotIconCount(orbitalCapacity);
+  const surfaceSlotCount = slotIconCount(surfaceCapacity);
   const orbitalNodes = buildRingNodes({
     lane: 'orbital',
-    capacity: orbitalCapacity,
+    slotCount: orbitalSlotCount,
     planned: orbitalPlanned,
     projected: orbitalProjected,
     selectedPlacementIndex,
@@ -259,7 +261,7 @@ function BodyRingMap({
   });
   const surfaceNodes = buildRingNodes({
     lane: 'surface',
-    capacity: surfaceCapacity,
+    slotCount: surfaceSlotCount,
     planned: surfacePlanned,
     projected: surfaceProjected,
     selectedPlacementIndex,
@@ -269,10 +271,8 @@ function BodyRingMap({
     onSelectPlacement,
     onSelectProjectedPlacement,
   });
-  const orbitalSlots = ringSlots(orbitalNodes.length, orbitRadius);
-  const surfaceSlots = ringSlots(surfaceNodes.length, surfaceRadius);
-  const orbitAddPoint = polarPoint(orbitRadius, -90);
-  const surfaceAddPoint = polarPoint(surfaceRadius, 0);
+  const orbitalSlots = ringSlots(orbitalSlotCount, orbitRadius);
+  const surfaceSlots = ringSlots(surfaceSlotCount, surfaceRadius);
 
   return (
     <section data-testid="body-slot-graph" className="mb-3 rounded border border-border/60 bg-bg3/35 px-2 py-3">
@@ -282,13 +282,13 @@ function BodyRingMap({
           viewBox="0 0 320 320"
           className="pointer-events-none absolute left-1/2 top-[8.9rem] h-[16rem] w-[16rem] -translate-x-1/2 -translate-y-1/2 overflow-visible"
         >
-          <circle cx="160" cy="160" r={ORBIT_BAND_RADIUS} fill="none" stroke="#00c8ff" strokeWidth="24" strokeOpacity="0.46" />
-          <circle cx="160" cy="160" r={SURFACE_BAND_RADIUS} fill="none" stroke="#ff9f1a" strokeWidth="16" strokeOpacity="0.48" />
+          <circle cx="160" cy="160" r={ORBIT_BAND_RADIUS} fill="none" stroke="#00c8ff" strokeWidth="40" strokeOpacity="0.46" />
+          <circle cx="160" cy="160" r={SURFACE_BAND_RADIUS} fill="none" stroke="#ff9f1a" strokeWidth="40" strokeOpacity="0.48" />
         </svg>
         <div className="pointer-events-none absolute left-1/2 top-[8.9rem] h-[6.4rem] w-[6.4rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-orange/45 bg-orange/10 shadow-[0_0_30px_rgba(255,122,20,0.2)]" />
 
         <div className="pointer-events-none absolute left-1/2 top-[8.9rem] -translate-x-1/2 -translate-y-1/2 text-center">
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Body core</div>
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver">Body core</div>
         </div>
 
         {orbitalNodes.map((node, index) => (
@@ -321,27 +321,6 @@ function BodyRingMap({
           />
         ))}
 
-        {orbitalNodes.length === 0 && (
-          <LaneAddNode
-            lane="orbital"
-            left={ringLeft(orbitAddPoint.x)}
-            top={ringTop(orbitAddPoint.y)}
-            enabled={hasTemplates}
-            disabledReason={!hasTemplates ? 'Facility catalogue loading.' : undefined}
-            onAdd={() => onAddLaneStructure('orbital')}
-          />
-        )}
-        {surfaceNodes.length === 0 && (
-          <LaneAddNode
-            lane="surface"
-            left={ringLeft(surfaceAddPoint.x)}
-            top={ringTop(surfaceAddPoint.y)}
-            enabled={hasTemplates && !surfaceBlocked}
-            disabledReason={surfaceBlocked ? 'Surface blocked for this body.' : (!hasTemplates ? 'Facility catalogue loading.' : undefined)}
-            onAdd={() => onAddLaneStructure('surface')}
-          />
-        )}
-
         <div className="pointer-events-none absolute left-2 top-2 rounded border border-cyan/35 bg-cyan/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-cyan">Orbit band</div>
         <div className="pointer-events-none absolute left-2 top-8 rounded border border-gold/35 bg-gold/8 px-2 py-1 font-mono text-[9px] uppercase tracking-[0.12em] text-gold">Surface band</div>
       </div>
@@ -368,7 +347,7 @@ interface RingNode {
 
 function buildRingNodes({
   lane,
-  capacity,
+  slotCount,
   planned,
   projected,
   selectedPlacementIndex,
@@ -379,7 +358,7 @@ function buildRingNodes({
   onSelectProjectedPlacement,
 }: {
   lane: BodyPlannerLane;
-  capacity: number | null;
+  slotCount: number;
   planned: BodyPlannerPlacementItem[];
   projected: BodyPlannerProjectedPlacementItem[];
   selectedPlacementIndex: number | null;
@@ -394,26 +373,21 @@ function buildRingNodes({
     ...projected.map((item) => structureRingNode(lane, item, selectedProjectedPlacementIndex === item.index, () => onSelectProjectedPlacement(item.index), true)),
   ];
 
-  if (capacity == null) return structures;
-  if (capacity <= 0) return structures;
+  if (slotCount <= 0) return [];
 
-  const nodes = Array.from({ length: capacity }, (_unused, index) => {
+  return Array.from({ length: slotCount }, (_unused, index) => {
     if (index < structures.length) return structures[index];
     return {
       id: `${lane}-empty-${index}`,
       kind: 'empty' as const,
-      label: '+',
+      label: String(index + 1),
       title: canAdd
-        ? `Add ${lane === 'orbital' ? 'orbit' : 'surface'} structure to empty slot`
+        ? `Add ${lane === 'orbital' ? 'orbit' : 'surface'} structure to slot ${index + 1}`
         : 'Empty slot',
       selected: false,
       onClick: canAdd ? onAdd : undefined,
     };
   });
-
-  return structures.length > capacity
-    ? [...nodes, ...structures.slice(capacity)]
-    : nodes;
 }
 
 function structureRingNode(
@@ -445,13 +419,15 @@ function polarPoint(radius: number, angleDegrees: number) {
   };
 }
 
+function slotIconCount(capacity: number | null) {
+  return capacity == null ? 0 : Math.max(0, capacity);
+}
+
 function ringSlots(count: number, radius: number) {
   if (count <= 0) return [];
-  if (count === 1) return [polarPoint(radius, -90)];
-  const spread = Math.min(320, Math.max(140, 50 * count));
-  const start = -90 - spread / 2;
-  const step = spread / (count - 1);
-  return new Array(count).fill(null).map((_, index) => polarPoint(radius, start + step * index));
+  return Array.from({ length: count }, (_unused, index) => (
+    polarPoint(radius, (360 / count) * index)
+  ));
 }
 
 function ringLeft(x: number) {
@@ -520,7 +496,7 @@ function RingPlacementToken({
         onClick={onClick}
         style={{ left, top, transform: 'translate(-50%, -50%)' }}
         className={[
-          'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em] transition-transform hover:scale-105',
+          'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-base font-bold uppercase leading-none tracking-normal transition-transform hover:scale-105',
           toneClass,
           selectedClass,
         ].join(' ')}
@@ -536,50 +512,12 @@ function RingPlacementToken({
       title={title}
       style={{ left, top, transform: 'translate(-50%, -50%)' }}
       className={[
-        'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-[9px] font-bold uppercase tracking-[0.08em]',
+        'absolute z-30 grid h-8 w-8 place-items-center rounded-full border font-mono text-base font-bold uppercase leading-none tracking-normal',
         toneClass,
       ].join(' ')}
     >
       {label}
     </div>
-  );
-}
-
-function LaneAddNode({
-  lane,
-  left,
-  top,
-  enabled,
-  disabledReason,
-  onAdd,
-}: {
-  lane: BodyPlannerLane;
-  left: string;
-  top: string;
-  enabled: boolean;
-  disabledReason?: string;
-  onAdd: () => void;
-}) {
-  const label = lane === 'orbital'
-    ? 'Add orbit structure'
-    : 'Add surface structure';
-  return (
-    <button
-      type="button"
-      aria-label={label}
-      title={enabled ? label : disabledReason ?? label}
-      disabled={!enabled}
-      onClick={onAdd}
-      style={{ left, top, transform: 'translate(-50%, -50%)' }}
-      className={[
-        'absolute z-40 grid h-8 w-8 place-items-center rounded-full border text-sm font-bold transition-transform',
-        enabled
-          ? 'border-orange/55 bg-orange/18 text-orange hover:scale-110'
-          : 'cursor-not-allowed border-gold/35 bg-gold/10 text-gold/70',
-      ].join(' ')}
-    >
-      +
-    </button>
   );
 }
 
@@ -679,7 +617,7 @@ function LaneCapacityMap({
   return (
     <div className="mb-2 rounded border border-border/55 bg-bg3/30 px-2 py-2">
       <div className="flex flex-wrap items-center justify-between gap-2 font-mono text-[10px]">
-        <span className="uppercase tracking-[0.14em] text-silver-dk">Predicted capacity</span>
+        <span className="uppercase tracking-[0.14em] text-silver">Predicted capacity</span>
         <span className="text-silver">{used}/{capacity} slots including projection</span>
       </div>
       <div className="mt-2 flex flex-wrap gap-1.5">
@@ -725,7 +663,7 @@ function CapacityCell({
       ? projected
         ? 'border-cyan/45 bg-cyan/10 text-cyan'
         : 'border-orange/55 bg-orange/16 text-orange'
-      : 'border-border/60 bg-bg2/45 text-silver-dk',
+      : 'border-border/60 bg-bg2/45 text-silver',
     selected ? 'ring-2 ring-orange/70' : '',
     onClick ? 'cursor-pointer hover:border-orange/75' : '',
   ].join(' ');
@@ -778,7 +716,7 @@ function LaneSlots({
     return (
       <div
         data-testid={`slot-lane-empty-${laneKey}`}
-        className="rounded border border-dashed border-border/55 bg-bg3/30 px-3 py-2 font-mono text-[10px] text-silver-dk"
+        className="rounded border border-dashed border-border/55 bg-bg3/30 px-3 py-2 font-mono text-[10px] text-silver"
       >
         {emptyText}
       </div>
@@ -934,7 +872,7 @@ function FactChip({
               ? 'border-green/35 bg-green/10 text-green'
               : tone === 'gold'
                 ? 'border-gold/35 bg-gold/10 text-gold'
-                : 'border-border/60 bg-bg2/60 text-silver-dk',
+                : 'border-border/60 bg-bg2/60 text-silver',
       ].join(' ')}
     >
       {label}

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
@@ -163,6 +163,55 @@ describe('ColonyTopologyRail', () => {
     expect(screen.getByTestId('topology-body-button-2').getAttribute('aria-pressed')).toBe('false');
   });
 
+  it('filters non-physical Barycentre and Null entries from the system tree and slot calculations', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const customSystem = {
+      ...system,
+      bodies: [
+        { id: 0, name: 'Tree System A', body_type: 'Star', subtype: 'K' },
+        { id: 1, name: 'Tree System A 1', body_type: 'Planet', subtype: 'High metal content world', is_landable: true },
+        { id: 99, name: 'Tree System Barycentre', body_type: 'Barycentre', subtype: 'Barycentre' },
+        { id: 100, name: 'Null Body', body_type: 'Planet', subtype: 'Null' },
+      ],
+    } as unknown as SystemDetail;
+
+    try {
+      render(
+        <ColonyTopologyRail
+          system={customSystem}
+          snapshot={{ placements: [], templates, targetArchetype: 'refinery_industrial', slotPredictions: null }}
+          selection={{ type: 'system' }}
+          onSelect={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('topology-body-0')).toBeTruthy();
+      expect(screen.getByTestId('topology-body-1')).toBeTruthy();
+      expect(screen.queryByText(/Barycentre/i)).toBeNull();
+      expect(screen.queryByText(/Null Body/i)).toBeNull();
+      expect(logSpy).toHaveBeenCalledWith(
+        'Calculated Slots:',
+        expect.arrayContaining([
+          expect.objectContaining({ bodyId: '1' }),
+        ]),
+      );
+      expect(logSpy).not.toHaveBeenCalledWith(
+        'Calculated Slots:',
+        expect.arrayContaining([
+          expect.objectContaining({ bodyId: '99' }),
+        ]),
+      );
+      expect(logSpy).not.toHaveBeenCalledWith(
+        'Calculated Slots:',
+        expect.arrayContaining([
+          expect.objectContaining({ bodyId: '100' }),
+        ]),
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it('renders unknown and unassigned placement groups without exposing raw IDs by default', () => {
     render(<RailHarness />);
 

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
@@ -117,7 +117,7 @@ export function ColonyTopologyRail({
         Whole-system slot map
       </div>
       {snapshot.slotPredictions && (
-        <div className="mt-2 rounded border border-cyan/25 bg-cyan/5 px-2 py-1.5 font-mono text-[10px] text-silver-dk">
+        <div className="mt-2 rounded border border-cyan/25 bg-cyan/5 px-2 py-1.5 font-mono text-[10px] text-silver">
           <div className="text-cyan">Predicted slots</div>
           <div className="mt-0.5">{snapshot.slotPredictions.disclaimer}</div>
           <div className="mt-0.5 italic">{snapshot.slotPredictions.validation_note}</div>
@@ -144,7 +144,7 @@ export function ColonyTopologyRail({
           <div className="truncate font-mono text-[11px] font-bold text-silver">
             {system.name || 'Unknown system'}
           </div>
-          <div className="mt-0.5 font-mono text-[10px] text-silver-dk">
+          <div className="mt-0.5 font-mono text-[10px] text-silver">
             System root
           </div>
         </div>
@@ -153,7 +153,7 @@ export function ColonyTopologyRail({
       </button>
 
       {bodies.length === 0 ? (
-        <p className="mt-3 rounded border border-border/45 bg-bg2/45 px-2 py-2 font-mono text-[10px] leading-snug text-silver-dk">
+        <p className="mt-3 rounded border border-border/45 bg-bg2/45 px-2 py-2 font-mono text-[10px] leading-snug text-silver">
           No body layout imported yet. Use the planner tools to import/refresh layout when available.
         </p>
       ) : (
@@ -209,13 +209,13 @@ export function ColonyTopologyRail({
           className="mt-3 rounded border border-cyan/30 bg-cyan/5 px-2 py-1.5 font-mono text-[10px] text-cyan"
         >
           <div className="uppercase tracking-[0.14em]">Projected plan</div>
-          <div className="mt-1 text-silver-dk">
+          <div className="mt-1 text-silver">
             This plan uses: <span className="text-silver">{projectedBodyLabels.join(', ')}</span>
           </div>
         </div>
       )}
 
-      <div className="mt-3 rounded border border-border/45 bg-bg3/30 px-2 py-1.5 font-mono text-[10px] text-silver-dk">
+      <div className="mt-3 rounded border border-border/45 bg-bg3/30 px-2 py-1.5 font-mono text-[10px] text-silver">
         Click a body to plan there.
       </div>
     </aside>
@@ -303,7 +303,7 @@ function BodyTreeRow({
             <div className="truncate font-mono text-[11px] font-bold text-silver">
               {compactName}
             </div>
-            <div className="mt-0.5 truncate font-mono text-[10px] text-silver-dk">
+            <div className="mt-0.5 truncate font-mono text-[10px] text-silver">
               {compactBodyKind(node.body)}
             </div>
           </div>
@@ -317,7 +317,7 @@ function BodyTreeRow({
       </div>
       {placements.length > 0 && (
         <div className="ml-3 mt-1 space-y-1 border-l border-border/50 pl-2">
-          <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-silver-dk">Planned</div>
+          <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-silver">Planned</div>
           {placements.map((item) => (
             <PlacementButton
               key={`${item.index}-${item.placement.facility_template_id}`}
@@ -401,7 +401,7 @@ function PlacementGroupRow({
         <span className="mt-0.5 w-4 shrink-0 text-center text-gold" aria-hidden="true">?</span>
         <div className="min-w-0 flex-1">
           <div className="truncate font-mono text-[11px] text-gold">{title}</div>
-          <div className="mt-0.5 truncate font-mono text-[10px] text-silver-dk">{description}</div>
+          <div className="mt-0.5 truncate font-mono text-[10px] text-silver">{description}</div>
         </div>
         <CountChip>{placements.length}</CountChip>
       </button>
@@ -441,7 +441,7 @@ function PlacementButton({
         'flex w-full min-w-0 cursor-pointer items-center justify-between gap-2 rounded border px-2 py-1 text-left font-mono text-[10px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70',
         selected
           ? 'border-orange/55 bg-orange/15 text-orange'
-          : 'border-border/45 bg-bg2/45 text-silver-dk hover:border-orange/35 hover:text-silver',
+          : 'border-border/45 bg-bg2/45 text-silver hover:border-orange/35 hover:text-white',
       ].join(' ')}
     >
       <span className="min-w-0 truncate">#{item.placement.build_order} {label}</span>
@@ -474,7 +474,7 @@ function SlotLaneRow({
 }) {
   if (capacity == null) {
     return (
-      <div className="flex items-center gap-1.5 font-mono text-[9px] text-silver-dk">
+      <div className="flex items-center gap-1.5 font-mono text-[9px] text-silver">
         <span className="w-10 uppercase tracking-[0.12em]">{label}</span>
         <span className="rounded border border-gold/35 bg-gold/10 px-1 text-gold" data-testid={`slot-lane-unknown-${laneKey}`}>[?]</span>
       </div>
@@ -507,7 +507,7 @@ function SlotLaneRow({
   });
 
   return (
-    <div className="flex items-center gap-1.5 font-mono text-[9px] text-silver-dk">
+    <div className="flex items-center gap-1.5 font-mono text-[9px] text-silver">
       <span className="w-10 uppercase tracking-[0.12em]">{label}</span>
       <div className="flex min-w-0 flex-wrap gap-1">
         {cells.map((cell, index) => (
@@ -520,7 +520,7 @@ function SlotLaneRow({
                 ? 'border-orange/55 bg-orange/15 text-orange'
                 : cell.tone === 'projected'
                   ? 'border-cyan/45 bg-cyan/10 text-cyan'
-                  : 'border-border/60 bg-bg2/45 text-silver-dk',
+                  : 'border-border/60 bg-bg2/45 text-silver',
             ].join(' ')}
             title={cell.label || 'Empty slot'}
           >
@@ -835,7 +835,7 @@ function Marker({
           ? 'border-gold/40 bg-gold/10 text-gold'
           : tone === 'cyan'
             ? 'border-cyan/35 bg-cyan/10 text-cyan'
-            : 'border-border/60 bg-bg2/60 text-silver-dk',
+            : 'border-border/60 bg-bg2/60 text-silver',
       ].join(' ')}
     >
       {children}
@@ -849,7 +849,7 @@ function Chip({ children, tone = 'silver' }: { children: React.ReactNode; tone?:
     cyan: 'border-cyan/30 bg-cyan/5 text-cyan',
     green: 'border-green/35 bg-green/10 text-green',
     gold: 'border-gold/35 bg-gold/10 text-gold',
-    silver: 'border-border/60 bg-bg2/60 text-silver-dk',
+    silver: 'border-border/60 bg-bg2/60 text-silver',
   }[tone];
   return (
     <span className={['shrink-0 rounded border px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-[0.12em]', toneClass].join(' ')}>

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -141,6 +141,26 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(missingPredictionBody?.groundSlots[1].title).toContain('No economy metadata');
   });
 
+  it('excludes Barycentre and Null entries from the real system tree rows', () => {
+    const rows = buildRavenPlannerRows({
+      ...system,
+      bodies: [
+        ...(system.bodies ?? []),
+        { id: 90, name: 'Real Data System Barycentre', body_type: 'Barycentre', subtype: 'Barycentre' },
+        { id: 91, name: 'Null Body', body_type: 'Planet', subtype: 'Null' },
+      ],
+    } as unknown as SystemDetail, {
+      ...snapshot,
+      placements: [],
+      projection: null,
+      slotPredictions: null,
+    });
+
+    expect(rows.find((row) => row.id === '90')).toBeUndefined();
+    expect(rows.find((row) => row.id === '91')).toBeUndefined();
+    expect(rows.map((row) => row.displayName).join(' ')).not.toMatch(/Barycentre|Null Body/i);
+  });
+
   it('renders real planner lanes without static mock bodies or attached-structure column', () => {
     render(<RavenStylePlannerCanvas system={system} snapshot={snapshot} selection={{ type: 'system' }} onSelect={vi.fn()} />);
 

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -169,7 +169,7 @@ export function RavenStylePlannerCanvas({
           </div>
           <div className="min-w-0">
             <h2 className="font-display text-lg text-orange">Whole-System Build Canvas</h2>
-            <p className="truncate text-xs leading-relaxed text-silver-dk">
+            <p className="truncate text-xs leading-relaxed text-silver">
               Real bodies, validated slot predictions, Build Plan placements, and selected Suggested Build projection.
             </p>
           </div>
@@ -190,17 +190,17 @@ export function RavenStylePlannerCanvas({
       <div className="overflow-x-auto">
         <div className="min-w-[860px]">
           <div
-            className="grid border-b border-orange/20 bg-bg2/70 px-3 py-2 font-mono text-[11px] uppercase tracking-[0.1em] text-silver-dk"
+            className="mb-4 grid border-b border-orange/20 bg-bg2/70 px-3 py-4 font-mono text-2xl font-bold uppercase tracking-wide text-silver"
             style={gridStyle}
           >
-            <div className="text-cyan">System tree</div>
+            <div className="text-cyan">System Tree</div>
             <div>Orbit</div>
             <div>Surface</div>
           </div>
 
           <div className="divide-y divide-border/45">
             {rows.length === 0 ? (
-              <div className="px-3 py-5 text-sm text-silver-dk">No real body layout is available for this system.</div>
+              <div className="px-3 py-5 text-sm text-silver">No real body layout is available for this system.</div>
             ) : rows.map((row) => (
               <RavenPlannerBodyRow
                 key={row.id}
@@ -258,7 +258,7 @@ export function RavenPlannerTelemetryPanel({
         </div>
         <div>
           <h2 className="font-display text-base text-orange">Planning Telemetry</h2>
-          <p className="text-xs leading-relaxed text-silver-dk">Live planner data, Preview remains explicit.</p>
+          <p className="text-xs leading-relaxed text-silver">Live planner data, Preview remains explicit.</p>
         </div>
       </div>
 
@@ -277,7 +277,7 @@ export function RavenPlannerTelemetryPanel({
 
       <div className="mt-4 border-t border-border/70 pt-3">
         <h3 className="font-mono text-[11px] uppercase tracking-[0.12em] text-cyan">Economy mix</h3>
-        <p className="mt-1 text-xs leading-relaxed text-silver-dk">{PLANNING_ECONOMY_NOTE}</p>
+        <p className="mt-1 text-xs leading-relaxed text-silver">{PLANNING_ECONOMY_NOTE}</p>
         <div className="mt-2">
           <PlanningEconomyStrip ledger={economyLedger} testId="raven-telemetry-economy-ledger" />
         </div>
@@ -293,8 +293,8 @@ export function RavenPlannerTelemetryPanel({
       <div className="mt-4 border-t border-cyan/25 pt-3">
         <div className="font-mono text-[11px] uppercase tracking-[0.12em] text-cyan">Selected focus</div>
         <div className="mt-1 text-base font-semibold leading-snug text-silver">{selectedContext.label}</div>
-        <div className="mt-1 text-sm text-silver-dk">{selectedContext.kind}</div>
-        <p className="mt-2 text-sm leading-relaxed text-silver-dk">{selectedContext.detail}</p>
+        <div className="mt-1 text-sm text-silver">{selectedContext.kind}</div>
+        <p className="mt-2 text-sm leading-relaxed text-silver">{selectedContext.detail}</p>
       </div>
 
       {bodyDetail && <SelectedBodyTelemetryCard detail={bodyDetail} />}
@@ -438,7 +438,7 @@ function TreeCell({
               testId={`raven-body-slot-indicators-${row.id}`}
             />
           </span>
-          <span className="mt-0.5 block truncate text-xs leading-snug text-silver-dk">{row.bodyKind}</span>
+          <span className="mt-0.5 block truncate text-xs leading-snug text-silver">{row.bodyKind}</span>
         </span>
       </button>
     </div>
@@ -515,7 +515,7 @@ function RavenSlotBox({
     <>
       {slot.kind === 'projected' && <span data-testid="raven-projected-ghost-structure" className="sr-only">{slot.fullName}</span>}
       {slot.status !== 'unknown' && (
-        <span className={slot.kind === 'projected' ? 'absolute right-1 top-0.5 text-[8px] text-cyan' : 'absolute right-1 top-0.5 text-[8px] text-silver-dk'}>
+        <span className={slot.kind === 'projected' ? 'absolute right-1 top-0.5 text-[8px] text-cyan' : 'absolute right-1 top-0.5 text-[8px] text-silver'}>
           {slot.kind === 'projected' ? 'PROJ' : slot.kind === 'overflow' ? 'OVER' : 'PLAN'}
         </span>
       )}
@@ -644,7 +644,7 @@ function ProjectionComparisonCard({
         <ProjectionViewButton view="slots" active={view === 'slots'} disabled={controlsDisabled} onSelect={onViewChange} />
       </div>
       {!summary.hasProjection ? (
-        <p className="mt-2 text-xs leading-relaxed text-silver-dk">
+        <p className="mt-2 text-xs leading-relaxed text-silver">
           Select a Suggested Build candidate to compare ghost structures against the current Build Plan. Loading and Preview stay explicit.
         </p>
       ) : view === 'bodies' ? (
@@ -679,7 +679,7 @@ function ProjectionViewButton({
       onClick={() => onSelect(view)}
       className={[
         'rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.1em] transition-colors disabled:cursor-not-allowed disabled:opacity-45',
-        active ? 'border-orange/55 bg-orange/15 text-orange' : 'border-border/60 bg-bg3/45 text-silver-dk hover:border-cyan/45 hover:text-cyan',
+        active ? 'border-orange/55 bg-orange/15 text-orange' : 'border-border/60 bg-bg3/45 text-silver hover:border-cyan/45 hover:text-cyan',
       ].join(' ')}
     >
       {label}
@@ -718,13 +718,13 @@ function ProjectionEconomyView({ summary }: { summary: ProjectionComparisonSumma
               style={{ width: `${entry.projected > 0 && entry.total > 0 ? Math.max(8, (entry.projected / entry.total) * 100) : 0}%` }}
             />
           </span>
-          <span className="text-right text-silver-dk">
+          <span className="text-right text-silver">
             <span className="text-orange">{entry.planned}</span>
             <span className="text-cyan"> +{entry.projected}</span>
           </span>
         </div>
       )) : (
-        <p className="rounded border border-border/55 bg-bg3/35 px-2 py-1 font-mono text-[10px] text-silver-dk">No economy metadata to compare.</p>
+        <p className="rounded border border-border/55 bg-bg3/35 px-2 py-1 font-mono text-[10px] text-silver">No economy metadata to compare.</p>
       )}
     </div>
   );
@@ -750,7 +750,7 @@ function ProjectionMetric({ label, value, tone }: { label: string; value: number
   }[tone];
   return (
     <div className="rounded border border-border/55 bg-bg3/35 px-2 py-1 font-mono">
-      <div className="truncate text-[9px] uppercase tracking-[0.12em] text-silver-dk">{label}</div>
+      <div className="truncate text-[9px] uppercase tracking-[0.12em] text-silver">{label}</div>
       <div className={["mt-0.5 text-[13px] font-semibold", toneClass].join(' ')}>{value}</div>
     </div>
   );
@@ -759,7 +759,7 @@ function ProjectionMetric({ label, value, tone }: { label: string; value: number
 function ProjectionBodyList({ label, values }: { label: string; values: string[] }) {
   return (
     <div className="rounded border border-border/55 bg-bg3/35 px-2 py-1 font-mono text-[10px]">
-      <div className="uppercase tracking-[0.12em] text-silver-dk">{label}</div>
+      <div className="uppercase tracking-[0.12em] text-silver">{label}</div>
       <div className="mt-0.5 truncate text-silver">{values.length > 0 ? values.join(', ') : 'None'}</div>
     </div>
   );
@@ -832,7 +832,7 @@ function SelectedStructureTelemetryCard({ detail }: { detail: StructureTelemetry
           ))
           : <TelemetryChip label="No economy metadata" tone="gold" />}
       </div>
-      <p className="mt-2 break-all font-mono text-[10px] text-silver-dk">{detail.templateId}</p>
+      <p className="mt-2 break-all font-mono text-[10px] text-silver">{detail.templateId}</p>
     </section>
   );
 }
@@ -855,7 +855,7 @@ function TelemetryField({
   }[tone];
   return (
     <div className="rounded border border-border/55 bg-bg3/35 px-2 py-1">
-      <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-silver-dk">{label}</div>
+      <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-silver">{label}</div>
       <div className={["mt-0.5 truncate text-[11px] font-semibold", toneClass].join(' ')}>{value}</div>
     </div>
   );
@@ -869,7 +869,7 @@ function TelemetryChip({
   tone?: 'silver' | 'orange' | 'cyan' | 'green' | 'gold';
 }) {
   const toneClass = {
-    silver: 'border-border/60 bg-bg3/45 text-silver-dk',
+    silver: 'border-border/60 bg-bg3/45 text-silver',
     orange: 'border-orange/35 bg-orange/10 text-orange',
     cyan: 'border-cyan/35 bg-cyan/10 text-cyan',
     green: 'border-green/35 bg-green/10 text-green',
@@ -965,7 +965,7 @@ function countBodyPlacements(placements: SimulateBuildPlacement[], bodyId: strin
 function TelemetryMetric({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="grid grid-cols-[1fr_auto] items-baseline gap-2">
-      <div className="truncate font-mono text-[10px] uppercase tracking-[0.1em] text-silver-dk">{label}</div>
+      <div className="truncate font-mono text-[10px] uppercase tracking-[0.1em] text-silver">{label}</div>
       <div className="text-right font-display text-base text-silver">{value}</div>
     </div>
   );
@@ -982,7 +982,7 @@ function ZeroCenteredStatBar({ id, label, value }: { id: string; label: string; 
       data-direction={direction}
       className="grid grid-cols-[7.5rem_1fr_3.6rem] items-center gap-2 font-mono text-[11px]"
     >
-      <span className="truncate text-silver-dk">{label}</span>
+      <span className="truncate text-silver">{label}</span>
       <span className="relative h-4 overflow-hidden rounded-sm border border-border/60 bg-bg4/80 shadow-inner-soft">
         <span data-testid={`raven-stat-${id}-zero-axis`} aria-hidden className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-silver/55" />
         <span
@@ -1017,7 +1017,7 @@ function ZeroCenteredStatBar({ id, label, value }: { id: string; label: string; 
 
 function CanvasPill({ label, tone }: { label: string; tone: 'silver' | 'orange' | 'cyan' | 'green' | 'gold' }) {
   const toneClass = {
-    silver: 'border-border/60 bg-bg3/45 text-silver-dk',
+    silver: 'border-border/60 bg-bg3/45 text-silver',
     orange: 'border-orange/35 bg-orange/10 text-orange',
     cyan: 'border-cyan/35 bg-cyan/10 text-cyan',
     green: 'border-green/35 bg-green/10 text-green',

--- a/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
+++ b/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
@@ -88,11 +88,11 @@ export function shouldUseBodyDataSlotFallback(
 
 export function systemBodyData(system: SystemDetail): SystemBody[] {
   const directBodies = system.bodies;
-  if (Array.isArray(directBodies)) return directBodies;
+  if (Array.isArray(directBodies)) return directBodies.filter(isRenderablePhysicalBody);
 
   const bodyData = (system as { bodyData?: unknown }).bodyData
     ?? (system as { body_data?: unknown }).body_data;
-  return Array.isArray(bodyData) ? (bodyData as SystemBody[]) : [];
+  return Array.isArray(bodyData) ? (bodyData as SystemBody[]).filter(isRenderablePhysicalBody) : [];
 }
 
 export function hasEstimatedSlotFallback(system: SystemDetail, snapshot: TopologyPlanSnapshot): boolean {
@@ -153,6 +153,11 @@ function estimateBodySlots(
 function isBuildableBodyCandidate(body: SystemBody): boolean {
   const type = `${body.body_type ?? ''} ${body.subtype ?? ''}`.toLowerCase();
   return !type.includes('star') && !type.includes('barycentre');
+}
+
+function isRenderablePhysicalBody(body: SystemBody): boolean {
+  const text = `${body.body_type ?? ''} ${body.subtype ?? ''} ${body.name ?? ''}`.toLowerCase();
+  return !text.includes('barycentre') && !text.includes('null');
 }
 
 function readRadiusKm(body: SystemBody): number | null {


### PR DESCRIPTION
## Summary
- Filter non-physical Barycentre/Null bodies before rendering system topology or calculating fallback slots.
- Keep Orbit and Surface bands visible, generate slot icons dynamically from calculated counts, and align icons on the bands.
- Improve modal/tree typography and contrast for slot labels, section headings, and small supporting text.

## Validation
- npm run typecheck
- npm run build
- npm test