### PR TITLE
[codex] Restore rating profile and Coalsack background

### DIFF
--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -129,6 +129,8 @@ vi.mock('@/features/colony-planner/ColonyPlannerWorkspace', () => ({
 
 afterEach(() => {
   window.location.hash = '';
+  document.documentElement.style.removeProperty('--coalsack-bg-2560');
+  document.documentElement.style.removeProperty('--coalsack-bg-1600');
 });
 
 describe('App Advanced Search Tuning route', () => {
@@ -144,6 +146,19 @@ describe('App Advanced Search Tuning route', () => {
 });
 
 describe('App Colony Planner workspace route', () => {
+  it('sets base-aware Coalsack background image URLs', async () => {
+    window.location.hash = '#finder';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Search form')).toBeTruthy();
+    });
+
+    expect(document.documentElement.style.getPropertyValue('--coalsack-bg-2560')).toContain('bg/coalsack-2560.jpg');
+    expect(document.documentElement.style.getPropertyValue('--coalsack-bg-1600')).toContain('bg/coalsack-1600.jpg');
+  });
+
   it('renders the dedicated workspace without opening the System Detail modal', async () => {
     window.location.hash = '#colony-planner/system/123';
 

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -53,6 +53,13 @@ export default function App() {
 function AppInner() {
   const hashRoute = useHashRoute();
 
+  useEffect(() => {
+    const base = import.meta.env.BASE_URL || '/';
+    const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+    document.documentElement.style.setProperty('--coalsack-bg-2560', `url("${normalizedBase}bg/coalsack-2560.jpg?v=2")`);
+    document.documentElement.style.setProperty('--coalsack-bg-1600', `url("${normalizedBase}bg/coalsack-1600.jpg?v=2")`);
+  }, []);
+
   if (hashRoute.route === 'colony-planner-prototype') {
     return <PrototypeAppShell navigate={hashRoute.navigate} />;
   }

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -10,6 +10,18 @@ const system = {
   name: 'Real Data System',
   population: 1250000,
   score: 72,
+  score_agriculture: 38,
+  score_refinery: 83,
+  score_industrial: 71,
+  score_hightech: 44,
+  score_military: 52,
+  score_tourism: 29,
+  score_extraction: 68,
+  economy_suggestion: 'Refinery',
+  terraforming_potential: 23,
+  body_diversity: 18,
+  confidence: 0.82,
+  rationale: 'Strong Refinery; dense HMC and rocky body stack with solid slot capacity.',
   bodies: [
     { id: 1, name: 'Real Data System A', body_type: 'Star', subtype: 'K' },
     { id: 2, name: 'Real Data System A 1', body_type: 'Planet', subtype: 'High metal content world', is_landable: true, parent_body_id: 1, distance_from_star: 220 },
@@ -298,6 +310,12 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(screen.getByTestId('raven-stat-security-negative').style.width).not.toBe('0%');
     expect(screen.getByText('+72')).toBeTruthy();
     expect(screen.getByText('-20.9')).toBeTruthy();
+    expect(screen.getByTestId('raven-rating-profile-card')).toBeTruthy();
+    expect(screen.getByTestId('raven-rating-overall-score').textContent).toContain('72');
+    expect(screen.getByTestId('raven-rating-economy-breakdown')).toBeTruthy();
+    expect(screen.getByTestId('raven-rating-axis-refinery').textContent).toContain('83');
+    expect(screen.getByText(/High 82%/)).toBeTruthy();
+    expect(screen.getByTestId('raven-rating-rationale').textContent).toContain('Strong Refinery');
     expect(within(screen.getByTestId('raven-telemetry-economy-ledger')).getByText(/Ind/i)).toBeTruthy();
     expect(screen.getByTestId('raven-projection-comparison')).toBeTruthy();
     expect(screen.getByTestId('projection-comparison-bodies')).toBeTruthy();

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -1,7 +1,8 @@
 import { Network, Sparkles, Target } from 'lucide-react';
 import { useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
-import { formatPopulation } from '@/lib/format';
+import { displayRationale } from '@/lib/rationale';
+import { formatConfidence, formatPopulation, ratingTier } from '@/lib/format';
 import type { BodySlotPrediction, FacilityTemplate, SimulateBuildPlacement, SystemBody, SystemDetail } from '@/types/api';
 import {
   bodyDisplayName,
@@ -268,6 +269,8 @@ export function RavenPlannerTelemetryPanel({
         <TelemetryMetric label="Planned haul" value={`${snapshot.placements.length} builds`} />
         <TelemetryMetric label="Build staged" value={`${snapshot.placements.length}${snapshot.projection ? ` +${snapshot.projection.placements.length}` : ''}`} />
       </div>
+
+      <RatingProfileCard system={system} />
 
       <div className="mt-4 space-y-2">
         {stats.map((stat) => (
@@ -967,6 +970,158 @@ function TelemetryMetric({ label, value }: { label: string; value: ReactNode }) 
     <div className="grid grid-cols-[1fr_auto] items-baseline gap-2">
       <div className="truncate font-mono text-[10px] uppercase tracking-[0.1em] text-silver">{label}</div>
       <div className="text-right font-display text-base text-silver">{value}</div>
+    </div>
+  );
+}
+
+function RatingProfileCard({ system }: { system: SystemDetail }) {
+  const score = numericValue(system.score);
+  const tier = ratingTier(score);
+  const confidence = formatConfidence(system.confidence);
+  const rationale = displayRationale(system.rationale);
+  const axes = ratingAxes(system);
+  const hasAnyAxis = axes.some((axis) => axis.value != null);
+  const supplemental = [
+    { label: 'Terraforming', value: numericValue(system.terraforming_potential) },
+    { label: 'Diversity', value: numericValue(system.body_diversity) },
+  ].filter((item): item is { label: string; value: number } => item.value != null);
+
+  return (
+    <section
+      data-testid="raven-rating-profile-card"
+      className="mt-4 rounded border border-orange/30 bg-orange/5 p-2"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-mono text-[11px] uppercase tracking-[0.14em] text-orange">Rating profile</h3>
+          <div className="mt-1 text-[10px] leading-relaxed text-silver">
+            Stored colonisation suitability from the ratings engine.
+          </div>
+        </div>
+        <div
+          data-testid="raven-rating-overall-score"
+          className="shrink-0 rounded border px-2 py-1 text-right font-mono"
+          style={{
+            borderColor: `${tier.fillColor}88`,
+            background: `linear-gradient(180deg, ${tier.fillColor}24, rgba(18,20,24,0.52))`,
+            color: tier.fillColor,
+          }}
+          title={`Stored rating score: ${score ?? 'n/a'}/100`}
+        >
+          <div className="text-[9px] uppercase tracking-[0.12em]">{tier.label}</div>
+          <div className="text-lg font-bold leading-none">{score ?? '-'}</div>
+        </div>
+      </div>
+
+      <div className="mt-2 grid grid-cols-2 gap-1.5 font-mono text-[10px]">
+        <RatingFact label="Suggested" value={system.economy_suggestion ?? 'Unknown'} tone="orange" />
+        <RatingFact
+          label="Confidence"
+          value={confidence ? `${confidence.symbol} ${confidence.tier} ${confidence.pct}%` : 'Unknown'}
+          tone={confidence?.tier === 'High' ? 'green' : confidence?.tier === 'Medium' ? 'gold' : undefined}
+        />
+      </div>
+
+      {hasAnyAxis ? (
+        <div className="mt-3 space-y-1.5" data-testid="raven-rating-economy-breakdown">
+          {axes.map((axis) => (
+            <RatingAxisBar key={axis.label} label={axis.label} value={axis.value} highlighted={axis.highlighted} />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-3 rounded border border-gold/35 bg-gold/10 px-2 py-1 font-mono text-[10px] text-gold">
+          No per-economy rating scores are present on this system record.
+        </p>
+      )}
+
+      {supplemental.length > 0 && (
+        <div className="mt-2 grid grid-cols-2 gap-1.5 font-mono text-[10px]">
+          {supplemental.map((item) => (
+            <RatingFact key={item.label} label={item.label} value={String(item.value)} />
+          ))}
+        </div>
+      )}
+
+      {rationale && (
+        <p data-testid="raven-rating-rationale" className="mt-2 rounded border border-border/55 bg-bg3/35 px-2 py-1.5 text-[10px] italic leading-relaxed text-silver">
+          {rationale}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function ratingAxes(system: SystemDetail) {
+  return [
+    { label: 'Agriculture', value: numericValue(system.score_agriculture) },
+    { label: 'Refinery', value: numericValue(system.score_refinery) },
+    { label: 'Industrial', value: numericValue(system.score_industrial) },
+    { label: 'HighTech', value: numericValue(system.score_hightech) },
+    { label: 'Military', value: numericValue(system.score_military) },
+    { label: 'Tourism', value: numericValue(system.score_tourism) },
+    { label: 'Extraction', value: numericValue(system.score_extraction) },
+  ].map((axis) => ({
+    ...axis,
+    highlighted: system.economy_suggestion === axis.label,
+  }));
+}
+
+function RatingFact({
+  label,
+  value,
+  tone = 'silver',
+}: {
+  label: string;
+  value: ReactNode;
+  tone?: 'silver' | 'orange' | 'green' | 'gold';
+}) {
+  const toneClass = {
+    silver: 'text-silver',
+    orange: 'text-orange',
+    green: 'text-green',
+    gold: 'text-gold',
+  }[tone];
+  return (
+    <div className="rounded border border-border/55 bg-bg3/35 px-2 py-1">
+      <div className="truncate uppercase tracking-[0.12em] text-silver">{label}</div>
+      <div className={['mt-0.5 truncate font-semibold', toneClass].join(' ')} title={String(value)}>{value}</div>
+    </div>
+  );
+}
+
+function RatingAxisBar({
+  label,
+  value,
+  highlighted,
+}: {
+  label: string;
+  value: number | null;
+  highlighted: boolean;
+}) {
+  const pct = Math.max(0, Math.min(100, value ?? 0));
+  const color = highlighted ? '#ffb074' : '#c8ccd1';
+  return (
+    <div
+      data-testid={`raven-rating-axis-${label.toLowerCase()}`}
+      className="grid grid-cols-[5.9rem_1fr_2.4rem] items-center gap-2 font-mono text-[10px]"
+    >
+      <span className={highlighted ? 'truncate font-bold text-orange-lt' : 'truncate text-silver'}>{label}</span>
+      <span className="relative h-2 overflow-hidden rounded-full border border-border/60 bg-bg4/80 shadow-inner-soft">
+        <span
+          aria-hidden
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{
+            width: `${pct}%`,
+            background: highlighted
+              ? 'linear-gradient(90deg, #ff7a14, #ffb074)'
+              : 'linear-gradient(90deg, #8a8f96, #c8ccd1)',
+            boxShadow: highlighted ? '0 0 8px rgba(255,122,20,0.55)' : undefined,
+          }}
+        />
+      </span>
+      <span className={highlighted ? 'text-right font-bold text-orange-lt' : 'text-right text-silver'} style={{ color }}>
+        {value ?? '-'}
+      </span>
     </div>
   );
 }

--- a/frontend-v2/src/index.css
+++ b/frontend-v2/src/index.css
@@ -13,6 +13,8 @@
 
 :root {
   color-scheme: dark;
+  --coalsack-bg-2560: url('/bg/coalsack-2560.jpg?v=2');
+  --coalsack-bg-1600: url('/bg/coalsack-1600.jpg?v=2');
 }
 
 html {
@@ -48,7 +50,7 @@ body {
         rgba(8, 10, 14, 0.55) 55%,
         rgba(8, 10, 14, 0.82) 100%),
     /* the nebula itself */
-    url('/bg/coalsack-2560.jpg?v=2');
+    var(--coalsack-bg-2560);
   background-size: cover, cover, cover;
   background-position: top right, center center, center center;
   background-attachment: fixed, fixed, fixed;
@@ -62,7 +64,7 @@ body {
           rgba(8, 10, 14, 0.22) 0%,
           rgba(8, 10, 14, 0.62) 55%,
           rgba(8, 10, 14, 0.88) 100%),
-      url('/bg/coalsack-1600.jpg?v=2');
+      var(--coalsack-bg-1600);
     background-attachment: scroll, scroll;
   }
 }


### PR DESCRIPTION
## Summary
- Restore the stored ratings profile in the planner telemetry rail, including overall score, suggested economy, confidence, per-economy bars, terraforming, diversity, and rationale.
- Make the Coalsack Nebula background base-aware so production /v2 builds resolve the image assets correctly.
- Add coverage for the restored rating profile and base-aware background URLs.

## Validation
- npm run typecheck
- npm test -- RavenStylePlannerCanvas App
- npm run build
- npm test