### PR TITLE
[codex] Fix Coalsack background path resolution

### DIFF
--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -131,6 +131,7 @@ afterEach(() => {
   window.location.hash = '';
   document.documentElement.style.removeProperty('--coalsack-bg-2560');
   document.documentElement.style.removeProperty('--coalsack-bg-1600');
+  vi.unstubAllGlobals();
 });
 
 describe('App Advanced Search Tuning route', () => {
@@ -147,6 +148,16 @@ describe('App Advanced Search Tuning route', () => {
 
 describe('App Colony Planner workspace route', () => {
   it('sets base-aware Coalsack background image URLs', async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request) => ({
+      ok: String(url).startsWith('/v2/bg/'),
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() !== 'content-type') return null;
+          return String(url).startsWith('/v2/bg/') ? 'image/jpeg' : 'text/html';
+        },
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
     window.location.hash = '#finder';
 
     render(<App />);
@@ -155,8 +166,12 @@ describe('App Colony Planner workspace route', () => {
       expect(screen.getByText('Search form')).toBeTruthy();
     });
 
-    expect(document.documentElement.style.getPropertyValue('--coalsack-bg-2560')).toContain('bg/coalsack-2560.jpg');
-    expect(document.documentElement.style.getPropertyValue('--coalsack-bg-1600')).toContain('bg/coalsack-1600.jpg');
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--coalsack-bg-2560')).toContain('/v2/bg/coalsack-2560.jpg');
+      expect(document.documentElement.style.getPropertyValue('--coalsack-bg-1600')).toContain('/v2/bg/coalsack-1600.jpg');
+    });
+    expect(fetchMock).toHaveBeenCalledWith('/v2/bg/coalsack-2560.jpg?v=2', { method: 'HEAD', cache: 'no-cache' });
+    expect(fetchMock).toHaveBeenCalledWith('/v2/bg/coalsack-1600.jpg?v=2', { method: 'HEAD', cache: 'no-cache' });
   });
 
   it('renders the dedicated workspace without opening the System Detail modal', async () => {

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -29,6 +29,57 @@ import { EddnTicker } from '@/features/eddn/EddnTicker';
 import { useHashRoute, type HashRoute } from '@/hooks/useHashRoute';
 import './index.css';
 
+const COALSACK_BG_VERSION = 'v=2';
+const COALSACK_BG_2560 = 'coalsack-2560.jpg';
+const COALSACK_BG_1600 = 'coalsack-1600.jpg';
+
+function coalsackBackgroundCandidates(fileName: string): string[] {
+  const base = import.meta.env.BASE_URL || '/';
+  const normalizedBase = base.endsWith('/') ? base : `${base}/`;
+  return Array.from(new Set([
+    // Production can serve the app bundle from / while the v2 image assets live under /v2.
+    `/v2/bg/${fileName}?${COALSACK_BG_VERSION}`,
+    `${normalizedBase}bg/${fileName}?${COALSACK_BG_VERSION}`,
+    `/bg/${fileName}?${COALSACK_BG_VERSION}`,
+  ]));
+}
+
+async function resolveCoalsackBackgroundUrl(fileName: string): Promise<string> {
+  const candidates = coalsackBackgroundCandidates(fileName);
+  if (typeof fetch !== 'function') return candidates[0];
+
+  for (const candidate of candidates) {
+    try {
+      const response = await fetch(candidate, { method: 'HEAD', cache: 'no-cache' });
+      const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+      if (response.ok && contentType.startsWith('image/')) {
+        return candidate;
+      }
+    } catch {
+      // Try the next known deployment path.
+    }
+  }
+
+  return candidates[0];
+}
+
+function setCoalsackBackgroundVariables(): () => void {
+  let cancelled = false;
+  const root = document.documentElement;
+
+  void resolveCoalsackBackgroundUrl(COALSACK_BG_2560).then((url) => {
+    if (!cancelled) root.style.setProperty('--coalsack-bg-2560', `url("${url}")`);
+  });
+
+  void resolveCoalsackBackgroundUrl(COALSACK_BG_1600).then((url) => {
+    if (!cancelled) root.style.setProperty('--coalsack-bg-1600', `url("${url}")`);
+  });
+
+  return () => {
+    cancelled = true;
+  };
+}
+
 /**
  * v2 root: NavBar + tab content + system-detail modal overlay.
  *
@@ -53,12 +104,7 @@ export default function App() {
 function AppInner() {
   const hashRoute = useHashRoute();
 
-  useEffect(() => {
-    const base = import.meta.env.BASE_URL || '/';
-    const normalizedBase = base.endsWith('/') ? base : `${base}/`;
-    document.documentElement.style.setProperty('--coalsack-bg-2560', `url("${normalizedBase}bg/coalsack-2560.jpg?v=2")`);
-    document.documentElement.style.setProperty('--coalsack-bg-1600', `url("${normalizedBase}bg/coalsack-1600.jpg?v=2")`);
-  }, []);
+  useEffect(() => setCoalsackBackgroundVariables(), []);
 
   if (hashRoute.route === 'colony-planner-prototype') {
     return <PrototypeAppShell navigate={hashRoute.navigate} />;

--- a/frontend-v2/src/index.css
+++ b/frontend-v2/src/index.css
@@ -13,8 +13,8 @@
 
 :root {
   color-scheme: dark;
-  --coalsack-bg-2560: url('/bg/coalsack-2560.jpg?v=2');
-  --coalsack-bg-1600: url('/bg/coalsack-1600.jpg?v=2');
+  --coalsack-bg-2560: url('/v2/bg/coalsack-2560.jpg?v=2');
+  --coalsack-bg-1600: url('/v2/bg/coalsack-1600.jpg?v=2');
 }
 
 html {


### PR DESCRIPTION
## Summary
- Resolve Coalsack background image URLs at runtime and verify they return image content.
- Default the CSS background variables to the deployed /v2/bg/... asset paths for first paint.
- Update the App test to cover the production /v2/bg/... resolution path.

## Root Cause
Production serves the app bundle from /assets/... with a base of /, while the Coalsack image assets are available under /v2/bg/.... The previous runtime code resolved the image to /bg/..., which redirects to app HTML instead of an image.

## Validation
- npm run typecheck
- npm test -- App
- npm run build
- npm test