### PR TITLE
[codex] Add UI error boundary and normalize project store

### DIFF
--- a/frontend-v2/src/components/ErrorBoundary.test.tsx
+++ b/frontend-v2/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function BrokenChild(): ReactElement {
+  throw new Error('render failed');
+}
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders a reload fallback when a child throws', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const reload = vi.fn();
+    vi.stubGlobal('location', { ...window.location, reload });
+
+    render(
+      <ErrorBoundary>
+        <BrokenChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByText('A critical UI error occurred')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reload application/i }));
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalled();
+  });
+});

--- a/frontend-v2/src/components/ErrorBoundary.tsx
+++ b/frontend-v2/src/components/ErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[ED:Finder] Critical UI error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <main
+        role="alert"
+        aria-live="assertive"
+        style={{
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+          padding: '2rem',
+          background: 'radial-gradient(circle at 50% 0%, rgba(255, 122, 20, 0.18), transparent 34%), #05070a',
+          color: '#f8fafc',
+          fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        }}
+      >
+        <section
+          style={{
+            width: 'min(100%, 34rem)',
+            border: '1px solid rgba(255, 122, 20, 0.45)',
+            borderRadius: '0.75rem',
+            background: 'rgba(12, 16, 24, 0.94)',
+            padding: '1.5rem',
+            boxShadow: '0 24px 80px rgba(0, 0, 0, 0.45)',
+          }}
+        >
+          <p
+            style={{
+              margin: 0,
+              color: '#ff7a14',
+              fontSize: '0.75rem',
+              fontWeight: 800,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+            }}
+          >
+            ED:Finder UI Recovery
+          </p>
+          <h1 style={{ margin: '0.75rem 0 0', fontSize: '1.5rem', lineHeight: 1.2 }}>
+            A critical UI error occurred
+          </h1>
+          <p style={{ margin: '0.75rem 0 0', color: '#d8dee9', lineHeight: 1.6 }}>
+            Reload the application to clear the current UI state and reconnect to the planner.
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            style={{
+              marginTop: '1.25rem',
+              border: '1px solid rgba(255, 122, 20, 0.72)',
+              borderRadius: '0.5rem',
+              background: '#ff7a14',
+              color: '#080a0e',
+              cursor: 'pointer',
+              fontWeight: 800,
+              padding: '0.7rem 1rem',
+            }}
+          >
+            Reload application
+          </button>
+        </section>
+      </main>
+    );
+  }
+}

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -215,10 +215,15 @@ function renderPlanner(props?: Partial<Parameters<typeof ColonyPlannerWorkspace>
   );
 }
 
+function storedProjectByName(projectName: string) {
+  return Object.values(useColonyProjectStore.getState().projects)
+    .find((project) => project.project_name === projectName) ?? null;
+}
+
 describe('ColonyPlannerWorkspace', () => {
   beforeEach(() => {
     localStorage.clear();
-    useColonyProjectStore.setState({ projects: [] });
+    useColonyProjectStore.setState({ projects: {} });
     mockedSimulationPreviewPanel.mockClear();
     mockedUseSystemDetail.mockReturnValue({
       data: null,
@@ -242,7 +247,7 @@ describe('ColonyPlannerWorkspace', () => {
     mockedGetSimulationSummary.mockReset();
     mockedGetSlotPredictions.mockReset();
     localStorage.clear();
-    useColonyProjectStore.setState({ projects: [] });
+    useColonyProjectStore.setState({ projects: {} });
   });
 
   it('renders a no-system state for direct #colony-planner visits', () => {
@@ -509,40 +514,41 @@ describe('ColonyPlannerWorkspace', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save project' }));
 
     expect(screen.getByTestId('project-unsaved-indicator').textContent).toContain('Saved');
-    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Local starter');
-    expect(useColonyProjectStore.getState().projects[0].build_plan_placements).toHaveLength(1);
-    expect(useColonyProjectStore.getState().projects[0].declared_roles).toEqual([]);
+    expect(storedProjectByName('Local starter')?.build_plan_placements).toHaveLength(1);
+    expect(storedProjectByName('Local starter')?.declared_roles).toEqual([]);
 
     fireEvent.change(screen.getByLabelText('Project name'), { target: { value: 'Renamed local starter' } });
     fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
-    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Renamed local starter');
+    expect(storedProjectByName('Renamed local starter')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Duplicate project' }));
-    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Renamed local starter copy');
-    expect(useColonyProjectStore.getState().projects[0].declared_roles).toEqual([]);
+    expect(storedProjectByName('Renamed local starter copy')).toBeTruthy();
+    expect(storedProjectByName('Renamed local starter copy')?.declared_roles).toEqual([]);
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete / archive project' }));
     expect(screen.getByText(/Archive this local project/)).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Archive project' }));
-    expect(useColonyProjectStore.getState().projects[0].archived_at).toBeTruthy();
+    expect(storedProjectByName('Renamed local starter copy')?.archived_at).toBeTruthy();
   });
 
   it('loads old local projects without declared roles safely', async () => {
     useColonyProjectStore.setState({
-      projects: [{
-        id: 'old-project',
-        system_id64: 123,
-        system_name: 'Workspace System',
-        project_name: 'Old project',
-        build_plan_placements: [],
-        selected_body_assignments: {},
-        target_archetype: 'refinery_industrial',
-        notes: 'No role field.',
-        status: 'draft',
-        created_at: '2026-05-01T00:00:00.000Z',
-        updated_at: '2026-05-01T00:00:00.000Z',
-        archived_at: null,
-      } as never],
+      projects: {
+        'old-project': {
+          id: 'old-project',
+          system_id64: 123,
+          system_name: 'Workspace System',
+          project_name: 'Old project',
+          build_plan_placements: [],
+          selected_body_assignments: {},
+          target_archetype: 'refinery_industrial',
+          notes: 'No role field.',
+          status: 'draft',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+          archived_at: null,
+        } as never,
+      },
     });
     mockedUseSystemDetail.mockReturnValue({
       data: system,

--- a/frontend-v2/src/features/colony-planner/colonyProjectStore.test.ts
+++ b/frontend-v2/src/features/colony-planner/colonyProjectStore.test.ts
@@ -10,7 +10,7 @@ const placement = { facility_template_id: 'orbital_port', local_body_id: 'body1'
 describe('colonyProjectStore', () => {
   beforeEach(() => {
     localStorage.clear();
-    useColonyProjectStore.setState({ projects: [] });
+    useColonyProjectStore.setState({ projects: {} });
   });
 
   it('saves and matches a local colony project snapshot', () => {
@@ -27,7 +27,7 @@ describe('colonyProjectStore', () => {
     expect(saved.status).toBe('draft');
     expect(saved.selected_body_assignments).toEqual({ 0: 'body1' });
     expect(saved.declared_roles).toEqual([]);
-    expect(useColonyProjectStore.getState().projects).toHaveLength(1);
+    expect(Object.values(useColonyProjectStore.getState().projects)).toHaveLength(1);
     expect(projectMatchesSnapshot(saved, [placement], 'refinery_industrial', 'Check Architect mode.', 'Starter project')).toBe(true);
     expect(projectMatchesSnapshot(saved, [placement], 'refinery_industrial', 'Changed notes.', 'Starter project')).toBe(false);
   });
@@ -74,7 +74,7 @@ describe('colonyProjectStore', () => {
     });
 
     useColonyProjectStore.getState().renameProject(saved.id, 'Renamed project');
-    expect(useColonyProjectStore.getState().projects[0].project_name).toBe('Renamed project');
+    expect(useColonyProjectStore.getState().projects[saved.id].project_name).toBe('Renamed project');
 
     const duplicate = useColonyProjectStore.getState().duplicateProject(saved.id);
     expect(duplicate?.project_name).toBe('Renamed project copy');
@@ -83,7 +83,37 @@ describe('colonyProjectStore', () => {
 
     useColonyProjectStore.getState().archiveProject(saved.id);
     const projects = useColonyProjectStore.getState().projects;
-    expect(projects.find((project) => project.id === saved.id)?.archived_at).toBeTruthy();
-    expect(activeProjectsForSystem(projects, 123).map((project) => project.id)).toEqual([duplicate?.id]);
+    expect(projects[saved.id].archived_at).toBeTruthy();
+    expect(activeProjectsForSystem(Object.values(projects), 123).map((project) => project.id)).toEqual([duplicate?.id]);
+  });
+
+  it('migrates old persisted arrays and deletes projects by key', async () => {
+    const legacyProject = {
+      id: 'legacy-project',
+      system_id64: 123,
+      system_name: 'Workspace System',
+      project_name: 'Legacy project',
+      build_plan_placements: [placement],
+      selected_body_assignments: { 0: 'body1' },
+      declared_roles: undefined,
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      status: 'draft',
+      created_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+      archived_at: null,
+    };
+    localStorage.setItem('ed_colony_projects_v1', JSON.stringify({
+      state: { projects: [legacyProject] },
+      version: 1,
+    }));
+
+    await useColonyProjectStore.persist.rehydrate();
+
+    expect(useColonyProjectStore.getState().projects['legacy-project'].project_name).toBe('Legacy project');
+    expect(useColonyProjectStore.getState().projects['legacy-project'].declared_roles).toEqual([]);
+
+    useColonyProjectStore.getState().deleteProject('legacy-project');
+    expect(useColonyProjectStore.getState().projects['legacy-project']).toBeUndefined();
   });
 });

--- a/frontend-v2/src/features/colony-planner/colonyProjectStore.ts
+++ b/frontend-v2/src/features/colony-planner/colonyProjectStore.ts
@@ -33,11 +33,12 @@ export interface ColonyProjectInput {
 }
 
 interface ColonyProjectState {
-  projects: ColonyProject[];
+  projects: Record<string, ColonyProject>;
   saveProject: (projectId: string | null, input: ColonyProjectInput) => ColonyProject;
   renameProject: (projectId: string, name: string) => void;
   duplicateProject: (projectId: string) => ColonyProject | null;
   archiveProject: (projectId: string) => void;
+  deleteProject: (projectId: string) => void;
 }
 
 const STORAGE_KEY = 'ed_colony_projects_v1';
@@ -45,10 +46,10 @@ const STORAGE_KEY = 'ed_colony_projects_v1';
 export const useColonyProjectStore = create<ColonyProjectState>()(
   persist(
     (set, get) => ({
-      projects: [],
+      projects: {},
       saveProject: (projectId, input) => {
         const now = new Date().toISOString();
-        const existing = projectId ? get().projects.find((project) => project.id === projectId) ?? null : null;
+        const existing = projectId ? get().projects[projectId] ?? null : null;
         const project: ColonyProject = {
           id: existing?.id ?? createProjectId(input.system_id64),
           system_id64: input.system_id64,
@@ -64,26 +65,24 @@ export const useColonyProjectStore = create<ColonyProjectState>()(
           updated_at: now,
           archived_at: null,
         };
-        set({
-          projects: [
-            project,
-            ...get().projects.filter((item) => item.id !== project.id),
-          ],
-        });
+        set((state) => ({ projects: { ...state.projects, [project.id]: project } }));
         return project;
       },
       renameProject: (projectId, name) => {
         const trimmed = name.trim();
         if (!trimmed) return;
+        const project = get().projects[projectId];
+        if (!project) return;
         const now = new Date().toISOString();
-        set({
-          projects: get().projects.map((project) => (
-            project.id === projectId ? { ...project, project_name: trimmed, updated_at: now } : project
-          )),
-        });
+        set((state) => ({
+          projects: {
+            ...state.projects,
+            [projectId]: { ...project, project_name: trimmed, updated_at: now },
+          },
+        }));
       },
       duplicateProject: (projectId) => {
-        const source = get().projects.find((project) => project.id === projectId);
+        const source = get().projects[projectId];
         if (!source) return null;
         const now = new Date().toISOString();
         const duplicate: ColonyProject = {
@@ -98,21 +97,41 @@ export const useColonyProjectStore = create<ColonyProjectState>()(
           updated_at: now,
           archived_at: null,
         };
-        set({ projects: [duplicate, ...get().projects] });
+        set((state) => ({ projects: { ...state.projects, [duplicate.id]: duplicate } }));
         return duplicate;
       },
       archiveProject: (projectId) => {
+        const project = get().projects[projectId];
+        if (!project) return;
         const now = new Date().toISOString();
-        set({
-          projects: get().projects.map((project) => (
-            project.id === projectId ? { ...project, archived_at: now, updated_at: now } : project
-          )),
+        set((state) => ({
+          projects: {
+            ...state.projects,
+            [projectId]: { ...project, archived_at: now, updated_at: now },
+          },
+        }));
+      },
+      deleteProject: (projectId) => {
+        set((state) => {
+          const projects = { ...state.projects };
+          delete projects[projectId];
+          return { projects };
         });
       },
     }),
     {
       name: STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
+      version: 2,
+      migrate: (persistedState) => ({
+        ...(persistedState as Partial<ColonyProjectState> | undefined),
+        projects: normaliseProjectRecord((persistedState as { projects?: unknown } | undefined)?.projects),
+      }),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...(persistedState as Partial<ColonyProjectState> | undefined),
+        projects: normaliseProjectRecord((persistedState as { projects?: unknown } | undefined)?.projects),
+      }),
     },
   ),
 );
@@ -172,6 +191,30 @@ function bodyAssignments(placements: SimulateBuildPlacement[]) {
   return placements.reduce<Record<number, string | null>>((assignments, placement, index) => {
     assignments[index] = placement.local_body_id ?? null;
     return assignments;
+  }, {});
+}
+
+function normaliseProjectRecord(projects: unknown): Record<string, ColonyProject> {
+  const entries = Array.isArray(projects)
+    ? projects
+    : projects && typeof projects === 'object'
+      ? Object.values(projects)
+      : [];
+
+  return entries.reduce<Record<string, ColonyProject>>((record, project) => {
+    if (!project || typeof project !== 'object') return record;
+    const candidate = project as ColonyProject;
+    if (!candidate.id) return record;
+    record[candidate.id] = {
+      ...candidate,
+      build_plan_placements: clonePlacements(candidate.build_plan_placements),
+      selected_body_assignments: candidate.selected_body_assignments && typeof candidate.selected_body_assignments === 'object'
+        ? candidate.selected_body_assignments
+        : {},
+      declared_roles: normaliseDeclaredRoles(candidate.declared_roles),
+      archived_at: candidate.archived_at ?? null,
+    };
+    return record;
   }, {});
 }
 

--- a/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
+++ b/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
@@ -17,12 +17,13 @@ import {
 import { projectRequestFromProject } from './workspaceUtils';
 
 export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: TopologyPlanSnapshot) {
-  const projects = useColonyProjectStore((state) => state.projects);
+  const projectRecord = useColonyProjectStore((state) => state.projects);
   const saveProject = useColonyProjectStore((state) => state.saveProject);
   const renameProject = useColonyProjectStore((state) => state.renameProject);
   const duplicateProject = useColonyProjectStore((state) => state.duplicateProject);
   const archiveProject = useColonyProjectStore((state) => state.archiveProject);
 
+  const projects = useMemo(() => Object.values(projectRecord), [projectRecord]);
   const systemProjects = useMemo(() => activeProjectsForSystem(projects, system.id64), [projects, system.id64]);
   const [activeProjectId, setActiveProjectId] = useState<string | null>(() => systemProjects[0]?.id ?? null);
   const [pendingProjectId, setPendingProjectId] = useState<string>('');

--- a/frontend-v2/src/main.tsx
+++ b/frontend-v2/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 const rootEl = document.getElementById('root');
 if (!rootEl) {
@@ -42,7 +43,9 @@ async function bootstrap() {
     const { default: RedesignApp } = await import('./_redesign/RedesignApp.jsx');
     root.render(
       <StrictMode>
-        <RedesignApp />
+        <ErrorBoundary>
+          <RedesignApp />
+        </ErrorBoundary>
       </StrictMode>,
     );
   } else {
@@ -50,7 +53,9 @@ async function bootstrap() {
     const { default: App } = await import('./App');
     root.render(
       <StrictMode>
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </StrictMode>,
     );
   }


### PR DESCRIPTION
## Summary
- Add a global React ErrorBoundary around both v2 and redesign root render paths.
- Render a high-contrast dark fallback with a reload action when the UI crashes.
- Normalize the Colony Planner project store from an array to Record<string, ColonyProject>.
- Update project save/rename/duplicate/archive/delete operations to use keyed object updates.
- Add persisted-state migration from the old array shape and update project consumers/tests to use Object.values(...) for list rendering.

## Guardrail
Checked non-test store consumers for direct array methods on the selected projects record. The only consumer selects state.projects as projectRecord and converts with Object.values(projectRecord); no direct .map, .filter, .length, .find, .some, or indexing is used on the selected store record.

## Validation
- npm run typecheck
- npm test -- colonyProjectStore ErrorBoundary
- npm test
- npm run build