### PR TITLE
[codex] Repair Raven canvas building add flow

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1727,6 +1727,36 @@ Remaining gap:
 
 - real economy display is limited to ED-Finder's current template metadata and planning ledger. It does not yet have validated RavenColonial-equivalent per-facility bonus magnitudes unless such data is present in ED-Finder's own model.
 
+## Stage 17N.1 - Core Interaction Repair: Raven Canvas Add Building (Implemented)
+
+Stage 17N.1 repairs the blocker where the visible Raven-style canvas could show slots and selected-body lanes but main-canvas add actions did not open a usable structure picker.
+
+Delivered:
+
+- a whole-system `CanvasStructurePicker` owned by `WholeSystemColonyPlanner`
+- Raven row add buttons for orbital and surface lanes
+- empty Raven slot clicks now select the body and open the lane-aware picker
+- selected-body lane add controls now use the same whole-system picker path
+- selecting a template appends a resequenced Build Plan placement through the existing local placement state path
+- the added placement appears immediately in the Raven slot lane, inline selected-body detail, planner status count, project unsaved state, and Advanced Planner initial Build Plan state
+- successful adds show visible feedback; invalid surface lanes show visible disabled reasons
+
+Lane filtering boundary:
+
+- orbital shows templates that will render into orbital placement lanes with the current placement model
+- surface shows templates that will render into surface/ground placement lanes and blocks clear water-world/non-landable cases
+- incompatible templates are hidden and counted in the picker summary
+- flexible/unknown structures remain a later manual-editing gap because the current Build Plan wire model has no per-placement lane field and backend simulation requests forbid extra placement properties
+
+Safety boundary:
+
+- no auto Preview
+- no auto Suggested Build generation
+- no candidate auto-load
+- no drag/drop slot editing
+- no Architect-observed slot storage
+- no CP/economy/scoring/backend changes
+
 ## Stage 18 - Colony Architect Assistant Foundation (Planned)
 
 Stage 18 should add an assistant foundation while keeping deterministic planner authority:

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -1059,6 +1059,36 @@ Safety boundary:
 - no CP/economy/scoring mechanic changes
 - no RavenColonial API/code/CSS/assets usage
 
+## Stage 17N.1 Raven Canvas Add Flow
+
+The Raven-style canvas now owns a direct manual add flow:
+
+1. User selects a body, clicks a Raven row add control, or clicks an empty orbital/surface slot.
+2. `WholeSystemColonyPlanner` stores `{ bodyId, lane }` picker context and keeps the selected body active.
+3. `CanvasStructurePicker` renders outside Advanced Planner with the selected body name, requested lane, compatible count, and facility metadata.
+4. Selecting a template calls the existing local `addStructure(bodyId, lane, templateId)` placement path.
+5. The Build Plan placements are resequenced and the same snapshot feeds Raven canvas, selected-body inline detail, planner status, local project unsaved state, and Advanced Planner when it is later opened.
+
+Compatibility rules:
+
+- orbital picker shows orbital templates and dual-location port templates that the current renderer will place in orbit
+- surface picker shows surface templates and dual-location non-port templates that the current renderer will place on a valid landable surface
+- water-world and non-landable surface lanes are disabled with visible reasons
+- incompatible templates are hidden and counted in the picker
+- empty catalogue/loading and no-compatible-template states are explicit
+
+Passivity guarantees:
+
+- picker open does not mount Advanced Planner
+- template selection does not run Preview
+- template selection does not generate Suggested Builds
+- template selection does not load a projected candidate
+- projected ghost slot click remains selection/context only
+
+Known limitation:
+
+- the simulation request model still has no per-placement lane or slot index field and backend request validation forbids extra placement properties, so flexible/unknown structure placement remains a later manual-editing gap rather than being faked in Stage 17N.1.
+
 ## Stage 18 Assistant Foundation Boundary
 
 Planned assistant layer should sit above this architecture:

--- a/docs/colonisation-redesign/stage-17a-colony-architect-report.md
+++ b/docs/colonisation-redesign/stage-17a-colony-architect-report.md
@@ -434,3 +434,31 @@ Stage 17N refines the Stage 17M shape without reopening the three-column split. 
 The telemetry panel now has projection comparison controls for Bodies, Economy, and Slots. These controls make Suggested Build ghosts easier to evaluate before any load action: bodies compare current Build Plan coverage with projected ghost bodies, economy shows planned plus projected counts by template economy, and slots summarize projected orbital/ground/unknown lane pressure and overflow risk. The controls are read-only and do not run Preview, generate, load, save, import, mutate observations, or call RavenColonial.
 
 The summary rail is compact by default, showing save state, build counts, warning count, focus, projection label, and economy strip. Local project controls remain available only after manual expansion.
+
+## Stage 17N.1 Core Interaction Repair
+
+Stage 17N.1 makes the Raven-style whole-system canvas a working manual editing surface, not only a viewer.
+
+Implemented behavior:
+
+- visible Raven row add controls and empty slot clicks open a lane-aware structure picker
+- the picker displays the selected body, requested orbit/surface lane, compatible count, structure name, category/type, economy, tier, pad, and location metadata
+- water-world and non-landable surface attempts show disabled reasons instead of silently doing nothing
+- incompatible templates are hidden and counted
+- template selection writes through the same local Build Plan placement state used by Advanced Planner
+- added structures immediately render in the Raven whole-system lane and the selected-body inline detail
+- project unsaved state updates from the same placement snapshot
+
+Explicit non-behavior:
+
+- opening the picker does not mount Advanced Planner
+- adding a structure does not run Preview
+- adding a structure does not generate Suggested Builds
+- projected ghost slot clicks remain selection/context only and do not load a candidate
+
+Remaining manual editing gaps:
+
+- no drag/drop placement movement
+- no explicit slot index persistence
+- no per-placement lane storage for truly flexible/unknown structures; lane-specific pickers therefore only show templates that the current placement model can render reliably into that lane
+- no Architect observed slot storage

--- a/frontend-v2/src/features/colony-planner/CanvasStructurePicker.test.tsx
+++ b/frontend-v2/src/features/colony-planner/CanvasStructurePicker.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { FacilityTemplate, SystemBody } from '@/types/api';
+import { CanvasStructurePicker } from './CanvasStructurePicker';
+
+const landableBody = {
+  id: 1,
+  name: 'Body 1',
+  body_type: 'Planet',
+  subtype: 'Rocky body',
+  is_landable: true,
+} as SystemBody;
+
+const waterWorld = {
+  ...landableBody,
+  id: 2,
+  name: 'Water World',
+  subtype: 'Water world',
+  is_water_world: true,
+  is_landable: false,
+} as SystemBody;
+
+const nonLandableBody = {
+  ...landableBody,
+  id: 3,
+  name: 'High Metal Content Body',
+  is_landable: false,
+} as SystemBody;
+
+const templates: FacilityTemplate[] = [
+  {
+    id: 'orbital_port',
+    name: 'Orbital Port',
+    category: 'port',
+    tier: 3,
+    economy: 'Industrial',
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'orbital',
+    pad_size: 'large',
+    confidence: 'confirmed',
+    notes: null,
+    yellow_cp_generated: 1,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'surface_hub',
+    name: 'Surface Hub',
+    category: 'support',
+    tier: 1,
+    economy: 'Agriculture',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface',
+    pad_size: 'medium',
+    confidence: 'confirmed',
+    notes: null,
+    yellow_cp_generated: 0,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+];
+
+describe('CanvasStructurePicker', () => {
+  it('shows selected body, lane, compatible count, close control, and selectable templates', () => {
+    const onClose = vi.fn();
+    const onPickTemplate = vi.fn();
+
+    render(
+      <CanvasStructurePicker
+        body={landableBody}
+        lane="orbital"
+        templates={templates}
+        templatesLoading={false}
+        onClose={onClose}
+        onPickTemplate={onPickTemplate}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Body 1' })).toBeTruthy();
+    expect(screen.getByText(/Add orbit structure/i)).toBeTruthy();
+    expect(screen.getByText(/1 compatible option shown/i)).toBeTruthy();
+    expect(screen.getByTestId('canvas-picker-compatibility-summary').textContent).toContain('1 incompatible hidden');
+    expect(screen.getByTestId('body-structure-template-orbital_port')).toBeTruthy();
+    expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Orbital Port to Body 1/i }));
+    expect(onPickTemplate).toHaveBeenCalledWith('orbital_port');
+  });
+
+  it('shows a disabled reason for invalid surface lanes', () => {
+    render(
+      <CanvasStructurePicker
+        body={waterWorld}
+        lane="surface"
+        templates={templates}
+        templatesLoading={false}
+        onClose={vi.fn()}
+        onPickTemplate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Add surface structure/i)).toBeTruthy();
+    expect(screen.getByTestId('canvas-picker-disabled-reason').textContent).toContain('Surface limited: water world.');
+    expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
+  });
+
+  it('shows a disabled reason for non-landable surface lanes', () => {
+    render(
+      <CanvasStructurePicker
+        body={nonLandableBody}
+        lane="surface"
+        templates={templates}
+        templatesLoading={false}
+        onClose={vi.fn()}
+        onPickTemplate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('canvas-picker-disabled-reason').textContent).toContain('Surface limited: non-landable body.');
+    expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
+  });
+
+  it('shows catalogue loading and disables template selection while templates load', () => {
+    render(
+      <CanvasStructurePicker
+        body={landableBody}
+        lane="orbital"
+        templates={templates}
+        templatesLoading
+        onClose={vi.fn()}
+        onPickTemplate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('canvas-picker-loading').textContent).toContain('Facility catalogue loading.');
+    expect((screen.getByTestId('body-structure-template-orbital_port') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('shows an empty state when no templates are compatible with the lane and body', () => {
+    render(
+      <CanvasStructurePicker
+        body={landableBody}
+        lane="orbital"
+        templates={[templates[1]]}
+        templatesLoading={false}
+        onClose={vi.fn()}
+        onPickTemplate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('canvas-picker-empty-state').textContent).toContain('No compatible structures available for this lane/body.');
+  });
+});

--- a/frontend-v2/src/features/colony-planner/CanvasStructurePicker.tsx
+++ b/frontend-v2/src/features/colony-planner/CanvasStructurePicker.tsx
@@ -1,0 +1,214 @@
+import { Search, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import type { FacilityTemplate, SystemBody } from '@/types/api';
+import { bodyDisplayName } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
+import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
+import type { BodyPlannerLane } from './BodySlotPlanner';
+
+export function CanvasStructurePicker({
+  body,
+  lane,
+  templates,
+  templatesLoading,
+  templatesErrorMessage,
+  onClose,
+  onPickTemplate,
+}: {
+  body: SystemBody | null;
+  lane: BodyPlannerLane | null;
+  templates: FacilityTemplate[];
+  templatesLoading: boolean;
+  templatesErrorMessage?: string | null;
+  onClose: () => void;
+  onPickTemplate: (templateId: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    setQuery('');
+  }, [body?.id, lane]);
+
+  const bodyName = body ? bodyDisplayName(body) : 'Selected body';
+  const laneLabel = lane === 'orbital' ? 'orbit' : 'surface';
+  const disabledReason = body && lane ? laneDisabledReason(body, lane) : null;
+  const normalisedQuery = query.trim().toLowerCase();
+
+  const laneCompatibleTemplates = useMemo(() => (
+    lane ? templates.filter((template) => templateMatchesLane(template, lane)) : []
+  ), [lane, templates]);
+
+  const bodyCompatibleTemplates = useMemo(() => (
+    body && lane && !disabledReason
+      ? laneCompatibleTemplates.filter((template) => templateCanFitBody(template, body, lane))
+      : []
+  ), [body, disabledReason, lane, laneCompatibleTemplates]);
+
+  const visibleTemplates = useMemo(() => (
+    bodyCompatibleTemplates
+      .filter((template) => {
+        if (!normalisedQuery) return true;
+        return [
+          templateDisplayName(template),
+          template.name,
+          template.id,
+          template.category,
+          template.economy ?? '',
+          template.allowed_location,
+          template.pad_size ?? '',
+        ].join(' ').toLowerCase().includes(normalisedQuery);
+      })
+      .sort((a, b) => (a.tier - b.tier) || templateDisplayName(a).localeCompare(templateDisplayName(b)))
+  ), [bodyCompatibleTemplates, normalisedQuery]);
+
+  if (!body || body.id == null || !lane) return null;
+
+  const laneHiddenCount = Math.max(0, templates.length - laneCompatibleTemplates.length);
+  const bodyHiddenCount = Math.max(0, laneCompatibleTemplates.length - bodyCompatibleTemplates.length);
+  const canSelectTemplate = !templatesLoading && !templatesErrorMessage && !disabledReason;
+
+  return (
+    <section
+      aria-labelledby="canvas-structure-picker-title"
+      data-testid="body-structure-picker"
+      data-lane={lane}
+      className="rounded-chunk-lg border border-orange/35 bg-bg2/90 px-3 py-3 shadow-metal"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">
+            Add {laneLabel} structure
+          </div>
+          <h3 id="canvas-structure-picker-title" className="mt-0.5 text-base font-bold text-silver">
+            {bodyName}
+          </h3>
+          <p className="mt-0.5 font-mono text-[10px] text-silver-dk">
+            {canSelectTemplate
+              ? `${visibleTemplates.length} compatible option${visibleTemplates.length === 1 ? '' : 's'} shown for this ${laneLabel} lane.`
+              : `Picker is disabled for this ${laneLabel} lane.`}
+          </p>
+        </div>
+        <button
+          type="button"
+          aria-label="Close structure picker"
+          onClick={onClose}
+          className="inline-flex items-center gap-1 rounded border border-border/60 bg-bg3/45 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-silver-dk hover:border-orange/45 hover:text-orange"
+        >
+          <X size={12} />
+          Close
+        </button>
+      </div>
+
+      {templatesLoading && (
+        <p data-testid="canvas-picker-loading" className="mt-3 rounded border border-gold/35 bg-gold/10 px-3 py-2 text-[11px] text-gold">
+          Facility catalogue loading.
+        </p>
+      )}
+
+      {templatesErrorMessage && (
+        <p data-testid="canvas-picker-error" className="mt-3 rounded border border-gold/35 bg-gold/10 px-3 py-2 text-[11px] text-gold">
+          {templatesErrorMessage}
+        </p>
+      )}
+
+      {disabledReason && (
+        <p data-testid="canvas-picker-disabled-reason" className="mt-3 rounded border border-gold/35 bg-gold/10 px-3 py-2 text-[11px] text-gold">
+          {disabledReason}
+        </p>
+      )}
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+        <label className="relative block">
+          <span className="mb-1 block text-[10px] uppercase tracking-[0.14em] text-silver-dk">Filter structures</span>
+          <Search size={13} className="pointer-events-none absolute bottom-2.5 left-2 text-silver-dk" />
+          <input
+            aria-label="Filter structures"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by name, economy, or type"
+            className="w-full rounded border border-border/70 bg-bg2 px-8 py-2 font-mono text-xs text-silver outline-none focus:border-cyan/60"
+          />
+        </label>
+        <div data-testid="canvas-picker-compatibility-summary" className="rounded border border-border/60 bg-bg3/45 px-2 py-1 font-mono text-[10px] text-silver-dk">
+          {laneHiddenCount + bodyHiddenCount > 0
+            ? `${laneHiddenCount + bodyHiddenCount} incompatible hidden`
+            : 'No incompatible templates hidden'}
+        </div>
+      </div>
+
+      {disabledReason ? null : !templatesLoading && !templatesErrorMessage && (templates.length === 0 || visibleTemplates.length === 0) ? (
+        <p data-testid="canvas-picker-empty-state" className="mt-3 rounded border border-border/55 bg-bg3/35 px-3 py-2 text-[11px] text-silver-dk">
+          No compatible structures available for this lane/body.
+        </p>
+      ) : visibleTemplates.length > 0 ? (
+        <div className="mt-3 grid max-h-80 gap-1.5 overflow-y-auto" data-testid="canvas-picker-template-list">
+          {visibleTemplates.map((template) => (
+            <button
+              key={template.id}
+              type="button"
+              data-testid={`body-structure-template-${template.id}`}
+              aria-label={`Add ${templateDisplayName(template)} to ${bodyName}`}
+              disabled={!canSelectTemplate}
+              onClick={() => onPickTemplate(template.id)}
+              className="flex items-center justify-between gap-2 rounded border border-border/55 bg-bg3/35 px-3 py-2 text-left hover:border-orange/45 hover:bg-orange/8 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <span className="min-w-0">
+                <span className="block truncate text-[11px] font-bold text-silver">{templateDisplayName(template)}</span>
+                <span className="mt-1 flex flex-wrap gap-1.5">
+                  <PickerFact label={`tier ${template.tier}`} />
+                  <PickerFact label={template.category || 'unknown type'} />
+                  {template.economy && <PickerFact label={template.economy} />}
+                  {template.pad_size && <PickerFact label={`${template.pad_size} pad`} />}
+                  <PickerFact label={templateLocationKind(template)} tone="cyan" />
+                </span>
+              </span>
+              <span className="shrink-0 rounded border border-orange/35 bg-orange/10 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-orange">
+                Add
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function laneDisabledReason(body: SystemBody, lane: BodyPlannerLane): string | null {
+  if (lane !== 'surface') return null;
+  if (body.is_water_world === true) return 'Surface limited: water world.';
+  if (body.is_landable === false) return 'Surface limited: non-landable body.';
+  return null;
+}
+
+export function templateMatchesLane(template: FacilityTemplate, lane: BodyPlannerLane): boolean {
+  const location = templateLocationKind(template);
+  if (lane === 'orbital') return location === 'orbital' || (location === 'both' && template.is_port);
+  return location === 'surface' || (location === 'both' && !template.is_port);
+}
+
+export function templateCanFitBody(template: FacilityTemplate, body: SystemBody, lane: BodyPlannerLane): boolean {
+  if (laneDisabledReason(body, lane)) return false;
+  const location = templateLocationKind(template);
+  if (location === 'surface') return body.is_landable === true && body.is_water_world !== true;
+  return true;
+}
+
+function templateDisplayName(template: FacilityTemplate): string {
+  const displayName = (template as unknown as { display_name?: unknown }).display_name;
+  return typeof displayName === 'string' && displayName.trim() ? displayName.trim() : template.name;
+}
+
+function PickerFact({ label, tone = 'silver' }: { label: string; tone?: 'silver' | 'cyan' }) {
+  return (
+    <span
+      className={[
+        'rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em]',
+        tone === 'cyan'
+          ? 'border-cyan/35 bg-cyan/10 text-cyan'
+          : 'border-border/60 bg-bg2/60 text-silver-dk',
+      ].join(' ')}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -323,4 +323,99 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       expect(within(screen.getByTestId('body-planning-economy')).getByText(/Agri/i)).toBeTruthy();
     });
   });
+
+  it('adds structures directly from Raven canvas slots without Preview, generation, or Advanced Planner dependency', async () => {
+    mockedApiSystem.mockResolvedValue(slotMapSystem);
+    mockedGetFacilityTemplates.mockResolvedValue(templates);
+    mockedGetSimulationSummary.mockResolvedValue({
+      classification: { primary_archetype: 'refinery_industrial' },
+      buildability: { recommended_build_order: [] },
+      regional_context: null,
+    } as unknown as SimulationSummary);
+    mockedGetSlotPredictions.mockResolvedValue({
+      system_id64: 123,
+      data_source: 'eddn',
+      body_count: 1,
+      predicted_orbital_slots_total: 4,
+      predicted_ground_slots_total: 5,
+      prediction_status: 'predicted',
+      prediction_version: 'validated-slot-v1',
+      confidence_label: 'validated_high_accuracy',
+      disclaimer: 'Predicted slots — high-accuracy algorithm, not guaranteed. Verify in Architect Mode.',
+      validation_note: 'Validated against the supplied evidence set with only 2 true mismatches after data-entry corrections.',
+      required_input_missing: [],
+      predictions: [
+        {
+          system_address: 123,
+          body_id: 1,
+          body_name: 'Body 1',
+          predicted_orbital_slots: 4,
+          predicted_ground_slots: 5,
+          prediction_status: 'predicted',
+          reasons: [],
+        },
+      ],
+    } as any);
+
+    renderWorkspace();
+
+    await screen.findByTestId('raven-real-body-row-1');
+    await waitFor(() => {
+      expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
+      expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('1-orbital-add'));
+    const orbitalPicker = await screen.findByTestId('body-structure-picker');
+    expect(orbitalPicker).toBeTruthy();
+    expect(within(orbitalPicker).getByRole('heading', { name: 'Body 1' })).toBeTruthy();
+    expect(within(orbitalPicker).getByText(/Add orbit structure/i)).toBeTruthy();
+    expect(within(orbitalPicker).getByText(/1 compatible option shown/i)).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-orbital_port')).toBeTruthy();
+    expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
+
+    fireEvent.click(screen.getByTestId('1-ground-add'));
+    const surfaceAddPicker = await screen.findByTestId('body-structure-picker');
+    expect(surfaceAddPicker).toBeTruthy();
+    expect(within(surfaceAddPicker).getByText(/Add surface structure/i)).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-surface_hub')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
+
+    fireEvent.click(screen.getByTestId('1-orbital-slot-3'));
+    expect(within(await screen.findByTestId('body-structure-picker')).getByText(/Add orbit structure/i)).toBeTruthy();
+    fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
+    await waitFor(() => {
+      expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Added Orbital Port to Body 1.');
+      expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '')).toMatch(/Orbital|Port/i);
+      expect(screen.getByTestId('raven-inline-body-expansion-1')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-orbital')).getByText('1/4 planned')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-orbital')).getByText(/Orbital Port/i)).toBeTruthy();
+      expect(within(screen.getByTestId('planner-status-strip')).getByText('1 planned')).toBeTruthy();
+      expect(within(screen.getByTestId('planner-status-strip')).getByText('Unsaved changes')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('1-ground-slot-4'));
+    expect(within(await screen.findByTestId('body-structure-picker')).getByText(/Add surface structure/i)).toBeTruthy();
+    fireEvent.click(screen.getByTestId('body-structure-template-surface_hub'));
+    await waitFor(() => {
+      expect((screen.getByTestId('1-ground-slot-0').textContent ?? '')).toMatch(/Surface|Hub/i);
+      expect(within(screen.getByTestId('slot-lane-surface')).getByText('1/5 planned')).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-surface')).getByText(/Surface Hub/i)).toBeTruthy();
+      expect(within(screen.getByTestId('planner-status-strip')).getByText('2 planned')).toBeTruthy();
+    });
+
+    expect(screen.queryByTestId('advanced-planner-content')).toBeNull();
+    expect(mockedSimulateBuild).not.toHaveBeenCalled();
+    expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /Copy to Build Plan/i })).toBeNull();
+
+    fireEvent.click(screen.getByTestId('advanced-workspace-toggle'));
+    const advanced = await screen.findByTestId('advanced-planner-content');
+    expect(within(advanced).getByText('2 placements in Build Plan')).toBeTruthy();
+    expect(within(advanced).getAllByText(/Orbital Port/i).length).toBeGreaterThan(0);
+    expect(within(advanced).getAllByText(/Surface Hub/i).length).toBeGreaterThan(0);
+    expect(mockedSimulateBuild).not.toHaveBeenCalled();
+    expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
+  });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -426,7 +426,8 @@ describe('ColonyPlannerWorkspace', () => {
     expect(picker).toBeTruthy();
     expect(within(picker).getByText(/Add orbit structure/i)).toBeTruthy();
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
-    expect(screen.getByTestId('body-structure-template-flex_lab')).toBeTruthy();
+    expect(screen.queryByTestId('body-structure-template-flex_lab')).toBeNull();
+    expect(within(picker).getByTestId('canvas-picker-compatibility-summary').textContent).toContain('2 incompatible hidden');
     fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
 
     expect((screen.getByTestId('body1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -215,6 +215,37 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(onSelect).toHaveBeenCalledWith({ type: 'projected-placement', placementIndex: 0 });
   });
 
+  it('requests lane-aware adds from row add controls and empty slots', () => {
+    const onRequestAddStructure = vi.fn();
+    render(
+      <RavenStylePlannerCanvas
+        system={system}
+        snapshot={{
+          ...snapshot,
+          projection: null,
+          placements: [
+            { facility_template_id: 'dodec_starport', local_body_id: '2', is_primary_port: true, build_order: 1 },
+          ],
+        }}
+        selection={{ type: 'system' }}
+        onSelect={vi.fn()}
+        onRequestAddStructure={onRequestAddStructure}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('2-orbital-add'));
+    expect(onRequestAddStructure).toHaveBeenCalledWith('2', 'orbital');
+
+    fireEvent.click(screen.getByTestId('2-ground-add'));
+    expect(onRequestAddStructure).toHaveBeenCalledWith('2', 'surface');
+
+    fireEvent.click(screen.getByTestId('2-orbital-slot-1'));
+    expect(onRequestAddStructure).toHaveBeenCalledWith('2', 'orbital');
+
+    fireEvent.click(screen.getByTestId('2-ground-slot-0'));
+    expect(onRequestAddStructure).toHaveBeenCalledWith('2', 'surface');
+  });
+
   it('matches projected structures to large numeric system body ids', () => {
     const exactBodyId = '1044927859400806427';
     const roundedBodyId = String(Number(exactBodyId));

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -1,4 +1,4 @@
-import { Network, Sparkles, Target } from 'lucide-react';
+import { Network, Plus, Sparkles, Target } from 'lucide-react';
 import { useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { displayRationale } from '@/lib/rationale';
@@ -12,7 +12,7 @@ import {
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
 import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import type { TopologyPlanSnapshot, TopologySelection, TopologySelectionContext } from './ColonyTopologyRail';
-import { SlotCapacityDots } from './BodySlotPlanner';
+import { SlotCapacityDots, type BodyPlannerLane } from './BodySlotPlanner';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import {
   ESTIMATED_SLOT_LAYOUT_DISCLAIMER,
@@ -135,12 +135,14 @@ export function RavenStylePlannerCanvas({
   selection,
   expandedBodyDetail,
   onSelect,
+  onRequestAddStructure,
 }: {
   system: SystemDetail;
   snapshot: TopologyPlanSnapshot;
   selection: TopologySelection;
   expandedBodyDetail?: ReactNode;
   onSelect: (selection: TopologySelection) => void;
+  onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
 }) {
   const rows = buildRavenPlannerRows(system, snapshot);
   const selectedBodyId = selection.type === 'body'
@@ -212,6 +214,7 @@ export function RavenStylePlannerCanvas({
                 selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
                 gridStyle={gridStyle}
                 onSelect={onSelect}
+                onRequestAddStructure={onRequestAddStructure}
               />
             ))}
           </div>
@@ -323,6 +326,7 @@ function RavenPlannerBodyRow({
   selectedProjectedPlacementIndex,
   gridStyle,
   onSelect,
+  onRequestAddStructure,
 }: {
   row: RavenPlannerRow;
   selected: boolean;
@@ -331,6 +335,7 @@ function RavenPlannerBodyRow({
   selectedProjectedPlacementIndex: number | null;
   gridStyle: CSSProperties;
   onSelect: (selection: TopologySelection) => void;
+  onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
 }) {
   const rowTone = selected
     ? 'bg-orange/10 shadow-[inset_3px_0_0_rgba(255,122,20,0.95)]'
@@ -355,21 +360,25 @@ function RavenPlannerBodyRow({
         <TreeCell row={row} selected={selected} onSelect={() => onSelect({ type: 'body', bodyId: row.id })} />
         <RavenSlotLane
           bodyId={row.id}
+          bodyName={row.displayName}
           lane="orbital"
           capacity={row.orbitalCapacity}
           slots={row.orbitalSlots}
           selectedPlacementIndex={selectedPlacementIndex}
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
           onSelect={onSelect}
+          onRequestAddStructure={onRequestAddStructure}
         />
         <RavenSlotLane
           bodyId={row.id}
+          bodyName={row.displayName}
           lane="ground"
           capacity={row.groundCapacity}
           slots={row.groundSlots}
           selectedPlacementIndex={selectedPlacementIndex}
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
           onSelect={onSelect}
+          onRequestAddStructure={onRequestAddStructure}
         />
       </div>
       {selected && expandedDetail && (
@@ -454,35 +463,63 @@ function occupiedSlotCount(slots: RavenStructureSlot[]) {
 
 function RavenSlotLane({
   bodyId,
+  bodyName,
   lane,
   capacity,
   slots,
   selectedPlacementIndex,
   selectedProjectedPlacementIndex,
   onSelect,
+  onRequestAddStructure,
 }: {
   bodyId: string;
+  bodyName: string;
   lane: RavenLane;
   capacity: number | null;
   slots: RavenStructureSlot[];
   selectedPlacementIndex: number | null;
   selectedProjectedPlacementIndex: number | null;
   onSelect: (selection: TopologySelection) => void;
+  onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
 }) {
   const knownCount = capacity == null ? '?' : String(capacity);
   const laneLabel = lane === 'orbital' ? `O${knownCount}` : `S${knownCount}`;
+  const plannerLane = ravenLaneToPlannerLane(lane);
+  const addLabel = lane === 'orbital'
+    ? `Add orbit structure to ${bodyName}`
+    : `Add surface structure to ${bodyName}`;
+  const requestAdd = onRequestAddStructure
+    ? () => onRequestAddStructure(bodyId, plannerLane)
+    : undefined;
 
   return (
     <div data-testid={`${bodyId}-${lane}-lane`} className="flex min-w-0 items-center gap-2 pr-2">
-      <span className="w-10 shrink-0 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">{laneLabel}</span>
+      <span className="flex w-14 shrink-0 items-center gap-1 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">
+        <span>{laneLabel}</span>
+        {requestAdd && (
+          <button
+            type="button"
+            data-testid={`${bodyId}-${lane}-add`}
+            aria-label={addLabel}
+            title={addLabel}
+            onClick={requestAdd}
+            className="grid h-5 w-5 place-items-center rounded border border-orange/45 bg-orange/10 text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70"
+          >
+            <Plus size={12} />
+          </button>
+        )}
+      </span>
       <div className="flex min-w-0 flex-wrap gap-1.5">
         {slots.map((slot, index) => (
           <RavenSlotBox
             key={slot.id}
             slot={slot}
+            lane={lane}
+            bodyName={bodyName}
             testId={`${bodyId}-${lane}-slot-${index}`}
             selected={(slot.placementIndex != null && slot.placementIndex === selectedPlacementIndex) || (slot.projectionIndex != null && slot.projectionIndex === selectedProjectedPlacementIndex)}
             onSelect={onSelect}
+            onAdd={slot.kind === 'empty' ? requestAdd : undefined}
           />
         ))}
       </div>
@@ -492,14 +529,20 @@ function RavenSlotLane({
 
 function RavenSlotBox({
   slot,
+  lane,
+  bodyName,
   testId,
   selected,
   onSelect,
+  onAdd,
 }: {
   slot: RavenStructureSlot;
+  lane: RavenLane;
+  bodyName: string;
   testId: string;
   selected: boolean;
   onSelect: (selection: TopologySelection) => void;
+  onAdd?: () => void;
 }) {
   const primaryEconomy = slot.economySegments[0]?.economy;
   const color = primaryEconomy ? ECONOMY_COLORS[primaryEconomy] : undefined;
@@ -547,6 +590,25 @@ function RavenSlotBox({
       ? { type: 'projected-placement' as const, placementIndex: slot.projectionIndex }
       : null;
 
+  if (!selectionTarget && slot.kind === 'empty' && onAdd) {
+    const addLabel = lane === 'orbital'
+      ? `Add orbit structure to ${bodyName} from empty slot`
+      : `Add surface structure to ${bodyName} from empty slot`;
+    return (
+      <button
+        type="button"
+        data-testid={testId}
+        title={addLabel}
+        aria-label={addLabel}
+        onClick={onAdd}
+        className={className}
+        style={slotStyle}
+      >
+        {content}
+      </button>
+    );
+  }
+
   if (!selectionTarget) {
     return (
       <span data-testid={testId} title={slot.title} className={className} style={slotStyle}>
@@ -568,6 +630,10 @@ function RavenSlotBox({
       {content}
     </button>
   );
+}
+
+function ravenLaneToPlannerLane(lane: RavenLane): BodyPlannerLane {
+  return lane === 'ground' ? 'surface' : 'orbital';
 }
 
 function StructureEconomyMicroBar({ segments }: { segments: RavenEconomySegment[] }) {

--- a/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
@@ -1,5 +1,4 @@
 import { PanelTopOpen, Sparkles, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
 import type { FacilityTemplate, SimulateBuildPlacement, SystemBody, SystemDetail } from '@/types/api';
 import {
   bodyDisplayName,
@@ -42,7 +41,7 @@ export function SelectedBodyPlannerCanvas({
   selectedProjectedPlacementIndex,
   templatesLoading,
   templatesErrorMessage,
-  onAddStructure,
+  onRequestAddStructure,
   onOpenAdvanced,
   onReviewStructures,
   onClose,
@@ -58,7 +57,7 @@ export function SelectedBodyPlannerCanvas({
   selectedProjectedPlacementIndex: number | null;
   templatesLoading: boolean;
   templatesErrorMessage: string | null;
-  onAddStructure: (bodyId: string, lane: BodyPlannerLane, templateId: string) => void;
+  onRequestAddStructure: (bodyId: string, lane: BodyPlannerLane) => void;
   onOpenAdvanced: (mode?: SimulationWorkspaceMode) => void;
   onReviewStructures: (bodyId: string) => void;
   onClose: () => void;
@@ -66,25 +65,6 @@ export function SelectedBodyPlannerCanvas({
   onSelectPlacement: (placementIndex: number) => void;
   onSelectProjectedPlacement: (placementIndex: number) => void;
 }) {
-  const [pickerContext, setPickerContext] = useState<{ bodyId: string; lane: BodyPlannerLane } | null>(null);
-
-  useEffect(() => {
-    if (!body?.id || !pickerContext) return;
-    if (!sameBodyId(body.id, pickerContext.bodyId)) {
-      setPickerContext(null);
-    }
-  }, [body?.id, pickerContext]);
-
-  const pickerBody = pickerContext && body?.id != null && sameBodyId(body.id, pickerContext.bodyId)
-    ? body
-    : null;
-
-  const pickTemplateForBody = (templateId: string) => {
-    if (!pickerContext) return;
-    onAddStructure(pickerContext.bodyId, pickerContext.lane, templateId);
-    setPickerContext(null);
-  };
-
   if (!body || body.id == null) {
     return (
       <section data-testid="selected-body-planner-canvas" data-readability="stage17k" className="text-sm leading-relaxed">
@@ -150,7 +130,7 @@ export function SelectedBodyPlannerCanvas({
         hasTemplates={snapshot.templates.length > 0}
         onSelectPlacement={onSelectPlacement}
         onSelectProjectedPlacement={onSelectProjectedPlacement}
-        onAddLaneStructure={(lane) => setPickerContext({ bodyId, lane })}
+        onAddLaneStructure={(lane) => onRequestAddStructure(bodyId, lane)}
       />
 
       {warnings.length > 0 && (
@@ -181,13 +161,6 @@ export function SelectedBodyPlannerCanvas({
         </button>
       </div>
 
-      <BodyStructurePickerDrawer
-        body={pickerBody}
-        lane={pickerContext?.lane ?? null}
-        templates={snapshot.templates}
-        onClose={() => setPickerContext(null)}
-        onPickTemplate={pickTemplateForBody}
-      />
     </div>
   );
 }
@@ -633,122 +606,6 @@ function sumKnownCapacity(items: SystemOverviewItem[], lane: 'orbital' | 'surfac
     const value = lane === 'orbital' ? item.orbitalCapacity : item.surfaceCapacity;
     return sum + (value ?? 0);
   }, 0);
-}
-
-function BodyStructurePickerDrawer({
-  body,
-  lane,
-  templates,
-  onClose,
-  onPickTemplate,
-}: {
-  body: SystemBody | null;
-  lane: BodyPlannerLane | null;
-  templates: FacilityTemplate[];
-  onClose: () => void;
-  onPickTemplate: (templateId: string) => void;
-}) {
-  const [query, setQuery] = useState('');
-
-  if (!body || body.id == null || !lane) return null;
-
-  const bodyName = bodyDisplayName(body);
-  const laneLabel = lane === 'orbital' ? 'orbit' : 'surface';
-  const filtered = templates
-    .filter((template) => templateMatchesLane(template, lane))
-    .filter((template) => templateCanFitBody(template, body, lane))
-    .filter((template) => {
-      const text = `${template.name} ${template.id} ${template.category} ${template.economy ?? ''}`.toLowerCase();
-      return text.includes(query.trim().toLowerCase());
-    })
-    .sort((a, b) => (a.tier - b.tier) || a.name.localeCompare(b.name));
-
-  return (
-    <section
-      data-testid="body-structure-picker"
-      className="mb-3 rounded-chunk-lg border border-orange/35 bg-bg2/75 px-3 py-3"
-    >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">
-            Add {laneLabel} structure
-          </div>
-          <h4 className="mt-0.5 text-sm font-bold text-silver">{bodyName}</h4>
-          <p className="mt-0.5 font-mono text-[10px] text-silver-dk">
-            Filtered to {laneLabel}-compatible templates for this body.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="rounded border border-border/60 bg-bg3/45 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-silver-dk hover:border-orange/45 hover:text-orange"
-        >
-          Close
-        </button>
-      </div>
-
-      <label className="mt-3 block">
-        <span className="block text-[10px] uppercase tracking-[0.14em] text-silver-dk">Filter structures</span>
-        <input
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search by name, economy, or category"
-          className="mt-1 w-full"
-        />
-      </label>
-
-      {templates.length === 0 ? (
-        <p className="mt-3 rounded border border-gold/35 bg-gold/10 px-3 py-2 text-[11px] text-gold">
-          Facility catalogue is loading.
-        </p>
-      ) : filtered.length === 0 ? (
-        <p className="mt-3 rounded border border-border/55 bg-bg3/35 px-3 py-2 text-[11px] text-silver-dk">
-          No matching {laneLabel} structures for this body and filter.
-        </p>
-      ) : (
-        <div className="mt-3 grid max-h-72 gap-1.5 overflow-y-auto">
-          {filtered.map((template) => (
-            <button
-              key={template.id}
-              type="button"
-              data-testid={`body-structure-template-${template.id}`}
-              onClick={() => onPickTemplate(template.id)}
-              className="flex items-center justify-between gap-2 rounded border border-border/55 bg-bg3/35 px-3 py-2 text-left hover:border-orange/45 hover:bg-orange/8"
-            >
-              <div className="min-w-0">
-                <div className="truncate text-[11px] font-bold text-silver">{template.name}</div>
-                <div className="mt-0.5 flex flex-wrap gap-1.5">
-                  <BodyFact label={`tier ${template.tier}`} />
-                  <BodyFact label={template.category} />
-                  {template.economy && <BodyFact label={template.economy} />}
-                  <BodyFact label={templateLocationKind(template)} tone="cyan" />
-                </div>
-              </div>
-              <span className="rounded border border-orange/35 bg-orange/10 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-orange">
-                Add
-              </span>
-            </button>
-          ))}
-        </div>
-      )}
-    </section>
-  );
-}
-
-function templateCanFitBody(template: FacilityTemplate, body: SystemBody, lane: BodyPlannerLane) {
-  const location = templateLocationKind(template);
-  if (lane === 'surface') {
-    if (body.is_water_world) return false;
-    if (body.is_landable === false) return false;
-  }
-  if (location === 'surface') return Boolean(body.is_landable) && !body.is_water_world;
-  return true;
-}
-
-function templateMatchesLane(template: FacilityTemplate, lane: BodyPlannerLane) {
-  const location = templateLocationKind(template);
-  if (lane === 'orbital') return location === 'orbital' || location === 'both';
-  return location === 'surface' || location === 'both' || location === 'unknown';
 }
 
 function BodyStartAction({ label, detail }: { label: string; detail: string }) {

--- a/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
@@ -5,8 +5,15 @@ import type { FacilityTemplate, SimulateBuildPlacement, SimulationSummary, Syste
 import { getFacilityTemplates, getSimulationSummary, getSlotPredictions } from '@/lib/api';
 import type { SimulationWorkspaceMode } from '@/features/system-detail/simulation-preview/WorkspaceModeTabs';
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
+import { bodyDisplayName } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
 import { archetypeFromEconomy, resequence } from '@/features/system-detail/simulation-preview/utils/placementHelpers';
 import type { BodyPlannerLane } from './BodySlotPlanner';
+import {
+  CanvasStructurePicker,
+  laneDisabledReason,
+  templateCanFitBody,
+  templateMatchesLane,
+} from './CanvasStructurePicker';
 import {
   describeTopologySelection,
   type TopologyPlanSnapshot,
@@ -33,6 +40,8 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   const [telemetryDockOpen, setTelemetryDockOpen] = useState(false);
   const [workspaceCommand, setWorkspaceCommand] = useState<PlannerWorkspaceCommand | null>(null);
   const [lastHandledWorkspaceCommandToken, setLastHandledWorkspaceCommandToken] = useState(0);
+  const [structurePicker, setStructurePicker] = useState<{ bodyId: string; lane: BodyPlannerLane } | null>(null);
+  const [structureAddFeedback, setStructureAddFeedback] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const workspaceCommandToken = useRef(0);
   const appliedProjectFingerprint = useRef<string | null>(null);
 
@@ -64,6 +73,8 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     setSelection({ type: 'system' });
     setPlacements([]);
     setProjection(null);
+    setStructurePicker(null);
+    setStructureAddFeedback(null);
     setTargetArchetype(archetypeFromEconomy(system.economy_suggestion ?? system.primary_economy) ?? 'refinery_industrial');
     appliedProjectFingerprint.current = null;
   }, [system.economy_suggestion, system.id64, system.primary_economy]);
@@ -116,6 +127,10 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   );
   const selectedPlacementIndex = selection.type === 'placement' ? selection.placementIndex : null;
   const selectedProjectedPlacementIndex = selection.type === 'projected-placement' ? selection.placementIndex : null;
+  const pickerBody = useMemo(() => {
+    if (!structurePicker) return null;
+    return (system.bodies ?? []).find((body) => sameBodyId(body.id, structurePicker.bodyId)) ?? null;
+  }, [structurePicker, system.bodies]);
   const systemEconomyLedger = useMemo(() => buildPlanningEconomyLedger({
     placements,
     projectedPlacements: projection?.placements ?? [],
@@ -127,9 +142,28 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     setAdvancedPanelOpen(true);
   }, []);
 
-  const addStructure = useCallback((bodyId: string, _lane: BodyPlannerLane, templateId: string) => {
+  const requestAddStructure = useCallback((bodyId: string, lane: BodyPlannerLane) => {
+    setSelection({ type: 'body', bodyId });
+    setStructureAddFeedback(null);
+    setStructurePicker({ bodyId, lane });
+  }, []);
+
+  const addStructure = useCallback((bodyId: string, lane: BodyPlannerLane, templateId: string) => {
     const template = templates.find((candidate) => candidate.id === templateId);
-    if (!template) return;
+    if (!template) {
+      return { ok: false as const, message: 'Facility template is no longer available.' };
+    }
+    const body = (system.bodies ?? []).find((candidate) => sameBodyId(candidate.id, bodyId));
+    if (!body) {
+      return { ok: false as const, message: 'Selected body is no longer available.' };
+    }
+    const disabledReason = laneDisabledReason(body, lane);
+    if (disabledReason) {
+      return { ok: false as const, message: disabledReason };
+    }
+    if (!templateMatchesLane(template, lane) || !templateCanFitBody(template, body, lane)) {
+      return { ok: false as const, message: `${templateDisplayName(template)} is not compatible with this ${lane === 'orbital' ? 'orbit' : 'surface'} lane.` };
+    }
     setSelection({ type: 'body', bodyId });
     setPlacements((current) => resequence([
       ...current,
@@ -140,7 +174,20 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
         build_order: current.length + 1,
       },
     ]));
-  }, [templates]);
+    return {
+      ok: true as const,
+      message: `Added ${templateDisplayName(template)} to ${bodyDisplayName(body)}.`,
+    };
+  }, [system.bodies, templates]);
+
+  const pickStructureTemplate = useCallback((templateId: string) => {
+    if (!structurePicker) return;
+    const result = addStructure(structurePicker.bodyId, structurePicker.lane, templateId);
+    setStructureAddFeedback({ tone: result.ok ? 'success' : 'error', message: result.message });
+    if (result.ok) {
+      setStructurePicker(null);
+    }
+  }, [addStructure, structurePicker]);
 
   const issueWorkspaceCommand = useCallback((kind: PlannerWorkspaceCommand['kind'], bodyId: string, templateId?: string | null) => {
     workspaceCommandToken.current += 1;
@@ -191,6 +238,33 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
           unsavedChanges={projectState.unsavedChanges}
           economyLedger={systemEconomyLedger}
         />
+        {(structurePicker || structureAddFeedback) && (
+          <div className="space-y-2" data-testid="canvas-structure-picker-region">
+            {structureAddFeedback && (
+              <p
+                role={structureAddFeedback.tone === 'error' ? 'alert' : 'status'}
+                data-testid="canvas-add-structure-feedback"
+                className={[
+                  'rounded border px-3 py-2 text-sm leading-relaxed',
+                  structureAddFeedback.tone === 'error'
+                    ? 'border-gold/35 bg-gold/10 text-gold'
+                    : 'border-green/35 bg-green/10 text-green',
+                ].join(' ')}
+              >
+                {structureAddFeedback.message}
+              </p>
+            )}
+            <CanvasStructurePicker
+              body={pickerBody}
+              lane={structurePicker?.lane ?? null}
+              templates={templates}
+              templatesLoading={templatesQuery.isLoading}
+              templatesErrorMessage={templatesQuery.isError ? templatesQuery.error?.message ?? 'Facility catalogue failed to load.' : null}
+              onClose={() => setStructurePicker(null)}
+              onPickTemplate={pickStructureTemplate}
+            />
+          </div>
+        )}
         <RavenStylePlannerCanvas
           system={system}
           snapshot={planSnapshot}
@@ -205,7 +279,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
               selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
               templatesLoading={templatesQuery.isLoading}
               templatesErrorMessage={templatesQuery.isError ? templatesQuery.error?.message ?? 'Facility catalogue failed to load.' : null}
-              onAddStructure={addStructure}
+              onRequestAddStructure={requestAddStructure}
               onOpenAdvanced={openAdvanced}
               onReviewStructures={reviewBodyStructures}
               onClose={() => setSelection({ type: 'system' })}
@@ -215,6 +289,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
             />
           ) : null}
           onSelect={setSelection}
+          onRequestAddStructure={requestAddStructure}
         />
         <AdvancedPlannerDrawer
           open={advancedPanelOpen}
@@ -345,4 +420,9 @@ function projectionEqual(
   if (a.candidateId !== b.candidateId) return false;
   if (a.label !== b.label) return false;
   return placementsEqual(a.placements, b.placements);
+}
+
+function templateDisplayName(template: FacilityTemplate): string {
+  const displayName = (template as unknown as { display_name?: unknown }).display_name;
+  return typeof displayName === 'string' && displayName.trim() ? displayName.trim() : template.name;
 }


### PR DESCRIPTION
## Summary
- add a lane-aware Raven canvas structure picker for orbital and surface add flows
- wire Raven row add controls, empty slot clicks, and selected-body lane add controls through the shared Build Plan placement path
- add coverage for picker states, direct add behavior, passivity, and docs for Stage 17N.1

## Root cause
The main Raven whole-system canvas did not mount or call a structure picker for its visible add affordances. Empty Raven slots were inert, while selected-body detail had a separate internal picker path.

## Validation
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `cd frontend-v2 && npm test` (60 files, 394 tests)
- `git diff --check`

Build still reports the pre-existing Coalsack background runtime-resolution warnings and chunk-size warning.