### PR TITLE
[codex] Implement Stage 17N.1b add flow cleanup

### DIFF
--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -1065,6 +1065,8 @@ class FacilityTemplateResponse(BaseModel):
     pad_size:            Optional[str] = None
     confidence:          Optional[str] = None
     notes:               Optional[str] = None
+    prerequisites:       list[dict[str, Any]] = Field(default_factory=list)
+    economy_effects:     dict[str, Any] = Field(default_factory=dict)
     yellow_cp_generated: int = 0
     green_cp_generated:  int = 0
     yellow_cp_cost:      int = 0

--- a/apps/api/src/routers/simulate.py
+++ b/apps/api/src/routers/simulate.py
@@ -48,6 +48,8 @@ async def get_facility_templates(
             pad_size=f.pad_size,
             confidence=f.data_confidence,
             notes=f.stat_effects.get('note') if isinstance(f.stat_effects, dict) else None,
+            prerequisites=f.prerequisites if isinstance(f.prerequisites, list) else [],
+            economy_effects=f.economy_effects if isinstance(f.economy_effects, dict) else {},
             yellow_cp_generated=f.yellow_cp_generated,
             green_cp_generated=f.green_cp_generated,
             yellow_cp_cost=f.yellow_cp_cost,

--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1757,6 +1757,47 @@ Safety boundary:
 - no Architect-observed slot storage
 - no CP/economy/scoring/backend changes
 
+## Stage 17N.1b - Raven Canvas Add Flow UX Cleanup (Implemented)
+
+Stage 17N.1b cleans up the direct Raven add flow after the Stage 17N.1 functional repair. The canvas now separates body selection, placement selection, projected placement selection, and add actions more clearly.
+
+Delivered:
+
+- the main canvas heading is user-facing: `System Build Map` with concise slot-disclaimer copy
+- body rows remain selectable through body controls, occupied planned slots select placements, projected ghost slots select projection context only, and add actions are visibly marked as add actions
+- display-only capacity and passive slot boxes no longer use fake hover/lift affordances
+- Raven row add controls and selected-body lane add controls share the same picker state and Build Plan placement path
+- the picker uses lane/body compatibility without splitting dual-location templates by `is_port`, so orbital outposts/installations and surface ports/hubs/settlements remain visible when valid
+- facility template API responses expose prerequisite and economy-effect metadata from the domain catalogue
+- unmet prerequisites warn in the picker, Raven slots, selected-body detail, telemetry, and plan health, but they do not block planning
+- hard-invalid placements still block with visible reasons, including surface builds on water worlds or non-landable bodies
+- station/port templates without direct economy metadata show contextual economy copy instead of appearing blank or broken
+- successful adds show a short feedback message with structure, body, and lane
+
+Catalogue and prerequisite boundary:
+
+- the picker must preserve readable display names and variants from the facility catalogue
+- catalogue families include stations/ports, orbital outposts, orbital installations, planetary ports, settlements, hubs, extraction, refinery, industrial, agriculture, tourism, military/security, high-tech/research, support/logistics, and named variants where present
+- prerequisites are treated as planning warnings, not physical incompatibilities
+- Preview/validation remains the authoritative unresolved-prerequisite and economy outcome surface
+
+Safety boundary:
+
+- no auto Preview
+- no auto Suggested Build generation
+- no candidate auto-load
+- no fake economy values for station templates without direct economy metadata
+- no drag/drop slot editing
+- no Architect-observed slot storage
+- no economy-strength backend ledger changes
+
+Remaining manual editing gaps:
+
+- no quick-add prerequisite action from the warning chip yet
+- no explicit slot index persistence
+- no per-placement lane storage for truly flexible/unknown structures
+- prerequisite matching is catalogue-token based until the API provides normalized prerequisite target identifiers
+
 ## Stage 18 - Colony Architect Assistant Foundation (Planned)
 
 Stage 18 should add an assistant foundation while keeping deterministic planner authority:

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -1071,8 +1071,8 @@ The Raven-style canvas now owns a direct manual add flow:
 
 Compatibility rules:
 
-- orbital picker shows orbital templates and dual-location port templates that the current renderer will place in orbit
-- surface picker shows surface templates and dual-location non-port templates that the current renderer will place on a valid landable surface
+- orbital picker shows orbital and dual-location templates that the current renderer can place in orbit
+- surface picker shows surface and dual-location templates that the current renderer can place on a valid landable surface
 - water-world and non-landable surface lanes are disabled with visible reasons
 - incompatible templates are hidden and counted in the picker
 - empty catalogue/loading and no-compatible-template states are explicit
@@ -1088,6 +1088,33 @@ Passivity guarantees:
 Known limitation:
 
 - the simulation request model still has no per-placement lane or slot index field and backend request validation forbids extra placement properties, so flexible/unknown structure placement remains a later manual-editing gap rather than being faked in Stage 17N.1.
+
+## Stage 17N.1b Add Flow UX, Catalogue, And Prerequisites
+
+Stage 17N.1b keeps the Stage 17N.1 ownership model but tightens the user-facing behavior:
+
+- Raven canvas copy is `System Build Map` with a concise predicted-slot disclaimer.
+- Body controls select bodies; occupied planned slots select placements; projected slots select projection context without loading; visible add controls open the lane-aware picker.
+- Passive capacity boxes and passive empty slots do not use button-like hover or pointer affordances.
+- The picker uses shared compatibility helpers and no longer splits dual-location templates by `is_port`; valid orbital outposts/installations and valid surface ports/hubs/settlements remain visible when the body/lane allows them.
+- Facility template API responses include `prerequisites` and `economy_effects` from the catalogue so the frontend can display full family, variant, economy, and warning context.
+- Prerequisites warn but do not block. The user can plan a future structure with missing support, and the picker, slots, selected-structure context, status strip, and plan health surface the unresolved prerequisite.
+- Hard-invalid physical placement still blocks with a visible reason.
+- Stations and ports without direct economy metadata render contextual copy: economy is inherited from body/system/plan context and requires explicit Preview for validation. The UI must not invent fake economy values.
+- Successful adds show structure, body, and lane feedback while preserving the no-auto-preview/no-auto-generation/no-auto-load guarantees.
+
+Remaining manual editing gaps:
+
+- no one-click add-prerequisite action from warnings yet
+- no explicit slot index persistence
+- no per-placement lane storage for truly flexible/unknown structures
+- prerequisite matching is description/token based until normalized prerequisite target identifiers are available in the API
+
+Advanced Planner contract:
+
+- Advanced Planner remains secondary and explicitly opened.
+- Raven adds write the same Build Plan state Advanced Planner reads.
+- Existing Simulation Preview picker views should use the same structure display language where practical, especially family labels, prerequisite warnings, and contextual station economy copy.
 
 ## Stage 18 Assistant Foundation Boundary
 

--- a/docs/colonisation-redesign/stage-17a-colony-architect-report.md
+++ b/docs/colonisation-redesign/stage-17a-colony-architect-report.md
@@ -462,3 +462,33 @@ Remaining manual editing gaps:
 - no explicit slot index persistence
 - no per-placement lane storage for truly flexible/unknown structures; lane-specific pickers therefore only show templates that the current placement model can render reliably into that lane
 - no Architect observed slot storage
+
+## Stage 17N.1b Add Flow UX And Catalogue Coverage
+
+Stage 17N.1b keeps the Stage 17N.1 direct-add architecture and makes the interaction clearer and more complete.
+
+Implemented behavior:
+
+- the Raven canvas title is now `System Build Map`; the subtitle is `Plan structures directly into predicted orbital and surface slots.`
+- body controls select bodies, occupied planned slots select placements, projected ghost slots select projected placement context, and visible `+ Add` controls open the structure picker
+- passive slot/capacity boxes no longer use misleading hover or pointer-style treatment
+- the picker no longer treats `both + is_port` as orbital-only or `both + !is_port` as surface-only, so valid outposts, installations, hubs, settlements, ports, and variants remain available for compatible lanes
+- facility template responses now include catalogue prerequisite metadata and economy-effect metadata for frontend display and warnings
+- missing prerequisites are shown as warnings in the picker, structure slots, selected structure context, status/telemetry, and plan health, but they do not block adding planned structures
+- true invalid placement still blocks with a visible reason, including surface builds on water worlds and non-landable bodies
+- station/port templates without direct economy metadata show contextual economy and role copy instead of blank economy fields
+- successful adds report the structure, body, and lane in the canvas feedback message
+
+Explicit non-behavior:
+
+- no Advanced Planner requirement for manual Raven adds
+- no automatic Preview run
+- no automatic Suggested Build generation
+- no projected candidate auto-load
+- no invented station economy values
+
+Remaining manual editing gaps:
+
+- missing-prerequisite warnings do not yet include a one-click prerequisite insertion action
+- slot index and explicit lane storage are still absent from the simulation request model
+- prerequisite matching is based on catalogue descriptions/tokens until normalized prerequisite target IDs are available

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
@@ -11,6 +11,7 @@ import { ProjectedStructureSlot } from './ProjectedStructureSlot';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import { buildPlanningEconomyLedger } from './planningEconomy';
 import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity, type BodyDataSlotEstimate } from './slotCapacityFallback';
+import { laneDisabledReason, missingPrerequisitesForPlacement } from './structurePlanningRules';
 
 export type BodyPlannerLane = 'orbital' | 'surface';
 
@@ -67,12 +68,8 @@ export function BodySlotPlanner({
   const orbitalSlots = orbitalCapacity.value;
   const surfaceSlots = surfaceCapacity.value;
   const hasEstimatedSlots = orbitalCapacity.estimated || surfaceCapacity.estimated;
-  const surfaceBlocked = body.is_water_world === true || body.is_landable === false;
-  const surfaceBlockedReason = body.is_water_world
-    ? 'Surface limited: water world.'
-    : body.is_landable === false
-      ? 'Surface limited: non-landable body.'
-      : null;
+  const surfaceBlockedReason = laneDisabledReason(body, 'surface');
+  const surfaceBlocked = Boolean(surfaceBlockedReason);
   const occupiedSlots = {
     orbital: orbitalPlanned.length + orbitalProjected.length,
     surface: surfacePlanned.length + surfaceProjected.length,
@@ -166,6 +163,7 @@ export function BodySlotPlanner({
           <LaneSlots
             body={body}
             laneKey="orbital"
+            allPlacements={placements}
             planned={orbitalPlanned}
             projected={orbitalProjected}
             selectedPlacementIndex={selectedPlacementIndex}
@@ -199,6 +197,7 @@ export function BodySlotPlanner({
           <LaneSlots
             body={body}
             laneKey="surface"
+            allPlacements={placements}
             planned={surfacePlanned}
             projected={surfaceProjected}
             selectedPlacementIndex={selectedPlacementIndex}
@@ -693,6 +692,7 @@ function CapacityCell({
 function LaneSlots({
   body,
   laneKey,
+  allPlacements,
   planned,
   projected,
   selectedPlacementIndex,
@@ -703,6 +703,7 @@ function LaneSlots({
 }: {
   body: SystemBody;
   laneKey: BodyPlannerLane;
+  allPlacements: BodyPlannerPlacementItem[];
   planned: BodyPlannerPlacementItem[];
   projected: BodyPlannerProjectedPlacementItem[];
   selectedPlacementIndex: number | null;
@@ -727,7 +728,7 @@ function LaneSlots({
       {planned.map((item) => (
         <BodyStructureSlot
           key={`planned-${laneKey}-${item.index}-${item.placement.facility_template_id}`}
-          item={toStructureSlotItem(item, body)}
+          item={toStructureSlotItem(item, body, allPlacements)}
           selected={selectedPlacementIndex === item.index}
           onSelect={() => onSelectPlacement(item.index)}
         />
@@ -744,12 +745,16 @@ function LaneSlots({
   );
 }
 
-function toStructureSlotItem(item: BodyPlannerPlacementItem, body: SystemBody): BodyStructureSlotItem {
+function toStructureSlotItem(item: BodyPlannerPlacementItem, body: SystemBody, allPlacements: BodyPlannerPlacementItem[]): BodyStructureSlotItem {
+  const templates = allPlacements.map((candidate) => candidate.template).filter((template): template is FacilityTemplate => Boolean(template));
+  const placementModels = allPlacements.map((candidate) => candidate.placement);
+  const prerequisiteWarnings = missingPrerequisitesForPlacement(item.placement, placementModels, templates);
   return {
     placement: item.placement,
     index: item.index,
     template: item.template,
-    warningCount: getPlacementWarnings(item, body).length,
+    warningCount: getPlacementWarnings(item, body).length + prerequisiteWarnings.length,
+    warningLabels: prerequisiteWarnings,
   };
 }
 
@@ -759,8 +764,7 @@ function laneForTemplate(template: FacilityTemplate | undefined, body: SystemBod
   if (location === 'orbital') return 'orbital';
   if (location === 'surface') return 'surface';
   if (location === 'both') {
-    if (template.is_port) return 'orbital';
-    return body.is_landable === true && body.is_water_world !== true ? 'surface' : 'orbital';
+    return fallbackLaneForBody(body);
   }
   return fallbackLaneForBody(body);
 }

--- a/frontend-v2/src/features/colony-planner/BodyStructureSlot.tsx
+++ b/frontend-v2/src/features/colony-planner/BodyStructureSlot.tsx
@@ -1,12 +1,14 @@
 import type { FacilityTemplate, SimulateBuildPlacement } from '@/types/api';
 import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import { normalisePlanningEconomy, type PlanningEconomyName } from './planningEconomy';
+import { contextualEconomyLabel, contextualRoleLabel, structureFamilyLabel, templateDisplayName } from './structurePlanningRules';
 
 export interface BodyStructureSlotItem {
   placement: SimulateBuildPlacement;
   index: number;
   template?: FacilityTemplate;
   warningCount?: number;
+  warningLabels?: string[];
 }
 
 export function BodyStructureSlot({
@@ -26,8 +28,11 @@ export function BodyStructureSlot({
       : location === 'both'
         ? 'Orbit or Surface'
         : 'Unknown';
-  const label = item.template?.name ?? item.placement.facility_template_id;
+  const label = item.template ? templateDisplayName(item.template) : item.placement.facility_template_id;
   const economy = normalisePlanningEconomy(item.template?.economy);
+  const economyContext = contextualEconomyLabel(item.template);
+  const roleLabel = contextualRoleLabel(item.template, item.placement);
+  const warningLabels = item.warningLabels ?? [];
 
   return (
     <button
@@ -47,11 +52,24 @@ export function BodyStructureSlot({
       </div>
       <div className="mt-1 flex flex-wrap gap-1">
         <SlotChip label={locationLabel} tone="cyan" />
+        {item.template && <SlotChip label={structureFamilyLabel(item.template)} />}
         {item.template?.category && <SlotChip label={item.template.category} />}
         {item.template?.economy && <SlotChip label={item.template.economy} />}
+        {!item.template?.economy && economyContext && <SlotChip label="contextual economy" tone="cyan" />}
+        {roleLabel && <SlotChip label={roleLabel} tone="cyan" />}
         {item.placement.is_primary_port && <SlotChip label="primary" tone="gold" />}
         {(item.warningCount ?? 0) > 0 && <SlotChip label={`${item.warningCount} warn`} tone="gold" />}
       </div>
+      {economyContext && (
+        <div data-testid="body-structure-contextual-economy" className="mt-1 text-[10px] leading-snug text-cyan">
+          {economyContext}
+        </div>
+      )}
+      {warningLabels.length > 0 && (
+        <div data-testid="body-structure-prerequisite-warning" className="mt-1 text-[10px] leading-snug text-gold">
+          Missing prerequisite: {warningLabels.join('; ')}
+        </div>
+      )}
       {economy && <StructureEconomyMicroBar economy={economy} />}
     </button>
   );

--- a/frontend-v2/src/features/colony-planner/CanvasStructurePicker.test.tsx
+++ b/frontend-v2/src/features/colony-planner/CanvasStructurePicker.test.tsx
@@ -64,6 +64,117 @@ const templates: FacilityTemplate[] = [
   },
 ];
 
+const catalogueTemplates: FacilityTemplate[] = [
+  {
+    id: 'coriolis_station',
+    name: 'Coriolis',
+    category: 'port',
+    tier: 2,
+    economy: null,
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'orbital',
+    pad_size: 'L',
+    confidence: 'observed',
+    notes: null,
+    prerequisites: [],
+    yellow_cp_generated: 8,
+    green_cp_generated: 2,
+    yellow_cp_cost: 3,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'orbital_installation_mining_outpost',
+    name: 'Mining Outpost',
+    category: 'extraction',
+    tier: 2,
+    economy: 'Extraction',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'orbital',
+    pad_size: null,
+    confidence: 'observed',
+    notes: null,
+    prerequisites: [],
+    yellow_cp_generated: 2,
+    green_cp_generated: 0,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'orbital_installation_research_station',
+    name: 'Research Station',
+    category: 'hightech',
+    tier: 2,
+    economy: 'HighTech',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'orbital',
+    pad_size: null,
+    confidence: 'observed',
+    notes: null,
+    prerequisites: [{ description: 'Settlement - Research Bio' }],
+    yellow_cp_generated: 2,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'surface_settlement_tourism_t1_s',
+    name: 'Tourism T1 S',
+    category: 'port',
+    tier: 1,
+    economy: 'Tourism',
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'surface',
+    pad_size: 'S',
+    confidence: 'observed',
+    notes: null,
+    prerequisites: [{ description: 'Installation - Satellite' }],
+    yellow_cp_generated: 4,
+    green_cp_generated: 0,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'surface_hub_outpost',
+    name: 'Outpost',
+    category: 'hub',
+    tier: 2,
+    economy: null,
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface',
+    pad_size: null,
+    confidence: 'observed',
+    notes: null,
+    prerequisites: [{ description: 'Installation - Space Farm' }],
+    yellow_cp_generated: 1,
+    green_cp_generated: 0,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'flexible_support',
+    name: 'Flexible Support',
+    category: 'support',
+    tier: 1,
+    economy: 'Industrial',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'orbital_or_surface',
+    pad_size: null,
+    confidence: 'estimated',
+    notes: null,
+    prerequisites: [],
+    yellow_cp_generated: 1,
+    green_cp_generated: 0,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+];
+
 describe('CanvasStructurePicker', () => {
   it('shows selected body, lane, compatible count, close control, and selectable templates', () => {
     const onClose = vi.fn();
@@ -156,5 +267,52 @@ describe('CanvasStructurePicker', () => {
     );
 
     expect(screen.getByTestId('canvas-picker-empty-state').textContent).toContain('No compatible structures available for this lane/body.');
+  });
+
+  it('shows stations, non-station orbital structures, variants, contextual economy, and prerequisite warnings', () => {
+    render(
+      <CanvasStructurePicker
+        body={landableBody}
+        lane="orbital"
+        templates={catalogueTemplates}
+        placements={[]}
+        templatesLoading={false}
+        onClose={vi.fn()}
+        onPickTemplate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('body-structure-template-coriolis_station')).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-orbital_installation_mining_outpost')).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-orbital_installation_research_station')).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-flexible_support')).toBeTruthy();
+    expect(screen.getByTestId('canvas-picker-contextual-economy-coriolis_station').textContent).toContain('Economy: Contextual');
+    expect(screen.getByTestId('canvas-picker-prerequisite-warning-orbital_installation_research_station').textContent).toContain('Settlement - Research Bio');
+    expect(screen.queryByTestId('body-structure-template-surface_settlement_tourism_t1_s')).toBeNull();
+  });
+
+  it('shows ground settlements, hubs, flexible templates, and missing prerequisites without disabling selection', () => {
+    const onPickTemplate = vi.fn();
+    render(
+      <CanvasStructurePicker
+        body={landableBody}
+        lane="surface"
+        templates={catalogueTemplates}
+        placements={[]}
+        templatesLoading={false}
+        onClose={vi.fn()}
+        onPickTemplate={onPickTemplate}
+      />,
+    );
+
+    expect(screen.getByTestId('body-structure-template-surface_settlement_tourism_t1_s')).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-surface_hub_outpost')).toBeTruthy();
+    expect(screen.getByTestId('body-structure-template-flexible_support')).toBeTruthy();
+    expect(screen.getByTestId('canvas-picker-prerequisite-warning-surface_settlement_tourism_t1_s').textContent).toContain('Installation - Satellite');
+
+    const tourismButton = screen.getByRole('button', { name: /Add Tourism T1 S to Body 1/i }) as HTMLButtonElement;
+    expect(tourismButton.disabled).toBe(false);
+    fireEvent.click(tourismButton);
+    expect(onPickTemplate).toHaveBeenCalledWith('surface_settlement_tourism_t1_s');
   });
 });

--- a/frontend-v2/src/features/colony-planner/CanvasStructurePicker.tsx
+++ b/frontend-v2/src/features/colony-planner/CanvasStructurePicker.tsx
@@ -1,14 +1,26 @@
 import { Search, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
-import type { FacilityTemplate, SystemBody } from '@/types/api';
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
 import { bodyDisplayName } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
 import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import type { BodyPlannerLane } from './BodySlotPlanner';
+import {
+  contextualEconomyLabel,
+  isContextualEconomyTemplate,
+  laneDisabledReason,
+  missingPrerequisitesForTemplate,
+  structureFamilyLabel,
+  templateCanFitBody,
+  templateDisplayName,
+  templateMatchesLane,
+  templatePrerequisiteDescriptions,
+} from './structurePlanningRules';
 
 export function CanvasStructurePicker({
   body,
   lane,
   templates,
+  placements = [],
   templatesLoading,
   templatesErrorMessage,
   onClose,
@@ -17,6 +29,7 @@ export function CanvasStructurePicker({
   body: SystemBody | null;
   lane: BodyPlannerLane | null;
   templates: FacilityTemplate[];
+  placements?: SimulateBuildPlacement[];
   templatesLoading: boolean;
   templatesErrorMessage?: string | null;
   onClose: () => void;
@@ -156,11 +169,30 @@ export function CanvasStructurePicker({
                 <span className="block truncate text-[11px] font-bold text-silver">{templateDisplayName(template)}</span>
                 <span className="mt-1 flex flex-wrap gap-1.5">
                   <PickerFact label={`tier ${template.tier}`} />
+                  <PickerFact label={structureFamilyLabel(template)} />
                   <PickerFact label={template.category || 'unknown type'} />
-                  {template.economy && <PickerFact label={template.economy} />}
+                  {template.economy ? <PickerFact label={template.economy} /> : isContextualEconomyTemplate(template) ? <PickerFact label="contextual economy" tone="gold" /> : null}
                   {template.pad_size && <PickerFact label={`${template.pad_size} pad`} />}
                   <PickerFact label={templateLocationKind(template)} tone="cyan" />
+                  {templatePrerequisiteDescriptions(template).length > 0 && (
+                    <PickerFact
+                      label={missingPrerequisitesForTemplate(template, placements, templates).length > 0
+                        ? `${missingPrerequisitesForTemplate(template, placements, templates).length} prerequisite missing`
+                        : 'prerequisites satisfied'}
+                      tone={missingPrerequisitesForTemplate(template, placements, templates).length > 0 ? 'gold' : 'green'}
+                    />
+                  )}
                 </span>
+                {isContextualEconomyTemplate(template) && (
+                  <span data-testid={`canvas-picker-contextual-economy-${template.id}`} className="mt-1 block text-[10px] leading-snug text-cyan">
+                    {contextualEconomyLabel(template)}
+                  </span>
+                )}
+                {missingPrerequisitesForTemplate(template, placements, templates).length > 0 && (
+                  <span data-testid={`canvas-picker-prerequisite-warning-${template.id}`} className="mt-1 block text-[10px] leading-snug text-gold">
+                    Missing prerequisite: {missingPrerequisitesForTemplate(template, placements, templates).join('; ')}. Planning can continue.
+                  </span>
+                )}
               </span>
               <span className="shrink-0 rounded border border-orange/35 bg-orange/10 px-2 py-1 text-[10px] uppercase tracking-[0.12em] text-orange">
                 Add
@@ -173,39 +205,18 @@ export function CanvasStructurePicker({
   );
 }
 
-export function laneDisabledReason(body: SystemBody, lane: BodyPlannerLane): string | null {
-  if (lane !== 'surface') return null;
-  if (body.is_water_world === true) return 'Surface limited: water world.';
-  if (body.is_landable === false) return 'Surface limited: non-landable body.';
-  return null;
-}
-
-export function templateMatchesLane(template: FacilityTemplate, lane: BodyPlannerLane): boolean {
-  const location = templateLocationKind(template);
-  if (lane === 'orbital') return location === 'orbital' || (location === 'both' && template.is_port);
-  return location === 'surface' || (location === 'both' && !template.is_port);
-}
-
-export function templateCanFitBody(template: FacilityTemplate, body: SystemBody, lane: BodyPlannerLane): boolean {
-  if (laneDisabledReason(body, lane)) return false;
-  const location = templateLocationKind(template);
-  if (location === 'surface') return body.is_landable === true && body.is_water_world !== true;
-  return true;
-}
-
-function templateDisplayName(template: FacilityTemplate): string {
-  const displayName = (template as unknown as { display_name?: unknown }).display_name;
-  return typeof displayName === 'string' && displayName.trim() ? displayName.trim() : template.name;
-}
-
-function PickerFact({ label, tone = 'silver' }: { label: string; tone?: 'silver' | 'cyan' }) {
+function PickerFact({ label, tone = 'silver' }: { label: string; tone?: 'silver' | 'cyan' | 'gold' | 'green' }) {
   return (
     <span
       className={[
         'rounded border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em]',
         tone === 'cyan'
           ? 'border-cyan/35 bg-cyan/10 text-cyan'
-          : 'border-border/60 bg-bg2/60 text-silver-dk',
+          : tone === 'gold'
+            ? 'border-gold/35 bg-gold/10 text-gold'
+            : tone === 'green'
+              ? 'border-green/35 bg-green/10 text-green'
+              : 'border-border/60 bg-bg2/60 text-silver-dk',
       ].join(' ')}
     >
       {label}

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -202,7 +202,8 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(screen.getByTestId('raven-real-planner-canvas')).toBeTruthy();
     expect(screen.getByTestId('planner-telemetry-region').getAttribute('data-layout')).toBe('telemetry-context-panel');
     expect(screen.getByRole('complementary', { name: /Workspace summary/i })).toBeTruthy();
-    expect(screen.getByText('Whole-System Build Canvas')).toBeTruthy();
+    expect(screen.getByText('System Build Map')).toBeTruthy();
+    expect(screen.queryByText('Whole-System Build Canvas')).toBeNull();
     expect(screen.getByText('Planner summary')).toBeTruthy();
     expect(await screen.findByText('Whole-System Planner')).toBeTruthy();
     expect(screen.getByTestId('raven-real-body-row-body1')).toBeTruthy();
@@ -309,7 +310,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     await waitFor(() => {
       expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('slot-lane-orbital')).getByText('1/4 planned')).toBeTruthy();
-      expect(within(screen.getByTestId('slot-lane-items-orbital')).getByText(/Orbital Port/i)).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-orbital')).getAllByText(/Orbital Port/i).length).toBeGreaterThan(0);
       expect((screen.getByTestId('center-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
     });
 
@@ -318,7 +319,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('slot-lane-surface')).getByText('1/5 planned')).toBeTruthy();
-      expect(within(screen.getByTestId('slot-lane-items-surface')).getByText(/Surface Hub/i)).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-surface')).getAllByText(/Surface Hub/i).length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('workspace-economy-ledger')).getByText(/Agri/i)).toBeTruthy();
       expect(within(screen.getByTestId('body-planning-economy')).getByText(/Agri/i)).toBeTruthy();
     });
@@ -386,11 +387,11 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(within(await screen.findByTestId('body-structure-picker')).getByText(/Add orbit structure/i)).toBeTruthy();
     fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
-      expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Added Orbital Port to Body 1.');
+      expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Added Orbital Port to Body 1 / Orbit.');
       expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '')).toMatch(/Orbital|Port/i);
       expect(screen.getByTestId('raven-inline-body-expansion-1')).toBeTruthy();
       expect(within(screen.getByTestId('slot-lane-orbital')).getByText('1/4 planned')).toBeTruthy();
-      expect(within(screen.getByTestId('slot-lane-items-orbital')).getByText(/Orbital Port/i)).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-orbital')).getAllByText(/Orbital Port/i).length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('planner-status-strip')).getByText('1 planned')).toBeTruthy();
       expect(within(screen.getByTestId('planner-status-strip')).getByText('Unsaved changes')).toBeTruthy();
     });
@@ -400,8 +401,9 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     fireEvent.click(screen.getByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '')).toMatch(/Surface|Hub/i);
+      expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Body 1 / Surface');
       expect(within(screen.getByTestId('slot-lane-surface')).getByText('1/5 planned')).toBeTruthy();
-      expect(within(screen.getByTestId('slot-lane-items-surface')).getByText(/Surface Hub/i)).toBeTruthy();
+      expect(within(screen.getByTestId('slot-lane-items-surface')).getAllByText(/Surface Hub/i).length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('planner-status-strip')).getByText('2 planned')).toBeTruthy();
     });
 

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -330,7 +330,8 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.getByTestId('workspace-economy-ledger')).toBeTruthy();
     expect(screen.getByTestId('summary-economy-ledger')).toBeTruthy();
     expect(screen.getByRole('region', { name: /Raven-style real planner canvas/i })).toBeTruthy();
-    expect(screen.getByText('Whole-System Build Canvas')).toBeTruthy();
+    expect(screen.getByText('System Build Map')).toBeTruthy();
+    expect(screen.queryByText('Whole-System Build Canvas')).toBeNull();
     expect(screen.getByTestId('raven-real-body-row-body1')).toBeTruthy();
     expect(await screen.findByText('Whole-System Planner')).toBeTruthy();
     expect(screen.queryByTestId('selected-body-planner-canvas')).toBeNull();
@@ -426,13 +427,13 @@ describe('ColonyPlannerWorkspace', () => {
     expect(picker).toBeTruthy();
     expect(within(picker).getByText(/Add orbit structure/i)).toBeTruthy();
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
-    expect(screen.queryByTestId('body-structure-template-flex_lab')).toBeNull();
-    expect(within(picker).getByTestId('canvas-picker-compatibility-summary').textContent).toContain('2 incompatible hidden');
+    expect(screen.getByTestId('body-structure-template-flex_lab')).toBeTruthy();
+    expect(within(picker).getByTestId('canvas-picker-compatibility-summary').textContent).toContain('1 incompatible hidden');
     fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
 
     expect((screen.getByTestId('body1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
     expect(within(screen.getByTestId('slot-lane-orbital')).getByText('1/4 planned')).toBeTruthy();
-    expect(within(screen.getByTestId('slot-lane-items-orbital')).getByText(/Orbital Port/i)).toBeTruthy();
+    expect(within(screen.getByTestId('slot-lane-items-orbital')).getAllByText(/Orbital Port/i).length).toBeGreaterThan(0);
     expect(screen.queryByTestId('advanced-planner-content')).toBeNull();
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });

--- a/frontend-v2/src/features/colony-planner/PlannerStatusStrip.tsx
+++ b/frontend-v2/src/features/colony-planner/PlannerStatusStrip.tsx
@@ -9,6 +9,7 @@ export function PlannerStatusStrip({
   projectedCount,
   unsavedChanges,
   economyLedger,
+  prerequisiteIssueCount = 0,
 }: {
   selection: TopologySelection;
   planningFocusLabel: string | null;
@@ -16,6 +17,7 @@ export function PlannerStatusStrip({
   projectedCount: number;
   unsavedChanges: boolean;
   economyLedger: PlanningEconomyLedger;
+  prerequisiteIssueCount?: number;
 }) {
   const title = selection.type === 'body' || selection.type === 'placement' || selection.type === 'projected-placement'
     ? 'Body Planner'
@@ -36,6 +38,7 @@ export function PlannerStatusStrip({
         <div className="flex flex-wrap gap-1.5" aria-label="Planner status">
           <StatusChip label={`${placementCount} planned`} tone={placementCount > 0 ? 'orange' : 'silver'} />
           {projectedCount > 0 && <StatusChip label={`${projectedCount} projected`} tone="cyan" />}
+          {prerequisiteIssueCount > 0 && <StatusChip label={`${prerequisiteIssueCount} prerequisite warning${prerequisiteIssueCount === 1 ? '' : 's'}`} tone="gold" />}
           <StatusChip label={unsavedChanges ? 'Unsaved changes' : 'Saved locally'} tone={unsavedChanges ? 'gold' : 'silver'} />
         </div>
       </div>

--- a/frontend-v2/src/features/colony-planner/ProjectedStructureSlot.tsx
+++ b/frontend-v2/src/features/colony-planner/ProjectedStructureSlot.tsx
@@ -1,6 +1,7 @@
 import type { FacilityTemplate, SimulateBuildPlacement } from '@/types/api';
 import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import { normalisePlanningEconomy, type PlanningEconomyName } from './planningEconomy';
+import { contextualEconomyLabel, structureFamilyLabel, templateDisplayName } from './structurePlanningRules';
 
 export function ProjectedStructureSlot({
   item,
@@ -23,8 +24,9 @@ export function ProjectedStructureSlot({
       : location === 'both'
         ? 'Orbit or Surface'
         : 'Unknown';
-  const label = item.template?.name ?? item.placement.facility_template_id;
+  const label = item.template ? templateDisplayName(item.template) : item.placement.facility_template_id;
   const economy = normalisePlanningEconomy(item.template?.economy);
+  const economyContext = contextualEconomyLabel(item.template);
   const className = [
     'relative flex min-h-[3.75rem] min-w-[11rem] flex-col justify-between overflow-hidden rounded border border-cyan/35 bg-cyan/8 px-2 py-2 pb-3 text-left',
     selected ? 'ring-2 ring-cyan/70 shadow-[0_0_18px_rgba(125,211,252,0.18)]' : '',
@@ -37,9 +39,16 @@ export function ProjectedStructureSlot({
       </div>
       <div className="mt-1 flex flex-wrap gap-1">
         <SlotChip label={locationLabel} />
+        {item.template && <SlotChip label={structureFamilyLabel(item.template)} />}
         {item.template?.economy && <SlotChip label={item.template.economy} />}
+        {!item.template?.economy && economyContext && <SlotChip label="contextual economy" />}
         <SlotChip label="projected" tone="strong" />
       </div>
+      {economyContext && (
+        <div data-testid="projected-structure-contextual-economy" className="mt-1 text-[10px] leading-snug text-cyan">
+          {economyContext}
+        </div>
+      )}
       {economy && <StructureEconomyMicroBar economy={economy} />}
     </>
   );

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -91,6 +91,41 @@ const templates: FacilityTemplate[] = [
     yellow_cp_cost: 0,
     green_cp_cost: 0,
   },
+  {
+    id: 'contextual_station',
+    name: 'Contextual Station',
+    category: 'port',
+    tier: 2,
+    economy: null,
+    is_port: true,
+    is_support_facility: false,
+    allowed_location: 'orbital',
+    pad_size: 'large',
+    confidence: 'observed',
+    notes: null,
+    yellow_cp_generated: 4,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
+  {
+    id: 'research_station',
+    name: 'Research Station',
+    category: 'hightech',
+    tier: 2,
+    economy: 'HighTech',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'orbital',
+    pad_size: null,
+    confidence: 'observed',
+    notes: null,
+    prerequisites: [{ description: 'Settlement - Research Bio' }],
+    yellow_cp_generated: 2,
+    green_cp_generated: 1,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
 ];
 
 const slotPredictions: SlotPredictionResponse = {
@@ -137,6 +172,15 @@ const snapshot: TopologyPlanSnapshot = {
 };
 
 describe('RavenStylePlannerCanvas real data adapter', () => {
+  it('renders user-facing build map copy and concise slot disclaimer', () => {
+    render(<RavenStylePlannerCanvas system={system} snapshot={snapshot} selection={{ type: 'system' }} onSelect={vi.fn()} />);
+
+    expect(screen.getByText('System Build Map')).toBeTruthy();
+    expect(screen.getByText('Plan structures directly into predicted orbital and surface slots.')).toBeTruthy();
+    expect(screen.queryByText('Whole-System Build Canvas')).toBeNull();
+    expect(screen.queryByText(/Real bodies, validated slot predictions/i)).toBeNull();
+  });
+
   it('maps real bodies, slot predictions, placements, projections, and economy metadata into rows', () => {
     const rows = buildRavenPlannerRows(system, snapshot);
     const body = rows.find((row) => row.id === '2');
@@ -244,6 +288,42 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
 
     fireEvent.click(screen.getByTestId('2-ground-slot-0'));
     expect(onRequestAddStructure).toHaveBeenCalledWith('2', 'surface');
+
+    expect(screen.getByRole('button', { name: /Add orbit structure to Real Data System A 1 from empty slot/i })).toBeTruthy();
+    expect(screen.getByTestId('2-orbital-slot-1').textContent).toContain('+ Add');
+  });
+
+  it('keeps passive display slots from presenting button or hover affordances', () => {
+    render(<RavenStylePlannerCanvas system={system} snapshot={{ ...snapshot, placements: [], projection: null }} selection={{ type: 'system' }} onSelect={vi.fn()} />);
+
+    const unknownSlot = screen.getByTestId('3-orbital-slot-0');
+    expect(unknownSlot.tagName.toLowerCase()).toBe('span');
+    expect(unknownSlot.className).not.toContain('hover:-translate-y');
+  });
+
+  it('shows disabled surface lane reasons directly in the canvas', () => {
+    const onRequestAddStructure = vi.fn();
+    render(<RavenStylePlannerCanvas system={system} snapshot={{ ...snapshot, placements: [], projection: null }} selection={{ type: 'system' }} onSelect={vi.fn()} onRequestAddStructure={onRequestAddStructure} />);
+
+    expect(screen.getByTestId('3-ground-disabled-reason').textContent).toContain('Surface limited: non-landable body.');
+    expect((screen.getByTestId('3-ground-add') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('renders contextual station economy and prerequisite warnings on added structures', () => {
+    const contextualSnapshot: TopologyPlanSnapshot = {
+      ...snapshot,
+      placements: [
+        { facility_template_id: 'contextual_station', local_body_id: '2', is_primary_port: true, build_order: 1 },
+        { facility_template_id: 'research_station', local_body_id: '2', build_order: 2 },
+      ],
+      projection: null,
+    };
+
+    render(<RavenStylePlannerCanvas system={system} snapshot={contextualSnapshot} selection={{ type: 'placement', placementIndex: 0 }} onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId('raven-contextual-economy-chip')).toBeTruthy();
+    expect(screen.getByTitle(/Contextual - inherits from body\/system plan/i)).toBeTruthy();
+    expect(screen.getByTestId('raven-prerequisite-warning-chip')).toBeTruthy();
   });
 
   it('matches projected structures to large numeric system body ids', () => {

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -15,7 +15,6 @@ import type { TopologyPlanSnapshot, TopologySelection, TopologySelectionContext 
 import { SlotCapacityDots, type BodyPlannerLane } from './BodySlotPlanner';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import {
-  ESTIMATED_SLOT_LAYOUT_DISCLAIMER,
   buildBodyDataSlotEstimateMap,
   resolveSlotCapacity,
   systemBodyData,
@@ -27,6 +26,15 @@ import {
   type PlanningEconomyLedger,
   type PlanningEconomyName,
 } from './planningEconomy';
+import {
+  contextualEconomyLabel,
+  contextualRoleLabel,
+  laneDisabledReason,
+  missingPrerequisitesForPlacement,
+  prerequisiteSummaryLabel,
+  templateDisplayName,
+  type PrerequisiteIssue,
+} from './structurePlanningRules';
 
 type RavenLane = 'orbital' | 'ground';
 type RavenSlotKind = 'empty' | 'planned' | 'projected' | 'unknown' | 'overflow';
@@ -50,6 +58,8 @@ export interface RavenStructureSlot {
   projectionIndex: number | null;
   buildOrder: number | null;
   status: 'planned' | 'projected' | 'unknown';
+  economyContextLabel: string | null;
+  warningLabels: string[];
 }
 
 interface BgsTelemetryStat {
@@ -109,6 +119,7 @@ interface StructureBucketItem {
   template?: FacilityTemplate;
   index: number;
   projected: boolean;
+  warningLabels: string[];
 }
 
 const ECONOMY_COLORS: Record<PlanningEconomyName, string> = {
@@ -136,6 +147,7 @@ export function RavenStylePlannerCanvas({
   expandedBodyDetail,
   onSelect,
   onRequestAddStructure,
+  prerequisiteIssues = [],
 }: {
   system: SystemDetail;
   snapshot: TopologyPlanSnapshot;
@@ -143,6 +155,7 @@ export function RavenStylePlannerCanvas({
   expandedBodyDetail?: ReactNode;
   onSelect: (selection: TopologySelection) => void;
   onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
+  prerequisiteIssues?: PrerequisiteIssue[];
 }) {
   const rows = buildRavenPlannerRows(system, snapshot);
   const selectedBodyId = selection.type === 'body'
@@ -171,9 +184,9 @@ export function RavenStylePlannerCanvas({
             <Network size={16} />
           </div>
           <div className="min-w-0">
-            <h2 className="font-display text-lg text-orange">Whole-System Build Canvas</h2>
+            <h2 className="font-display text-lg text-orange">System Build Map</h2>
             <p className="truncate text-xs leading-relaxed text-silver">
-              Real bodies, validated slot predictions, Build Plan placements, and selected Suggested Build projection.
+              Plan structures directly into predicted orbital and surface slots.
             </p>
           </div>
         </div>
@@ -186,7 +199,7 @@ export function RavenStylePlannerCanvas({
       </header>
       {hasEstimatedSlots && (
         <div data-testid="raven-slot-estimate-disclaimer" className="border-b border-gold/25 bg-gold/8 px-3 py-2 font-mono text-[10px] italic text-gold">
-          {ESTIMATED_SLOT_LAYOUT_DISCLAIMER}
+          Predicted slots - verify in Architect Mode.
         </div>
       )}
 
@@ -215,6 +228,7 @@ export function RavenStylePlannerCanvas({
                 gridStyle={gridStyle}
                 onSelect={onSelect}
                 onRequestAddStructure={onRequestAddStructure}
+                prerequisiteIssues={prerequisiteIssues}
               />
             ))}
           </div>
@@ -228,12 +242,14 @@ export function RavenPlannerTelemetryPanel({
   system,
   snapshot,
   economyLedger,
+  prerequisiteIssues = [],
   selectedContext,
   selection,
 }: {
   system: SystemDetail;
   snapshot: TopologyPlanSnapshot;
   economyLedger: PlanningEconomyLedger;
+  prerequisiteIssues?: PrerequisiteIssue[];
   selectedContext: TopologySelectionContext;
   selection: TopologySelection;
 }) {
@@ -247,7 +263,7 @@ export function RavenPlannerTelemetryPanel({
   const selectedProjectedCount = selectedBodyId ? countBodyPlacements(snapshot.projection?.placements ?? [], selectedBodyId) : 0;
   const bodyDetail = buildSelectedBodyTelemetryDetail(rows, snapshot, selection);
   const structureDetail = buildSelectedStructureTelemetryDetail(system, snapshot, selection);
-  const warningItems = buildTelemetryWarningItems(system, snapshot, economyLedger, selectedContext);
+  const warningItems = buildTelemetryWarningItems(system, snapshot, economyLedger, selectedContext, prerequisiteIssues);
 
   return (
     <aside
@@ -327,6 +343,7 @@ function RavenPlannerBodyRow({
   gridStyle,
   onSelect,
   onRequestAddStructure,
+  prerequisiteIssues,
 }: {
   row: RavenPlannerRow;
   selected: boolean;
@@ -336,12 +353,14 @@ function RavenPlannerBodyRow({
   gridStyle: CSSProperties;
   onSelect: (selection: TopologySelection) => void;
   onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
+  prerequisiteIssues: PrerequisiteIssue[];
 }) {
   const rowTone = selected
     ? 'bg-orange/10 shadow-[inset_3px_0_0_rgba(255,122,20,0.95)]'
     : row.projected
-      ? 'bg-cyan/5 hover:bg-cyan/10'
-      : 'bg-transparent hover:bg-bg3/35';
+      ? 'bg-cyan/5'
+      : 'bg-transparent';
+  const surfaceDisabledReason = laneDisabledReason(row.body, 'surface');
 
   return (
     <div
@@ -368,6 +387,7 @@ function RavenPlannerBodyRow({
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
           onSelect={onSelect}
           onRequestAddStructure={onRequestAddStructure}
+          prerequisiteIssues={prerequisiteIssues}
         />
         <RavenSlotLane
           bodyId={row.id}
@@ -379,6 +399,8 @@ function RavenPlannerBodyRow({
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
           onSelect={onSelect}
           onRequestAddStructure={onRequestAddStructure}
+          disabledReason={surfaceDisabledReason}
+          prerequisiteIssues={prerequisiteIssues}
         />
       </div>
       {selected && expandedDetail && (
@@ -471,6 +493,8 @@ function RavenSlotLane({
   selectedProjectedPlacementIndex,
   onSelect,
   onRequestAddStructure,
+  disabledReason,
+  prerequisiteIssues,
 }: {
   bodyId: string;
   bodyName: string;
@@ -481,6 +505,8 @@ function RavenSlotLane({
   selectedProjectedPlacementIndex: number | null;
   onSelect: (selection: TopologySelection) => void;
   onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
+  disabledReason?: string | null;
+  prerequisiteIssues: PrerequisiteIssue[];
 }) {
   const knownCount = capacity == null ? '?' : String(capacity);
   const laneLabel = lane === 'orbital' ? `O${knownCount}` : `S${knownCount}`;
@@ -488,22 +514,23 @@ function RavenSlotLane({
   const addLabel = lane === 'orbital'
     ? `Add orbit structure to ${bodyName}`
     : `Add surface structure to ${bodyName}`;
-  const requestAdd = onRequestAddStructure
+  const requestAdd = onRequestAddStructure && !disabledReason
     ? () => onRequestAddStructure(bodyId, plannerLane)
     : undefined;
 
   return (
-    <div data-testid={`${bodyId}-${lane}-lane`} className="flex min-w-0 items-center gap-2 pr-2">
+    <div data-testid={`${bodyId}-${lane}-lane`} data-disabled={disabledReason ? 'true' : 'false'} className="flex min-w-0 items-center gap-2 pr-2">
       <span className="flex w-14 shrink-0 items-center gap-1 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">
         <span>{laneLabel}</span>
-        {requestAdd && (
+        {onRequestAddStructure && (
           <button
             type="button"
             data-testid={`${bodyId}-${lane}-add`}
             aria-label={addLabel}
-            title={addLabel}
+            title={disabledReason ?? `Quick ${addLabel.toLowerCase()}`}
+            disabled={Boolean(disabledReason)}
             onClick={requestAdd}
-            className="grid h-5 w-5 place-items-center rounded border border-orange/45 bg-orange/10 text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70"
+            className="grid h-5 w-5 place-items-center rounded border border-orange/45 bg-orange/10 text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70 disabled:cursor-not-allowed disabled:border-gold/35 disabled:bg-gold/10 disabled:text-gold/70 disabled:hover:bg-gold/10"
           >
             <Plus size={12} />
           </button>
@@ -520,8 +547,14 @@ function RavenSlotLane({
             selected={(slot.placementIndex != null && slot.placementIndex === selectedPlacementIndex) || (slot.projectionIndex != null && slot.projectionIndex === selectedProjectedPlacementIndex)}
             onSelect={onSelect}
             onAdd={slot.kind === 'empty' ? requestAdd : undefined}
+            warningCount={slot.placementIndex != null ? prerequisiteIssues.find((issue) => issue.placementIndex === slot.placementIndex)?.missing.length ?? 0 : 0}
           />
         ))}
+        {disabledReason && (
+          <span data-testid={`${bodyId}-${lane}-disabled-reason`} className="rounded border border-gold/35 bg-gold/10 px-1.5 py-1 font-mono text-[10px] text-gold">
+            {disabledReason}
+          </span>
+        )}
       </div>
     </div>
   );
@@ -535,6 +568,7 @@ function RavenSlotBox({
   selected,
   onSelect,
   onAdd,
+  warningCount = 0,
 }: {
   slot: RavenStructureSlot;
   lane: RavenLane;
@@ -543,10 +577,12 @@ function RavenSlotBox({
   selected: boolean;
   onSelect: (selection: TopologySelection) => void;
   onAdd?: () => void;
+  warningCount?: number;
 }) {
   const primaryEconomy = slot.economySegments[0]?.economy;
   const color = primaryEconomy ? ECONOMY_COLORS[primaryEconomy] : undefined;
   const isStructure = slot.kind === 'planned' || slot.kind === 'projected' || slot.kind === 'overflow';
+  const interactive = Boolean(onAdd || slot.placementIndex != null || slot.projectionIndex != null);
   const slotStyle: CSSProperties = {};
   if (slot.kind === 'planned' && color) {
     slotStyle.borderColor = color;
@@ -566,18 +602,22 @@ function RavenSlotBox({
         </span>
       )}
       <span data-testid={isStructure ? 'raven-structure-slot-pill' : undefined} className="max-w-full truncate">
-        {slot.label}
+        {slot.kind === 'empty' && onAdd ? '+ Add' : slot.label}
       </span>
       {slot.economySegments.length > 0 && <StructureEconomyMicroBar segments={slot.economySegments} />}
+      {slot.economyContextLabel && <span data-testid="raven-contextual-economy-chip" className="absolute bottom-0.5 left-1 right-1 truncate text-[8px] text-cyan">Contextual economy</span>}
+      {(warningCount > 0 || slot.warningLabels.length > 0) && (
+        <span data-testid="raven-prerequisite-warning-chip" className="absolute left-1 top-0.5 text-[8px] text-gold">REQ</span>
+      )}
     </>
   );
 
   const className = [
     'group/slot relative flex overflow-hidden rounded border px-1.5 text-center font-mono text-[10px] font-bold uppercase leading-tight transition',
     isStructure ? 'h-10 min-w-[94px] max-w-[138px] items-start justify-center pb-2.5 pt-3' : 'h-8 min-w-[74px] max-w-[112px] items-center justify-center',
-    'hover:-translate-y-0.5 hover:border-orange-lt hover:shadow-brand-glow',
+    interactive && 'hover:-translate-y-0.5 hover:border-orange-lt hover:shadow-brand-glow',
     selected && 'ring-2 ring-orange/70',
-    slot.kind === 'empty' && 'border-border/70 bg-bg2/75 text-silver-2',
+    slot.kind === 'empty' && (onAdd ? 'border-orange/45 bg-orange/10 text-orange' : 'border-border/70 bg-bg2/45 text-silver-2'),
     slot.kind === 'planned' && 'text-silver',
     slot.kind === 'projected' && 'border-dashed text-cyan opacity-80',
     slot.kind === 'unknown' && 'border-dashed border-gold/65 bg-gold/10 text-gold',
@@ -850,6 +890,9 @@ interface StructureTelemetryDetail {
   category: string;
   buildOrder: number | null;
   economySegments: RavenEconomySegment[];
+  economyContextLabel: string | null;
+  roleLabel: string | null;
+  prerequisiteWarnings: string[];
   strength: number | null;
 }
 
@@ -899,8 +942,21 @@ function SelectedStructureTelemetryCard({ detail }: { detail: StructureTelemetry
               tone={detail.status === 'projected' ? 'cyan' : 'orange'}
             />
           ))
-          : <TelemetryChip label="No economy metadata" tone="gold" />}
+          : detail.economyContextLabel
+            ? <TelemetryChip label="Contextual economy" tone="cyan" />
+            : <TelemetryChip label="No economy metadata" tone="gold" />}
+        {detail.roleLabel && <TelemetryChip label={detail.roleLabel} tone="cyan" />}
       </div>
+      {detail.economyContextLabel && (
+        <p data-testid="raven-telemetry-contextual-economy" className="mt-2 rounded border border-cyan/30 bg-cyan/8 px-2 py-1 font-mono text-[10px] leading-snug text-cyan">
+          {detail.economyContextLabel}
+        </p>
+      )}
+      {detail.prerequisiteWarnings.length > 0 && (
+        <p data-testid="raven-telemetry-prerequisite-warning" className="mt-2 rounded border border-gold/35 bg-gold/10 px-2 py-1 font-mono text-[10px] leading-snug text-gold">
+          Missing prerequisite: {detail.prerequisiteWarnings.join('; ')}
+        </p>
+      )}
       <p className="mt-2 break-all font-mono text-[10px] text-silver">{detail.templateId}</p>
     </section>
   );
@@ -993,6 +1049,9 @@ function buildSelectedStructureTelemetryDetail(
     category: template?.category ?? 'unknown variant',
     buildOrder: placement.build_order ?? null,
     economySegments: structureEconomySegments(template, projected),
+    economyContextLabel: contextualEconomyLabel(template),
+    roleLabel: contextualRoleLabel(template, placement),
+    prerequisiteWarnings: projected ? [] : missingPrerequisitesForPlacement(placement, snapshot.placements, snapshot.templates),
     strength,
   };
 }
@@ -1002,6 +1061,7 @@ function buildTelemetryWarningItems(
   snapshot: TopologyPlanSnapshot,
   economyLedger: PlanningEconomyLedger,
   selectedContext: TopologySelectionContext,
+  prerequisiteIssues: PrerequisiteIssue[] = [],
 ): string[] {
   const bodies = systemBodyData(system);
   const bodyIds = new Set(bodies.filter((body) => body.id != null).map((body) => bodyIdKey(body.id)));
@@ -1016,6 +1076,7 @@ function buildTelemetryWarningItems(
     unassigned > 0 ? `${unassigned} unassigned` : null,
     unknownBodies > 0 ? `${unknownBodies} unmatched body` : null,
     economyLedger.unknownCount > 0 ? `${economyLedger.unknownCount} no economy metadata` : null,
+    prerequisiteIssues.length > 0 ? prerequisiteSummaryLabel(prerequisiteIssues.length) : null,
     slotGaps > 0 ? `${Math.min(slotGaps, 99)} slot gap${slotGaps === 1 ? '' : 's'}` : null,
   ].filter((item): item is string => Boolean(item)).slice(0, 5);
 }
@@ -1298,7 +1359,8 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
       groundSlots: buildLaneSlots(node.id, 'ground', groundCapacity, groundStructures),
       bodyEconomy: bodyLedger,
       projected: projectedBodyIds.has(node.id),
-      warningCount: countRowWarnings(node.body, prediction, bodyLedger),
+      warningCount: countRowWarnings(node.body, prediction, bodyLedger)
+        + [...planned.orbital, ...planned.ground].filter((item) => item.warningLabels.length > 0).length,
     };
   });
 }
@@ -1421,7 +1483,13 @@ function bucketStructures(
     const template = templatesById.get(placement.facility_template_id);
     const lane = laneForPlacement(template, bodyById.get(bodyId));
     const current = buckets.get(bodyId) ?? emptyStructureBuckets();
-    current[lane].push({ placement, template, index, projected });
+    current[lane].push({
+      placement,
+      template,
+      index,
+      projected,
+      warningLabels: projected ? [] : missingPrerequisitesForPlacement(placement, placements, Array.from(templatesById.values())),
+    });
     buckets.set(bodyId, current);
   });
 
@@ -1465,8 +1533,10 @@ function structureSlot(bodyId: string, lane: RavenLane, item: StructureBucketIte
   const fullName = structureDisplayName(item.template, item.placement.facility_template_id);
   const segments = structureEconomySegments(item.template, item.projected);
   const status = item.projected ? 'projected' : 'planned';
+  const economyContext = contextualEconomyLabel(item.template);
+  const prerequisiteWarnings = item.warningLabels;
   const economyText = segments.length === 0
-    ? 'No economy metadata'
+    ? economyContext ?? 'No economy metadata'
     : segments.map((segment) => {
       const strength = segment.strength == null ? 'strength unavailable' : `+${segment.strength} CP strength`;
       return `${segment.economy} ${segment.share}% share | ${strength}`;
@@ -1477,12 +1547,17 @@ function structureSlot(bodyId: string, lane: RavenLane, item: StructureBucketIte
     kind: item.projected ? 'projected' : 'planned',
     label: `${item.projected ? 'Ghost ' : ''}${compactStructureName(fullName)}`,
     fullName,
-    title: `${fullName} | Status: ${item.projected ? 'Projected Suggested Build' : 'Planned Build Plan'} | ${economyText}`,
+    title: [
+      `${fullName} | Status: ${item.projected ? 'Projected Suggested Build' : 'Planned Build Plan'} | ${economyText}`,
+      prerequisiteWarnings.length > 0 ? `Missing prerequisite: ${prerequisiteWarnings.join('; ')}` : null,
+    ].filter(Boolean).join(' | '),
     economySegments: segments,
     placementIndex: item.projected ? null : item.index,
     projectionIndex: item.projected ? item.index : null,
     buildOrder: item.placement.build_order ?? null,
     status,
+    economyContextLabel: economyContext,
+    warningLabels: prerequisiteWarnings,
   };
 }
 
@@ -1498,6 +1573,8 @@ function unknownSlot(bodyId: string, lane: RavenLane): RavenStructureSlot {
     projectionIndex: null,
     buildOrder: null,
     status: 'unknown',
+    economyContextLabel: null,
+    warningLabels: [],
   };
 }
 
@@ -1513,6 +1590,8 @@ function emptySlot(bodyId: string, lane: RavenLane, index: number, label = ''): 
     projectionIndex: null,
     buildOrder: null,
     status: 'unknown',
+    economyContextLabel: null,
+    warningLabels: [],
   };
 }
 
@@ -1529,6 +1608,8 @@ function overflowSlot(bodyId: string, lane: RavenLane, count: number): RavenStru
     projectionIndex: null,
     buildOrder: null,
     status: 'unknown',
+    economyContextLabel: null,
+    warningLabels: [],
   };
 }
 
@@ -1545,11 +1626,7 @@ function structureEconomySegments(template: FacilityTemplate | undefined, projec
 }
 
 function structureDisplayName(template: FacilityTemplate | undefined, fallback: string): string {
-  const displayCarrier = template as unknown as { display_name?: unknown } | undefined;
-  const displayName = typeof displayCarrier?.display_name === 'string'
-    ? displayCarrier.display_name.trim()
-    : '';
-  return displayName || template?.name || readableTemplateId(fallback);
+  return template ? templateDisplayName(template) : readableTemplateId(fallback);
 }
 
 function compactStructureName(name: string): string {
@@ -1591,7 +1668,7 @@ function laneForPlacement(template: FacilityTemplate | undefined, body: SystemBo
   const location = templateLocationKind(template);
   if (location === 'orbital') return 'orbital';
   if (location === 'surface') return 'ground';
-  if (location === 'both') return template.is_port ? 'orbital' : body?.is_landable === true && body.is_water_world !== true ? 'ground' : 'orbital';
+  if (location === 'both') return fallbackRavenLane(body);
   return fallbackRavenLane(body);
 }
 

--- a/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
@@ -541,8 +541,7 @@ function overviewLaneForTemplate(template: FacilityTemplate | undefined, body: S
   if (location === 'orbital') return 'orbital';
   if (location === 'surface') return 'surface';
   if (location === 'both') {
-    if (template.is_port) return 'orbital';
-    return body?.is_landable === true && body.is_water_world !== true ? 'surface' : 'orbital';
+    return fallbackOverviewLane(body);
   }
   return fallbackOverviewLane(body);
 }

--- a/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
@@ -5,15 +5,9 @@ import type { FacilityTemplate, SimulateBuildPlacement, SimulationSummary, Syste
 import { getFacilityTemplates, getSimulationSummary, getSlotPredictions } from '@/lib/api';
 import type { SimulationWorkspaceMode } from '@/features/system-detail/simulation-preview/WorkspaceModeTabs';
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
-import { bodyDisplayName } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
 import { archetypeFromEconomy, resequence } from '@/features/system-detail/simulation-preview/utils/placementHelpers';
 import type { BodyPlannerLane } from './BodySlotPlanner';
-import {
-  CanvasStructurePicker,
-  laneDisabledReason,
-  templateCanFitBody,
-  templateMatchesLane,
-} from './CanvasStructurePicker';
+import { CanvasStructurePicker } from './CanvasStructurePicker';
 import {
   describeTopologySelection,
   type TopologyPlanSnapshot,
@@ -27,6 +21,14 @@ import { getPlanningFocusLabel, type PlannerWorkspaceCommand } from './workspace
 import { buildPlanningEconomyLedger } from './planningEconomy';
 import { AdvancedPlannerDrawer } from './AdvancedPlannerDrawer';
 import { RavenPlannerTelemetryPanel, RavenStylePlannerCanvas } from './RavenStylePlannerCanvas';
+import {
+  buildPlanPrerequisiteIssues,
+  describePlacementTarget,
+  laneDisabledReason,
+  templateCanFitBody,
+  templateDisplayName,
+  templateMatchesLane,
+} from './structurePlanningRules';
 
 export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   const [selection, setSelection] = useState<TopologySelection>({ type: 'system' });
@@ -84,6 +86,12 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     setTargetArchetype((current) => current || suggestedArchetype);
   }, [placements.length, suggestedArchetype]);
 
+  useEffect(() => {
+    if (!structureAddFeedback || structureAddFeedback.tone !== 'success') return undefined;
+    const timeout = window.setTimeout(() => setStructureAddFeedback(null), 5000);
+    return () => window.clearTimeout(timeout);
+  }, [structureAddFeedback]);
+
   const planSnapshot = useMemo<TopologyPlanSnapshot>(() => ({
     placements,
     templates,
@@ -136,6 +144,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     projectedPlacements: projection?.placements ?? [],
     templates,
   }), [placements, projection?.placements, templates]);
+  const prerequisiteIssues = useMemo(() => buildPlanPrerequisiteIssues(placements, templates), [placements, templates]);
 
   const openAdvanced = useCallback((mode: SimulationWorkspaceMode = 'build-plan') => {
     setAdvancedInitialMode(mode);
@@ -176,7 +185,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     ]));
     return {
       ok: true as const,
-      message: `Added ${templateDisplayName(template)} to ${bodyDisplayName(body)}.`,
+      message: `Added ${templateDisplayName(template)} to ${describePlacementTarget(body, lane)}.`,
     };
   }, [system.bodies, templates]);
 
@@ -237,6 +246,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
           projectedCount={projection?.placements.length ?? 0}
           unsavedChanges={projectState.unsavedChanges}
           economyLedger={systemEconomyLedger}
+          prerequisiteIssueCount={prerequisiteIssues.length}
         />
         {(structurePicker || structureAddFeedback) && (
           <div className="space-y-2" data-testid="canvas-structure-picker-region">
@@ -258,6 +268,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
               body={pickerBody}
               lane={structurePicker?.lane ?? null}
               templates={templates}
+              placements={placements}
               templatesLoading={templatesQuery.isLoading}
               templatesErrorMessage={templatesQuery.isError ? templatesQuery.error?.message ?? 'Facility catalogue failed to load.' : null}
               onClose={() => setStructurePicker(null)}
@@ -290,6 +301,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
           ) : null}
           onSelect={setSelection}
           onRequestAddStructure={requestAddStructure}
+          prerequisiteIssues={prerequisiteIssues}
         />
         <AdvancedPlannerDrawer
           open={advancedPanelOpen}
@@ -347,6 +359,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
             system={system}
             snapshot={planSnapshot}
             economyLedger={systemEconomyLedger}
+            prerequisiteIssues={prerequisiteIssues}
             selectedContext={selectedContext}
             selection={selection}
           />
@@ -354,6 +367,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
             system={system}
             snapshot={planSnapshot}
             economyLedger={systemEconomyLedger}
+            prerequisiteIssues={prerequisiteIssues}
             selection={selection}
             selectedContext={selectedContext}
             projects={projectState.projects}
@@ -420,9 +434,4 @@ function projectionEqual(
   if (a.candidateId !== b.candidateId) return false;
   if (a.label !== b.label) return false;
   return placementsEqual(a.placements, b.placements);
-}
-
-function templateDisplayName(template: FacilityTemplate): string {
-  const displayName = (template as unknown as { display_name?: unknown }).display_name;
-  return typeof displayName === 'string' && displayName.trim() ? displayName.trim() : template.name;
 }

--- a/frontend-v2/src/features/colony-planner/WorkspaceSummaryRail.tsx
+++ b/frontend-v2/src/features/colony-planner/WorkspaceSummaryRail.tsx
@@ -12,11 +12,13 @@ import {
 } from './workspaceUtils';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import type { PlanningEconomyLedger } from './planningEconomy';
+import type { PrerequisiteIssue } from './structurePlanningRules';
 
 export function WorkspaceSummaryRail({
   system,
   snapshot,
   economyLedger,
+  prerequisiteIssues = [],
   selection,
   selectedContext,
   projects,
@@ -39,6 +41,7 @@ export function WorkspaceSummaryRail({
   system: SystemDetail;
   snapshot: TopologyPlanSnapshot;
   economyLedger: PlanningEconomyLedger;
+  prerequisiteIssues?: PrerequisiteIssue[];
   selection: TopologySelection;
   selectedContext: TopologySelectionContext;
   projects: ColonyProject[];
@@ -90,6 +93,7 @@ export function WorkspaceSummaryRail({
           placementCount={health.placementCount}
           projectedCount={snapshot.projection?.placements.length ?? 0}
           warningCount={health.warningCount}
+          prerequisiteIssueCount={prerequisiteIssues.length}
           economyLedger={economyLedger}
         />
       ) : (
@@ -121,6 +125,7 @@ export function WorkspaceSummaryRail({
             previewStatus={health.previewStatus}
             saveStatus={health.saveStatus}
             economyLedger={economyLedger}
+            prerequisiteIssues={prerequisiteIssues}
           />
 
           <SelectionSummaryCard selectedContext={selectedContext} />
@@ -143,6 +148,7 @@ function CompactSummary({
   placementCount,
   projectedCount,
   warningCount,
+  prerequisiteIssueCount,
   economyLedger,
 }: {
   saveStatus: string;
@@ -151,6 +157,7 @@ function CompactSummary({
   placementCount: number;
   projectedCount: number;
   warningCount: number;
+  prerequisiteIssueCount: number;
   economyLedger: PlanningEconomyLedger;
 }) {
   return (
@@ -158,7 +165,7 @@ function CompactSummary({
       <div className="grid grid-cols-2 gap-1.5">
         <CompactMetric label="Save" value={saveStatus} tone={saveStatus === 'Saved' ? 'green' : 'gold'} />
         <CompactMetric label="Builds" value={`${placementCount}${projectedCount > 0 ? ` +${projectedCount}` : ''}`} tone={projectedCount > 0 ? 'cyan' : 'orange'} />
-        <CompactMetric label="Warnings" value={String(warningCount)} tone={warningCount > 0 ? 'gold' : 'green'} />
+        <CompactMetric label="Warnings" value={prerequisiteIssueCount > 0 ? `${warningCount} / ${prerequisiteIssueCount} prereq` : String(warningCount)} tone={warningCount > 0 || prerequisiteIssueCount > 0 ? 'gold' : 'green'} />
         <CompactMetric label="Focus" value={selectedContext.kind} tone="cyan" />
       </div>
       <div className="rounded border border-border/55 bg-bg3/35 px-2 py-1 font-mono text-[10px]">
@@ -198,6 +205,7 @@ function PlanHealthCard({
   previewStatus,
   saveStatus,
   economyLedger,
+  prerequisiteIssues,
 }: {
   targetArchetype: string;
   placementCount: number;
@@ -206,6 +214,7 @@ function PlanHealthCard({
   previewStatus: string;
   saveStatus: string;
   economyLedger: PlanningEconomyLedger;
+  prerequisiteIssues: PrerequisiteIssue[];
 }) {
   return (
     <section className="rounded border border-orange/25 bg-orange/5 p-2" data-testid="plan-health-card">
@@ -217,9 +226,15 @@ function PlanHealthCard({
         <SummaryRow label="Placements" value={String(placementCount)} tone="orange" />
         <SummaryRow label="Unassigned" value={String(unassignedCount)} tone={unassignedCount > 0 ? 'gold' : 'green'} />
         <SummaryRow label="Warnings" value={String(warningCount)} tone={warningCount > 0 ? 'gold' : 'green'} />
+        <SummaryRow label="Prerequisites" value={String(prerequisiteIssues.length)} tone={prerequisiteIssues.length > 0 ? 'gold' : 'green'} />
         <SummaryRow label="Preview" value={previewStatus} tone="cyan" />
         <SummaryRow label="Save" value={saveStatus} tone={saveStatus === 'Saved' ? 'green' : 'gold'} />
       </dl>
+      {prerequisiteIssues.length > 0 && (
+        <div data-testid="plan-health-prerequisite-warnings" className="mt-2 rounded border border-gold/35 bg-gold/10 px-2 py-1 font-mono text-[10px] text-gold">
+          Missing prerequisite: {prerequisiteIssues.slice(0, 3).map((issue) => `${issue.templateName}: ${issue.missing.join('; ')}`).join(' / ')}
+        </div>
+      )}
       <div className="mt-2">
         <PlanningEconomyStrip ledger={economyLedger} compact testId="plan-health-economy-ledger" />
       </div>

--- a/frontend-v2/src/features/colony-planner/planningEconomy.ts
+++ b/frontend-v2/src/features/colony-planner/planningEconomy.ts
@@ -64,8 +64,10 @@ export function buildPlanningEconomyLedger({
   let unknownCount = 0;
 
   const add = (placement: SimulateBuildPlacement, kind: 'planned' | 'projected') => {
-    const economy = normalisePlanningEconomy(templatesById.get(placement.facility_template_id)?.economy);
+    const template = templatesById.get(placement.facility_template_id);
+    const economy = normalisePlanningEconomy(template?.economy);
     if (!economy) {
+      if (template?.is_port) return;
       unknownCount += 1;
       return;
     }

--- a/frontend-v2/src/features/colony-planner/structurePlanningRules.ts
+++ b/frontend-v2/src/features/colony-planner/structurePlanningRules.ts
@@ -1,0 +1,201 @@
+import type { FacilityTemplate, SimulateBuildPlacement, SystemBody } from '@/types/api';
+import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
+import { bodyDisplayName } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
+import { normalisePlanningEconomy } from './planningEconomy';
+import type { BodyPlannerLane } from './BodySlotPlanner';
+
+export interface PrerequisiteIssue {
+  placementIndex: number;
+  templateId: string;
+  templateName: string;
+  missing: string[];
+}
+
+export function laneDisabledReason(body: SystemBody, lane: BodyPlannerLane): string | null {
+  if (lane !== 'surface') return null;
+  if (body.is_water_world === true) return 'Surface limited: water world.';
+  if (body.is_landable === false) return 'Surface limited: non-landable body.';
+  return null;
+}
+
+export function templateMatchesLane(template: FacilityTemplate, lane: BodyPlannerLane): boolean {
+  const location = templateLocationKind(template);
+  if (lane === 'orbital') return location === 'orbital' || location === 'both';
+  return location === 'surface' || location === 'both';
+}
+
+export function templateCanFitBody(template: FacilityTemplate, body: SystemBody, lane: BodyPlannerLane): boolean {
+  if (laneDisabledReason(body, lane)) return false;
+  if (!templateMatchesLane(template, lane)) return false;
+  const location = templateLocationKind(template);
+  if (location === 'surface' || lane === 'surface') {
+    return body.is_landable === true && body.is_water_world !== true;
+  }
+  return true;
+}
+
+export function templateDisplayName(template: FacilityTemplate): string {
+  const displayName = (template as unknown as { display_name?: unknown }).display_name;
+  return typeof displayName === 'string' && displayName.trim() ? displayName.trim() : template.name;
+}
+
+export function structureFamilyLabel(template: FacilityTemplate): string {
+  const haystack = [
+    template.id,
+    template.name,
+    template.category,
+    template.allowed_location,
+  ].join(' ').toLowerCase();
+
+  if (haystack.includes('starport') || haystack.includes('coriolis') || haystack.includes('orbis') || haystack.includes('ocellus') || haystack.includes('dodecahedron')) {
+    return 'Station / starport';
+  }
+  if (haystack.includes('outpost')) return 'Outpost';
+  if (haystack.includes('installation')) return 'Installation';
+  if (haystack.includes('settlement')) return 'Settlement';
+  if (haystack.includes('hub')) return 'Hub';
+  if (template.is_port) return templateLocationKind(template) === 'surface' ? 'Planetary port' : 'Orbital port';
+  return readableLabel(template.category || 'Structure');
+}
+
+export function laneLabel(lane: BodyPlannerLane): string {
+  return lane === 'orbital' ? 'Orbit' : 'Surface';
+}
+
+export function isContextualEconomyTemplate(template: FacilityTemplate | undefined): boolean {
+  return Boolean(template?.is_port && !normalisePlanningEconomy(template.economy));
+}
+
+export function contextualEconomyLabel(template: FacilityTemplate | undefined): string | null {
+  if (!isContextualEconomyTemplate(template)) return null;
+  return 'Economy: Contextual - inherits from body/system plan. Run Preview for validated economy outcome.';
+}
+
+export function contextualRoleLabel(template: FacilityTemplate | undefined, placement?: SimulateBuildPlacement): string | null {
+  if (!isContextualEconomyTemplate(template)) return null;
+  if (placement?.is_primary_port) return 'Primary port';
+  return template?.is_port ? 'Port infrastructure' : 'Contextual infrastructure';
+}
+
+export function templatePrerequisiteDescriptions(template: FacilityTemplate | undefined): string[] {
+  const raw = (template as unknown as { prerequisites?: unknown } | undefined)?.prerequisites;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((item) => prerequisiteDescription(item))
+    .filter((item): item is string => Boolean(item));
+}
+
+export function missingPrerequisitesForTemplate(
+  template: FacilityTemplate | undefined,
+  placements: SimulateBuildPlacement[],
+  templates: FacilityTemplate[],
+): string[] {
+  const prerequisites = templatePrerequisiteDescriptions(template);
+  if (prerequisites.length === 0) return [];
+  const placedTemplates = placements
+    .map((placement) => templates.find((candidate) => candidate.id === placement.facility_template_id))
+    .filter((candidate): candidate is FacilityTemplate => Boolean(candidate));
+
+  return prerequisites.filter((description) => !placedTemplates.some((placedTemplate) => prerequisiteMatchesTemplate(description, placedTemplate)));
+}
+
+export function missingPrerequisitesForPlacement(
+  placement: SimulateBuildPlacement,
+  placements: SimulateBuildPlacement[],
+  templates: FacilityTemplate[],
+): string[] {
+  const template = templates.find((candidate) => candidate.id === placement.facility_template_id);
+  return missingPrerequisitesForTemplate(template, placements.filter((candidate) => candidate !== placement), templates);
+}
+
+export function buildPlanPrerequisiteIssues(
+  placements: SimulateBuildPlacement[],
+  templates: FacilityTemplate[],
+): PrerequisiteIssue[] {
+  return placements
+    .map((placement, placementIndex) => {
+      const template = templates.find((candidate) => candidate.id === placement.facility_template_id);
+      const missing = missingPrerequisitesForPlacement(placement, placements, templates);
+      return {
+        placementIndex,
+        templateId: placement.facility_template_id,
+        templateName: template ? templateDisplayName(template) : readableLabel(placement.facility_template_id),
+        missing,
+      };
+    })
+    .filter((issue) => issue.missing.length > 0);
+}
+
+export function prerequisiteSummaryLabel(issueCount: number): string {
+  return `${issueCount} prerequisite warning${issueCount === 1 ? '' : 's'}`;
+}
+
+export function describePlacementTarget(body: SystemBody, lane: BodyPlannerLane): string {
+  return `${bodyDisplayName(body)} / ${laneLabel(lane)}`;
+}
+
+function prerequisiteDescription(item: unknown): string | null {
+  if (typeof item === 'string') return item.trim() || null;
+  if (!item || typeof item !== 'object') return null;
+  const record = item as Record<string, unknown>;
+  const description = record.description;
+  if (typeof description === 'string' && description.trim()) return description.trim();
+  for (const key of ['facility', 'template', 'facility_template_id', 'prerequisite']) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return readableLabel(value);
+  }
+  const entries = Object.entries(record)
+    .map(([key, value]) => `${readableLabel(key)} ${typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' ? String(value) : ''}`.trim())
+    .filter(Boolean);
+  return entries.length > 0 ? entries.join(', ') : null;
+}
+
+function prerequisiteMatchesTemplate(description: string, template: FacilityTemplate): boolean {
+  const descriptionTokens = significantTokens(description);
+  if (descriptionTokens.length === 0) return false;
+  const candidateLabels = [
+    template.id,
+    template.name,
+    templateDisplayName(template),
+    template.category,
+    `${template.category} ${template.name}`,
+    `${structureFamilyLabel(template)} ${template.name}`,
+    sourceStructure(template),
+  ].filter((item): item is string => Boolean(item));
+
+  return candidateLabels.some((candidate) => {
+    const candidateTokens = significantTokens(candidate);
+    if (candidateTokens.length === 0) return false;
+    const candidateInDescription = candidateTokens.every((token) => descriptionTokens.includes(token));
+    const descriptionInCandidate = descriptionTokens.every((token) => candidateTokens.includes(token));
+    return candidateInDescription || descriptionInCandidate;
+  });
+}
+
+function sourceStructure(template: FacilityTemplate): string | null {
+  const sourceFields = (template.stat_effects as { source_fields?: unknown } | undefined)?.source_fields;
+  if (sourceFields && typeof sourceFields === 'object') {
+    const structure = (sourceFields as Record<string, unknown>).structure;
+    if (typeof structure === 'string') return structure;
+  }
+  return null;
+}
+
+function significantTokens(value: string): string[] {
+  return Array.from(new Set(
+    value
+      .toLowerCase()
+      .replace(/[_/|>➔→-]+/g, ' ')
+      .replace(/[^a-z0-9 ]+/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length > 2 && !['the', 'and', 'for', 'with'].includes(token)),
+  ));
+}
+
+function readableLabel(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}

--- a/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/StructurePickerTable.tsx
@@ -15,6 +15,13 @@ import {
   deriveStructurePickerGroupLabel,
   groupStructurePickerTemplates,
 } from './structurePickerGroupingUtils';
+import {
+  contextualEconomyLabel,
+  isContextualEconomyTemplate,
+  structureFamilyLabel,
+  templateDisplayName,
+  templatePrerequisiteDescriptions,
+} from '@/features/colony-planner/structurePlanningRules';
 
 export function StructurePickerTable({
   templates,
@@ -46,9 +53,11 @@ export function StructurePickerTable({
       if (!normalizedQuery) return true;
       return [
         template.name,
+        templateDisplayName(template),
         template.category,
         template.economy ?? '',
         template.allowed_location,
+        structureFamilyLabel(template),
         deriveStructurePickerGroupLabel(template),
       ].join(' ').toLowerCase().includes(normalizedQuery);
     });
@@ -172,17 +181,27 @@ export function StructurePickerTable({
                         ].join(' ')}
                       >
                         <td className="px-2 py-2 text-silver">
-                          <div className="font-semibold">{template.name}</div>
+                          <div className="font-semibold">{templateDisplayName(template)}</div>
                           <div className="mt-1 flex flex-wrap gap-1">
                             {template.is_port ? <Chip>Port</Chip> : null}
+                            <Chip>{structureFamilyLabel(template)}</Chip>
                             {isSelected ? <Chip tone="good">Current</Chip> : null}
                             {isProposed ? <Chip tone="warn">Proposed</Chip> : null}
+                            {templatePrerequisiteDescriptions(template).length > 0 ? <Chip tone="warn">Prerequisites</Chip> : null}
                           </div>
+                          {contextualEconomyLabel(template) && (
+                            <div className="mt-1 text-[10px] leading-snug text-cyan">{contextualEconomyLabel(template)}</div>
+                          )}
+                          {templatePrerequisiteDescriptions(template).length > 0 && (
+                            <div className="mt-1 text-[10px] leading-snug text-gold">
+                              Requires: {templatePrerequisiteDescriptions(template).join('; ')}
+                            </div>
+                          )}
                         </td>
                         <td className="px-2 py-2 text-silver-dk">{formatLocation(template.allowed_location)}</td>
                         <td className="px-2 py-2 text-silver-dk">{template.tier}</td>
                         <td className="px-2 py-2 text-silver-dk">{template.pad_size ?? 'Unknown'}</td>
-                        <td className="px-2 py-2 text-silver-dk">{template.economy ?? 'Unknown'}</td>
+                        <td className="px-2 py-2 text-silver-dk">{template.economy ?? (isContextualEconomyTemplate(template) ? 'Contextual' : 'Unknown')}</td>
                         <td className="px-2 py-2 text-silver-dk">{template.category}</td>
                         <td className="px-2 py-2 text-silver-dk">Y+{template.yellow_cp_generated} G+{template.green_cp_generated}</td>
                         <td className="px-2 py-2 text-silver-dk">Y{template.yellow_cp_cost} G{template.green_cp_cost}</td>

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -1866,6 +1866,10 @@ export interface components {
             confidence?: string | null;
             /** Notes */
             notes?: string | null;
+            /** Prerequisites */
+            prerequisites?: Record<string, unknown>[];
+            /** Economy Effects */
+            economy_effects?: Record<string, unknown>;
             /**
              * Yellow Cp Generated
              * @default 0

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -128,6 +128,8 @@ export interface FacilityTemplate {
   pad_size?: string | null;
   confidence?: string | null;
   notes?: string | null;
+  prerequisites?: Array<Record<string, unknown>> | null;
+  economy_effects?: Record<string, unknown> | null;
   yellow_cp_generated: number;
   green_cp_generated: number;
   yellow_cp_cost: number;


### PR DESCRIPTION
## Summary
- cleans up Raven canvas add-flow affordances and header copy
- centralizes lane/body/template compatibility for the canvas picker
- exposes catalogue prerequisite and economy-effect metadata to the frontend
- adds prerequisite warnings without blocking planned placements
- adds contextual station/port economy display and success feedback
- updates tests and Stage 17N documentation

## Root Cause
The Raven picker was filtering dual-location templates using `is_port`, which hid valid non-station orbital templates and valid surface templates. Port/station templates with no direct economy metadata also appeared empty instead of explaining their contextual economy behavior.

## Validation
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `cd frontend-v2 && npm test`
- `/home/brian/Documents/GitHub/ed-finder/.venv/bin/pytest tests/test_facility_catalogue.py tests/test_simulation_preview.py -q`
- `git diff --check`

## Artifacts
Captured locally under `.codex-artifacts/stage17n1b-add-flow-ux/` and intentionally not committed.