### PR TITLE
[codex] Stage 17N.1c Raven canvas clarity

### DIFF
--- a/docs/colonisation-redesign/engine-roadmap.md
+++ b/docs/colonisation-redesign/engine-roadmap.md
@@ -1798,6 +1798,45 @@ Remaining manual editing gaps:
 - no per-placement lane storage for truly flexible/unknown structures
 - prerequisite matching is catalogue-token based until the API provides normalized prerequisite target identifiers
 
+## Stage 17N.1c - Graphical Raven Canvas Declutter And Slot Correctness (Implemented)
+
+Stage 17N.1c tightens the manual Raven canvas after live review showed that the add flow worked but still looked too text-heavy and ambiguous.
+
+Delivered:
+
+- the whole-system Raven row is more graphical first:
+  - compact body tree markers and lane capacity chips carry the scan state
+  - selected rows expose the primary `Add Orbit` and `Add Surface` controls
+  - unselected rows suppress competing empty-slot add controls
+  - empty selected slots show a simple `+` add target instead of verbose repeated text
+  - station contextual economy is reduced to a compact `CTX` chip on the canvas, with the full explanation kept in tooltip/detail surfaces
+- lane correctness is shared between picker, Raven rows, selected-body detail, and overview summaries:
+  - orbital-only structures render only in orbital lanes
+  - surface-only structures render only in surface lanes
+  - dual-location/flexible placements use the selected add lane when the user added them directly
+  - dual-location/flexible placements without a lane hint render as compact `Needs lane` instead of being guessed into ground/surface
+- zero-slot lanes no longer create fake empty slot boxes; selected rows show compact `No orbital slots` or `No surface slots` state when useful
+- the picker heading is task-oriented (`Add to [body]`) with lane/count chips and search now includes family, tier, pad, economy, location, variant/name, and prerequisite text
+- selected-body detail uses the same lane hints and exposes unassigned/flexible placements separately instead of misclassifying them
+- projected ghost structures remain selectable context only and are never auto-loaded
+
+Preserved from 17N.1/17N.1b:
+
+- no Advanced Planner requirement for direct manual adds
+- no automatic Preview
+- no automatic Suggested Build generation
+- no projected candidate auto-load
+- prerequisite gaps warn but do not block planning
+- station/port economy remains contextual when direct template economy metadata is absent
+- no fake economy values
+
+Remaining manual editing gaps:
+
+- no drag/drop or slot index persistence
+- no normalized persisted lane field in the simulation request model
+- no one-click prerequisite insertion action yet
+- Architect observed slot truth remains a later stage
+
 ## Stage 18 - Colony Architect Assistant Foundation (Planned)
 
 Stage 18 should add an assistant foundation while keeping deterministic planner authority:

--- a/docs/colonisation-redesign/simulation-preview-ui-architecture.md
+++ b/docs/colonisation-redesign/simulation-preview-ui-architecture.md
@@ -1116,6 +1116,51 @@ Advanced Planner contract:
 - Raven adds write the same Build Plan state Advanced Planner reads.
 - Existing Simulation Preview picker views should use the same structure display language where practical, especially family labels, prerequisite warnings, and contextual station economy copy.
 
+## Stage 17N.1c Graphical Raven Canvas Contract
+
+Stage 17N.1c updates the manual Raven canvas toward the RavenColonial visual model: graphical slots and status markers first, text detail second.
+
+Canvas interaction contract:
+
+- unselected rows are scan-first and do not show competing add buttons or clickable-looking empty slots
+- selected rows show the primary add targets for each valid lane
+- empty selected slots use an unmistakable `+` target
+- occupied planned slots select planned placement context
+- projected ghost slots select projected placement context and never load the candidate
+- display-only capacity indicators must not use pointer/hover-lift treatment
+- zero-slot lanes render no fake empty boxes and no add target
+
+Lane correctness contract:
+
+- orbital-only templates render only in orbit lanes
+- surface-only templates render only in surface lanes
+- dual-location templates added from the Raven picker carry the chosen lane in local planner state
+- dual-location or unknown placements without a reliable lane hint render as `Needs lane`, including in selected-body detail and telemetry
+- picker filtering and canvas rendering must use the same compatibility/classification helpers so visible options and final slot placement agree
+
+Picker contract:
+
+- heading: `Add to [body]`
+- visible lane chip and compatible count
+- search covers display name, template name/variant, family, category, economy, tier, pad size, location, and prerequisite text
+- station/port templates without direct economy metadata show contextual economy language and do not invent values
+- missing prerequisites are warnings that allow selection, while hard-invalid lane/body placements remain blocked
+
+Safety boundary:
+
+- no Advanced Planner requirement for manual adds
+- no automatic Preview
+- no automatic Suggested Build generation
+- no candidate auto-load
+- no fake economy values
+- no drag/drop or Architect observed slot truth storage in this pass
+
+Remaining manual editing gaps:
+
+- no one-click add prerequisite action yet
+- no explicit persisted slot index
+- no normalized persisted lane field in backend simulation requests
+
 ## Stage 18 Assistant Foundation Boundary
 
 Planned assistant layer should sit above this architecture:

--- a/docs/colonisation-redesign/stage-17a-colony-architect-report.md
+++ b/docs/colonisation-redesign/stage-17a-colony-architect-report.md
@@ -492,3 +492,41 @@ Remaining manual editing gaps:
 - missing-prerequisite warnings do not yet include a one-click prerequisite insertion action
 - slot index and explicit lane storage are still absent from the simulation request model
 - prerequisite matching is based on catalogue descriptions/tokens until normalized prerequisite target IDs are available
+
+## Stage 17N.1c Graphical Declutter And Lane Correctness
+
+Stage 17N.1c keeps the same manual Raven add flow but changes how the canvas communicates it. The goal is that the build map can be scanned visually before the user has to read detail copy.
+
+Implemented behavior:
+
+- unselected body rows are primarily passive map rows: body marker, body name, compact slot indicators, planned/projected structure pills, and warnings
+- selected body rows expose the clear add targets for manual editing: `Add Orbit`, `Add Surface`, and selected empty-slot `+` targets
+- passive empty capacity is represented by compact dots or no visible box; inert empty boxes do not look like buttons
+- zero-slot lanes render no fake empty boxes and no add target; selected rows show a compact no-slot state when useful
+- the canvas and selected-body detail share the same lane classifier
+- orbital-only templates are displayed only in orbit lanes, surface-only templates only in surface lanes
+- dual-location placements added from the Raven picker keep the selected lane as a local lane hint
+- dual-location placements without a reliable lane hint are shown as `Needs lane` rather than guessed into ground
+- selected-structure telemetry reports `needs lane` for unresolved flexible placements
+- the picker now uses `Add to [body]`, lane chips, compatible counts, and search across display name, variant/name, family, category, economy, tier, pad, location, and prerequisite text
+
+RavenColonial visual direction adopted:
+
+- structure state is carried by slot pills, small status chips, economy micro-bars, warning chips, and tree/slot geometry rather than long repeated sentences
+- longer explanations such as contextual station economy and prerequisite details remain available in tooltips, selected structure detail, telemetry, or plan health
+- compact `CTX` and `REQ` chips mark contextual economy and prerequisite warning states on the main canvas
+
+Safety and passivity:
+
+- clicking projected ghost slots selects projection context only
+- opening the picker does not open Advanced Planner
+- adding from the picker does not run Preview, generate a Suggested Build, or load a projected candidate
+- prerequisites remain warnings, not blockers
+- hard-invalid physical placement remains blocked by lane/body compatibility checks
+
+Remaining manual editing gaps:
+
+- no drag/drop or slot index persistence
+- no backend-persisted per-placement lane field
+- no one-click prerequisite insertion action
+- no Architect observed slot storage

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.test.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.test.tsx
@@ -53,12 +53,12 @@ describe('BodySlotPlanner', () => {
     expect(orbitSlot.style.left).toContain('px');
     expect(orbitSlot.style.top).toContain('8.9rem');
     expect(orbitSlot.style.left).not.toContain('130px');
-    expect(orbitSlot.textContent).toBe('1');
+    expect(orbitSlot.textContent).toBe('+');
     expect(surfaceSlot.style.left).toContain('calc(50%');
     expect(surfaceSlot.style.left).toContain('px');
     expect(surfaceSlot.style.top).toContain('8.9rem');
     expect(surfaceSlot.style.left).not.toContain('92px');
-    expect(surfaceSlot.textContent).toBe('1');
+    expect(surfaceSlot.textContent).toBe('+');
     expect(screen.getByTestId('ring-orbital-slot-3')).toBeTruthy();
     expect(screen.getByTestId('ring-surface-slot-4')).toBeTruthy();
   });

--- a/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/BodySlotPlanner.tsx
@@ -4,14 +4,13 @@ import {
   bodyTags,
   getPlacementWarnings,
 } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
-import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import { BodySlotLane } from './BodySlotLane';
 import { BodyStructureSlot, type BodyStructureSlotItem } from './BodyStructureSlot';
 import { ProjectedStructureSlot } from './ProjectedStructureSlot';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
 import { buildPlanningEconomyLedger } from './planningEconomy';
 import { ESTIMATED_SLOT_LAYOUT_DISCLAIMER, resolveSlotCapacity, type BodyDataSlotEstimate } from './slotCapacityFallback';
-import { laneDisabledReason, missingPrerequisitesForPlacement } from './structurePlanningRules';
+import { laneDisabledReason, missingPrerequisitesForPlacement, placementLaneForTemplate, type PlacementLaneAssignment } from './structurePlanningRules';
 
 export type BodyPlannerLane = 'orbital' | 'surface';
 
@@ -35,6 +34,8 @@ export function BodySlotPlanner({
   bodyDataSlotEstimate,
   placements,
   projectedPlacements,
+  placementLaneHints = {},
+  projectedPlacementLaneHints = {},
   selectedPlacementIndex,
   selectedProjectedPlacementIndex,
   hasTemplates,
@@ -47,6 +48,8 @@ export function BodySlotPlanner({
   bodyDataSlotEstimate?: BodyDataSlotEstimate | null;
   placements: BodyPlannerPlacementItem[];
   projectedPlacements: BodyPlannerProjectedPlacementItem[];
+  placementLaneHints?: Record<number, BodyPlannerLane>;
+  projectedPlacementLaneHints?: Record<number, BodyPlannerLane>;
   selectedPlacementIndex: number | null;
   selectedProjectedPlacementIndex: number | null;
   hasTemplates: boolean;
@@ -57,11 +60,13 @@ export function BodySlotPlanner({
   const tags = bodyTags(body).slice(0, 2);
   const flags = bodyFlags(body);
 
-  const orbitalPlanned = placements.filter((item) => laneForTemplate(item.template, body) === 'orbital');
-  const surfacePlanned = placements.filter((item) => laneForTemplate(item.template, body) === 'surface');
+  const orbitalPlanned = placements.filter((item) => laneForItem(item, body, placementLaneHints) === 'orbital');
+  const surfacePlanned = placements.filter((item) => laneForItem(item, body, placementLaneHints) === 'surface');
+  const unassignedPlanned = placements.filter((item) => laneForItem(item, body, placementLaneHints) === 'unassigned');
 
-  const orbitalProjected = projectedPlacements.filter((item) => laneForTemplate(item.template, body) === 'orbital');
-  const surfaceProjected = projectedPlacements.filter((item) => laneForTemplate(item.template, body) === 'surface');
+  const orbitalProjected = projectedPlacements.filter((item) => laneForItem(item, body, projectedPlacementLaneHints) === 'orbital');
+  const surfaceProjected = projectedPlacements.filter((item) => laneForItem(item, body, projectedPlacementLaneHints) === 'surface');
+  const unassignedProjected = projectedPlacements.filter((item) => laneForItem(item, body, projectedPlacementLaneHints) === 'unassigned');
 
   const orbitalCapacity = resolveSlotCapacity(body, slotPrediction, 'orbital', bodyDataSlotEstimate);
   const surfaceCapacity = resolveSlotCapacity(body, slotPrediction, 'surface', bodyDataSlotEstimate);
@@ -70,6 +75,14 @@ export function BodySlotPlanner({
   const hasEstimatedSlots = orbitalCapacity.estimated || surfaceCapacity.estimated;
   const surfaceBlockedReason = laneDisabledReason(body, 'surface');
   const surfaceBlocked = Boolean(surfaceBlockedReason);
+  const orbitalAddDisabledReason = !hasTemplates
+    ? 'Facility catalogue loading.'
+    : orbitalSlots === 0
+      ? 'No orbital slots.'
+      : undefined;
+  const surfaceAddDisabledReason = !hasTemplates
+    ? 'Facility catalogue loading.'
+    : surfaceBlockedReason ?? (surfaceSlots === 0 ? 'No surface slots.' : undefined);
   const occupiedSlots = {
     orbital: orbitalPlanned.length + orbitalProjected.length,
     surface: surfacePlanned.length + surfaceProjected.length,
@@ -143,11 +156,11 @@ export function BodySlotPlanner({
         <BodySlotLane
           laneKey="orbital"
           label="Orbit"
-          helper="Ports, stations, and facilities in orbit."
+          helper="Stations and orbital facilities."
           slotStatus={laneSlotStatusLabel(orbitalSlots, orbitalPlanned.length, orbitalProjected.length)}
           onAdd={() => onAddLaneStructure('orbital')}
-          disabled={!hasTemplates}
-          disabledReason={!hasTemplates ? 'Facility catalogue loading.' : undefined}
+          disabled={Boolean(orbitalAddDisabledReason)}
+          disabledReason={orbitalAddDisabledReason}
         >
           <LaneCapacityMap
             laneKey="orbital"
@@ -158,11 +171,12 @@ export function BodySlotPlanner({
             selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
             onSelectPlacement={onSelectPlacement}
             onSelectProjectedPlacement={onSelectProjectedPlacement}
-            onAddEmptySlot={hasTemplates ? () => onAddLaneStructure('orbital') : undefined}
+            onAddEmptySlot={!orbitalAddDisabledReason ? () => onAddLaneStructure('orbital') : undefined}
           />
           <LaneSlots
             body={body}
             laneKey="orbital"
+            placementLane="orbital"
             allPlacements={placements}
             planned={orbitalPlanned}
             projected={orbitalProjected}
@@ -177,11 +191,11 @@ export function BodySlotPlanner({
         <BodySlotLane
           laneKey="surface"
           label="Surface"
-          helper="Planetary outposts and ground facilities."
+          helper="Ground ports and surface facilities."
           slotStatus={laneSlotStatusLabel(surfaceSlots, surfacePlanned.length, surfaceProjected.length)}
           onAdd={() => onAddLaneStructure('surface')}
-          disabled={!hasTemplates || surfaceBlocked}
-          disabledReason={!hasTemplates ? 'Facility catalogue loading.' : surfaceBlockedReason ?? undefined}
+          disabled={Boolean(surfaceAddDisabledReason)}
+          disabledReason={surfaceAddDisabledReason}
         >
           <LaneCapacityMap
             laneKey="surface"
@@ -192,11 +206,12 @@ export function BodySlotPlanner({
             selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
             onSelectPlacement={onSelectPlacement}
             onSelectProjectedPlacement={onSelectProjectedPlacement}
-            onAddEmptySlot={hasTemplates && !surfaceBlocked ? () => onAddLaneStructure('surface') : undefined}
+            onAddEmptySlot={!surfaceAddDisabledReason ? () => onAddLaneStructure('surface') : undefined}
           />
           <LaneSlots
             body={body}
             laneKey="surface"
+            placementLane="surface"
             allPlacements={placements}
             planned={surfacePlanned}
             projected={surfaceProjected}
@@ -208,6 +223,34 @@ export function BodySlotPlanner({
           />
         </BodySlotLane>
 
+        {(unassignedPlanned.length > 0 || unassignedProjected.length > 0) && (
+          <section data-testid="slot-lane-unassigned" className="rounded border border-gold/35 bg-gold/6 p-2.5">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="font-mono text-[11px] font-bold uppercase tracking-[0.12em] text-gold">Needs lane</div>
+              <span className="rounded border border-gold/35 bg-gold/10 px-1.5 py-0.5 font-mono text-[10px] text-gold">
+                {unassignedPlanned.length + unassignedProjected.length} unassigned
+              </span>
+            </div>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+              {unassignedPlanned.map((item) => (
+                <BodyStructureSlot
+                  key={`unassigned-planned-${item.index}-${item.placement.facility_template_id}`}
+                  item={toStructureSlotItem(item, body, placements, 'unassigned')}
+                  selected={selectedPlacementIndex === item.index}
+                  onSelect={() => onSelectPlacement(item.index)}
+                />
+              ))}
+              {unassignedProjected.map((item) => (
+                <ProjectedStructureSlot
+                  key={`unassigned-projected-${item.index}-${item.placement.facility_template_id}`}
+                  item={{ ...item, lane: 'unassigned' }}
+                  selected={selectedProjectedPlacementIndex === item.index}
+                  onSelect={() => onSelectProjectedPlacement(item.index)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
       </div>
     </section>
   );
@@ -379,7 +422,7 @@ function buildRingNodes({
     return {
       id: `${lane}-empty-${index}`,
       kind: 'empty' as const,
-      label: String(index + 1),
+      label: canAdd ? '+' : String(index + 1),
       title: canAdd
         ? `Add ${lane === 'orbital' ? 'orbit' : 'surface'} structure to slot ${index + 1}`
         : 'Empty slot',
@@ -624,7 +667,7 @@ function LaneCapacityMap({
           <CapacityCell
             key={cell.key}
             testId={`center-${laneKey}-slot-${index}`}
-            label={cell.label}
+            label={cell.label || (cell.onClick ? '+' : '')}
             fullLabel={cell.fullLabel}
             projected={cell.projected}
             selected={cell.selected}
@@ -692,6 +735,7 @@ function CapacityCell({
 function LaneSlots({
   body,
   laneKey,
+  placementLane,
   allPlacements,
   planned,
   projected,
@@ -703,6 +747,7 @@ function LaneSlots({
 }: {
   body: SystemBody;
   laneKey: BodyPlannerLane;
+  placementLane: BodyPlannerLane;
   allPlacements: BodyPlannerPlacementItem[];
   planned: BodyPlannerPlacementItem[];
   projected: BodyPlannerProjectedPlacementItem[];
@@ -728,7 +773,7 @@ function LaneSlots({
       {planned.map((item) => (
         <BodyStructureSlot
           key={`planned-${laneKey}-${item.index}-${item.placement.facility_template_id}`}
-          item={toStructureSlotItem(item, body, allPlacements)}
+          item={toStructureSlotItem(item, body, allPlacements, placementLane)}
           selected={selectedPlacementIndex === item.index}
           onSelect={() => onSelectPlacement(item.index)}
         />
@@ -736,7 +781,7 @@ function LaneSlots({
       {projected.map((item) => (
         <ProjectedStructureSlot
           key={`projected-${laneKey}-${item.index}-${item.placement.facility_template_id}`}
-          item={item}
+          item={{ ...item, lane: placementLane }}
           selected={selectedProjectedPlacementIndex === item.index}
           onSelect={() => onSelectProjectedPlacement(item.index)}
         />
@@ -745,7 +790,12 @@ function LaneSlots({
   );
 }
 
-function toStructureSlotItem(item: BodyPlannerPlacementItem, body: SystemBody, allPlacements: BodyPlannerPlacementItem[]): BodyStructureSlotItem {
+function toStructureSlotItem(
+  item: BodyPlannerPlacementItem,
+  body: SystemBody,
+  allPlacements: BodyPlannerPlacementItem[],
+  lane: BodyPlannerLane | 'unassigned',
+): BodyStructureSlotItem {
   const templates = allPlacements.map((candidate) => candidate.template).filter((template): template is FacilityTemplate => Boolean(template));
   const placementModels = allPlacements.map((candidate) => candidate.placement);
   const prerequisiteWarnings = missingPrerequisitesForPlacement(item.placement, placementModels, templates);
@@ -753,24 +803,18 @@ function toStructureSlotItem(item: BodyPlannerPlacementItem, body: SystemBody, a
     placement: item.placement,
     index: item.index,
     template: item.template,
+    lane,
     warningCount: getPlacementWarnings(item, body).length + prerequisiteWarnings.length,
     warningLabels: prerequisiteWarnings,
   };
 }
 
-function laneForTemplate(template: FacilityTemplate | undefined, body: SystemBody): BodyPlannerLane {
-  if (!template) return fallbackLaneForBody(body);
-  const location = templateLocationKind(template);
-  if (location === 'orbital') return 'orbital';
-  if (location === 'surface') return 'surface';
-  if (location === 'both') {
-    return fallbackLaneForBody(body);
-  }
-  return fallbackLaneForBody(body);
-}
-
-function fallbackLaneForBody(body: SystemBody): BodyPlannerLane {
-  return body.is_landable === true && body.is_water_world !== true ? 'surface' : 'orbital';
+function laneForItem(
+  item: BodyPlannerPlacementItem | BodyPlannerProjectedPlacementItem,
+  body: SystemBody,
+  laneHints: Record<number, BodyPlannerLane>,
+): PlacementLaneAssignment {
+  return placementLaneForTemplate(item.template, body, laneHints[item.index]);
 }
 
 function laneSlotStatusLabel(slotCount: number | null, plannedCount: number, projectedCount: number) {

--- a/frontend-v2/src/features/colony-planner/BodyStructureSlot.tsx
+++ b/frontend-v2/src/features/colony-planner/BodyStructureSlot.tsx
@@ -1,5 +1,6 @@
 import type { FacilityTemplate, SimulateBuildPlacement } from '@/types/api';
 import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
+import type { BodyPlannerLane } from './BodySlotPlanner';
 import { normalisePlanningEconomy, type PlanningEconomyName } from './planningEconomy';
 import { contextualEconomyLabel, contextualRoleLabel, structureFamilyLabel, templateDisplayName } from './structurePlanningRules';
 
@@ -7,6 +8,7 @@ export interface BodyStructureSlotItem {
   placement: SimulateBuildPlacement;
   index: number;
   template?: FacilityTemplate;
+  lane?: BodyPlannerLane | 'unassigned';
   warningCount?: number;
   warningLabels?: string[];
 }
@@ -21,13 +23,19 @@ export function BodyStructureSlot({
   onSelect: () => void;
 }) {
   const location = item.template ? templateLocationKind(item.template) : 'unknown';
-  const locationLabel = location === 'orbital'
+  const locationLabel = item.lane === 'orbital'
     ? 'Orbit'
-    : location === 'surface'
+    : item.lane === 'surface'
       ? 'Surface'
-      : location === 'both'
-        ? 'Orbit or Surface'
-        : 'Unknown';
+      : item.lane === 'unassigned'
+        ? 'Needs lane'
+        : location === 'orbital'
+          ? 'Orbit'
+          : location === 'surface'
+            ? 'Surface'
+            : location === 'both'
+              ? 'Orbit or Surface'
+              : 'Unknown';
   const label = item.template ? templateDisplayName(item.template) : item.placement.facility_template_id;
   const economy = normalisePlanningEconomy(item.template?.economy);
   const economyContext = contextualEconomyLabel(item.template);

--- a/frontend-v2/src/features/colony-planner/CanvasStructurePicker.test.tsx
+++ b/frontend-v2/src/features/colony-planner/CanvasStructurePicker.test.tsx
@@ -191,9 +191,9 @@ describe('CanvasStructurePicker', () => {
       />,
     );
 
-    expect(screen.getByRole('heading', { name: 'Body 1' })).toBeTruthy();
-    expect(screen.getByText(/Add orbit structure/i)).toBeTruthy();
-    expect(screen.getByText(/1 compatible option shown/i)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Add to Body 1' })).toBeTruthy();
+    expect(screen.getAllByText(/Orbit lane/i).length).toBeGreaterThan(0);
+    expect(screen.getByTestId('canvas-picker-compatible-count').textContent).toContain('1 compatible option');
     expect(screen.getByTestId('canvas-picker-compatibility-summary').textContent).toContain('1 incompatible hidden');
     expect(screen.getByTestId('body-structure-template-orbital_port')).toBeTruthy();
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
@@ -217,7 +217,8 @@ describe('CanvasStructurePicker', () => {
       />,
     );
 
-    expect(screen.getByText(/Add surface structure/i)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Add to Water World' })).toBeTruthy();
+    expect(screen.getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
     expect(screen.getByTestId('canvas-picker-disabled-reason').textContent).toContain('Surface limited: water world.');
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
   });

--- a/frontend-v2/src/features/colony-planner/CanvasStructurePicker.tsx
+++ b/frontend-v2/src/features/colony-planner/CanvasStructurePicker.tsx
@@ -64,10 +64,13 @@ export function CanvasStructurePicker({
           templateDisplayName(template),
           template.name,
           template.id,
+          structureFamilyLabel(template),
           template.category,
           template.economy ?? '',
           template.allowed_location,
           template.pad_size ?? '',
+          `tier ${template.tier}`,
+          ...templatePrerequisiteDescriptions(template),
         ].join(' ').toLowerCase().includes(normalisedQuery);
       })
       .sort((a, b) => (a.tier - b.tier) || templateDisplayName(a).localeCompare(templateDisplayName(b)))
@@ -88,13 +91,18 @@ export function CanvasStructurePicker({
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">
-            Add {laneLabel} structure
-          </div>
-          <h3 id="canvas-structure-picker-title" className="mt-0.5 text-base font-bold text-silver">
-            {bodyName}
+          <h3 id="canvas-structure-picker-title" className="text-base font-bold text-silver">
+            Add to {bodyName}
           </h3>
-          <p className="mt-0.5 font-mono text-[10px] text-silver-dk">
+          <p className="mt-1 flex flex-wrap items-center gap-1.5 font-mono text-[10px] text-silver-dk">
+            <PickerFact label={laneLabel === 'orbit' ? 'Orbit lane' : 'Surface lane'} tone="cyan" />
+            <span data-testid="canvas-picker-compatible-count">
+              {canSelectTemplate
+                ? `${visibleTemplates.length} compatible option${visibleTemplates.length === 1 ? '' : 's'}`
+                : `Picker is disabled for this ${laneLabel} lane.`}
+            </span>
+          </p>
+          <p className="sr-only">
             {canSelectTemplate
               ? `${visibleTemplates.length} compatible option${visibleTemplates.length === 1 ? '' : 's'} shown for this ${laneLabel} lane.`
               : `Picker is disabled for this ${laneLabel} lane.`}

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -288,12 +288,12 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     renderWorkspace();
 
     await screen.findByTestId('raven-real-body-row-1');
+    fireEvent.click(screen.getByTestId('topology-body-button-1'));
     await waitFor(() => {
       expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
       expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByTestId('topology-body-button-1'));
     await screen.findByText(/Planning focus:/i);
     expect(screen.getByTestId('raven-inline-body-expansion-1')).toBeTruthy();
     await waitFor(() => {
@@ -361,6 +361,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     renderWorkspace();
 
     await screen.findByTestId('raven-real-body-row-1');
+    fireEvent.click(screen.getByTestId('topology-body-button-1'));
     await waitFor(() => {
       expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
       expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
@@ -369,9 +370,9 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     fireEvent.click(screen.getByTestId('1-orbital-add'));
     const orbitalPicker = await screen.findByTestId('body-structure-picker');
     expect(orbitalPicker).toBeTruthy();
-    expect(within(orbitalPicker).getByRole('heading', { name: 'Body 1' })).toBeTruthy();
-    expect(within(orbitalPicker).getByText(/Add orbit structure/i)).toBeTruthy();
-    expect(within(orbitalPicker).getByText(/1 compatible option shown/i)).toBeTruthy();
+    expect(within(orbitalPicker).getByRole('heading', { name: 'Add to Body 1' })).toBeTruthy();
+    expect(within(orbitalPicker).getAllByText(/Orbit lane/i).length).toBeGreaterThan(0);
+    expect(within(orbitalPicker).getByTestId('canvas-picker-compatible-count').textContent).toContain('1 compatible option');
     expect(screen.getByTestId('body-structure-template-orbital_port')).toBeTruthy();
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
@@ -379,12 +380,12 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     fireEvent.click(screen.getByTestId('1-ground-add'));
     const surfaceAddPicker = await screen.findByTestId('body-structure-picker');
     expect(surfaceAddPicker).toBeTruthy();
-    expect(within(surfaceAddPicker).getByText(/Add surface structure/i)).toBeTruthy();
+    expect(within(surfaceAddPicker).getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
     expect(screen.getByTestId('body-structure-template-surface_hub')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
 
     fireEvent.click(screen.getByTestId('1-orbital-slot-3'));
-    expect(within(await screen.findByTestId('body-structure-picker')).getByText(/Add orbit structure/i)).toBeTruthy();
+    expect(within(await screen.findByTestId('body-structure-picker')).getAllByText(/Orbit lane/i).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
       expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Added Orbital Port to Body 1 / Orbit.');
@@ -397,7 +398,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     });
 
     fireEvent.click(screen.getByTestId('1-ground-slot-4'));
-    expect(within(await screen.findByTestId('body-structure-picker')).getByText(/Add surface structure/i)).toBeTruthy();
+    expect(within(await screen.findByTestId('body-structure-picker')).getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '')).toMatch(/Surface|Hub/i);

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -337,8 +337,8 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.queryByTestId('selected-body-planner-canvas')).toBeNull();
     expect(screen.queryByTestId('system-overview-planner-canvas')).toBeNull();
     expect(screen.queryByTestId('system-overview-map')).toBeNull();
-    expect(await screen.findByTestId('body1-orbital-slot-3')).toBeTruthy();
-    expect(screen.getByTestId('body1-ground-slot-4')).toBeTruthy();
+    expect(screen.queryByTestId('body1-orbital-slot-3')).toBeNull();
+    expect(screen.queryByTestId('body1-ground-slot-4')).toBeNull();
     expect(screen.getByTestId('advanced-workspace-toggle')).toBeTruthy();
     expect(screen.getByTestId('advanced-workspace-toggle').textContent).toContain('Open');
     expect(screen.queryByTestId('advanced-planner-content')).toBeNull();
@@ -365,6 +365,7 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.getByText(/Planning focus: Workspace System A 1/i)).toBeTruthy();
     expect(screen.getByTestId('raven-real-body-row-body1').getAttribute('data-expanded')).toBe('true');
     const inlineExpansion = screen.getByTestId('raven-inline-body-expansion-body1');
+    expect(await screen.findByTestId('body1-orbital-slot-3')).toBeTruthy();
     expect(within(screen.getByTestId('raven-real-planner-canvas')).getByTestId('raven-inline-body-expansion-body1')).toBeTruthy();
     expect(screen.queryByTestId('selected-role-summary-card')).toBeNull();
     expect(screen.queryByText('Body Hint')).toBeNull();
@@ -425,7 +426,8 @@ describe('ColonyPlannerWorkspace', () => {
 
     const picker = screen.getByTestId('body-structure-picker');
     expect(picker).toBeTruthy();
-    expect(within(picker).getByText(/Add orbit structure/i)).toBeTruthy();
+    expect(within(picker).getByRole('heading', { name: /Add to Workspace System A 1/i })).toBeTruthy();
+    expect(within(picker).getAllByText(/Orbit lane/i).length).toBeGreaterThan(0);
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
     expect(screen.getByTestId('body-structure-template-flex_lab')).toBeTruthy();
     expect(within(picker).getByTestId('canvas-picker-compatibility-summary').textContent).toContain('1 incompatible hidden');

--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.tsx
@@ -26,6 +26,7 @@ import {
   systemBodyData,
   type BodyDataSlotEstimate,
 } from './slotCapacityFallback';
+import type { BodyPlannerLane } from './BodySlotPlanner';
 
 export type TopologySelection =
   | { type: 'system' }
@@ -39,10 +40,12 @@ export interface TopologyPlanSnapshot {
   templates: FacilityTemplate[];
   targetArchetype: string;
   slotPredictions?: SlotPredictionResponse | null;
+  placementLaneHints?: Record<number, BodyPlannerLane>;
   projection?: {
     candidateId: string;
     label: string;
     placements: SimulateBuildPlacement[];
+    placementLaneHints?: Record<number, BodyPlannerLane>;
   } | null;
 }
 

--- a/frontend-v2/src/features/colony-planner/ProjectedStructureSlot.tsx
+++ b/frontend-v2/src/features/colony-planner/ProjectedStructureSlot.tsx
@@ -1,5 +1,6 @@
 import type { FacilityTemplate, SimulateBuildPlacement } from '@/types/api';
 import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
+import type { BodyPlannerLane } from './BodySlotPlanner';
 import { normalisePlanningEconomy, type PlanningEconomyName } from './planningEconomy';
 import { contextualEconomyLabel, structureFamilyLabel, templateDisplayName } from './structurePlanningRules';
 
@@ -12,18 +13,25 @@ export function ProjectedStructureSlot({
     placement: SimulateBuildPlacement;
     index: number;
     template?: FacilityTemplate;
+    lane?: BodyPlannerLane | 'unassigned';
   };
   selected?: boolean;
   onSelect?: () => void;
 }) {
   const location = item.template ? templateLocationKind(item.template) : 'unknown';
-  const locationLabel = location === 'orbital'
+  const locationLabel = item.lane === 'orbital'
     ? 'Orbit'
-    : location === 'surface'
+    : item.lane === 'surface'
       ? 'Surface'
-      : location === 'both'
-        ? 'Orbit or Surface'
-        : 'Unknown';
+      : item.lane === 'unassigned'
+        ? 'Needs lane'
+        : location === 'orbital'
+          ? 'Orbit'
+          : location === 'surface'
+            ? 'Surface'
+            : location === 'both'
+              ? 'Orbit or Surface'
+              : 'Unknown';
   const label = item.template ? templateDisplayName(item.template) : item.placement.facility_template_id;
   const economy = normalisePlanningEconomy(item.template?.economy);
   const economyContext = contextualEconomyLabel(item.template);

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -126,6 +126,23 @@ const templates: FacilityTemplate[] = [
     yellow_cp_cost: 0,
     green_cp_cost: 0,
   },
+  {
+    id: 'flexible_support',
+    name: 'Flexible Support Array',
+    category: 'support',
+    tier: 1,
+    economy: 'HighTech',
+    is_port: false,
+    is_support_facility: true,
+    allowed_location: 'surface_or_orbit',
+    pad_size: null,
+    confidence: 'estimated',
+    notes: null,
+    yellow_cp_generated: 1,
+    green_cp_generated: 0,
+    yellow_cp_cost: 0,
+    green_cp_cost: 0,
+  },
 ];
 
 const slotPredictions: SlotPredictionResponse = {
@@ -232,6 +249,75 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(screen.queryByText('Facilities and economy')).toBeNull();
   });
 
+  it('keeps lane display strict and leaves dual-location placements unassigned until a lane is known', () => {
+    const flexibleSnapshot: TopologyPlanSnapshot = {
+      ...snapshot,
+      placements: [
+        { facility_template_id: 'flexible_support', local_body_id: '2', build_order: 1 },
+      ],
+      projection: null,
+    };
+
+    const unassignedRow = buildRavenPlannerRows(system, flexibleSnapshot).find((row) => row.id === '2');
+    expect(unassignedRow?.orbitalSlots.some((slot) => slot.fullName === 'Flexible Support Array')).toBe(false);
+    expect(unassignedRow?.groundSlots.some((slot) => slot.fullName === 'Flexible Support Array')).toBe(false);
+    expect(unassignedRow?.unassignedSlots[0]).toEqual(expect.objectContaining({ fullName: 'Flexible Support Array' }));
+
+    const orbitalRow = buildRavenPlannerRows(system, {
+      ...flexibleSnapshot,
+      placementLaneHints: { 0: 'orbital' },
+    }).find((row) => row.id === '2');
+    expect(orbitalRow?.orbitalSlots[0]).toEqual(expect.objectContaining({ fullName: 'Flexible Support Array' }));
+    expect(orbitalRow?.groundSlots.some((slot) => slot.fullName === 'Flexible Support Array')).toBe(false);
+
+    const surfaceRow = buildRavenPlannerRows(system, {
+      ...flexibleSnapshot,
+      placementLaneHints: { 0: 'surface' },
+    }).find((row) => row.id === '2');
+    expect(surfaceRow?.groundSlots[0]).toEqual(expect.objectContaining({ fullName: 'Flexible Support Array' }));
+    expect(surfaceRow?.orbitalSlots.some((slot) => slot.fullName === 'Flexible Support Array')).toBe(false);
+  });
+
+  it('renders zero-slot lanes compactly without fake empty slot boxes or add targets', () => {
+    const zeroSlotSnapshot: TopologyPlanSnapshot = {
+      ...snapshot,
+      placements: [],
+      projection: null,
+      slotPredictions: {
+        ...slotPredictions,
+        predictions: [
+          {
+            ...slotPredictions.predictions[0],
+            predicted_orbital_slots: 0,
+            predicted_ground_slots: 0,
+          },
+        ],
+      },
+    };
+    const rows = buildRavenPlannerRows(system, zeroSlotSnapshot);
+    const row = rows.find((candidate) => candidate.id === '2');
+
+    expect(row?.orbitalSlots).toHaveLength(0);
+    expect(row?.groundSlots).toHaveLength(0);
+
+    render(
+      <RavenStylePlannerCanvas
+        system={system}
+        snapshot={zeroSlotSnapshot}
+        selection={{ type: 'body', bodyId: '2' }}
+        onSelect={vi.fn()}
+        onRequestAddStructure={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('2-orbital-slot-0')).toBeNull();
+    expect(screen.queryByTestId('2-ground-slot-0')).toBeNull();
+    expect(screen.getByTestId('2-orbital-compact-state').textContent).toContain('No orbital slots');
+    expect(screen.getByTestId('2-ground-compact-state').textContent).toContain('No surface slots');
+    expect(screen.queryByTestId('2-orbital-add')).toBeNull();
+    expect(screen.queryByTestId('2-ground-add')).toBeNull();
+  });
+
   it('expands selected bodies inline and supports projected structure selection', () => {
     render(
       <RavenStylePlannerCanvas
@@ -271,7 +357,7 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
             { facility_template_id: 'dodec_starport', local_body_id: '2', is_primary_port: true, build_order: 1 },
           ],
         }}
-        selection={{ type: 'system' }}
+        selection={{ type: 'body', bodyId: '2' }}
         onSelect={vi.fn()}
         onRequestAddStructure={onRequestAddStructure}
       />,
@@ -290,7 +376,7 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(onRequestAddStructure).toHaveBeenCalledWith('2', 'surface');
 
     expect(screen.getByRole('button', { name: /Add orbit structure to Real Data System A 1 from empty slot/i })).toBeTruthy();
-    expect(screen.getByTestId('2-orbital-slot-1').textContent).toContain('+ Add');
+    expect(screen.getByTestId('2-orbital-slot-1').textContent).toContain('+');
   });
 
   it('keeps passive display slots from presenting button or hover affordances', () => {
@@ -303,7 +389,7 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
 
   it('shows disabled surface lane reasons directly in the canvas', () => {
     const onRequestAddStructure = vi.fn();
-    render(<RavenStylePlannerCanvas system={system} snapshot={{ ...snapshot, placements: [], projection: null }} selection={{ type: 'system' }} onSelect={vi.fn()} onRequestAddStructure={onRequestAddStructure} />);
+    render(<RavenStylePlannerCanvas system={system} snapshot={{ ...snapshot, placements: [], projection: null }} selection={{ type: 'body', bodyId: '3' }} onSelect={vi.fn()} onRequestAddStructure={onRequestAddStructure} />);
 
     expect(screen.getByTestId('3-ground-disabled-reason').textContent).toContain('Surface limited: non-landable body.');
     expect((screen.getByTestId('3-ground-add') as HTMLButtonElement).disabled).toBe(true);

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -10,7 +10,6 @@ import {
   compactBodyDisplayName,
 } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
-import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import type { TopologyPlanSnapshot, TopologySelection, TopologySelectionContext } from './ColonyTopologyRail';
 import { SlotCapacityDots, type BodyPlannerLane } from './BodySlotPlanner';
 import { PlanningEconomyStrip } from './PlanningEconomyStrip';
@@ -31,12 +30,14 @@ import {
   contextualRoleLabel,
   laneDisabledReason,
   missingPrerequisitesForPlacement,
+  placementLaneForTemplate,
   prerequisiteSummaryLabel,
   templateDisplayName,
   type PrerequisiteIssue,
 } from './structurePlanningRules';
 
-type RavenLane = 'orbital' | 'ground';
+type RavenLane = 'orbital' | 'ground' | 'unassigned';
+type VisibleRavenLane = Exclude<RavenLane, 'unassigned'>;
 type RavenSlotKind = 'empty' | 'planned' | 'projected' | 'unknown' | 'overflow';
 type ProjectionComparisonView = 'bodies' | 'economy' | 'slots';
 
@@ -95,6 +96,7 @@ export interface RavenPlannerRow {
   groundCapacityEstimated: boolean;
   orbitalSlots: RavenStructureSlot[];
   groundSlots: RavenStructureSlot[];
+  unassignedSlots: RavenStructureSlot[];
   bodyEconomy: PlanningEconomyLedger;
   projected: boolean;
   warningCount: number;
@@ -206,7 +208,7 @@ export function RavenStylePlannerCanvas({
       <div className="overflow-x-auto">
         <div className="min-w-[860px]">
           <div
-            className="mb-4 grid border-b border-orange/20 bg-bg2/70 px-3 py-4 font-mono text-2xl font-bold uppercase tracking-wide text-silver"
+            className="grid border-b border-orange/20 bg-bg2/70 px-3 py-2 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-silver-dk"
             style={gridStyle}
           >
             <div className="text-cyan">System Tree</div>
@@ -387,6 +389,7 @@ function RavenPlannerBodyRow({
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
           onSelect={onSelect}
           onRequestAddStructure={onRequestAddStructure}
+          selectedBody={selected}
           prerequisiteIssues={prerequisiteIssues}
         />
         <RavenSlotLane
@@ -400,9 +403,38 @@ function RavenPlannerBodyRow({
           onSelect={onSelect}
           onRequestAddStructure={onRequestAddStructure}
           disabledReason={surfaceDisabledReason}
+          selectedBody={selected}
           prerequisiteIssues={prerequisiteIssues}
         />
       </div>
+      {row.unassignedSlots.length > 0 && (
+        <div
+          data-testid={`${row.id}-unassigned-lane`}
+          className="grid border-t border-gold/20 bg-gold/5 px-3 py-2"
+          style={gridStyle}
+        >
+          <div />
+          <div className="col-span-2 flex min-w-0 flex-wrap items-center gap-2">
+            <span className="rounded border border-gold/35 bg-gold/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-gold">
+              Needs lane
+            </span>
+            <div className="flex min-w-0 flex-wrap gap-1.5">
+              {row.unassignedSlots.map((slot, index) => (
+                <RavenSlotBox
+                  key={slot.id}
+                  slot={slot}
+                  lane="unassigned"
+                  bodyName={row.displayName}
+                  testId={`${row.id}-unassigned-slot-${index}`}
+                  selected={(slot.placementIndex != null && slot.placementIndex === selectedPlacementIndex) || (slot.projectionIndex != null && slot.projectionIndex === selectedProjectedPlacementIndex)}
+                  onSelect={onSelect}
+                  warningCount={slot.placementIndex != null ? prerequisiteIssues.find((issue) => issue.placementIndex === slot.placementIndex)?.missing.length ?? 0 : 0}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
       {selected && expandedDetail && (
         <div
           data-testid={`raven-inline-body-expansion-${row.id}`}
@@ -494,11 +526,12 @@ function RavenSlotLane({
   onSelect,
   onRequestAddStructure,
   disabledReason,
+  selectedBody,
   prerequisiteIssues,
 }: {
   bodyId: string;
   bodyName: string;
-  lane: RavenLane;
+  lane: VisibleRavenLane;
   capacity: number | null;
   slots: RavenStructureSlot[];
   selectedPlacementIndex: number | null;
@@ -506,6 +539,7 @@ function RavenSlotLane({
   onSelect: (selection: TopologySelection) => void;
   onRequestAddStructure?: (bodyId: string, lane: BodyPlannerLane) => void;
   disabledReason?: string | null;
+  selectedBody: boolean;
   prerequisiteIssues: PrerequisiteIssue[];
 }) {
   const knownCount = capacity == null ? '?' : String(capacity);
@@ -514,30 +548,35 @@ function RavenSlotLane({
   const addLabel = lane === 'orbital'
     ? `Add orbit structure to ${bodyName}`
     : `Add surface structure to ${bodyName}`;
-  const requestAdd = onRequestAddStructure && !disabledReason
+  const hasKnownZeroCapacity = capacity === 0;
+  const showAddControl = Boolean(selectedBody && onRequestAddStructure && !hasKnownZeroCapacity);
+  const requestAdd = showAddControl && onRequestAddStructure && !disabledReason
     ? () => onRequestAddStructure(bodyId, plannerLane)
     : undefined;
+  const visibleSlots = selectedBody ? slots : slots.filter((slot) => slot.kind !== 'empty');
+  const laneName = lane === 'orbital' ? 'orbital' : 'surface';
 
   return (
     <div data-testid={`${bodyId}-${lane}-lane`} data-disabled={disabledReason ? 'true' : 'false'} className="flex min-w-0 items-center gap-2 pr-2">
-      <span className="flex w-14 shrink-0 items-center gap-1 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">
-        <span>{laneLabel}</span>
-        {onRequestAddStructure && (
+      <span className="flex min-w-[7rem] shrink-0 items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">
+        <span className="rounded border border-cyan/25 bg-cyan/5 px-1.5 py-1">{laneLabel}</span>
+        {showAddControl && (
           <button
             type="button"
             data-testid={`${bodyId}-${lane}-add`}
             aria-label={addLabel}
-            title={disabledReason ?? `Quick ${addLabel.toLowerCase()}`}
+            title={disabledReason ?? addLabel}
             disabled={Boolean(disabledReason)}
             onClick={requestAdd}
-            className="grid h-5 w-5 place-items-center rounded border border-orange/45 bg-orange/10 text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70 disabled:cursor-not-allowed disabled:border-gold/35 disabled:bg-gold/10 disabled:text-gold/70 disabled:hover:bg-gold/10"
+            className="inline-flex items-center gap-1 rounded border border-orange/45 bg-orange/10 px-2 py-1 text-[10px] text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70 disabled:cursor-not-allowed disabled:border-gold/35 disabled:bg-gold/10 disabled:text-gold/70 disabled:hover:bg-gold/10"
           >
             <Plus size={12} />
+            {lane === 'orbital' ? 'Add Orbit' : 'Add Surface'}
           </button>
         )}
       </span>
       <div className="flex min-w-0 flex-wrap gap-1.5">
-        {slots.map((slot, index) => (
+        {visibleSlots.length > 0 ? visibleSlots.map((slot, index) => (
           <RavenSlotBox
             key={slot.id}
             slot={slot}
@@ -549,14 +588,67 @@ function RavenSlotLane({
             onAdd={slot.kind === 'empty' ? requestAdd : undefined}
             warningCount={slot.placementIndex != null ? prerequisiteIssues.find((issue) => issue.placementIndex === slot.placementIndex)?.missing.length ?? 0 : 0}
           />
-        ))}
-        {disabledReason && (
+        )) : (
+          <LaneCompactState
+            laneName={laneName}
+            capacity={capacity}
+            selectedBody={selectedBody}
+            disabledReason={disabledReason}
+            testId={`${bodyId}-${lane}-compact-state`}
+          />
+        )}
+        {selectedBody && disabledReason && (
           <span data-testid={`${bodyId}-${lane}-disabled-reason`} className="rounded border border-gold/35 bg-gold/10 px-1.5 py-1 font-mono text-[10px] text-gold">
             {disabledReason}
           </span>
         )}
       </div>
     </div>
+  );
+}
+
+function LaneCompactState({
+  laneName,
+  capacity,
+  selectedBody,
+  disabledReason,
+  testId,
+}: {
+  laneName: string;
+  capacity: number | null;
+  selectedBody: boolean;
+  disabledReason?: string | null;
+  testId: string;
+}) {
+  if (disabledReason && !selectedBody) {
+    return <span data-testid={testId} className="sr-only">{disabledReason}</span>;
+  }
+  if (capacity == null) {
+    return (
+      <span data-testid={testId} title={`${laneName} slot count unknown`} className="rounded border border-gold/35 bg-gold/10 px-2 py-1 font-mono text-[10px] text-gold">
+        ? slots
+      </span>
+    );
+  }
+  if (capacity <= 0) {
+    return selectedBody ? (
+      <span data-testid={testId} className="rounded border border-border/45 bg-bg3/30 px-2 py-1 font-mono text-[10px] text-silver-dk">
+        No {laneName} slots
+      </span>
+    ) : <span data-testid={testId} className="sr-only">No {laneName} slots</span>;
+  }
+  const dotCount = Math.min(capacity, 5);
+  return (
+    <span
+      data-testid={testId}
+      title={`${capacity} open ${laneName} slot${capacity === 1 ? '' : 's'}`}
+      className="inline-flex items-center gap-1 rounded border border-border/35 bg-bg3/25 px-2 py-1"
+    >
+      {Array.from({ length: dotCount }, (_unused, index) => (
+        <span key={index} className="h-1.5 w-1.5 rounded-full bg-silver-dk/70" />
+      ))}
+      {capacity > dotCount && <span className="font-mono text-[9px] text-silver-dk">+{capacity - dotCount}</span>}
+    </span>
   );
 }
 
@@ -602,10 +694,10 @@ function RavenSlotBox({
         </span>
       )}
       <span data-testid={isStructure ? 'raven-structure-slot-pill' : undefined} className="max-w-full truncate">
-        {slot.kind === 'empty' && onAdd ? '+ Add' : slot.label}
+        {slot.kind === 'empty' && onAdd ? '+' : slot.label}
       </span>
       {slot.economySegments.length > 0 && <StructureEconomyMicroBar segments={slot.economySegments} />}
-      {slot.economyContextLabel && <span data-testid="raven-contextual-economy-chip" className="absolute bottom-0.5 left-1 right-1 truncate text-[8px] text-cyan">Contextual economy</span>}
+      {slot.economyContextLabel && <span data-testid="raven-contextual-economy-chip" className="absolute bottom-0.5 left-1 right-1 truncate text-[8px] text-cyan">CTX</span>}
       {(warningCount > 0 || slot.warningLabels.length > 0) && (
         <span data-testid="raven-prerequisite-warning-chip" className="absolute left-1 top-0.5 text-[8px] text-gold">REQ</span>
       )}
@@ -672,7 +764,7 @@ function RavenSlotBox({
   );
 }
 
-function ravenLaneToPlannerLane(lane: RavenLane): BodyPlannerLane {
+function ravenLaneToPlannerLane(lane: VisibleRavenLane): BodyPlannerLane {
   return lane === 'ground' ? 'surface' : 'orbital';
 }
 
@@ -844,6 +936,7 @@ function ProjectionSlotsView({ summary }: { summary: ProjectionComparisonSummary
     <div className="mt-2 grid grid-cols-2 gap-1.5" data-testid="projection-comparison-slots">
       <ProjectionMetric label="Ghost orbit" value={summary.projectedOrbitalCount} tone="cyan" />
       <ProjectionMetric label="Ghost surface" value={summary.projectedGroundCount} tone="cyan" />
+      <ProjectionMetric label="Needs lane" value={summary.projectedUnknownLaneCount} tone={summary.projectedUnknownLaneCount > 0 ? 'gold' : 'green'} />
       <ProjectionMetric label="Overflow risks" value={summary.slotOverflowCount} tone={summary.slotOverflowCount > 0 ? 'gold' : 'green'} />
     </div>
   );
@@ -885,7 +978,7 @@ interface StructureTelemetryDetail {
   name: string;
   templateId: string;
   status: 'planned' | 'projected';
-  lane: 'orbital' | 'ground';
+  lane: RavenLane;
   bodyName: string;
   category: string;
   buildOrder: number | null;
@@ -928,7 +1021,7 @@ function SelectedStructureTelemetryCard({ detail }: { detail: StructureTelemetry
       </div>
       <div className="mt-2 text-sm font-semibold leading-snug text-silver">{detail.name}</div>
       <div className="mt-2 grid grid-cols-2 gap-2">
-        <TelemetryField label="Lane" value={`${detail.lane === 'ground' ? 'surface' : 'orbit'} / ${detail.bodyName}`} tone="cyan" />
+        <TelemetryField label="Lane" value={`${detail.lane === 'unassigned' ? 'needs lane' : detail.lane === 'ground' ? 'surface' : 'orbit'} / ${detail.bodyName}`} tone="cyan" />
         <TelemetryField label="Build order" value={detail.buildOrder == null ? 'n/a' : `#${detail.buildOrder}`} />
         <TelemetryField label="Variant" value={detail.category} />
         <TelemetryField label="Strength" value={detail.strength == null ? 'n/a' : `+${detail.strength} CP`} tone={detail.strength ? 'green' : 'silver'} />
@@ -1038,7 +1131,11 @@ function buildSelectedStructureTelemetryDetail(
   const body = bodyId
     ? systemBodyData(system).find((candidate) => sameBodyId(candidate.id, bodyId))
     : null;
-  const lane = laneForPlacement(template, body ?? undefined);
+  const lane = ravenLaneForPlacement(
+    template,
+    body ?? undefined,
+    projected ? snapshot.projection?.placementLaneHints?.[selection.placementIndex] : snapshot.placementLaneHints?.[selection.placementIndex],
+  );
   const strength = template ? Math.max(0, (template.yellow_cp_generated ?? 0) + (template.green_cp_generated ?? 0)) : null;
   return {
     name: structureDisplayName(template, placement.facility_template_id),
@@ -1320,8 +1417,8 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
       .filter((body) => body.id != null)
       .map((body) => [bodyIdKey(body.id), body]),
   );
-  const plannedByBody = bucketStructures(snapshot.placements, templatesById, bodyById, false);
-  const projectedByBody = bucketStructures(snapshot.projection?.placements ?? [], templatesById, bodyById, true);
+  const plannedByBody = bucketStructures(snapshot.placements, templatesById, bodyById, false, snapshot.placementLaneHints);
+  const projectedByBody = bucketStructures(snapshot.projection?.placements ?? [], templatesById, bodyById, true, snapshot.projection?.placementLaneHints);
   const projectedBodyIds = new Set(Array.from(projectedByBody.keys()));
 
   return flattenBodyNodes(bodies).map((node) => {
@@ -1331,13 +1428,14 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
     const projected = projectedByBody.get(node.id) ?? emptyStructureBuckets();
     const orbitalStructures = [...planned.orbital, ...projected.orbital];
     const groundStructures = [...planned.ground, ...projected.ground];
+    const unassignedStructures = [...planned.unassigned, ...projected.unassigned];
     const orbitalSlotCapacity = resolveSlotCapacity(node.body, prediction, 'orbital', bodyDataSlotEstimate);
     const groundSlotCapacity = resolveSlotCapacity(node.body, prediction, 'surface', bodyDataSlotEstimate);
     const orbitalCapacity = orbitalSlotCapacity.value;
     const groundCapacity = groundSlotCapacity.value;
     const bodyLedger = buildPlanningEconomyLedger({
-      placements: [...planned.orbital, ...planned.ground].map((item) => item.placement),
-      projectedPlacements: [...projected.orbital, ...projected.ground].map((item) => item.placement),
+      placements: [...planned.orbital, ...planned.ground, ...planned.unassigned].map((item) => item.placement),
+      projectedPlacements: [...projected.orbital, ...projected.ground, ...projected.unassigned].map((item) => item.placement),
       templates: snapshot.templates,
     });
 
@@ -1357,10 +1455,11 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
       groundCapacityEstimated: groundSlotCapacity.estimated,
       orbitalSlots: buildLaneSlots(node.id, 'orbital', orbitalCapacity, orbitalStructures),
       groundSlots: buildLaneSlots(node.id, 'ground', groundCapacity, groundStructures),
+      unassignedSlots: unassignedStructures.map((item, index) => structureSlot(node.id, 'unassigned', item, index)),
       bodyEconomy: bodyLedger,
       projected: projectedBodyIds.has(node.id),
       warningCount: countRowWarnings(node.body, prediction, bodyLedger)
-        + [...planned.orbital, ...planned.ground].filter((item) => item.warningLabels.length > 0).length,
+        + [...planned.orbital, ...planned.ground, ...planned.unassigned].filter((item) => item.warningLabels.length > 0).length,
     };
   });
 }
@@ -1414,11 +1513,17 @@ export function buildProjectionComparison(
   const laneCounts = (snapshot.projection?.placements ?? []).reduce((counts, placement) => {
     const bodyId = placementBodyId(placement);
     const template = templatesById.get(placement.facility_template_id);
-    const lane = laneForPlacement(template, bodyId ? bodyById.get(bodyId) : undefined);
+    const lane = ravenLaneForPlacement(
+      template,
+      bodyId ? bodyById.get(bodyId) : undefined,
+      snapshot.projection?.placementLaneHints?.[counts.index],
+    );
     if (lane === 'orbital') counts.orbital += 1;
-    else counts.ground += 1;
+    else if (lane === 'ground') counts.ground += 1;
+    else counts.unknown += 1;
+    counts.index += 1;
     return counts;
-  }, { orbital: 0, ground: 0 });
+  }, { orbital: 0, ground: 0, unknown: 0, index: 0 });
   const slotOverflowCount = rows.reduce((sum, row) => (
     sum
       + row.orbitalSlots.filter((slot) => slot.kind === 'overflow').length
@@ -1437,7 +1542,7 @@ export function buildProjectionComparison(
     plannedOnlyBodyLabels: bodyLabelsForIds(plannedOnlyBodyIds, bodyById, system.name),
     projectedOrbitalCount: laneCounts.orbital,
     projectedGroundCount: laneCounts.ground,
-    projectedUnknownLaneCount: 0,
+    projectedUnknownLaneCount: laneCounts.unknown,
     slotOverflowCount,
     economyDeltas: economyLedger.entries.map((entry) => ({
       economy: entry.economy,
@@ -1474,6 +1579,7 @@ function bucketStructures(
   templatesById: Map<string, FacilityTemplate>,
   bodyById: Map<string, SystemBody>,
   projected: boolean,
+  laneHints: Record<number, BodyPlannerLane> = {},
 ) {
   const buckets = new Map<string, ReturnType<typeof emptyStructureBuckets>>();
 
@@ -1481,7 +1587,7 @@ function bucketStructures(
     const bodyId = placementBodyId(placement);
     if (!bodyId || !bodyById.has(bodyId)) return;
     const template = templatesById.get(placement.facility_template_id);
-    const lane = laneForPlacement(template, bodyById.get(bodyId));
+    const lane = ravenLaneForPlacement(template, bodyById.get(bodyId), laneHints[index]);
     const current = buckets.get(bodyId) ?? emptyStructureBuckets();
     current[lane].push({
       placement,
@@ -1500,6 +1606,7 @@ function emptyStructureBuckets() {
   return {
     orbital: [] as StructureBucketItem[],
     ground: [] as StructureBucketItem[],
+    unassigned: [] as StructureBucketItem[],
   };
 }
 
@@ -1517,7 +1624,7 @@ function buildLaneSlots(
   }
 
   if (capacity <= 0) {
-    if (structures.length === 0) return [emptySlot(bodyId, lane, 0, '0')];
+    if (structures.length === 0) return [];
     return [overflowSlot(bodyId, lane, structures.length)];
   }
 
@@ -1663,17 +1770,14 @@ function readableTemplateId(value: string): string {
     .replace(/\b\w/g, (character) => character.toUpperCase());
 }
 
-function laneForPlacement(template: FacilityTemplate | undefined, body: SystemBody | undefined): 'orbital' | 'ground' {
-  if (!template) return fallbackRavenLane(body);
-  const location = templateLocationKind(template);
-  if (location === 'orbital') return 'orbital';
-  if (location === 'surface') return 'ground';
-  if (location === 'both') return fallbackRavenLane(body);
-  return fallbackRavenLane(body);
-}
-
-function fallbackRavenLane(body: SystemBody | undefined): 'orbital' | 'ground' {
-  return body?.is_landable === true && body.is_water_world !== true ? 'ground' : 'orbital';
+function ravenLaneForPlacement(
+  template: FacilityTemplate | undefined,
+  body: SystemBody | undefined,
+  laneHint?: BodyPlannerLane | null,
+): RavenLane {
+  const lane = placementLaneForTemplate(template, body, laneHint);
+  if (lane === 'surface') return 'ground';
+  return lane;
 }
 
 function placementBodyId(placement: SimulateBuildPlacement | undefined): string | null {

--- a/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/SelectedBodyPlannerCanvas.tsx
@@ -7,7 +7,6 @@ import {
   getBodyGroupWarnings,
 } from '@/features/system-detail/simulation-preview/buildPlanLayoutUtils';
 import { bodyIdKey, sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
-import { templateLocationKind } from '@/features/system-detail/simulation-preview/structurePickerUtils';
 import type { SimulationWorkspaceMode } from '@/features/system-detail/simulation-preview/WorkspaceModeTabs';
 import { BodySlotPlanner, type BodyPlannerLane } from './BodySlotPlanner';
 import type { TopologyPlanSnapshot, TopologySelection } from './ColonyTopologyRail';
@@ -17,6 +16,7 @@ import {
   resolveSlotCapacity,
   systemBodyData,
 } from './slotCapacityFallback';
+import { placementLaneForTemplate, type PlacementLaneAssignment } from './structurePlanningRules';
 
 interface PlacementViewItem {
   placement: SimulateBuildPlacement;
@@ -125,6 +125,8 @@ export function SelectedBodyPlannerCanvas({
         bodyDataSlotEstimate={bodyDataSlotEstimate}
         placements={placements}
         projectedPlacements={projectedPlacements}
+        placementLaneHints={snapshot.placementLaneHints}
+        projectedPlacementLaneHints={snapshot.projection?.placementLaneHints}
         selectedPlacementIndex={selectedPlacementIndex}
         selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
         hasTemplates={snapshot.templates.length > 0}
@@ -178,6 +180,8 @@ interface SystemOverviewItem {
   plannedSurface: number;
   projectedOrbital: number;
   projectedSurface: number;
+  plannedUnassigned: number;
+  projectedUnassigned: number;
   slotLayoutEstimated: boolean;
   score: number;
 }
@@ -293,8 +297,8 @@ function SystemOverviewBodyButton({
   item: SystemOverviewItem;
   onSelect: () => void;
 }) {
-  const plannedTotal = item.plannedOrbital + item.plannedSurface;
-  const projectedTotal = item.projectedOrbital + item.projectedSurface;
+  const plannedTotal = item.plannedOrbital + item.plannedSurface + item.plannedUnassigned;
+  const projectedTotal = item.projectedOrbital + item.projectedSurface + item.projectedUnassigned;
 
   return (
     <button
@@ -314,6 +318,7 @@ function SystemOverviewBodyButton({
         </div>
         {plannedTotal > 0 && <MiniLegend label={String(plannedTotal)} tone="orange" />}
         {projectedTotal > 0 && <MiniLegend label={`+${projectedTotal}`} tone="cyan" />}
+        {item.plannedUnassigned + item.projectedUnassigned > 0 && <MiniLegend label="lane ?" tone="gold" />}
       </div>
       <div className="mt-2 grid gap-1.5">
         <OverviewLane
@@ -468,8 +473,8 @@ function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSn
   );
   const templatesById = new Map(snapshot.templates.map((template) => [template.id, template]));
   const bodiesById = new Map(bodies.filter((body) => body.id != null).map((body) => [bodyIdKey(body.id), body]));
-  const plannedCounts = countPlacementsByBody(snapshot.placements, templatesById, bodiesById);
-  const projectedCounts = countPlacementsByBody(snapshot.projection?.placements ?? [], templatesById, bodiesById);
+  const plannedCounts = countPlacementsByBody(snapshot.placements, templatesById, bodiesById, snapshot.placementLaneHints);
+  const projectedCounts = countPlacementsByBody(snapshot.projection?.placements ?? [], templatesById, bodiesById, snapshot.projection?.placementLaneHints);
 
   return bodies
     .filter((body) => body.id != null)
@@ -498,6 +503,8 @@ function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSn
         plannedSurface: planned.surface,
         projectedOrbital: projected.orbital,
         projectedSurface: projected.surface,
+        plannedUnassigned: planned.unassigned,
+        projectedUnassigned: projected.unassigned,
         slotLayoutEstimated: orbitalSlotCapacity.estimated || surfaceSlotCapacity.estimated,
         score,
       };
@@ -512,42 +519,37 @@ function buildSystemOverviewItems(system: SystemDetail, snapshot: TopologyPlanSn
 interface LaneCounts {
   orbital: number;
   surface: number;
+  unassigned: number;
 }
 
 function countPlacementsByBody(
   placements: SimulateBuildPlacement[],
   templatesById: Map<string, FacilityTemplate>,
   bodiesById: Map<string, SystemBody>,
+  laneHints: Record<number, BodyPlannerLane> = {},
 ) {
   const counts = new Map<string, LaneCounts>();
-  for (const placement of placements) {
-    if (placement.local_body_id == null) continue;
+  placements.forEach((placement, index) => {
+    if (placement.local_body_id == null) return;
     const bodyId = bodyIdKey(placement.local_body_id);
     const current = counts.get(bodyId) ?? emptyLaneCounts();
-    const lane = overviewLaneForTemplate(templatesById.get(placement.facility_template_id), bodiesById.get(bodyId));
+    const lane = overviewLaneForTemplate(templatesById.get(placement.facility_template_id), bodiesById.get(bodyId), laneHints[index]);
     current[lane] += 1;
     counts.set(bodyId, current);
-  }
+  });
   return counts;
 }
 
 function emptyLaneCounts(): LaneCounts {
-  return { orbital: 0, surface: 0 };
+  return { orbital: 0, surface: 0, unassigned: 0 };
 }
 
-function overviewLaneForTemplate(template: FacilityTemplate | undefined, body: SystemBody | undefined): BodyPlannerLane {
-  if (!template) return fallbackOverviewLane(body);
-  const location = templateLocationKind(template);
-  if (location === 'orbital') return 'orbital';
-  if (location === 'surface') return 'surface';
-  if (location === 'both') {
-    return fallbackOverviewLane(body);
-  }
-  return fallbackOverviewLane(body);
-}
-
-function fallbackOverviewLane(body: SystemBody | undefined): BodyPlannerLane {
-  return body?.is_landable === true && body.is_water_world !== true ? 'surface' : 'orbital';
+function overviewLaneForTemplate(
+  template: FacilityTemplate | undefined,
+  body: SystemBody | undefined,
+  laneHint?: BodyPlannerLane | null,
+): PlacementLaneAssignment {
+  return placementLaneForTemplate(template, body, laneHint);
 }
 
 function overviewBodyScore(
@@ -558,8 +560,8 @@ function overviewBodyScore(
   surfaceCapacity: number | null,
   tags: string[],
 ) {
-  const plannedTotal = planned.orbital + planned.surface;
-  const projectedTotal = projected.orbital + projected.surface;
+  const plannedTotal = planned.orbital + planned.surface + planned.unassigned;
+  const projectedTotal = projected.orbital + projected.surface + projected.unassigned;
   const type = `${body.body_type ?? ''} ${body.subtype ?? ''}`.toLowerCase();
   const isBarycentre = type.includes('barycentre');
   if (isBarycentre && plannedTotal === 0 && projectedTotal === 0) return 0;

--- a/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
@@ -33,6 +33,7 @@ import {
 export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   const [selection, setSelection] = useState<TopologySelection>({ type: 'system' });
   const [placements, setPlacements] = useState<SimulateBuildPlacement[]>([]);
+  const [placementLaneHints, setPlacementLaneHints] = useState<Record<number, BodyPlannerLane>>({});
   const [targetArchetype, setTargetArchetype] = useState(() => (
     archetypeFromEconomy(system.economy_suggestion ?? system.primary_economy) ?? 'refinery_industrial'
   ));
@@ -74,6 +75,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   useEffect(() => {
     setSelection({ type: 'system' });
     setPlacements([]);
+    setPlacementLaneHints({});
     setProjection(null);
     setStructurePicker(null);
     setStructureAddFeedback(null);
@@ -97,8 +99,9 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     templates,
     targetArchetype,
     slotPredictions: slotPredictionsQuery.data ?? null,
+    placementLaneHints,
     projection,
-  }), [placements, projection, slotPredictionsQuery.data, targetArchetype, templates]);
+  }), [placementLaneHints, placements, projection, slotPredictionsQuery.data, targetArchetype, templates]);
 
   const projectState = useWorkspaceProjectState(system, planSnapshot);
   const projectRequestFingerprint = useMemo(
@@ -120,6 +123,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     appliedProjectFingerprint.current = projectRequestFingerprint;
     setTargetArchetype(projectState.projectRequest.target_archetype);
     setPlacements(resequence(projectState.projectRequest.placements));
+    setPlacementLaneHints({});
     setProjection(null);
   }, [projectRequestFingerprint, projectState.projectRequest]);
 
@@ -174,15 +178,19 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
       return { ok: false as const, message: `${templateDisplayName(template)} is not compatible with this ${lane === 'orbital' ? 'orbit' : 'surface'} lane.` };
     }
     setSelection({ type: 'body', bodyId });
-    setPlacements((current) => resequence([
-      ...current,
-      {
-        facility_template_id: template.id,
-        local_body_id: bodyId,
-        is_primary_port: template.is_port && !current.some((placement) => placement.is_primary_port),
-        build_order: current.length + 1,
-      },
-    ]));
+    setPlacements((current) => {
+      const next = resequence([
+        ...current,
+        {
+          facility_template_id: template.id,
+          local_body_id: bodyId,
+          is_primary_port: template.is_port && !current.some((placement) => placement.is_primary_port),
+          build_order: current.length + 1,
+        },
+      ]);
+      setPlacementLaneHints((currentHints) => ({ ...currentHints, [next.length - 1]: lane }));
+      return next;
+    });
     return {
       ok: true as const,
       message: `Added ${templateDisplayName(template)} to ${describePlacementTarget(body, lane)}.`,
@@ -220,7 +228,11 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   }, []);
 
   const handleAdvancedPlanSnapshotChange = useCallback((snapshot: TopologyPlanSnapshot) => {
-    setPlacements((current) => placementsEqual(current, snapshot.placements) ? current : resequence(snapshot.placements));
+    setPlacements((current) => {
+      if (placementsEqual(current, snapshot.placements)) return current;
+      setPlacementLaneHints({});
+      return resequence(snapshot.placements);
+    });
     setTargetArchetype((current) => current === snapshot.targetArchetype ? current : snapshot.targetArchetype);
     setProjection((current) => projectionEqual(current, snapshot.projection) ? current : snapshot.projection ?? null);
   }, []);

--- a/frontend-v2/src/features/colony-planner/structurePlanningRules.ts
+++ b/frontend-v2/src/features/colony-planner/structurePlanningRules.ts
@@ -11,6 +11,8 @@ export interface PrerequisiteIssue {
   missing: string[];
 }
 
+export type PlacementLaneAssignment = BodyPlannerLane | 'unassigned';
+
 export function laneDisabledReason(body: SystemBody, lane: BodyPlannerLane): string | null {
   if (lane !== 'surface') return null;
   if (body.is_water_world === true) return 'Surface limited: water world.';
@@ -32,6 +34,25 @@ export function templateCanFitBody(template: FacilityTemplate, body: SystemBody,
     return body.is_landable === true && body.is_water_world !== true;
   }
   return true;
+}
+
+export function placementLaneForTemplate(
+  template: FacilityTemplate | undefined,
+  body: SystemBody | undefined,
+  laneHint?: BodyPlannerLane | null,
+): PlacementLaneAssignment {
+  if (!template) return 'unassigned';
+  const location = templateLocationKind(template);
+  if (location === 'orbital') return 'orbital';
+  if (location === 'surface') return 'surface';
+  if (location === 'both') {
+    if (laneHint && templateMatchesLane(template, laneHint)) {
+      if (laneHint === 'surface' && body && laneDisabledReason(body, 'surface')) return 'unassigned';
+      return laneHint;
+    }
+    return 'unassigned';
+  }
+  return 'unassigned';
 }
 
 export function templateDisplayName(template: FacilityTemplate): string {


### PR DESCRIPTION
## Summary

Implements Stage 17N.1c for the Raven-style colony planner canvas.

- declutters Raven canvas rows so unselected bodies are scannable and selected bodies expose clear Add Orbit/Add Surface targets
- adds shared placement lane assignment rules so orbital, surface, both-compatible, and unknown placements render in the correct lane
- preserves lane hints for direct Raven adds so both-compatible variants appear where the user chose to build
- hides fake zero-slot boxes and renders unknown/unassigned placement states compactly
- improves picker heading/search/metadata coverage for variants, families, prerequisites, and lane context
- keeps prerequisite issues as warnings, not blockers, and keeps station economy contextual rather than inventing fake values
- updates tests and colonisation redesign docs for the graphical-first Raven canvas direction

## Root Cause

The manual Raven canvas was still using a fallback lane classifier that treated ambiguous or both-compatible templates as a body-derived lane, often surface/ground. It also rendered empty capacity boxes and add affordances too broadly, making passive display areas look interactive and obscuring the real add targets.

## Validation

- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm run build`
- `cd frontend-v2 && npm test`
- `git diff --check`

Build still reports the existing Vite warnings for unresolved `/v2/bg/coalsack-*.jpg?v=2` runtime assets and large chunk size. Tests still emit existing jsdom navigation and React act warning noise.