### PR TITLE
Stage 17N.2d-K: add EDSM metadata-only station type apply

### DIFF
--- a/apps/importer/src/edsm_station_enrichment_probe.py
+++ b/apps/importer/src/edsm_station_enrichment_probe.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Targeted EDSM station/body enrichment dry-run.
+"""Targeted EDSM station/body enrichment dry-run and metadata-only apply.
 
 This command compares one ED-Finder system against EDSM per-system station and
 body payloads. It reports possible station-data and station/body-link
-enrichment, but deliberately performs no database writes.
+enrichment. By default it performs no writes; --apply-metadata may update only
+safe local station metadata fields.
 """
 
 from __future__ import annotations
@@ -63,12 +64,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--dsn', default=os.environ.get('DATABASE_URL'), help='Postgres DSN. Defaults to DATABASE_URL.')
     parser.add_argument('--system-name', default=None, help='System name to probe.')
     parser.add_argument('--system-id64', type=int, default=None, help='Local ED system address/id64, if known.')
-    parser.add_argument('--dry-run', action='store_true', help='Accepted for clarity; dry-run is always enabled.')
+    parser.add_argument('--dry-run', action='store_true', help='Force dry-run mode. This is the default.')
+    parser.add_argument(
+        '--apply-metadata',
+        action='store_true',
+        help='Apply safe station metadata only. Currently limited to Unknown -> permanent station_type.',
+    )
     parser.add_argument('--json', action='store_true', help='Emit machine-readable JSON report.')
     parser.add_argument('--timeout', type=float, default=DEFAULT_TIMEOUT_SECONDS, help='EDSM request timeout in seconds.')
     parser.add_argument('--no-network', action='store_true', help='Skip EDSM requests and report local-only unresolved matches.')
     parser.add_argument('--local-only', action='store_true', help='Alias for --no-network.')
-    parser.add_argument('--apply', action='store_true', help='Not implemented. This probe never writes database changes.')
+    parser.add_argument('--apply', action='store_true', help='Not implemented. Use --apply-metadata for metadata-only writes.')
     return parser.parse_args(argv)
 
 
@@ -218,6 +224,12 @@ def build_enrichment_report(
         ignored for station in station_reports
         if (ignored := _ignored_transient_entry(station)) is not None
     ]
+    metadata_updates = _metadata_update_candidates(station_reports)
+    skipped = _metadata_skipped_entries(station_reports)
+    unresolved = [
+        entry for station in station_reports
+        if (entry := _unresolved_entry(station)) is not None
+    ]
 
     summary = Counter()
     for station in station_reports:
@@ -249,10 +261,27 @@ def build_enrichment_report(
             'edsm_bodies': len(edsm_bodies),
             'unmatched_edsm_stations': len(unmatched_edsm_stations),
             'station_metadata_changes': len(station_metadata_changes),
+            'metadata_updates_planned': len(metadata_updates),
+            'metadata_updates_applied': 0,
             'association_changes': len(association_changes),
             'conflicts': len(conflicts),
             'ignored_transient_non_slot': len(ignored_transient_non_slot),
+            'skipped': len(skipped),
+            'unresolved': len(unresolved),
             **dict(sorted(summary.items())),
+        },
+        'apply_mode': 'dry_run',
+        'metadata_apply_contract': {
+            'safe_fields': ['station_type'],
+            'station_type_rule': 'Unknown -> known permanent station type only, from exact matched station identity with no conflicts.',
+            'never_applied': [
+                'station_body_links',
+                'body_id',
+                'body_name',
+                'distance_from_star',
+                'association_status',
+                'association_confidence',
+            ],
         },
         'matching_rules': {
             'station_identity': [
@@ -267,9 +296,13 @@ def build_enrichment_report(
             ],
         },
         'station_metadata_changes': station_metadata_changes,
+        'metadata_updates_planned': metadata_updates,
+        'metadata_updates_applied': [],
         'association_changes': association_changes,
         'conflicts': conflicts,
         'ignored_transient_non_slot': ignored_transient_non_slot,
+        'skipped': skipped,
+        'unresolved': unresolved,
         'stations': station_reports,
         'unmatched_edsm_stations': unmatched_edsm_stations,
     }
@@ -517,6 +550,154 @@ def _ignored_transient_entry(station: Mapping[str, Any]) -> dict[str, Any] | Non
         'reason': _clean_text(station['proposed'].get('resolver_notes')),
         'conflicts': station.get('conflicts', []),
     }
+
+
+def _unresolved_entry(station: Mapping[str, Any]) -> dict[str, Any] | None:
+    if station['station_match'].get('status') == 'matched':
+        return None
+    return {
+        'local_station': station['local_station'],
+        'station_match': station['station_match'],
+        'reason': station['station_match'].get('reason') or 'Station was not matched to EDSM.',
+    }
+
+
+def _metadata_update_candidates(station_reports: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        update for station in station_reports
+        if (update := _metadata_update_candidate(station)) is not None
+    ]
+
+
+def _metadata_skipped_entries(station_reports: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        skip for station in station_reports
+        if (skip := _metadata_skip_entry(station)) is not None
+    ]
+
+
+def _metadata_update_candidate(station: Mapping[str, Any]) -> dict[str, Any] | None:
+    skip_reason = _metadata_apply_skip_reason(station)
+    if skip_reason is not None:
+        return None
+
+    evidence = station.get('station_type_evidence') or {}
+    local_station = station['local_station']
+    return {
+        'local_station': local_station,
+        'edsm_station': station.get('edsm_station'),
+        'station_match': station['station_match'],
+        'field': 'station_type',
+        'old_value': evidence.get('local'),
+        'new_value': evidence.get('proposed'),
+        'station_id': _read_int(local_station.get('id')),
+        'system_id64': _read_int(local_station.get('system_id64')),
+    }
+
+
+def _metadata_skip_entry(station: Mapping[str, Any]) -> dict[str, Any] | None:
+    reason = _metadata_apply_skip_reason(station)
+    if reason is None:
+        return None
+    if (
+        station['station_match'].get('status') == 'matched'
+        and 'station_type' not in station.get('fields_that_would_change', [])
+        and not station.get('ignored_transient_non_slot')
+    ):
+        return None
+    return {
+        'local_station': station['local_station'],
+        'edsm_station': station.get('edsm_station'),
+        'station_match': station['station_match'],
+        'station_type_evidence': station.get('station_type_evidence'),
+        'reason': reason,
+    }
+
+
+def _metadata_apply_skip_reason(station: Mapping[str, Any]) -> str | None:
+    match = station['station_match']
+    if match.get('status') != 'matched':
+        return 'unresolved_station_match'
+    if station.get('ignored_transient_non_slot'):
+        return 'transient_non_slot_ignored'
+
+    fields = set(station.get('fields_that_would_change', []))
+    if 'station_type' not in fields:
+        unsupported_fields = sorted(fields)
+        if unsupported_fields:
+            return f"unsupported_metadata_fields:{','.join(unsupported_fields)}"
+        return 'no_station_type_change'
+
+    if match.get('confidence') != 'exact' or match.get('source') not in ('id_name', 'exact_name'):
+        return 'weak_station_identity'
+
+    conflict_types = {conflict.get('type') for conflict in station.get('conflicts', [])}
+    if conflict_types:
+        return f"conflicting_evidence:{','.join(sorted(str(kind) for kind in conflict_types))}"
+
+    evidence = station.get('station_type_evidence') or {}
+    local_type = evidence.get('local')
+    proposed_type = evidence.get('proposed')
+    if local_type != 'Unknown':
+        return 'known_station_type_preserved'
+    if not is_permanent_colony_slot_station_type(proposed_type):
+        return 'non_permanent_station_type'
+    if _read_int(station['local_station'].get('id')) is None:
+        return 'missing_station_id'
+    if _read_int(station['local_station'].get('system_id64')) is None:
+        return 'missing_system_id64'
+    return None
+
+
+def apply_metadata_updates(conn, report: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Apply planned safe station metadata updates and return applied/skipped rows."""
+    applied: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for update in report.get('metadata_updates_planned', []):
+        station_id = _read_int(update.get('station_id'))
+        system_id64 = _read_int(update.get('system_id64'))
+        new_value = _clean_text(update.get('new_value'))
+        if station_id is None or system_id64 is None or not is_permanent_colony_slot_station_type(new_value):
+            skipped.append({
+                **update,
+                'reason': 'invalid_metadata_update_plan',
+            })
+            continue
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute("""
+                UPDATE stations
+                SET station_type = %s::station_type
+                WHERE id = %s
+                  AND system_id64 = %s
+                  AND station_type = 'Unknown'::station_type
+                RETURNING id, system_id64, name, station_type::text AS station_type
+            """, (new_value, station_id, system_id64))
+            row = cur.fetchone()
+        if row is None:
+            skipped.append({
+                **update,
+                'reason': 'station_row_changed_or_not_unknown',
+            })
+            continue
+        applied.append({
+            **update,
+            'applied_station': {
+                'id': _read_int(row.get('id')),
+                'system_id64': _read_int(row.get('system_id64')),
+                'name': _clean_text(row.get('name')),
+                'station_type': _clean_text(row.get('station_type')),
+            },
+        })
+    return applied, skipped
+
+
+def apply_metadata_result(report: dict[str, Any], applied: Sequence[Mapping[str, Any]], skipped: Sequence[Mapping[str, Any]]) -> None:
+    report['dry_run'] = False
+    report['apply_mode'] = 'metadata'
+    report['metadata_updates_applied'] = [dict(row) for row in applied]
+    report['skipped'] = [*report.get('skipped', []), *[dict(row) for row in skipped]]
+    report['counts']['metadata_updates_applied'] = len(applied)
+    report['counts']['skipped'] = len(report['skipped'])
 
 
 def _match_edsm_station(
@@ -1030,6 +1211,7 @@ def _public_local_station(station: Mapping[str, Any]) -> dict[str, Any]:
     return {
         'id': _read_int(station.get('id')),
         'market_id': _read_int(station.get('market_id')),
+        'system_id64': _read_int(station.get('system_id64')),
         'name': _clean_text(station.get('name')),
         'station_type': normalise_station_type_label(station.get('station_type')) or 'Unknown',
         'distance_from_star': _read_float(station.get('distance_from_star')),
@@ -1209,8 +1391,9 @@ def _json_default(value: Any) -> str:
 
 def render_text_report(report: Mapping[str, Any]) -> str:
     lines = [
-        f"EDSM station enrichment dry-run: {report['system']['name']} ({report['system']['id64']})",
+        f"EDSM station enrichment report: {report['system']['name']} ({report['system']['id64']})",
         f"network={'enabled' if report.get('network_enabled') else 'skipped'} source={report['source']}",
+        f"apply_mode={report.get('apply_mode', 'dry_run')}",
         'counts:',
     ]
     for key, value in sorted(report['counts'].items()):
@@ -1225,6 +1408,15 @@ def render_text_report(report: Mapping[str, Any]) -> str:
         lines.append(
             f"  - {local['name']} [{local['id']}]: fields={fields} "
             f"type={evidence.get('local')}->{evidence.get('proposed')}"
+        )
+    lines.append('metadata_updates_applied:')
+    if not report.get('metadata_updates_applied'):
+        lines.append('  none')
+    for update in report.get('metadata_updates_applied', []):
+        local = update['local_station']
+        lines.append(
+            f"  - {local['name']} [{local['id']}]: "
+            f"{update.get('field')}={update.get('old_value')}->{update.get('new_value')}"
         )
     lines.append('association_changes:')
     if not report.get('association_changes'):
@@ -1254,13 +1446,34 @@ def render_text_report(report: Mapping[str, Any]) -> str:
             f"  - {local['name']} [{local['id']}]: type={evidence.get('local')}->{evidence.get('proposed')} "
             f"body_evidence={body.get('body_name') or body.get('body_id') or 'none'}"
         )
+    lines.append('skipped:')
+    if not report.get('skipped'):
+        lines.append('  none')
+    for entry in report.get('skipped', []):
+        local = entry.get('local_station') or {}
+        lines.append(f"  - {local.get('name')} [{local.get('id')}]: {entry.get('reason')}")
+    lines.append('unresolved:')
+    if not report.get('unresolved'):
+        lines.append('  none')
+    for entry in report.get('unresolved', []):
+        local = entry.get('local_station') or {}
+        lines.append(f"  - {local.get('name')} [{local.get('id')}]: {entry.get('reason')}")
     return '\n'.join(lines)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     if args.apply:
-        print('--apply is not implemented for EDSM station enrichment; this tool is dry-run only.', file=sys.stderr)
+        print('--apply is not implemented for EDSM station enrichment; use --apply-metadata for metadata-only writes.', file=sys.stderr)
+        return 2
+    if args.apply_metadata and args.dry_run:
+        print('--dry-run and --apply-metadata are mutually exclusive.', file=sys.stderr)
+        return 2
+    if args.apply_metadata and args.system_id64 is None:
+        print('--apply-metadata requires --system-id64 to keep writes scoped to one local system.', file=sys.stderr)
+        return 2
+    if args.apply_metadata and (args.no_network or args.local_only):
+        print('--apply-metadata requires network EDSM evidence; remove --no-network/--local-only.', file=sys.stderr)
         return 2
     if not args.dsn:
         print('DATABASE_URL or --dsn is required.', file=sys.stderr)
@@ -1298,6 +1511,16 @@ def main(argv: Sequence[str] | None = None) -> int:
         edsm_bodies_payload=edsm_payload['bodies'],
         network_enabled=network_enabled,
     )
+
+    if args.apply_metadata:
+        try:
+            with psycopg2.connect(args.dsn) as conn:
+                applied, apply_skipped = apply_metadata_updates(conn, report)
+                apply_metadata_result(report, applied, apply_skipped)
+                conn.commit()
+        except Exception as exc:
+            print(f'Failed to apply station metadata updates: {exc}', file=sys.stderr)
+            return 1
 
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True, default=_json_default))

--- a/docs/colonisation-redesign/edsm-data-audit.md
+++ b/docs/colonisation-redesign/edsm-data-audit.md
@@ -84,15 +84,15 @@ write directly over core truth.
    add explicit source-id columns/tables instead of assuming all ids are the
    same namespace.
 
-## Stage 17N.2d-J Targeted Station Probe
+## Stage 17N.2d-J/K Targeted Station Probe
 
 Script: `apps/importer/src/edsm_station_enrichment_probe.py`
 
-The first implementation is an operator dry-run only. It loads one local system
-from ED-Finder, fetches EDSM `/api-system-v1/stations` and
-`/api-system-v1/bodies` for the same system name, and prints a station-centric
-diff. It does not write evidence tables, core station rows, or
-`station_body_links`.
+The probe loads one local system from ED-Finder, fetches EDSM
+`/api-system-v1/stations` and `/api-system-v1/bodies` for the same system name,
+and prints a station-centric diff. Default mode is dry-run. Stage 17N.2d-K adds
+`--apply-metadata`, which can write only safe local station metadata. It still
+does not write evidence tables or `station_body_links`.
 
 Local fields that can be compared today:
 
@@ -108,7 +108,7 @@ Local fields that can be compared today:
 - `stations.body_name`: local weak body evidence, useful for conflict context.
 - `stations.primary_economy`, `has_market`, and `has_shipyard`: reported as
   possible enrichment/conflict evidence only. They do not affect slot
-  occupancy.
+  occupancy and are not applied by Stage 17N.2d-K.
 - `bodies.id`, `bodies.name`, and `bodies.distance_from_star`: local body rows
   used to confirm exact body-name matches or infer unique distance matches.
 
@@ -147,8 +147,10 @@ Confidence rules:
   body evidence, or blocking conflicts. Unknown/unmapped station types keep
   `lane=unknown`; exact body evidence can still be reported, but it is not
   occupied-slot proof.
-- `FleetCarrier` and `MegaShip` may be reported with body evidence, but their
-  lane remains `unknown` and `occupies_colony_slot=false`.
+- `FleetCarrier`, raw `Carrier`, and `MegaShip` are reported under
+  `ignored_transient_non_slot` when matched. They may include diagnostic body
+  evidence, but they never produce `association_changes`, never create
+  `station_body_links`, and never occupy colony capacity.
 
 Conflict reporting:
 
@@ -164,19 +166,77 @@ Run one Exioce dry-run locally:
 ```bash
 PYTHONPATH=apps/api/src DATABASE_URL="$DATABASE_URL" \
   python apps/importer/src/edsm_station_enrichment_probe.py \
-    --system-name Exioce --system-id64 2008132031194 --json
+    --system-name Exioce --system-id64 2008132031194 --dry-run --json
 ```
 
 Run through the importer container after deployment:
 
 ```bash
-docker compose --profile import run --rm importer \
-  edsm_station_enrichment_probe.py \
-  --system-name Exioce --system-id64 2008132031194 --json
+docker compose --profile import run --rm \
+  --entrypoint python3 \
+  -v /opt/ed-finder/apps/importer/src:/workspace/apps/importer/src:ro \
+  -v /opt/ed-finder/apps/api/src:/workspace/apps/api/src:ro \
+  importer \
+  /workspace/apps/importer/src/edsm_station_enrichment_probe.py \
+  --system-name Exioce \
+  --system-id64 2008132031194 \
+  --dry-run --json
 ```
 
-`--apply` intentionally hard-fails with "not implemented". Bulk EDSM station
-dump imports are still out of scope.
+Metadata-only apply after reviewing the dry-run:
+
+```bash
+docker compose --profile import run --rm \
+  --entrypoint python3 \
+  -v /opt/ed-finder/apps/importer/src:/workspace/apps/importer/src:ro \
+  -v /opt/ed-finder/apps/api/src:/workspace/apps/api/src:ro \
+  importer \
+  /workspace/apps/importer/src/edsm_station_enrichment_probe.py \
+  --system-name Exioce \
+  --system-id64 2008132031194 \
+  --apply-metadata --json
+```
+
+`--apply` still hard-fails. `--apply-metadata` requires `--system-id64` and
+currently applies only `stations.station_type` when all of these are true:
+
+- the station is matched by exact id/name or unique exact name
+- local `station_type` is `Unknown`
+- EDSM station type normalizes to a permanent station type
+- there are no conflicts
+
+It does not apply `body_id`, `body_name`, `distance_from_star`, economies,
+service flags, association status/confidence, or `station_body_links`. For
+Exioce, the expected dry-run/apply metadata changes are:
+
+- Macmillan Depot: `Unknown -> Orbis`
+- Fort Lawrence: `Unknown -> Orbis`
+- Miller Terminal: `Unknown -> Coriolis`
+
+The Exioce fleet carriers (`WFK-N6Z`, `K2W-77Q`, `WFW-4TZ`, `T9J-B2N`,
+`XFK-T4M`) remain under `ignored_transient_non_slot`. The expected
+`association_changes` count remains `0`.
+
+Rollback/check query after a metadata apply:
+
+```sql
+SELECT id, name, station_type::text
+FROM stations
+WHERE system_id64 = 2008132031194
+  AND name IN ('Macmillan Depot', 'Fort Lawrence', 'Miller Terminal')
+ORDER BY name;
+```
+
+If a reviewed metadata-only apply needs to be rolled back manually:
+
+```sql
+UPDATE stations
+SET station_type = 'Unknown'::station_type
+WHERE system_id64 = 2008132031194
+  AND name IN ('Macmillan Depot', 'Fort Lawrence', 'Miller Terminal');
+```
+
+Bulk EDSM station dump imports are still out of scope.
 
 ## Schema Recommendations
 

--- a/docs/colonisation-redesign/occupied-slot-source-of-truth.md
+++ b/docs/colonisation-redesign/occupied-slot-source-of-truth.md
@@ -200,35 +200,61 @@ PYTHONPATH=apps/api/src DATABASE_URL="$DATABASE_URL" \
 Default behaviour preserves confirmed links. Use `--overwrite-confirmed` only
 for a deliberate correction pass.
 
-## Targeted EDSM Dry-Run Probe
+## Targeted EDSM Probe And Metadata-Only Apply
 
 Script: `apps/importer/src/edsm_station_enrichment_probe.py`
 
-Stage 17N.2d-J adds a one-system EDSM comparison probe. It is not a user-path
-API call, not a scheduled importer, and not an apply tool. Its output is
-external evidence that can explain which local station rows could later be
-enriched.
+Stage 17N.2d-J adds a one-system EDSM comparison probe. Stage 17N.2d-K adds a
+metadata-only apply mode. It is not a user-path API call, not a scheduled
+importer, and not a bulk enrichment path. Its output is external evidence that
+can explain which local station rows could later be enriched.
 
 Local run:
 
 ```bash
 PYTHONPATH=apps/api/src DATABASE_URL="$DATABASE_URL" \
   python apps/importer/src/edsm_station_enrichment_probe.py \
-    --system-name Exioce --system-id64 2008132031194 --json
+    --system-name Exioce --system-id64 2008132031194 --dry-run --json
 ```
 
 Importer container run:
 
 ```bash
-docker compose --profile import run --rm importer \
-  edsm_station_enrichment_probe.py \
-  --system-name Exioce --system-id64 2008132031194 --json
+docker compose --profile import run --rm \
+  --entrypoint python3 \
+  -v /opt/ed-finder/apps/importer/src:/workspace/apps/importer/src:ro \
+  -v /opt/ed-finder/apps/api/src:/workspace/apps/api/src:ro \
+  importer \
+  /workspace/apps/importer/src/edsm_station_enrichment_probe.py \
+  --system-name Exioce \
+  --system-id64 2008132031194 \
+  --dry-run --json
+```
+
+Metadata-only apply, after reviewing dry-run output:
+
+```bash
+docker compose --profile import run --rm \
+  --entrypoint python3 \
+  -v /opt/ed-finder/apps/importer/src:/workspace/apps/importer/src:ro \
+  -v /opt/ed-finder/apps/api/src:/workspace/apps/api/src:ro \
+  importer \
+  /workspace/apps/importer/src/edsm_station_enrichment_probe.py \
+  --system-name Exioce \
+  --system-id64 2008132031194 \
+  --apply-metadata --json
 ```
 
 Interpretation:
 
+- `station_metadata_changes`: safe metadata evidence found by the dry-run. In
+  Stage 17N.2d-K, only `station_type` can be applied.
+- `metadata_updates_applied`: actual `stations.station_type` writes made by
+  `--apply-metadata`.
+- `association_changes`: station/body link evidence only. It is never applied
+  by the EDSM probe.
 - `confirmed`: exact local station identity plus exact same-system body name
-  evidence. This is still dry-run evidence until a future apply path exists.
+  evidence. For `association_changes`, this remains evidence only.
 - `inferred`: unique distance-only body match. It can explain occupied-slot
   review queues, but must remain labelled inferred.
 - `unresolved`: no exact station/body match, ambiguous station/body candidates,
@@ -237,13 +263,25 @@ Interpretation:
   become occupied-slot proof.
 - `conflicts`: review items. They never overwrite existing confirmed
   `station_body_links` rows.
-- `occupies_colony_slot=false`: FleetCarrier, MegaShip, unknown, or otherwise
-  non-permanent infrastructure. It may remain visible but does not consume
-  orbital/surface colony capacity.
+- `ignored_transient_non_slot`: `FleetCarrier`, raw `Carrier`, `MegaShip`, or
+  other mobile/transient infrastructure. It may remain visible but does not
+  consume orbital/surface colony capacity.
 
-`--apply` is deliberately not implemented. The next safe step is to run this
-against a small list of unresolved systems, inspect conflicts, and design an
-evidence table or manual review workflow before any write path.
+`--apply` is deliberately not implemented. `--apply-metadata` writes only
+`stations.station_type` for matched permanent stations when local type is
+`Unknown`, EDSM type is known/permanent, and no conflicts are present. It does
+not write `station_body_links`, `body_id`, `body_name`, `distance_from_star`,
+association status/confidence, economies, or service flags.
+
+For Exioce, dry-run should show:
+
+- `station_metadata_changes=3`: Macmillan Depot and Fort Lawrence
+  `Unknown -> Orbis`; Miller Terminal `Unknown -> Coriolis`
+- `ignored_transient_non_slot=5`: WFK-N6Z, K2W-77Q, WFW-4TZ, T9J-B2N, XFK-T4M
+- `association_changes=0`
+
+The matching metadata-only apply would update those three `station_type` values
+only.
 
 ## Diagnostic Queries
 

--- a/docs/operations/stage17n2c-data-trust-runbook.md
+++ b/docs/operations/stage17n2c-data-trust-runbook.md
@@ -407,28 +407,81 @@ PYTHONPATH=apps/api/src DATABASE_URL="$DATABASE_URL" \
 
 Default backfill behaviour does not overwrite existing confirmed links.
 
-Stage 17N.2d-J EDSM targeted dry-run:
+Stage 17N.2d-J/K EDSM targeted probe:
 
 ```bash
 PYTHONPATH=apps/api/src DATABASE_URL="$DATABASE_URL" \
   python apps/importer/src/edsm_station_enrichment_probe.py \
-    --system-name Exioce --system-id64 2008132031194 --json
+    --system-name Exioce --system-id64 2008132031194 --dry-run --json
 ```
 
-Container form:
+Container dry-run form:
 
 ```bash
-docker compose --profile import run --rm importer \
-  edsm_station_enrichment_probe.py \
-  --system-name Exioce --system-id64 2008132031194 --json
+docker compose --profile import run --rm \
+  --entrypoint python3 \
+  -v /opt/ed-finder/apps/importer/src:/workspace/apps/importer/src:ro \
+  -v /opt/ed-finder/apps/api/src:/workspace/apps/api/src:ro \
+  importer \
+  /workspace/apps/importer/src/edsm_station_enrichment_probe.py \
+  --system-name Exioce \
+  --system-id64 2008132031194 \
+  --dry-run --json
 ```
 
 This command fetches EDSM station/body evidence for one named system only. It
-does not run on a normal user path, does not import a bulk dump, and does not
-write to the database. `--apply` hard-fails as not implemented. Treat its
-`confirmed` rows as proposed evidence only, `inferred` rows as reviewable
-distance matches, `unresolved` rows as still-visible infrastructure, and
-`conflicts` as stop/review items.
+does not run on a normal user path and does not import a bulk dump. Default
+mode is dry-run. `--apply` hard-fails as not implemented.
+
+Metadata-only apply form, after reviewing dry-run output:
+
+```bash
+docker compose --profile import run --rm \
+  --entrypoint python3 \
+  -v /opt/ed-finder/apps/importer/src:/workspace/apps/importer/src:ro \
+  -v /opt/ed-finder/apps/api/src:/workspace/apps/api/src:ro \
+  importer \
+  /workspace/apps/importer/src/edsm_station_enrichment_probe.py \
+  --system-name Exioce \
+  --system-id64 2008132031194 \
+  --apply-metadata --json
+```
+
+`--apply-metadata` is intentionally narrow. It can update only
+`stations.station_type` from `Unknown` to a known permanent station type when
+the station match is exact and conflict-free. It must not write
+`station_body_links`, `body_id`, `body_name`, `distance_from_star`,
+association status/confidence, economies, service flags, or occupied-slot
+capacity. Fleet carriers, raw carriers, and megaships stay under
+`ignored_transient_non_slot` and are ignored for colony planning occupancy.
+
+Expected Exioce shape:
+
+- dry-run: `station_metadata_changes=3`, `association_changes=0`,
+  `ignored_transient_non_slot=5`
+- metadata-only apply: Macmillan Depot and Fort Lawrence `Unknown -> Orbis`;
+  Miller Terminal `Unknown -> Coriolis`
+- fleet carriers WFK-N6Z, K2W-77Q, WFW-4TZ, T9J-B2N, and XFK-T4M remain
+  ignored transient/non-slot rows
+
+Rollback/check after apply:
+
+```sql
+SELECT id, name, station_type::text
+FROM stations
+WHERE system_id64 = 2008132031194
+  AND name IN ('Macmillan Depot', 'Fort Lawrence', 'Miller Terminal')
+ORDER BY name;
+
+UPDATE stations
+SET station_type = 'Unknown'::station_type
+WHERE system_id64 = 2008132031194
+  AND name IN ('Macmillan Depot', 'Fort Lawrence', 'Miller Terminal');
+```
+
+Treat `association_changes.confirmed` rows as proposed evidence only,
+`inferred` rows as reviewable distance matches, `unresolved` rows as
+still-visible infrastructure, and `conflicts` as stop/review items.
 
 Association diagnostics:
 

--- a/tests/test_edsm_station_enrichment_probe.py
+++ b/tests/test_edsm_station_enrichment_probe.py
@@ -56,6 +56,40 @@ def conflict_types(station_report):
     return {conflict['type'] for conflict in station_report['conflicts']}
 
 
+class FakeApplyConnection:
+    def __init__(self, rows):
+        self.rows = rows
+        self.statements = []
+        self.last_row = None
+
+    def cursor(self, *args, **kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params):
+        self.statements.append((sql, params))
+        new_type, station_id, system_id64 = params
+        row = self.rows.get((station_id, system_id64))
+        if row is None or row['station_type'] != 'Unknown':
+            self.last_row = None
+            return
+        row['station_type'] = new_type
+        self.last_row = {
+            'id': station_id,
+            'system_id64': system_id64,
+            'name': row['name'],
+            'station_type': new_type,
+        }
+
+    def fetchone(self):
+        return self.last_row
+
+
 def test_import_path_supports_repo_and_flat_container_layouts():
     repo_paths = probe._station_resolver_import_paths(
         ROOT / 'apps' / 'importer' / 'src' / 'edsm_station_enrichment_probe.py'
@@ -145,6 +179,56 @@ def test_exioce_like_orbis_and_coriolis_type_evidence_are_metadata_changes():
     assert all('station_type' in change['fields_that_would_change'] for change in changes_by_name.values())
 
 
+def test_dry_run_report_does_not_apply_metadata_updates():
+    report = report_for(
+        local_station(station_type='Unknown'),
+        {
+            'id': 1001,
+            'name': 'Harper Plant',
+            'type': 'Orbis Starport',
+            'distanceToArrival': 120.0,
+        },
+    )
+
+    assert report['dry_run'] is True
+    assert report['apply_mode'] == 'dry_run'
+    assert report['metadata_updates_applied'] == []
+    assert report['counts']['metadata_updates_applied'] == 0
+    assert report['metadata_updates_planned'][0]['new_value'] == 'Orbis'
+
+
+def test_apply_metadata_updates_unknown_to_orbis_and_coriolis():
+    report = probe.build_enrichment_report(
+        local_system=SYSTEM,
+        local_stations=[
+            local_station(id=2001, market_id=2001, name='Macmillan Depot', station_type='Unknown'),
+            local_station(id=2002, market_id=2002, name='Miller Terminal', station_type='Unknown'),
+        ],
+        local_bodies=BODIES,
+        existing_links={},
+        edsm_stations_payload={'stations': [
+            {'id': 2001, 'name': 'Macmillan Depot', 'type': 'Orbis Starport'},
+            {'id': 2002, 'name': 'Miller Terminal', 'type': 'Coriolis Starport'},
+        ]},
+        edsm_bodies_payload={'bodies': []},
+    )
+    conn = FakeApplyConnection({
+        (2001, 2008132031194): {'name': 'Macmillan Depot', 'station_type': 'Unknown'},
+        (2002, 2008132031194): {'name': 'Miller Terminal', 'station_type': 'Unknown'},
+    })
+
+    applied, skipped = probe.apply_metadata_updates(conn, report)
+    probe.apply_metadata_result(report, applied, skipped)
+
+    assert skipped == []
+    assert [row['new_value'] for row in applied] == ['Orbis', 'Coriolis']
+    assert conn.rows[(2001, 2008132031194)]['station_type'] == 'Orbis'
+    assert conn.rows[(2002, 2008132031194)]['station_type'] == 'Coriolis'
+    assert report['dry_run'] is False
+    assert report['apply_mode'] == 'metadata'
+    assert report['counts']['metadata_updates_applied'] == 2
+
+
 def test_fleet_carrier_is_ignored_for_station_body_links_even_with_body_evidence():
     report = report_for(
         local_station(station_type='Unknown'),
@@ -193,6 +277,29 @@ def test_megaship_is_ignored_for_station_body_links():
     assert report['ignored_transient_non_slot'][0]['body_evidence']['body_name'] == 'Exioce 1'
 
 
+def test_metadata_apply_does_not_update_transient_rows():
+    report = report_for(
+        local_station(station_type='Unknown'),
+        {
+            'id': 1001,
+            'name': 'Harper Plant',
+            'type': 'Fleet Carrier',
+            'bodyName': 'Exioce 1',
+            'distanceToArrival': 120.0,
+        },
+    )
+    conn = FakeApplyConnection({
+        (1001, 2008132031194): {'name': 'Harper Plant', 'station_type': 'Unknown'},
+    })
+
+    applied, skipped = probe.apply_metadata_updates(conn, report)
+
+    assert applied == []
+    assert skipped == []
+    assert conn.statements == []
+    assert report['association_changes'] == []
+
+
 def test_carrier_like_rows_do_not_produce_association_changes():
     report = probe.build_enrichment_report(
         local_system=SYSTEM,
@@ -214,6 +321,30 @@ def test_carrier_like_rows_do_not_produce_association_changes():
     assert report['association_changes'] == []
     assert report['counts']['ignored_transient_non_slot'] == 3
     assert len(report['ignored_transient_non_slot']) == 3
+
+
+def test_metadata_apply_never_writes_association_changes():
+    report = report_for(
+        local_station(station_type='Unknown'),
+        {
+            'id': 1001,
+            'name': 'Harper Plant',
+            'type': 'Orbis Starport',
+            'bodyName': 'Exioce 1',
+            'distanceToArrival': 120.0,
+        },
+    )
+    conn = FakeApplyConnection({
+        (1001, 2008132031194): {'name': 'Harper Plant', 'station_type': 'Unknown'},
+    })
+
+    applied, skipped = probe.apply_metadata_updates(conn, report)
+
+    assert report['association_changes']
+    assert len(applied) == 1
+    assert skipped == []
+    assert all('station_body_links' not in sql for sql, _params in conn.statements)
+    assert conn.rows[(1001, 2008132031194)]['station_type'] == 'Orbis'
 
 
 def test_exact_body_name_confirms_same_system_body_association():
@@ -304,6 +435,74 @@ def test_conflicting_station_distance_reports_conflict_and_blocks_body_proposal(
     assert report['conflicts'][0]['conflict']['type'] == 'station_distance_mismatch'
 
 
+def test_metadata_apply_skips_distance_mismatch_conflict():
+    report = report_for(
+        local_station(station_type='Unknown', distance_from_star=120.0),
+        {
+            'id': 1001,
+            'name': 'Harper Plant',
+            'type': 'Coriolis Starport',
+            'bodyName': 'Exioce 2',
+            'distanceToArrival': 240.0,
+        },
+    )
+    conn = FakeApplyConnection({
+        (1001, 2008132031194): {'name': 'Harper Plant', 'station_type': 'Unknown'},
+    })
+
+    applied, skipped = probe.apply_metadata_updates(conn, report)
+
+    assert applied == []
+    assert skipped == []
+    assert conn.statements == []
+    assert any(entry['reason'].startswith('conflicting_evidence') for entry in report['skipped'])
+
+
+def test_metadata_apply_does_not_overwrite_known_station_type_conflict():
+    report = report_for(
+        local_station(station_type='Coriolis'),
+        {
+            'id': 1001,
+            'name': 'Harper Plant',
+            'type': 'Orbis Starport',
+            'distanceToArrival': 120.0,
+        },
+    )
+    conn = FakeApplyConnection({
+        (1001, 2008132031194): {'name': 'Harper Plant', 'station_type': 'Coriolis'},
+    })
+
+    applied, skipped = probe.apply_metadata_updates(conn, report)
+
+    assert applied == []
+    assert skipped == []
+    assert conn.statements == []
+    assert any(entry['reason'].startswith('conflicting_evidence') for entry in report['skipped'])
+
+
+def test_unresolved_station_match_is_reported_and_not_applied():
+    report = report_for(
+        local_station(id=4001, market_id=4001, name='Unmatched Station', station_type='Unknown'),
+        {
+            'id': 9999,
+            'name': 'Different Station',
+            'type': 'Orbis Starport',
+            'distanceToArrival': 120.0,
+        },
+    )
+    conn = FakeApplyConnection({
+        (4001, 2008132031194): {'name': 'Unmatched Station', 'station_type': 'Unknown'},
+    })
+
+    applied, skipped = probe.apply_metadata_updates(conn, report)
+
+    assert applied == []
+    assert skipped == []
+    assert conn.statements == []
+    assert report['unresolved'][0]['reason'] == 'No exact EDSM station id/name or unique station name match.'
+    assert report['skipped'][0]['reason'] == 'unresolved_station_match'
+
+
 def test_confirmed_existing_link_is_preserved_against_weaker_edsm_evidence():
     existing_links = {
         1001: {
@@ -342,3 +541,25 @@ def test_apply_hard_fails_before_db_or_network(capsys):
     captured = capsys.readouterr()
     assert result == 2
     assert 'not implemented' in captured.err
+
+
+def test_apply_metadata_requires_scoped_system_id64_before_db_or_network(capsys):
+    result = probe.main(['--system-name', 'Exioce', '--dsn', 'postgresql://example', '--apply-metadata'])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert '--system-id64' in captured.err
+
+
+def test_dry_run_and_apply_metadata_are_mutually_exclusive(capsys):
+    result = probe.main([
+        '--system-name', 'Exioce',
+        '--system-id64', '2008132031194',
+        '--dsn', 'postgresql://example',
+        '--dry-run',
+        '--apply-metadata',
+    ])
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert 'mutually exclusive' in captured.err


### PR DESCRIPTION
Adds safe metadata-only station type apply mode for EDSM evidence. Does not apply station_body_links, body links, distance writes, carrier occupancy, or UI changes.