### PR TITLE
[codex] Stage 17N.2d-V EDSM pacing

### DIFF
--- a/apps/importer/src/edsm_station_enrichment_probe.py
+++ b/apps/importer/src/edsm_station_enrichment_probe.py
@@ -10,6 +10,7 @@ safe local station metadata fields.
 from __future__ import annotations
 
 import argparse
+import email.utils
 import http.client
 import json
 import os
@@ -17,6 +18,7 @@ import socket
 import sys
 import time
 from collections import Counter
+from datetime import datetime, timezone
 from math import isfinite
 from pathlib import Path
 from typing import Any, Mapping, Sequence
@@ -73,6 +75,9 @@ EDSM_SYSTEM_API_BASE = 'https://www.edsm.net/api-system-v1'
 DEFAULT_TIMEOUT_SECONDS = _env_float('EDSM_HTTP_TIMEOUT_SECONDS', 60.0)
 DEFAULT_HTTP_RETRIES = _env_int('EDSM_HTTP_RETRIES', 3)
 DEFAULT_HTTP_RETRY_BACKOFF_SECONDS = _env_float('EDSM_HTTP_RETRY_BACKOFF_SECONDS', 3.0)
+DEFAULT_HTTP_REQUEST_DELAY_SECONDS = _env_float('EDSM_HTTP_REQUEST_DELAY_SECONDS', 0.5)
+DEFAULT_HTTP_429_BACKOFF_SECONDS = _env_float('EDSM_HTTP_429_BACKOFF_SECONDS', 60.0)
+DEFAULT_HTTP_429_BACKOFF_MULTIPLIER = _env_float('EDSM_HTTP_429_BACKOFF_MULTIPLIER', 2.0)
 STATION_DISTANCE_CONFLICT_TOLERANCE_LS = DISTANCE_MATCH_TOLERANCE_LS
 TRUSTED_STATION_DISTANCE_PRECISION_TOLERANCE_LS = 0.05
 BODY_DISTANCE_MATCH_TOLERANCE_LS = DISTANCE_MATCH_TOLERANCE_LS
@@ -115,6 +120,9 @@ class EdsmFetchError(RuntimeError):
         endpoint: str,
         attempts: int,
         reason: str,
+        status_code: int | None = None,
+        retry_after_seconds: float | None = None,
+        retry_after_header: str | None = None,
     ) -> None:
         super().__init__(message)
         self.system_name = system_name
@@ -122,6 +130,22 @@ class EdsmFetchError(RuntimeError):
         self.endpoint = endpoint
         self.attempts = attempts
         self.reason = reason
+        self.status_code = status_code
+        self.retry_after_seconds = retry_after_seconds
+        self.retry_after_header = retry_after_header
+        self.rate_limited = status_code == 429 or 'too many requests' in reason.lower()
+
+
+class EdsmRateLimitError(EdsmFetchError):
+    """Raised when EDSM keeps returning 429/Too Many Requests after retries."""
+
+
+class _EdsmHttpStatusError(RuntimeError):
+    def __init__(self, status_code: int, reason: str, headers: Any = None) -> None:
+        super().__init__(f'HTTP {status_code} {reason}')
+        self.status = status_code
+        self.reason = reason
+        self.headers = headers
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -155,6 +179,24 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=float,
         default=DEFAULT_HTTP_RETRY_BACKOFF_SECONDS,
         help='Initial EDSM retry backoff in seconds; later retries use exponential backoff.',
+    )
+    parser.add_argument(
+        '--edsm-request-delay-seconds',
+        type=float,
+        default=DEFAULT_HTTP_REQUEST_DELAY_SECONDS,
+        help='Delay between EDSM HTTP requests. Defaults to EDSM_HTTP_REQUEST_DELAY_SECONDS.',
+    )
+    parser.add_argument(
+        '--edsm-429-backoff-seconds',
+        type=float,
+        default=DEFAULT_HTTP_429_BACKOFF_SECONDS,
+        help='Initial EDSM 429 retry backoff in seconds when Retry-After is absent.',
+    )
+    parser.add_argument(
+        '--edsm-429-backoff-multiplier',
+        type=float,
+        default=DEFAULT_HTTP_429_BACKOFF_MULTIPLIER,
+        help='Multiplier for repeated EDSM 429 retry backoff when Retry-After is absent.',
     )
     parser.add_argument('--no-network', action='store_true', help='Skip EDSM requests and report local-only unresolved matches.')
     parser.add_argument('--local-only', action='store_true', help='Alias for --no-network.')
@@ -247,33 +289,42 @@ def fetch_edsm_system(
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
     retries: int = DEFAULT_HTTP_RETRIES,
     retry_backoff_seconds: float = DEFAULT_HTTP_RETRY_BACKOFF_SECONDS,
+    request_delay_seconds: float = DEFAULT_HTTP_REQUEST_DELAY_SECONDS,
+    rate_limit_backoff_seconds: float = DEFAULT_HTTP_429_BACKOFF_SECONDS,
+    rate_limit_backoff_multiplier: float = DEFAULT_HTTP_429_BACKOFF_MULTIPLIER,
     sleep: Any = time.sleep,
     logger: Any = None,
     system_id64: int | None = None,
 ) -> dict[str, Any]:
     """Fetch EDSM station and body payloads for one named system."""
-    return {
-        'stations': _fetch_edsm_endpoint(
-            'stations',
-            system_name,
-            timeout=timeout,
-            retries=retries,
-            retry_backoff_seconds=retry_backoff_seconds,
-            sleep=sleep,
-            logger=logger,
-            system_id64=system_id64,
-        ),
-        'bodies': _fetch_edsm_endpoint(
-            'bodies',
-            system_name,
-            timeout=timeout,
-            retries=retries,
-            retry_backoff_seconds=retry_backoff_seconds,
-            sleep=sleep,
-            logger=logger,
-            system_id64=system_id64,
-        ),
-    }
+    stations = _fetch_edsm_endpoint(
+        'stations',
+        system_name,
+        timeout=timeout,
+        retries=retries,
+        retry_backoff_seconds=retry_backoff_seconds,
+        rate_limit_backoff_seconds=rate_limit_backoff_seconds,
+        rate_limit_backoff_multiplier=rate_limit_backoff_multiplier,
+        sleep=sleep,
+        logger=logger,
+        system_id64=system_id64,
+    )
+    delay = max(0.0, float(request_delay_seconds or 0.0))
+    if delay > 0:
+        sleep(delay)
+    bodies = _fetch_edsm_endpoint(
+        'bodies',
+        system_name,
+        timeout=timeout,
+        retries=retries,
+        retry_backoff_seconds=retry_backoff_seconds,
+        rate_limit_backoff_seconds=rate_limit_backoff_seconds,
+        rate_limit_backoff_multiplier=rate_limit_backoff_multiplier,
+        sleep=sleep,
+        logger=logger,
+        system_id64=system_id64,
+    )
+    return {'stations': stations, 'bodies': bodies}
 
 
 def _fetch_edsm_endpoint(
@@ -283,6 +334,8 @@ def _fetch_edsm_endpoint(
     timeout: float,
     retries: int = DEFAULT_HTTP_RETRIES,
     retry_backoff_seconds: float = DEFAULT_HTTP_RETRY_BACKOFF_SECONDS,
+    rate_limit_backoff_seconds: float = DEFAULT_HTTP_429_BACKOFF_SECONDS,
+    rate_limit_backoff_multiplier: float = DEFAULT_HTTP_429_BACKOFF_MULTIPLIER,
     sleep: Any = time.sleep,
     logger: Any = None,
     system_id64: int | None = None,
@@ -296,25 +349,59 @@ def _fetch_edsm_endpoint(
     for attempt in range(1, attempts + 1):
         try:
             with urlopen(request, timeout=timeout) as response:
+                status_code = _http_status_code(response)
+                if status_code is not None and status_code >= 400:
+                    raise _EdsmHttpStatusError(
+                        status_code,
+                        _http_response_reason(response, status_code),
+                        _http_response_headers(response),
+                    )
                 return json.loads(response.read().decode('utf-8'))
         except Exception as exc:
             reason = _exception_reason(exc)
+            status_code = _http_status_code(exc)
+            retry_after_header = _retry_after_header(exc)
+            retry_after_seconds = _retry_after_seconds(retry_after_header)
+            rate_limited = _is_rate_limit_exception(exc, reason=reason, status_code=status_code)
             if attempt >= attempts:
                 _log(logger, f'EDSM fetch failed system={label} endpoint={endpoint} attempt={attempt}/{attempts}: {reason}')
-                raise EdsmFetchError(
+                error_cls = EdsmRateLimitError if rate_limited else EdsmFetchError
+                raise error_cls(
                     f'EDSM {endpoint} fetch failed for {system_name!r} after {attempts} attempt(s): {reason}',
                     system_name=system_name,
                     system_id64=system_id64,
                     endpoint=endpoint,
                     attempts=attempts,
                     reason=reason,
+                    status_code=status_code,
+                    retry_after_seconds=retry_after_seconds,
+                    retry_after_header=retry_after_header,
                 ) from exc
-            delay = _retry_delay_seconds(retry_backoff_seconds, attempt)
-            _log(
-                logger,
-                f'EDSM fetch retry system={label} endpoint={endpoint} '
-                f'next_attempt={attempt + 1}/{attempts} reason={reason} backoff_seconds={delay:g}',
-            )
+            if rate_limited:
+                delay = _rate_limit_delay_seconds(
+                    retry_after_seconds=retry_after_seconds,
+                    backoff_seconds=rate_limit_backoff_seconds,
+                    multiplier=rate_limit_backoff_multiplier,
+                    failed_attempt=attempt,
+                )
+                retry_after_text = (
+                    f' retry_after={retry_after_header!r}'
+                    if retry_after_header is not None
+                    else ''
+                )
+                _log(
+                    logger,
+                    f'EDSM rate limit retry system={label} endpoint={endpoint} '
+                    f'next_attempt={attempt + 1}/{attempts} reason={reason}{retry_after_text} '
+                    f'backoff_seconds={delay:g}',
+                )
+            else:
+                delay = _retry_delay_seconds(retry_backoff_seconds, attempt)
+                _log(
+                    logger,
+                    f'EDSM fetch retry system={label} endpoint={endpoint} '
+                    f'next_attempt={attempt + 1}/{attempts} reason={reason} backoff_seconds={delay:g}',
+                )
             if delay > 0:
                 sleep(delay)
 
@@ -328,7 +415,111 @@ def _retry_delay_seconds(backoff_seconds: float, failed_attempt: int) -> float:
     return base_delay * (2 ** max(0, failed_attempt - 1))
 
 
+def _rate_limit_delay_seconds(
+    *,
+    retry_after_seconds: float | None,
+    backoff_seconds: float,
+    multiplier: float,
+    failed_attempt: int,
+) -> float:
+    if retry_after_seconds is not None:
+        return max(0.0, retry_after_seconds)
+    base_delay = max(0.0, float(backoff_seconds or 0.0))
+    factor = max(1.0, float(multiplier or 1.0))
+    return base_delay * (factor ** max(0, failed_attempt - 1))
+
+
+def _retry_after_header(exc_or_response: Any) -> str | None:
+    headers = getattr(exc_or_response, 'headers', None) or getattr(exc_or_response, 'hdrs', None)
+    if headers is None:
+        return None
+    for name in ('Retry-After', 'retry-after'):
+        try:
+            value = headers.get(name)
+        except AttributeError:
+            value = headers.get(name) if isinstance(headers, Mapping) else None
+        if value is not None:
+            text = str(value).strip()
+            return text or None
+    return None
+
+
+def _retry_after_seconds(header: str | None, *, now: datetime | None = None) -> float | None:
+    if header is None:
+        return None
+    text = header.strip()
+    if not text:
+        return None
+    try:
+        return max(0.0, float(text))
+    except ValueError:
+        pass
+    try:
+        retry_at = email.utils.parsedate_to_datetime(text)
+    except (TypeError, ValueError, IndexError, OverflowError):
+        return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    return max(0.0, (retry_at - current).total_seconds())
+
+
+def _http_response_headers(response: Any) -> Any:
+    headers = getattr(response, 'headers', None) or getattr(response, 'hdrs', None)
+    if headers is not None:
+        return headers
+    info = getattr(response, 'info', None)
+    if callable(info):
+        try:
+            return info()
+        except Exception:
+            return None
+    return None
+
+
+def _http_response_reason(response: Any, status_code: int) -> str:
+    reason = getattr(response, 'reason', None) or getattr(response, 'msg', None)
+    if reason:
+        return str(reason)
+    if status_code == 429:
+        return 'Too Many Requests'
+    return 'HTTP error'
+
+
+def _http_status_code(exc_or_response: Any) -> int | None:
+    for attr in ('code', 'status'):
+        value = getattr(exc_or_response, attr, None)
+        parsed = _read_int(value)
+        if parsed is not None:
+            return parsed
+    getcode = getattr(exc_or_response, 'getcode', None)
+    if callable(getcode):
+        try:
+            return _read_int(getcode())
+        except Exception:
+            return None
+    return None
+
+
+def _is_rate_limit_exception(
+    exc: BaseException,
+    *,
+    reason: str | None = None,
+    status_code: int | None = None,
+) -> bool:
+    status = status_code if status_code is not None else _http_status_code(exc)
+    if status == 429:
+        return True
+    text = reason if reason is not None else _exception_reason(exc)
+    return 'too many requests' in text.lower()
+
+
 def _exception_reason(exc: BaseException) -> str:
+    status_code = _http_status_code(exc)
+    if status_code is not None:
+        message = getattr(exc, 'reason', None) or getattr(exc, 'msg', None) or str(exc).strip()
+        message_text = str(message).strip()
+        return f'HTTP {status_code} {message_text}'.strip()
     reason = getattr(exc, 'reason', None)
     if reason is not None:
         return str(reason)
@@ -2084,6 +2275,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.edsm_retry_backoff_seconds < 0:
         print('--edsm-retry-backoff-seconds must be zero or greater.', file=sys.stderr)
         return 2
+    if args.edsm_request_delay_seconds < 0:
+        print('--edsm-request-delay-seconds must be zero or greater.', file=sys.stderr)
+        return 2
+    if args.edsm_429_backoff_seconds < 0:
+        print('--edsm-429-backoff-seconds must be zero or greater.', file=sys.stderr)
+        return 2
+    if args.edsm_429_backoff_multiplier < 1:
+        print('--edsm-429-backoff-multiplier must be at least 1.', file=sys.stderr)
+        return 2
     if not args.dsn:
         print('DATABASE_URL or --dsn is required.', file=sys.stderr)
         return 2
@@ -2109,6 +2309,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 timeout=args.timeout,
                 retries=args.edsm_retries,
                 retry_backoff_seconds=args.edsm_retry_backoff_seconds,
+                request_delay_seconds=args.edsm_request_delay_seconds,
+                rate_limit_backoff_seconds=args.edsm_429_backoff_seconds,
+                rate_limit_backoff_multiplier=args.edsm_429_backoff_multiplier,
                 logger=_stderr_log,
                 system_id64=_read_int(local['system'].get('id64')),
             )

--- a/apps/importer/src/enrich_system_data.py
+++ b/apps/importer/src/enrich_system_data.py
@@ -28,7 +28,7 @@ from dirty_flags import mark_systems_rating_dirty
 from ring_facts import normalise_ring_payload, ring_rows_for_body
 
 
-DEFAULT_EDSM_RATE_LIMIT_SECONDS = 0.25
+DEFAULT_EDSM_RATE_LIMIT_SECONDS = edsm_probe.DEFAULT_HTTP_REQUEST_DELAY_SECONDS
 DEFAULT_SPANSH_SOURCE = 'spansh_dump'
 INT32_MIN = -2147483648
 INT32_MAX = 2147483647
@@ -65,7 +65,25 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=edsm_probe.DEFAULT_HTTP_RETRY_BACKOFF_SECONDS,
         help='Initial EDSM retry backoff in seconds; later retries use exponential backoff.',
     )
-    parser.add_argument('--rate-limit-seconds', type=float, default=DEFAULT_EDSM_RATE_LIMIT_SECONDS, help='Delay between EDSM systems.')
+    parser.add_argument(
+        '--edsm-429-backoff-seconds',
+        type=float,
+        default=edsm_probe.DEFAULT_HTTP_429_BACKOFF_SECONDS,
+        help='Initial EDSM 429 retry backoff in seconds when Retry-After is absent.',
+    )
+    parser.add_argument(
+        '--edsm-429-backoff-multiplier',
+        type=float,
+        default=edsm_probe.DEFAULT_HTTP_429_BACKOFF_MULTIPLIER,
+        help='Multiplier for repeated EDSM 429 retry backoff when Retry-After is absent.',
+    )
+    parser.add_argument(
+        '--rate-limit-seconds',
+        '--edsm-request-delay-seconds',
+        type=float,
+        default=DEFAULT_EDSM_RATE_LIMIT_SECONDS,
+        help='Delay between EDSM systems and between station/body endpoint requests.',
+    )
     return parser.parse_args(argv)
 
 
@@ -103,6 +121,12 @@ def validate_args(args: argparse.Namespace) -> list[str]:
         errors.append('--edsm-retries must be zero or greater.')
     if args.edsm_retry_backoff_seconds < 0:
         errors.append('--edsm-retry-backoff-seconds must be zero or greater.')
+    if args.edsm_429_backoff_seconds < 0:
+        errors.append('--edsm-429-backoff-seconds must be zero or greater.')
+    if args.edsm_429_backoff_multiplier < 1:
+        errors.append('--edsm-429-backoff-multiplier must be at least 1.')
+    if args.rate_limit_seconds < 0:
+        errors.append('--rate-limit-seconds must be zero or greater.')
     if not args.dsn:
         errors.append('DATABASE_URL or --dsn is required.')
     return errors
@@ -166,13 +190,26 @@ def run(
                 ring_systems = select_ring_systems(conn, args)
                 for index, system in enumerate(_skip_checkpointed(ring_systems, checkpoint)):
                     local_bodies = fetch_local_bodies(conn, system['id64'])
-                    edsm_payload = _call_edsm_fetcher(
-                        edsm_fetcher,
-                        system['name'],
-                        args=args,
-                        sleep=sleep,
-                        system_id64=_read_int(system.get('id64')),
-                    )
+                    try:
+                        edsm_payload = _call_edsm_fetcher(
+                            edsm_fetcher,
+                            system['name'],
+                            args=args,
+                            sleep=sleep,
+                            system_id64=_read_int(system.get('id64')),
+                        )
+                    except Exception as exc:
+                        if not edsm_probe.is_edsm_fetch_error(exc):
+                            raise
+                        fetch_error = _station_fetch_error_entry(system, exc)
+                        _log_stderr(
+                            f"Skipping EDSM ring enrichment system={system.get('name')!r} "
+                            f"id64={_read_int(system.get('id64'))} reason={fetch_error['message']}"
+                        )
+                        _merge_ring_report(report, _ring_fetch_failed_report(fetch_error))
+                        if index + 1 < len(ring_systems) and args.rate_limit_seconds > 0:
+                            sleep(args.rate_limit_seconds)
+                        continue
                     ring_report = process_ring_system_payload(
                         conn,
                         edsm_payload.get('bodies') or {},
@@ -210,7 +247,8 @@ def run(
         _log_stderr(
             'EDSM station enrichment fetch_failed='
             f"{len(report['stations']['systems_fetch_failed'])} "
-            f"fetch_errors={len(report['stations']['fetch_errors'])}"
+            f"fetch_errors={len(report['stations']['fetch_errors'])} "
+            f"rate_limit_errors={len(report['stations']['rate_limit_errors'])}"
         )
     return report
 
@@ -297,7 +335,11 @@ def process_station_system(
         )
         return {
             'system': fetch_error['system'],
-            'counts': {'fetch_errors': 1, 'systems_fetch_failed': 1},
+            'counts': {
+                'fetch_errors': 1,
+                'systems_fetch_failed': 1,
+                **({'rate_limit_errors': 1} if fetch_error.get('rate_limited') else {}),
+            },
             'metadata_updates_planned': [],
             'metadata_updates_applied': [],
             'confirmed_link_updates_planned': [],
@@ -307,6 +349,7 @@ def process_station_system(
             'ignored_transient_non_slot': [],
             'unresolved': [],
             'fetch_errors': [fetch_error],
+            'rate_limit_errors': [fetch_error] if fetch_error.get('rate_limited') else [],
             'systems_fetch_failed': [fetch_error['system']],
             'fetch_failed': True,
             'dirty_system_ids': [],
@@ -344,6 +387,7 @@ def process_station_system(
         'ignored_transient_non_slot': report.get('ignored_transient_non_slot', []),
         'unresolved': report.get('unresolved', []),
         'fetch_errors': [],
+        'rate_limit_errors': [],
         'systems_fetch_failed': [],
         'fetch_failed': False,
         'dirty_system_ids': sorted(dirty_ids),
@@ -734,6 +778,17 @@ def _call_edsm_fetcher(
             'edsm_retry_backoff_seconds',
             edsm_probe.DEFAULT_HTTP_RETRY_BACKOFF_SECONDS,
         ),
+        'request_delay_seconds': getattr(args, 'rate_limit_seconds', edsm_probe.DEFAULT_HTTP_REQUEST_DELAY_SECONDS),
+        'rate_limit_backoff_seconds': getattr(
+            args,
+            'edsm_429_backoff_seconds',
+            edsm_probe.DEFAULT_HTTP_429_BACKOFF_SECONDS,
+        ),
+        'rate_limit_backoff_multiplier': getattr(
+            args,
+            'edsm_429_backoff_multiplier',
+            edsm_probe.DEFAULT_HTTP_429_BACKOFF_MULTIPLIER,
+        ),
         'sleep': sleep,
         'logger': _log_stderr,
         'system_id64': system_id64,
@@ -759,6 +814,14 @@ def _station_fetch_error_entry(system: Mapping[str, Any], exc: BaseException) ->
     system_id64 = _read_int(system.get('id64'))
     system_name = _clean_text(system.get('name'))
     cause = exc.__cause__ or exc
+    status_code = _read_int(getattr(exc, 'status_code', None)) or _read_int(getattr(cause, 'code', None))
+    rate_limited = bool(getattr(exc, 'rate_limited', False)) or status_code == 429
+    retry_after_header = getattr(exc, 'retry_after_header', None)
+    if retry_after_header is None:
+        retry_after_header = edsm_probe._retry_after_header(cause)
+    retry_after_seconds = getattr(exc, 'retry_after_seconds', None)
+    if retry_after_seconds is None:
+        retry_after_seconds = edsm_probe._retry_after_seconds(retry_after_header)
     return {
         'system': {'id64': system_id64, 'name': system_name},
         'system_id64': system_id64,
@@ -768,6 +831,32 @@ def _station_fetch_error_entry(system: Mapping[str, Any], exc: BaseException) ->
         'message': str(exc),
         'endpoint': getattr(exc, 'endpoint', None),
         'attempts': getattr(exc, 'attempts', None),
+        'status_code': status_code,
+        'rate_limited': rate_limited,
+        'retry_after_seconds': retry_after_seconds,
+        'retry_after_header': retry_after_header,
+    }
+
+
+def _ring_fetch_failed_report(fetch_error: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'system': None,
+        'rows': [],
+        'applied': [],
+        'scan_fact_applied': [],
+        'scan_fact_skipped': [],
+        'skipped': [],
+        'apply_skipped': [],
+        'conflicts': [],
+        'fetch_errors': [dict(fetch_error)],
+        'rate_limit_errors': [dict(fetch_error)] if fetch_error.get('rate_limited') else [],
+        'systems_fetch_failed': [fetch_error['system']],
+        'counts': {
+            'fetch_errors': 1,
+            'systems_fetch_failed': 1,
+            **({'rate_limit_errors': 1} if fetch_error.get('rate_limited') else {}),
+        },
+        'dirty_system_ids': [],
     }
 
 
@@ -871,6 +960,7 @@ def _new_report(args: argparse.Namespace, *, dry_run: bool) -> dict[str, Any]:
             'ignored_transient_non_slot': [],
             'unresolved': [],
             'fetch_errors': [],
+            'rate_limit_errors': [],
             'systems_fetch_failed': [],
             'counts': {},
         },
@@ -883,6 +973,9 @@ def _new_report(args: argparse.Namespace, *, dry_run: bool) -> dict[str, Any]:
             'skipped': [],
             'apply_skipped': [],
             'conflicts': [],
+            'fetch_errors': [],
+            'rate_limit_errors': [],
+            'systems_fetch_failed': [],
             'counts': {},
         },
         'dirty': {
@@ -908,6 +1001,7 @@ def _merge_station_report(report: dict[str, Any], station_report: Mapping[str, A
         'ignored_transient_non_slot',
         'unresolved',
         'fetch_errors',
+        'rate_limit_errors',
         'systems_fetch_failed',
     ):
         section[key].extend(station_report.get(key, []))
@@ -922,7 +1016,17 @@ def _merge_ring_report(report: dict[str, Any], ring_report: Mapping[str, Any]) -
         section['systems'].append(ring_report['system'])
     section['systems'].extend(ring_report.get('systems', []))
     section['rows_planned'].extend(ring_report.get('rows', []))
-    for key in ('applied', 'scan_fact_applied', 'scan_fact_skipped', 'skipped', 'apply_skipped', 'conflicts'):
+    for key in (
+        'applied',
+        'scan_fact_applied',
+        'scan_fact_skipped',
+        'skipped',
+        'apply_skipped',
+        'conflicts',
+        'fetch_errors',
+        'rate_limit_errors',
+        'systems_fetch_failed',
+    ):
         section[key].extend(ring_report.get(key, []))
     for key, value in ring_report.get('counts', {}).items():
         section['counts'][key] = section['counts'].get(key, 0) + int(value)
@@ -935,7 +1039,11 @@ def _finalise_report(report: dict[str, Any]) -> None:
     station_conflicts = len(report['stations']['conflicts'])
     ring_conflicts = len(report['rings']['conflicts'])
     station_fetch_errors = len(report['stations']['fetch_errors'])
+    station_rate_limit_errors = len(report['stations']['rate_limit_errors'])
     station_systems_fetch_failed = len(report['stations']['systems_fetch_failed'])
+    ring_fetch_errors = len(report['rings']['fetch_errors'])
+    ring_rate_limit_errors = len(report['rings']['rate_limit_errors'])
+    ring_systems_fetch_failed = len(report['rings']['systems_fetch_failed'])
     report['summary'] = {
         'systems_processed': len({
             *[system.get('id64') for system in report['stations']['systems']],
@@ -953,6 +1061,7 @@ def _finalise_report(report: dict[str, Any]) -> None:
             'skipped': len(report['stations']['skipped']),
             'conflicts': station_conflicts,
             'fetch_errors': station_fetch_errors,
+            'rate_limit_errors': station_rate_limit_errors,
             'systems_fetch_failed': station_systems_fetch_failed,
         },
         'rings': {
@@ -962,12 +1071,16 @@ def _finalise_report(report: dict[str, Any]) -> None:
             'scan_fact_skipped': len(report['rings']['scan_fact_skipped']),
             'skipped': len(report['rings']['skipped']) + len(report['rings']['apply_skipped']),
             'conflicts': ring_conflicts,
+            'fetch_errors': ring_fetch_errors,
+            'rate_limit_errors': ring_rate_limit_errors,
+            'systems_fetch_failed': ring_systems_fetch_failed,
         },
         'dirty_systems_planned': len(dirty_ids),
         'dirty_systems_marked': report['dirty']['marked'],
         'conflicts': station_conflicts + ring_conflicts,
-        'fetch_errors': station_fetch_errors,
-        'systems_fetch_failed': station_systems_fetch_failed,
+        'fetch_errors': station_fetch_errors + ring_fetch_errors,
+        'rate_limit_errors': station_rate_limit_errors + ring_rate_limit_errors,
+        'systems_fetch_failed': station_systems_fetch_failed + ring_systems_fetch_failed,
     }
 
 

--- a/env.example
+++ b/env.example
@@ -22,6 +22,12 @@ EXPOSE_ERROR_DETAIL=false
 # Logging level for all Python services.
 LOG_LEVEL=INFO
 
+# Targeted EDSM enrichment pacing. Keep these conservative for bulk station/body
+# backfills; Retry-After from EDSM is honored before these 429 defaults.
+EDSM_HTTP_REQUEST_DELAY_SECONDS=0.5
+EDSM_HTTP_429_BACKOFF_SECONDS=60
+EDSM_HTTP_429_BACKOFF_MULTIPLIER=2
+
 # Grafana admin credentials (only used with --profile monitoring).
 GRAFANA_USER=admin
 GRAFANA_PASSWORD=change-me

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -1510,7 +1510,7 @@ export interface components {
             /** Is Ringed */
             is_ringed?: boolean | null;
             /** Ring State */
-            ring_state?: "ringed" | "not_ringed" | "unknown" | null;
+            ring_state?: ("ringed" | "not_ringed" | "unknown") | null;
             /** Rings */
             rings?: components["schemas"]["BodyRingModel"][] | null;
             /** Ring Count */
@@ -3321,12 +3321,30 @@ export interface components {
             station_type?: string | null;
             /** Distance From Star */
             distance_from_star?: number | null;
+            /** Distance Source */
+            distance_source?: string | null;
+            /** Distance Confidence */
+            distance_confidence?: string | null;
+            /** Distance Updated At */
+            distance_updated_at?: unknown | null;
+            /** Station Type Source */
+            station_type_source?: string | null;
+            /** Station Type Confidence */
+            station_type_confidence?: string | null;
+            /** Station Type Updated At */
+            station_type_updated_at?: unknown | null;
             /** Body Id */
             body_id?: number | null;
             /** Body Name */
             body_name?: string | null;
             /** Station Body Name */
             station_body_name?: string | null;
+            /** Body Name Source */
+            body_name_source?: string | null;
+            /** Body Name Confidence */
+            body_name_confidence?: string | null;
+            /** Body Name Updated At */
+            body_name_updated_at?: unknown | null;
             /** Lane */
             lane?: string | null;
             /** Association Status */

--- a/tests/test_edsm_station_enrichment_probe.py
+++ b/tests/test_edsm_station_enrichment_probe.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+from urllib.error import HTTPError
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -98,6 +99,7 @@ def test_edsm_fetch_timeout_retries_and_succeeds(monkeypatch):
         timeout=7,
         retries=1,
         retry_backoff_seconds=0.5,
+        request_delay_seconds=0,
         sleep=sleeps.append,
         logger=logs.append,
         system_id64=2008132031194,
@@ -143,6 +145,81 @@ def test_edsm_fetch_timeout_exhausts_retries(monkeypatch):
     assert error.attempts == 3
     assert 'timed out' in error.reason
     assert any('attempt=3/3' in line for line in logs)
+
+
+def test_edsm_fetch_429_honours_retry_after(monkeypatch):
+    calls = []
+    sleeps = []
+    logs = []
+    body_attempts = 0
+
+    def fake_urlopen(request, timeout):
+        nonlocal body_attempts
+        calls.append((request.full_url, timeout))
+        if '/stations?' in request.full_url:
+            return FakeHttpResponse({'stations': [{'name': 'Harper Plant'}]})
+        body_attempts += 1
+        if body_attempts == 1:
+            raise HTTPError(
+                request.full_url,
+                429,
+                'Too Many Requests',
+                {'Retry-After': '2.5'},
+                None,
+            )
+        return FakeHttpResponse({'bodies': [{'name': 'Exioce 1'}]})
+
+    monkeypatch.setattr(probe, 'urlopen', fake_urlopen)
+
+    payload = probe.fetch_edsm_system(
+        'Exioce',
+        timeout=7,
+        retries=1,
+        retry_backoff_seconds=0.5,
+        request_delay_seconds=0,
+        rate_limit_backoff_seconds=60,
+        sleep=sleeps.append,
+        logger=logs.append,
+        system_id64=2008132031194,
+    )
+
+    assert len(calls) == 3
+    assert sleeps == [2.5]
+    assert payload['bodies']['bodies'][0]['name'] == 'Exioce 1'
+    assert any('EDSM rate limit retry' in line and "retry_after='2.5'" in line for line in logs)
+
+
+def test_edsm_fetch_429_uses_configured_backoff_without_retry_after(monkeypatch):
+    calls = []
+    sleeps = []
+    body_attempts = 0
+
+    def fake_urlopen(request, timeout):
+        nonlocal body_attempts
+        calls.append(request.full_url)
+        if '/stations?' in request.full_url:
+            return FakeHttpResponse({'stations': [{'name': 'Harper Plant'}]})
+        body_attempts += 1
+        if body_attempts < 3:
+            raise HTTPError(request.full_url, 429, 'Too Many Requests', {}, None)
+        return FakeHttpResponse({'bodies': [{'name': 'Exioce 1'}]})
+
+    monkeypatch.setattr(probe, 'urlopen', fake_urlopen)
+
+    payload = probe.fetch_edsm_system(
+        'Exioce',
+        timeout=7,
+        retries=2,
+        request_delay_seconds=0,
+        rate_limit_backoff_seconds=4,
+        rate_limit_backoff_multiplier=3,
+        sleep=sleeps.append,
+        system_id64=2008132031194,
+    )
+
+    assert len(calls) == 4
+    assert sleeps == [4, 12]
+    assert payload['bodies']['bodies'][0]['name'] == 'Exioce 1'
 
 
 class FakeApplyConnection:

--- a/tests/test_stage17n2d_backfill_framework.py
+++ b/tests/test_stage17n2d_backfill_framework.py
@@ -808,6 +808,54 @@ def test_station_fetch_timeout_exhaustion_reports_failure_without_writes(monkeyp
     assert apply_calls == []
 
 
+def test_station_fetch_rate_limit_reports_separate_error_without_writes(monkeypatch):
+    args = enrich.parse_args([
+        '--stations',
+        '--system-id64', str(SYSTEM['id64']),
+        '--apply-confirmed-links',
+        '--mark-dirty',
+    ])
+    apply_calls = []
+
+    def fail_fetch(system_name, **_kwargs):
+        raise edsm_probe.EdsmRateLimitError(
+            'EDSM bodies fetch failed for Exioce after 3 attempt(s): HTTP 429 Too Many Requests',
+            system_name=system_name,
+            system_id64=SYSTEM['id64'],
+            endpoint='bodies',
+            attempts=3,
+            reason='HTTP 429 Too Many Requests',
+            status_code=429,
+            retry_after_seconds=60.0,
+            retry_after_header='60',
+        )
+
+    monkeypatch.setattr(edsm_probe, 'fetch_local_payload', lambda *_args, **_kwargs: station_local_payload(SYSTEM))
+    monkeypatch.setattr(
+        edsm_probe,
+        'apply_confirmed_link_updates',
+        lambda *_args, **_kwargs: apply_calls.append(True) or ([], []),
+    )
+
+    report = enrich.process_station_system(
+        MinimalBatchConnection(),
+        SYSTEM,
+        args=args,
+        dry_run=False,
+        edsm_fetcher=fail_fetch,
+        sleep=lambda _seconds: None,
+    )
+
+    assert report['fetch_failed'] is True
+    assert report['counts']['fetch_errors'] == 1
+    assert report['counts']['rate_limit_errors'] == 1
+    assert report['rate_limit_errors'][0]['status_code'] == 429
+    assert report['rate_limit_errors'][0]['retry_after_seconds'] == 60.0
+    assert report['fetch_errors'][0]['rate_limited'] is True
+    assert report['confirmed_link_updates_applied'] == []
+    assert apply_calls == []
+
+
 def test_apply_confirmed_links_skips_failed_system_and_applies_valid_systems(monkeypatch):
     systems = [
         {'id64': 1, 'name': 'Timeout System'},
@@ -894,6 +942,39 @@ def test_json_report_includes_fetch_error_summary():
     assert '"fetch_errors"' in payload
     assert report['summary']['fetch_errors'] == 1
     assert report['summary']['systems_fetch_failed'] == 1
+
+
+def test_json_report_includes_rate_limit_error_summary():
+    report = enrich._new_report(
+        enrich.parse_args(['--stations', '--system-id64', str(SYSTEM['id64'])]),
+        dry_run=True,
+    )
+    rate_limit_error = {
+        'system': SYSTEM,
+        'system_id64': SYSTEM['id64'],
+        'system_name': SYSTEM['name'],
+        'reason': 'edsm_fetch_failed',
+        'message': 'HTTP 429 Too Many Requests',
+        'status_code': 429,
+        'rate_limited': True,
+        'retry_after_seconds': 60.0,
+    }
+    enrich._merge_station_report(report, {
+        'system': SYSTEM,
+        'counts': {'fetch_errors': 1, 'systems_fetch_failed': 1, 'rate_limit_errors': 1},
+        'fetch_errors': [rate_limit_error],
+        'rate_limit_errors': [rate_limit_error],
+        'systems_fetch_failed': [SYSTEM],
+        'fetch_failed': True,
+        'dirty_system_ids': [],
+    })
+    enrich._finalise_report(report)
+
+    payload = enrich.json.dumps(report, default=enrich._json_default)
+
+    assert '"rate_limit_errors"' in payload
+    assert report['summary']['rate_limit_errors'] == 1
+    assert report['summary']['stations']['rate_limit_errors'] == 1
 
 
 def test_spansh_ring_payload_plans_trusted_body_ring_rows():
@@ -1055,6 +1136,41 @@ def test_run_mark_dirty_path_is_called_for_applied_rings(monkeypatch):
     assert marked == [2008132031194]
     assert report['dirty']['marked'] == 1
     assert conn.committed is True
+
+
+def test_edsm_ring_rate_limit_does_not_abort_batch(monkeypatch):
+    systems = [
+        {'id64': 1, 'name': 'Limited System'},
+        {'id64': 2, 'name': 'Valid System'},
+    ]
+    conn = MinimalBatchConnection()
+
+    def fetcher(system_name, **_kwargs):
+        if system_name == 'Limited System':
+            raise edsm_probe.EdsmRateLimitError(
+                'EDSM bodies fetch failed for Limited System after 1 attempt(s): HTTP 429 Too Many Requests',
+                system_name=system_name,
+                system_id64=1,
+                endpoint='bodies',
+                attempts=1,
+                reason='HTTP 429 Too Many Requests',
+                status_code=429,
+            )
+        return {
+            'bodies': {'bodies': [{'name': 'Exioce 1', 'rings': [{'name': 'Exioce 1 A Ring'}]}]},
+        }
+
+    monkeypatch.setattr(enrich, 'select_ring_systems', lambda _conn, _args: systems)
+    monkeypatch.setattr(enrich, 'fetch_local_bodies', lambda _conn, _system_id64: BODIES)
+
+    args = enrich.parse_args(['--rings', '--source', 'edsm', '--limit', '2'])
+    report = enrich.run(args, connect=lambda _dsn: conn, edsm_fetcher=fetcher, sleep=lambda _seconds: None)
+
+    assert report['rings']['systems_fetch_failed'] == [{'id64': 1, 'name': 'Limited System'}]
+    assert report['rings']['rate_limit_errors'][0]['status_code'] == 429
+    assert report['summary']['rings']['rate_limit_errors'] == 1
+    assert report['summary']['rings']['planned'] == 1
+    assert conn.rolled_back is True
 
 
 def test_json_summary_includes_station_and_ring_counts():


### PR DESCRIPTION
## Summary
- Add EDSM HTTP request pacing defaults and CLI/env controls.
- Handle HTTP 429 separately, honoring Retry-After before configured 429 backoff.
- Keep per-system batch processing non-fatal and report rate_limit_errors in JSON.

## Validation
- `/home/brian/Documents/GitHub/ed-finder/.venv/bin/pytest tests/test_edsm_station_enrichment_probe.py tests/test_stage17n2d_backfill_framework.py -q`
- `/home/brian/Documents/GitHub/ed-finder/.venv/bin/python -m compileall apps/importer/src/edsm_station_enrichment_probe.py apps/importer/src/enrich_system_data.py`