### PR TITLE
docs: add colonisation source authority pack

### DIFF
--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -24,6 +24,7 @@ It supersedes the old assumption that the project should simply continue from St
 | Document | Status | Purpose |
 |---|---|---|
 | [`stage-17p-current-state-forward-plan.md`](./stage-17p-current-state-forward-plan.md) | Active control | Current state, source-authority warning, non-negotiable boundaries, and next work queue. |
+| [`../reference/colonisation/README.md`](../reference/colonisation/README.md) | Source authority entry point | Committed source hierarchy, inventory placeholders, and future Codex prompt snippet for mechanics-heavy work. |
 | [`engine-roadmap.md`](./engine-roadmap.md) | Living historical roadmap | Broad colonisation engine evolution and delivered stage summaries. |
 | [`enrichment-roadmap.md`](./enrichment-roadmap.md) | Active for enrichment | Guarded station enrichment, body/ring enrichment, offline warehouse, reconciliation, and operator-status roadmap. |
 | [`simulation-preview-ui-architecture.md`](./simulation-preview-ui-architecture.md) | Architecture reference | Simulation Preview / Colony Planner component ownership and delivered UI architecture notes. |
@@ -57,13 +58,14 @@ Instead:
 
 ## Source Pack Reminder
 
-Stage 17A identified that the expected reference-pack path was missing from `main` at the time of review. Mechanics-heavy work should not claim direct source verification from uncommitted local files.
+Stage 17A identified that the expected reference-pack path was missing from
+`main` at the time of review. Stage 17Q adds the committed reference entry
+point under [`docs/reference/colonisation/`](../reference/colonisation/),
+including source priority, source inventory placeholders, and a Codex prompt
+snippet.
 
-Before future mechanics-heavy work, commit or verify:
-
-- `docs/reference/colonisation/README.md`
-- `docs/reference/colonisation/source-priority.md`
-- `docs/reference/colonisation/codex-reference-prompt-snippet.md`
-- permitted source inventories, placeholders, or redistributable references
-
-Until then, prompts and PRs must clearly say whether they used committed docs, attached files, or local/operator knowledge.
+The reference entry point does not commit restricted guide files, spreadsheets,
+PDFs, screenshots, or third-party assets. Mechanics-heavy work should read the
+committed reference docs first, then clearly state whether any direct source
+verification used committed docs, attached files, external sources, or
+local/operator-only files.

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -45,22 +45,30 @@ Use this order before starting new colonisation work:
 3. `docs/colonisation-redesign/engine-roadmap.md` for broad engine history and delivered stage summaries.
 4. `docs/colonisation-redesign/enrichment-roadmap.md` for station/body/ring enrichment, warehouse, and operator-roadmap work.
 5. Specific stage docs only when they directly apply to the task.
-6. `docs/reference/colonisation/README.md` and `docs/reference/colonisation/source-priority.md` once the reference pack is committed.
+6. For mechanics-heavy or source-sensitive work, read `docs/reference/colonisation/README.md`, `docs/reference/colonisation/source-priority.md`, and `docs/reference/colonisation/source-inventory.md`.
 
 If this file conflicts with an older "recommended next stage" section, treat this file as newer planning control unless the older doc is being used only for historical context.
 
 ## Source Authority Rule
 
-The source-pack issue from Stage 17A is still important. Mechanics-heavy work should not rely on a local ZIP or uncommitted reference archive as if it were repo truth.
-
-Before future mechanics-heavy implementation, add or verify the committed reference-pack path:
+The source-pack issue from Stage 17A remains important, but Stage 17Q now adds
+the committed reference entry point:
 
 - `docs/reference/colonisation/README.md`
 - `docs/reference/colonisation/source-priority.md`
+- `docs/reference/colonisation/source-inventory.md`
 - `docs/reference/colonisation/codex-reference-prompt-snippet.md`
-- permitted guide/spreadsheet/diagram references or placeholders
 
-Until that path exists, implementation prompts must explicitly state whether they are using committed docs, attached files, or local/operator knowledge. Do not claim direct source verification from files that are not committed or attached.
+The committed path records the source hierarchy, conflict rules, and inventory
+placeholders. It does not commit restricted guide files, spreadsheets, PDFs,
+screenshots, or third-party assets unless their redistribution status is
+explicitly safe.
+
+Future mechanics-heavy implementation prompts must read the committed reference
+docs first, then explicitly state whether direct source verification used
+committed docs, attached files, external sources, or local/operator-only files.
+Do not claim direct source verification from files that are not committed or
+attached.
 
 ## Non-Negotiable Product Boundaries
 

--- a/docs/reference/colonisation/README.md
+++ b/docs/reference/colonisation/README.md
@@ -1,0 +1,59 @@
+# Colonisation Reference Pack
+
+This directory is the committed source-authority entry point for ED-Finder
+colonisation and Colony Planner mechanics work.
+
+It intentionally does not include restricted guide files, spreadsheets, PDFs,
+screenshots, or extracted third-party assets unless their redistribution status
+is explicitly safe. Where a source cannot be committed safely, this reference
+pack records an inventory entry and citation rule instead.
+
+## Read Order
+
+For mechanics-heavy or source-sensitive work, read these files before changing
+code or scoring rules:
+
+1. [`source-priority.md`](./source-priority.md) - source hierarchy, conflict
+   rules, and authority boundaries.
+2. [`source-inventory.md`](./source-inventory.md) - known source inventory,
+   redistribution status, and citation/use rules.
+3. [`codex-reference-prompt-snippet.md`](./codex-reference-prompt-snippet.md) -
+   reusable prompt text for future Codex runs.
+
+Then read the active roadmap:
+
+1. [`docs/colonisation-redesign/README.md`](../../colonisation-redesign/README.md)
+2. [`docs/colonisation-redesign/stage-17p-current-state-forward-plan.md`](../../colonisation-redesign/stage-17p-current-state-forward-plan.md)
+3. [`docs/colonisation-redesign/engine-roadmap.md`](../../colonisation-redesign/engine-roadmap.md)
+4. [`docs/colonisation-redesign/enrichment-roadmap.md`](../../colonisation-redesign/enrichment-roadmap.md)
+
+## Current Pack Contents
+
+Committed now:
+
+- Source-priority rules.
+- Source inventory and placeholders.
+- Future Codex prompt snippet.
+
+Not committed:
+
+- Elite Dangerous Colonization Mega Guide source files.
+- OASIS guide source files.
+- Fandom, Frontier, or AetherWave PDFs.
+- DaftMav workbook files.
+- RavenColonial screenshots, frames, source, CSS, assets, icons, or API
+  material.
+- User spreadsheets or empirical datasets whose redistribution status is not
+  explicit.
+
+## Mechanics Boundary
+
+This pack is a reference baseline, not a behaviour change. Adding this directory
+does not change app behaviour, mechanics, scoring, CP formulas, economy/service
+logic, optimiser ranking, Simulation Preview execution, Suggested Build
+generation, or Build Plan loading.
+
+Future PRs should cite committed docs first. If a claim depends on an attached,
+external, or local-only source file, the PR should name that source and state
+whether the file was committed, attached to the review, or only inspected
+locally.

--- a/docs/reference/colonisation/codex-reference-prompt-snippet.md
+++ b/docs/reference/colonisation/codex-reference-prompt-snippet.md
@@ -1,0 +1,34 @@
+# Codex Reference Prompt Snippet
+
+Use this snippet at the start of future mechanics-heavy colonisation prompts:
+
+```md
+Before changing colonisation mechanics, planner warnings, picker validity, CP
+logic, strong/weak links, dependencies, economy influence, source-sensitive UI
+copy, or enrichment trust behaviour, read:
+
+1. docs/reference/colonisation/README.md
+2. docs/reference/colonisation/source-priority.md
+3. docs/reference/colonisation/source-inventory.md
+4. docs/colonisation-redesign/README.md
+5. docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+
+Treat the Elite Dangerous Colonization Mega Guide as the primary mechanics
+authority. If it conflicts with OASIS, DaftMav, Fandom, Frontier forum PDFs,
+AetherWave PDFs, diagrams, spreadsheets, screenshots, or future external data,
+prefer the Mega Guide unless newer verified evidence is explicitly documented.
+
+Treat user empirical findings and spreadsheet analysis as high-value evidence,
+especially for surface-slot prediction, but do not label prediction evidence as
+confirmed truth without observed/imported Architect evidence.
+
+Treat RavenColonial as UI/tooling inspiration and possible handoff target only.
+Do not copy RavenColonial source, CSS, assets, icons, proprietary implementation
+details, API keys, private plugin data, logistics workflow, or mutating API
+behaviour.
+
+Do not introduce automatic Simulation Preview execution, automatic Suggested
+Build generation, automatic Suggested Build loading, silent Build Plan mutation,
+hidden scoring/CP/economy/service/buildability/optimiser-ranking changes, or
+coercion of unknown data to zero/false.
+```

--- a/docs/reference/colonisation/source-inventory.md
+++ b/docs/reference/colonisation/source-inventory.md
@@ -1,0 +1,29 @@
+# Colonisation Source Inventory
+
+This inventory records known colonisation reference sources and how future PRs
+should cite or use them. It is deliberately conservative: if redistribution is
+not explicitly safe, the source file is not committed here.
+
+| Source name | Purpose | Authority level | File status | Redistribution/licensing status | Future PR citation/use |
+|---|---|---|---|---|---|
+| Elite Dangerous Colonization Mega Guide | Primary mechanics reference for colonisation rules, body rules, links, dependencies, CP/economy mechanics, and planner warning claims. | Primary mechanics authority | Not committed; external/attached/local-only source expected when used. | Not confirmed safe to redistribute in this repo. | Cite as "Elite Dangerous Colonization Mega Guide" with inspected version/date when available. Prefer it in source conflicts unless newer verified evidence is documented. |
+| User empirical findings and spreadsheet analysis | Empirical evidence for prediction work, especially surface-slot prediction, anomalies, and validation rows. | High-value evidence; prediction evidence, not confirmed truth | Not committed unless anonymised/source-permitted fixtures are added later. | Unknown unless the user explicitly marks a fixture safe to commit. | Cite dataset/spreadsheet name, attachment/local status, row scope, and whether evidence is prediction-only or observed/imported truth. |
+| DaftMav Colonization Construction spreadsheet | Facility catalogue, construction, comparison, support values, and structure table reference. | Catalogue/construction/support reference | Not committed; external/attached/local-only workbook expected when used. | Not confirmed safe to redistribute in this repo. | Cite workbook name/version/date and the exact sheet/column used. Do not import workbook facts silently into mechanics without tests and source notes. |
+| OASIS Guide for Bootstrapping a Bubble | Planning workflow support, bootstrapping strategy, and player workflow context. | Planning workflow support | Not committed; external/attached/local-only source expected when used. | Not confirmed safe to redistribute in this repo. | Cite as supporting workflow context. Do not override Mega Guide mechanics claims without documented verification. |
+| Fandom System Colonisation reference | Secondary clarification and cross-checking for system colonisation concepts. | Secondary clarification | Not committed; external source. | Not confirmed safe to redistribute in this repo. | Cite URL/title/date if used. Treat as secondary clarification only. |
+| Frontier forum strong/weak link references | Secondary clarification for strong/weak link concepts and community explanations. | Secondary clarification | Not committed; external source. | Not confirmed safe to redistribute in this repo. | Cite forum thread/title/date if used. Prefer Mega Guide for mechanics conflicts. |
+| AetherWave PDFs and diagrams | Secondary visual explanation, diagrams, and cross-checking. | Secondary clarification | Not committed; external/attached/local-only source expected when used. | Not confirmed safe to redistribute in this repo. | Cite file/title/date and keep diagrams as explanatory evidence, not automatic mechanics truth. |
+| Construction prerequisite images, link diagrams, and infographics | Visual clarification of dependencies, links, and construction flow. | Secondary clarification | Not committed; external/attached/local-only source expected when used. | Not confirmed safe to redistribute in this repo. | Cite source/title/date. Recreate only repo-native explanatory diagrams when licensing is safe or when based on original ED-Finder analysis. |
+| RavenColonial screenshots/tooling observations | UI/workflow inspiration, planning clarity comparison, and possible future handoff/export research. | UI/tooling inspiration only | Not committed here; existing ED-Finder docs may describe clean-room observations. | Screenshots/assets/source/API material are not confirmed safe to redistribute. | Cite as clean-room workflow observation only. Never use as mechanics authority or copy source/CSS/assets/icons/API behaviour. |
+| EDMC, EDDiscovery, EDSM, EDDN, Spansh, RavenColonial plugin data, imported snapshots | Future evidence/source data for enrichment, observations, validation, and source coverage. | Evidence/source data, not automatic truth | Not committed as source authority; fixtures may be committed only when safe and anonymised. | Varies by source; verify before committing. | Track source, timestamp, freshness, confidence, import method, and review path. Keep data passive unless a future stage explicitly scopes mechanics changes. |
+
+## Placeholder Policy
+
+- Do not commit DOCX, PDF, XLSX, screenshot, extracted-frame, plugin, API,
+  commander, or private-data files unless redistribution is explicitly safe.
+- Use small anonymised fixtures only when they are permitted and necessary for
+  tests or deterministic examples.
+- If a future PR depends on a non-committed source file, state whether that file
+  is attached to the PR/review, external, or local-only.
+- If source files are later added here, update this inventory with file path,
+  version/date, redistribution status, and citation instructions.

--- a/docs/reference/colonisation/source-priority.md
+++ b/docs/reference/colonisation/source-priority.md
@@ -1,0 +1,50 @@
+# Colonisation Source Priority
+
+Use this hierarchy for ED-Finder colonisation mechanics, planner warnings,
+picker validity, CP logic, strong/weak links, dependencies, economy influence,
+and source-sensitive UI copy.
+
+## Authority Hierarchy
+
+| Priority | Source | Authority and use |
+|---:|---|---|
+| 1 | Elite Dangerous Colonization Mega Guide | Primary mechanics authority. If another source conflicts, prefer the Mega Guide unless newer verified evidence is explicitly documented. |
+| 2 | User empirical findings and spreadsheet analysis | High-value evidence, especially surface-slot prediction and anomaly analysis. Prediction evidence is not confirmed truth unless backed by observed/imported Architect evidence. |
+| 3 | DaftMav Colonization Construction spreadsheet | Catalogue, construction, support, comparison, and structure-table reference. Use for facility/catalogue enrichment where redistribution and versioning are safe. |
+| 4 | OASIS Guide for Bootstrapping a Bubble | Planning workflow support, bootstrapping strategy, and operator/player workflow context. Not higher authority than the Mega Guide for mechanics conflicts. |
+| 5 | Fandom, Frontier forum posts/PDFs, AetherWave PDFs, diagrams, and infographics | Secondary clarification, visual explanation, and cross-checking. Use to clarify or document conflicts, not to silently override primary mechanics authority. |
+| 6 | RavenColonial screenshots/tooling | UI/tooling inspiration and possible future handoff target only. Not mechanics authority for ED-Finder scoring, CP, economy, service, buildability, or optimiser ranking. |
+| 7 | Future external data sources: EDMC, EDDiscovery, EDSM, EDDN, Spansh, RavenColonial plugin data, imported snapshots | Evidence/source data with source, timestamp, freshness, confidence, and review controls. Not automatic mechanics truth. |
+
+## Conflict Rules
+
+When sources conflict:
+
+1. Prefer the Elite Dangerous Colonization Mega Guide.
+2. Record the conflict explicitly in the relevant implementation, test, or doc.
+3. Treat newer evidence as a candidate update only when its source and
+   verification path are documented.
+4. Do not silently average, merge, or hide conflicting claims.
+5. Keep unknown data unknown. Missing coordinates, distances, slot counts,
+   rings, or body associations must not be coerced to zero or false.
+
+## Planner Trust Rules
+
+- Predicted surface slots are labelled prediction/evidence, not known or
+  confirmed Architect truth.
+- Existing infrastructure is not a Build Plan placement.
+- Projected Suggested Build structures are ghost/projection-only until the user
+  explicitly loads them.
+- Observed/imported data is evidence first. It must not silently mutate Build
+  Plans, Simulation Preview mechanics, scoring, CP, economy/service state,
+  buildability, validation state, or optimiser ranking.
+- Declared/inferred/observed roles remain guidance unless a future stage
+  explicitly scopes mechanics behaviour.
+
+## RavenColonial Boundary
+
+RavenColonial can inform workflow observations such as readable body hierarchy,
+local placement clarity, compact warnings, and handoff/export ideas. ED-Finder
+must not copy RavenColonial source code, CSS, assets, icons, proprietary
+implementation details, API keys, private plugin data, logistics workflow, or
+mutating API behaviour.


### PR DESCRIPTION
## What changed

- Added the committed colonisation reference entry point under `docs/reference/colonisation/`.
- Added source priority, source inventory, and future Codex prompt guidance for mechanics-heavy work.
- Updated the colonisation redesign README and Stage 17P forward plan now that the reference path exists as docs/placeholders.

## Validation

- `git diff --check`
- `find docs -type f -name '*.md' -print0 | xargs -0 grep -n "C:\\Users\\brian\\Downloads\\ed-finder-colonisation-reference-pack.zip" || true`

## Boundaries

- Documentation/source-authority only.
- No app behaviour changes.
- No mechanics, scoring, CP, economy, service, buildability, optimiser, preview, Suggested Build generation, or Build Plan loading changes.
- Restricted third-party source files were not committed; inventory placeholders were used instead.