### PR TITLE
Stage 17R planner trust audit

### DIFF
--- a/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyTopologyRail.test.tsx
@@ -7,6 +7,7 @@ import {
   describeTopologySelection,
   type TopologySelection,
 } from './ColonyTopologyRail';
+import { buildBodyDataSlotEstimateMap } from './slotCapacityFallback';
 
 const templates: FacilityTemplate[] = [
   {
@@ -164,7 +165,6 @@ describe('ColonyTopologyRail', () => {
   });
 
   it('filters non-physical Barycentre and Null entries from the system tree and slot calculations', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const customSystem = {
       ...system,
       bodies: [
@@ -175,41 +175,22 @@ describe('ColonyTopologyRail', () => {
       ],
     } as unknown as SystemDetail;
 
-    try {
-      render(
-        <ColonyTopologyRail
-          system={customSystem}
-          snapshot={{ placements: [], templates, targetArchetype: 'refinery_industrial', slotPredictions: null }}
-          selection={{ type: 'system' }}
-          onSelect={vi.fn()}
-        />,
-      );
+    const estimateMap = buildBodyDataSlotEstimateMap(customSystem, null);
 
-      expect(screen.getByTestId('topology-body-0')).toBeTruthy();
-      expect(screen.getByTestId('topology-body-1')).toBeTruthy();
-      expect(screen.queryByText(/Barycentre/i)).toBeNull();
-      expect(screen.queryByText(/Null Body/i)).toBeNull();
-      expect(logSpy).toHaveBeenCalledWith(
-        'Calculated Slots:',
-        expect.arrayContaining([
-          expect.objectContaining({ bodyId: '1' }),
-        ]),
-      );
-      expect(logSpy).not.toHaveBeenCalledWith(
-        'Calculated Slots:',
-        expect.arrayContaining([
-          expect.objectContaining({ bodyId: '99' }),
-        ]),
-      );
-      expect(logSpy).not.toHaveBeenCalledWith(
-        'Calculated Slots:',
-        expect.arrayContaining([
-          expect.objectContaining({ bodyId: '100' }),
-        ]),
-      );
-    } finally {
-      logSpy.mockRestore();
-    }
+    render(
+      <ColonyTopologyRail
+        system={customSystem}
+        snapshot={{ placements: [], templates, targetArchetype: 'refinery_industrial', slotPredictions: null }}
+        selection={{ type: 'system' }}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('topology-body-0')).toBeTruthy();
+    expect(screen.getByTestId('topology-body-1')).toBeTruthy();
+    expect(screen.queryByText(/Barycentre/i)).toBeNull();
+    expect(screen.queryByText(/Null Body/i)).toBeNull();
+    expect(Array.from(estimateMap.keys())).toEqual(['1']);
   });
 
   it('renders unknown and unassigned placement groups without exposing raw IDs by default', () => {
@@ -314,8 +295,7 @@ describe('ColonyTopologyRail', () => {
     expect(screen.getByTestId('2-ground-slot-4')).toBeTruthy();
   });
 
-  it('forces calculated body-data slots when confirmed slot predictions are empty', () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  it('uses calculated body-data slots when canonical slot predictions are absent', () => {
     const customSystem = {
       ...system,
       bodies: [
@@ -331,30 +311,23 @@ describe('ColonyTopologyRail', () => {
       ],
     } as unknown as SystemDetail;
 
-    try {
-      render(
-        <ColonyTopologyRail
-          system={customSystem}
-          snapshot={{ placements: [], templates, targetArchetype: 'refinery_industrial', slotPredictions: null }}
-          selection={{ type: 'system' }}
-          onSelect={vi.fn()}
-        />,
-      );
+    const estimateMap = buildBodyDataSlotEstimateMap(customSystem, null);
 
-      expect(screen.getByTestId('topology-slot-estimate-disclaimer').textContent).toContain(
-        'Slot layout estimated from body data',
-      );
-      expect(screen.getByTestId('2-orbital-slot-0')).toBeTruthy();
-      expect(screen.getByTestId('2-ground-slot-0')).toBeTruthy();
-      expect(logSpy).toHaveBeenCalledWith(
-        'Calculated Slots:',
-        expect.arrayContaining([
-          expect.objectContaining({ bodyId: '2', orbital: 1, surface: 1 }),
-        ]),
-      );
-    } finally {
-      logSpy.mockRestore();
-    }
+    render(
+      <ColonyTopologyRail
+        system={customSystem}
+        snapshot={{ placements: [], templates, targetArchetype: 'refinery_industrial', slotPredictions: null }}
+        selection={{ type: 'system' }}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('topology-slot-estimate-disclaimer').textContent).toContain(
+      'Slot layout estimated from body data',
+    );
+    expect(screen.getByTestId('2-orbital-slot-0')).toBeTruthy();
+    expect(screen.getByTestId('2-ground-slot-0')).toBeTruthy();
+    expect(estimateMap.get('2')).toEqual(expect.objectContaining({ bodyId: '2', orbital: 1, surface: 1 }));
   });
 
   it('shows overflow when structures exceed predicted capacity', () => {

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -286,19 +286,23 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     const summary = buildRavenPlannerOccupancySummary(occupiedSystem, occupiedSnapshot);
 
     expect(body?.existingCount).toBe(2);
+    expect(body?.inferredExistingCount).toBe(2);
     expect(body?.plannedCount).toBe(0);
     expect(body?.orbitalSlots[0]).toEqual(expect.objectContaining({
       kind: 'existing',
       fullName: 'Holden Orbital',
       existingStructureId: 'existing-9001',
+      warningLabels: ['Inferred association'],
     }));
     expect(body?.orbitalSlots[1]).toEqual(expect.objectContaining({ kind: 'empty' }));
     expect(body?.groundSlots[0]).toEqual(expect.objectContaining({
       kind: 'existing',
       fullName: 'Kepler Surface Port',
+      warningLabels: ['Inferred association'],
     }));
     expect(summary).toEqual(expect.objectContaining({
       existingCount: 2,
+      inferredExistingCount: 2,
       plannedCount: 0,
       projectedCount: 0,
       emptySlotCount: 2,
@@ -308,8 +312,10 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
 
     expect(screen.getByTestId('raven-existing-infrastructure-summary').textContent).toContain('Existing infrastructure detected');
     expect(screen.getAllByTestId('raven-existing-structure')).toHaveLength(2);
+    expect(screen.getAllByTestId('raven-inferred-existing-marker')).toHaveLength(2);
     expect(screen.getAllByText('Holden Orbital').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Kepler Surface Port').length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle(/Body match inferred \(frontend_body_name_fallback\).*verify against backend resolver metadata/i)).toHaveLength(2);
     expect((screen.getByTestId('2-orbital-add') as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByTestId('2-ground-add') as HTMLButtonElement).disabled).toBe(false);
   });

--- a/frontend-v2/src/features/colony-planner/existingInfrastructure.test.ts
+++ b/frontend-v2/src/features/colony-planner/existingInfrastructure.test.ts
@@ -18,7 +18,7 @@ const baseSystem = {
 } as unknown as SystemDetail;
 
 describe('existing infrastructure resolver', () => {
-  it('maps exact body names and orbital station types', () => {
+  it('maps legacy exact body-name fallbacks as inferred orbital station associations', () => {
     const resolution = resolveExistingInfrastructure({
       ...baseSystem,
       stations: [
@@ -37,10 +37,12 @@ describe('existing infrastructure resolver', () => {
     expect(resolution.mapped[0]).toEqual(expect.objectContaining({
       source: 'existing',
       body_id: '2',
-      body_match_confidence: 'exact',
+      body_match_confidence: 'inferred',
+      body_match_reason: 'Matched station body name; verify against backend resolver metadata.',
       lane: 'orbital',
-      association_status: 'confirmed',
-      association_confidence: 'exact',
+      association_status: 'inferred',
+      association_confidence: 'strong_inference',
+      association_source: 'frontend_body_name_fallback',
       economy: 'Refinery',
     }));
   });

--- a/frontend-v2/src/features/colony-planner/existingInfrastructure.ts
+++ b/frontend-v2/src/features/colony-planner/existingInfrastructure.ts
@@ -48,6 +48,13 @@ export interface ExistingInfrastructureResolution {
   }>;
 }
 
+type StationBodyMatch = {
+  body: SystemBody | null;
+  confidence: ExistingStructureBodyMatchConfidence;
+  reason: string;
+  source: string;
+};
+
 export function resolveExistingInfrastructure(system: SystemDetail): ExistingInfrastructureResolution {
   const bodies = (system.bodies ?? []).filter((body) => body?.id != null);
   const structures = (system.stations ?? []).map((station, index) => resolveStation(bodies, station, index));
@@ -165,7 +172,7 @@ function resolveStation(
     lane,
     association_status: bodyMatch.confidence === 'exact' ? 'confirmed' : bodyMatch.confidence === 'inferred' ? 'inferred' : 'unresolved',
     association_confidence: bodyMatch.confidence === 'exact' ? 'exact' : bodyMatch.confidence === 'inferred' ? 'strong_inference' : 'unresolved',
-    association_source: bodyMatch.confidence === 'exact' ? 'frontend_fallback' : bodyMatch.confidence === 'inferred' ? 'frontend_distance_fallback' : 'frontend_unresolved_fallback',
+    association_source: bodyMatch.source,
     economy: readString(record.primary_economy) ?? readEconomyName(record.economies, 0),
     secondary_economy: readString(record.secondary_economy) ?? readEconomyName(record.economies, 1),
     pad_size: readString(record.landing_pad_size) ?? readString(record.pad_size),
@@ -263,23 +270,33 @@ function matchStationBody(
   explicitBodyId: string | null,
   stationBodyName: string | null,
   stationDistanceFromStar: number | null,
-): { body: SystemBody | null; confidence: ExistingStructureBodyMatchConfidence; reason: string } {
+): StationBodyMatch {
   if (explicitBodyId) {
     const body = bodies.find((candidate) => sameBodyId(candidate.id, explicitBodyId));
     if (body) {
-      return { body, confidence: 'exact', reason: 'Matched exact body id.' };
+      return { body, confidence: 'exact', reason: 'Matched exact body id.', source: 'frontend_body_id_fallback' };
     }
-    return { body: null, confidence: 'unresolved', reason: 'Station body id does not match a known body.' };
+    return { body: null, confidence: 'unresolved', reason: 'Station body id does not match a known body.', source: 'frontend_body_id_fallback' };
   }
 
   if (stationBodyName) {
     const bodyName = normaliseName(stationBodyName);
     const matches = bodies.filter((candidate) => normaliseName(candidate.name) === bodyName);
     if (matches.length === 1) {
-      return { body: matches[0], confidence: 'exact', reason: 'Matched exact body name.' };
+      return {
+        body: matches[0],
+        confidence: 'inferred',
+        reason: 'Matched station body name; verify against backend resolver metadata.',
+        source: 'frontend_body_name_fallback',
+      };
     }
     if (matches.length > 1) {
-      return { body: null, confidence: 'unresolved', reason: 'Station body name matches multiple bodies.' };
+      return {
+        body: null,
+        confidence: 'unresolved',
+        reason: 'Station body name matches multiple bodies.',
+        source: 'frontend_body_name_fallback',
+      };
     }
   }
 
@@ -289,14 +306,29 @@ function matchStationBody(
       return bodyDistance != null && Math.abs(bodyDistance - stationDistanceFromStar) <= 0.01;
     });
     if (matches.length === 1) {
-      return { body: matches[0], confidence: 'inferred', reason: 'Inferred from unique distance-from-star match.' };
+      return {
+        body: matches[0],
+        confidence: 'inferred',
+        reason: 'Inferred from unique distance-from-star match.',
+        source: 'frontend_distance_fallback',
+      };
     }
     if (matches.length > 1) {
-      return { body: null, confidence: 'unresolved', reason: 'Distance-from-star match is ambiguous.' };
+      return {
+        body: null,
+        confidence: 'unresolved',
+        reason: 'Distance-from-star match is ambiguous.',
+        source: 'frontend_distance_fallback',
+      };
     }
   }
 
-  return { body: null, confidence: 'unresolved', reason: 'No reliable body association is available.' };
+  return {
+    body: null,
+    confidence: 'unresolved',
+    reason: 'No reliable body association is available.',
+    source: 'frontend_unresolved_fallback',
+  };
 }
 
 function readEconomyName(value: unknown, index: number): string | null {

--- a/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
+++ b/frontend-v2/src/features/colony-planner/slotCapacityFallback.ts
@@ -54,12 +54,12 @@ export function resolveSlotCapacity(
 
 export function buildBodyDataSlotEstimateMap(
   system: SystemDetail,
-  confirmedSlots: BodySlotPrediction[] | null | undefined,
+  slotPredictions: BodySlotPrediction[] | null | undefined,
 ): Map<string, BodyDataSlotEstimate> {
   const bodyData = systemBodyData(system);
-  if (!shouldUseBodyDataSlotFallback(system, confirmedSlots)) return new Map();
+  if (!shouldUseBodyDataSlotFallback(system, slotPredictions)) return new Map();
 
-  const calculatedArray = bodyData
+  const calculatedEstimates = bodyData
     .filter((body) => body.id != null)
     .map((body) => {
       const slots = estimateBodySlots(body, { allowMinimalBodyDataEstimate: true });
@@ -73,17 +73,15 @@ export function buildBodyDataSlotEstimateMap(
     })
     .filter((estimate): estimate is BodyDataSlotEstimate => estimate != null);
 
-  console.log('Calculated Slots:', calculatedArray);
-
-  return new Map(calculatedArray.map((estimate) => [estimate.bodyId, estimate]));
+  return new Map(calculatedEstimates.map((estimate) => [estimate.bodyId, estimate]));
 }
 
 export function shouldUseBodyDataSlotFallback(
   system: SystemDetail,
-  confirmedSlots: BodySlotPrediction[] | null | undefined,
+  slotPredictions: BodySlotPrediction[] | null | undefined,
 ): boolean {
   const bodyData = systemBodyData(system);
-  return (!confirmedSlots || confirmedSlots.length === 0) && bodyData.length > 0;
+  return (!slotPredictions || slotPredictions.length === 0) && bodyData.length > 0;
 }
 
 export function systemBodyData(system: SystemDetail): SystemBody[] {


### PR DESCRIPTION
## Summary
- Remove the temporary slot fallback debug log and uncouple tests from console output.
- Treat legacy station body-name fallback as inferred/verify instead of confirmed.
- Keep existing infrastructure separate from Build Plan placements while preserving lane capacity accounting.

## Validation
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm test -- src/lib/format.test.ts src/lib/rationale.test.ts src/features/system-detail/RatingRadar.test.tsx src/components/ResultCard.test.tsx`
- `cd frontend-v2 && npm test -- RavenStylePlannerCanvas WholeSystemColonyPlanner`
- `cd frontend-v2 && npm test -- ColonyPlannerWorkspace` (nearest current WholeSystemColonyPlanner coverage)
- `cd frontend-v2 && npm run build`
- `.venv/bin/pytest tests/test_stage17n2c_data_trust.py tests/test_smoke.py -q`
- `git diff --check`

## Boundaries
- No automatic preview.
- No automatic Suggested Build generation or load.
- No scoring, CP, economy, service, buildability, or optimiser-ranking changes.
- Unknown data remains unknown.
- Existing infrastructure remains display/capacity context only, not Build Plan mutation.