### PR TITLE
Stage 17S existing infrastructure UX

### DIFF
--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.test.tsx
@@ -293,6 +293,7 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
       fullName: 'Holden Orbital',
       existingStructureId: 'existing-9001',
       warningLabels: ['Inferred association'],
+      trustStatus: 'inferred',
     }));
     expect(body?.orbitalSlots[1]).toEqual(expect.objectContaining({ kind: 'empty' }));
     expect(body?.groundSlots[0]).toEqual(expect.objectContaining({
@@ -316,8 +317,58 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(screen.getAllByText('Holden Orbital').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Kepler Surface Port').length).toBeGreaterThan(0);
     expect(screen.getAllByTitle(/Body match inferred \(frontend_body_name_fallback\).*verify against backend resolver metadata/i)).toHaveLength(2);
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Existing 1 / verify 1');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Planned 0');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Ghost 0');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Open 1');
     expect((screen.getByTestId('2-orbital-add') as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByTestId('2-ground-add') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('renders confirmed backend associations in lane with explicit known marker', () => {
+    const confirmedSystem = {
+      ...system,
+      stations: [
+        {
+          id: 9301,
+          market_id: 9301,
+          name: 'Confirmed Body Starport',
+          station_type: 'Coriolis',
+          body_id: 2,
+          body_name: 'Real Data System A 1',
+          lane: 'orbital',
+          association_status: 'confirmed',
+          association_confidence: 'exact',
+          association_source: 'resolver_body_id',
+          resolver_notes: 'Exact body id from backend station resolver.',
+        },
+      ],
+    } as unknown as SystemDetail;
+    const confirmedSnapshot: TopologyPlanSnapshot = {
+      ...snapshot,
+      placements: [],
+      projection: null,
+    };
+    const row = buildRavenPlannerRows(confirmedSystem, confirmedSnapshot).find((candidate) => candidate.id === '2');
+
+    expect(row?.existingCount).toBe(1);
+    expect(row?.inferredExistingCount).toBe(0);
+    expect(row?.plannedCount).toBe(0);
+    expect(row?.orbitalSlots[0]).toEqual(expect.objectContaining({
+      kind: 'existing',
+      fullName: 'Confirmed Body Starport',
+      warningLabels: [],
+      trustStatus: 'confirmed',
+    }));
+
+    render(<RavenStylePlannerCanvas system={confirmedSystem} snapshot={confirmedSnapshot} selection={{ type: 'body', bodyId: '2' }} onSelect={vi.fn()} onRequestAddStructure={vi.fn()} />);
+
+    expect(screen.getByTestId('raven-confirmed-existing-marker').textContent).toContain('known');
+    expect(screen.queryByTestId('raven-inferred-existing-marker')).toBeNull();
+    expect(screen.getByTitle(/Body match confirmed \(resolver_body_id\)/i)).toBeTruthy();
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Existing 1');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).not.toContain('verify');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Open 1');
   });
 
   it('renders inferred backend associations in lane with explicit verify marker', () => {
@@ -361,6 +412,7 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(screen.getByText('1 inferred')).toBeTruthy();
     expect(screen.getByTestId('raven-inferred-existing-marker').textContent).toContain('verify');
     expect(screen.getByTitle(/Body match inferred \(resolver_distance\)/i)).toBeTruthy();
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Existing 1 / verify 1');
   });
 
   it('keeps transient backend unknown-lane associations out of lane capacity and unresolved warnings', () => {
@@ -390,6 +442,42 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     expect(buildRavenPlannerOccupancySummary(unknownLaneSystem, { ...snapshot, placements: [], projection: null }).unresolvedExistingCount).toBe(0);
   });
 
+  it('shows permanent unknown-lane infrastructure outside lane capacity', () => {
+    const unknownLaneSystem = {
+      ...system,
+      stations: [
+        {
+          id: 9302,
+          market_id: 9302,
+          name: 'Known Body Mystery Facility',
+          station_type: 'Unknown',
+          body_id: 2,
+          body_name: 'Real Data System A 1',
+          lane: 'unknown',
+          association_status: 'confirmed',
+          association_confidence: 'exact',
+          association_source: 'resolver_body_id',
+          resolver_notes: 'Backend confirmed the body but could not classify the lane.',
+        },
+      ],
+    } as unknown as SystemDetail;
+    const cleanSnapshot = { ...snapshot, placements: [], projection: null };
+    const rows = buildRavenPlannerRows(unknownLaneSystem, cleanSnapshot);
+    const row = rows.find((candidate) => candidate.id === '2');
+    const summary = buildRavenPlannerOccupancySummary(unknownLaneSystem, cleanSnapshot);
+
+    expect(row?.existingCount).toBe(0);
+    expect(row?.orbitalOccupancy.existingCount).toBe(0);
+    expect(row?.groundOccupancy.existingCount).toBe(0);
+    expect(summary.existingCount).toBe(0);
+    expect(summary.unresolvedExistingCount).toBe(1);
+
+    render(<RavenStylePlannerCanvas system={unknownLaneSystem} snapshot={cleanSnapshot} selection={{ type: 'system' }} onSelect={vi.fn()} />);
+
+    expect(screen.getByTestId('raven-unresolved-existing-structure').textContent).toContain('lane unknown');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Existing 0');
+  });
+
   it('includes existing occupancy in add capacity and overflow calculations', () => {
     const oneExistingSystem = {
       ...system,
@@ -410,9 +498,17 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
       existingCount: 1,
       plannedCount: 1,
       remaining: 0,
-      disabledReason: 'No empty orbital slots',
+      disabledReason: expect.stringContaining('No empty orbital slots'),
     }));
+    expect(fullState.disabledReason).toContain('2 slots, 1 existing, 1 planned');
     expect(fullRow?.orbitalSlots.map((slot) => slot.kind)).toEqual(['existing', 'planned']);
+    expect(fullRow?.orbitalOccupancy).toEqual(expect.objectContaining({
+      capacity: 2,
+      existingCount: 1,
+      plannedCount: 1,
+      projectedCount: 0,
+      remainingForPlan: 0,
+    }));
     expect(fullRow?.orbitalSlots.some((slot) => slot.kind === 'overflow')).toBe(false);
 
     const overflowSnapshot: TopologyPlanSnapshot = {
@@ -428,6 +524,59 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     render(<RavenStylePlannerCanvas system={oneExistingSystem} snapshot={fullSnapshot} selection={{ type: 'body', bodyId: '2' }} onSelect={vi.fn()} onRequestAddStructure={vi.fn()} />);
     expect((screen.getByTestId('2-orbital-add') as HTMLButtonElement).disabled).toBe(true);
     expect(screen.getByTestId('2-orbital-disabled-reason').textContent).toContain('No empty orbital slots');
+    expect(screen.getByTestId('2-orbital-disabled-reason').textContent).toContain('2 slots, 1 existing, 1 planned');
+    expect(screen.getByTestId('2-orbital-occupancy-summary').textContent).toContain('Open 0');
+  });
+
+  it('keeps Suggested Build projected occupancy ghost-only in lane capacity display', () => {
+    const oneExistingSystem = {
+      ...system,
+      stations: [occupiedSystem.stations?.[0]],
+    } as unknown as SystemDetail;
+    const ghostSnapshot: TopologyPlanSnapshot = {
+      ...snapshot,
+      placements: [],
+      projection: {
+        candidateId: 'ghost-orbit',
+        label: 'Ghost Orbit',
+        placements: [
+          { facility_template_id: 'dodec_starport', local_body_id: '2', build_order: 1 },
+        ],
+      },
+    };
+    const state = getRavenLaneCapacityState(oneExistingSystem, ghostSnapshot, '2', 'orbital');
+    const row = buildRavenPlannerRows(oneExistingSystem, ghostSnapshot).find((candidate) => candidate.id === '2');
+    const summary = buildRavenPlannerOccupancySummary(oneExistingSystem, ghostSnapshot);
+
+    expect(state).toEqual(expect.objectContaining({
+      capacity: 2,
+      existingCount: 1,
+      plannedCount: 0,
+      projectedCount: 1,
+      remaining: 1,
+      disabledReason: null,
+    }));
+    expect(row?.orbitalOccupancy).toEqual(expect.objectContaining({
+      existingCount: 1,
+      plannedCount: 0,
+      projectedCount: 1,
+      remainingForPlan: 1,
+    }));
+    expect(summary).toEqual(expect.objectContaining({
+      existingCount: 1,
+      plannedCount: 0,
+      projectedCount: 1,
+    }));
+
+    render(<RavenStylePlannerCanvas system={oneExistingSystem} snapshot={ghostSnapshot} selection={{ type: 'body', bodyId: '2' }} onSelect={vi.fn()} onRequestAddStructure={vi.fn()} />);
+
+    const occupancy = screen.getByTestId('2-orbital-occupancy-summary');
+    expect(occupancy.textContent).toContain('Existing 1 / verify 1');
+    expect(occupancy.textContent).toContain('Planned 0');
+    expect(occupancy.textContent).toContain('Ghost 1');
+    expect(occupancy.textContent).toContain('Open 1');
+    expect(screen.getByTestId('2-orbital-slot-1').textContent).toContain('Ghost');
+    expect((screen.getByTestId('2-orbital-add') as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('shows unresolved permanent existing infrastructure compactly instead of forcing a body or lane', () => {
@@ -450,6 +599,7 @@ describe('RavenStylePlannerCanvas real data adapter', () => {
     const unresolved = screen.getByTestId('raven-unresolved-existing-infrastructure');
     expect(unresolved.textContent).toContain('Existing infrastructure not matched to body');
     expect(unresolved.textContent).toContain('Lost Outpost');
+    expect(unresolved.textContent).toContain('unresolved');
     expect(buildRavenPlannerOccupancySummary(unresolvedSystem, { ...snapshot, placements: [], projection: null }).unresolvedExistingCount).toBe(1);
   });
 

--- a/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
+++ b/frontend-v2/src/features/colony-planner/RavenStylePlannerCanvas.tsx
@@ -79,6 +79,7 @@ export interface RavenStructureSlot {
   status: 'existing' | 'planned' | 'projected' | 'unknown';
   economyContextLabel: string | null;
   warningLabels: string[];
+  trustStatus?: 'confirmed' | 'inferred' | 'unresolved';
 }
 
 interface BgsTelemetryStat {
@@ -125,6 +126,18 @@ export interface RavenPlannerRow {
   emptySlotCount: number;
   orbitalAddDisabledReason: string | null;
   groundAddDisabledReason: string | null;
+  orbitalOccupancy: RavenLaneOccupancySummary;
+  groundOccupancy: RavenLaneOccupancySummary;
+}
+
+interface RavenLaneOccupancySummary {
+  capacity: number | null;
+  existingCount: number;
+  inferredExistingCount: number;
+  plannedCount: number;
+  projectedCount: number;
+  remainingForPlan: number | null;
+  projectedOverflowCount: number;
 }
 
 interface BodyNode {
@@ -422,6 +435,7 @@ function RavenPlannerBodyRow({
           bodyName={row.displayName}
           lane="orbital"
           capacity={row.orbitalCapacity}
+          occupancy={row.orbitalOccupancy}
           slots={row.orbitalSlots}
           selectedPlacementIndex={selectedPlacementIndex}
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
@@ -436,6 +450,7 @@ function RavenPlannerBodyRow({
           bodyName={row.displayName}
           lane="ground"
           capacity={row.groundCapacity}
+          occupancy={row.groundOccupancy}
           slots={row.groundSlots}
           selectedPlacementIndex={selectedPlacementIndex}
           selectedProjectedPlacementIndex={selectedProjectedPlacementIndex}
@@ -495,10 +510,17 @@ function UnresolvedExistingInfrastructure({ structures }: { structures: Existing
           {visible.map((structure) => (
             <span
               key={structure.id}
-              title={`${structure.name} | ${existingStructureDisplayType(structure)} | ${structure.unresolved_reason ?? structure.body_match_reason}`}
+              data-testid="raven-unresolved-existing-structure"
+              title={[
+                structure.name,
+                existingStructureDisplayType(structure),
+                `Association: ${existingAssociationLabel(structure)}`,
+                `Source: ${structure.association_source}`,
+                structure.unresolved_reason ?? structure.body_match_reason,
+              ].filter(Boolean).join(' | ')}
               className="max-w-[14rem] truncate rounded border border-gold/30 bg-bg3/45 px-2 py-1 font-mono text-[10px] text-silver"
             >
-              {structure.name} / {existingStructureDisplayType(structure)}
+              {structure.name} / {existingStructureDisplayType(structure)} / {existingAssociationLabel(structure)}
             </span>
           ))}
           {extra > 0 && (
@@ -510,6 +532,14 @@ function UnresolvedExistingInfrastructure({ structures }: { structures: Existing
       </div>
     </section>
   );
+}
+
+function existingAssociationLabel(structure: ExistingStructure): string {
+  if (structure.transient) return 'transient';
+  if (structure.association_status === 'unresolved') return 'unresolved';
+  if (structure.lane === 'unknown') return 'lane unknown';
+  if (structure.association_status === 'inferred') return 'verify';
+  return 'confirmed';
 }
 
 function TreeCell({
@@ -618,6 +648,7 @@ function RavenSlotLane({
   bodyName,
   lane,
   capacity,
+  occupancy,
   slots,
   selectedPlacementIndex,
   selectedProjectedPlacementIndex,
@@ -631,6 +662,7 @@ function RavenSlotLane({
   bodyName: string;
   lane: VisibleRavenLane;
   capacity: number | null;
+  occupancy: RavenLaneOccupancySummary;
   slots: RavenStructureSlot[];
   selectedPlacementIndex: number | null;
   selectedProjectedPlacementIndex: number | null;
@@ -655,59 +687,108 @@ function RavenSlotLane({
   const laneName = lane === 'orbital' ? 'orbital' : 'surface';
 
   return (
-    <div data-testid={`${bodyId}-${lane}-lane`} data-disabled={disabledReason ? 'true' : 'false'} className="flex min-w-0 items-center gap-2 pr-2">
-      <span className="flex min-w-[7rem] shrink-0 items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">
-        <span
-          data-testid={`${bodyId}-${lane}-capacity-badge`}
-          data-capacity={knownCount}
-          className="inline-flex items-baseline gap-0.5 rounded border border-cyan/35 bg-cyan/8 px-2 py-0.5 text-cyan"
-        >
-          <span className="text-[11px] font-semibold tracking-wide">{laneFullName}</span>
-          <span className="font-display text-[15px] font-bold leading-none tabular-nums">{knownCount}</span>
-        </span>
-        {showAddControl && (
-          <button
-            type="button"
-            data-testid={`${bodyId}-${lane}-add`}
-            aria-label={addLabel}
-            title={disabledReason ?? addLabel}
-            disabled={Boolean(disabledReason)}
-            onClick={requestAdd}
-            className="inline-flex items-center gap-1 rounded border border-orange/55 bg-orange/15 px-2.5 py-1 text-[11px] font-semibold text-orange hover:bg-orange/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70 disabled:cursor-not-allowed disabled:border-gold/35 disabled:bg-gold/10 disabled:text-gold/70 disabled:hover:bg-gold/10"
+    <div data-testid={`${bodyId}-${lane}-lane`} data-disabled={disabledReason ? 'true' : 'false'} className="flex min-w-0 flex-col gap-1 pr-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="flex min-w-[7rem] shrink-0 items-center gap-1.5 font-mono text-[11px] uppercase tracking-[0.1em] text-cyan">
+          <span
+            data-testid={`${bodyId}-${lane}-capacity-badge`}
+            data-capacity={knownCount}
+            className="inline-flex items-baseline gap-0.5 rounded border border-cyan/35 bg-cyan/8 px-2 py-0.5 text-cyan"
           >
-            <Plus size={12} />
-            {lane === 'orbital' ? 'Add Orbit' : 'Add Surface'}
-          </button>
-        )}
-      </span>
-      <div className="flex min-w-0 flex-wrap gap-1.5">
-        {visibleSlots.length > 0 ? visibleSlots.map((slot, index) => (
-          <RavenSlotBox
-            key={slot.id}
-            slot={slot}
-            lane={lane}
-            bodyName={bodyName}
-            testId={`${bodyId}-${lane}-slot-${index}`}
-            selected={(slot.placementIndex != null && slot.placementIndex === selectedPlacementIndex) || (slot.projectionIndex != null && slot.projectionIndex === selectedProjectedPlacementIndex)}
-            onSelect={onSelect}
-            onAdd={undefined}
-            warningCount={slot.placementIndex != null ? prerequisiteIssues.find((issue) => issue.placementIndex === slot.placementIndex)?.missing.length ?? 0 : 0}
-          />
-        )) : (
-          <LaneCompactState
-            laneName={laneName}
-            capacity={capacity}
-            selectedBody={selectedBody}
-            disabledReason={disabledReason}
-            testId={`${bodyId}-${lane}-compact-state`}
-          />
-        )}
-        {selectedBody && disabledReason && (
-          <span data-testid={`${bodyId}-${lane}-disabled-reason`} className="rounded border border-gold/35 bg-gold/10 px-1.5 py-1 font-mono text-[10px] text-gold">
-            {disabledReason}
+            <span className="text-[11px] font-semibold tracking-wide">{laneFullName}</span>
+            <span className="font-display text-[15px] font-bold leading-none tabular-nums">{knownCount}</span>
           </span>
-        )}
+          {showAddControl && (
+            <button
+              type="button"
+              data-testid={`${bodyId}-${lane}-add`}
+              aria-label={addLabel}
+              title={disabledReason ?? addLabel}
+              disabled={Boolean(disabledReason)}
+              onClick={requestAdd}
+              className="inline-flex items-center gap-1 rounded border border-orange/55 bg-orange/15 px-2.5 py-1 text-[11px] font-semibold text-orange hover:bg-orange/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/70 disabled:cursor-not-allowed disabled:border-gold/35 disabled:bg-gold/10 disabled:text-gold/70 disabled:hover:bg-gold/10"
+            >
+              <Plus size={12} />
+              {lane === 'orbital' ? 'Add Orbit' : 'Add Surface'}
+            </button>
+          )}
+        </span>
+        <div className="flex min-w-0 flex-wrap gap-1.5">
+          {visibleSlots.length > 0 ? visibleSlots.map((slot, index) => (
+            <RavenSlotBox
+              key={slot.id}
+              slot={slot}
+              lane={lane}
+              bodyName={bodyName}
+              testId={`${bodyId}-${lane}-slot-${index}`}
+              selected={(slot.placementIndex != null && slot.placementIndex === selectedPlacementIndex) || (slot.projectionIndex != null && slot.projectionIndex === selectedProjectedPlacementIndex)}
+              onSelect={onSelect}
+              onAdd={undefined}
+              warningCount={slot.placementIndex != null ? prerequisiteIssues.find((issue) => issue.placementIndex === slot.placementIndex)?.missing.length ?? 0 : 0}
+            />
+          )) : (
+            <LaneCompactState
+              laneName={laneName}
+              capacity={capacity}
+              selectedBody={selectedBody}
+              disabledReason={disabledReason}
+              testId={`${bodyId}-${lane}-compact-state`}
+            />
+          )}
+          {selectedBody && disabledReason && (
+            <span data-testid={`${bodyId}-${lane}-disabled-reason`} className="rounded border border-gold/35 bg-gold/10 px-1.5 py-1 font-mono text-[10px] text-gold">
+              {disabledReason}
+            </span>
+          )}
+        </div>
       </div>
+      <LaneOccupancySummary
+        testId={`${bodyId}-${lane}-occupancy-summary`}
+        laneLabel={laneName}
+        occupancy={occupancy}
+      />
+    </div>
+  );
+}
+
+function LaneOccupancySummary({
+  testId,
+  laneLabel,
+  occupancy,
+}: {
+  testId: string;
+  laneLabel: string;
+  occupancy: RavenLaneOccupancySummary;
+}) {
+  const slotsLabel = occupancy.capacity == null ? 'unknown' : String(occupancy.capacity);
+  const remainingLabel = occupancy.remainingForPlan == null ? 'unknown' : String(occupancy.remainingForPlan);
+  const inferredLabel = occupancy.inferredExistingCount > 0 ? ` / verify ${occupancy.inferredExistingCount}` : '';
+  const title = [
+    `${laneLabel} slots: ${slotsLabel}`,
+    `existing occupied: ${occupancy.existingCount}${inferredLabel}`,
+    `planned occupied: ${occupancy.plannedCount}`,
+    `projected ghost occupied: ${occupancy.projectedCount}`,
+    `remaining for Build Plan: ${remainingLabel}`,
+    'Projected ghosts do not reserve Build Plan capacity until loaded.',
+    occupancy.projectedOverflowCount > 0 ? `projection over capacity: +${occupancy.projectedOverflowCount}` : null,
+  ].filter(Boolean).join(' | ');
+
+  return (
+    <div
+      data-testid={testId}
+      title={title}
+      className="flex min-w-0 flex-wrap gap-1 font-mono text-[9px] uppercase tracking-[0.08em] text-silver-dk"
+    >
+      <span className="rounded border border-cyan/25 bg-cyan/8 px-1.5 py-0.5 text-cyan">Slots {slotsLabel}</span>
+      <span className="rounded border border-green/25 bg-green/8 px-1.5 py-0.5 text-green">Existing {occupancy.existingCount}{inferredLabel}</span>
+      <span className="rounded border border-orange/25 bg-orange/8 px-1.5 py-0.5 text-orange">Planned {occupancy.plannedCount}</span>
+      <span className="rounded border border-cyan/25 bg-cyan/8 px-1.5 py-0.5 text-cyan">Ghost {occupancy.projectedCount}</span>
+      <span className={occupancy.remainingForPlan === 0 ? 'rounded border border-gold/35 bg-gold/10 px-1.5 py-0.5 text-gold' : 'rounded border border-border/45 bg-bg3/30 px-1.5 py-0.5 text-silver'}>
+        Open {remainingLabel}
+      </span>
+      {occupancy.projectedOverflowCount > 0 && (
+        <span className="rounded border border-gold/35 bg-gold/10 px-1.5 py-0.5 text-gold">Ghost over +{occupancy.projectedOverflowCount}</span>
+      )}
     </div>
   );
 }
@@ -779,7 +860,8 @@ function RavenSlotBox({
   const primaryEconomy = slot.economySegments[0]?.economy;
   const color = primaryEconomy ? economyColor(primaryEconomy) : undefined;
   const isStructure = slot.kind === 'existing' || slot.kind === 'planned' || slot.kind === 'projected' || slot.kind === 'overflow';
-  const inferredExisting = slot.kind === 'existing' && slot.warningLabels.includes('Inferred association');
+  const inferredExisting = slot.kind === 'existing' && slot.trustStatus === 'inferred';
+  const confirmedExisting = slot.kind === 'existing' && slot.trustStatus === 'confirmed';
   const interactive = Boolean(onAdd || slot.placementIndex != null || slot.projectionIndex != null);
   const slotStyle: CSSProperties = {};
   if (slot.kind === 'existing') {
@@ -804,6 +886,11 @@ function RavenSlotBox({
       {inferredExisting && (
         <span data-testid="raven-inferred-existing-marker" className="absolute right-1 top-1 rounded border border-gold/45 bg-gold/15 px-1 text-[8px] leading-tight text-gold">
           verify
+        </span>
+      )}
+      {confirmedExisting && (
+        <span data-testid="raven-confirmed-existing-marker" className="absolute right-1 top-1 rounded border border-green/45 bg-green/15 px-1 text-[8px] leading-tight text-green">
+          known
         </span>
       )}
       {slot.economySegments.length > 0 && <StructureEconomyMicroBar segments={slot.economySegments} />}
@@ -1606,6 +1693,8 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
         const plannedCount = planned.orbital.length + planned.ground.length + planned.unassigned.length;
         const projectedCount = projected.orbital.length + projected.ground.length + projected.unassigned.length;
         const emptySlotCount = [...orbitalSlots, ...groundSlots].filter((slot) => slot.kind === 'empty').length;
+        const orbitalOccupancy = buildLaneOccupancy(orbitalCapacity, existing.orbital, planned.orbital.length, projected.orbital.length);
+        const groundOccupancy = buildLaneOccupancy(groundCapacity, existing.surface, planned.ground.length, projected.ground.length);
         return {
           orbitalSlots,
           groundSlots,
@@ -1617,6 +1706,8 @@ export function buildRavenPlannerRows(system: SystemDetail, snapshot: TopologyPl
           plannedCount,
           projectedCount,
           emptySlotCount,
+          orbitalOccupancy,
+          groundOccupancy,
           orbitalAddDisabledReason: addDisabledReasonForLane(node.body, 'orbital', orbitalCapacity, existing.orbital.length, planned.orbital.length),
           groundAddDisabledReason: addDisabledReasonForLane(node.body, 'surface', groundCapacity, existing.surface.length, planned.ground.length),
           warningCount: countRowWarnings(node.body, prediction, bodyLedger, overflowCount) + placementWarningCount,
@@ -1714,6 +1805,28 @@ function summarizeRavenPlannerRows(rows: RavenPlannerRow[], unresolvedExistingCo
   });
 }
 
+function buildLaneOccupancy(
+  capacity: number | null,
+  existingStructures: ExistingStructure[],
+  plannedCount: number,
+  projectedCount: number,
+): RavenLaneOccupancySummary {
+  const existingCount = existingStructures.length;
+  const inferredExistingCount = existingStructures
+    .filter((structure) => structure.association_status === 'inferred').length;
+  const remainingForPlan = capacity == null ? null : Math.max(0, capacity - existingCount - plannedCount);
+  const projectedOverflowCount = capacity == null ? 0 : Math.max(0, existingCount + plannedCount + projectedCount - capacity);
+  return {
+    capacity,
+    existingCount,
+    inferredExistingCount,
+    plannedCount,
+    projectedCount,
+    remainingForPlan,
+    projectedOverflowCount,
+  };
+}
+
 function countPlacementsInLane(
   placements: SimulateBuildPlacement[],
   templatesById: Map<string, FacilityTemplate>,
@@ -1741,8 +1854,14 @@ function addDisabledReasonForLane(
   const physicalReason = laneDisabledReason(body, lane);
   if (physicalReason) return physicalReason;
   if (capacity == null) return null;
-  if (capacity <= 0 || existingCount + plannedCount >= capacity) {
-    return lane === 'orbital' ? 'No empty orbital slots' : 'All surface slots occupied';
+  if (capacity <= 0) {
+    return lane === 'orbital' ? 'No orbital slots predicted.' : 'No surface slots predicted.';
+  }
+  if (existingCount + plannedCount >= capacity) {
+    const summary = `${capacity} slots, ${existingCount} existing, ${plannedCount} planned`;
+    return lane === 'orbital'
+      ? `No empty orbital slots (${summary}).`
+      : `All surface slots occupied (${summary}).`;
   }
   return null;
 }
@@ -2033,6 +2152,7 @@ function existingStructureSlot(
     status: 'existing',
     economyContextLabel: baselineSegments.length > 0 ? 'Economy: inherited/contextual baseline - run Preview for validated outcome.' : null,
     warningLabels: structure.association_status === 'inferred' ? ['Inferred association'] : [],
+    trustStatus: structure.association_status,
   };
 }
 


### PR DESCRIPTION
## Summary
- add compact Raven lane occupancy summaries for slots, existing, planned, projected ghosts, and open capacity
- label confirmed existing infrastructure as known and inferred infrastructure as verify
- keep unresolved and unknown-lane infrastructure visible without forcing lane occupancy
- expand Add lane disabled reasons with existing/planned capacity counts

## Validation
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm test -- RavenStylePlannerCanvas WholeSystemColonyPlanner SelectedBodyPlannerCanvas`
- `cd frontend-v2 && npm test -- ColonyPlannerWorkspace BodySlotPlanner`
- `cd frontend-v2 && npm run build`
- `git diff --check`

## Boundaries
- no automatic preview
- no automatic Suggested Build generation or load
- no scoring/CP/economy/service/buildability changes
- unknown data remains unknown
- existing infrastructure does not mutate the Build Plan