### PR TITLE
Stage 17T suggested builds strategy advisor

### DIFF
--- a/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/SimulationPreview.tsx
@@ -370,6 +370,9 @@ export function SimulationPreview({
               onCandidateSelect={handleSuggestedCandidateSelection}
               bodyLabelsById={bodyLabelsById}
               templates={templates}
+              system={system}
+              slotPredictions={slotPredictionsQuery.data ?? null}
+              declaredRoles={declaredRoles}
             />
           )}
         </div>

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateCard.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateCard.tsx
@@ -1,15 +1,18 @@
 import type { OptimiserCandidate, RankedOptimiserCandidate } from '@/types/api';
 import { formatPercent, formatScore, rankTone, strategyLabel } from './optimiserUtils';
 import { suggestedBuildPresentation } from './optimiserQualityUtils';
+import type { SuggestedBuildStrategyAdvisor } from './suggestedBuildStrategyAdvisor';
 
 export function OptimiserCandidateCard({
   candidate,
   ranking,
+  advisor,
   selected,
   onSelect,
 }: {
   candidate: OptimiserCandidate;
   ranking?: RankedOptimiserCandidate;
+  advisor?: SuggestedBuildStrategyAdvisor;
   selected: boolean;
   onSelect: () => void;
 }) {
@@ -52,6 +55,11 @@ export function OptimiserCandidateCard({
             </span>
           </div>
           <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-silver-dk">{presentation.purpose}</p>
+          {advisor && (
+            <p className="mt-1 line-clamp-2 font-mono text-[10px] leading-snug text-silver-dk">
+              Advisor: {advisor.cardLine}
+            </p>
+          )}
           <div className="mt-2 truncate text-sm font-semibold text-silver">{candidate.label}</div>
           <div className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
             {strategyLabel(candidate.strategy)}

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateDetails.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidateDetails.tsx
@@ -8,6 +8,7 @@ import { OptimiserRankingBreakdown } from './OptimiserRankingBreakdown';
 import { OptimiserComparisonPanel, compareBuildSources, sourceFromCurrentPreview, sourceFromOptimiserCandidate } from './comparison';
 import { formatScore, rankTone, strategyLabel } from './optimiserUtils';
 import { suggestedBuildPresentation } from './optimiserQualityUtils';
+import type { SuggestedBuildStrategyAdvisor } from './suggestedBuildStrategyAdvisor';
 
 export function OptimiserCandidateDetails({
   candidate,
@@ -23,6 +24,7 @@ export function OptimiserCandidateDetails({
   currentControlTargetArchetype,
   bodyLabelsById,
   templates = [],
+  advisor,
 }: {
   candidate?: OptimiserCandidate;
   ranking?: RankedOptimiserCandidate;
@@ -37,6 +39,7 @@ export function OptimiserCandidateDetails({
   currentControlTargetArchetype?: string | null;
   bodyLabelsById?: Record<string, string>;
   templates?: FacilityTemplate[];
+  advisor?: SuggestedBuildStrategyAdvisor;
 }) {
   const [loadConfirmation, setLoadConfirmation] = useState<'replace' | 'stale' | 'stale_replace' | null>(null);
   const comparison = useMemo(() => {
@@ -144,6 +147,8 @@ export function OptimiserCandidateDetails({
         <SummaryBox title="Tradeoff" body={presentation.tradeoff} />
         <SummaryBox title="Next action" body={presentation.nextAction} />
       </div>
+
+      {advisor && <StrategyAdvisorSection advisor={advisor} />}
 
       <div className="rounded border border-orange/25 bg-orange/8 px-3 py-2">
         <h5 className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">Plan scale</h5>
@@ -303,6 +308,43 @@ function SummaryBox({ title, body }: { title: string; body: string }) {
   return (
     <div className="rounded border border-cyan/25 bg-cyan/5 px-3 py-2">
       <h5 className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">{title}</h5>
+      <p className="mt-1 text-[11px] leading-snug text-silver-dk">{body}</p>
+    </div>
+  );
+}
+
+function StrategyAdvisorSection({ advisor }: { advisor: SuggestedBuildStrategyAdvisor }) {
+  return (
+    <section
+      data-testid="suggested-build-strategy-advisor"
+      className="border-t border-border/45 pt-3"
+    >
+      <h5 className="font-mono text-[10px] uppercase tracking-[0.16em] text-cyan">Strategy advisor</h5>
+      <div className="mt-2 grid gap-x-4 gap-y-2 md:grid-cols-2">
+        <AdvisorFact title="Body choice" body={advisor.bodyChoice} />
+        <AdvisorFact title="Existing infrastructure" body={advisor.existingInfrastructure} />
+        <AdvisorFact title="Slot pressure" body={advisor.slotPressure} />
+        <AdvisorFact title="Economy intent" body={advisor.economyIntent} />
+        <AdvisorFact title="Declared roles" body={advisor.roleContext} />
+        <AdvisorFact title="Uncertainty" body={advisor.uncertainty} />
+      </div>
+      <details className="mt-3 border-t border-border/35 pt-2">
+        <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Projection and manual review
+        </summary>
+        <div className="mt-2 space-y-1 text-[11px] leading-snug text-silver-dk">
+          <p>{advisor.projectionEffect}</p>
+          <p>{advisor.manualBoundary}</p>
+        </div>
+      </details>
+    </section>
+  );
+}
+
+function AdvisorFact({ title, body }: { title: string; body: string }) {
+  return (
+    <div>
+      <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">{title}</div>
       <p className="mt-1 text-[11px] leading-snug text-silver-dk">{body}</p>
     </div>
   );

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.test.tsx
@@ -1,7 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetchOptimiserCandidates } from '@/lib/api';
-import type { FacilityTemplate, OptimiserCandidate, OptimiserCandidatesResponse, OptimiserRanking, SimulateBuildPlacement } from '@/types/api';
+import type { FacilityTemplate, OptimiserCandidate, OptimiserCandidatesResponse, OptimiserRanking, SimulateBuildPlacement, SlotPredictionResponse, SystemDetail } from '@/types/api';
+import type { DeclaredColonyRole } from '@/features/colony-planner/colonyRoles';
 import { OptimiserCandidateCard } from './OptimiserCandidateCard';
 import { OptimiserCandidateDetails } from './OptimiserCandidateDetails';
 import { OptimiserCandidatePanel } from './OptimiserCandidatePanel';
@@ -9,6 +10,7 @@ import { OptimiserPlacementList } from './OptimiserPlacementList';
 import { OptimiserRankingBreakdown } from './OptimiserRankingBreakdown';
 import { candidatePlacementsToPreviewPlacements, sortCandidatesForDisplay } from './optimiserUtils';
 import { filterUsefulSuggestedBuilds, suggestedBuildPresentation, suggestedBuildScale } from './optimiserQualityUtils';
+import { buildSuggestedBuildStrategyAdvisor } from './suggestedBuildStrategyAdvisor';
 
 vi.mock('@/lib/api', () => ({
   fetchOptimiserCandidates: vi.fn(),
@@ -123,6 +125,98 @@ const ranking: OptimiserRanking = {
   warnings: [],
   assumptions: [],
 };
+
+const advisorSystem = {
+  id64: 123,
+  name: 'Advisor Test',
+  bodies: [
+    {
+      id: 1,
+      name: 'Advisor Test 1',
+      body_type: 'Planet',
+      subtype: 'High metal content world',
+      is_landable: true,
+      is_water_world: false,
+      is_ringed: true,
+      radius: 4500,
+    },
+    {
+      id: 2,
+      name: 'Advisor Test 2',
+      body_type: 'Planet',
+      subtype: 'Icy body',
+      is_landable: false,
+      is_water_world: false,
+      is_ringed: false,
+    },
+  ],
+  stations: [
+    {
+      id: 1001,
+      name: 'Known Orbital',
+      station_type: 'Coriolis',
+      body_id: 1,
+      body_name: 'Advisor Test 1',
+      lane: 'orbital',
+      association_status: 'confirmed',
+      association_confidence: 'exact',
+      association_source: 'imported_architect',
+    },
+    {
+      id: 1002,
+      name: 'Verify Surface Port',
+      station_type: 'PlanetaryPort',
+      body_id: 1,
+      body_name: 'Advisor Test 1',
+      lane: 'surface',
+      association_status: 'inferred',
+      association_confidence: 'strong_inference',
+      association_source: 'resolver',
+      resolver_notes: 'Matched by body name.',
+    },
+    {
+      id: 1003,
+      name: 'Unresolved Facility',
+      station_type: 'Installation',
+      lane: 'unknown',
+      association_status: 'unresolved',
+      association_confidence: 'unresolved',
+      association_source: 'resolver',
+      resolver_notes: 'No reliable body association is available.',
+    },
+  ],
+} as SystemDetail;
+
+const advisorSlotPredictions: SlotPredictionResponse = {
+  system_id64: 123,
+  data_source: 'eddn',
+  body_count: 2,
+  prediction_status: 'predicted',
+  prediction_version: 'test',
+  disclaimer: 'test',
+  validation_note: 'test',
+  predictions: [
+    {
+      system_address: 123,
+      body_id: 1,
+      body_name: 'Advisor Test 1',
+      predicted_orbital_slots: 2,
+      predicted_ground_slots: 1,
+      prediction_status: 'predicted',
+    },
+  ],
+};
+
+const advisorDeclaredRoles: DeclaredColonyRole[] = [
+  {
+    id: 'declared:1:main_station_body',
+    body_id: '1',
+    role_id: 'main_station_body',
+    source: 'declared',
+    confidence: 'strong',
+    label: 'Main Station Body',
+  },
+];
 
 function response(overrides: Partial<OptimiserCandidatesResponse> = {}): OptimiserCandidatesResponse {
   return {
@@ -259,6 +353,49 @@ describe('optimiser candidate comparison UI', () => {
     expect(suggestedBuildPresentation(starter).bodyCount).toBe(3);
   });
 
+  it('builds strategic advisor context without mutating candidate or current Build Plan inputs', () => {
+    const selected = {
+      ...candidate('advisor-candidate', 'Advisor candidate'),
+      placements: [
+        { facility_template_id: 'generic_port_alpha', local_body_id: '1', is_primary_port: true, build_order: 1 },
+        { facility_template_id: 'agri_support_a', local_body_id: '1', is_primary_port: false, build_order: 2 },
+      ],
+      warnings: ['Candidate scale is limited by sparse body or facility data.'],
+      assumptions: ['Generate additional data/imports to unlock larger strategic plans for this system.'],
+    };
+    const currentPlacements: SimulateBuildPlacement[] = [
+      { facility_template_id: 'generic_port_alpha', local_body_id: '2', is_primary_port: true, build_order: 1 },
+    ];
+    const beforeCandidate = structuredClone(selected);
+    const beforeCurrent = structuredClone(currentPlacements);
+
+    const advisor = buildSuggestedBuildStrategyAdvisor({
+      candidate: selected,
+      system: advisorSystem,
+      templates,
+      bodyLabelsById: { '1': 'Advisor Test 1', '2': 'Advisor Test 2' },
+      currentPreviewPlacements: currentPlacements,
+      declaredRoles: advisorDeclaredRoles,
+      slotPredictions: advisorSlotPredictions,
+    });
+
+    expect(advisor.bodyChoice).toMatch(/main body is Advisor Test 1/i);
+    expect(advisor.roleContext).toMatch(/Advisor Test 1: Main Station/i);
+    expect(advisor.existingInfrastructure).toMatch(/2 existing slot occupant/i);
+    expect(advisor.existingInfrastructure).toMatch(/1 confirmed, 1 verify\/inferred/i);
+    expect(advisor.existingInfrastructure).toMatch(/unresolved.*unknown-lane/i);
+    expect(advisor.slotPressure).toMatch(/Advisor Test 1 Surface/i);
+    expect(advisor.slotPressure).toMatch(/projected ghost 1/i);
+    expect(advisor.slotPressure).toMatch(/exceed visible capacity by 1/i);
+    expect(advisor.economyIntent).toMatch(/Agri x1/i);
+    expect(advisor.uncertainty).toMatch(/sparse, estimated, or incomplete data/i);
+    expect(advisor.projectionEffect).toMatch(/ghost structure/i);
+    expect(advisor.manualBoundary).toMatch(/Load explicitly/i);
+    expect(advisor.manualBoundary).toMatch(/Run Preview remains explicit/i);
+    expect(selected).toEqual(beforeCandidate);
+    expect(currentPlacements).toEqual(beforeCurrent);
+  });
+
   it('defaults Suggested Builds scale to Expansion and avoids bootstrap-first display', async () => {
     const bootstrap = {
       ...candidate('bootstrap-option', 'Bootstrap option'),
@@ -367,6 +504,52 @@ describe('optimiser candidate comparison UI', () => {
     expect(screen.queryByText(/advisory and preview-only/i)).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Show comparison' }));
     expect(screen.getByText(/advisory and preview-only/i)).toBeTruthy();
+  });
+
+  it('renders compact strategy advisor details while keeping load and Preview explicit', () => {
+    const load = vi.fn();
+    const selected = {
+      ...candidate('advisor-candidate', 'Advisor candidate'),
+      placements: [
+        { facility_template_id: 'generic_port_alpha', local_body_id: '1', is_primary_port: true, build_order: 1 },
+        { facility_template_id: 'agri_support_a', local_body_id: '1', is_primary_port: false, build_order: 2 },
+      ],
+      warnings: ['Candidate scale is limited by sparse body or facility data.'],
+      assumptions: ['Generate additional data/imports to unlock larger strategic plans for this system.'],
+    };
+    const advisor = buildSuggestedBuildStrategyAdvisor({
+      candidate: selected,
+      system: advisorSystem,
+      templates,
+      bodyLabelsById: { '1': 'Advisor Test 1', '2': 'Advisor Test 2' },
+      declaredRoles: advisorDeclaredRoles,
+      slotPredictions: advisorSlotPredictions,
+    });
+
+    const { container } = render(
+      <OptimiserCandidateDetails
+        candidate={selected}
+        response={response()}
+        onLoadCandidate={load}
+        templates={templates}
+        advisor={advisor}
+      />,
+    );
+
+    expect(screen.getByTestId('suggested-build-strategy-advisor')).toBeTruthy();
+    expect(screen.getByText('Strategy advisor')).toBeTruthy();
+    expect(container.textContent).toMatch(/Body choice: main body is Advisor Test 1/i);
+    expect(container.textContent).toMatch(/Existing items remain Existing and are not Build Plan placements/i);
+    expect(container.textContent).toMatch(/projection would exceed visible capacity by 1/i);
+    expect(container.textContent).toMatch(/Declared roles: Advisor Test 1: Main Station/i);
+    expect(container.textContent).toMatch(/Uncertainty: candidate warnings or assumptions use sparse/i);
+    expect(container.textContent).toMatch(/ghost structure\(s\)/i);
+    expect(container.textContent).toMatch(/Load explicitly copies this candidate into the editable Build Plan/i);
+    expect(container.textContent).toMatch(/Run Preview remains explicit/i);
+    expect(load).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load into Planner Workspace' }));
+    expect(load).toHaveBeenCalledWith(selected);
   });
 
   it('renders comparison empty copy when no current Build Plan exists', () => {

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/OptimiserCandidatePanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { fetchOptimiserCandidates } from '@/lib/api';
-import type { FacilityTemplate, OptimiserCandidate, OptimiserCandidatesResponse, RankedOptimiserCandidate, SimulateBuildPlacement } from '@/types/api';
+import type { FacilityTemplate, OptimiserCandidate, OptimiserCandidatesResponse, RankedOptimiserCandidate, SimulateBuildPlacement, SlotPredictionResponse, SystemDetail } from '@/types/api';
 import { OptimiserCandidateCard } from './OptimiserCandidateCard';
 import { OptimiserCandidateDetails } from './OptimiserCandidateDetails';
 import { OptimiserEmptyState } from './OptimiserEmptyState';
@@ -8,6 +8,8 @@ import { OptimiserErrorState } from './OptimiserErrorState';
 import { buildRankLookup, sortCandidatesForDisplay } from './optimiserUtils';
 import { filterUsefulSuggestedBuilds, suggestedBuildScale, type SuggestedBuildScale } from './optimiserQualityUtils';
 import { humanizeArchetype } from '@/features/colony-planner/workspaceUtils';
+import type { DeclaredColonyRole } from '@/features/colony-planner/colonyRoles';
+import { buildSuggestedBuildStrategyAdvisor } from './suggestedBuildStrategyAdvisor';
 
 type GeneratedCandidateParams = {
   targetArchetype: string;
@@ -29,6 +31,9 @@ export function OptimiserCandidatePanel({
   currentTargetArchetype,
   currentPreviewLabel,
   templates = [],
+  system = null,
+  slotPredictions = null,
+  declaredRoles = [],
 }: {
   systemId64: number;
   targetArchetype: string;
@@ -40,6 +45,9 @@ export function OptimiserCandidatePanel({
   currentTargetArchetype?: string | null;
   currentPreviewLabel?: string;
   templates?: FacilityTemplate[];
+  system?: SystemDetail | null;
+  slotPredictions?: SlotPredictionResponse | null;
+  declaredRoles?: DeclaredColonyRole[];
 }) {
   const [maxCandidates, setMaxCandidates] = useState(5);
   const [allowEstimatedData, setAllowEstimatedData] = useState(true);
@@ -59,8 +67,21 @@ export function OptimiserCandidatePanel({
     () => allUsefulCandidates.filter((candidate) => scaleMatchesFilter(suggestedBuildScale(candidate), scale)),
     [allUsefulCandidates, scale],
   );
+  const advisorLookup = useMemo(() => new Map(candidates.map((candidate) => [
+    candidate.candidate_id,
+    buildSuggestedBuildStrategyAdvisor({
+      candidate,
+      system,
+      templates,
+      bodyLabelsById,
+      currentPreviewPlacements,
+      declaredRoles,
+      slotPredictions,
+    }),
+  ])), [bodyLabelsById, candidates, currentPreviewPlacements, declaredRoles, slotPredictions, system, templates]);
   const selectedCandidate = candidates.find((candidate) => candidate.candidate_id === selectedId) ?? candidates[0];
   const selectedCandidateId = selectedCandidate?.candidate_id ?? null;
+  const selectedAdvisor = selectedCandidate ? advisorLookup.get(selectedCandidate.candidate_id) : undefined;
   const lastNotifiedCandidateIdRef = useRef<string | null | undefined>(undefined);
   const currentParams: GeneratedCandidateParams = { targetArchetype, maxCandidates, allowEstimatedData, scale };
   const controlsChangedSinceGeneration = Boolean(generatedParams && (
@@ -232,6 +253,7 @@ export function OptimiserCandidatePanel({
                 key={candidate.candidate_id}
                 candidate={candidate}
                 ranking={rankLookup.get(candidate.candidate_id)}
+                advisor={advisorLookup.get(candidate.candidate_id)}
                 selected={candidate.candidate_id === selectedCandidate?.candidate_id}
                 onSelect={() => setSelectedId(candidate.candidate_id)}
               />
@@ -251,6 +273,7 @@ export function OptimiserCandidatePanel({
             currentControlTargetArchetype={currentParams.targetArchetype}
             bodyLabelsById={bodyLabelsById}
             templates={templates}
+            advisor={selectedAdvisor}
           />
         </div>
       )}

--- a/frontend-v2/src/features/system-detail/simulation-preview/optimiser/suggestedBuildStrategyAdvisor.ts
+++ b/frontend-v2/src/features/system-detail/simulation-preview/optimiser/suggestedBuildStrategyAdvisor.ts
@@ -1,0 +1,453 @@
+import type {
+  FacilityTemplate,
+  OptimiserCandidate,
+  OptimiserCandidatePlacement,
+  SimulateBuildPlacement,
+  SlotPredictionResponse,
+  SystemBody,
+  SystemDetail,
+} from '@/types/api';
+import type { BodyPlannerLane } from '@/features/colony-planner/BodySlotPlanner';
+import { roleCompactLabel, type DeclaredColonyRole } from '@/features/colony-planner/colonyRoles';
+import { resolveExistingInfrastructure } from '@/features/colony-planner/existingInfrastructure';
+import { compactEconomyLabel, normalisePlanningEconomy } from '@/features/colony-planner/planningEconomy';
+import { buildBodyDataSlotEstimateMap, resolveSlotCapacity, systemBodyData } from '@/features/colony-planner/slotCapacityFallback';
+import { placementLaneForTemplate } from '@/features/colony-planner/structurePlanningRules';
+import { bodyDisplayName, bodyTags } from '../buildPlanLayoutUtils';
+import { bodyIdKey } from '../bodyIdUtils';
+
+export interface SuggestedBuildStrategyAdvisor {
+  cardLine: string;
+  bodyChoice: string;
+  existingInfrastructure: string;
+  slotPressure: string;
+  economyIntent: string;
+  roleContext: string;
+  uncertainty: string;
+  projectionEffect: string;
+  manualBoundary: string;
+}
+
+interface AdvisorInput {
+  candidate: OptimiserCandidate;
+  system?: SystemDetail | null;
+  templates?: FacilityTemplate[];
+  bodyLabelsById?: Record<string, string>;
+  currentPreviewPlacements?: SimulateBuildPlacement[];
+  declaredRoles?: DeclaredColonyRole[];
+  slotPredictions?: SlotPredictionResponse | null;
+}
+
+type PlacementLike = Pick<SimulateBuildPlacement | OptimiserCandidatePlacement, 'facility_template_id' | 'local_body_id'>;
+
+interface LaneCounts {
+  orbital: number;
+  surface: number;
+}
+
+interface PlacementLaneSummary {
+  byBodyId: Map<string, LaneCounts>;
+  unassignedBody: number;
+  unknownBody: number;
+  unknownLane: number;
+  missingTemplate: number;
+}
+
+export function buildSuggestedBuildStrategyAdvisor({
+  candidate,
+  system,
+  templates = [],
+  bodyLabelsById = {},
+  currentPreviewPlacements = [],
+  declaredRoles = [],
+  slotPredictions = null,
+}: AdvisorInput): SuggestedBuildStrategyAdvisor {
+  const templatesById = new Map(templates.map((template) => [template.id, template]));
+  const bodies = system ? systemBodyData(system) : [];
+  const bodiesById = new Map(
+    bodies
+      .filter((body) => body.id != null)
+      .map((body) => [bodyIdKey(body.id), body]),
+  );
+  const usedBodyIds = candidateBodyIds(candidate);
+  const mainBodyId = bodyIdKey(
+    candidate.placements.find((placement) => placement.is_primary_port)?.local_body_id
+      ?? usedBodyIds[0]
+      ?? null,
+  ) || null;
+  const labelForBody = (bodyId: string) => (
+    bodyLabelsById[bodyId] ?? bodyLabelsById[bodyIdKey(bodyId)] ?? (bodiesById.get(bodyId) ? bodyDisplayName(bodiesById.get(bodyId)!) : `Body ${bodyId}`)
+  );
+
+  const currentLaneSummary = summarizePlacementLanes(currentPreviewPlacements, templatesById, bodiesById);
+  const projectedLaneSummary = summarizePlacementLanes(candidate.placements, templatesById, bodiesById);
+  const existingResolution = system ? resolveExistingInfrastructure(system) : null;
+
+  const bodyChoice = describeBodyChoice({
+    mainBodyId,
+    usedBodyIds,
+    bodiesById,
+    labelForBody,
+    projectedLaneSummary,
+  });
+  const roleContext = describeDeclaredRoles(usedBodyIds, declaredRoles, labelForBody);
+  const existingInfrastructure = describeExistingInfrastructure({
+    usedBodyIds,
+    existingResolution,
+  });
+  const slotPressure = describeSlotPressure({
+    system,
+    bodiesById,
+    labelForBody,
+    currentLaneSummary,
+    projectedLaneSummary,
+    slotPredictions,
+    existingResolution,
+  });
+  const economyIntent = describeEconomyIntent(candidate, templatesById);
+  const uncertainty = describeUncertainty({
+    candidate,
+    system,
+    bodies,
+    projectedLaneSummary,
+    slotPredictions,
+  });
+  const projectionEffect = describeProjectionEffect(candidate, usedBodyIds, projectedLaneSummary);
+  const manualBoundary = 'Manual boundary: select projects read-only ghosts, Load explicitly copies this candidate into the editable Build Plan, and Run Preview remains explicit.';
+
+  return {
+    cardLine: cardLineFor({ slotPressure, existingInfrastructure, uncertainty }),
+    bodyChoice,
+    existingInfrastructure,
+    slotPressure,
+    economyIntent,
+    roleContext,
+    uncertainty,
+    projectionEffect,
+    manualBoundary,
+  };
+}
+
+function describeBodyChoice({
+  mainBodyId,
+  usedBodyIds,
+  bodiesById,
+  labelForBody,
+  projectedLaneSummary,
+}: {
+  mainBodyId: string | null;
+  usedBodyIds: string[];
+  bodiesById: Map<string, SystemBody>;
+  labelForBody: (bodyId: string) => string;
+  projectedLaneSummary: PlacementLaneSummary;
+}) {
+  if (!mainBodyId && usedBodyIds.length === 0) {
+    return 'Body choice: system-level candidate with no explicit body assignments yet; body and lane selection need manual review.';
+  }
+  if (!mainBodyId) {
+    return `Body choice: ${usedBodyIds.map(labelForBody).join(', ')}. No primary-port body is declared by this candidate.`;
+  }
+
+  const mainBody = bodiesById.get(mainBodyId);
+  const tags = mainBody ? bodyTags(mainBody).slice(0, 3).join(', ') : null;
+  const supportBodies = usedBodyIds.filter((bodyId) => bodyId !== mainBodyId).map(labelForBody);
+  const unresolved = projectedLaneSummary.unknownBody > 0
+    ? ` ${projectedLaneSummary.unknownBody} placement(s) reference bodies not present in current body data.`
+    : '';
+  const support = supportBodies.length > 0 ? ` Support bodies: ${supportBodies.join(', ')}.` : '';
+
+  return `Body choice: main body is ${labelForBody(mainBodyId)}${tags ? ` (${tags})` : ''}.${support}${unresolved}`;
+}
+
+function describeDeclaredRoles(
+  usedBodyIds: string[],
+  declaredRoles: DeclaredColonyRole[],
+  labelForBody: (bodyId: string) => string,
+) {
+  if (declaredRoles.length === 0) return 'Declared roles: none available for candidate context.';
+  const used = new Set(usedBodyIds);
+  const rolesByBody = new Map<string, string[]>();
+  declaredRoles.forEach((role) => {
+    const key = bodyIdKey(role.body_id);
+    if (!used.has(key)) return;
+    const labels = rolesByBody.get(key) ?? [];
+    labels.push(roleCompactLabel(role.role_id));
+    rolesByBody.set(key, labels);
+  });
+
+  if (rolesByBody.size === 0) {
+    return 'Declared roles: roles exist elsewhere, but none are on the projected candidate bodies.';
+  }
+
+  const parts = Array.from(rolesByBody.entries()).map(([bodyId, labels]) => (
+    `${labelForBody(bodyId)}: ${Array.from(new Set(labels)).join(', ')}`
+  ));
+  return `Declared roles: ${parts.join('; ')}. Advisory only; no role mechanics are applied.`;
+}
+
+function describeExistingInfrastructure({
+  usedBodyIds,
+  existingResolution,
+}: {
+  usedBodyIds: string[];
+  existingResolution: ReturnType<typeof resolveExistingInfrastructure> | null;
+}) {
+  if (!existingResolution) {
+    return 'Existing infrastructure: system context is unavailable in this view.';
+  }
+  const permanent = existingResolution.structures.filter((structure) => !structure.transient);
+  if (permanent.length === 0) {
+    return 'Existing infrastructure: none visible in the current system data.';
+  }
+
+  const used = new Set(usedBodyIds);
+  const onCandidateBodies = existingResolution.mapped.filter((structure) => used.has(bodyIdKey(structure.body_id)));
+  const confirmed = onCandidateBodies.filter((structure) => structure.association_status === 'confirmed').length;
+  const inferred = onCandidateBodies.filter((structure) => structure.association_status === 'inferred').length;
+  const unresolved = existingResolution.unresolved.length;
+  const unknownLane = existingResolution.unresolved.filter((structure) => structure.lane === 'unknown').length;
+  const candidateLine = onCandidateBodies.length > 0
+    ? `${onCandidateBodies.length} existing slot occupant(s) on projected candidate bodies (${confirmed} confirmed, ${inferred} verify/inferred).`
+    : `${existingResolution.mapped.length} mapped existing slot occupant(s) are visible, but none are on projected candidate bodies.`;
+  const unresolvedLine = unresolved > 0
+    ? ` ${unresolved} unresolved${unknownLane > 0 ? ` / ${unknownLane} unknown-lane` : ''} infrastructure item(s) stay visible but are not forced into a lane.`
+    : '';
+
+  return `Existing infrastructure: ${candidateLine} Existing items remain Existing and are not Build Plan placements.${unresolvedLine}`;
+}
+
+function describeSlotPressure({
+  system,
+  bodiesById,
+  labelForBody,
+  currentLaneSummary,
+  projectedLaneSummary,
+  slotPredictions,
+  existingResolution,
+}: {
+  system?: SystemDetail | null;
+  bodiesById: Map<string, SystemBody>;
+  labelForBody: (bodyId: string) => string;
+  currentLaneSummary: PlacementLaneSummary;
+  projectedLaneSummary: PlacementLaneSummary;
+  slotPredictions: SlotPredictionResponse | null;
+  existingResolution: ReturnType<typeof resolveExistingInfrastructure> | null;
+}) {
+  const unresolvedProjection = projectedLaneSummary.unassignedBody
+    + projectedLaneSummary.unknownBody
+    + projectedLaneSummary.unknownLane
+    + projectedLaneSummary.missingTemplate;
+  const projectedLaneEntries = Array.from(projectedLaneSummary.byBodyId.entries())
+    .flatMap(([bodyId, counts]) => ([
+      { bodyId, lane: 'orbital' as BodyPlannerLane, projected: counts.orbital },
+      { bodyId, lane: 'surface' as BodyPlannerLane, projected: counts.surface },
+    ]))
+    .filter((entry) => entry.projected > 0);
+
+  if (!system || projectedLaneEntries.length === 0) {
+    if (unresolvedProjection > 0) {
+      return `Slot pressure: ${unresolvedProjection} projected placement(s) need body/lane/template resolution before lane capacity can be checked; they remain ghost-only.`;
+    }
+    return 'Slot pressure: no lane-specific projected occupancy is available for this candidate.';
+  }
+
+  const predictionByBodyId = new Map(
+    (slotPredictions?.predictions ?? []).map((prediction) => [bodyIdKey(prediction.body_id), prediction]),
+  );
+  const estimateMap = buildBodyDataSlotEstimateMap(system, slotPredictions?.predictions);
+  const entries = projectedLaneEntries.map((entry) => {
+    const body = bodiesById.get(entry.bodyId);
+    const current = currentLaneSummary.byBodyId.get(entry.bodyId)?.[entry.lane] ?? 0;
+    const existing = existingResolution?.byBodyId.get(entry.bodyId)?.[entry.lane].length ?? 0;
+    const capacity = body
+      ? resolveSlotCapacity(body, predictionByBodyId.get(entry.bodyId) ?? null, entry.lane, estimateMap.get(entry.bodyId))
+      : { value: null, estimated: false };
+    const remainingBeforeProjection = capacity.value == null ? null : capacity.value - existing - current;
+    const remainingAfterProjection = capacity.value == null ? null : capacity.value - existing - current - entry.projected;
+    return {
+      ...entry,
+      body,
+      current,
+      existing,
+      capacity,
+      remainingBeforeProjection,
+      remainingAfterProjection,
+    };
+  }).sort((left, right) => {
+    const leftOver = (left.remainingAfterProjection ?? 0) < 0 ? 1 : 0;
+    const rightOver = (right.remainingAfterProjection ?? 0) < 0 ? 1 : 0;
+    if (leftOver !== rightOver) return rightOver - leftOver;
+    return right.projected - left.projected;
+  });
+
+  const entry = entries[0];
+  const laneLabel = entry.lane === 'orbital' ? 'Orbit' : 'Surface';
+  const capacityLabel = entry.capacity.value == null
+    ? 'capacity unknown'
+    : `${entry.capacity.estimated ? 'estimated' : 'predicted'} capacity ${entry.capacity.value}`;
+  const prefix = `${labelForBody(entry.bodyId)} ${laneLabel}: ${capacityLabel}, existing ${entry.existing}, planned ${entry.current}, projected ghost ${entry.projected}`;
+  if (entry.remainingAfterProjection != null && entry.remainingAfterProjection < 0) {
+    return `Slot pressure: ${prefix}; projection would exceed visible capacity by ${Math.abs(entry.remainingAfterProjection)}.`;
+  }
+  if (entry.remainingBeforeProjection != null && entry.remainingAfterProjection != null) {
+    return `Slot pressure: ${prefix}; ${entry.remainingBeforeProjection} remaining before projection (${entry.remainingAfterProjection} after projection).`;
+  }
+  return `Slot pressure: ${prefix}; unknown capacity remains unknown until verified in the Raven canvas.`;
+}
+
+function describeEconomyIntent(
+  candidate: OptimiserCandidate,
+  templatesById: Map<string, FacilityTemplate>,
+) {
+  const counts = new Map<ReturnType<typeof normalisePlanningEconomy>, number>();
+  let contextualPorts = 0;
+  let unknown = 0;
+  candidate.placements.forEach((placement) => {
+    const template = templatesById.get(placement.facility_template_id);
+    const economy = normalisePlanningEconomy(template?.economy);
+    if (economy) {
+      counts.set(economy, (counts.get(economy) ?? 0) + 1);
+    } else if (template?.is_port) {
+      contextualPorts += 1;
+    } else {
+      unknown += 1;
+    }
+  });
+
+  const economies = Array.from(counts.entries())
+    .filter((entry): entry is [NonNullable<ReturnType<typeof normalisePlanningEconomy>>, number] => Boolean(entry[0]))
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, 3)
+    .map(([economy, count]) => `${compactEconomyLabel(economy)} x${count}`);
+  const economyLine = economies.length > 0
+    ? `Economy intent: ${economies.join(', ')}.`
+    : 'Economy intent: contextual or unknown from available templates.';
+  const portLine = contextualPorts > 0
+    ? ` ${contextualPorts} port placement(s) need Preview to validate inherited economy.`
+    : '';
+  const unknownLine = unknown > 0
+    ? ` ${unknown} placement(s) have unknown economy metadata.`
+    : '';
+  return `${economyLine}${portLine}${unknownLine}`;
+}
+
+function describeUncertainty({
+  candidate,
+  system,
+  bodies,
+  projectedLaneSummary,
+  slotPredictions,
+}: {
+  candidate: OptimiserCandidate;
+  system?: SystemDetail | null;
+  bodies: SystemBody[];
+  projectedLaneSummary: PlacementLaneSummary;
+  slotPredictions: SlotPredictionResponse | null;
+}) {
+  const signals = new Set<string>();
+  const warningText = [...candidate.warnings, ...candidate.assumptions].join(' ').toLowerCase();
+  if (/\b(sparse|estimated|inferred|no body|no matching|limited|unavailable|preview failed)\b/.test(warningText)) {
+    signals.add('candidate warnings or assumptions use sparse, estimated, or incomplete data');
+  }
+  if (!system) signals.add('system context is unavailable');
+  if (system && bodies.length === 0) signals.add('body catalogue is unavailable');
+  if (slotPredictions?.prediction_status === 'unknown' || slotPredictions?.data_source === 'none') {
+    signals.add('slot prediction status is unknown');
+  }
+  if (projectedLaneSummary.unassignedBody > 0) signals.add('some projected placements have no body assignment');
+  if (projectedLaneSummary.unknownBody > 0) signals.add('some projected bodies are not in current body data');
+  if (projectedLaneSummary.unknownLane > 0) signals.add('some projected lanes cannot be inferred from template/body data');
+  if (projectedLaneSummary.missingTemplate > 0) signals.add('some facility templates are missing from the loaded catalogue');
+  if (!candidate.preview_summary) {
+    signals.add('lightweight preview summary is unavailable');
+  } else if (candidate.preview_summary.confidence != null && candidate.preview_summary.confidence < 0.5) {
+    signals.add('lightweight preview confidence is low');
+  }
+
+  if (signals.size === 0) {
+    return 'Uncertainty: no additional data-quality signal beyond the candidate warnings; verify before loading or previewing.';
+  }
+  return `Uncertainty: ${Array.from(signals).join('; ')}.`;
+}
+
+function describeProjectionEffect(
+  candidate: OptimiserCandidate,
+  usedBodyIds: string[],
+  projectedLaneSummary: PlacementLaneSummary,
+) {
+  const unresolvedProjection = projectedLaneSummary.unassignedBody
+    + projectedLaneSummary.unknownBody
+    + projectedLaneSummary.unknownLane
+    + projectedLaneSummary.missingTemplate;
+  const bodyCount = usedBodyIds.length || 1;
+  const unresolvedLine = unresolvedProjection > 0
+    ? ` ${unresolvedProjection} placement(s) need manual body/lane/template review before capacity is reliable.`
+    : '';
+  return `Projection effect: selecting this candidate shows ${candidate.placements.length} ghost structure(s) across ${bodyCount} body/bodies on the Raven canvas; ghosts do not count as planned placements.${unresolvedLine}`;
+}
+
+function cardLineFor({
+  slotPressure,
+  existingInfrastructure,
+  uncertainty,
+}: {
+  slotPressure: string;
+  existingInfrastructure: string;
+  uncertainty: string;
+}) {
+  if (/exceed visible capacity/i.test(slotPressure)) return 'Slot pressure needs review before loading.';
+  if (/unresolved|unknown-lane/i.test(existingInfrastructure)) return 'Existing or unresolved infrastructure is called out in details.';
+  if (/sparse|estimated|unknown|unavailable|missing/i.test(uncertainty)) return 'Sparse or estimated data is called out in details.';
+  return 'Projection stays ghost-only until explicit load.';
+}
+
+function candidateBodyIds(candidate: OptimiserCandidate): string[] {
+  return Array.from(new Set(
+    candidate.placements
+      .map((placement) => bodyIdKey(placement.local_body_id))
+      .filter((bodyId) => Boolean(bodyId)),
+  ));
+}
+
+function summarizePlacementLanes(
+  placements: PlacementLike[],
+  templatesById: Map<string, FacilityTemplate>,
+  bodiesById: Map<string, SystemBody>,
+): PlacementLaneSummary {
+  const byBodyId = new Map<string, LaneCounts>();
+  const summary: PlacementLaneSummary = {
+    byBodyId,
+    unassignedBody: 0,
+    unknownBody: 0,
+    unknownLane: 0,
+    missingTemplate: 0,
+  };
+
+  placements.forEach((placement) => {
+    const bodyId = bodyIdKey(placement.local_body_id);
+    if (!bodyId) {
+      summary.unassignedBody += 1;
+      return;
+    }
+    const body = bodiesById.get(bodyId);
+    if (!body) {
+      summary.unknownBody += 1;
+      return;
+    }
+    const template = templatesById.get(placement.facility_template_id);
+    if (!template) {
+      summary.missingTemplate += 1;
+      return;
+    }
+    const lane = placementLaneForTemplate(template, body);
+    if (lane !== 'orbital' && lane !== 'surface') {
+      summary.unknownLane += 1;
+      return;
+    }
+    const counts = byBodyId.get(bodyId) ?? { orbital: 0, surface: 0 };
+    counts[lane] += 1;
+    byBodyId.set(bodyId, counts);
+  });
+
+  return summary;
+}


### PR DESCRIPTION
## What changed
- Added a frontend-only Suggested Build strategy advisor for candidate body choice, existing infrastructure, slot pressure, economy intent, declared roles, uncertainty, and projection/manual boundaries.
- Passed existing planner context into Suggested Builds display without changing generation, load, preview, ranking, or scoring mechanics.
- Added tests covering advisor copy, sparse-data explanation, ghost-only/manual boundaries, existing infrastructure separation, usefulness filtering, and no input mutation.

## Validation
- `cd frontend-v2 && npm run typecheck`
- `cd frontend-v2 && npm test -- OptimiserCandidatePanel OptimiserCandidateDetails RavenStylePlannerCanvas`
- `cd frontend-v2 && npm run build`
- `PYTHONPATH=apps/api/src .venv/bin/pytest tests/test_optimiser.py tests/test_simulation_contracts.py -q`
- `git diff --check`

## Boundaries
- No automatic preview.
- No automatic Suggested Build generation or load.
- No optimiser ranking/scoring/CP/economy/service/buildability mechanics changes.
- Existing infrastructure remains separate from Build Plan placements.
- Unknown data remains unknown.