### PR TITLE
[codex] harden warehouse reconciliation

### DIFF
--- a/apps/importer/src/enrichment_reconciliation.py
+++ b/apps/importer/src/enrichment_reconciliation.py
@@ -23,6 +23,9 @@ def station_reconciliation_candidates(rows: Sequence[Mapping[str, Any]]) -> list
             'market_id': first.get('market_id'),
             'edsm_station_id': first.get('edsm_station_id'),
             'station_name': first.get('station_name'),
+            'body_name': first.get('body_name'),
+            'source_class': first.get('source_class'),
+            'confidence': first.get('confidence'),
         }
         warnings = volatile_warnings(
             first,
@@ -64,6 +67,8 @@ def body_reconciliation_candidates(rows: Sequence[Mapping[str, Any]]) -> list[di
             'system_name': first.get('system_name'),
             'source_body_id': first.get('source_body_id'),
             'body_name': first.get('body_name'),
+            'source_class': first.get('source_class'),
+            'confidence': first.get('confidence'),
         }
         warnings = volatile_warnings(
             first,
@@ -110,6 +115,9 @@ def ring_reconciliation_candidates(rows: Sequence[Mapping[str, Any]]) -> list[di
             'source_body_id': first.get('source_body_id'),
             'body_name': first.get('body_name'),
             'ring_name': first.get('ring_name'),
+            'association_status': first.get('association_status'),
+            'source_class': first.get('source_class'),
+            'confidence': first.get('confidence'),
         }
         candidates.append(base_candidate(
             entity='ring',
@@ -222,6 +230,149 @@ def ring_canonical_matches(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, 
     return sort_candidate_rows(matches.values())
 
 
+def station_body_association_candidates(
+    station_candidates: Sequence[Mapping[str, Any]],
+    body_candidates: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build report-only station/body association review candidates.
+
+    This uses staged evidence already present in the reconciliation report. It
+    does not create station_body_links or promote source body names to truth.
+    """
+    body_index: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for body_candidate in body_candidates:
+        source = _source(body_candidate)
+        key = _association_key(source)
+        if key is not None:
+            body_index.setdefault(key, []).append(dict(body_candidate))
+
+    candidates = []
+    for station_candidate in station_candidates:
+        source = _source(station_candidate)
+        base = {
+            'entity': 'station_body_association',
+            'source': {
+                'source_record_hash': source.get('source_record_hash'),
+                'system_id64': source.get('system_id64'),
+                'system_name': source.get('system_name'),
+                'station_name': source.get('station_name'),
+                'body_name': source.get('body_name'),
+            },
+            'report_only': True,
+            'canonical_link_writes_planned': 0,
+        }
+        if _missing(source.get('body_name')):
+            candidates.append({
+                **base,
+                'candidate_action': 'station_body_name_missing',
+                'confidence': 'low',
+                'risk_flags': ['missing_station_body_name'],
+                'confidence_explanations': [
+                    'Station evidence has no body_name; association remains unknown.',
+                    'Output is report-only; it is not a station-body link write plan.',
+                ],
+                'matched_body_evidence': [],
+            })
+            continue
+
+        key = _association_key(source)
+        body_matches = body_index.get(key, []) if key is not None else []
+        if len(body_matches) == 1:
+            body_source = _source(body_matches[0])
+            candidates.append({
+                **base,
+                'candidate_action': 'station_body_supported_by_staged_body',
+                'confidence': 'medium',
+                'risk_flags': ['source_only_association'],
+                'confidence_explanations': [
+                    'Station body_name matches one staged body evidence row in the same system.',
+                    'The association remains report-only until a separate trusted write design exists.',
+                ],
+                'matched_body_evidence': [{
+                    'source_record_hash': body_source.get('source_record_hash'),
+                    'source_body_id': body_source.get('source_body_id'),
+                    'body_name': body_source.get('body_name'),
+                    'candidate_action': body_matches[0].get('candidate_action'),
+                    'confidence': body_matches[0].get('confidence'),
+                }],
+            })
+        elif len(body_matches) > 1:
+            candidates.append({
+                **base,
+                'candidate_action': 'station_body_ambiguous_staged_body',
+                'confidence': 'low',
+                'risk_flags': ['ambiguous_staged_body_evidence'],
+                'confidence_explanations': [
+                    'More than one staged body evidence row matched the station body_name.',
+                    'Manual review is required before any future association design.',
+                ],
+                'matched_body_evidence': [
+                    {
+                        'source_record_hash': _source(match).get('source_record_hash'),
+                        'source_body_id': _source(match).get('source_body_id'),
+                        'body_name': _source(match).get('body_name'),
+                        'candidate_action': match.get('candidate_action'),
+                        'confidence': match.get('confidence'),
+                    }
+                    for match in body_matches
+                ],
+            })
+        else:
+            candidates.append({
+                **base,
+                'candidate_action': 'station_body_unresolved_staged_body',
+                'confidence': 'low',
+                'risk_flags': ['missing_staged_body_evidence'],
+                'confidence_explanations': [
+                    'No staged body evidence matched the station body_name in the same system.',
+                    'The association stays unresolved and report-only.',
+                ],
+                'matched_body_evidence': [],
+            })
+    return sort_candidate_rows(candidates)
+
+
+def source_coverage_summary(
+    station_candidates: Sequence[Mapping[str, Any]],
+    body_candidates: Sequence[Mapping[str, Any]],
+    ring_candidates: Sequence[Mapping[str, Any]],
+    warnings: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Summarise source coverage without coercing unknown evidence to false."""
+    return {
+        'schema_version': 'enrichment_source_coverage_summary/v1',
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'entities': {
+            'station': _entity_coverage(station_candidates),
+            'body': _entity_coverage(body_candidates),
+            'ring': _entity_coverage(ring_candidates),
+        },
+        'ring_evidence': {
+            'staged_ring_candidates': len(ring_candidates),
+            'trusted_local_matched_ring_candidates': sum(
+                1 for candidate in ring_candidates
+                if (candidate.get('canonical') or {}).get('association_status') == 'local_matched'
+            ),
+            'missing_ring_arrays_state': 'unknown_not_false' if not ring_candidates else 'ring_evidence_present',
+            'ringed_truth_requires_trusted_body_rings': True,
+        },
+        'warnings': len(warnings),
+    }
+
+
+def confidence_risk_summary(candidates: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return {
+        'schema_version': 'enrichment_confidence_risk_summary/v1',
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'confidence_distribution': _distribution(candidates, 'confidence'),
+        'evidence_quality_distribution': _distribution(candidates, 'evidence_quality'),
+        'identifier_quality_distribution': _distribution(candidates, 'identifier_quality'),
+        'risk_flag_distribution': _risk_distribution(candidates),
+    }
+
+
 def diff_fields(row: Mapping[str, Any], field_pairs: Sequence[tuple[str, str]]) -> list[dict[str, Any]]:
     differences: list[dict[str, Any]] = []
     for staged_field, canonical_field in field_pairs:
@@ -280,3 +431,81 @@ def _normalise_compare_value(value: Any) -> Any:
         text = value.strip()
         return text or None
     return value
+
+
+def _source(candidate: Mapping[str, Any]) -> Mapping[str, Any]:
+    source = candidate.get('source')
+    return source if isinstance(source, Mapping) else {}
+
+
+def _association_key(source: Mapping[str, Any]) -> tuple[str, str] | None:
+    body_name = _normalise_key(source.get('body_name'))
+    if body_name is None:
+        return None
+    system_key = _system_key(source)
+    if system_key is None:
+        return None
+    return system_key, body_name
+
+
+def _system_key(source: Mapping[str, Any]) -> str | None:
+    if not _missing(source.get('system_id64')):
+        return f"id64:{source.get('system_id64')}"
+    system_name = _normalise_key(source.get('system_name'))
+    if system_name is not None:
+        return f'name:{system_name}'
+    return None
+
+
+def _normalise_key(value: Any) -> str | None:
+    if _missing(value):
+        return None
+    return str(value).strip().lower()
+
+
+def _entity_coverage(candidates: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    return {
+        'candidates': len(candidates),
+        'candidate_actions': _distribution(candidates, 'candidate_action'),
+        'confidence': _distribution(candidates, 'confidence'),
+        'source_runs': sorted({
+            str(_source(candidate).get('source_run_key'))
+            for candidate in candidates
+            if not _missing(_source(candidate).get('source_run_key'))
+        }),
+        'source_files': sorted({
+            str(_source(candidate).get('source_file_key'))
+            for candidate in candidates
+            if not _missing(_source(candidate).get('source_file_key'))
+        }),
+        'missing_system_identifiers': sum(1 for candidate in candidates if _system_key(_source(candidate)) is None),
+        'volatile_warnings': sum(
+            1 for candidate in candidates
+            for warning in candidate.get('warnings', [])
+            if isinstance(warning, Mapping)
+            and warning.get('reason') == 'volatile_source_evidence_not_canonical_update'
+        ),
+    }
+
+
+def _distribution(candidates: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        value = candidate.get(field_name)
+        if value is None:
+            continue
+        key = str(value)
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _risk_distribution(candidates: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        flags = candidate.get('risk_flags', [])
+        if not isinstance(flags, Sequence) or isinstance(flags, (str, bytes, bytearray)):
+            continue
+        for flag in flags:
+            key = str(flag)
+            counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))

--- a/apps/importer/src/enrichment_reconciliation_scoring.py
+++ b/apps/importer/src/enrichment_reconciliation_scoring.py
@@ -39,9 +39,17 @@ def candidate_confidence(
             risk_flags=risk_flags,
             differences=differences,
         ),
+        'confidence_explanations': confidence_explanations(
+            action=action,
+            identifier_quality=identifier_quality,
+            evidence_quality=evidence_quality,
+            risk_flags=risk_flags,
+            differences=differences,
+        ),
         'evidence_quality': evidence_quality,
         'identifier_quality': identifier_quality,
         'risk_flags': risk_flags,
+        'risk_explanations': risk_explanations(risk_flags),
     }
 
 
@@ -124,6 +132,45 @@ def confidence_reasons(
         reasons.append('stable_field_differences_present')
     reasons.extend(f'risk:{flag}' for flag in risk_flags)
     return sorted(reasons)
+
+
+def confidence_explanations(
+    *,
+    action: str,
+    identifier_quality: str,
+    evidence_quality: str,
+    risk_flags: Sequence[str],
+    differences: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    explanations = [
+        _action_explanation(action),
+        f'Identifier quality is {identifier_quality}.',
+        f'Evidence quality is {evidence_quality}.',
+        'Output is report-only; it is not a write plan.',
+    ]
+    if differences:
+        explanations.append('Stable staged fields differ from the matched canonical row.')
+    explanations.extend(risk_explanations(risk_flags))
+    return sorted(dict.fromkeys(explanations))
+
+
+def risk_explanations(risk_flags: Sequence[str]) -> list[str]:
+    mapping = {
+        'ambiguous_canonical_match': 'Multiple canonical rows matched; manual review is required.',
+        'insufficient_identifiers': 'Source evidence is missing identifiers needed for a canonical conclusion.',
+        'volatile_source_evidence': 'Volatile source evidence is retained for review and must not churn canonical rows.',
+    }
+    return [mapping[flag] for flag in sorted(risk_flags) if flag in mapping]
+
+
+def _action_explanation(action: str) -> str:
+    return {
+        'ambiguous_match': 'Staged evidence matched more than one canonical row.',
+        'candidate_insert_missing_canonical': 'No canonical row matched this staged evidence.',
+        'candidate_update': 'One canonical row matched, but stable staged fields differ.',
+        'insufficient_evidence': 'Staged evidence is too sparse to reconcile.',
+        'no_change': 'Staged evidence matches one canonical row.',
+    }.get(action, f'Reconciliation action is {action}.')
 
 
 def _missing(value: Any) -> bool:

--- a/apps/importer/src/enrichment_warehouse_repository.py
+++ b/apps/importer/src/enrichment_warehouse_repository.py
@@ -11,9 +11,17 @@ from typing import Any
 
 from enrichment_reconciliation import (
     body_reconciliation_candidates,
+    confidence_risk_summary,
     ring_reconciliation_candidates,
     sort_candidate_rows,
+    source_coverage_summary,
+    station_body_association_candidates,
     station_reconciliation_candidates,
+)
+from enrichment_analytics import (
+    build_colonisation_candidate_signals,
+    build_enrichment_analytics_signals,
+    build_mission_density_signals,
 )
 from enrichment_staged_reports import (
     STAGED_ROWS_REPORT_SCHEMA_VERSION,
@@ -245,8 +253,9 @@ def build_reconciliation_report(
         for candidate in station_candidates + body_candidates + ring_candidates
         for warning in candidate.get('warnings', [])
     )
-    all_candidates = station_candidates + body_candidates + ring_candidates
-    return {
+    association_candidates = station_body_association_candidates(station_candidates, body_candidates)
+    all_candidates = station_candidates + body_candidates + ring_candidates + association_candidates
+    report = {
         'schema_version': RECONCILIATION_REPORT_SCHEMA_VERSION,
         'dry_run': True,
         'filters': {
@@ -287,13 +296,27 @@ def build_reconciliation_report(
             'warnings': len(warnings),
             'errors': 0,
             'canonical_writes_planned': 0,
+            'station_body_association_candidates': len(association_candidates),
         },
         'station_candidates': station_candidates,
         'body_candidates': body_candidates,
         'ring_candidates': ring_candidates,
+        'station_body_association_candidates': association_candidates,
+        'source_coverage_summary': source_coverage_summary(
+            station_candidates,
+            body_candidates,
+            ring_candidates,
+            warnings,
+        ),
+        'confidence_risk_summary': confidence_risk_summary(all_candidates),
         'warnings': warnings,
         'errors': [],
     }
+    analytics_signals = build_enrichment_analytics_signals(report)
+    report['analytics_signals'] = analytics_signals
+    report['colonisation_signals'] = build_colonisation_candidate_signals(analytics_signals)
+    report['mission_density_signals'] = build_mission_density_signals(report)
+    return report
 
 
 def fetch_station_reconciliation_rows(

--- a/apps/importer/src/enrichment_warehouse_sql.py
+++ b/apps/importer/src/enrichment_warehouse_sql.py
@@ -266,6 +266,8 @@ def station_reconciliation_query(
                 ss.controlling_faction,
                 ss.allegiance,
                 ss.government,
+                ss.source_class,
+                ss.confidence,
                 sr.source_run_key,
                 sr.source,
                 sf.source_file_key
@@ -351,6 +353,8 @@ def body_reconciliation_query(
                 sb.is_terraformable,
                 sb.estimated_scan_value,
                 sb.estimated_mapping_value,
+                sb.source_class,
+                sb.confidence,
                 sr.source_run_key,
                 sr.source,
                 sf.source_file_key
@@ -438,6 +442,8 @@ def ring_reconciliation_query(
                 br.inner_radius,
                 br.outer_radius,
                 br.association_status,
+                br.source_class,
+                br.confidence,
                 sr.source_run_key,
                 sr.source,
                 sf.source_file_key

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -99,6 +99,20 @@ summary counts, staged/planned rows, skipped rows, conflicts, warnings,
 confidence/freshness/source-class distributions, candidate confidence/risk
 fields, and deterministic sorting for stable diffs.
 
+Stage 18B broadens the read-only reconciliation report with named sections:
+
+* `station_body_association_candidates` records staged station/body-name
+  association evidence as supported, unresolved, missing, or ambiguous. It is
+  report-only and does not create `station_body_links`.
+* `source_coverage_summary` records per-entity action/confidence/source
+  coverage, volatile warning counts, and ring-evidence state. Missing ring
+  arrays remain `unknown_not_false`.
+* `confidence_risk_summary` keeps aggregate confidence, identifier/evidence
+  quality, and risk-flag distributions explainable.
+* `analytics_signals`, `colonisation_signals`, and `mission_density_signals`
+  are embedded as report-only signal sections with
+  `canonical_writes_planned = 0`.
+
 ## Offline Fixture Loader
 
 Run from the repo root:

--- a/tests/test_enrichment_staging_reconciliation.py
+++ b/tests/test_enrichment_staging_reconciliation.py
@@ -366,6 +366,65 @@ def test_ring_candidate_matches_by_body_and_ring_identifiers():
     assert_read_only_sql(conn)
 
 
+def test_station_body_association_candidates_are_report_only():
+    conn = FakeConn(
+        station_rows=[station_row(body_name='Test 7')],
+        body_rows=[body_row()],
+    )
+
+    report = db_loader.build_reconciliation_report(conn)
+
+    candidate = report['station_body_association_candidates'][0]
+    assert candidate['entity'] == 'station_body_association'
+    assert candidate['candidate_action'] == 'station_body_supported_by_staged_body'
+    assert candidate['confidence'] == 'medium'
+    assert candidate['report_only'] is True
+    assert candidate['canonical_link_writes_planned'] == 0
+    assert candidate['source']['station_name'] == 'Test Port'
+    assert candidate['source']['body_name'] == 'Test 7'
+    assert candidate['matched_body_evidence'] == [{
+        'source_record_hash': 'body-hash',
+        'source_body_id': 7,
+        'body_name': 'Test 7',
+        'candidate_action': 'no_change',
+        'confidence': 'high',
+    }]
+    assert report['summary']['station_body_association_candidates'] == 1
+    assert report['confidence_risk_summary']['risk_flag_distribution']['source_only_association'] == 1
+    assert_read_only_sql(conn)
+
+
+def test_station_body_association_candidates_keep_unresolved_and_ambiguous_states():
+    conn = FakeConn(
+        station_rows=[
+            station_row(staging_station_id=1, body_name=None),
+            station_row(staging_station_id=2, body_name='Missing Body', station_name='Unresolved Port'),
+            station_row(staging_station_id=3, body_name='Test 7', station_name='Ambiguous Port'),
+        ],
+        body_rows=[
+            body_row(staging_body_id=10, body_name='Test 7', source_record_hash='body-a'),
+            body_row(staging_body_id=11, body_name='Test 7', source_record_hash='body-b'),
+        ],
+    )
+
+    report = db_loader.build_reconciliation_report(conn)
+    by_station = {
+        candidate['source']['station_name']: candidate['candidate_action']
+        for candidate in report['station_body_association_candidates']
+    }
+
+    assert by_station == {
+        'Test Port': 'station_body_name_missing',
+        'Unresolved Port': 'station_body_unresolved_staged_body',
+        'Ambiguous Port': 'station_body_ambiguous_staged_body',
+    }
+    risk_distribution = report['confidence_risk_summary']['risk_flag_distribution']
+    assert risk_distribution['ambiguous_staged_body_evidence'] == 1
+    assert risk_distribution['missing_staged_body_evidence'] == 1
+    assert risk_distribution['missing_station_body_name'] == 1
+    assert_read_only_sql(conn)
+
+
 def test_sparse_staged_records_become_insufficient_evidence():
     conn = FakeConn(
         station_rows=[station_row(station_name=None, canonical_station_id=None, canonical_match_count=0)],
@@ -399,12 +458,67 @@ def test_volatile_only_station_difference_does_not_raise_update_confidence():
     assert candidate['differences'] == []
     assert candidate['confidence'] == 'medium'
     assert candidate['risk_flags'] == ['volatile_source_evidence']
+    assert candidate['risk_explanations'] == [
+        'Volatile source evidence is retained for review and must not churn canonical rows.',
+    ]
+    assert 'Output is report-only; it is not a write plan.' in candidate['confidence_explanations']
     assert candidate['warnings'] == [{
         'entity': 'station',
         'field': 'distance_to_arrival',
         'reason': 'volatile_source_evidence_not_canonical_update',
         'source_record_hash': 'station-hash',
     }]
+    assert_read_only_sql(conn)
+
+
+def test_reconciliation_report_includes_source_coverage_and_report_only_signals():
+    conn = FakeConn(
+        station_rows=[station_row(distance_to_arrival=123.4, canonical_distance_to_arrival=99.9)],
+        body_rows=[body_row()],
+        ring_rows=[],
+    )
+
+    report = db_loader.build_reconciliation_report(conn)
+
+    coverage = report['source_coverage_summary']
+    assert coverage['schema_version'] == 'enrichment_source_coverage_summary/v1'
+    assert coverage['report_only'] is True
+    assert coverage['canonical_writes_planned'] == 0
+    assert coverage['entities']['station']['candidates'] == 1
+    assert coverage['entities']['station']['volatile_warnings'] == 1
+    assert coverage['entities']['body']['source_runs'] == ['run-bodies']
+    assert coverage['ring_evidence'] == {
+        'staged_ring_candidates': 0,
+        'trusted_local_matched_ring_candidates': 0,
+        'missing_ring_arrays_state': 'unknown_not_false',
+        'ringed_truth_requires_trusted_body_rings': True,
+    }
+
+    assert report['analytics_signals']['schema_version'] == 'enrichment_analytics_signals/v1'
+    assert report['analytics_signals']['dry_run'] is True
+    assert report['colonisation_signals']['schema_version'] == 'colonisation_candidate_signals/v1'
+    assert report['colonisation_signals']['summary']['canonical_writes_planned'] == 0
+    assert report['mission_density_signals']['schema_version'] == 'mission_density_signals/v1'
+    assert report['mission_density_signals']['summary']['canonical_writes_planned'] == 0
+    assert_read_only_sql(conn)
+
+
+def test_source_only_ring_association_status_does_not_confirm_ringed():
+    conn = FakeConn(ring_rows=[
+        ring_row(
+            association_status='local_matched',
+            canonical_ring_id=None,
+            canonical_association_status=None,
+        ),
+    ])
+
+    report = db_loader.build_reconciliation_report(conn, source='edsm_nightly_bodies')
+
+    ring_evidence = report['source_coverage_summary']['ring_evidence']
+    assert ring_evidence['staged_ring_candidates'] == 1
+    assert ring_evidence['trusted_local_matched_ring_candidates'] == 0
+    assert ring_evidence['missing_ring_arrays_state'] == 'ring_evidence_present'
+    assert ring_evidence['ringed_truth_requires_trusted_body_rings'] is True
     assert_read_only_sql(conn)
 
 


### PR DESCRIPTION
## Summary
- add reconciliation diagnostics for warehouse staging rows
- include supporting scoring/repository/SQL changes
- document the staged reconciliation behavior
- add focused reconciliation coverage

## Validation
- `git diff --check`
- `.venv/bin/pytest tests/test_enrichment_staging_reconciliation.py -q`