### PR TITLE
Stage 18C warehouse runbook and operator workflow

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -401,6 +401,10 @@ pure report-only analytics/signals. Optional real-Postgres smoke tests for the
 staging loaders and reconciliation are skipped by default unless
 `EDFINDER_STAGING_TEST_DSN` and `EDFINDER_CONFIRM_STAGING_TEST_DB=yes` are set.
 
+The operator workflow and current command examples live in
+[`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
+Use that runbook before loading any local snapshot into staging tables.
+
 This is the long-term replacement direction for large live API crawls: load
 repeatable offline snapshots into raw/staging evidence, compare read-only
 against canonical ED-Finder tables, produce pure versioned dry-run plans, and

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -141,6 +141,8 @@ The staging DB loader remains explicitly opt-in. Staging writes require
 `--write-staging`, `--dsn`, and `--confirm-staging-db`; read-only schema,
 staged-row, and reconciliation report modes require a DSN but do not require
 the staging-write confirmation flag. Canonical flags continue to fail closed.
+The Stage 18C operator workflow and exact command examples are documented in
+[`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 The repository writes only to:
 
 * `enrichment_source_runs`

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -264,6 +264,8 @@ Acceptance:
 
 Purpose: make the warehouse safe and repeatable to run.
 
+Runbook: `docs/operations/enrichment-warehouse-runbook.md`.
+
 Scope:
 
 - Document where snapshots come from, where they are stored, how they are loaded, and how dry-run reconciliation is run.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -1,0 +1,443 @@
+# Enrichment Warehouse Runbook
+
+This runbook covers the Stage 18C operator workflow for the offline enrichment
+warehouse. It explains how to inspect local snapshots, optionally load them into
+the warehouse staging tables, and produce read-only reconciliation and signal
+reports.
+
+It does not describe a canonical apply workflow. The warehouse stores source
+evidence and report output only. Warehouse evidence is not canonical truth.
+
+## Overview
+
+The current warehouse path is:
+
+```text
+offline snapshot file
+-> deterministic dry-run report
+-> optional gated staging-table load
+-> read-only comparison with canonical ED-Finder tables
+-> report-only reconciliation, coverage, confidence/risk, and signals
+```
+
+Snapshots come from operator-provided offline exports, such as local EDSM-style
+station snapshots or local EDSM-style body/ring snapshots. The current scripts
+do not fetch EDSM, Spansh, EDDN, or any other live API. Store real snapshots in
+an operator-managed location outside git, or in a local ignored workspace. Do
+not commit large snapshots, private host paths, DSNs, API keys, or credentials.
+The repository fixtures under `tests/fixtures/` are for deterministic examples
+and CI only.
+
+Current supported source adapters:
+
+| Source | Input file | Current purpose |
+|---|---|---|
+| `edsm_nightly_stations` | Local `.json` or `.json.gz` station snapshot. JSON array, NDJSON, or small object wrapper with a `stations` array. | Station evidence dry-run, staging load, staged-row summary, reconciliation. |
+| `edsm_nightly_bodies` | Local `.json` or `.json.gz` body records with optional `rings` arrays. JSON array or NDJSON. | Body/ring evidence dry-run, staging load, staged-row summary, reconciliation. |
+
+The scripts preserve source payloads and future/unknown fields in raw evidence.
+Missing evidence remains unknown. Missing ring arrays are reported as
+`unknown_not_false`; they are not proof that a body has no rings. Source-only
+ring evidence is not trusted local ring truth unless later reconciled to trusted
+`body_rings` evidence.
+
+## Safety Model
+
+Safe by default:
+
+- `apps/importer/src/enrichment_snapshot_loader.py` is dry-run only and has no
+  database, network, Docker, or canonical write path.
+- `apps/importer/src/enrichment_staging_db_loader.py` dry-run mode is also
+  no-write.
+- `--check-staging-schema`, `--report-staged-run`, and
+  `--report-reconciliation` are read-only DB modes.
+- Reconciliation and analytics output always reports
+  `canonical_writes_planned = 0`.
+
+Explicitly gated staging writes:
+
+- `--write-staging` requires `--dsn` and `--confirm-staging-db`.
+- Staging writes target only:
+  `enrichment_source_runs`, `enrichment_source_files`,
+  `enrichment_raw_records`, `staging_edsm_stations`,
+  `staging_edsm_bodies`, and `staging_body_rings`.
+- Use a staging or test enrichment DSN only. Do not point this at canonical
+  production app tables.
+
+Never use the warehouse scripts to write canonical production tables:
+
+- `systems`
+- `stations`
+- `bodies`
+- `body_rings`
+- `body_scan_facts`
+- `station_body_links`
+
+The canonical flags `--apply`, `--write`, and `--commit` fail closed. Do not add
+workarounds or SQL snippets that bypass that boundary.
+
+## Inputs
+
+Use fixture inputs first when checking commands:
+
+- `tests/fixtures/edsm_station_snapshot.json`
+- `tests/fixtures/edsm_body_ring_snapshot.json`
+
+Use larger local snapshots only after the fixture commands are boring. Keep
+operator snapshots outside git and name them by source and date, for example:
+
+```text
+<operator-snapshot-root>/edsm/stations-YYYY-MM-DD.json.gz
+<operator-snapshot-root>/edsm/bodies-YYYY-MM-DD.json.gz
+```
+
+For large files, start with `--limit` so skipped rows, warning counts, source
+metadata, and staged-row counts are easy to inspect before a full dry-run.
+
+`distanceToArrival` is volatile evidence. Reports retain it for review and may
+warn about differences, but it must not churn canonical
+`stations.distance_from_star` or body distance fields.
+
+## Dry-Run Commands
+
+Fixture station snapshot dry-run:
+
+```sh
+python3 apps/importer/src/enrichment_snapshot_loader.py \
+    --source-file tests/fixtures/edsm_station_snapshot.json \
+    --source edsm_nightly_stations \
+    --json
+```
+
+Fixture body/ring snapshot dry-run:
+
+```sh
+python3 apps/importer/src/enrichment_snapshot_loader.py \
+    --source-file tests/fixtures/edsm_body_ring_snapshot.json \
+    --source edsm_nightly_bodies \
+    --json
+```
+
+Larger local snapshot dry-run with a limit:
+
+```sh
+python3 apps/importer/src/enrichment_snapshot_loader.py \
+    --source-file "$EDSM_STATION_SNAPSHOT" \
+    --source edsm_nightly_stations \
+    --limit 1000 \
+    --json
+```
+
+For body/ring snapshots, use the body source adapter:
+
+```sh
+python3 apps/importer/src/enrichment_snapshot_loader.py \
+    --source-file "$EDSM_BODY_SNAPSHOT" \
+    --source edsm_nightly_bodies \
+    --limit 1000 \
+    --json
+```
+
+A good dry-run has:
+
+- `schema_version = "enrichment_snapshot_load_plan/v1"`
+- `dry_run = true`
+- expected `records_seen`, `raw_records`, and staged-row counts
+- `canonical_writes_planned = 0`
+- no unexpected skipped-row reasons
+- no source-file or unsupported-source errors
+
+Warnings that block moving to staging load:
+
+- required identity fields missing across most records
+- unexpected `record_is_not_object` or malformed JSON patterns
+- unsupported source adapter
+- remote URL used as `--source-file`
+- surprising `distance_to_arrival_classification` values; current
+  `distanceToArrival` should remain volatile
+
+## Staging DB Commands
+
+Set the DSN only in your shell or secret manager. Do not paste real DSNs into
+docs, PRs, issue comments, or committed files.
+
+```sh
+export EDFINDER_STAGING_DSN='postgresql://USER:PASSWORD@HOST:PORT/DBNAME'
+```
+
+Read-only schema/preflight check:
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --check-staging-schema \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --source edsm_nightly_stations \
+    --json
+```
+
+For body/ring warehouse tables:
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --check-staging-schema \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --source edsm_nightly_bodies \
+    --json
+```
+
+A good preflight has `ok = true`, empty `missing_tables`, empty
+`missing_columns`, and the expected target warehouse tables. If it returns
+`ok = false`, stop and fix the staging schema before loading.
+
+Staging-only DB load with explicit confirmation:
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --source-file "$EDSM_STATION_SNAPSHOT" \
+    --source edsm_nightly_stations \
+    --limit 1000 \
+    --write-staging \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --confirm-staging-db \
+    --json
+```
+
+For body/ring staging:
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --source-file "$EDSM_BODY_SNAPSHOT" \
+    --source edsm_nightly_bodies \
+    --limit 1000 \
+    --write-staging \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --confirm-staging-db \
+    --json
+```
+
+A good staging load has:
+
+- `dry_run = false`
+- `summary.write_mode = "staging_only"`
+- `summary.staging_writes_enabled = true`
+- non-zero `raw_records_written` and source-specific staged row counts when the
+  input contains valid records
+- target tables limited to the warehouse table family
+- `summary.canonical_writes_planned = 0`
+
+Staging-load warnings that block progress:
+
+- schema preflight failure
+- writes reported to any table outside the warehouse table family
+- unexpected rollback or non-zero `errors`
+- high skipped-row counts caused by malformed source shape
+- source-run or source-file metadata that does not match the intended snapshot
+
+## Reconciliation Reports
+
+Read-only reconciliation compares staged warehouse evidence with canonical
+tables and emits candidate sections. It does not write either warehouse or
+canonical data.
+
+Read-only reconciliation report:
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --report-reconciliation \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --source edsm_nightly_stations \
+    --source-run-key "$SOURCE_RUN_KEY" \
+    --source-file-key "$SOURCE_FILE_KEY" \
+    --limit 1000 \
+    --json
+```
+
+Use `--source edsm_nightly_bodies` for body/ring reconciliation, or omit
+`--source` to include all currently supported staged source families.
+`--source-run-key` and `--source-file-key` are optional for reconciliation but
+recommended for repeatable operator review.
+
+Important sections:
+
+- `station_candidates`: staged station evidence compared with canonical
+  station rows.
+- `body_candidates`: staged body evidence compared with canonical body rows.
+- `ring_candidates`: staged ring evidence compared with trusted local ring
+  rows.
+- `station_body_association_candidates`: report-only station/body-name
+  support, unresolved, missing, or ambiguous states. It is not a
+  `station_body_links` write plan.
+- `source_coverage_summary`: entity coverage, source files/runs, volatile
+  warning counts, and ring evidence state.
+- `confidence_risk_summary`: confidence, evidence quality, identifier quality,
+  and risk-flag distributions.
+
+Candidate actions to expect:
+
+| Action | Meaning |
+|---|---|
+| `no_change` | One canonical row matched and stable staged fields agree. |
+| `candidate_update` | One canonical row matched, but stable staged fields differ. Report-only. |
+| `candidate_insert_missing_canonical` | No canonical row matched. Treat as review evidence, not an insert instruction. |
+| `ambiguous_match` | More than one canonical row matched. Manual review required. |
+| `insufficient_evidence` | Source identifiers are too sparse for a conclusion. |
+
+Warnings that block any later stage:
+
+- `ambiguous_match`
+- `insufficient_evidence`
+- `volatile_source_evidence` where an operator expected a stable-field change
+- `source_only_association`, `ambiguous_staged_body_evidence`,
+  `missing_staged_body_evidence`, or `missing_station_body_name`
+- any non-zero `errors`
+- any report that omits `canonical_writes_planned = 0`
+
+## Staged-Row Summary
+
+Staged-row summaries are read-only and require a source run key.
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --report-staged-run \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --source-run-key "$SOURCE_RUN_KEY" \
+    --source-file-key "$SOURCE_FILE_KEY" \
+    --source edsm_nightly_stations \
+    --json
+```
+
+A good staged-row summary has:
+
+- `schema_version = "enrichment_staged_rows_summary/v1"`
+- `dry_run = true`
+- expected `source_run` and `source_files`
+- expected raw/staged counts for the source family
+- `warning_records = 0` and `error_records = 0` for clean fixture-sized loads
+- target tables limited to the source-specific warehouse tables
+
+## Analytics And Signals
+
+Analytics and signals currently come embedded in the reconciliation report.
+There is no separate analytics CLI flag.
+
+Run the reconciliation command and inspect these sections:
+
+```sh
+python3 apps/importer/src/enrichment_staging_db_loader.py \
+    --report-reconciliation \
+    --dsn "$EDFINDER_STAGING_DSN" \
+    --source-run-key "$SOURCE_RUN_KEY" \
+    --json
+```
+
+Signal sections:
+
+- `analytics_signals`: quality signals such as missing identifiers, ambiguous
+  matches, records without canonical matches, rings without body matches, and
+  high warning rates.
+- `colonisation_signals`: conservative review candidates grouped by system.
+  These are advisory `needs_review` records, not planner truth.
+- `mission_density_signals`: station/body/ring evidence counts by system,
+  useful for seeing where source density is high or sparse.
+
+A good signal report is deterministic, has `dry_run = true`, has
+`canonical_writes_planned = 0` in signal summaries where present, and keeps
+review flags as review flags rather than promotion instructions.
+
+## Status Publishing
+
+Stage 18A's station enrichment status JSON is a separate read-only operator
+status path for the guarded station enrichment job. It is useful context beside
+warehouse runs, but it is not the warehouse loader and it does not publish
+warehouse reconciliation reports.
+
+Safe status publishing path:
+
+```sh
+python3 scripts/station_enrichment_status.py --json \
+    > /data/logs/station-enrichment-status.json
+```
+
+The API reads the artifact configured by:
+
+```text
+ENRICHMENT_STATUS_JSON_PATH=/data/logs/station-enrichment-status.json
+```
+
+The status helper reads local files only. It does not call EDSM, connect to the
+database, invoke Docker, or mutate state. Missing status must stay unavailable,
+not zero.
+
+## Optional Postgres Smoke Tests
+
+These tests are skipped by default. They write only to warehouse staging tables
+and clean up after themselves, but they still require a disposable staging/test
+database.
+
+```sh
+EDFINDER_STAGING_TEST_DSN="$EDFINDER_STAGING_DSN" \
+EDFINDER_CONFIRM_STAGING_TEST_DB=yes \
+.venv/bin/pytest \
+    tests/test_enrichment_staging_db_loader_postgres_smoke.py \
+    tests/test_enrichment_body_ring_staging_loader_postgres_smoke.py \
+    tests/test_enrichment_staging_reconciliation_postgres_smoke.py \
+    -q
+```
+
+Do not run these against a production canonical database. The confirmation
+variable means the operator has verified the DSN is staging/test only.
+
+## Troubleshooting
+
+If dry-run fails:
+
+- Check that `--source-file` is a local file path, not a URL.
+- Check that the source is exactly `edsm_nightly_stations` or
+  `edsm_nightly_bodies`.
+- Run with a small `--limit` and inspect `skipped_rows`.
+- Treat missing evidence as unknown; do not patch fixture/source values to
+  force false conclusions.
+
+If schema preflight fails:
+
+- Confirm migration `sql/026_enrichment_staging_foundation.sql` has been
+  applied to the staging/test warehouse database.
+- Confirm `--source` matches the table family you are checking.
+- Do not proceed to `--write-staging` until `ok = true`.
+
+If reconciliation shows conflicts or warnings:
+
+- Ambiguous matches and insufficient identifiers block progress.
+- Volatile distance warnings are expected review evidence when only
+  `distanceToArrival` changed; they are not canonical update candidates.
+- Source-only ring evidence is review evidence until trusted local
+  `body_rings` rows support it.
+- Station/body association candidates remain report-only until a separate
+  canonical write design exists.
+
+## What Not To Do
+
+- Do not wire these commands into a production scheduler from this stage.
+- Do not run live EDSM/API crawls from the warehouse path.
+- Do not invoke Docker from UI/API code for this workflow.
+- Do not change planner, search, scoring, optimiser, Simulation Preview,
+  Suggested Build, or role behavior from warehouse report output.
+- Do not use report candidates as canonical write instructions.
+- Do not coerce missing rings, missing body links, missing distances, or sparse
+  source records to false or zero.
+- Do not paste private DSNs, API keys, or host-specific paths into reports or
+  committed docs.
+
+## Future DB Boundary Notes
+
+Stage 18I.5 is expected to review the database boundary. The preferred future
+direction may move the warehouse from same-database staging tables toward a
+separate `edfinder_enrichment` database on the same Postgres server, with a
+path to a separate instance later if operational load or retention risk
+requires it.
+
+Until that review lands, treat DSNs and paths in this runbook as current
+operator examples. Future work may rename the warehouse DSN variable, move the
+warehouse schema, or require different read-only access patterns for canonical
+comparison. The hard boundary remains unchanged: warehouse data is evidence and
+reports, not canonical truth.


### PR DESCRIPTION
## What changed

* Adds the enrichment warehouse operator runbook.
* Documents safe fixture/local snapshot dry-runs, gated staging loads, read-only reconciliation, staged-row summaries, analytics/signals, and Stage 18A status publishing.
* Links the runbook from the enrichment roadmap, staging architecture, and Stage 17P current plan.
* Captures blockers, good-output expectations, volatile distanceToArrival handling, unknown-vs-false ring evidence, and future Stage 18I.5 DB boundary notes.

## Boundaries

* Documentation/runbook stage only.
* No canonical writes.
* No production scheduler/job wiring.
* No live EDSM/API crawl.
* No planner/search/scoring/optimiser changes.
* Dry-run/report-only remains default.
* Unknown data remains unknown.

## Validation

* `.venv/bin/pytest tests/test_enrichment_staging.py tests/test_enrichment_snapshot_loader.py -q`
* `.venv/bin/pytest tests/test_enrichment_staging_reconciliation.py -q`
* `.venv/bin/pytest tests/test_station_enrichment_status.py tests/test_station_enrichment_guard.py -q`
* `.venv/bin/pytest tests/test_smoke.py -q`
* Additional enrichment warehouse/reconciliation/analytics/staged-report tests found by `rg`: 87 passed, 3 optional Postgres smoke tests skipped.
* `git diff --check`