### PR TITLE
[codex] Add snapshot source observability

### DIFF
--- a/apps/importer/src/enrichment_snapshot_loader.py
+++ b/apps/importer/src/enrichment_snapshot_loader.py
@@ -12,6 +12,7 @@ import gzip
 import hashlib
 import json
 import sys
+from collections import Counter
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,8 @@ from enrichment_staging import (
 ADAPTER_NAME = 'enrichment_snapshot_loader'
 SUPPORTED_SOURCES = {'edsm_nightly_stations', 'edsm_nightly_bodies'}
 DEFAULT_CHUNK_SIZE = 64 * 1024
+SOURCE_FORMAT_VERSION = 'json_snapshot_stream/v1'
+RING_ARRAY_UNKNOWN_STATE = 'unknown_not_false'
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -97,11 +100,13 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
     _assert_local_file(source_file)
 
     file_sha256, file_size_bytes = file_digest(source_file)
+    file_format = source_file_format_metadata(source_file)
     source_file_summary = normalise_source_file_metadata(
         source=normalised_source,
         source_file=source_file,
         file_sha256=file_sha256,
         file_size_bytes=file_size_bytes,
+        metadata=file_format,
     )
     source_run = normalise_source_run_metadata(
         source=normalised_source,
@@ -109,13 +114,17 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
         adapter_version=ADAPTER_VERSION,
         source_file_keys=[source_file_summary['source_file_key']],
         dry_run=True,
-        metadata={'supported_adapter': 'edsm_station_snapshot'},
+        metadata={
+            'supported_adapter': 'edsm_station_snapshot',
+            **file_format,
+        },
     )
 
     raw_records: list[dict[str, Any]] = []
     staged_rows: list[dict[str, Any]] = []
     skipped_rows: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
+    conflicts: list[dict[str, Any]] = []
 
     records_seen = 0
     for record_index, record in enumerate(iter_json_records(source_file), start=1):
@@ -140,6 +149,28 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             source_updated_at=source_updated_at_from_record(record),
         )
         raw_records.append(raw_record)
+        unsupported_shape = unsupported_source_shape(record, normalised_source)
+        if unsupported_shape is not None:
+            shape_warning = {
+                'field': unsupported_shape['field'],
+                'reason': 'unsupported_source_shape',
+                'source_shape': unsupported_shape['source_shape'],
+            }
+            raw_record['validation_status'] = 'skipped'
+            raw_record['validation_warnings'] = [shape_warning]
+            skipped_rows.append({
+                'record_index': record_index,
+                'source_record_hash': raw_record['source_record_hash'],
+                'reason': unsupported_shape['skip_reason'],
+                'warnings': [shape_warning],
+                'raw_payload': dict(record),
+            })
+            warnings.append({
+                'record_index': record_index,
+                'source_record_hash': raw_record['source_record_hash'],
+                **shape_warning,
+            })
+            continue
         row = normalise_edsm_station_snapshot_record(
             record,
             source=normalised_source,
@@ -172,12 +203,28 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
                 **warning,
             })
 
+    conflicts = source_identity_conflicts(staged_rows, entity='station')
+    source_summary = source_observability_summary(
+        raw_records=raw_records,
+        staged_rows=staged_rows,
+        planned_rows=(),
+        skipped_rows=skipped_rows,
+        warnings=warnings,
+        file_format=file_format,
+    )
+    apply_source_observability_metadata(
+        source_run=source_run,
+        source_file=source_file_summary,
+        source_summary=source_summary,
+    )
+
     return build_enrichment_snapshot_load_plan(
         source_run=source_run,
         source_file=source_file_summary,
         raw_records=raw_records,
         staged_rows=staged_rows,
         skipped_rows=skipped_rows,
+        conflicts=conflicts,
         warnings=warnings,
         summary_extra={
             'source': normalised_source,
@@ -187,6 +234,7 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             'dry_run_only': True,
             'canonical_writes_planned': 0,
             'distance_to_arrival_classification': classify_source_field(normalised_source, 'distanceToArrival'),
+            **source_summary,
         },
     )
 
@@ -204,11 +252,13 @@ def build_body_ring_snapshot_load_report(
     _assert_local_file(source_file)
 
     file_sha256, file_size_bytes = file_digest(source_file)
+    file_format = source_file_format_metadata(source_file)
     source_file_summary = normalise_source_file_metadata(
         source=normalised_source,
         source_file=source_file,
         file_sha256=file_sha256,
         file_size_bytes=file_size_bytes,
+        metadata=file_format,
     )
     source_run = normalise_source_run_metadata(
         source=normalised_source,
@@ -216,7 +266,10 @@ def build_body_ring_snapshot_load_report(
         adapter_version=ADAPTER_VERSION,
         source_file_keys=[source_file_summary['source_file_key']],
         dry_run=True,
-        metadata={'supported_adapter': 'edsm_body_ring_snapshot'},
+        metadata={
+            'supported_adapter': 'edsm_body_ring_snapshot',
+            **file_format,
+        },
     )
 
     raw_records: list[dict[str, Any]] = []
@@ -224,6 +277,7 @@ def build_body_ring_snapshot_load_report(
     ring_rows: list[dict[str, Any]] = []
     skipped_rows: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
+    ring_array_evidence = empty_ring_array_evidence_summary()
 
     records_seen = 0
     for record_index, record in enumerate(iter_json_records(source_file), start=1):
@@ -247,6 +301,28 @@ def build_body_ring_snapshot_load_report(
             source_updated_at=source_updated_at_from_record(record),
         )
         raw_records.append(raw_record)
+        unsupported_shape = unsupported_source_shape(record, normalised_source)
+        if unsupported_shape is not None:
+            shape_warning = {
+                'field': unsupported_shape['field'],
+                'reason': 'unsupported_source_shape',
+                'source_shape': unsupported_shape['source_shape'],
+            }
+            raw_record['validation_status'] = 'skipped'
+            raw_record['validation_warnings'] = [shape_warning]
+            skipped_rows.append({
+                'record_index': record_index,
+                'source_record_hash': raw_record['source_record_hash'],
+                'reason': unsupported_shape['skip_reason'],
+                'warnings': [shape_warning],
+                'raw_payload': dict(record),
+            })
+            warnings.append({
+                'record_index': record_index,
+                'source_record_hash': raw_record['source_record_hash'],
+                **shape_warning,
+            })
+            continue
         body_row = normalise_edsm_body_snapshot_record(
             record,
             source=normalised_source,
@@ -272,6 +348,9 @@ def build_body_ring_snapshot_load_report(
             continue
 
         body_row['validation_warnings'] = row_warnings
+        ring_state = classify_ring_array_evidence(record)
+        annotate_body_ring_array_evidence(body_row, ring_state)
+        update_ring_array_evidence_summary(ring_array_evidence, ring_state)
         body_rows.append(body_row)
         for warning in row_warnings:
             warnings.append({
@@ -280,6 +359,29 @@ def build_body_ring_snapshot_load_report(
                 **warning,
             })
 
+        if ring_state['state'] == 'non_array':
+            ring_warning = {
+                'field': 'rings',
+                'reason': 'ring_array_not_sequence',
+                'ring_array_state': 'non_array',
+            }
+            skipped_rows.append({
+                'record_index': record_index,
+                'source_record_hash': raw_record['source_record_hash'],
+                'reason': 'invalid_ring_snapshot_record',
+                'warnings': [ring_warning],
+                'raw_payload': dict(record),
+            })
+            warnings.append({
+                'record_index': record_index,
+                'source_record_hash': raw_record['source_record_hash'],
+                **ring_warning,
+            })
+            continue
+
+        for ring_skip in skipped_ring_rows_for_record(record, record_index, raw_record):
+            skipped_rows.append(ring_skip)
+
         for ring_row in normalise_edsm_body_ring_snapshot_records(
             record,
             source=normalised_source,
@@ -287,14 +389,48 @@ def build_body_ring_snapshot_load_report(
             raw_record=raw_record,
         ):
             if not ring_row.get('ring_name'):
+                ring_warning = {
+                    'field': 'ring_name',
+                    'reason': 'missing_ring_identity',
+                    'ring_index': ring_row['raw_payload']['ring_index'],
+                }
                 warnings.append({
                     'record_index': record_index,
                     'source_record_hash': ring_row['source_record_hash'],
-                    'field': 'ring_name',
-                    'reason': 'missing_ring_identity',
+                    **ring_warning,
+                })
+                skipped_rows.append({
+                    'record_index': record_index,
+                    'ring_index': ring_row['raw_payload']['ring_index'],
+                    'source_record_hash': ring_row['source_record_hash'],
+                    'reason': 'invalid_ring_snapshot_record',
+                    'warnings': [ring_warning],
+                    'raw_payload': ring_row['raw_payload'],
                 })
                 continue
             ring_rows.append(ring_row)
+
+    conflicts = (
+        source_identity_conflicts(body_rows, entity='body')
+        + source_identity_conflicts(ring_rows, entity='ring')
+    )
+    source_summary = source_observability_summary(
+        raw_records=raw_records,
+        staged_rows=body_rows,
+        planned_rows=ring_rows,
+        skipped_rows=skipped_rows,
+        warnings=warnings,
+        file_format=file_format,
+    )
+    source_summary['ring_array_evidence'] = finalise_ring_array_evidence_summary(
+        ring_array_evidence,
+        source_only_ring_rows=len(ring_rows),
+    )
+    apply_source_observability_metadata(
+        source_run=source_run,
+        source_file=source_file_summary,
+        source_summary=source_summary,
+    )
 
     report = build_enrichment_snapshot_load_plan(
         source_run=source_run,
@@ -303,6 +439,7 @@ def build_body_ring_snapshot_load_report(
         staged_rows=body_rows,
         planned_rows=ring_rows,
         skipped_rows=skipped_rows,
+        conflicts=conflicts,
         warnings=warnings,
         summary_extra={
             'source': normalised_source,
@@ -313,6 +450,7 @@ def build_body_ring_snapshot_load_report(
             'dry_run_only': True,
             'canonical_writes_planned': 0,
             'distance_to_arrival_classification': classify_source_field(normalised_source, 'distanceToArrival'),
+            **source_summary,
         },
     )
     report['staged_body_rows'] = report['staged_rows']
@@ -495,6 +633,335 @@ def _records_from_json_value(value: Any) -> Iterator[Any]:
                 yield station
         return
     yield value
+
+
+def source_file_format_metadata(source_file: Path) -> dict[str, Any]:
+    first_char = _first_non_whitespace_char(source_file)
+    if first_char == '[':
+        record_stream_shape = 'json_array'
+    elif first_char == '{':
+        record_stream_shape = 'json_object_or_ndjson'
+    elif first_char is None:
+        record_stream_shape = 'empty'
+    else:
+        record_stream_shape = 'ndjson'
+    return {
+        'source_format': 'json',
+        'source_format_version': SOURCE_FORMAT_VERSION,
+        'record_stream_shape': record_stream_shape,
+    }
+
+
+def unsupported_source_shape(record: Mapping[str, Any], source: str) -> dict[str, str] | None:
+    normalised_source = normalise_source_adapter(source)
+    if normalised_source == 'edsm_nightly_stations':
+        if isinstance(record.get('bodies'), list):
+            return {
+                'field': 'bodies',
+                'source_shape': 'nested_body_collection',
+                'skip_reason': 'unsupported_station_snapshot_source_shape',
+            }
+        if isinstance(record.get('systems'), list):
+            return {
+                'field': 'systems',
+                'source_shape': 'nested_system_collection',
+                'skip_reason': 'unsupported_station_snapshot_source_shape',
+            }
+    if normalised_source == 'edsm_nightly_bodies':
+        if isinstance(record.get('stations'), list):
+            return {
+                'field': 'stations',
+                'source_shape': 'nested_station_collection',
+                'skip_reason': 'unsupported_body_snapshot_source_shape',
+            }
+        if isinstance(record.get('systems'), list):
+            return {
+                'field': 'systems',
+                'source_shape': 'nested_system_collection',
+                'skip_reason': 'unsupported_body_snapshot_source_shape',
+            }
+        if isinstance(record.get('bodies'), list):
+            return {
+                'field': 'bodies',
+                'source_shape': 'nested_body_collection',
+                'skip_reason': 'unsupported_body_snapshot_source_shape',
+            }
+    return None
+
+
+def source_observability_summary(
+    *,
+    raw_records: Sequence[Mapping[str, Any]],
+    staged_rows: Sequence[Mapping[str, Any]],
+    planned_rows: Sequence[Mapping[str, Any]],
+    skipped_rows: Sequence[Mapping[str, Any]],
+    warnings: Sequence[Mapping[str, Any]],
+    file_format: Mapping[str, Any],
+) -> dict[str, Any]:
+    timestamp_summary = source_timestamp_summary(raw_records)
+    staged_and_planned = list(staged_rows) + list(planned_rows)
+    return {
+        'source_format': file_format.get('source_format'),
+        'source_format_version': file_format.get('source_format_version'),
+        'record_stream_shape': file_format.get('record_stream_shape'),
+        'source_timestamp_summary': timestamp_summary,
+        'source_freshness_summary': {
+            'freshness_distribution': field_distribution(staged_and_planned, 'freshness_class'),
+            'records_with_source_updated_at': timestamp_summary['records_with_source_updated_at'],
+            'records_without_source_updated_at': timestamp_summary['records_without_source_updated_at'],
+            'freshness_preserves_unknown': True,
+        },
+        'unsupported_source_shapes': sum(
+            1 for row in skipped_rows
+            if str(row.get('reason', '')).startswith('unsupported_')
+        ),
+        'malformed_rows': sum(
+            1 for row in skipped_rows
+            if row.get('reason') in {
+                'record_is_not_object',
+                'invalid_station_snapshot_record',
+                'invalid_body_snapshot_record',
+                'invalid_ring_snapshot_record',
+                'ring_record_is_not_object',
+            }
+        ),
+        'warning_reason_distribution': field_distribution(warnings, 'reason'),
+        'skipped_row_reason_distribution': field_distribution(skipped_rows, 'reason'),
+    }
+
+
+def apply_source_observability_metadata(
+    *,
+    source_run: dict[str, Any],
+    source_file: dict[str, Any],
+    source_summary: Mapping[str, Any],
+) -> None:
+    timestamp_summary = dict(source_summary.get('source_timestamp_summary') or {})
+    latest_source_updated_at = timestamp_summary.get('latest_source_updated_at')
+    if latest_source_updated_at is not None:
+        source_file['source_updated_at'] = latest_source_updated_at
+    source_file.setdefault('metadata', {}).update({
+        'source_format': source_summary.get('source_format'),
+        'source_format_version': source_summary.get('source_format_version'),
+        'record_stream_shape': source_summary.get('record_stream_shape'),
+        'source_timestamp_summary': timestamp_summary,
+    })
+    source_run.setdefault('metadata', {}).update({
+        'source_format': source_summary.get('source_format'),
+        'source_format_version': source_summary.get('source_format_version'),
+        'record_stream_shape': source_summary.get('record_stream_shape'),
+        'source_timestamp_summary': timestamp_summary,
+        'source_freshness_summary': source_summary.get('source_freshness_summary'),
+    })
+
+
+def source_timestamp_summary(raw_records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    timestamps = sorted({
+        str(row.get('source_updated_at'))
+        for row in raw_records
+        if row.get('source_updated_at') is not None
+    })
+    records_with_timestamp = sum(1 for row in raw_records if row.get('source_updated_at') is not None)
+    records_without_timestamp = len(raw_records) - records_with_timestamp
+    return {
+        'records_with_source_updated_at': records_with_timestamp,
+        'records_without_source_updated_at': records_without_timestamp,
+        'unique_source_updated_at_values': len(timestamps),
+        'earliest_source_updated_at': timestamps[0] if timestamps else None,
+        'latest_source_updated_at': timestamps[-1] if timestamps else None,
+    }
+
+
+def classify_ring_array_evidence(record: Mapping[str, Any]) -> dict[str, Any]:
+    if 'rings' in record:
+        field_name = 'rings'
+    elif 'Rings' in record:
+        field_name = 'Rings'
+    else:
+        return {
+            'field': None,
+            'state': 'missing',
+            'ring_count': None,
+            'meaning': RING_ARRAY_UNKNOWN_STATE,
+        }
+    rings = record.get(field_name)
+    if not isinstance(rings, Sequence) or isinstance(rings, (str, bytes, bytearray)):
+        return {
+            'field': field_name,
+            'state': 'non_array',
+            'ring_count': None,
+            'meaning': 'malformed_source_ring_array',
+        }
+    if len(rings) == 0:
+        return {
+            'field': field_name,
+            'state': 'empty',
+            'ring_count': 0,
+            'meaning': 'explicit_empty_source_array_report_only',
+        }
+    return {
+        'field': field_name,
+        'state': 'present',
+        'ring_count': len(rings),
+        'meaning': 'source_only_ring_evidence',
+    }
+
+
+def annotate_body_ring_array_evidence(body_row: dict[str, Any], ring_state: Mapping[str, Any]) -> None:
+    body_row['provenance'] = dict(body_row.get('provenance') or {})
+    body_row['provenance']['ring_array_state'] = ring_state.get('state')
+    body_row['provenance']['ring_array_meaning'] = ring_state.get('meaning')
+    body_row['provenance']['missing_ring_arrays_state'] = RING_ARRAY_UNKNOWN_STATE
+
+
+def empty_ring_array_evidence_summary() -> dict[str, int]:
+    return {
+        'body_rows_considered': 0,
+        'ring_arrays_present': 0,
+        'ring_arrays_empty': 0,
+        'ring_arrays_missing': 0,
+        'ring_arrays_non_array': 0,
+    }
+
+
+def update_ring_array_evidence_summary(summary: dict[str, int], ring_state: Mapping[str, Any]) -> None:
+    summary['body_rows_considered'] += 1
+    state = ring_state.get('state')
+    if state == 'present':
+        summary['ring_arrays_present'] += 1
+    elif state == 'empty':
+        summary['ring_arrays_empty'] += 1
+    elif state == 'missing':
+        summary['ring_arrays_missing'] += 1
+    elif state == 'non_array':
+        summary['ring_arrays_non_array'] += 1
+
+
+def finalise_ring_array_evidence_summary(
+    summary: Mapping[str, int],
+    *,
+    source_only_ring_rows: int,
+) -> dict[str, Any]:
+    return {
+        **dict(summary),
+        'source_only_ring_rows': source_only_ring_rows,
+        'missing_ring_arrays_state': RING_ARRAY_UNKNOWN_STATE,
+        'empty_ring_arrays_state': 'source_evidence_only_not_canonical_no_rings',
+        'source_only_ring_evidence_state': 'source_only_not_confirmed_truth',
+        'ringed_truth_requires_trusted_body_rings': True,
+    }
+
+
+def skipped_ring_rows_for_record(
+    record: Mapping[str, Any],
+    record_index: int,
+    raw_record: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    if 'rings' in record:
+        rings = record.get('rings')
+    elif 'Rings' in record:
+        rings = record.get('Rings')
+    else:
+        return []
+    if not isinstance(rings, Sequence) or isinstance(rings, (str, bytes, bytearray)):
+        return []
+    skipped = []
+    for ring_index, ring in enumerate(rings):
+        if isinstance(ring, Mapping):
+            continue
+        skipped.append({
+            'record_index': record_index,
+            'ring_index': ring_index,
+            'source_record_hash': raw_record.get('source_record_hash'),
+            'reason': 'ring_record_is_not_object',
+            'warnings': [{'field': 'rings', 'reason': 'ring_record_is_not_object'}],
+            'raw_payload': ring,
+        })
+    return skipped
+
+
+def source_identity_conflicts(rows: Sequence[Mapping[str, Any]], *, entity: str) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        identity_key = source_identity_key(row, entity=entity)
+        if identity_key is None:
+            continue
+        grouped.setdefault(identity_key, []).append(row)
+
+    conflicts = []
+    for identity_key, group in grouped.items():
+        hashes = sorted({
+            str(row.get('source_record_hash'))
+            for row in group
+            if row.get('source_record_hash') is not None
+        })
+        if len(hashes) < 2:
+            continue
+        conflicts.append({
+            'entity': entity,
+            'reason': 'duplicate_source_identity_conflict',
+            'source_identity_key': identity_key,
+            'source_record_hashes': hashes,
+            'source_record_keys': sorted(
+                str(row.get('source_record_key'))
+                for row in group
+                if row.get('source_record_key') is not None
+            ),
+            'handling': 'report_only_conflict_no_canonical_write',
+        })
+    return sorted(conflicts, key=lambda row: json.dumps(row, sort_keys=True, separators=(',', ':')))
+
+
+def source_identity_key(row: Mapping[str, Any], *, entity: str) -> str | None:
+    system_key = identity_part(row, 'system_id64', 'system_name')
+    if system_key is None:
+        return None
+    if entity == 'station':
+        entity_key = identity_part(row, 'market_id', 'edsm_station_id', 'station_name')
+    elif entity == 'body':
+        entity_key = identity_part(row, 'source_body_id', 'body_name')
+    else:
+        body_key = identity_part(row, 'source_body_id', 'body_name')
+        ring_name = read_text(row.get('ring_name'))
+        if body_key is None or ring_name is None:
+            return None
+        entity_key = f'{body_key}|ring:{ring_name.lower()}'
+    if entity_key is None:
+        return None
+    return f'{entity}|{system_key}|{entity_key}'
+
+
+def identity_part(row: Mapping[str, Any], *fields: str) -> str | None:
+    for field in fields:
+        value = row.get(field)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            text = value.strip()
+            if text:
+                return f'{field}:{text.lower()}'
+            continue
+        return f'{field}:{value}'
+    return None
+
+
+def field_distribution(rows: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, int]:
+    return dict(sorted(Counter(
+        str(row.get(field_name))
+        for row in rows
+        if row.get(field_name) is not None
+    ).items()))
+
+
+def _first_non_whitespace_char(source_file: Path) -> str | None:
+    with _open_text(source_file) as handle:
+        while True:
+            chunk = handle.read(1024)
+            if not chunk:
+                return None
+            stripped = chunk.lstrip()
+            if stripped:
+                return stripped[0]
 
 
 def _assert_local_file(path: Path) -> None:

--- a/apps/importer/src/enrichment_staging.py
+++ b/apps/importer/src/enrichment_staging.py
@@ -282,6 +282,7 @@ def build_report_skeleton(
     skipped = _sort_rows(skipped_rows)
     conflict_rows = _sort_rows(conflicts)
     warning_rows = _sort_rows(warnings)
+    duplicate_groups = _source_record_duplicate_groups(raw_record_rows)
     summary = {
         'source_runs': 1,
         'source_files': 1 if source_file else 0,
@@ -291,6 +292,10 @@ def build_report_skeleton(
         'skipped_rows': len(skipped),
         'conflicts': len(conflict_rows),
         'warnings': len(warning_rows),
+        'skipped_row_reasons': _distribution(skipped, 'reason'),
+        'warning_reasons': _distribution(warning_rows, 'reason'),
+        'duplicate_source_record_hashes': len(duplicate_groups),
+        'duplicate_source_records': sum(group['count'] - 1 for group in duplicate_groups),
         'confidence_distribution': _distribution(staged + planned, 'confidence'),
         'freshness_distribution': _distribution(staged + planned, 'freshness_class'),
         'source_class_distribution': _distribution(staged + planned, 'source_class'),
@@ -308,6 +313,7 @@ def build_report_skeleton(
         'skipped_rows': skipped,
         'conflicts': conflict_rows,
         'warnings': warning_rows,
+        'source_record_duplicate_groups': duplicate_groups,
     }
 
 
@@ -575,6 +581,31 @@ def read_bool(value: Any) -> bool | None:
 def _distribution(rows: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, int]:
     counter = Counter(str(row.get(field_name)) for row in rows if row.get(field_name) is not None)
     return dict(sorted(counter.items()))
+
+
+def _source_record_duplicate_groups(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        record_hash = row.get('source_record_hash')
+        if record_hash is None:
+            continue
+        grouped.setdefault(str(record_hash), []).append(row)
+
+    duplicates = []
+    for record_hash, group in grouped.items():
+        if len(group) < 2:
+            continue
+        duplicates.append({
+            'source_record_hash': record_hash,
+            'count': len(group),
+            'record_indexes': sorted(
+                int(row['record_index'])
+                for row in group
+                if isinstance(row.get('record_index'), int)
+            ),
+            'handling': 'reported_only_dry_run; explicit staging writes upsert by source_record_hash',
+        })
+    return sorted(duplicates, key=canonicalise_json_payload)
 
 
 def _sort_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -373,7 +373,7 @@ by:
 | `apps/importer/src/enrichment_analytics.py` | Pure report-only analytics, colonisation, and mission-density signal scaffolds. |
 | `tests/fixtures/edsm_station_snapshot.json` | Tiny deterministic EDSM station snapshot fixture. |
 | `tests/fixtures/edsm_body_ring_snapshot.json` | Tiny deterministic EDSM body/ring snapshot fixture. |
-| `tests/test_enrichment_staging.py` / `tests/test_enrichment_snapshot_loader.py` | Fixture-backed tests for hashes, source classes, report versions, JSON/GZIP loading, skipped rows, and deterministic output. |
+| `tests/test_enrichment_staging.py` / `tests/test_enrichment_snapshot_loader.py` | Fixture-backed tests for hashes, source classes, report versions, JSON/GZIP loading, source metadata, skipped rows, duplicates, unsupported shapes, and deterministic output. |
 
 This warehouse path is deliberately not wired into any operations job. It does
 not call EDSM, invoke Docker, connect to production Postgres, run migrations,
@@ -400,6 +400,14 @@ The current warehouse also supports local body/ring snapshots through
 pure report-only analytics/signals. Optional real-Postgres smoke tests for the
 staging loaders and reconciliation are skipped by default unless
 `EDFINDER_STAGING_TEST_DSN` and `EDFINDER_CONFIRM_STAGING_TEST_DB=yes` are set.
+
+Stage 18D keeps this path report-only while making snapshot inputs more
+explainable: reports expose source format/version, record stream shape,
+source timestamp/freshness summaries, skipped-row reason distributions,
+duplicate source-record hashes, report-only source-identity conflicts, and
+body/ring ring-array evidence. Missing ring arrays remain unknown, source-only
+ring evidence remains source-only, and future nested body source shapes are
+reported as unsupported until a dedicated adapter exists.
 
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -62,6 +62,16 @@ optionally write only to warehouse/staging tables when explicitly gated with
 staging-only DB flags. They do not make network calls, invoke containers, run
 production migrations, or write canonical tables.
 
+Stage 18D hardens the snapshot boundary by making source normalisation visible
+in the dry-run report. Source runs/files now carry source format/version,
+record stream shape, source timestamp summaries, and freshness summaries.
+Skipped rows are counted by explicit reason, exact duplicate source payloads
+are reported by `source_record_hash`, and repeated source identities with
+conflicting payload hashes become report-only conflicts instead of silent
+merges. Unsupported nested source shapes, including future system-with-`bodies`
+inputs, are skipped with explicit unsupported-shape reasons until a dedicated
+adapter exists.
+
 ## Source Evidence Classes
 
 The foundation tracks source stability without treating any source as canonical
@@ -98,6 +108,13 @@ and pure signal helpers emit report-only analytics contracts such as
 summary counts, staged/planned rows, skipped rows, conflicts, warnings,
 confidence/freshness/source-class distributions, candidate confidence/risk
 fields, and deterministic sorting for stable diffs.
+
+The snapshot load plan also includes source-normalisation observability:
+`source_timestamp_summary`, `source_freshness_summary`,
+`source_record_duplicate_groups`, skipped-row reason distributions, and
+body/ring `ring_array_evidence`. Missing ring arrays remain
+`unknown_not_false`; empty arrays are source evidence only and do not become a
+canonical no-rings conclusion.
 
 Stage 18B broadens the read-only reconciliation report with named sections:
 
@@ -176,6 +193,13 @@ evidence with these fields when present:
 
 Missing or invalid required station fields are skipped with warnings. They do
 not crash the loader and do not imply canonical writes.
+
+The body/ring adapter normalises body records and source-only ring payloads
+separately. Ring payloads remain `association_status = "source_only"` unless a
+later read-only reconciliation finds trusted local ring evidence. Missing ring
+arrays are preserved as unknown, non-array ring fields are reported as malformed
+ring evidence, and unsupported nested source shapes are not inferred into body
+or ring rows.
 
 ## Trust Boundaries
 

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -143,15 +143,43 @@ A good dry-run has:
 - `schema_version = "enrichment_snapshot_load_plan/v1"`
 - `dry_run = true`
 - expected `records_seen`, `raw_records`, and staged-row counts
+- `source_format_version = "json_snapshot_stream/v1"` and the expected
+  `record_stream_shape`
+- `source_timestamp_summary` and `source_freshness_summary` matching the
+  intended snapshot age
 - `canonical_writes_planned = 0`
 - no unexpected skipped-row reasons
 - no source-file or unsupported-source errors
+
+Snapshot-normalisation fields to inspect before staging loads:
+
+- `source_run.metadata` and `source_file.metadata` capture the adapter version,
+  source format/version, record stream shape, and source timestamp summary.
+- `source_file.source_updated_at` is the latest source timestamp observed in
+  raw mapping records, when present. Missing timestamps stay unknown and are
+  counted in `source_timestamp_summary`.
+- `skipped_row_reasons` and `skipped_row_reason_distribution` explain
+  malformed records, unsupported nested source shapes, and invalid station,
+  body, or ring rows.
+- `source_record_duplicate_groups` reports exact duplicate source payloads by
+  `source_record_hash`. This is a dry-run/report signal; explicit staging
+  writes still use warehouse upsert keys and never imply canonical truth.
+- `conflicts` reports repeated source identities with conflicting payload
+  hashes as `duplicate_source_identity_conflict`. Treat these as blockers for
+  operator review.
+- Body/ring reports include `ring_array_evidence`. Missing ring arrays remain
+  `unknown_not_false`; empty arrays are source evidence only and not a
+  canonical no-rings conclusion; staged ring rows remain source-only evidence.
 
 Warnings that block moving to staging load:
 
 - required identity fields missing across most records
 - unexpected `record_is_not_object` or malformed JSON patterns
 - unsupported source adapter
+- unsupported nested source shape, such as future system-with-`bodies`
+  snapshots, until a dedicated adapter exists
+- `duplicate_source_identity_conflict`
+- non-array `rings` fields or malformed ring rows in body/ring snapshots
 - remote URL used as `--source-file`
 - surprising `distance_to_arrival_classification` values; current
   `distanceToArrival` should remain volatile

--- a/tests/test_enrichment_body_ring_staging_loader.py
+++ b/tests/test_enrichment_body_ring_staging_loader.py
@@ -144,14 +144,39 @@ def test_body_ring_snapshot_loader_reads_json_fixture():
     assert report['schema_version'] == 'enrichment_snapshot_load_plan/v1'
     assert report['dry_run'] is True
     assert report['source_run']['source'] == 'edsm_nightly_bodies'
+    assert report['source_run']['metadata']['source_format_version'] == 'json_snapshot_stream/v1'
+    assert report['source_file']['source_updated_at'] == '2026-01-03T00:00:00Z'
+    assert report['source_file']['metadata']['source_timestamp_summary'] == {
+        'records_with_source_updated_at': 1,
+        'records_without_source_updated_at': 3,
+        'unique_source_updated_at_values': 1,
+        'earliest_source_updated_at': '2026-01-03T00:00:00Z',
+        'latest_source_updated_at': '2026-01-03T00:00:00Z',
+    }
     assert report['summary']['records_seen'] == 5
     assert report['summary']['raw_records'] == 4
     assert report['summary']['staged_edsm_bodies'] == 3
     assert report['summary']['staged_body_rings'] == 1
     assert report['summary']['skipped_rows'] == 2
+    assert report['summary']['skipped_row_reasons'] == {
+        'invalid_body_snapshot_record': 1,
+        'record_is_not_object': 1,
+    }
     assert report['summary']['warnings'] == 1
     assert report['summary']['canonical_writes_planned'] == 0
     assert report['summary']['distance_to_arrival_classification'] == 'volatile'
+    assert report['summary']['ring_array_evidence'] == {
+        'body_rows_considered': 3,
+        'ring_arrays_present': 1,
+        'ring_arrays_empty': 1,
+        'ring_arrays_missing': 1,
+        'ring_arrays_non_array': 0,
+        'source_only_ring_rows': 1,
+        'missing_ring_arrays_state': 'unknown_not_false',
+        'empty_ring_arrays_state': 'source_evidence_only_not_canonical_no_rings',
+        'source_only_ring_evidence_state': 'source_only_not_confirmed_truth',
+        'ringed_truth_requires_trusted_body_rings': True,
+    }
     assert report['staged_body_rows'] == report['staged_rows']
     assert report['staged_ring_rows'] == report['planned_rows']
 
@@ -170,6 +195,8 @@ def test_body_ring_snapshot_loader_reads_json_fixture():
 
     sparse = bodies_by_name['Sparse Body 1']
     assert sparse['source_body_id'] is None
+    assert sparse['provenance']['ring_array_state'] == 'missing'
+    assert sparse['provenance']['missing_ring_arrays_state'] == 'unknown_not_false'
     assert sparse['validation_warnings'] == [
         {'field': 'source_body_id', 'reason': 'missing_body_source_identity'},
     ]
@@ -410,6 +437,8 @@ def test_body_ring_duplicate_records_keep_stable_hashes_and_upserts(tmp_path):
     assert len(set(raw_hashes)) == 1
     assert len(set(body_hashes)) == 1
     assert len(set(ring_hashes)) == 1
+    assert report['summary']['duplicate_source_record_hashes'] == 1
+    assert report['summary']['duplicate_source_records'] == 1
     assert len({row['source_record_key'] for row in report['raw_records_planned']}) == 2
     assert len({row['db_id'] for row in report['staged_body_rows']}) == 1
     assert len({row['db_id'] for row in report['staged_ring_rows']}) == 1
@@ -417,6 +446,117 @@ def test_body_ring_duplicate_records_keep_stable_hashes_and_upserts(tmp_path):
     assert 'ON CONFLICT (source_run_id, source_file_id, source_record_hash)' in sql_text
     assert 'ON CONFLICT (source_run_id, source_record_hash)' in sql_text
     assert_only_body_ring_staging_sql(conn.statements)
+
+
+def test_body_ring_malformed_ring_rows_are_skipped_with_reasons(tmp_path):
+    source_file = tmp_path / 'malformed-rings.json'
+    source_file.write_text(
+        json.dumps([
+            {
+                'systemName': 'Malformed Rings',
+                'systemId64': 4343,
+                'id': 13,
+                'name': 'Malformed Rings 1',
+                'type': 'Planet',
+                'rings': [
+                    'not an object',
+                    {'type': 'Icy'},
+                ],
+            }
+        ]),
+        encoding='utf-8',
+    )
+
+    report = snapshot_loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_bodies',
+    )
+
+    assert report['summary']['staged_edsm_bodies'] == 1
+    assert report['summary']['staged_body_rings'] == 0
+    assert report['summary']['skipped_row_reasons'] == {
+        'invalid_ring_snapshot_record': 1,
+        'ring_record_is_not_object': 1,
+    }
+    by_reason = {row['reason']: row for row in report['skipped_rows']}
+    assert by_reason['ring_record_is_not_object']['ring_index'] == 0
+    assert by_reason['invalid_ring_snapshot_record']['ring_index'] == 1
+    assert by_reason['invalid_ring_snapshot_record']['warnings'] == [{
+        'field': 'ring_name',
+        'reason': 'missing_ring_identity',
+        'ring_index': 1,
+    }]
+    assert report['warnings'] == [{
+        'field': 'ring_name',
+        'reason': 'missing_ring_identity',
+        'record_index': 1,
+        'ring_index': 1,
+        'source_record_hash': by_reason['invalid_ring_snapshot_record']['source_record_hash'],
+    }]
+
+
+def test_body_ring_non_array_ring_field_is_reported_and_kept_unknown(tmp_path):
+    source_file = tmp_path / 'non-array-rings.json'
+    source_file.write_text(
+        json.dumps([
+            {
+                'systemName': 'Non Array Rings',
+                'systemId64': 4444,
+                'id': 14,
+                'name': 'Non Array Rings 1',
+                'type': 'Planet',
+                'rings': {'unexpected': True},
+            }
+        ]),
+        encoding='utf-8',
+    )
+
+    report = snapshot_loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_bodies',
+    )
+
+    body = report['staged_body_rows'][0]
+    assert body['provenance']['ring_array_state'] == 'non_array'
+    assert report['summary']['ring_array_evidence']['ring_arrays_non_array'] == 1
+    assert report['summary']['ring_array_evidence']['missing_ring_arrays_state'] == 'unknown_not_false'
+    assert report['summary']['skipped_row_reasons'] == {'invalid_ring_snapshot_record': 1}
+    assert report['skipped_rows'][0]['warnings'] == [{
+        'field': 'rings',
+        'reason': 'ring_array_not_sequence',
+        'ring_array_state': 'non_array',
+    }]
+
+
+def test_unsupported_body_source_shape_is_reported_for_future_spansh_style_input(tmp_path):
+    source_file = tmp_path / 'unsupported-body-shape.json'
+    source_file.write_text(
+        json.dumps([
+            {
+                'systemName': 'Nested System',
+                'systemId64': 4545,
+                'bodies': [{'name': 'Nested System 1'}],
+            }
+        ]),
+        encoding='utf-8',
+    )
+
+    report = snapshot_loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_bodies',
+    )
+
+    assert report['summary']['records_seen'] == 1
+    assert report['summary']['staged_edsm_bodies'] == 0
+    assert report['summary']['staged_body_rings'] == 0
+    assert report['summary']['unsupported_source_shapes'] == 1
+    assert report['skipped_rows'][0]['reason'] == 'unsupported_body_snapshot_source_shape'
+    assert report['skipped_rows'][0]['warnings'] == [{
+        'field': 'bodies',
+        'reason': 'unsupported_source_shape',
+        'source_shape': 'nested_body_collection',
+    }]
+    assert report['raw_records_planned'][0]['validation_status'] == 'skipped'
 
 
 def test_body_ring_unknown_source_and_canonical_flags_fail_closed():

--- a/tests/test_enrichment_snapshot_loader.py
+++ b/tests/test_enrichment_snapshot_loader.py
@@ -31,14 +31,33 @@ def test_loader_reads_local_edsm_station_snapshot_fixture():
     assert report['dry_run'] is True
     assert report['source_run']['source'] == 'edsm_nightly_stations'
     assert report['source_run']['source_class'] == 'semi-stable'
+    assert report['source_run']['adapter_version'] == 'v1'
+    assert report['source_run']['metadata']['source_format_version'] == 'json_snapshot_stream/v1'
     assert report['source_file']['source_file_name'] == 'edsm_station_snapshot.json'
     assert len(report['source_file']['file_sha256']) == 64
+    assert report['source_file']['source_updated_at'] == '2026-01-02T00:00:00Z'
+    assert report['source_file']['metadata']['record_stream_shape'] == 'json_array'
+    assert report['source_file']['metadata']['source_timestamp_summary'] == {
+        'records_with_source_updated_at': 2,
+        'records_without_source_updated_at': 1,
+        'unique_source_updated_at_values': 2,
+        'earliest_source_updated_at': '2026-01-01T00:00:00Z',
+        'latest_source_updated_at': '2026-01-02T00:00:00Z',
+    }
     assert report['summary']['raw_records'] == 3
     assert report['summary']['staged_rows'] == 2
     assert report['summary']['staged_edsm_stations'] == 2
     assert report['summary']['skipped_rows'] == 1
+    assert report['summary']['skipped_row_reasons'] == {'invalid_station_snapshot_record': 1}
     assert report['summary']['canonical_writes_planned'] == 0
     assert report['summary']['distance_to_arrival_classification'] == 'volatile'
+    assert report['summary']['source_format_version'] == 'json_snapshot_stream/v1'
+    assert report['summary']['source_freshness_summary'] == {
+        'freshness_distribution': {'source_updated_at': 2},
+        'records_with_source_updated_at': 2,
+        'records_without_source_updated_at': 1,
+        'freshness_preserves_unknown': True,
+    }
 
     by_name = {row['station_name']: row for row in report['staged_rows']}
     macmillan = by_name['Macmillan Depot']
@@ -98,6 +117,9 @@ def test_invalid_records_are_skipped_with_warnings_not_crashes():
     assert skipped[0]['warnings'] == [
         {'field': 'station_name', 'reason': 'missing_required_field'},
     ]
+    assert report['summary']['skipped_row_reason_distribution'] == {
+        'invalid_station_snapshot_record': 1,
+    }
 
 
 def test_normalisation_accepts_edsm_station_snapshot_shapes():
@@ -256,6 +278,78 @@ def test_duplicate_station_records_share_source_hash_and_report_deterministicall
     assert len(set(raw_hashes)) == 1
     assert len(set(staged_hashes)) == 1
     assert len({row['source_record_key'] for row in first['raw_records_planned']}) == 2
+    assert first['summary']['duplicate_source_record_hashes'] == 1
+    assert first['summary']['duplicate_source_records'] == 1
+    assert first['source_record_duplicate_groups'] == [{
+        'source_record_hash': raw_hashes[0],
+        'count': 2,
+        'record_indexes': [1, 2],
+        'handling': 'reported_only_dry_run; explicit staging writes upsert by source_record_hash',
+    }]
+
+
+def test_unsupported_station_source_shape_is_reported_without_guessing(tmp_path):
+    source_file = tmp_path / 'unsupported-station-shape.json'
+    source_file.write_text(
+        json.dumps([
+            {
+                'systemName': 'Nested System',
+                'bodies': [{'name': 'Nested 1'}],
+            }
+        ]),
+        encoding='utf-8',
+    )
+
+    report = loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+    )
+
+    assert report['summary']['records_seen'] == 1
+    assert report['summary']['staged_rows'] == 0
+    assert report['summary']['raw_records'] == 1
+    assert report['summary']['unsupported_source_shapes'] == 1
+    assert report['skipped_rows'] == [{
+        'record_index': 1,
+        'source_record_hash': report['raw_records_planned'][0]['source_record_hash'],
+        'reason': 'unsupported_station_snapshot_source_shape',
+        'warnings': [{
+            'field': 'bodies',
+            'reason': 'unsupported_source_shape',
+            'source_shape': 'nested_body_collection',
+        }],
+        'raw_payload': {
+            'systemName': 'Nested System',
+            'bodies': [{'name': 'Nested 1'}],
+        },
+    }]
+    assert report['raw_records_planned'][0]['validation_status'] == 'skipped'
+
+
+def test_conflicting_station_records_with_same_source_identity_are_report_only(tmp_path):
+    station = {
+        'systemName': 'Conflict Test',
+        'systemId64': 424242,
+        'marketId': 7654,
+        'name': 'Conflict Port',
+        'type': 'Outpost',
+    }
+    changed_station = dict(station)
+    changed_station['type'] = 'Coriolis Starport'
+    source_file = tmp_path / 'conflicting-stations.json'
+    source_file.write_text(json.dumps([station, changed_station]), encoding='utf-8')
+
+    report = loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+    )
+
+    assert report['summary']['staged_rows'] == 2
+    assert report['summary']['conflicts'] == 1
+    assert report['conflicts'][0]['reason'] == 'duplicate_source_identity_conflict'
+    assert report['conflicts'][0]['entity'] == 'station'
+    assert report['conflicts'][0]['handling'] == 'report_only_conflict_no_canonical_write'
+    assert report['summary']['canonical_writes_planned'] == 0
 
 
 def test_unknown_extra_fields_are_retained_in_raw_and_staging_evidence(tmp_path):


### PR DESCRIPTION
## Summary

Adds source-level observability to the EDSM snapshot loaders so dry-run load plans report source format metadata, source timestamp/freshness summaries, skipped-row reason distributions, duplicate source-record hashes, and report-only identity conflicts.

The body/ring snapshot path now distinguishes missing, empty, present, malformed, and non-array ring arrays without treating missing ring evidence as a canonical false value. Unsupported nested snapshot shapes are skipped with explicit reasons instead of guessed into station/body rows.

Docs and focused tests were updated for the new report fields and edge cases.

## Validation

- `git diff --check`
- `/home/brian/Documents/GitHub/ed-finder/.venv/bin/pytest tests/test_enrichment_snapshot_loader.py tests/test_enrichment_body_ring_staging_loader.py -q`