### PR TITLE
[codex] Add warehouse coverage reports

### DIFF
--- a/apps/importer/src/enrichment_coverage_reports.py
+++ b/apps/importer/src/enrichment_coverage_reports.py
@@ -1,0 +1,693 @@
+"""Versioned report-only warehouse evidence coverage summaries."""
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from enrichment_staging import canonicalise_json_payload
+
+
+WAREHOUSE_COVERAGE_REPORT_SCHEMA_VERSION = 'enrichment_warehouse_coverage_report/v1'
+EXAMPLE_LIMIT = 5
+
+
+def build_warehouse_coverage_report(
+    *,
+    station_candidates: Sequence[Mapping[str, Any]],
+    body_candidates: Sequence[Mapping[str, Any]],
+    ring_candidates: Sequence[Mapping[str, Any]],
+    station_body_association_candidates: Sequence[Mapping[str, Any]],
+    source_coverage_rows: Sequence[Mapping[str, Any]] = (),
+    warnings: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Build deterministic operator coverage sections from report-only evidence."""
+    stations = _candidate_rows(station_candidates)
+    bodies = _candidate_rows(body_candidates)
+    rings = _candidate_rows(ring_candidates)
+    associations = _candidate_rows(station_body_association_candidates)
+    source_rows = _source_rows(source_coverage_rows)
+    warning_rows = _rows(warnings)
+
+    station_evidence = _station_evidence_section(stations, bodies, rings)
+    station_body_links = _station_body_link_section(stations, associations)
+    ring_evidence = _ring_evidence_section(bodies, rings)
+    source_freshness = _source_freshness_section(stations + bodies + rings, source_rows)
+    source_quality = _source_quality_section(stations + bodies + rings, source_rows, warning_rows)
+    source_formats = _source_format_section(stations + bodies + rings, source_rows)
+    high_value_systems = _high_value_systems_section(
+        stations=stations,
+        bodies=bodies,
+        rings=rings,
+        station_evidence=station_evidence,
+        station_body_links=station_body_links,
+        ring_evidence=ring_evidence,
+        source_freshness=source_freshness,
+        source_quality=source_quality,
+    )
+    needs_attention = {
+        'systems_missing_station_evidence': station_evidence['systems_missing_station_evidence']['count'],
+        'unknown_ring_evidence_bodies': ring_evidence['bodies_with_unknown_ring_evidence']['count'],
+        'unresolved_station_body_links': station_body_links['unresolved_stations']['count'],
+        'stale_or_undated_sources': source_freshness['stale_or_undated_evidence']['records_without_source_updated_at'],
+        'skipped_or_malformed_raw_records': source_quality['malformed_or_skipped_source_rows']['count'],
+        'duplicate_source_records': source_quality['duplicate_source_records']['duplicate_records'],
+        'source_identity_conflicts': source_quality['source_identity_conflicts']['count'],
+        'high_value_systems_needing_better_evidence': high_value_systems['count'],
+    }
+
+    return {
+        'schema_version': WAREHOUSE_COVERAGE_REPORT_SCHEMA_VERSION,
+        'dry_run': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'summary': {
+            'systems_with_station_evidence': station_evidence['systems_with_station_evidence']['count'],
+            'systems_missing_station_evidence': station_evidence['systems_missing_station_evidence']['count'],
+            'trusted_ring_evidence_bodies': ring_evidence['bodies_with_trusted_ring_evidence']['count'],
+            'unknown_ring_evidence_bodies': ring_evidence['bodies_with_unknown_ring_evidence']['count'],
+            'explicit_no_ring_evidence_bodies': ring_evidence['bodies_with_explicit_no_ring_evidence']['count'],
+            'confirmed_station_body_links': station_body_links['stations_with_confirmed_body_links']['count'],
+            'inferred_or_verify_station_body_links': (
+                station_body_links['stations_with_inferred_or_verify_body_links']['count']
+            ),
+            'unresolved_stations': station_body_links['unresolved_stations']['count'],
+            'source_files_considered': len(source_rows),
+            'malformed_or_skipped_source_rows': source_quality['malformed_or_skipped_source_rows']['count'],
+            'source_identity_conflicts': source_quality['source_identity_conflicts']['count'],
+            'high_value_systems_needing_better_evidence': high_value_systems['count'],
+            'canonical_writes_planned': 0,
+        },
+        'station_evidence': station_evidence,
+        'ring_evidence': ring_evidence,
+        'station_body_links': station_body_links,
+        'source_freshness': source_freshness,
+        'source_quality': source_quality,
+        'source_formats': source_formats,
+        'high_value_systems_needing_better_evidence': high_value_systems,
+        'operator_review': {
+            'report_only': True,
+            'canonical_writes_planned': 0,
+            'needs_attention_buckets': needs_attention,
+            'review_guidance': [
+                'Treat coverage gaps as operator review signals, not write instructions.',
+                'Unknown station/body/ring evidence remains unknown until a trusted source proves it.',
+                'Source-only ring evidence does not confirm ring truth without trusted local body_rings rows.',
+                'Explicit no-ring coverage is counted only from trusted scan facts, not missing or empty arrays.',
+            ],
+        },
+        'warnings': [],
+        'errors': [],
+    }
+
+
+def _station_evidence_section(
+    station_candidates: Sequence[Mapping[str, Any]],
+    body_candidates: Sequence[Mapping[str, Any]],
+    ring_candidates: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    station_systems = _systems_from_candidates(station_candidates)
+    body_or_ring_systems = _systems_from_candidates(list(body_candidates) + list(ring_candidates))
+    missing_station_systems = {
+        key: value
+        for key, value in body_or_ring_systems.items()
+        if key not in station_systems and key != 'unknown-system'
+    }
+    return {
+        'systems_with_station_evidence': _count_examples(station_systems.values()),
+        'systems_missing_station_evidence': _count_examples(missing_station_systems.values()),
+        'scope_note': (
+            'Missing station evidence is measured against systems that have staged body or ring evidence '
+            'in this warehouse report; it is not a galaxy-wide canonical systems count.'
+        ),
+    }
+
+
+def _station_body_link_section(
+    station_candidates: Sequence[Mapping[str, Any]],
+    association_candidates: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    association_by_hash = {
+        str(_source(candidate).get('source_record_hash')): candidate
+        for candidate in association_candidates
+        if not _missing(_source(candidate).get('source_record_hash'))
+    }
+    by_state: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for candidate in station_candidates:
+        state = _station_link_state(candidate, association_by_hash)
+        by_state[state].append(_station_example(candidate, extra={
+            'candidate_action': candidate.get('candidate_action'),
+            'station_body_link_status': _station_body_link(candidate).get('association_status'),
+        }))
+    return {
+        'stations_with_confirmed_body_links': _count_examples(by_state['confirmed']),
+        'stations_with_inferred_or_verify_body_links': _count_examples(by_state['inferred_or_verify']),
+        'unresolved_stations': _count_examples(by_state['unresolved']),
+        'state_definitions': {
+            'confirmed': 'A canonical station_body_links row is present with association_status=confirmed.',
+            'inferred_or_verify': (
+                'A canonical station_body_links inferred row exists, or staged station body_name is '
+                'supported by exactly one staged body row. This remains verify/report-only evidence.'
+            ),
+            'unresolved': 'No confirmed or single supported body-link evidence is available.',
+        },
+    }
+
+
+def _ring_evidence_section(
+    body_candidates: Sequence[Mapping[str, Any]],
+    ring_candidates: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    trusted_ring_bodies = {
+        _body_key(_source(candidate)): _body_example_from_source(_source(candidate), extra={
+            'ring_name': _source(candidate).get('ring_name'),
+            'trusted_evidence': 'canonical_body_rings.local_matched',
+        })
+        for candidate in ring_candidates
+        if _trusted_ring_candidate(candidate)
+    }
+    source_only_ring_bodies = {
+        _body_key(_source(candidate)): _body_example_from_source(_source(candidate), extra={
+            'ring_name': _source(candidate).get('ring_name'),
+            'source_only_ring_evidence': True,
+        })
+        for candidate in ring_candidates
+        if not _trusted_ring_candidate(candidate)
+    }
+    explicit_no_ring_bodies = {
+        _body_key(_source(candidate)): _body_example_from_source(_source(candidate), extra={
+            'ring_semantics': 'trusted_body_scan_fact_false',
+        })
+        for candidate in body_candidates
+        if _trusted_explicit_no_ring_candidate(candidate)
+    }
+    empty_arrays_not_promoted = {
+        _body_key(_source(candidate)): _body_example_from_source(_source(candidate), extra={
+            'ring_array_state': 'empty',
+            'handling': 'source_evidence_only_not_canonical_no_rings',
+        })
+        for candidate in body_candidates
+        if _source(candidate).get('ring_array_state') == 'empty'
+        and _body_key(_source(candidate)) not in explicit_no_ring_bodies
+    }
+
+    unknown_ring_bodies: dict[str, dict[str, Any]] = {}
+    for candidate in body_candidates:
+        key = _body_key(_source(candidate))
+        if key in trusted_ring_bodies or key in explicit_no_ring_bodies:
+            continue
+        unknown_ring_bodies[key] = _body_example_from_source(_source(candidate), extra={
+            'ring_array_state': _source(candidate).get('ring_array_state') or 'unknown',
+            'unknown_reason': _ring_unknown_reason(candidate, key in source_only_ring_bodies),
+        })
+    for key, example in source_only_ring_bodies.items():
+        if key not in trusted_ring_bodies and key not in explicit_no_ring_bodies:
+            unknown_ring_bodies.setdefault(key, {
+                **example,
+                'unknown_reason': 'source_only_ring_evidence_not_trusted_ring_truth',
+            })
+
+    return {
+        'bodies_with_trusted_ring_evidence': _count_examples(trusted_ring_bodies.values()),
+        'bodies_with_unknown_ring_evidence': _count_examples(unknown_ring_bodies.values()),
+        'bodies_with_explicit_no_ring_evidence': _count_examples(explicit_no_ring_bodies.values()),
+        'source_only_ring_evidence_not_confirmed': _count_examples(source_only_ring_bodies.values()),
+        'empty_source_arrays_not_promoted': _count_examples(empty_arrays_not_promoted.values()),
+        'missing_ring_arrays_state': 'unknown_not_false',
+        'ringed_truth_requires_trusted_body_rings': True,
+        'explicit_no_ring_rule': (
+            'Only trusted local scan facts with is_ringed=false count as explicit no-ring evidence here. '
+            'Missing ring arrays and empty source arrays are not promoted to canonical no-rings.'
+        ),
+    }
+
+
+def _source_freshness_section(
+    candidates: Sequence[Mapping[str, Any]],
+    source_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    freshness = Counter(
+        str(_source(candidate).get('freshness_class'))
+        for candidate in candidates
+        if not _missing(_source(candidate).get('freshness_class'))
+    )
+    by_source: dict[str, dict[str, Any]] = {}
+    for row in source_rows:
+        source = str(row.get('source') or 'unknown_source')
+        bucket = by_source.setdefault(source, {
+            'source': source,
+            'raw_records': 0,
+            'records_with_source_updated_at': 0,
+            'records_without_source_updated_at': 0,
+            'latest_source_updated_at': None,
+        })
+        bucket['raw_records'] += _int(row.get('raw_records'))
+        bucket['records_with_source_updated_at'] += _int(row.get('records_with_source_updated_at'))
+        bucket['records_without_source_updated_at'] += _int(row.get('records_without_source_updated_at'))
+        latest = _text(row.get('latest_source_updated_at'))
+        if latest is not None and (bucket['latest_source_updated_at'] is None or latest > bucket['latest_source_updated_at']):
+            bucket['latest_source_updated_at'] = latest
+
+    records_without_timestamps = sum(_int(row.get('records_without_source_updated_at')) for row in source_rows)
+    return {
+        'freshness_class_distribution': dict(sorted(freshness.items())),
+        'source_timestamp_coverage_by_source': _sort_rows(by_source.values()),
+        'stale_or_undated_evidence': {
+            'records_without_source_updated_at': records_without_timestamps,
+            'file_snapshot_candidate_records': freshness.get('file_snapshot', 0),
+            'review_rule': (
+                'No wall-clock age threshold is applied in this deterministic report. '
+                'file_snapshot and missing source_updated_at evidence require operator freshness review.'
+            ),
+        },
+    }
+
+
+def _source_quality_section(
+    candidates: Sequence[Mapping[str, Any]],
+    source_rows: Sequence[Mapping[str, Any]],
+    warnings: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    malformed_or_skipped = sum(
+        _int(row.get('skipped_raw_records'))
+        + _int(row.get('invalid_raw_records'))
+        + _int(row.get('conflict_raw_records'))
+        for row in source_rows
+    )
+    warning_distribution: Counter[str] = Counter()
+    for row in source_rows:
+        warning_distribution.update(_json_mapping(row.get('warning_reason_distribution')))
+    warning_distribution.update(
+        str(row.get('reason'))
+        for row in warnings
+        if not _missing(row.get('reason'))
+    )
+    duplicate_source_records = sum(_int(row.get('duplicate_source_records')) for row in source_rows)
+    duplicate_hash_groups = sum(_int(row.get('duplicate_source_record_hashes')) for row in source_rows)
+    if not source_rows:
+        hashes = [
+            _source(candidate).get('source_record_hash')
+            for candidate in candidates
+            if not _missing(_source(candidate).get('source_record_hash'))
+        ]
+        duplicate_hash_groups = sum(1 for _hash, count in Counter(hashes).items() if count > 1)
+        duplicate_source_records = sum(count - 1 for _hash, count in Counter(hashes).items() if count > 1)
+
+    identity_conflicts = _source_identity_conflicts(candidates)
+    return {
+        'malformed_or_skipped_source_rows': {
+            'count': malformed_or_skipped,
+            'warning_reason_distribution': dict(sorted(warning_distribution.items())),
+        },
+        'duplicate_source_records': {
+            'duplicate_hash_groups': duplicate_hash_groups,
+            'duplicate_records': duplicate_source_records,
+            'handling': 'report_only; staging upserts remain keyed by source run and source_record_hash',
+        },
+        'source_identity_conflicts': {
+            'count': len(identity_conflicts),
+            'examples': _limited_examples(identity_conflicts),
+            'handling': 'report_only_conflict_no_canonical_write',
+        },
+    }
+
+
+def _source_format_section(
+    candidates: Sequence[Mapping[str, Any]],
+    source_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    source_distribution = Counter(
+        str(row.get('source') or 'unknown_source')
+        for row in source_rows
+    )
+    if not source_distribution:
+        source_distribution.update(
+            str(_source(candidate).get('source') or 'unknown_source')
+            for candidate in candidates
+        )
+    return {
+        'source_type_distribution': dict(sorted(source_distribution.items())),
+        'source_class_distribution': _distribution_from_rows(source_rows, 'source_class'),
+        'source_format_distribution': _distribution_from_rows(source_rows, 'source_format'),
+        'source_format_version_distribution': _distribution_from_rows(source_rows, 'source_format_version'),
+        'record_stream_shape_distribution': _distribution_from_rows(source_rows, 'record_stream_shape'),
+        'source_files': _limited_examples(
+            {
+                'source_run_key': row.get('source_run_key'),
+                'source_file_key': row.get('source_file_key'),
+                'source': row.get('source'),
+                'source_format': row.get('source_format'),
+                'source_format_version': row.get('source_format_version'),
+                'record_stream_shape': row.get('record_stream_shape'),
+                'raw_records': row.get('raw_records'),
+            }
+            for row in source_rows
+        ),
+    }
+
+
+def _high_value_systems_section(
+    *,
+    stations: Sequence[Mapping[str, Any]],
+    bodies: Sequence[Mapping[str, Any]],
+    rings: Sequence[Mapping[str, Any]],
+    station_evidence: Mapping[str, Any],
+    station_body_links: Mapping[str, Any],
+    ring_evidence: Mapping[str, Any],
+    source_freshness: Mapping[str, Any],
+    source_quality: Mapping[str, Any],
+) -> dict[str, Any]:
+    buckets: dict[str, dict[str, Any]] = defaultdict(lambda: {
+        'system_key': '',
+        'system_id64': None,
+        'system_name': None,
+        'station_evidence_count': 0,
+        'body_evidence_count': 0,
+        'ring_evidence_count': 0,
+        'trusted_ring_evidence_count': 0,
+        'review_reasons': set(),
+    })
+    for entity, rows in (('station', stations), ('body', bodies), ('ring', rings)):
+        for candidate in rows:
+            source = _source(candidate)
+            key = _system_key(source)
+            bucket = buckets[key]
+            bucket['system_key'] = key
+            bucket['system_id64'] = source.get('system_id64')
+            bucket['system_name'] = source.get('system_name')
+            bucket[f'{entity}_evidence_count'] += 1
+            if entity == 'ring' and _trusted_ring_candidate(candidate):
+                bucket['trusted_ring_evidence_count'] += 1
+            action = candidate.get('candidate_action')
+            if action in {'ambiguous_match', 'insufficient_evidence', 'candidate_insert_missing_canonical'}:
+                bucket['review_reasons'].add(str(action))
+
+    for example in station_evidence['systems_missing_station_evidence']['examples']:
+        buckets[example['system_key']]['review_reasons'].add('missing_station_evidence')
+    for example in station_body_links['unresolved_stations']['examples']:
+        buckets[example['system_key']]['review_reasons'].add('unresolved_station_body_link')
+    for example in ring_evidence['bodies_with_unknown_ring_evidence']['examples']:
+        buckets[example['system_key']]['review_reasons'].add('unknown_ring_evidence')
+    if source_quality['source_identity_conflicts']['count']:
+        for conflict in source_quality['source_identity_conflicts']['examples']:
+            system_key = conflict.get('system_key')
+            if system_key in buckets:
+                buckets[system_key]['review_reasons'].add('source_identity_conflict')
+
+    candidates = []
+    for bucket in buckets.values():
+        evidence_count = (
+            bucket['station_evidence_count']
+            + bucket['body_evidence_count']
+            + bucket['ring_evidence_count']
+        )
+        if not bucket['review_reasons']:
+            continue
+        if bucket['trusted_ring_evidence_count'] < 1 and evidence_count < 2:
+            continue
+        candidates.append({
+            'system_key': bucket['system_key'],
+            'system_id64': bucket['system_id64'],
+            'system_name': bucket['system_name'],
+            'station_evidence_count': bucket['station_evidence_count'],
+            'body_evidence_count': bucket['body_evidence_count'],
+            'ring_evidence_count': bucket['ring_evidence_count'],
+            'trusted_ring_evidence_count': bucket['trusted_ring_evidence_count'],
+            'candidate_action': 'needs_better_evidence',
+            'review_reasons': sorted(bucket['review_reasons']),
+            'report_only': True,
+        })
+    return {
+        'count': len(candidates),
+        'examples': _limited_examples(candidates, limit=10),
+        'selection_rule': (
+            'Conservative report-only bucket: systems with trusted ring evidence or multiple staged evidence rows '
+            'and at least one coverage/reconciliation review reason.'
+        ),
+    }
+
+
+def _station_link_state(
+    station_candidate: Mapping[str, Any],
+    association_by_hash: Mapping[str, Mapping[str, Any]],
+) -> str:
+    link = _station_body_link(station_candidate)
+    status = link.get('association_status')
+    if status == 'confirmed':
+        return 'confirmed'
+    if status == 'inferred':
+        return 'inferred_or_verify'
+    source_hash = _source(station_candidate).get('source_record_hash')
+    association = association_by_hash.get(str(source_hash))
+    if association and association.get('candidate_action') == 'station_body_supported_by_staged_body':
+        return 'inferred_or_verify'
+    return 'unresolved'
+
+
+def _station_body_link(station_candidate: Mapping[str, Any]) -> Mapping[str, Any]:
+    canonical = station_candidate.get('canonical')
+    if not isinstance(canonical, Mapping):
+        return {}
+    link = canonical.get('station_body_link')
+    return link if isinstance(link, Mapping) else {}
+
+
+def _trusted_ring_candidate(candidate: Mapping[str, Any]) -> bool:
+    canonical = candidate.get('canonical')
+    if not isinstance(canonical, Mapping):
+        return False
+    return canonical.get('association_status') == 'local_matched'
+
+
+def _trusted_explicit_no_ring_candidate(candidate: Mapping[str, Any]) -> bool:
+    canonical = candidate.get('canonical')
+    if not isinstance(canonical, Mapping):
+        return False
+    scan_fact = canonical.get('ring_scan_fact')
+    return isinstance(scan_fact, Mapping) and scan_fact.get('is_ringed') is False
+
+
+def _ring_unknown_reason(candidate: Mapping[str, Any], has_source_only_ring: bool) -> str:
+    if has_source_only_ring:
+        return 'source_only_ring_evidence_not_trusted_ring_truth'
+    state = _source(candidate).get('ring_array_state')
+    if state == 'missing':
+        return 'missing_ring_array_unknown_not_false'
+    if state == 'empty':
+        return 'empty_source_array_not_canonical_no_rings'
+    if state == 'non_array':
+        return 'malformed_ring_array_unknown'
+    return 'no_trusted_ring_or_no_ring_evidence'
+
+
+def _systems_from_candidates(candidates: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    systems = {}
+    for candidate in candidates:
+        source = _source(candidate)
+        key = _system_key(source)
+        systems[key] = _system_example_from_source(source)
+    return dict(sorted(systems.items()))
+
+
+def _source_identity_conflicts(candidates: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for candidate in candidates:
+        key = _candidate_identity_key(candidate)
+        if key is not None:
+            grouped[key].append(candidate)
+
+    conflicts = []
+    for identity_key, group in grouped.items():
+        hashes = sorted({
+            str(_source(candidate).get('source_record_hash'))
+            for candidate in group
+            if not _missing(_source(candidate).get('source_record_hash'))
+        })
+        if len(hashes) < 2:
+            continue
+        first_source = _source(group[0])
+        conflicts.append({
+            'entity': group[0].get('entity'),
+            'system_key': _system_key(first_source),
+            'source_identity_key': identity_key,
+            'source_record_hashes': hashes,
+            'handling': 'report_only_conflict_no_canonical_write',
+        })
+    return _sort_rows(conflicts)
+
+
+def _candidate_identity_key(candidate: Mapping[str, Any]) -> str | None:
+    source = _source(candidate)
+    entity = candidate.get('entity')
+    system_key = _system_key(source)
+    if system_key == 'unknown-system':
+        return None
+    if entity == 'station':
+        entity_key = _first_identity(source, 'market_id', 'edsm_station_id', 'station_name')
+    elif entity == 'body':
+        entity_key = _first_identity(source, 'source_body_id', 'body_name')
+    elif entity == 'ring':
+        body_key = _first_identity(source, 'source_body_id', 'body_name')
+        ring_name = _normalise_key(source.get('ring_name'))
+        entity_key = f'{body_key}|ring:{ring_name}' if body_key and ring_name else None
+    else:
+        return None
+    if entity_key is None:
+        return None
+    return f'{entity}|{system_key}|{entity_key}'
+
+
+def _first_identity(source: Mapping[str, Any], *fields: str) -> str | None:
+    for field in fields:
+        value = source.get(field)
+        if _missing(value):
+            continue
+        if isinstance(value, str):
+            return f'{field}:{value.strip().lower()}'
+        return f'{field}:{value}'
+    return None
+
+
+def _system_key(source: Mapping[str, Any]) -> str:
+    if not _missing(source.get('system_id64')):
+        return f"id64:{source.get('system_id64')}"
+    if not _missing(source.get('system_name')):
+        return f"name:{str(source.get('system_name')).strip()}"
+    return 'unknown-system'
+
+
+def _body_key(source: Mapping[str, Any]) -> str:
+    system_key = _system_key(source)
+    if not _missing(source.get('source_body_id')):
+        return f"{system_key}|body_id:{source.get('source_body_id')}"
+    if not _missing(source.get('body_name')):
+        return f"{system_key}|body_name:{str(source.get('body_name')).strip().lower()}"
+    return f'{system_key}|unknown-body'
+
+
+def _normalise_key(value: Any) -> str | None:
+    if _missing(value):
+        return None
+    return str(value).strip().lower()
+
+
+def _system_example_from_source(source: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'system_key': _system_key(source),
+        'system_id64': source.get('system_id64'),
+        'system_name': source.get('system_name'),
+    }
+
+
+def _station_example(candidate: Mapping[str, Any], *, extra: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    source = _source(candidate)
+    return {
+        **_system_example_from_source(source),
+        'station_name': source.get('station_name'),
+        'source_record_hash': source.get('source_record_hash'),
+        **dict(extra or {}),
+    }
+
+
+def _body_example_from_source(source: Mapping[str, Any], *, extra: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        **_system_example_from_source(source),
+        'body_key': _body_key(source),
+        'source_body_id': source.get('source_body_id'),
+        'body_name': source.get('body_name'),
+        'source_record_hash': source.get('source_record_hash'),
+        **dict(extra or {}),
+    }
+
+
+def _count_examples(rows: Sequence[Mapping[str, Any]] | Any) -> dict[str, Any]:
+    row_list = _sort_rows(rows)
+    return {
+        'count': len(row_list),
+        'examples': row_list[:EXAMPLE_LIMIT],
+    }
+
+
+def _distribution_from_rows(rows: Sequence[Mapping[str, Any]], field_name: str) -> dict[str, int]:
+    return dict(sorted(Counter(
+        str(row.get(field_name))
+        for row in rows
+        if not _missing(row.get(field_name))
+    ).items()))
+
+
+def _limited_examples(rows: Sequence[Mapping[str, Any]] | Any, *, limit: int = EXAMPLE_LIMIT) -> list[dict[str, Any]]:
+    return _sort_rows(rows)[:limit]
+
+
+def _candidate_rows(rows: Sequence[Mapping[str, Any]] | Any) -> list[dict[str, Any]]:
+    return _sort_rows(rows)
+
+
+def _source_rows(rows: Sequence[Mapping[str, Any]] | Any) -> list[dict[str, Any]]:
+    return _sort_rows(rows)
+
+
+def _rows(rows: Sequence[Mapping[str, Any]] | Any) -> list[dict[str, Any]]:
+    if isinstance(rows, Mapping):
+        return [dict(rows)]
+    if isinstance(rows, (str, bytes, bytearray)):
+        return []
+    try:
+        iterable = list(rows)
+    except TypeError:
+        return []
+    return [dict(row) for row in iterable if isinstance(row, Mapping)]
+
+
+def _sort_rows(rows: Sequence[Mapping[str, Any]] | Any) -> list[dict[str, Any]]:
+    return sorted(_rows(rows), key=canonicalise_json_payload)
+
+
+def _source(candidate: Mapping[str, Any]) -> Mapping[str, Any]:
+    source = candidate.get('source')
+    return source if isinstance(source, Mapping) else {}
+
+
+def _json_mapping(value: Any) -> dict[str, int]:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _int(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, Mapping):
+            return {
+                str(key): _int(item)
+                for key, item in parsed.items()
+            }
+    return {}
+
+
+def _int(value: Any) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and not value.strip():
+        return True
+    return False

--- a/apps/importer/src/enrichment_reconciliation.py
+++ b/apps/importer/src/enrichment_reconciliation.py
@@ -24,8 +24,11 @@ def station_reconciliation_candidates(rows: Sequence[Mapping[str, Any]]) -> list
             'edsm_station_id': first.get('edsm_station_id'),
             'station_name': first.get('station_name'),
             'body_name': first.get('body_name'),
+            'source': first.get('source'),
             'source_class': first.get('source_class'),
             'confidence': first.get('confidence'),
+            'freshness_class': first.get('freshness_class'),
+            'source_updated_at': first.get('source_updated_at'),
         }
         warnings = volatile_warnings(
             first,
@@ -67,8 +70,12 @@ def body_reconciliation_candidates(rows: Sequence[Mapping[str, Any]]) -> list[di
             'system_name': first.get('system_name'),
             'source_body_id': first.get('source_body_id'),
             'body_name': first.get('body_name'),
+            'source': first.get('source'),
             'source_class': first.get('source_class'),
             'confidence': first.get('confidence'),
+            'freshness_class': first.get('freshness_class'),
+            'source_updated_at': first.get('source_updated_at'),
+            **body_ring_array_source_fields(first),
         }
         warnings = volatile_warnings(
             first,
@@ -116,8 +123,11 @@ def ring_reconciliation_candidates(rows: Sequence[Mapping[str, Any]]) -> list[di
             'body_name': first.get('body_name'),
             'ring_name': first.get('ring_name'),
             'association_status': first.get('association_status'),
+            'source': first.get('source'),
             'source_class': first.get('source_class'),
             'confidence': first.get('confidence'),
+            'freshness_class': first.get('freshness_class'),
+            'source_updated_at': first.get('source_updated_at'),
         }
         candidates.append(base_candidate(
             entity='ring',
@@ -190,6 +200,8 @@ def station_canonical_matches(rows: Sequence[Mapping[str, Any]]) -> list[dict[st
             'station_id': row.get('canonical_station_id'),
             'station_name': row.get('canonical_station_name'),
             'station_type': row.get('canonical_station_type'),
+            'body_name': row.get('canonical_body_name'),
+            'station_body_link': station_body_link(row),
         }
         for row in rows
         if row.get('canonical_station_id') is not None
@@ -205,6 +217,7 @@ def body_canonical_matches(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, 
             'body_id': row.get('canonical_body_id'),
             'body_name': row.get('canonical_body_name'),
             'body_type': row.get('canonical_body_type'),
+            'ring_scan_fact': body_ring_scan_fact(row),
         }
         for row in rows
         if row.get('canonical_body_id') is not None
@@ -228,6 +241,56 @@ def ring_canonical_matches(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, 
         if row.get('canonical_ring_id') is not None
     }
     return sort_candidate_rows(matches.values())
+
+
+def station_body_link(row: Mapping[str, Any]) -> dict[str, Any]:
+    if (
+        _missing(row.get('canonical_station_body_link_body_id'))
+        and _missing(row.get('canonical_station_body_link_body_name'))
+        and _missing(row.get('canonical_station_body_link_status'))
+    ):
+        return {}
+    return {
+        'body_id': row.get('canonical_station_body_link_body_id'),
+        'body_name': row.get('canonical_station_body_link_body_name'),
+        'lane': row.get('canonical_station_body_link_lane'),
+        'association_status': row.get('canonical_station_body_link_status'),
+        'association_confidence': row.get('canonical_station_body_link_confidence'),
+        'association_source': row.get('canonical_station_body_link_source'),
+    }
+
+
+def body_ring_scan_fact(row: Mapping[str, Any]) -> dict[str, Any]:
+    if (
+        row.get('canonical_is_ringed') is None
+        and row.get('canonical_ring_scan_confidence') is None
+        and row.get('canonical_ring_scan_sources') is None
+    ):
+        return {}
+    data_sources = row.get('canonical_ring_scan_sources')
+    if isinstance(data_sources, str):
+        sources = [data_sources]
+    elif isinstance(data_sources, Sequence) and not isinstance(data_sources, (bytes, bytearray)):
+        sources = list(data_sources)
+    else:
+        sources = []
+    return {
+        'is_ringed': row.get('canonical_is_ringed'),
+        'confidence': row.get('canonical_ring_scan_confidence'),
+        'data_sources': sources,
+        'meaning': 'trusted_scan_fact_false' if row.get('canonical_is_ringed') is False else 'scan_fact_evidence',
+    }
+
+
+def body_ring_array_source_fields(row: Mapping[str, Any]) -> dict[str, Any]:
+    provenance = row.get('provenance')
+    if not isinstance(provenance, Mapping):
+        return {}
+    return {
+        'ring_array_state': provenance.get('ring_array_state'),
+        'ring_array_meaning': provenance.get('ring_array_meaning'),
+        'missing_ring_arrays_state': provenance.get('missing_ring_arrays_state'),
+    }
 
 
 def station_body_association_candidates(

--- a/apps/importer/src/enrichment_warehouse_repository.py
+++ b/apps/importer/src/enrichment_warehouse_repository.py
@@ -23,6 +23,7 @@ from enrichment_analytics import (
     build_enrichment_analytics_signals,
     build_mission_density_signals,
 )
+from enrichment_coverage_reports import build_warehouse_coverage_report
 from enrichment_staged_reports import (
     STAGED_ROWS_REPORT_SCHEMA_VERSION,
     build_report_from_staged_rows as staged_build_report_from_staged_rows,
@@ -39,6 +40,7 @@ from enrichment_warehouse_sql import (
     returned_id as _returned_id,
     ring_reconciliation_query,
     schema_columns_query,
+    source_coverage_query,
     station_reconciliation_query,
     target_tables_for_source as sql_target_tables_for_source,
 )
@@ -244,6 +246,12 @@ def build_reconciliation_report(
         if include_bodies
         else []
     )
+    source_coverage_rows = fetch_source_coverage_rows(
+        conn,
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        source=normalised_source,
+    )
 
     station_candidates = sort_candidate_rows(station_candidates)
     body_candidates = sort_candidate_rows(body_candidates)
@@ -308,6 +316,14 @@ def build_reconciliation_report(
             ring_candidates,
             warnings,
         ),
+        'warehouse_coverage_report': build_warehouse_coverage_report(
+            station_candidates=station_candidates,
+            body_candidates=body_candidates,
+            ring_candidates=ring_candidates,
+            station_body_association_candidates=association_candidates,
+            source_coverage_rows=source_coverage_rows,
+            warnings=warnings,
+        ),
         'confidence_risk_summary': confidence_risk_summary(all_candidates),
         'warnings': warnings,
         'errors': [],
@@ -360,6 +376,21 @@ def fetch_ring_reconciliation_rows(
         source_run_key=source_run_key,
         source_file_key=source_file_key,
         limit=limit,
+    )
+    return _select_rows(conn, sql, params)
+
+
+def fetch_source_coverage_rows(
+    conn: Any,
+    *,
+    source_run_key: str | None,
+    source_file_key: str | None,
+    source: str | None,
+) -> list[dict[str, Any]]:
+    sql, params = source_coverage_query(
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        source=source,
     )
     return _select_rows(conn, sql, params)
 

--- a/apps/importer/src/enrichment_warehouse_sql.py
+++ b/apps/importer/src/enrichment_warehouse_sql.py
@@ -7,7 +7,9 @@ from typing import Any
 from enrichment_staging import canonicalise_json_payload, normalise_source_adapter
 from enrichment_warehouse import (
     CANONICAL_BODIES_TABLE,
+    CANONICAL_BODY_SCAN_FACTS_TABLE,
     CANONICAL_BODY_RINGS_TABLE,
+    CANONICAL_STATION_BODY_LINKS_TABLE,
     CANONICAL_SYSTEMS_TABLE,
     CANONICAL_STATIONS_TABLE,
     WAREHOUSE_BODY_RING_WRITE_TABLES,
@@ -45,6 +47,7 @@ REQUIRED_SCHEMA_COLUMNS = {
         'compression',
         'file_size_bytes',
         'file_sha256',
+        'source_updated_at',
         'metadata',
     ),
     WAREHOUSE_RAW_RECORDS_TABLE: (
@@ -54,6 +57,7 @@ REQUIRED_SCHEMA_COLUMNS = {
         'record_index',
         'source_record_key',
         'source_record_hash',
+        'source_updated_at',
         'raw_payload',
         'validation_status',
         'validation_warnings',
@@ -71,6 +75,10 @@ REQUIRED_SCHEMA_COLUMNS = {
         'edsm_station_id',
         'station_name',
         'distance_to_arrival',
+        'source_class',
+        'confidence',
+        'freshness_class',
+        'source_updated_at',
         'raw_payload',
         'provenance',
     ),
@@ -89,6 +97,10 @@ REQUIRED_SCHEMA_COLUMNS = {
         'distance_to_arrival',
         'signals',
         'materials',
+        'source_class',
+        'confidence',
+        'freshness_class',
+        'source_updated_at',
         'raw_payload',
         'provenance',
     ),
@@ -107,6 +119,10 @@ REQUIRED_SCHEMA_COLUMNS = {
         'ring_type',
         'ring_class',
         'association_status',
+        'source_class',
+        'confidence',
+        'freshness_class',
+        'source_updated_at',
         'raw_payload',
         'provenance',
     ),
@@ -232,6 +248,151 @@ def staged_counts_query(
     )
 
 
+def source_coverage_query(
+    *,
+    source_run_key: str | None,
+    source_file_key: str | None,
+    source: str | None,
+) -> tuple[str, list[Any]]:
+    normalised_source = normalise_source_adapter(source) if source else None
+    params: list[Any] = [
+        source_file_key,
+        source_file_key,
+        source_run_key,
+        source_run_key,
+        normalised_source,
+        normalised_source,
+    ]
+    return (
+        f"""
+        WITH scoped AS (
+            SELECT
+                sr.id AS source_run_id,
+                sr.source_run_key,
+                sr.source,
+                sr.source_class,
+                sr.metadata AS source_run_metadata,
+                sf.id AS source_file_id,
+                sf.source_file_key,
+                sf.source_file_name,
+                sf.source_updated_at AS source_file_updated_at,
+                sf.metadata AS source_file_metadata
+            FROM {WAREHOUSE_SOURCE_RUNS_TABLE} sr
+            LEFT JOIN {WAREHOUSE_SOURCE_FILES_TABLE} sf
+              ON sf.source_run_id = sr.id
+             AND (%s IS NULL OR sf.source_file_key = %s)
+            WHERE (%s IS NULL OR sr.source_run_key = %s)
+              AND (%s IS NULL OR sr.source = %s)
+        ),
+        duplicate_hashes AS (
+            SELECT
+                source_run_id,
+                source_file_id,
+                source_record_hash,
+                COUNT(*) AS count_per_hash
+            FROM {WAREHOUSE_RAW_RECORDS_TABLE}
+            GROUP BY source_run_id, source_file_id, source_record_hash
+        ),
+        raw_counts AS (
+            SELECT
+                scoped.source_run_id,
+                scoped.source_file_id,
+                COUNT(rr.id)::integer AS raw_records,
+                COUNT(rr.id) FILTER (WHERE rr.validation_status = 'accepted')::integer
+                    AS accepted_raw_records,
+                COUNT(rr.id) FILTER (WHERE rr.validation_status = 'skipped')::integer
+                    AS skipped_raw_records,
+                COUNT(rr.id) FILTER (WHERE rr.validation_status = 'invalid')::integer
+                    AS invalid_raw_records,
+                COUNT(rr.id) FILTER (WHERE rr.validation_status = 'conflict')::integer
+                    AS conflict_raw_records,
+                GREATEST(COUNT(rr.id) - COUNT(DISTINCT rr.source_record_hash), 0)::integer
+                    AS duplicate_source_records,
+                COUNT(DISTINCT rr.source_record_hash) FILTER (WHERE duplicate_hashes.count_per_hash > 1)::integer
+                    AS duplicate_source_record_hashes,
+                COUNT(rr.id) FILTER (WHERE rr.source_updated_at IS NOT NULL)::integer
+                    AS records_with_source_updated_at,
+                COUNT(rr.id) FILTER (WHERE rr.id IS NOT NULL AND rr.source_updated_at IS NULL)::integer
+                    AS records_without_source_updated_at,
+                MIN(rr.source_updated_at) AS earliest_source_updated_at,
+                MAX(rr.source_updated_at) AS latest_source_updated_at
+            FROM scoped
+            LEFT JOIN {WAREHOUSE_RAW_RECORDS_TABLE} rr
+              ON rr.source_run_id = scoped.source_run_id
+             AND (scoped.source_file_id IS NULL OR rr.source_file_id = scoped.source_file_id)
+            LEFT JOIN duplicate_hashes
+              ON duplicate_hashes.source_run_id = rr.source_run_id
+             AND duplicate_hashes.source_file_id IS NOT DISTINCT FROM rr.source_file_id
+             AND duplicate_hashes.source_record_hash = rr.source_record_hash
+            GROUP BY scoped.source_run_id, scoped.source_file_id
+        ),
+        warning_counts AS (
+            SELECT
+                scoped.source_run_id,
+                scoped.source_file_id,
+                warning.value ->> 'reason' AS reason,
+                COUNT(*)::integer AS warning_count
+            FROM scoped
+            JOIN {WAREHOUSE_RAW_RECORDS_TABLE} rr
+              ON rr.source_run_id = scoped.source_run_id
+             AND (scoped.source_file_id IS NULL OR rr.source_file_id = scoped.source_file_id)
+            CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rr.validation_warnings, '[]'::jsonb)) warning(value)
+            WHERE warning.value ? 'reason'
+            GROUP BY scoped.source_run_id, scoped.source_file_id, warning.value ->> 'reason'
+        ),
+        warning_json AS (
+            SELECT
+                source_run_id,
+                source_file_id,
+                jsonb_object_agg(reason, warning_count ORDER BY reason) AS warning_reason_distribution
+            FROM warning_counts
+            GROUP BY source_run_id, source_file_id
+        )
+        SELECT
+            scoped.source_run_key,
+            scoped.source_file_key,
+            scoped.source_file_name,
+            scoped.source,
+            scoped.source_class,
+            COALESCE(
+                scoped.source_file_metadata ->> 'source_format',
+                scoped.source_run_metadata ->> 'source_format'
+            ) AS source_format,
+            COALESCE(
+                scoped.source_file_metadata ->> 'source_format_version',
+                scoped.source_run_metadata ->> 'source_format_version'
+            ) AS source_format_version,
+            COALESCE(
+                scoped.source_file_metadata ->> 'record_stream_shape',
+                scoped.source_run_metadata ->> 'record_stream_shape'
+            ) AS record_stream_shape,
+            COALESCE(raw_counts.raw_records, 0) AS raw_records,
+            COALESCE(raw_counts.accepted_raw_records, 0) AS accepted_raw_records,
+            COALESCE(raw_counts.skipped_raw_records, 0) AS skipped_raw_records,
+            COALESCE(raw_counts.invalid_raw_records, 0) AS invalid_raw_records,
+            COALESCE(raw_counts.conflict_raw_records, 0) AS conflict_raw_records,
+            COALESCE(raw_counts.duplicate_source_record_hashes, 0) AS duplicate_source_record_hashes,
+            COALESCE(raw_counts.duplicate_source_records, 0) AS duplicate_source_records,
+            COALESCE(raw_counts.records_with_source_updated_at, 0) AS records_with_source_updated_at,
+            COALESCE(raw_counts.records_without_source_updated_at, 0) AS records_without_source_updated_at,
+            raw_counts.earliest_source_updated_at,
+            raw_counts.latest_source_updated_at,
+            scoped.source_file_updated_at,
+            COALESCE(warning_json.warning_reason_distribution, '{{}}'::jsonb)
+                AS warning_reason_distribution
+        FROM scoped
+        LEFT JOIN raw_counts
+          ON raw_counts.source_run_id = scoped.source_run_id
+         AND raw_counts.source_file_id IS NOT DISTINCT FROM scoped.source_file_id
+        LEFT JOIN warning_json
+          ON warning_json.source_run_id = scoped.source_run_id
+         AND warning_json.source_file_id IS NOT DISTINCT FROM scoped.source_file_id
+        ORDER BY scoped.source, scoped.source_run_key, scoped.source_file_key NULLS FIRST
+        """,
+        params,
+    )
+
+
 def station_reconciliation_query(
     *,
     source_run_key: str | None,
@@ -268,6 +429,9 @@ def station_reconciliation_query(
                 ss.government,
                 ss.source_class,
                 ss.confidence,
+                ss.freshness_class,
+                ss.source_updated_at,
+                ss.provenance,
                 sr.source_run_key,
                 sr.source,
                 sf.source_file_key
@@ -292,6 +456,12 @@ def station_reconciliation_query(
             st.controlling_faction AS canonical_controlling_faction,
             st.allegiance AS canonical_allegiance,
             st.government AS canonical_government,
+            sbl.body_id AS canonical_station_body_link_body_id,
+            sbl.body_name AS canonical_station_body_link_body_name,
+            sbl.lane AS canonical_station_body_link_lane,
+            sbl.association_status AS canonical_station_body_link_status,
+            sbl.association_confidence AS canonical_station_body_link_confidence,
+            sbl.association_source AS canonical_station_body_link_source,
             COUNT(st.id) OVER (PARTITION BY staged.staging_station_id)::integer AS canonical_match_count
         FROM staged
         LEFT JOIN {CANONICAL_SYSTEMS_TABLE} sys
@@ -311,6 +481,9 @@ def station_reconciliation_query(
               OR (staged.edsm_station_id IS NOT NULL AND st.id = staged.edsm_station_id)
               OR (staged.station_name IS NOT NULL AND lower(st.name) = lower(staged.station_name))
          )
+        LEFT JOIN {CANONICAL_STATION_BODY_LINKS_TABLE} sbl
+          ON st.id IS NOT NULL
+         AND sbl.station_id = st.id
         ORDER BY staged.system_id64 NULLS LAST, staged.system_name NULLS LAST, staged.station_name NULLS LAST,
                  staged.staging_station_id, st.id NULLS LAST
         """,
@@ -355,6 +528,9 @@ def body_reconciliation_query(
                 sb.estimated_mapping_value,
                 sb.source_class,
                 sb.confidence,
+                sb.freshness_class,
+                sb.source_updated_at,
+                sb.provenance,
                 sr.source_run_key,
                 sr.source,
                 sf.source_file_key
@@ -382,6 +558,9 @@ def body_reconciliation_query(
             b.is_terraformable AS canonical_is_terraformable,
             b.estimated_scan_value AS canonical_estimated_scan_value,
             b.estimated_mapping_value AS canonical_estimated_mapping_value,
+            bsf.is_ringed AS canonical_is_ringed,
+            bsf.confidence AS canonical_ring_scan_confidence,
+            bsf.data_sources AS canonical_ring_scan_sources,
             COUNT(b.id) OVER (PARTITION BY staged.staging_body_id)::integer AS canonical_match_count
         FROM staged
         LEFT JOIN {CANONICAL_SYSTEMS_TABLE} sys
@@ -399,6 +578,12 @@ def body_reconciliation_query(
          AND (
               (staged.source_body_id IS NOT NULL AND b.id = staged.source_body_id)
               OR (staged.body_name IS NOT NULL AND lower(b.name) = lower(staged.body_name))
+         )
+        LEFT JOIN {CANONICAL_BODY_SCAN_FACTS_TABLE} bsf
+          ON bsf.system_address = COALESCE(sys.id64, staged.system_id64)
+         AND (
+              (b.id IS NOT NULL AND bsf.body_id = b.id)
+              OR (staged.source_body_id IS NOT NULL AND bsf.body_id = staged.source_body_id)
          )
         ORDER BY staged.system_id64 NULLS LAST, staged.system_name NULLS LAST,
                  staged.source_body_id NULLS LAST, staged.body_name NULLS LAST,
@@ -444,6 +629,9 @@ def ring_reconciliation_query(
                 br.association_status,
                 br.source_class,
                 br.confidence,
+                br.freshness_class,
+                br.source_updated_at,
+                br.provenance,
                 sr.source_run_key,
                 sr.source,
                 sf.source_file_key

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -409,6 +409,16 @@ body/ring ring-array evidence. Missing ring arrays remain unknown, source-only
 ring evidence remains source-only, and future nested body source shapes are
 reported as unsupported until a dedicated adapter exists.
 
+Stage 18E adds a versioned `warehouse_coverage_report` section to read-only
+reconciliation output. It is for operator review of evidence completeness:
+station coverage by system, missing station evidence where body/ring evidence
+exists, trusted versus unknown ring evidence, explicit trusted no-ring scan
+evidence, confirmed/inferred/unresolved station-body links, stale or undated
+source evidence, skipped/malformed source rows, duplicate source-record hashes,
+source identity conflicts, high-value systems needing better evidence, and
+source type/source-format coverage. It remains dry-run/report-only and does
+not promote source-only evidence to canonical truth.
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -116,6 +116,13 @@ body/ring `ring_array_evidence`. Missing ring arrays remain
 `unknown_not_false`; empty arrays are source evidence only and do not become a
 canonical no-rings conclusion.
 
+Stage 18E keeps those semantics in warehouse coverage reports: source-only ring
+rows are counted separately from trusted local `body_rings` evidence, missing
+ring arrays stay unknown, and explicit no-ring coverage is counted only from
+trusted local scan facts such as `body_scan_facts.is_ringed = false`. Empty
+source arrays remain review evidence unless a future source adapter proves
+stronger semantics.
+
 Stage 18B broadens the read-only reconciliation report with named sections:
 
 * `station_body_association_candidates` records staged station/body-name
@@ -124,6 +131,13 @@ Stage 18B broadens the read-only reconciliation report with named sections:
 * `source_coverage_summary` records per-entity action/confidence/source
   coverage, volatile warning counts, and ring-evidence state. Missing ring
   arrays remain `unknown_not_false`.
+* `warehouse_coverage_report` records Stage 18E operator coverage sections for
+  systems with and missing station evidence, trusted/unknown/explicit no-ring
+  body coverage, confirmed/inferred/unresolved station-body links, stale or
+  undated source evidence, duplicate and skipped source coverage, high-value
+  systems needing better evidence, and source type/format coverage. It is
+  versioned as `enrichment_warehouse_coverage_report/v1`, deterministic, and
+  report-only.
 * `confidence_risk_summary` keeps aggregate confidence, identifier/evidence
   quality, and risk-flag distributions explainable.
 * `analytics_signals`, `colonisation_signals`, and `mission_density_signals`

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -297,6 +297,13 @@ Important sections:
   `station_body_links` write plan.
 - `source_coverage_summary`: entity coverage, source files/runs, volatile
   warning counts, and ring evidence state.
+- `warehouse_coverage_report`: Stage 18E operator review coverage. It shows
+  systems with station evidence, systems with only body/ring evidence, trusted
+  ring evidence, unknown ring evidence, explicit trusted no-ring scan evidence,
+  confirmed/inferred/unresolved station-body links, stale or undated evidence,
+  malformed/skipped source rows, duplicate source-record hashes, source
+  identity conflicts, high-value systems needing better evidence, and source
+  type/source-format coverage.
 - `confidence_risk_summary`: confidence, evidence quality, identifier quality,
   and risk-flag distributions.
 
@@ -317,8 +324,28 @@ Warnings that block any later stage:
 - `volatile_source_evidence` where an operator expected a stable-field change
 - `source_only_association`, `ambiguous_staged_body_evidence`,
   `missing_staged_body_evidence`, or `missing_station_body_name`
+- non-zero `warehouse_coverage_report.operator_review.needs_attention_buckets`
+  values that the operator cannot explain from the source file and staging
+  filters
 - any non-zero `errors`
 - any report that omits `canonical_writes_planned = 0`
+
+Coverage report rules:
+
+- `warehouse_coverage_report` is deterministic and report-only. It is not a
+  write plan and must keep `canonical_writes_planned = 0`.
+- Missing station evidence means no staged station evidence for a system that
+  does have staged body or ring evidence in the current report scope; it is not
+  a galaxy-wide absence claim.
+- Trusted ring evidence requires matched local `body_rings` rows with trusted
+  association status.
+- Source-only ring rows remain source-only and do not confirm ring truth.
+- Explicit no-ring coverage is counted only from trusted local scan facts such
+  as `body_scan_facts.is_ringed = false`. Missing arrays and empty source
+  arrays remain review evidence, not canonical no-rings.
+- Stale or undated coverage uses source timestamp/freshness fields only; the
+  report does not apply a wall-clock age threshold so output stays
+  deterministic and offline-safe.
 
 ## Staged-Row Summary
 

--- a/tests/test_enrichment_staging_reconciliation.py
+++ b/tests/test_enrichment_staging_reconciliation.py
@@ -49,6 +49,9 @@ class FakeCursor:
         if 'from staging_body_rings' in sql_lower:
             self._rows = _limited(self.conn.ring_rows, limit)
             return
+        if 'warning_reason_distribution' in sql_lower and 'enrichment_raw_records' in sql_lower:
+            self._rows = list(self.conn.source_coverage_rows)
+            return
         self._rows = []
 
     def fetchall(self):
@@ -65,10 +68,12 @@ class FakeConn:
         station_rows: list[dict[str, object]] | None = None,
         body_rows: list[dict[str, object]] | None = None,
         ring_rows: list[dict[str, object]] | None = None,
+        source_coverage_rows: list[dict[str, object]] | None = None,
     ) -> None:
         self.station_rows = station_rows or []
         self.body_rows = body_rows or []
         self.ring_rows = ring_rows or []
+        self.source_coverage_rows = source_coverage_rows or []
         self.statements: list[tuple[str, tuple[object, ...]]] = []
         self.commits = 0
         self.rollbacks = 0
@@ -124,6 +129,12 @@ def station_row(**overrides):
         'controlling_faction': 'Test Faction',
         'allegiance': 'Federation',
         'government': 'Democracy',
+        'source': 'edsm_nightly_stations',
+        'source_class': 'semi-stable',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'source_updated_at': '2026-01-02T00:00:00Z',
+        'provenance': {},
         'canonical_system_id64': 42,
         'canonical_system_name': 'Test System',
         'canonical_station_id': 1001,
@@ -134,6 +145,12 @@ def station_row(**overrides):
         'canonical_controlling_faction': 'Test Faction',
         'canonical_allegiance': 'Federation',
         'canonical_government': 'Democracy',
+        'canonical_station_body_link_body_id': None,
+        'canonical_station_body_link_body_name': None,
+        'canonical_station_body_link_lane': None,
+        'canonical_station_body_link_status': None,
+        'canonical_station_body_link_confidence': None,
+        'canonical_station_body_link_source': None,
         'canonical_match_count': 1,
     }
     row.update(overrides)
@@ -159,6 +176,12 @@ def body_row(**overrides):
         'is_terraformable': False,
         'estimated_scan_value': 1000,
         'estimated_mapping_value': 2000,
+        'source': 'edsm_nightly_bodies',
+        'source_class': 'semi-stable',
+        'confidence': 'source_body_snapshot',
+        'freshness_class': 'source_updated_at',
+        'source_updated_at': '2026-01-03T00:00:00Z',
+        'provenance': {'ring_array_state': 'missing', 'missing_ring_arrays_state': 'unknown_not_false'},
         'canonical_system_id64': 42,
         'canonical_system_name': 'Test System',
         'canonical_body_id': 7,
@@ -171,6 +194,9 @@ def body_row(**overrides):
         'canonical_is_terraformable': False,
         'canonical_estimated_scan_value': 1000,
         'canonical_estimated_mapping_value': 2000,
+        'canonical_is_ringed': None,
+        'canonical_ring_scan_confidence': None,
+        'canonical_ring_scan_sources': None,
         'canonical_match_count': 1,
     }
     row.update(overrides)
@@ -195,6 +221,12 @@ def ring_row(**overrides):
         'inner_radius': 10.0,
         'outer_radius': 20.0,
         'association_status': 'source_only',
+        'source': 'edsm_nightly_bodies',
+        'source_class': 'semi-stable',
+        'confidence': 'source_ring_payload',
+        'freshness_class': 'source_updated_at',
+        'source_updated_at': '2026-01-03T00:00:00Z',
+        'provenance': {'source_only_ring_evidence': True},
         'canonical_system_id64': 42,
         'canonical_system_name': 'Test System',
         'canonical_body_id': 7,
@@ -519,6 +551,242 @@ def test_source_only_ring_association_status_does_not_confirm_ringed():
     assert ring_evidence['trusted_local_matched_ring_candidates'] == 0
     assert ring_evidence['missing_ring_arrays_state'] == 'ring_evidence_present'
     assert ring_evidence['ringed_truth_requires_trusted_body_rings'] is True
+    assert_read_only_sql(conn)
+
+
+def test_warehouse_coverage_report_splits_operator_review_sections():
+    conn = FakeConn(
+        station_rows=[
+            station_row(
+                staging_station_id=1,
+                station_name='Confirmed Port',
+                body_name='Test 7',
+                source_record_hash='station-confirmed',
+                canonical_station_id=1001,
+                canonical_station_name='Confirmed Port',
+                canonical_body_name='Test 7',
+                canonical_station_body_link_body_id=7,
+                canonical_station_body_link_body_name='Test 7',
+                canonical_station_body_link_lane='surface',
+                canonical_station_body_link_status='confirmed',
+                canonical_station_body_link_confidence='exact',
+                canonical_station_body_link_source='edsm_body_name',
+            ),
+            station_row(
+                staging_station_id=2,
+                market_id=1002,
+                edsm_station_id=1002,
+                station_name='Verify Port',
+                body_name='Test 8',
+                source_record_hash='station-verify',
+                canonical_station_id=1002,
+                canonical_station_name='Verify Port',
+                canonical_body_name='Test 8',
+            ),
+            station_row(
+                staging_station_id=3,
+                system_id64=43,
+                system_name='Sparse System',
+                market_id=1003,
+                edsm_station_id=1003,
+                station_name='Loose Port',
+                body_name=None,
+                source_record_hash='station-unresolved',
+                canonical_system_id64=43,
+                canonical_system_name='Sparse System',
+                canonical_station_id=1003,
+                canonical_station_name='Loose Port',
+                canonical_body_name=None,
+            ),
+            station_row(
+                staging_station_id=4,
+                system_id64=50,
+                system_name='Conflict System',
+                market_id=2000,
+                edsm_station_id=2000,
+                station_name='Conflict Port',
+                source_record_hash='conflict-a',
+                canonical_system_id64=50,
+                canonical_system_name='Conflict System',
+                canonical_station_id=None,
+                canonical_station_name=None,
+                canonical_match_count=0,
+            ),
+            station_row(
+                staging_station_id=5,
+                system_id64=50,
+                system_name='Conflict System',
+                market_id=2000,
+                edsm_station_id=2000,
+                station_name='Conflict Port',
+                station_type='Ocellus Starport',
+                source_record_hash='conflict-b',
+                canonical_system_id64=50,
+                canonical_system_name='Conflict System',
+                canonical_station_id=None,
+                canonical_station_name=None,
+                canonical_match_count=0,
+            ),
+        ],
+        body_rows=[
+            body_row(
+                staging_body_id=10,
+                source_body_id=7,
+                body_name='Test 7',
+                source_record_hash='body-no-rings',
+                provenance={'ring_array_state': 'empty', 'missing_ring_arrays_state': 'unknown_not_false'},
+                canonical_is_ringed=False,
+                canonical_ring_scan_confidence=1.0,
+                canonical_ring_scan_sources=['eddn_scan'],
+            ),
+            body_row(
+                staging_body_id=11,
+                source_body_id=8,
+                body_name='Test 8',
+                source_record_hash='body-trusted-ring',
+                provenance={'ring_array_state': 'missing', 'missing_ring_arrays_state': 'unknown_not_false'},
+                canonical_body_id=8,
+                canonical_body_name='Test 8',
+            ),
+            body_row(
+                staging_body_id=12,
+                system_id64=99,
+                system_name='Body Only System',
+                source_body_id=1,
+                body_name='Body Only 1',
+                source_record_hash='body-only',
+                provenance={'ring_array_state': 'empty', 'missing_ring_arrays_state': 'unknown_not_false'},
+                canonical_system_id64=99,
+                canonical_system_name='Body Only System',
+                canonical_body_id=1,
+                canonical_body_name='Body Only 1',
+            ),
+        ],
+        ring_rows=[
+            ring_row(
+                staging_ring_id=20,
+                source_body_id=8,
+                body_name='Test 8',
+                ring_name='Test 8 A Ring',
+                source_record_hash='ring-trusted',
+                canonical_body_id=8,
+                canonical_body_name='Test 8',
+                canonical_ring_id=30,
+                canonical_ring_name='Test 8 A Ring',
+                canonical_association_status='local_matched',
+            ),
+            ring_row(
+                staging_ring_id=21,
+                system_id64=99,
+                system_name='Body Only System',
+                source_body_id=1,
+                body_name='Body Only 1',
+                ring_name='Body Only 1 A Ring',
+                source_record_hash='ring-source-only',
+                canonical_system_id64=99,
+                canonical_system_name='Body Only System',
+                canonical_body_id=1,
+                canonical_body_name='Body Only 1',
+                canonical_ring_id=None,
+                canonical_ring_name=None,
+                canonical_association_status=None,
+                canonical_match_count=0,
+            ),
+        ],
+        source_coverage_rows=[
+            {
+                'source_run_key': 'run-stations',
+                'source_file_key': 'file-stations',
+                'source_file_name': 'stations.json',
+                'source': 'edsm_nightly_stations',
+                'source_class': 'semi-stable',
+                'source_format': 'json',
+                'source_format_version': 'json_snapshot_stream/v1',
+                'record_stream_shape': 'json_array',
+                'raw_records': 6,
+                'accepted_raw_records': 5,
+                'skipped_raw_records': 1,
+                'invalid_raw_records': 0,
+                'conflict_raw_records': 0,
+                'duplicate_source_record_hashes': 1,
+                'duplicate_source_records': 1,
+                'records_with_source_updated_at': 5,
+                'records_without_source_updated_at': 1,
+                'latest_source_updated_at': '2026-01-02T00:00:00Z',
+                'warning_reason_distribution': {'missing_required_field': 1},
+            },
+            {
+                'source_run_key': 'run-bodies',
+                'source_file_key': 'file-bodies',
+                'source_file_name': 'bodies.json',
+                'source': 'edsm_nightly_bodies',
+                'source_class': 'semi-stable',
+                'source_format': 'json',
+                'source_format_version': 'json_snapshot_stream/v1',
+                'record_stream_shape': 'ndjson',
+                'raw_records': 3,
+                'accepted_raw_records': 3,
+                'skipped_raw_records': 0,
+                'invalid_raw_records': 0,
+                'conflict_raw_records': 0,
+                'duplicate_source_record_hashes': 0,
+                'duplicate_source_records': 0,
+                'records_with_source_updated_at': 3,
+                'records_without_source_updated_at': 0,
+                'latest_source_updated_at': '2026-01-03T00:00:00Z',
+                'warning_reason_distribution': {},
+            },
+        ],
+    )
+
+    report = db_loader.build_reconciliation_report(conn)
+    coverage = report['warehouse_coverage_report']
+
+    assert coverage['schema_version'] == 'enrichment_warehouse_coverage_report/v1'
+    assert coverage['dry_run'] is True
+    assert coverage['report_only'] is True
+    assert coverage['canonical_writes_planned'] == 0
+    assert coverage['station_evidence']['systems_with_station_evidence']['count'] == 3
+    assert coverage['station_evidence']['systems_missing_station_evidence']['examples'] == [{
+        'system_id64': 99,
+        'system_key': 'id64:99',
+        'system_name': 'Body Only System',
+    }]
+    assert coverage['ring_evidence']['bodies_with_trusted_ring_evidence']['count'] == 1
+    assert coverage['ring_evidence']['bodies_with_explicit_no_ring_evidence']['count'] == 1
+    assert coverage['ring_evidence']['bodies_with_unknown_ring_evidence']['count'] == 1
+    assert coverage['ring_evidence']['empty_source_arrays_not_promoted']['count'] == 1
+    assert coverage['ring_evidence']['ringed_truth_requires_trusted_body_rings'] is True
+    assert coverage['station_body_links']['stations_with_confirmed_body_links']['count'] == 1
+    assert coverage['station_body_links']['stations_with_inferred_or_verify_body_links']['count'] == 1
+    assert coverage['station_body_links']['unresolved_stations']['count'] == 3
+    assert coverage['source_freshness']['freshness_class_distribution'] == {'source_updated_at': 10}
+    assert (
+        coverage['source_freshness']['stale_or_undated_evidence']['records_without_source_updated_at']
+        == 1
+    )
+    assert coverage['source_quality']['malformed_or_skipped_source_rows']['count'] == 1
+    assert coverage['source_quality']['malformed_or_skipped_source_rows']['warning_reason_distribution'] == {
+        'missing_required_field': 1,
+    }
+    assert coverage['source_quality']['duplicate_source_records'] == {
+        'duplicate_hash_groups': 1,
+        'duplicate_records': 1,
+        'handling': 'report_only; staging upserts remain keyed by source run and source_record_hash',
+    }
+    assert coverage['source_quality']['source_identity_conflicts']['count'] == 1
+    assert coverage['source_formats']['source_type_distribution'] == {
+        'edsm_nightly_bodies': 1,
+        'edsm_nightly_stations': 1,
+    }
+    assert coverage['source_formats']['record_stream_shape_distribution'] == {
+        'json_array': 1,
+        'ndjson': 1,
+    }
+    assert coverage['high_value_systems_needing_better_evidence']['count'] == 2
+    assert coverage['operator_review']['needs_attention_buckets']['systems_missing_station_evidence'] == 1
+    assert coverage['operator_review']['needs_attention_buckets']['source_identity_conflicts'] == 1
+    assert report['summary']['canonical_writes_planned'] == 0
     assert_read_only_sql(conn)
 
 


### PR DESCRIPTION
## Summary

Adds Stage 18E warehouse coverage reporting as a report-only, versioned reconciliation section.

- Adds `warehouse_coverage_report` with named sections for station evidence, missing station evidence, trusted/unknown/explicit no-ring evidence, station-body association states, stale/undated source coverage, duplicate/source-record identity conflicts, malformed/skipped-row coverage, high-value needs-evidence buckets, and source type/format coverage.
- Wires the report into read-only reconciliation output and adds source coverage query support for enrichment warehouse tables.
- Adds deterministic fixture tests and updates operator/staging documentation.

## Validation

- `.venv/bin/pytest tests/test_enrichment_staging.py tests/test_enrichment_snapshot_loader.py -q`
- `.venv/bin/pytest tests/test_enrichment_staging_reconciliation.py -q`
- `.venv/bin/pytest tests/test_enrichment_body_ring_staging_loader.py -q`
- `.venv/bin/pytest tests/test_station_enrichment_status.py tests/test_station_enrichment_guard.py -q`
- `.venv/bin/pytest tests/test_smoke.py -q`
- `.venv/bin/pytest tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_warehouse_repository.py tests/test_enrichment_analytics.py tests/test_enrichment_report_contracts.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_write_plans.py tests/test_body_ring_enrichment_plan.py -q`
- `.venv/bin/python -m py_compile apps/importer/src/enrichment_coverage_reports.py apps/importer/src/enrichment_reconciliation.py apps/importer/src/enrichment_warehouse_repository.py apps/importer/src/enrichment_warehouse_sql.py`
- `git diff --check`

Optional Postgres smoke tests were invoked and skipped because `EDFINDER_STAGING_TEST_DSN` / confirmation env vars were not set.

## Boundaries

- Report-only output; no canonical station/body/system writes.
- No production scheduler/job wiring.
- No live EDSM/API crawl.
- No Docker invocation.
- No planner/search/scoring/optimiser changes.
- Dry-run/report-only remains default.
- Unknown and missing source values remain unknown.
- Missing ring arrays remain unknown.
- Source-only ring evidence remains source-only; explicit no-ring evidence is counted only where trusted scan semantics support it.