### PR TITLE
Stage 18F reconciliation confidence model

### DIFF
--- a/apps/importer/src/enrichment_reconciliation.py
+++ b/apps/importer/src/enrichment_reconciliation.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from enrichment_reconciliation_scoring import candidate_confidence
+from enrichment_reconciliation_scoring import (
+    association_confidence_metadata,
+    candidate_confidence,
+)
 from enrichment_staging import canonicalise_json_payload
 
 
@@ -320,56 +323,51 @@ def station_body_association_candidates(
                 'system_name': source.get('system_name'),
                 'station_name': source.get('station_name'),
                 'body_name': source.get('body_name'),
+                'source_class': source.get('source_class'),
+                'freshness_class': source.get('freshness_class'),
+                'source_updated_at': source.get('source_updated_at'),
+                'source_confidence': source.get('confidence'),
             },
             'report_only': True,
             'canonical_link_writes_planned': 0,
         }
         if _missing(source.get('body_name')):
-            candidates.append({
-                **base,
-                'candidate_action': 'station_body_name_missing',
-                'confidence': 'low',
-                'risk_flags': ['missing_station_body_name'],
-                'confidence_explanations': [
-                    'Station evidence has no body_name; association remains unknown.',
-                    'Output is report-only; it is not a station-body link write plan.',
-                ],
-                'matched_body_evidence': [],
-            })
+            action = 'station_body_name_missing'
+            candidates.append(_association_candidate(
+                base,
+                action=action,
+                confidence='low',
+                risk_flags=['missing_station_body_name'],
+                matched_body_evidence=[],
+            ))
             continue
 
         key = _association_key(source)
         body_matches = body_index.get(key, []) if key is not None else []
         if len(body_matches) == 1:
             body_source = _source(body_matches[0])
-            candidates.append({
-                **base,
-                'candidate_action': 'station_body_supported_by_staged_body',
-                'confidence': 'medium',
-                'risk_flags': ['source_only_association'],
-                'confidence_explanations': [
-                    'Station body_name matches one staged body evidence row in the same system.',
-                    'The association remains report-only until a separate trusted write design exists.',
-                ],
-                'matched_body_evidence': [{
+            action = 'station_body_supported_by_staged_body'
+            candidates.append(_association_candidate(
+                base,
+                action=action,
+                confidence='medium',
+                risk_flags=['source_only_association'],
+                matched_body_evidence=[{
                     'source_record_hash': body_source.get('source_record_hash'),
                     'source_body_id': body_source.get('source_body_id'),
                     'body_name': body_source.get('body_name'),
                     'candidate_action': body_matches[0].get('candidate_action'),
                     'confidence': body_matches[0].get('confidence'),
                 }],
-            })
+            ))
         elif len(body_matches) > 1:
-            candidates.append({
-                **base,
-                'candidate_action': 'station_body_ambiguous_staged_body',
-                'confidence': 'low',
-                'risk_flags': ['ambiguous_staged_body_evidence'],
-                'confidence_explanations': [
-                    'More than one staged body evidence row matched the station body_name.',
-                    'Manual review is required before any future association design.',
-                ],
-                'matched_body_evidence': [
+            action = 'station_body_ambiguous_staged_body'
+            candidates.append(_association_candidate(
+                base,
+                action=action,
+                confidence='low',
+                risk_flags=['ambiguous_staged_body_evidence'],
+                matched_body_evidence=[
                     {
                         'source_record_hash': _source(match).get('source_record_hash'),
                         'source_body_id': _source(match).get('source_body_id'),
@@ -379,20 +377,40 @@ def station_body_association_candidates(
                     }
                     for match in body_matches
                 ],
-            })
+            ))
         else:
-            candidates.append({
-                **base,
-                'candidate_action': 'station_body_unresolved_staged_body',
-                'confidence': 'low',
-                'risk_flags': ['missing_staged_body_evidence'],
-                'confidence_explanations': [
-                    'No staged body evidence matched the station body_name in the same system.',
-                    'The association stays unresolved and report-only.',
-                ],
-                'matched_body_evidence': [],
-            })
+            action = 'station_body_unresolved_staged_body'
+            candidates.append(_association_candidate(
+                base,
+                action=action,
+                confidence='low',
+                risk_flags=['missing_staged_body_evidence'],
+                matched_body_evidence=[],
+            ))
     return sort_candidate_rows(candidates)
+
+
+def _association_candidate(
+    base: Mapping[str, Any],
+    *,
+    action: str,
+    confidence: str,
+    risk_flags: Sequence[str],
+    matched_body_evidence: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    source = base.get('source')
+    source_identity = source if isinstance(source, Mapping) else {}
+    return {
+        **dict(base),
+        'candidate_action': action,
+        **association_confidence_metadata(
+            action=action,
+            confidence=confidence,
+            source_identity=source_identity,
+            risk_flags=risk_flags,
+        ),
+        'matched_body_evidence': [dict(row) for row in matched_body_evidence],
+    }
 
 
 def source_coverage_summary(
@@ -430,9 +448,16 @@ def confidence_risk_summary(candidates: Sequence[Mapping[str, Any]]) -> dict[str
         'report_only': True,
         'canonical_writes_planned': 0,
         'confidence_distribution': _distribution(candidates, 'confidence'),
+        'confidence_level_distribution': _distribution(candidates, 'confidence_level'),
         'evidence_quality_distribution': _distribution(candidates, 'evidence_quality'),
         'identifier_quality_distribution': _distribution(candidates, 'identifier_quality'),
+        'reconciliation_state_distribution': _distribution(candidates, 'reconciliation_state'),
+        'risk_class_distribution': _distribution(candidates, 'risk_class'),
         'risk_flag_distribution': _risk_distribution(candidates),
+        'review_classification_distribution': _review_classification_distribution(candidates),
+        'source_freshness_impact_distribution': _source_freshness_impact_distribution(candidates),
+        'future_canonical_review_candidates': _future_review_candidate_count(candidates),
+        'important_review_examples': _important_review_examples(candidates),
     }
 
 
@@ -572,3 +597,58 @@ def _risk_distribution(candidates: Sequence[Mapping[str, Any]]) -> dict[str, int
             key = str(flag)
             counts[key] = counts.get(key, 0) + 1
     return dict(sorted(counts.items()))
+
+
+def _review_classification_distribution(candidates: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        classifications = candidate.get('review_classifications', [])
+        if not isinstance(classifications, Sequence) or isinstance(classifications, (str, bytes, bytearray)):
+            continue
+        for classification in classifications:
+            key = str(classification)
+            counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _source_freshness_impact_distribution(candidates: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        source_freshness = candidate.get('source_freshness')
+        if not isinstance(source_freshness, Mapping):
+            continue
+        impact = source_freshness.get('freshness_impact')
+        if _missing(impact):
+            continue
+        key = str(impact)
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _future_review_candidate_count(candidates: Sequence[Mapping[str, Any]]) -> int:
+    return sum(
+        1 for candidate in candidates
+        if isinstance(candidate.get('future_canonical_review_candidate'), Mapping)
+        and candidate['future_canonical_review_candidate'].get('marker') == 'future_canonical_review_candidate'
+    )
+
+
+def _important_review_examples(candidates: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    examples = []
+    for candidate in candidates:
+        if candidate.get('risk_class') not in {'blocked', 'risky', 'stale', 'volatile'}:
+            continue
+        source = _source(candidate)
+        examples.append({
+            'entity': candidate.get('entity'),
+            'candidate_action': candidate.get('candidate_action'),
+            'confidence': candidate.get('confidence'),
+            'reconciliation_state': candidate.get('reconciliation_state'),
+            'risk_class': candidate.get('risk_class'),
+            'risk_flags': list(candidate.get('risk_flags', [])),
+            'system_id64': source.get('system_id64'),
+            'system_name': source.get('system_name'),
+            'source_record_hash': source.get('source_record_hash'),
+            'report_only': True,
+        })
+    return sort_candidate_rows(examples)[:10]

--- a/apps/importer/src/enrichment_reconciliation_scoring.py
+++ b/apps/importer/src/enrichment_reconciliation_scoring.py
@@ -5,6 +5,23 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 
+CONFIDENCE_MODEL_SCHEMA_VERSION = 'enrichment_reconciliation_confidence/v1'
+BLOCKING_RISK_FLAGS = {
+    'ambiguous_canonical_match',
+    'ambiguous_staged_body_evidence',
+    'insufficient_identifiers',
+    'missing_staged_body_evidence',
+    'missing_station_body_name',
+}
+STALE_RISK_FLAGS = {'stale_source_evidence', 'undated_source_evidence'}
+VOLATILE_RISK_FLAGS = {'volatile_source_class', 'volatile_source_evidence'}
+RISKY_RISK_FLAGS = {
+    'canonical_difference_review',
+    'source_only_association',
+    'source_only_evidence',
+}
+
+
 def candidate_confidence(
     *,
     entity: str,
@@ -16,8 +33,12 @@ def candidate_confidence(
 ) -> dict[str, Any]:
     """Build transparent confidence metadata for a report-only candidate."""
     identifier_quality = identifier_quality_for_candidate(entity, source_identity, action)
-    risk_flags = candidate_risk_flags(action, warnings)
+    source_freshness = source_freshness_impact(source_identity)
+    risk_flags = candidate_risk_flags(action, warnings, source_identity, source_freshness)
     evidence_quality = evidence_quality_for_candidate(action, identifier_quality, canonical_matches, differences)
+    reconciliation_state = reconciliation_state_for_candidate(action, canonical_matches, risk_flags)
+    risk_class = risk_class_for_candidate(risk_flags)
+    review_classifications = review_classifications_for_candidate(reconciliation_state, risk_flags)
 
     if action in {'insufficient_evidence', 'ambiguous_match'}:
         confidence = 'low'
@@ -30,13 +51,22 @@ def candidate_confidence(
     else:
         confidence = 'low'
 
+    confidence = confidence_after_freshness(confidence, source_freshness, risk_flags)
+    future_review_candidate = future_canonical_review_marker(
+        action=action,
+        risk_class=risk_class,
+        risk_flags=risk_flags,
+    )
     return {
+        'confidence_model_version': CONFIDENCE_MODEL_SCHEMA_VERSION,
         'confidence': confidence,
+        'confidence_level': confidence,
         'confidence_reasons': confidence_reasons(
             action=action,
             identifier_quality=identifier_quality,
             evidence_quality=evidence_quality,
             risk_flags=risk_flags,
+            source_freshness=source_freshness,
             differences=differences,
         ),
         'confidence_explanations': confidence_explanations(
@@ -44,12 +74,22 @@ def candidate_confidence(
             identifier_quality=identifier_quality,
             evidence_quality=evidence_quality,
             risk_flags=risk_flags,
+            source_freshness=source_freshness,
+            reconciliation_state=reconciliation_state,
+            risk_class=risk_class,
             differences=differences,
         ),
         'evidence_quality': evidence_quality,
         'identifier_quality': identifier_quality,
+        'reconciliation_state': reconciliation_state,
+        'risk_class': risk_class,
         'risk_flags': risk_flags,
         'risk_explanations': risk_explanations(risk_flags),
+        'review_classifications': review_classifications,
+        'source_freshness': source_freshness,
+        'future_canonical_review_candidate': future_review_candidate,
+        'report_only': True,
+        'canonical_writes_planned': 0,
     }
 
 
@@ -87,14 +127,30 @@ def identifier_quality_for_candidate(entity: str, source_identity: Mapping[str, 
     return 'missing'
 
 
-def candidate_risk_flags(action: str, warnings: Sequence[Mapping[str, Any]]) -> list[str]:
+def candidate_risk_flags(
+    action: str,
+    warnings: Sequence[Mapping[str, Any]],
+    source_identity: Mapping[str, Any],
+    source_freshness: Mapping[str, Any],
+) -> list[str]:
     flags: list[str] = []
     if action == 'ambiguous_match':
         flags.append('ambiguous_canonical_match')
     if action == 'insufficient_evidence':
         flags.append('insufficient_identifiers')
+    if action == 'candidate_update':
+        flags.append('canonical_difference_review')
+    if action == 'candidate_insert_missing_canonical':
+        flags.append('source_only_evidence')
     if any(warning.get('reason') == 'volatile_source_evidence_not_canonical_update' for warning in warnings):
         flags.append('volatile_source_evidence')
+    if source_identity.get('source_class') == 'volatile':
+        flags.append('volatile_source_class')
+    freshness_impact = source_freshness.get('freshness_impact')
+    if freshness_impact == 'file_snapshot_review':
+        flags.append('stale_source_evidence')
+    elif freshness_impact == 'undated_source_review':
+        flags.append('undated_source_evidence')
     return sorted(flags)
 
 
@@ -115,18 +171,223 @@ def evidence_quality_for_candidate(
     return 'weak'
 
 
+def source_freshness_impact(source_identity: Mapping[str, Any]) -> dict[str, Any]:
+    freshness_class = source_identity.get('freshness_class')
+    source_updated_at = source_identity.get('source_updated_at')
+    if freshness_class == 'source_updated_at' and not _missing(source_updated_at):
+        freshness_impact = 'timestamped_source'
+        review_reason = 'source_timestamp_present'
+    elif freshness_class == 'file_snapshot':
+        freshness_impact = 'file_snapshot_review'
+        review_reason = 'file_snapshot_without_record_timestamp'
+    elif _missing(source_updated_at):
+        freshness_impact = 'undated_source_review'
+        review_reason = 'source_updated_at_missing'
+    else:
+        freshness_impact = 'source_timestamp_unknown_semantics'
+        review_reason = 'source_timestamp_semantics_need_review'
+    return {
+        'freshness_class': freshness_class,
+        'source_updated_at': source_updated_at,
+        'freshness_impact': freshness_impact,
+        'review_reason': review_reason,
+        'wall_clock_age_threshold_applied': False,
+    }
+
+
+def reconciliation_state_for_candidate(
+    action: str,
+    canonical_matches: Sequence[Mapping[str, Any]],
+    risk_flags: Sequence[str],
+) -> str:
+    if set(risk_flags) & BLOCKING_RISK_FLAGS:
+        return 'blocked'
+    if action == 'no_change' and len(canonical_matches) == 1:
+        return 'confirmed'
+    if action in {'candidate_insert_missing_canonical', 'candidate_update'}:
+        return 'source_only'
+    if action == 'insufficient_evidence':
+        return 'unresolved'
+    return 'unknown'
+
+
+def risk_class_for_candidate(risk_flags: Sequence[str]) -> str:
+    flags = set(risk_flags)
+    if flags & BLOCKING_RISK_FLAGS:
+        return 'blocked'
+    if flags & VOLATILE_RISK_FLAGS:
+        return 'volatile'
+    if flags & STALE_RISK_FLAGS:
+        return 'stale'
+    if flags & RISKY_RISK_FLAGS:
+        return 'risky'
+    return 'clear'
+
+
+def review_classifications_for_candidate(
+    reconciliation_state: str,
+    risk_flags: Sequence[str],
+) -> list[str]:
+    classifications = {'report_only', reconciliation_state}
+    flags = set(risk_flags)
+    if flags & BLOCKING_RISK_FLAGS:
+        classifications.add('blocked')
+        classifications.add('unknown')
+    if flags & RISKY_RISK_FLAGS:
+        classifications.add('risky')
+    if flags & STALE_RISK_FLAGS:
+        classifications.add('stale')
+    if flags & VOLATILE_RISK_FLAGS:
+        classifications.add('volatile')
+    if reconciliation_state == 'source_only':
+        classifications.add('source_only')
+    if reconciliation_state in {'unknown', 'unresolved'}:
+        classifications.add('unknown')
+    return sorted(classifications)
+
+
+def confidence_after_freshness(
+    confidence: str,
+    source_freshness: Mapping[str, Any],
+    risk_flags: Sequence[str],
+) -> str:
+    if source_freshness.get('freshness_impact') == 'timestamped_source':
+        return confidence
+    if set(risk_flags) & BLOCKING_RISK_FLAGS:
+        return 'low'
+    if confidence == 'high':
+        return 'medium'
+    return confidence
+
+
+def future_canonical_review_marker(
+    *,
+    action: str,
+    risk_class: str,
+    risk_flags: Sequence[str],
+) -> dict[str, Any]:
+    is_candidate = action in {
+        'candidate_insert_missing_canonical',
+        'candidate_update',
+        'station_body_supported_by_staged_body',
+    }
+    if risk_class == 'blocked':
+        marker = 'blocked_from_future_canonical_review'
+    elif is_candidate:
+        marker = 'future_canonical_review_candidate'
+    else:
+        marker = 'not_a_future_canonical_review_candidate'
+    return {
+        'marker': marker,
+        'report_only': True,
+        'auto_promote_to_canonical': False,
+        'canonical_writes_planned': 0,
+        'reason': future_review_reason(action, risk_class, risk_flags),
+    }
+
+
+def future_review_reason(action: str, risk_class: str, risk_flags: Sequence[str]) -> str:
+    if risk_class == 'blocked':
+        return 'blocked risk flags require manual resolution before any future design review'
+    if action == 'candidate_update':
+        return 'stable staged fields differ from canonical data; review only, no automatic eligibility'
+    if action == 'candidate_insert_missing_canonical':
+        return 'source evidence has no canonical match; review only, no automatic insert eligibility'
+    if action == 'station_body_supported_by_staged_body':
+        return 'station/body association is staged-source supported; review only, no automatic link eligibility'
+    if risk_flags:
+        return 'candidate has review-only risk flags'
+    return 'candidate does not propose a future canonical review action'
+
+
+def association_confidence_metadata(
+    *,
+    action: str,
+    confidence: str,
+    source_identity: Mapping[str, Any],
+    risk_flags: Sequence[str],
+) -> dict[str, Any]:
+    source_freshness = source_freshness_impact(source_identity)
+    combined_risk_flags = sorted(set(risk_flags) | set(_freshness_risk_flags(source_freshness)))
+    risk_class = risk_class_for_candidate(combined_risk_flags)
+    reconciliation_state = association_reconciliation_state(action)
+    confidence = confidence_after_freshness(confidence, source_freshness, combined_risk_flags)
+    return {
+        'confidence_model_version': CONFIDENCE_MODEL_SCHEMA_VERSION,
+        'confidence': confidence,
+        'confidence_level': confidence,
+        'confidence_reasons': confidence_reasons(
+            action=action,
+            identifier_quality='source_body_name',
+            evidence_quality='moderate' if action == 'station_body_supported_by_staged_body' else 'weak',
+            risk_flags=combined_risk_flags,
+            source_freshness=source_freshness,
+            differences=[],
+        ),
+        'confidence_explanations': confidence_explanations(
+            action=action,
+            identifier_quality='source_body_name',
+            evidence_quality='moderate' if action == 'station_body_supported_by_staged_body' else 'weak',
+            risk_flags=combined_risk_flags,
+            source_freshness=source_freshness,
+            reconciliation_state=reconciliation_state,
+            risk_class=risk_class,
+            differences=[],
+        ),
+        'evidence_quality': 'moderate' if action == 'station_body_supported_by_staged_body' else 'weak',
+        'identifier_quality': 'source_body_name',
+        'reconciliation_state': reconciliation_state,
+        'risk_class': risk_class,
+        'risk_flags': combined_risk_flags,
+        'risk_explanations': risk_explanations(combined_risk_flags),
+        'review_classifications': review_classifications_for_candidate(
+            reconciliation_state,
+            combined_risk_flags,
+        ),
+        'source_freshness': source_freshness,
+        'future_canonical_review_candidate': future_canonical_review_marker(
+            action=action,
+            risk_class=risk_class,
+            risk_flags=combined_risk_flags,
+        ),
+        'report_only': True,
+        'canonical_writes_planned': 0,
+    }
+
+
+def association_reconciliation_state(action: str) -> str:
+    if action == 'station_body_supported_by_staged_body':
+        return 'inferred_verify'
+    if action in {'station_body_name_missing', 'station_body_unresolved_staged_body'}:
+        return 'unresolved'
+    if action == 'station_body_ambiguous_staged_body':
+        return 'blocked'
+    return 'unknown'
+
+
+def _freshness_risk_flags(source_freshness: Mapping[str, Any]) -> list[str]:
+    freshness_impact = source_freshness.get('freshness_impact')
+    if freshness_impact == 'file_snapshot_review':
+        return ['stale_source_evidence']
+    if freshness_impact == 'undated_source_review':
+        return ['undated_source_evidence']
+    return []
+
+
 def confidence_reasons(
     *,
     action: str,
     identifier_quality: str,
     evidence_quality: str,
     risk_flags: Sequence[str],
+    source_freshness: Mapping[str, Any],
     differences: Sequence[Mapping[str, Any]],
 ) -> list[str]:
     reasons = [
         f'action:{action}',
         f'identifier_quality:{identifier_quality}',
         f'evidence_quality:{evidence_quality}',
+        f"freshness_impact:{source_freshness.get('freshness_impact')}",
     ]
     if differences:
         reasons.append('stable_field_differences_present')
@@ -140,12 +401,18 @@ def confidence_explanations(
     identifier_quality: str,
     evidence_quality: str,
     risk_flags: Sequence[str],
+    source_freshness: Mapping[str, Any],
+    reconciliation_state: str,
+    risk_class: str,
     differences: Sequence[Mapping[str, Any]],
 ) -> list[str]:
     explanations = [
         _action_explanation(action),
         f'Identifier quality is {identifier_quality}.',
         f'Evidence quality is {evidence_quality}.',
+        f'Reconciliation state is {reconciliation_state}.',
+        f'Risk class is {risk_class}.',
+        _freshness_explanation(source_freshness),
         'Output is report-only; it is not a write plan.',
     ]
     if differences:
@@ -157,7 +424,16 @@ def confidence_explanations(
 def risk_explanations(risk_flags: Sequence[str]) -> list[str]:
     mapping = {
         'ambiguous_canonical_match': 'Multiple canonical rows matched; manual review is required.',
+        'ambiguous_staged_body_evidence': 'More than one staged body row matched this station body_name.',
+        'canonical_difference_review': 'Stable source evidence differs from canonical data; keep it in review.',
         'insufficient_identifiers': 'Source evidence is missing identifiers needed for a canonical conclusion.',
+        'missing_staged_body_evidence': 'No staged body row supports this station body_name.',
+        'missing_station_body_name': 'Station evidence has no body_name; association remains unknown.',
+        'source_only_association': 'Station/body association is supported only by staged source evidence.',
+        'source_only_evidence': 'Source evidence has no trusted canonical match and remains source-only.',
+        'stale_source_evidence': 'Source evidence came from a file snapshot without a record timestamp; review freshness.',
+        'undated_source_evidence': 'Source evidence has no source_updated_at timestamp; freshness remains unknown.',
+        'volatile_source_class': 'The source class is volatile and must remain review-only evidence.',
         'volatile_source_evidence': 'Volatile source evidence is retained for review and must not churn canonical rows.',
     }
     return [mapping[flag] for flag in sorted(risk_flags) if flag in mapping]
@@ -170,7 +446,22 @@ def _action_explanation(action: str) -> str:
         'candidate_update': 'One canonical row matched, but stable staged fields differ.',
         'insufficient_evidence': 'Staged evidence is too sparse to reconcile.',
         'no_change': 'Staged evidence matches one canonical row.',
+        'station_body_ambiguous_staged_body': 'Station body_name matched more than one staged body row.',
+        'station_body_name_missing': 'Station evidence has no source body_name.',
+        'station_body_supported_by_staged_body': 'Station body_name is supported by exactly one staged body row.',
+        'station_body_unresolved_staged_body': 'Station body_name has no matching staged body row.',
     }.get(action, f'Reconciliation action is {action}.')
+
+
+def _freshness_explanation(source_freshness: Mapping[str, Any]) -> str:
+    impact = source_freshness.get('freshness_impact')
+    if impact == 'timestamped_source':
+        return 'Source freshness is timestamped by source_updated_at.'
+    if impact == 'file_snapshot_review':
+        return 'Source freshness depends on the snapshot file and needs operator review.'
+    if impact == 'undated_source_review':
+        return 'Source freshness is unknown because source_updated_at is missing.'
+    return 'Source freshness semantics need review.'
 
 
 def _missing(value: Any) -> bool:

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -419,6 +419,14 @@ source identity conflicts, high-value systems needing better evidence, and
 source type/source-format coverage. It remains dry-run/report-only and does
 not promote source-only evidence to canonical truth.
 
+Stage 18F hardens reconciliation confidence as a versioned, report-only model.
+Candidates now carry deterministic confidence levels, reason codes, source
+freshness impact, risk classes, review classifications, and future canonical
+review markers that explicitly disable auto-promotion. These labels explain
+confirmed, inferred/verify, unresolved, source-only, stale, volatile, blocked,
+report-only, and unknown states for operator review only; they do not change
+planner scoring, canonical write eligibility, or any production job wiring.
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -139,7 +139,12 @@ Stage 18B broadens the read-only reconciliation report with named sections:
   versioned as `enrichment_warehouse_coverage_report/v1`, deterministic, and
   report-only.
 * `confidence_risk_summary` keeps aggregate confidence, identifier/evidence
-  quality, and risk-flag distributions explainable.
+  quality, risk-class, review-classification, source-freshness-impact, and
+  future-review-marker distributions explainable. Stage 18F keeps this model
+  report-only and versioned as `enrichment_reconciliation_confidence/v1`;
+  blocked, risky, stale, volatile, source-only, confirmed, inferred/verify,
+  unresolved, report-only, and unknown states are labels for operator review,
+  not canonical eligibility or write instructions.
 * `analytics_signals`, `colonisation_signals`, and `mission_density_signals`
   are embedded as report-only signal sections with
   `canonical_writes_planned = 0`.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -305,7 +305,11 @@ Important sections:
   identity conflicts, high-value systems needing better evidence, and source
   type/source-format coverage.
 - `confidence_risk_summary`: confidence, evidence quality, identifier quality,
-  and risk-flag distributions.
+  reconciliation state, risk-class, review-classification, source-freshness
+  impact, future-review-marker, and risk-flag distributions. Stage 18F
+  confidence fields explain why a candidate is confirmed, inferred/verify,
+  unresolved, source-only, stale, volatile, blocked, report-only, or unknown;
+  they are not canonical eligibility or write instructions.
 
 Candidate actions to expect:
 
@@ -329,6 +333,8 @@ Warnings that block any later stage:
   filters
 - any non-zero `errors`
 - any report that omits `canonical_writes_planned = 0`
+- confidence/risk output that labels a candidate as a future canonical review
+  candidate without also keeping `auto_promote_to_canonical = false`
 
 Coverage report rules:
 

--- a/tests/test_enrichment_staging_reconciliation.py
+++ b/tests/test_enrichment_staging_reconciliation.py
@@ -301,6 +301,12 @@ def test_station_candidate_missing_canonical_becomes_insert_candidate():
     assert candidate['candidate_action'] == 'candidate_insert_missing_canonical'
     assert candidate['source']['station_name'] == 'Test Port'
     assert candidate['canonical'] is None
+    assert candidate['reconciliation_state'] == 'source_only'
+    assert candidate['risk_class'] == 'risky'
+    assert candidate['risk_flags'] == ['source_only_evidence']
+    assert candidate['review_classifications'] == ['report_only', 'risky', 'source_only']
+    assert candidate['future_canonical_review_candidate']['marker'] == 'future_canonical_review_candidate'
+    assert candidate['future_canonical_review_candidate']['canonical_writes_planned'] == 0
     assert report['summary']['canonical_misses'] == 1
     assert_read_only_sql(conn)
 
@@ -313,9 +319,16 @@ def test_station_candidate_matching_canonical_data_is_no_change():
     candidate = report['station_candidates'][0]
     assert candidate['candidate_action'] == 'no_change'
     assert candidate['confidence'] == 'high'
+    assert candidate['confidence_level'] == 'high'
+    assert candidate['confidence_model_version'] == 'enrichment_reconciliation_confidence/v1'
     assert candidate['identifier_quality'] == 'stable'
     assert candidate['evidence_quality'] == 'strong'
+    assert candidate['reconciliation_state'] == 'confirmed'
+    assert candidate['risk_class'] == 'clear'
+    assert candidate['review_classifications'] == ['confirmed', 'report_only']
+    assert candidate['source_freshness']['freshness_impact'] == 'timestamped_source'
     assert candidate['risk_flags'] == []
+    assert candidate['future_canonical_review_candidate']['marker'] == 'not_a_future_canonical_review_candidate'
     assert candidate['canonical']['station_id'] == 1001
     assert candidate['differences'] == []
     assert report['summary']['canonical_matches_found'] == 1
@@ -332,8 +345,13 @@ def test_station_candidate_differing_staged_evidence_is_candidate_update():
     candidate = report['station_candidates'][0]
     assert candidate['candidate_action'] == 'candidate_update'
     assert candidate['confidence'] == 'medium'
+    assert candidate['confidence_model_version'] == 'enrichment_reconciliation_confidence/v1'
     assert candidate['identifier_quality'] == 'stable'
-    assert candidate['risk_flags'] == []
+    assert candidate['risk_class'] == 'risky'
+    assert candidate['reconciliation_state'] == 'source_only'
+    assert candidate['risk_flags'] == ['canonical_difference_review']
+    assert candidate['future_canonical_review_candidate']['marker'] == 'future_canonical_review_candidate'
+    assert candidate['future_canonical_review_candidate']['auto_promote_to_canonical'] is False
     assert candidate['differences'] == [
         {'field': 'station_type', 'staged': 'Ocellus Starport', 'canonical': 'Orbis Starport'},
     ]
@@ -353,6 +371,9 @@ def test_station_ambiguous_match_is_not_guessed():
     assert candidate['candidate_action'] == 'ambiguous_match'
     assert candidate['confidence'] == 'low'
     assert candidate['identifier_quality'] == 'ambiguous'
+    assert candidate['risk_class'] == 'blocked'
+    assert candidate['reconciliation_state'] == 'blocked'
+    assert candidate['review_classifications'] == ['blocked', 'report_only', 'unknown']
     assert candidate['risk_flags'] == ['ambiguous_canonical_match']
     assert candidate['canonical'] is None
     assert [row['station_id'] for row in candidate['canonical_matches']] == [1001, 1002]
@@ -410,8 +431,13 @@ def test_station_body_association_candidates_are_report_only():
     assert candidate['entity'] == 'station_body_association'
     assert candidate['candidate_action'] == 'station_body_supported_by_staged_body'
     assert candidate['confidence'] == 'medium'
+    assert candidate['reconciliation_state'] == 'inferred_verify'
+    assert candidate['risk_class'] == 'risky'
+    assert candidate['review_classifications'] == ['inferred_verify', 'report_only', 'risky']
     assert candidate['report_only'] is True
     assert candidate['canonical_link_writes_planned'] == 0
+    assert candidate['future_canonical_review_candidate']['marker'] == 'future_canonical_review_candidate'
+    assert candidate['future_canonical_review_candidate']['auto_promote_to_canonical'] is False
     assert candidate['source']['station_name'] == 'Test Port'
     assert candidate['source']['body_name'] == 'Test 7'
     assert candidate['matched_body_evidence'] == [{
@@ -469,6 +495,8 @@ def test_sparse_staged_records_become_insufficient_evidence():
     assert report['station_candidates'][0]['candidate_action'] == 'insufficient_evidence'
     assert report['station_candidates'][0]['confidence'] == 'low'
     assert report['station_candidates'][0]['identifier_quality'] == 'missing'
+    assert report['station_candidates'][0]['risk_class'] == 'blocked'
+    assert 'unknown' in report['station_candidates'][0]['review_classifications']
     assert report['station_candidates'][0]['risk_flags'] == ['insufficient_identifiers']
     assert report['body_candidates'][0]['candidate_action'] == 'insufficient_evidence'
     assert report['body_candidates'][0]['confidence'] == 'low'
@@ -489,10 +517,14 @@ def test_volatile_only_station_difference_does_not_raise_update_confidence():
     assert candidate['candidate_action'] == 'no_change'
     assert candidate['differences'] == []
     assert candidate['confidence'] == 'medium'
+    assert candidate['risk_class'] == 'volatile'
+    assert candidate['reconciliation_state'] == 'confirmed'
+    assert candidate['review_classifications'] == ['confirmed', 'report_only', 'volatile']
     assert candidate['risk_flags'] == ['volatile_source_evidence']
     assert candidate['risk_explanations'] == [
         'Volatile source evidence is retained for review and must not churn canonical rows.',
     ]
+    assert 'Risk class is volatile.' in candidate['confidence_explanations']
     assert 'Output is report-only; it is not a write plan.' in candidate['confidence_explanations']
     assert candidate['warnings'] == [{
         'entity': 'station',
@@ -500,6 +532,61 @@ def test_volatile_only_station_difference_does_not_raise_update_confidence():
         'reason': 'volatile_source_evidence_not_canonical_update',
         'source_record_hash': 'station-hash',
     }]
+    assert_read_only_sql(conn)
+
+
+def test_stale_source_freshness_is_visible_without_wall_clock_threshold():
+    conn = FakeConn(station_rows=[
+        station_row(
+            freshness_class='file_snapshot',
+            source_updated_at=None,
+        ),
+    ])
+
+    report = db_loader.build_reconciliation_report(conn, source='edsm_nightly_stations')
+
+    candidate = report['station_candidates'][0]
+    assert candidate['candidate_action'] == 'no_change'
+    assert candidate['confidence'] == 'medium'
+    assert candidate['reconciliation_state'] == 'confirmed'
+    assert candidate['risk_class'] == 'stale'
+    assert candidate['risk_flags'] == ['stale_source_evidence']
+    assert candidate['review_classifications'] == ['confirmed', 'report_only', 'stale']
+    assert candidate['source_freshness'] == {
+        'freshness_class': 'file_snapshot',
+        'source_updated_at': None,
+        'freshness_impact': 'file_snapshot_review',
+        'review_reason': 'file_snapshot_without_record_timestamp',
+        'wall_clock_age_threshold_applied': False,
+    }
+    assert 'freshness_impact:file_snapshot_review' in candidate['confidence_reasons']
+
+    summary = report['confidence_risk_summary']
+    assert summary['risk_class_distribution'] == {'blocked': 1, 'stale': 1}
+    assert summary['source_freshness_impact_distribution'] == {'file_snapshot_review': 2}
+    assert summary['review_classification_distribution']['stale'] == 2
+    assert_read_only_sql(conn)
+
+
+def test_undated_source_freshness_preserves_unknown_not_false():
+    conn = FakeConn(body_rows=[
+        body_row(
+            freshness_class=None,
+            source_updated_at=None,
+        ),
+    ])
+
+    report = db_loader.build_reconciliation_report(conn, source='edsm_nightly_bodies')
+
+    candidate = report['body_candidates'][0]
+    assert candidate['candidate_action'] == 'no_change'
+    assert candidate['confidence'] == 'medium'
+    assert candidate['risk_class'] == 'stale'
+    assert candidate['risk_flags'] == ['undated_source_evidence']
+    assert candidate['source_freshness']['freshness_impact'] == 'undated_source_review'
+    assert candidate['source_freshness']['wall_clock_age_threshold_applied'] is False
+    assert 'undated_source_evidence' in candidate['risk_flags']
+    assert report['summary']['canonical_writes_planned'] == 0
     assert_read_only_sql(conn)
 
 


### PR DESCRIPTION
## What changed

* Hardens reconciliation confidence/risk explanations.
* Adds or improves source-labelled confidence reasons, risk classes, freshness impact, volatile evidence handling, and report-only review markers.
* Keeps reconciliation output report-only and deterministic.

## Boundaries

* No canonical writes.
* No production scheduler/job wiring.
* No live EDSM/API crawl.
* No Docker invocation.
* No planner/search/scoring/optimiser changes.
* Dry-run/report-only remains default.
* Unknown data remains unknown.
* Source-only evidence remains source-only.

## Validation

* `.venv/bin/pytest tests/test_enrichment_staging.py tests/test_enrichment_snapshot_loader.py -q` -> 28 passed
* `.venv/bin/pytest tests/test_enrichment_staging_reconciliation.py -q` -> 19 passed
* `.venv/bin/pytest tests/test_enrichment_body_ring_staging_loader.py -q` -> 18 passed
* `.venv/bin/pytest tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_warehouse_repository.py tests/test_enrichment_analytics.py tests/test_enrichment_report_contracts.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_write_plans.py tests/test_body_ring_enrichment_plan.py -q` -> 77 passed
* `.venv/bin/pytest tests/test_station_enrichment_status.py tests/test_station_enrichment_guard.py -q` -> 41 passed
* `.venv/bin/pytest tests/test_smoke.py -q` -> 56 passed
* `.venv/bin/python -m py_compile apps/importer/src/enrichment_reconciliation.py apps/importer/src/enrichment_reconciliation_scoring.py` -> passed
* `rg -n "enrichment_reconciliation|enrichment_analytics|enrichment_warehouse|enrichment_staged_reports|confidence|risk" tests apps/importer/src` -> completed; additional relevant non-smoke enrichment tests are included above
* `git diff --check` -> passed