### PR TITLE
Stage 18H warehouse-to-planner evidence bridge

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -435,6 +435,21 @@ records, and canonical-safety flags. Missing or invalid artifacts remain
 unavailable/unknown; the panel does not run warehouse scripts, query the
 warehouse, call live APIs, or add write controls.
 
+Stage 18H adds a read-only warehouse-to-planner evidence bridge. It lets the
+Colony Planner present selected warehouse/report-only evidence as evidence, not
+truth. Because the Stage 18G warehouse artifact is admin-token-gated and
+aggregate-only (it carries review counts, not per-`system_id64` rows), there is
+no safe key to link warehouse evidence to a planner system yet. Per the stage
+decision gate, Stage 18H ships the conservative path: a typed read-only
+`PlannerWarehouseEvidence` model, a compact source-labelled planner card that
+defaults to a safe unavailable/unknown state, tests proving the unavailable
+state and no-mutation guarantee, and a design doc with the future per-system
+integration path
+(`docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md`).
+It adds no backend endpoint, makes no live calls, and never mutates planner,
+Build Plan, role, observed-evidence, validation, scoring, Preview, optimiser, or
+canonical state.
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -164,6 +164,19 @@ warehouse database, generate reports, invoke Docker, call live APIs, or write
 canonical rows. Operators publish the artifact from a separate reviewed
 warehouse run, usually a reconciliation report.
 
+## Planner Evidence Bridge (Stage 18H)
+
+Stage 18H surfaces warehouse evidence in the Colony Planner as report-only
+evidence, not canonical truth. The current Stage 18G warehouse artifact is
+admin-token-gated and aggregate-only, so it cannot be safely joined to a planner
+system by `system_id64`. Following the stage decision gate, Stage 18H ships a
+typed read-only model (`PlannerWarehouseEvidence`), a compact source-labelled
+planner card that defaults to a safe unavailable/unknown state, no-mutation
+tests, and a design doc with the future per-system artifact contract. It adds no
+backend endpoint and makes no live calls. See
+`stage-18h-warehouse-planner-evidence-bridge.md` for the artifact contract and
+integration path.
+
 ## Offline Fixture Loader
 
 Run from the repo root:

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -375,6 +375,15 @@ Acceptance:
 
 - The planner can display warehouse evidence context without treating report-only evidence as canonical data.
 
+Status: delivered (conservative placeholder path). The Stage 18G warehouse
+artifact is admin-gated and aggregate-only, so per-system linking is not yet
+safe. Stage 18H shipped a typed read-only `PlannerWarehouseEvidence` model, a
+compact source-labelled planner card defaulting to a safe unavailable/unknown
+state, no-mutation tests, and a design doc with the future per-system
+integration path
+(`stage-18h-warehouse-planner-evidence-bridge.md`). No backend endpoint, no live
+calls, no canonical or planner state mutation.
+
 ### Stage 18I — Canonical Write Design Review
 
 Purpose: design, but not implement, the rules for promoting warehouse evidence into canonical data.

--- a/docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md
+++ b/docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md
@@ -1,0 +1,160 @@
+# Stage 18H — Warehouse-to-Planner Evidence Bridge (Read-Only)
+
+Stage 18H lets the Colony Planner *see* selected warehouse/report-only evidence
+as **evidence, not truth**. It is strictly read-only. It does not mutate planner
+state, Build Plans, scoring, CP, economy/service, buildability, Simulation
+Preview, optimiser output, roles, observed evidence, validation, or canonical
+data.
+
+## Decision Gate Outcome
+
+Stage 18H reached the architectural decision gate defined in the stage brief and
+took the **conservative placeholder path**. The reasons are concrete and come
+from the existing Stage 18G implementation, not from caution alone:
+
+1. **Warehouse evidence is admin-gated.** The only published warehouse evidence
+   surface is the Stage 18G Admin panel, served by
+   `GET /api/admin/enrichment/warehouse-status`, which requires the admin token
+   (`apps/api/src/routers/admin.py`). The Colony Planner is a normal
+   user-facing workspace. Reusing the admin-gated artifact in the planner would
+   leak operator-only data to non-admin users.
+2. **The artifact is aggregate-only.** `sanitize_warehouse_status`
+   (`apps/api/src/enrichment_operator_status.py`) returns *counts and
+   distributions* only — `systems_with_station_evidence`,
+   `unresolved_stations`, `blocked_conflicts`, `risky_conflicts`,
+   `stale_records`, etc. It contains **no `system_id64`** and no per-system
+   evidence rows. There is no key on which to join warehouse evidence to the
+   planner's current system.
+3. **The runbook forbids planner coupling.** `docs/operations/enrichment-warehouse-runbook.md`
+   ("What Not To Do") explicitly says: *"Do not change planner, search, scoring,
+   optimiser, Simulation Preview, Suggested Build, or role behavior from
+   warehouse report output."*
+
+The stage brief is explicit: *"If warehouse evidence cannot be safely linked by
+system ID or artifact metadata, show a safe unavailable state instead of
+guessing"* and *"Do not force full planner UI integration if the access boundary
+is not safe."*
+
+Therefore Stage 18H implements:
+
+- a typed, read-only planner evidence model (`PlannerWarehouseEvidence`),
+- a compact, pure, read-only planner card that **defaults to a safe
+  unavailable/report-only state**,
+- tests proving the unavailable state, the source-labelled report-only labels,
+  the stale/risky/blocked wording, source separation, and the absence of any
+  mutation, and
+- this design document plus a clear future integration path.
+
+It does **not** add a planner-facing warehouse API endpoint, does not fetch any
+data, and does not link warehouse evidence to a specific system, because no safe
+per-system artifact contract exists yet.
+
+## What the Planner Card Shows
+
+The card is a presentation-only React component
+(`frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.tsx`). It takes
+an optional `evidence?: PlannerWarehouseEvidence` prop and renders:
+
+- A persistent source-boundary line:
+  *"Planner is using canonical data; warehouse evidence is report-only."*
+- When no evidence model is supplied (the default today): a safe unavailable
+  state — *"No warehouse evidence artifact is available."* — with an
+  `unknown` source label.
+- When an evidence model *is* supplied (future integration, and exercised by
+  tests): conservative, source-labelled findings using only the approved
+  vocabulary — `report-only`, `needs review`, `verify`, `unresolved`, `stale`,
+  `blocked`, `unknown`.
+
+The card never renders a button, toggle, form, or any control that could mutate
+planner state. It has no callbacks.
+
+## Typed Model
+
+`frontend-v2/src/types/api.ts` adds a small read-only model:
+
+```ts
+type WarehouseEvidenceSource =
+  | 'canonical'
+  | 'observed'
+  | 'warehouse_report_only'
+  | 'unknown';
+
+type WarehouseEvidenceAvailability =
+  | 'unavailable'   // no artifact / not safely linkable -> stays unknown
+  | 'report_only';  // a report-only evidence summary is present
+
+type WarehouseEvidenceLabel =
+  | 'report_only'
+  | 'needs_review'
+  | 'verify'
+  | 'unresolved'
+  | 'stale'
+  | 'blocked'
+  | 'unknown';
+
+interface PlannerWarehouseEvidenceItem {
+  label: WarehouseEvidenceLabel;
+  source: WarehouseEvidenceSource;
+  summary: string;          // short, human, no secrets/paths
+}
+
+interface PlannerWarehouseEvidence {
+  availability: WarehouseEvidenceAvailability;
+  // Always true in Stage 18H: warehouse evidence is never canonical truth.
+  reportOnly: true;
+  items: PlannerWarehouseEvidenceItem[];
+}
+```
+
+`availability: 'unavailable'` is the default and means *unknown*, never
+"no evidence exists" and never "false". Missing artifacts/status stay
+unavailable/unknown.
+
+## Boundaries Held
+
+- Read-only only; no canonical writes; no planner/Build Plan/role/evidence/
+  validation mutation.
+- No automatic Suggested Build generation or load; no automatic Preview; no
+  optimiser changes.
+- No live EDSM/API crawl, no Docker invocation, no production scheduler/job
+  wiring, no new backend endpoint.
+- Report-only warehouse evidence is never treated as canonical truth and never
+  overrides canonical app data or infrastructure counts.
+- Missing artifact/status remains unavailable/unknown.
+- Source labels (`canonical`, `observed`, `warehouse_report_only`, `unknown`)
+  are always visible.
+- No secrets, DSNs, file paths, or private operator details are exposed; the
+  model carries only short human summaries chosen by the caller.
+
+## Future Integration Path
+
+To safely surface *per-system* warehouse evidence in the user planner later, a
+future stage (after the Stage 18I canonical-write design review and the Stage
+18I.5 database-boundary review) would need:
+
+1. **A per-system, report-only artifact contract.** Operators would publish a
+   sanitized JSON artifact keyed by `system_id64`, e.g.
+   `warehouse_planner_evidence/v1`, derived from the read-only reconciliation
+   report. It must carry source labels, freshness, and conservative labels, and
+   must never include canonical write instructions, secrets, DSNs, or paths.
+2. **A read-only, appropriately-gated endpoint.** Either a non-admin,
+   read-only endpoint that serves only the sanitized per-system evidence
+   summary, or an explicit product decision that this remains operator-only.
+   The access boundary must be decided deliberately, not inherited from the
+   admin token by accident.
+3. **A safe-join key.** The planner would request evidence by the current
+   system's `id64`. If the artifact has no entry for that system, the card
+   stays `unavailable` (unknown), never `false`.
+4. **Unchanged trust semantics.** Even fully wired, warehouse evidence remains
+   `reportOnly` and source-labelled; it must not mutate Build Plans, roles,
+   observed evidence, validation, scoring, Preview, or optimiser state.
+
+Until that contract and boundary review exist, the planner card stays in its
+safe unavailable/report-only state.
+
+## Validation
+
+See the PR body for the exact commands. Stage 18H adds frontend component tests
+for the unavailable state, report-only/source-labelled rendering, stale/risky/
+blocked wording, source separation, and the no-control/no-mutation guarantee. It
+changes no backend behaviour and no canonical data.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -445,6 +445,16 @@ missing, invalid, unset, or oversized artifacts as unavailable instead of zero.
 It does not query the warehouse database, invoke Docker, call live APIs, run
 importer scripts, or write canonical data.
 
+Stage 18H adds a read-only warehouse-to-planner evidence bridge in the Colony
+Planner. It presents warehouse evidence as report-only, never canonical truth.
+Because this warehouse status artifact is admin-gated and aggregate-only (it has
+no per-`system_id64` rows), the planner card cannot safely link evidence to a
+system yet and defaults to a safe unavailable/unknown state. It adds no backend
+endpoint, makes no live calls, and changes no planner, Build Plan, role,
+observed-evidence, validation, scoring, Preview, optimiser, or canonical state.
+The future per-system artifact contract is documented in
+`docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md`.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -2,6 +2,7 @@ import { ArrowLeft, Rocket } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { WholeSystemColonyPlanner } from './WholeSystemColonyPlanner';
+import { WarehouseEvidenceCard } from './WarehouseEvidenceCard';
 import { WorkspaceHeader, WorkspaceHeaderSkeleton } from './WorkspaceHeader';
 
 export interface ColonyPlannerWorkspaceProps {
@@ -72,6 +73,14 @@ export function ColonyPlannerWorkspace({
         onOpenSystemDetail={onOpenSystemDetail}
       />
       <WholeSystemColonyPlanner system={data} />
+      {/*
+       * Stage 18H: read-only warehouse evidence bridge. No data is passed
+       * today (the warehouse artifact is admin-gated and aggregate-only with
+       * no per-system linkage), so this renders the safe unavailable/unknown
+       * state. It never mutates planner state. See
+       * docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md.
+       */}
+      <WarehouseEvidenceCard />
     </WorkspaceShell>
   );
 }

--- a/frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.test.tsx
+++ b/frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { PlannerWarehouseEvidence } from '@/types/api';
+import { WarehouseEvidenceCard } from './WarehouseEvidenceCard';
+
+/**
+ * Stage 18H — Warehouse-to-Planner Evidence Bridge (read-only).
+ *
+ * These tests pin the safe boundaries: the planner always presents warehouse
+ * evidence as report-only, defaults to an unavailable/unknown state, renders
+ * conservative source-labelled findings, and exposes NO controls that could
+ * mutate planner state.
+ */
+describe('WarehouseEvidenceCard', () => {
+  it('renders the safe unavailable/unknown state when no evidence is supplied', () => {
+    render(<WarehouseEvidenceCard />);
+
+    const card = screen.getByTestId('planner-warehouse-evidence');
+    expect(card).toBeTruthy();
+    const unavailable = within(card).getByTestId('warehouse-evidence-unavailable');
+    expect(unavailable.textContent).toContain('No warehouse evidence artifact is available.');
+    // Unknown source label, not a "no evidence" / false claim.
+    expect(within(unavailable).getByTestId('warehouse-evidence-source-unknown')).toBeTruthy();
+    expect(within(card).queryByTestId('warehouse-evidence-items')).toBeNull();
+  });
+
+  it('treats an explicitly unavailable summary the same as missing (stays unknown)', () => {
+    const evidence: PlannerWarehouseEvidence = {
+      availability: 'unavailable',
+      reportOnly: true,
+      items: [],
+    };
+    render(<WarehouseEvidenceCard evidence={evidence} />);
+
+    expect(screen.getByTestId('warehouse-evidence-unavailable')).toBeTruthy();
+    expect(screen.queryByTestId('warehouse-evidence-item')).toBeNull();
+  });
+
+  it('always states that the planner uses canonical data and warehouse evidence is report-only', () => {
+    render(<WarehouseEvidenceCard />);
+
+    expect(screen.getByTestId('warehouse-evidence-source-boundary').textContent).toBe(
+      'Planner is using canonical data; warehouse evidence is report-only.',
+    );
+    expect(screen.getByTestId('warehouse-evidence-report-only-tag').textContent).toMatch(/report-only/i);
+  });
+
+  it('renders conservative, source-labelled report-only findings when supplied', () => {
+    const evidence: PlannerWarehouseEvidence = {
+      availability: 'report_only',
+      reportOnly: true,
+      items: [
+        {
+          label: 'report_only',
+          source: 'warehouse_report_only',
+          summary: 'Warehouse has newer report-only evidence for this system.',
+        },
+        {
+          label: 'verify',
+          source: 'warehouse_report_only',
+          summary: 'Station/body association available as verify evidence.',
+        },
+      ],
+    };
+    render(<WarehouseEvidenceCard evidence={evidence} />);
+
+    const items = screen.getAllByTestId('warehouse-evidence-item');
+    expect(items).toHaveLength(2);
+    expect(screen.getByText('Warehouse has newer report-only evidence for this system.')).toBeTruthy();
+    expect(screen.getAllByTestId('warehouse-evidence-source-warehouse_report_only').length).toBe(2);
+    expect(screen.getByTestId('warehouse-evidence-label-verify')).toBeTruthy();
+    expect(screen.queryByTestId('warehouse-evidence-unavailable')).toBeNull();
+  });
+
+  it('renders stale, risky/needs-review, unresolved, and blocked findings conservatively', () => {
+    const evidence: PlannerWarehouseEvidence = {
+      availability: 'report_only',
+      reportOnly: true,
+      items: [
+        { label: 'stale', source: 'warehouse_report_only', summary: 'Warehouse coverage says this system has stale/undated source evidence.' },
+        { label: 'needs_review', source: 'warehouse_report_only', summary: 'Warehouse report has risky conflicts.' },
+        { label: 'unresolved', source: 'warehouse_report_only', summary: 'Station/body association unresolved in warehouse report.' },
+        { label: 'blocked', source: 'warehouse_report_only', summary: 'Warehouse report has blocked conflicts.' },
+      ],
+    };
+    render(<WarehouseEvidenceCard evidence={evidence} />);
+
+    expect(screen.getByTestId('warehouse-evidence-label-stale').textContent).toMatch(/stale/i);
+    expect(screen.getByTestId('warehouse-evidence-label-needs_review').textContent).toMatch(/needs review/i);
+    expect(screen.getByTestId('warehouse-evidence-label-unresolved').textContent).toMatch(/unresolved/i);
+    expect(screen.getByTestId('warehouse-evidence-label-blocked').textContent).toMatch(/blocked/i);
+    // No promotion / canonical / apply wording anywhere in the card.
+    expect(screen.getByTestId('planner-warehouse-evidence').textContent).not.toMatch(
+      /promote|apply|canonical write|make canonical|overwrite/i,
+    );
+  });
+
+  it('keeps canonical, observed, warehouse report-only, and unknown sources visually separated', () => {
+    const evidence: PlannerWarehouseEvidence = {
+      availability: 'report_only',
+      reportOnly: true,
+      items: [
+        { label: 'report_only', source: 'canonical', summary: 'Planner is using canonical data.' },
+        { label: 'report_only', source: 'observed', summary: 'Observed evidence exists separately.' },
+        { label: 'report_only', source: 'warehouse_report_only', summary: 'Warehouse report-only evidence.' },
+        { label: 'unknown', source: 'unknown', summary: 'Source not established.' },
+      ],
+    };
+    render(<WarehouseEvidenceCard evidence={evidence} />);
+
+    expect(screen.getByTestId('warehouse-evidence-source-canonical').textContent).toBe('Canonical');
+    expect(screen.getByTestId('warehouse-evidence-source-observed').textContent).toBe('Observed');
+    expect(screen.getByTestId('warehouse-evidence-source-warehouse_report_only').textContent).toBe('Warehouse report-only');
+    expect(screen.getByTestId('warehouse-evidence-source-unknown').textContent).toBe('Unknown');
+  });
+
+  it('exposes NO interactive controls (read-only, no mutation surface)', () => {
+    const evidence: PlannerWarehouseEvidence = {
+      availability: 'report_only',
+      reportOnly: true,
+      items: [
+        { label: 'report_only', source: 'warehouse_report_only', summary: 'Warehouse report-only evidence.' },
+      ],
+    };
+    const { container } = render(<WarehouseEvidenceCard evidence={evidence} />);
+
+    expect(container.querySelectorAll('button').length).toBe(0);
+    expect(container.querySelectorAll('a').length).toBe(0);
+    expect(container.querySelectorAll('input, select, textarea').length).toBe(0);
+    expect(container.querySelectorAll('[role="button"]').length).toBe(0);
+  });
+});

--- a/frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.tsx
+++ b/frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.tsx
@@ -1,0 +1,129 @@
+import type {
+  PlannerWarehouseEvidence,
+  WarehouseEvidenceLabel,
+  WarehouseEvidenceSource,
+} from '@/types/api';
+
+/**
+ * Stage 18H — Warehouse-to-Planner Evidence Bridge (read-only).
+ *
+ * A compact, presentation-only card that surfaces carefully selected warehouse
+ * / report-only evidence context inside the Colony Planner. It is EVIDENCE,
+ * NOT TRUTH.
+ *
+ * Hard boundaries (see
+ * `docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md`):
+ *   - Read-only. No callbacks, no controls, no fetch, no mutation of planner
+ *     state, Build Plans, roles, observed evidence, validation, scoring,
+ *     Simulation Preview, optimiser output, or canonical data.
+ *   - The planner always runs on canonical data; warehouse evidence is
+ *     report-only and source-labelled.
+ *   - When no evidence summary is supplied (the default today, because the
+ *     Stage 18G artifact is admin-gated and aggregate-only with no per-system
+ *     linkage), the card shows a safe unavailable/unknown state. Missing
+ *     evidence stays unknown — it never means false / no evidence.
+ */
+export interface WarehouseEvidenceCardProps {
+  /**
+   * Optional read-only evidence summary. Omitted / `null` renders the safe
+   * unavailable (unknown) state.
+   */
+  evidence?: PlannerWarehouseEvidence | null;
+}
+
+const SOURCE_LABEL: Record<WarehouseEvidenceSource, string> = {
+  canonical:             'Canonical',
+  observed:              'Observed',
+  warehouse_report_only: 'Warehouse report-only',
+  unknown:               'Unknown',
+};
+
+const FINDING_LABEL: Record<WarehouseEvidenceLabel, string> = {
+  report_only:  'Report-only',
+  needs_review: 'Needs review',
+  verify:       'Verify',
+  unresolved:   'Unresolved',
+  stale:        'Stale',
+  blocked:      'Blocked',
+  unknown:      'Unknown',
+};
+
+export function WarehouseEvidenceCard({ evidence }: WarehouseEvidenceCardProps) {
+  const isUnavailable =
+    !evidence ||
+    evidence.availability === 'unavailable' ||
+    evidence.items.length === 0;
+
+  return (
+    <aside
+      data-testid="planner-warehouse-evidence"
+      aria-label="Warehouse evidence (report-only)"
+      className="panel-thin p-3 font-mono text-[11px] text-silver-dk space-y-2"
+    >
+      <div className="flex items-center gap-2">
+        <span className="font-display tracking-[0.14em] text-orange-lt text-xs">
+          Warehouse evidence
+        </span>
+        <span
+          data-testid="warehouse-evidence-report-only-tag"
+          className="px-1.5 py-0.5 rounded border border-border bg-bg4 text-[9px] uppercase tracking-wider text-text-dim"
+        >
+          Report-only
+        </span>
+      </div>
+
+      <p
+        data-testid="warehouse-evidence-source-boundary"
+        className="leading-snug text-text-dim"
+      >
+        Planner is using canonical data; warehouse evidence is report-only.
+      </p>
+
+      {isUnavailable ? (
+        <div
+          data-testid="warehouse-evidence-unavailable"
+          className="flex items-center gap-2 border-t border-border pt-2"
+        >
+          <SourceBadge source="unknown" />
+          <span>No warehouse evidence artifact is available.</span>
+        </div>
+      ) : (
+        <ul data-testid="warehouse-evidence-items" className="space-y-1.5 border-t border-border pt-2">
+          {evidence!.items.map((item, i) => (
+            <li
+              key={`${item.label}-${item.source}-${i}`}
+              data-testid="warehouse-evidence-item"
+              className="flex flex-wrap items-center gap-1.5"
+            >
+              <FindingBadge label={item.label} />
+              <SourceBadge source={item.source} />
+              <span className="leading-snug text-text">{item.summary}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+}
+
+function SourceBadge({ source }: { source: WarehouseEvidenceSource }) {
+  return (
+    <span
+      data-testid={`warehouse-evidence-source-${source}`}
+      className="px-1.5 py-0.5 rounded border border-border bg-bg4 text-[9px] uppercase tracking-wider text-silver-dk"
+    >
+      {SOURCE_LABEL[source]}
+    </span>
+  );
+}
+
+function FindingBadge({ label }: { label: WarehouseEvidenceLabel }) {
+  return (
+    <span
+      data-testid={`warehouse-evidence-label-${label}`}
+      className="px-1.5 py-0.5 rounded border border-border bg-bg4 text-[9px] uppercase tracking-wider text-orange-lt"
+    >
+      {FINDING_LABEL[label]}
+    </span>
+  );
+}

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -205,6 +205,61 @@ export interface EnrichmentWarehouseStatus {
   errors: string[];
 }
 
+// ─── Stage 18H Warehouse-to-Planner Evidence Bridge (read-only) ───────────
+//
+// A typed, read-only model for surfacing carefully selected warehouse /
+// report-only evidence context in planner-facing UI. It is EVIDENCE, NOT
+// TRUTH. It must never mutate planner state, Build Plans, roles, observed
+// evidence, validation, scoring, Simulation Preview, optimiser output, or
+// canonical data. See
+// `docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md`.
+//
+// Stage 18H ships the model plus a safe, source-labelled placeholder card.
+// The current Stage 18G warehouse artifact is admin-gated and aggregate-only
+// (no per-system linkage), so the planner card defaults to the `unavailable`
+// (unknown) state rather than guessing. Missing evidence stays unknown — it
+// never means false / no evidence.
+
+/** Where a piece of planner evidence comes from. Always shown to the user. */
+export type WarehouseEvidenceSource =
+  | 'canonical'              // ED-Finder canonical app data (the planner's truth)
+  | 'observed'               // user/imported observed evidence
+  | 'warehouse_report_only'  // offline warehouse reconciliation report evidence
+  | 'unknown';               // source not established / not safely linkable
+
+/** Whether any warehouse evidence summary is available for display. */
+export type WarehouseEvidenceAvailability =
+  | 'unavailable'   // no artifact / not safely linkable -> remains unknown
+  | 'report_only';  // a report-only evidence summary is present
+
+/** Conservative, source-labelled finding wording. No promotion language. */
+export type WarehouseEvidenceLabel =
+  | 'report_only'
+  | 'needs_review'
+  | 'verify'
+  | 'unresolved'
+  | 'stale'
+  | 'blocked'
+  | 'unknown';
+
+export interface PlannerWarehouseEvidenceItem {
+  label:   WarehouseEvidenceLabel;
+  source:  WarehouseEvidenceSource;
+  /** Short, human-readable summary. Must not contain secrets, DSNs, or paths. */
+  summary: string;
+}
+
+export interface PlannerWarehouseEvidence {
+  availability: WarehouseEvidenceAvailability;
+  /**
+   * Always true in Stage 18H: warehouse-derived evidence is report-only and is
+   * never canonical truth. Typed as the literal `true` so callers cannot mark
+   * warehouse evidence as canonical.
+   */
+  reportOnly:   true;
+  items:        PlannerWarehouseEvidenceItem[];
+}
+
 export interface SlotReason {
   factor: string;
   delta?: number | null;


### PR DESCRIPTION
## What changed

Adds a read-only **warehouse-to-planner evidence bridge** so the Colony Planner can present selected warehouse/report-only evidence as **evidence, not truth**.

Following the stage **architectural decision gate**, this ships the conservative placeholder path. The Stage 18G warehouse status artifact (`ENRICHMENT_WAREHOUSE_STATUS_JSON_PATH`, served by the admin-token-gated `/api/admin/enrichment/warehouse-status`) is **aggregate-only** — it carries review counts, not per-`system_id64` rows — so warehouse evidence cannot be safely linked to a planner system yet.

- `frontend-v2/src/types/api.ts`: typed read-only `PlannerWarehouseEvidence` model (source labels `canonical|observed|warehouse_report_only|unknown`, availability `unavailable|report_only`, conservative finding labels, `reportOnly: true` literal).
- `frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.tsx`: compact, pure, read-only planner card. Defaults to a safe unavailable/unknown state. No callbacks, fetch, or mutation surface.
- `frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx`: renders the card compactly; no data passed today, so it shows the safe unavailable state.
- `frontend-v2/src/features/colony-planner/WarehouseEvidenceCard.test.tsx`: tests for unavailable state, report-only/source-labelled findings, stale/risky/blocked wording, canonical/observed/warehouse/unknown source separation, and no interactive controls.
- Docs: new design doc `docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md` plus notes in the enrichment roadmap, staging architecture, warehouse runbook, and Stage 17P plan.

## Boundaries

- Read-only only. No canonical writes. No planner / Build Plan / role / observed-evidence / validation / scoring / CP / economy / service / buildability / Simulation Preview / optimiser mutation.
- No new backend endpoint, no live EDSM/API crawl, no Docker invocation, no production scheduler/job wiring.
- Report-only warehouse evidence is never treated as canonical truth and never overrides canonical data or infrastructure counts.
- Missing artifact/status stays unavailable/unknown — never false / no-evidence.
- Source labels (canonical, observed, warehouse report-only, unknown) are always visible. No secrets, DSNs, or file paths exposed.

## Validation

- `npm run typecheck` — clean
- `npm run build` — success
- `npx eslint` on changed files — clean
- `npx vitest run AdminTab ColonyPlannerWorkspace RavenStylePlannerCanvas SimulationPreview ObservedEvidence Validation OptimiserCandidate WarehouseEvidenceCard` — 184 passed
- `.venv/bin/pytest tests/test_station_enrichment_status.py tests/test_station_enrichment_guard.py tests/test_smoke.py tests/test_enrichment_staging_reconciliation.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_report_contracts.py -q` — 150 passed
- `git diff --check` — clean

## Review notes

- The decision-gate rationale (admin-gated + aggregate-only artifact, no safe per-system join key) is documented in the design doc, with the future per-system artifact contract (`warehouse_planner_evidence/v1` keyed by `system_id64`, appropriately-gated read-only endpoint, safe-join fallback to unknown).
- Branch was created from `origin/main` and includes the Stage 18G merge (`6dd07f5`).
- Stage 18I was **not** started.