### PR TITLE
Stage 18J station type canonical pilot

### DIFF
--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -387,7 +387,9 @@ def validate_apply_request(
     if expected_candidate_count < 0:
         raise Stage18JPlanError('expected candidate count must be >= 0')
     if max_rows is None:
-        max_rows = expected_candidate_count
+        raise Stage18JPlanError('explicit max rows is required')
+    if max_rows < 0:
+        raise Stage18JPlanError('max rows must be >= 0')
     if max_rows > MAX_FIRST_PILOT_LIMIT:
         raise Stage18JPlanError(f'max rows must be <= {MAX_FIRST_PILOT_LIMIT} for the first Stage 18J pilot')
     if len(candidates) > max_rows:
@@ -660,6 +662,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             '--approved-field': args.approved_field,
             '--approved-source-run': args.approved_source_run,
             '--approval-id': args.approval_id,
+            '--max-rows': args.max_rows,
             '--dsn': args.dsn,
         }
         missing = [name for name, value in required.items() if value in (None, '')]

--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -1,0 +1,823 @@
+"""Stage 18J station-type-only canonical pilot dry-run planner.
+
+This module consumes a read-only enrichment reconciliation report and produces a
+stricter, station-type-only canonical pilot artifact. Its default mode is
+always dry-run. The guarded apply helpers are deliberately separate, require a
+checksumed artifact plus explicit approval parameters, and update only
+``stations.station_type`` after re-validating canonical pre-images.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+def _station_resolver_import_paths(script_path: Path) -> list[Path]:
+    """Return import paths for repo checkouts and flat importer container mounts."""
+    resolved = script_path.resolve()
+    candidates = [resolved.parent]
+    if len(resolved.parents) > 2:
+        candidates.insert(0, resolved.parents[2] / 'api' / 'src')
+    return candidates
+
+
+for import_path in _station_resolver_import_paths(Path(__file__)):
+    if import_path.exists() and str(import_path) not in sys.path:
+        sys.path.insert(0, str(import_path))
+
+from station_body_resolver import (  # noqa: E402
+    is_permanent_colony_slot_station_type,
+    is_transient_non_slot_station_type,
+    normalise_station_type_label,
+)
+
+
+DRY_RUN_SCHEMA_VERSION = 'station_type_canonical_pilot_dry_run/v1'
+APPLY_SCHEMA_VERSION = 'station_type_canonical_pilot_apply/v1'
+VERIFICATION_SCHEMA_VERSION = 'station_type_canonical_pilot_verification/v1'
+ROLLBACK_PREIMAGE_SCHEMA_VERSION = 'station_type_canonical_pilot_rollback_preimage/v1'
+TOOL_NAME = 'station_type_canonical_pilot'
+TOOL_VERSION = 'v1'
+APPROVED_TABLE = 'stations'
+APPROVED_FIELD = 'station_type'
+DEFAULT_LIMIT = 5
+MAX_FIRST_PILOT_LIMIT = 20
+ELIGIBLE_OLD_TYPE_LABELS = {None, '', 'Unknown'}
+BLOCKING_RISK_CLASSES = {'blocked', 'risky', 'stale', 'volatile', 'unknown'}
+BLOCKING_RECONCILIATION_STATES = {'blocked', 'source_only', 'unresolved', 'unknown'}
+BLOCKING_REVIEW_CLASSIFICATIONS = {
+    'blocked',
+    'risky',
+    'stale',
+    'volatile',
+    'source_only',
+    'unknown',
+}
+BLOCKING_RISK_FLAGS = {
+    'ambiguous_canonical_match',
+    'ambiguous_staged_body_evidence',
+    'canonical_difference_review',
+    'insufficient_identifiers',
+    'missing_staged_body_evidence',
+    'missing_station_body_name',
+    'source_only_association',
+    'source_only_evidence',
+    'stale_source_evidence',
+    'undated_source_evidence',
+    'volatile_source_class',
+    'volatile_source_evidence',
+}
+
+
+class Stage18JPlanError(ValueError):
+    """Raised when a Stage 18J dry-run artifact cannot be constructed safely."""
+
+
+def canonical_json(value: Any) -> str:
+    """Return stable JSON for hashing, diffs, and fixture comparisons."""
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def artifact_sha256(value: Mapping[str, Any]) -> str:
+    """Hash an artifact after removing its self-referential integrity block."""
+    payload = deepcopy(dict(value))
+    payload.pop('artifact_integrity', None)
+    return hashlib.sha256(canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def build_station_type_pilot_dry_run(
+    reconciliation_report: Mapping[str, Any],
+    *,
+    limit: int | None = DEFAULT_LIMIT,
+    allow_edsm_station_id: bool = False,
+    allow_undated_source_exception: bool = False,
+    generated_at: str | None = None,
+    git_commit: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic dry-run artifact for exact station type promotion."""
+    if limit is not None and limit < 0:
+        raise Stage18JPlanError('limit must be >= 0')
+    if limit is not None and limit > MAX_FIRST_PILOT_LIMIT:
+        raise Stage18JPlanError(f'limit must be <= {MAX_FIRST_PILOT_LIMIT} for the first Stage 18J pilot')
+
+    source_scope = _source_scope(reconciliation_report)
+    eligible: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+    rows_considered = 0
+
+    for candidate in reconciliation_report.get('station_candidates', []) or []:
+        if not isinstance(candidate, Mapping):
+            continue
+        rows_considered += 1
+        decision = evaluate_station_type_candidate(
+            candidate,
+            allow_edsm_station_id=allow_edsm_station_id,
+            allow_undated_source_exception=allow_undated_source_exception,
+        )
+        if decision['eligible'] and (limit is None or len(eligible) < limit):
+            eligible.append(decision['candidate'])
+        elif decision['eligible']:
+            blocked.append({
+                'candidate_id': decision['candidate']['candidate_id'],
+                'source_identity': decision['candidate']['source_identity'],
+                'canonical': decision['candidate']['canonical'],
+                'blocking_reasons': ['pilot_limit_excluded'],
+                'eligible_if_limit_allows': True,
+            })
+        else:
+            blocked.append(decision['blocked_candidate'])
+
+    eligible = sorted(eligible, key=canonical_json)
+    blocked = sorted(blocked, key=canonical_json)
+    blocked_by_reason = _blocked_reason_distribution(blocked)
+    now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    artifact: dict[str, Any] = {
+        'schema_version': DRY_RUN_SCHEMA_VERSION,
+        'generated_at': now,
+        'tool': {
+            'name': TOOL_NAME,
+            'version': TOOL_VERSION,
+            'git_commit': git_commit,
+        },
+        'dry_run': True,
+        'pilot_scope': {
+            'canonical_table': APPROVED_TABLE,
+            'canonical_field': APPROVED_FIELD,
+            'default_limit': DEFAULT_LIMIT,
+            'max_first_pilot_limit': MAX_FIRST_PILOT_LIMIT,
+            'apply_requires_separate_guarded_mode': True,
+        },
+        'source_scope': source_scope,
+        'filters': {
+            'limit': limit,
+            'allow_edsm_station_id': allow_edsm_station_id,
+            'allow_undated_source_exception': allow_undated_source_exception,
+        },
+        'summary': {
+            'station_candidates_considered': rows_considered,
+            'eligible_candidates': len(eligible),
+            'blocked_candidates': len(blocked),
+            'blocked_by_reason': blocked_by_reason,
+            'canonical_writes_planned': len(eligible),
+            'approved_table': APPROVED_TABLE,
+            'approved_field': APPROVED_FIELD,
+            'errors': 0,
+            'warnings': 0,
+        },
+        'eligible_candidates': eligible,
+        'blocked_candidates': blocked,
+        'operator_review': {
+            'manual_approval_required': True,
+            'apply_requires_separate_guarded_tool': True,
+            'ordinary_warehouse_loaders_must_remain_canonical_read_only': True,
+            'review_guidance': [
+                'Approve only a checksumed dry-run artifact with a small row count.',
+                'Apply must be table-specific, field-specific, source-run-specific, and fail closed.',
+                'Source-only, stale, volatile, risky, blocked, unknown, and report-only evidence remains non-canonical.',
+            ],
+        },
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+        'canonicalization': 'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False) excluding artifact_integrity',
+    }
+    return artifact
+
+
+def evaluate_station_type_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    allow_edsm_station_id: bool = False,
+    allow_undated_source_exception: bool = False,
+) -> dict[str, Any]:
+    """Evaluate one reconciliation station candidate against Stage 18J rules."""
+    source = _mapping(candidate.get('source'))
+    canonical = _mapping(candidate.get('canonical'))
+    canonical_matches = _sequence_of_mappings(candidate.get('canonical_matches'))
+    differences = _sequence_of_mappings(candidate.get('differences'))
+    warnings = _sequence_of_mappings(candidate.get('warnings'))
+    source_station_type = _station_type_difference_value(differences)
+    old_value = canonical.get('station_type')
+    new_value = normalise_station_type_label(source_station_type)
+    source_system_id64 = _read_int(source.get('system_id64'))
+    canonical_system_id64 = _read_int(canonical.get('system_id64'))
+    canonical_station_id = _read_int(canonical.get('station_id'))
+    source_market_id = _read_int(source.get('market_id'))
+    source_edsm_station_id = _read_int(source.get('edsm_station_id'))
+    source_name = source.get('station_name')
+    canonical_name = canonical.get('station_name')
+
+    checks = {
+        'entity_is_station': candidate.get('entity') == 'station',
+        'target_difference_is_station_type_only': _has_only_station_type_difference(differences),
+        'exactly_one_canonical_match': len(canonical_matches) == 1 and bool(canonical),
+        'canonical_station_exists': canonical_station_id is not None,
+        'source_system_id64_present': source_system_id64 is not None,
+        'system_id64_matches': source_system_id64 is not None and source_system_id64 == canonical_system_id64,
+        'stable_station_identifier_matches': False,
+        'station_name_matches': _normalise_name(source_name) is not None and _normalise_name(source_name) == _normalise_name(canonical_name),
+        'source_station_type_present': source_station_type not in (None, ''),
+        'source_station_type_normalised': new_value is not None,
+        'source_station_type_permanent': bool(new_value) and is_permanent_colony_slot_station_type(new_value),
+        'source_station_type_not_transient': bool(new_value) and not is_transient_non_slot_station_type(new_value),
+        'canonical_old_value_eligible': _canonical_old_value_eligible(old_value),
+        'risk_class_clear': candidate.get('risk_class') == 'clear',
+        'reconciliation_state_allowed': candidate.get('reconciliation_state') == 'confirmed',
+        'no_blocking_risk_flags': not (set(candidate.get('risk_flags') or []) & BLOCKING_RISK_FLAGS),
+        'no_blocking_review_classifications': not (set(candidate.get('review_classifications') or []) & BLOCKING_REVIEW_CLASSIFICATIONS),
+        'source_record_hash_present': bool(source.get('source_record_hash')),
+        'source_run_key_present': bool(source.get('source_run_key')),
+        'source_file_key_present': bool(source.get('source_file_key')),
+        'source_not_volatile': source.get('source_class') != 'volatile',
+        'no_volatile_warnings': not any(warning.get('reason') == 'volatile_source_evidence_not_canonical_update' for warning in warnings),
+        'freshness_allowed': _freshness_allowed(candidate, allow_undated_source_exception=allow_undated_source_exception),
+    }
+
+    identifier_match_type = None
+    if source_market_id is not None and canonical_station_id is not None and source_market_id == canonical_station_id:
+        checks['stable_station_identifier_matches'] = True
+        identifier_match_type = 'market_id'
+    elif (
+        allow_edsm_station_id
+        and source_edsm_station_id is not None
+        and canonical_station_id is not None
+        and source_edsm_station_id == canonical_station_id
+    ):
+        checks['stable_station_identifier_matches'] = True
+        identifier_match_type = 'edsm_station_id'
+
+    blocking_reasons = [name for name, passed in checks.items() if not passed]
+    candidate_id = _candidate_id(source=source, canonical_station_id=canonical_station_id, new_value=new_value)
+    common = {
+        'candidate_id': candidate_id,
+        'source_identity': {
+            'source_run_key': source.get('source_run_key'),
+            'source_file_key': source.get('source_file_key'),
+            'source_record_key': source.get('source_record_key'),
+            'source_record_hash': source.get('source_record_hash'),
+            'system_id64': source.get('system_id64'),
+            'system_name': source.get('system_name'),
+            'market_id': source.get('market_id'),
+            'edsm_station_id': source.get('edsm_station_id'),
+            'station_name': source_name,
+            'station_type': source_station_type,
+            'normalised_station_type': new_value,
+            'source_class': source.get('source_class'),
+            'confidence': source.get('confidence'),
+            'freshness_class': source.get('freshness_class'),
+            'source_updated_at': source.get('source_updated_at'),
+        },
+        'canonical': {
+            'station_id': canonical_station_id,
+            'system_id64': canonical_system_id64,
+            'station_name': canonical_name,
+            'station_type': old_value,
+        },
+        'match_proof': {
+            'canonical_match_count': len(canonical_matches),
+            'identifier_match_type': identifier_match_type,
+            'source_system_id64': source_system_id64,
+            'canonical_system_id64': canonical_system_id64,
+            'normalised_source_station_name': _normalise_name(source_name),
+            'normalised_canonical_station_name': _normalise_name(canonical_name),
+            'allow_edsm_station_id': allow_edsm_station_id,
+        },
+        'eligibility_checks': checks,
+        'source_reconciliation': {
+            'candidate_action': candidate.get('candidate_action'),
+            'confidence': candidate.get('confidence'),
+            'risk_class': candidate.get('risk_class'),
+            'risk_flags': sorted(candidate.get('risk_flags') or []),
+            'review_classifications': sorted(candidate.get('review_classifications') or []),
+            'reconciliation_state': candidate.get('reconciliation_state'),
+            'source_freshness': candidate.get('source_freshness'),
+            'report_only': candidate.get('report_only'),
+            'canonical_writes_planned': candidate.get('canonical_writes_planned'),
+        },
+    }
+
+    if blocking_reasons:
+        return {
+            'eligible': False,
+            'blocked_candidate': {
+                **common,
+                'blocking_reasons': blocking_reasons,
+            },
+        }
+
+    eligible_candidate = {
+        **common,
+        'canonical_table': APPROVED_TABLE,
+        'canonical_pk': canonical_station_id,
+        'canonical_system_id64': canonical_system_id64,
+        'canonical_station_name': canonical_name,
+        'field': APPROVED_FIELD,
+        'old_value': old_value,
+        'new_value': new_value,
+        'rollback_pre_image': {
+            'canonical_table': APPROVED_TABLE,
+            'canonical_pk': canonical_station_id,
+            'field': APPROVED_FIELD,
+            'pre_image_value': old_value,
+            'planned_value': new_value,
+        },
+        'audit_metadata': {
+            'reason_codes': ['exact_station_identity_station_type_promotion'],
+            'requires_manual_approval': True,
+            'source_record_hash': source.get('source_record_hash'),
+        },
+    }
+    return {'eligible': True, 'candidate': eligible_candidate}
+
+
+def validate_apply_request(
+    artifact: Mapping[str, Any],
+    *,
+    artifact_sha256_expected: str,
+    expected_candidate_count: int,
+    approved_table: str,
+    approved_field: str,
+    approved_source_run: str,
+    approved_source_file: str | None = None,
+    approval_id: str | None = None,
+    confirmation: bool = False,
+    max_rows: int | None = None,
+) -> list[dict[str, Any]]:
+    """Validate operator approval parameters before any canonical apply."""
+    if not confirmation:
+        raise Stage18JPlanError('explicit Stage 18J confirmation flag is required')
+    if not approval_id:
+        raise Stage18JPlanError('approval id/text is required')
+    if artifact.get('schema_version') != DRY_RUN_SCHEMA_VERSION:
+        raise Stage18JPlanError('unsupported dry-run artifact schema')
+    recomputed_sha = artifact_sha256(artifact)
+    if recomputed_sha != artifact_sha256_expected:
+        raise Stage18JPlanError('dry-run artifact checksum mismatch')
+    embedded_sha = _mapping(artifact.get('artifact_integrity')).get('canonical_json_sha256')
+    if embedded_sha and embedded_sha != recomputed_sha:
+        raise Stage18JPlanError('dry-run artifact embedded checksum is stale')
+    if approved_table != APPROVED_TABLE:
+        raise Stage18JPlanError('approved table must be stations')
+    if approved_field != APPROVED_FIELD:
+        raise Stage18JPlanError('approved field must be station_type')
+
+    candidates = _sequence_of_mappings(artifact.get('eligible_candidates'))
+    if len(candidates) != expected_candidate_count:
+        raise Stage18JPlanError('expected candidate count does not match artifact')
+    if expected_candidate_count < 0:
+        raise Stage18JPlanError('expected candidate count must be >= 0')
+    if max_rows is None:
+        max_rows = expected_candidate_count
+    if max_rows > MAX_FIRST_PILOT_LIMIT:
+        raise Stage18JPlanError(f'max rows must be <= {MAX_FIRST_PILOT_LIMIT} for the first Stage 18J pilot')
+    if len(candidates) > max_rows:
+        raise Stage18JPlanError('artifact candidate count exceeds approved max rows')
+
+    source_scope = _mapping(artifact.get('source_scope'))
+    if source_scope.get('source_run_key') != approved_source_run:
+        raise Stage18JPlanError('approved source run does not match artifact')
+    if approved_source_file is not None and source_scope.get('source_file_key') != approved_source_file:
+        raise Stage18JPlanError('approved source file does not match artifact')
+
+    for row in candidates:
+        if row.get('canonical_table') != APPROVED_TABLE or row.get('field') != APPROVED_FIELD:
+            raise Stage18JPlanError('candidate targets an unapproved table or field')
+        if _mapping(row.get('source_identity')).get('source_run_key') != approved_source_run:
+            raise Stage18JPlanError('candidate source run does not match approval')
+        if approved_source_file is not None and _mapping(row.get('source_identity')).get('source_file_key') != approved_source_file:
+            raise Stage18JPlanError('candidate source file does not match approval')
+    return candidates
+
+
+def apply_station_type_pilot(
+    conn: Any,
+    artifact: Mapping[str, Any],
+    *,
+    artifact_sha256_expected: str,
+    expected_candidate_count: int,
+    approved_table: str,
+    approved_field: str,
+    approved_source_run: str,
+    approved_source_file: str | None = None,
+    approval_id: str | None = None,
+    confirmation: bool = False,
+    max_rows: int | None = None,
+    apply_run_id: str | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Apply an approved station-type pilot artifact through a DB connection."""
+    candidates = validate_apply_request(
+        artifact,
+        artifact_sha256_expected=artifact_sha256_expected,
+        expected_candidate_count=expected_candidate_count,
+        approved_table=approved_table,
+        approved_field=approved_field,
+        approved_source_run=approved_source_run,
+        approved_source_file=approved_source_file,
+        approval_id=approval_id,
+        confirmation=confirmation,
+        max_rows=max_rows,
+    )
+    run_id = apply_run_id or _apply_run_id(artifact_sha256_expected, approval_id, len(candidates))
+    now = generated_at or _utc_now()
+    row_results: list[dict[str, Any]] = []
+    rollback_rows: list[dict[str, Any]] = []
+    cur = conn.cursor()
+    try:
+        for candidate in candidates:
+            station_id = _read_int(candidate.get('canonical_pk'))
+            system_id64 = _read_int(candidate.get('canonical_system_id64'))
+            old_value = candidate.get('old_value')
+            new_value = candidate.get('new_value')
+            cur.execute(
+                """
+                SELECT id, system_id64, name, station_type::text AS station_type
+                FROM stations
+                WHERE id = %s AND system_id64 = %s
+                """,
+                (station_id, system_id64),
+            )
+            current = _fetchone_mapping(cur)
+            if not current:
+                raise Stage18JPlanError(f'canonical station missing before apply: {station_id}')
+            if _normalise_station_type_value(current.get('station_type')) != _normalise_station_type_value(old_value):
+                raise Stage18JPlanError(f'canonical pre-image mismatch for station {station_id}')
+            cur.execute(
+                """
+                UPDATE stations
+                SET station_type = %s::station_type
+                WHERE id = %s
+                  AND system_id64 = %s
+                  AND station_type::text IS NOT DISTINCT FROM %s
+                RETURNING id, system_id64, name, station_type::text AS station_type
+                """,
+                (new_value, station_id, system_id64, old_value),
+            )
+            updated = _fetchone_mapping(cur)
+            if not updated:
+                raise Stage18JPlanError(f'canonical station update did not affect the approved row: {station_id}')
+            row_results.append({
+                'candidate_id': candidate.get('candidate_id'),
+                'canonical_table': APPROVED_TABLE,
+                'canonical_pk': station_id,
+                'field': APPROVED_FIELD,
+                'old_value': old_value,
+                'new_value': new_value,
+                'result': 'applied',
+            })
+            rollback_rows.append({
+                'candidate_id': candidate.get('candidate_id'),
+                'canonical_table': APPROVED_TABLE,
+                'canonical_pk': station_id,
+                'canonical_system_id64': system_id64,
+                'field': APPROVED_FIELD,
+                'pre_image_value': old_value,
+                'applied_value': new_value,
+                'source_trace': _mapping(candidate.get('source_identity')),
+            })
+        verification = verify_station_type_apply(conn, candidates)
+        if not verification['summary']['ok']:
+            raise Stage18JPlanError('post-apply verification failed')
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        close = getattr(cur, 'close', None)
+        if callable(close):
+            close()
+
+    audit = {
+        'schema_version': APPLY_SCHEMA_VERSION,
+        'apply_run_id': run_id,
+        'generated_at': now,
+        'tool': {'name': TOOL_NAME, 'version': TOOL_VERSION},
+        'dry_run_artifact_sha256': artifact_sha256_expected,
+        'approval': {
+            'approval_id': approval_id,
+            'approved_table': approved_table,
+            'approved_field': approved_field,
+            'approved_source_run': approved_source_run,
+            'approved_source_file': approved_source_file,
+            'expected_candidate_count': expected_candidate_count,
+            'max_rows': max_rows,
+        },
+        'summary': {
+            'planned': len(candidates),
+            'applied': len(row_results),
+            'skipped': 0,
+            'blocked': 0,
+            'canonical_table': APPROVED_TABLE,
+            'canonical_field': APPROVED_FIELD,
+        },
+        'rows': row_results,
+        'rollback_preimage': build_rollback_preimage(
+            apply_run_id=run_id,
+            dry_run_artifact_sha256=artifact_sha256_expected,
+            rows=rollback_rows,
+            generated_at=now,
+        ),
+        'post_apply_verification': verification,
+    }
+    audit['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(audit),
+    }
+    return audit
+
+
+def verify_station_type_apply(conn: Any, candidates: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Verify approved rows now have the approved station_type values."""
+    rows: list[dict[str, Any]] = []
+    cur = conn.cursor()
+    try:
+        for candidate in candidates:
+            station_id = _read_int(candidate.get('canonical_pk'))
+            system_id64 = _read_int(candidate.get('canonical_system_id64'))
+            expected = candidate.get('new_value')
+            cur.execute(
+                """
+                SELECT id, system_id64, name, station_type::text AS station_type
+                FROM stations
+                WHERE id = %s AND system_id64 = %s
+                """,
+                (station_id, system_id64),
+            )
+            current = _fetchone_mapping(cur)
+            actual = current.get('station_type') if current else None
+            rows.append({
+                'candidate_id': candidate.get('candidate_id'),
+                'canonical_pk': station_id,
+                'canonical_system_id64': system_id64,
+                'field': APPROVED_FIELD,
+                'expected_value': expected,
+                'actual_value': actual,
+                'ok': _normalise_station_type_value(actual) == _normalise_station_type_value(expected),
+            })
+    finally:
+        close = getattr(cur, 'close', None)
+        if callable(close):
+            close()
+    artifact = {
+        'schema_version': VERIFICATION_SCHEMA_VERSION,
+        'generated_at': _utc_now(),
+        'summary': {
+            'checked': len(rows),
+            'ok': all(row['ok'] for row in rows),
+            'canonical_table': APPROVED_TABLE,
+            'canonical_field': APPROVED_FIELD,
+        },
+        'rows': rows,
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+    }
+    return artifact
+
+
+def build_rollback_preimage(
+    *,
+    apply_run_id: str,
+    dry_run_artifact_sha256: str,
+    rows: Sequence[Mapping[str, Any]],
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    artifact = {
+        'schema_version': ROLLBACK_PREIMAGE_SCHEMA_VERSION,
+        'apply_run_id': apply_run_id,
+        'generated_at': generated_at or _utc_now(),
+        'dry_run_artifact_sha256': dry_run_artifact_sha256,
+        'summary': {
+            'rows': len(rows),
+            'canonical_table': APPROVED_TABLE,
+            'canonical_field': APPROVED_FIELD,
+        },
+        'rows': sorted([dict(row) for row in rows], key=canonical_json),
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+    }
+    return artifact
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Stage 18J station-type canonical pilot tooling.')
+    parser.add_argument('--reconciliation-report', default=None, help='Path to read-only warehouse reconciliation JSON for dry-run mode.')
+    parser.add_argument('--output', default=None, help='Optional output path. Defaults to stdout only.')
+    parser.add_argument('--limit', type=int, default=DEFAULT_LIMIT, help='Maximum eligible candidates to include.')
+    parser.add_argument('--allow-edsm-station-id', action='store_true', help='Allow edsm_station_id as a reviewed stable identifier.')
+    parser.add_argument('--allow-undated-source-exception', action='store_true', help='Allow otherwise eligible undated/file-snapshot rows in dry-run review.')
+    parser.add_argument('--json', action='store_true', help='Accepted for compatibility; output is always JSON.')
+    parser.add_argument('--dry-run', action='store_true', default=True, help='Dry-run mode. This is the default.')
+    parser.add_argument('--apply', action='store_true', help='Run guarded apply mode from a checksumed dry-run artifact.')
+    parser.add_argument('--artifact', default=None, help='Dry-run artifact path for apply mode.')
+    parser.add_argument('--artifact-sha256', default=None, help='Expected dry-run artifact SHA-256 for apply mode.')
+    parser.add_argument('--expected-candidate-count', type=int, default=None, help='Expected eligible candidate count for apply mode.')
+    parser.add_argument('--approved-table', default=None, help='Approved canonical table for apply mode; must be stations.')
+    parser.add_argument('--approved-field', default=None, help='Approved canonical field for apply mode; must be station_type.')
+    parser.add_argument('--approved-source-run', default=None, help='Approved source run key for apply mode.')
+    parser.add_argument('--approved-source-file', default=None, help='Optional approved source file key for apply mode.')
+    parser.add_argument('--approval-id', default=None, help='Operator approval reference for apply mode.')
+    parser.add_argument('--confirm-station-type-canonical-pilot', action='store_true', help='Required explicit apply confirmation.')
+    parser.add_argument('--max-rows', type=int, default=None, help='Maximum rows approved for apply mode.')
+    parser.add_argument('--dsn', default=None, help='Canonical apply DSN. Required for apply mode.')
+    parser.add_argument('--write', action='store_true', help='Unsupported alias; use --apply with explicit approval parameters.')
+    parser.add_argument('--commit', action='store_true', help='Unsupported alias; use --apply with explicit approval parameters.')
+    args = parser.parse_args(argv)
+    if args.write or args.commit:
+        parser.error('--write/--commit are not supported; use --apply with explicit Stage 18J approval parameters')
+    if args.apply:
+        required = {
+            '--artifact': args.artifact,
+            '--artifact-sha256': args.artifact_sha256,
+            '--expected-candidate-count': args.expected_candidate_count,
+            '--approved-table': args.approved_table,
+            '--approved-field': args.approved_field,
+            '--approved-source-run': args.approved_source_run,
+            '--approval-id': args.approval_id,
+            '--dsn': args.dsn,
+        }
+        missing = [name for name, value in required.items() if value in (None, '')]
+        if missing:
+            parser.error('apply mode requires ' + ', '.join(missing))
+        if not args.confirm_station_type_canonical_pilot:
+            parser.error('apply mode requires --confirm-station-type-canonical-pilot')
+    elif not args.reconciliation_report:
+        parser.error('--reconciliation-report is required in dry-run mode')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.apply:
+            with open(args.artifact, 'r', encoding='utf-8') as handle:
+                dry_run_artifact = json.load(handle)
+            conn = _connect_postgres(args.dsn)
+            artifact = apply_station_type_pilot(
+                conn,
+                dry_run_artifact,
+                artifact_sha256_expected=args.artifact_sha256,
+                expected_candidate_count=args.expected_candidate_count,
+                approved_table=args.approved_table,
+                approved_field=args.approved_field,
+                approved_source_run=args.approved_source_run,
+                approved_source_file=args.approved_source_file,
+                approval_id=args.approval_id,
+                confirmation=args.confirm_station_type_canonical_pilot,
+                max_rows=args.max_rows,
+            )
+        else:
+            with open(args.reconciliation_report, 'r', encoding='utf-8') as handle:
+                reconciliation_report = json.load(handle)
+            artifact = build_station_type_pilot_dry_run(
+                reconciliation_report,
+                limit=args.limit,
+                allow_edsm_station_id=args.allow_edsm_station_id,
+                allow_undated_source_exception=args.allow_undated_source_exception,
+            )
+    except (OSError, ValueError, TypeError) as exc:
+        print(f'Stage 18J station type pilot failed: {exc}', file=sys.stderr)
+        return 2
+
+    output = json.dumps(artifact, sort_keys=True, indent=2)
+    if args.output:
+        Path(args.output).write_text(output + '\n', encoding='utf-8')
+    print(output)
+    return 0
+
+
+def _connect_postgres(dsn: str) -> Any:
+    try:
+        import psycopg2  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised only in real apply environments
+        raise Stage18JPlanError('psycopg2 is required for guarded apply mode') from exc
+    return psycopg2.connect(dsn)
+
+
+def _fetchone_mapping(cur: Any) -> dict[str, Any] | None:
+    row = cur.fetchone()
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return dict(row)
+    description = getattr(cur, 'description', None)
+    if description:
+        keys = [col[0] for col in description]
+        return dict(zip(keys, row))
+    return None
+
+
+def _normalise_station_type_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    return normalise_station_type_label(value)
+
+
+def _apply_run_id(artifact_sha: str, approval_id: str | None, count: int) -> str:
+    return hashlib.sha256(canonical_json(['stage18j_apply_run', artifact_sha, approval_id, count]).encode('utf-8')).hexdigest()
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def _source_scope(report: Mapping[str, Any]) -> dict[str, Any]:
+    filters = _mapping(report.get('filters'))
+    return {
+        'input_schema_version': report.get('schema_version'),
+        'input_dry_run': report.get('dry_run'),
+        'source_run_key': filters.get('source_run_key'),
+        'source_file_key': filters.get('source_file_key'),
+        'source': filters.get('source'),
+        'input_canonical_writes_planned': _mapping(report.get('summary')).get('canonical_writes_planned'),
+    }
+
+
+def _station_type_difference_value(differences: Sequence[Mapping[str, Any]]) -> Any:
+    for difference in differences:
+        if difference.get('field') == APPROVED_FIELD:
+            return difference.get('staged')
+    return None
+
+
+def _has_only_station_type_difference(differences: Sequence[Mapping[str, Any]]) -> bool:
+    return len(differences) == 1 and differences[0].get('field') == APPROVED_FIELD
+
+
+def _canonical_old_value_eligible(value: Any) -> bool:
+    if value is None:
+        return True
+    text = str(value).strip()
+    if text == '':
+        return True
+    return normalise_station_type_label(text) == 'Unknown'
+
+
+def _freshness_allowed(candidate: Mapping[str, Any], *, allow_undated_source_exception: bool) -> bool:
+    freshness = _mapping(candidate.get('source_freshness'))
+    impact = freshness.get('freshness_impact')
+    if impact == 'timestamped_source':
+        return True
+    if impact in {'file_snapshot_review', 'undated_source_review'}:
+        return allow_undated_source_exception
+    return False
+
+
+def _candidate_id(*, source: Mapping[str, Any], canonical_station_id: int | None, new_value: str | None) -> str:
+    return hashlib.sha256(canonical_json([
+        'stage18j_station_type_candidate',
+        source.get('source_run_key'),
+        source.get('source_file_key'),
+        source.get('source_record_hash'),
+        canonical_station_id,
+        APPROVED_FIELD,
+        new_value,
+    ]).encode('utf-8')).hexdigest()
+
+
+def _blocked_reason_distribution(blocked: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in blocked:
+        for reason in row.get('blocking_reasons', []) or []:
+            counts[str(reason)] = counts.get(str(reason), 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _normalise_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = ' '.join(str(value).strip().lower().split())
+    return text or None
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _sequence_of_mappings(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]
+
+
+def _read_int(value: Any) -> int | None:
+    if value is None or value == '':
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+if __name__ == '__main__':  # pragma: no cover
+    raise SystemExit(main())

--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -53,6 +53,7 @@ BLOCKING_RISK_CLASSES = {'blocked', 'risky', 'stale', 'volatile', 'unknown'}
 BLOCKING_RECONCILIATION_STATES = {'blocked', 'source_only', 'unresolved', 'unknown'}
 BLOCKING_REVIEW_CLASSIFICATIONS = {
     'blocked',
+    'report_only',
     'risky',
     'stale',
     'volatile',
@@ -211,6 +212,8 @@ def evaluate_station_type_candidate(
     canonical_station_id = _read_int(canonical.get('station_id'))
     source_market_id = _read_int(source.get('market_id'))
     source_edsm_station_id = _read_int(source.get('edsm_station_id'))
+    canonical_market_id = _read_int(canonical.get('market_id'))
+    canonical_edsm_station_id = _read_int(canonical.get('edsm_station_id'))
     source_name = source.get('station_name')
     canonical_name = canonical.get('station_name')
 
@@ -232,6 +235,7 @@ def evaluate_station_type_candidate(
         'reconciliation_state_allowed': candidate.get('reconciliation_state') == 'confirmed',
         'no_blocking_risk_flags': not (set(candidate.get('risk_flags') or []) & BLOCKING_RISK_FLAGS),
         'no_blocking_review_classifications': not (set(candidate.get('review_classifications') or []) & BLOCKING_REVIEW_CLASSIFICATIONS),
+        'not_report_only_evidence': candidate.get('report_only') is not True,
         'source_record_hash_present': bool(source.get('source_record_hash')),
         'source_run_key_present': bool(source.get('source_run_key')),
         'source_file_key_present': bool(source.get('source_file_key')),
@@ -241,14 +245,17 @@ def evaluate_station_type_candidate(
     }
 
     identifier_match_type = None
-    if source_market_id is not None and canonical_station_id is not None and source_market_id == canonical_station_id:
+    # canonical.station_id is the database update target. It is not accepted as
+    # external identity proof unless the canonical payload also exposes the
+    # matching external identity field.
+    if source_market_id is not None and canonical_market_id is not None and source_market_id == canonical_market_id:
         checks['stable_station_identifier_matches'] = True
         identifier_match_type = 'market_id'
     elif (
         allow_edsm_station_id
         and source_edsm_station_id is not None
-        and canonical_station_id is not None
-        and source_edsm_station_id == canonical_station_id
+        and canonical_edsm_station_id is not None
+        and source_edsm_station_id == canonical_edsm_station_id
     ):
         checks['stable_station_identifier_matches'] = True
         identifier_match_type = 'edsm_station_id'
@@ -277,12 +284,18 @@ def evaluate_station_type_candidate(
         'canonical': {
             'station_id': canonical_station_id,
             'system_id64': canonical_system_id64,
+            'market_id': canonical_market_id,
+            'edsm_station_id': canonical_edsm_station_id,
             'station_name': canonical_name,
             'station_type': old_value,
         },
         'match_proof': {
             'canonical_match_count': len(canonical_matches),
             'identifier_match_type': identifier_match_type,
+            'source_market_id': source_market_id,
+            'canonical_market_id': canonical_market_id,
+            'source_edsm_station_id': source_edsm_station_id,
+            'canonical_edsm_station_id': canonical_edsm_station_id,
             'source_system_id64': source_system_id64,
             'canonical_system_id64': canonical_system_id64,
             'normalised_source_station_name': _normalise_name(source_name),
@@ -441,12 +454,15 @@ def apply_station_type_pilot(
                 SELECT id, system_id64, name, station_type::text AS station_type
                 FROM stations
                 WHERE id = %s AND system_id64 = %s
+                FOR UPDATE
                 """,
                 (station_id, system_id64),
             )
             current = _fetchone_mapping(cur)
             if not current:
                 raise Stage18JPlanError(f'canonical station missing before apply: {station_id}')
+            if _normalise_name(current.get('name')) != _normalise_name(candidate.get('canonical_station_name')):
+                raise Stage18JPlanError(f'canonical station identity pre-image mismatch for station {station_id}')
             if _normalise_station_type_value(current.get('station_type')) != _normalise_station_type_value(old_value):
                 raise Stage18JPlanError(f'canonical pre-image mismatch for station {station_id}')
             cur.execute(

--- a/docs/colonisation-redesign/stage-18j-station-type-canonical-pilot-plan.md
+++ b/docs/colonisation-redesign/stage-18j-station-type-canonical-pilot-plan.md
@@ -1,0 +1,440 @@
+# Stage 18J — Station Type Canonical Write Pilot Plan
+
+## Executive Summary
+
+Stage 18J should proceed, if and only if its prerequisites are satisfied, as a **narrow exact station type promotion pilot**. The pilot should update only `stations.station_type` for already-existing canonical station rows whose identity is matched by exact trusted station evidence, whose source type is present and normalized to an approved permanent station type, and whose current canonical value is eligible under a deliberately conservative update rule. This remains the safest first canonical write pilot because it changes one stable descriptive field on an existing station and does not invent systems, stations, bodies, body links, rings, distances, services, economies, planner state, scoring state, or build-plan state.[1]
+
+Stage 18J must not be treated as a general warehouse-to-canonical bridge. The current warehouse and reconciliation pipeline is intentionally report-only: snapshot loading is offline, staging writes are gated to warehouse tables, reconciliation is read-only, operator/admin status reads prepublished JSON artifacts only, and current report candidates keep `canonical_writes_planned = 0`.[2] [3] [4] The Stage 18I design review also states that ordinary warehouse loaders must remain unable to write canonical tables, and that any future canonical write must use a separate guarded apply path with a dry-run artifact, manual approval, audit trail, rollback pre-image, and post-apply verification.[1]
+
+The most important implementation warning is that **current reconciliation `candidate_update` rows are not apply-ready candidates**. Today, a station type difference is shaped as a report-only candidate update and is scored with `canonical_difference_review`, `reconciliation_state = source_only`, and `risk_class = risky` under the existing scoring model.[5] Stage 18J therefore needs a separate canonical pilot planner that consumes read-only evidence and produces a stricter, deterministic station-type-only dry-run artifact. That artifact must not be executable by the ordinary warehouse loader.
+
+| Decision point | Recommendation |
+|---|---|
+| Safest first canonical write pilot | Yes: exact `stations.station_type` promotion for existing canonical stations only. |
+| Stage 18I.5 dependency | Still blocking. PR #103 is open, mergeable, and not merged at review time; Stage 18J must wait until the boundary decision is accepted or a documented temporary equivalent safety arrangement is explicitly approved.[6] |
+| Apply path placement | Use a **dedicated canonical apply module/tool**, invoked from importer/maintenance CLI wiring if needed, but not embedded in the warehouse staging loader, API, UI, scheduler, or planner. |
+| First implementation mode | Start with dry-run only. Apply mode must be a separate command path and fail closed unless every approval parameter matches the deterministic artifact. |
+| Production pilot size | Default to a very small limit, such as 5 rows, with an explicit maximum no higher than 20 rows for the first production pilot. |
+| Production readiness | Requires a non-production rehearsal that proves only approved `stations.station_type` values changed and that rollback pre-images are sufficient. |
+
+## Preconditions
+
+Stage 18J should not begin merely because a report identifies station type differences. The accepted prerequisite chain is stricter. Stage 17P defines Stage 18J as a first narrow canonical write pilot only after Stage 18I and Stage 18I.5, and Stage 18I explicitly states that Stage 18J cannot begin until the warehouse database boundary is complete.[1] [7]
+
+The current PR #103 document for Stage 18I.5 recommends Option B, a separate `edfinder_enrichment` database on the same Postgres stack if feasible, while preserving future Option C compatibility. It also states that Stage 18J cannot start until the boundary decision is accepted, and either Option B is implemented or an explicit temporary bounded arrangement with equivalent controls is accepted.[6]
+
+| Precondition | Required state before Stage 18J implementation | Current review status |
+|---|---|---|
+| Stage 18I design review | Complete and merged. It recommends exact station type promotion as first pilot but authorizes no writes.[1] | Satisfied by current main-branch document. |
+| Stage 18I.5 boundary review | Accepted/merged, or an explicit temporary equivalent safety arrangement is approved. | Not satisfied at review time: PR #103 is open and mergeable but not merged.[6] |
+| Ordinary warehouse loader boundary | Must remain unable to write canonical tables. | Existing code and tests enforce staging table allow-lists and canonical deny-lists.[3] [8] |
+| Read-only reconciliation boundary | Must remain report-only and keep `canonical_writes_planned = 0`. | Existing repository report builder hard-codes `canonical_writes_planned = 0`.[4] |
+| Canonical apply identity | Must be separate from warehouse loader identity and scoped to the approved pilot. | Future requirement in Stage 18I.5; not present in current implementation.[6] |
+| Operator approval | Must name a specific artifact checksum, row count, table, field, and source run. | Not implemented yet. |
+| Non-production rehearsal | Must pass before production apply. | Not implemented yet. |
+
+If Stage 18I.5 remains unmerged or the boundary implementation/temporary exception is not accepted, Stage 18J may still produce documentation and dry-run design notes, but **must not implement or run an apply path**.
+
+## Why Station Type First
+
+Exact station type promotion is still the safest first canonical write pilot. It has a smaller blast radius than station/body links, body fields, rings, explicit no-ring evidence, systems, services, economies, factions, government, allegiance, distances, or planner-derived signals. Updating `stations.station_type` does not create a new entity, does not attach a station to a body, does not affect ring truth, and does not require treating volatile `distanceToArrival` evidence as canonical truth.[1]
+
+The existing warehouse architecture already stages station snapshot fields such as `system_id64`, `market_id`, `edsm_station_id`, `station_name`, `station_type`, `distance_to_arrival`, `body_name`, services, economies, faction, allegiance, government, source timestamps, source class, confidence, and provenance.[2] This is enough to build a station-type-only dry run, but not enough to authorize broad metadata promotion. Stage 18J must therefore select only the stable field that Stage 18I identified as the first pilot and reject all other differences even when they appear in the same source row.
+
+| Candidate path | First-pilot decision | Reason |
+|---|---|---|
+| Exact `stations.station_type` promotion | Eligible | One existing row, one field, exact identity, reversible pre-image, and no new entity creation. |
+| Exact station/body link promotion | Later only | Incorrect links affect planner capacity, lane association, and existing-infrastructure reasoning.[1] |
+| Trusted body ring rows | Later only | Ring truth affects body/resource reasoning and needs stronger source semantics.[1] |
+| Explicit no-ring evidence | Not first | Empty/missing arrays and no-ring semantics are too source-sensitive for the first pilot.[1] |
+| `distanceFromStar` / `distanceToArrival` | Banned | Distance evidence is volatile and must not churn canonical distance values.[2] |
+| Services/economies/faction/government/allegiance | Banned | Broader metadata promotion has higher churn and downstream UI/planner risk. |
+| Inserts of systems/stations/bodies/links/rings | Banned | First pilot must update only an existing station row. |
+
+## Scope
+
+The Stage 18J pilot scope is **only** exact `stations.station_type` promotion. The only canonical target table is `stations`, and the only canonical target field is `station_type`. The target station row must already exist before the dry run is generated, and the apply path must fail if that row no longer exists or if its pre-image no longer matches the dry-run artifact.
+
+The pilot may read warehouse staging evidence, source-run metadata, source-file metadata, raw record hashes, read-only canonical station rows, and read-only canonical system rows for identity verification. It may also write local JSON artifacts for dry-run, approval, apply audit, rollback pre-image, and post-apply verification. If a future implementation uses an apply queue or audit table, that storage must be part of a separately reviewed canonical apply boundary; it must not turn ordinary warehouse staging into an executable command channel.[6]
+
+| Item | In scope for Stage 18J |
+|---|---|
+| Canonical table | `stations` only. |
+| Canonical field | `station_type` only. |
+| Canonical row requirement | Existing row only; exactly one row matched. |
+| Evidence source | Offline staged station snapshot evidence, preferably from a named source run/file. |
+| Identity keys | Exact `system_id64`, normalized station name, and stable station identifier. Prefer `market_id`; allow `edsm_station_id` only when the source adapter proves stability. |
+| Artifact outputs | Dry-run artifact, approval record, apply artifact, audit record, rollback pre-image, post-apply verification artifact. |
+| Limits | Very small bounded pilot; default 5 rows and first-production maximum 20 rows. |
+
+## Explicit Non-Scope
+
+Everything outside `stations.station_type` is non-scope. Stage 18J must reject any candidate, artifact, command, test fixture, or implementation path that writes or implies writes to systems, stations other than the one approved field, bodies, station-body links, body rings, body scan facts, distance fields, services, economies, faction fields, government, allegiance, planner state, Build Plans, scoring, Simulation Preview, optimizers, roles, API job runners, live crawlers, or production schedulers.
+
+| Explicitly out of scope | Required behavior |
+|---|---|
+| Station inserts, deletes, or row merges | Block. First pilot updates existing rows only. |
+| `systems` writes | Block. |
+| `bodies` writes | Block. |
+| `station_body_links` writes | Block. |
+| `body_rings` writes | Block. |
+| `body_scan_facts` writes | Block. |
+| `stations.distance_from_star` / `distanceToArrival` | Block as volatile evidence. |
+| `stations.body_name` | Block for first pilot, even if staged evidence differs. |
+| Services/economies/faction/government/allegiance | Block. |
+| Planner, Build Plan, role, scoring, Simulation Preview, optimizer mutations | Block. |
+| Live EDSM/API crawl | Block. Stage 18J should consume offline/staged evidence. |
+| Docker invocation from UI/API | Block. Existing admin endpoints are read-only artifact readers.[9] |
+| Production scheduler wiring | Block. |
+| Broad backfill | Block. |
+| Unknown, missing, source-only, stale, volatile, or risky evidence | Keep unknown/report-only; do not coerce to canonical truth. |
+
+## Candidate Eligibility Rules
+
+A station type candidate should be eligible only when every rule in this section is satisfied. The implementation should evaluate the rules in a deterministic order and include a pass/fail reason for every candidate considered, not just for candidates selected.
+
+The core eligibility rule is that the source row must prove exact identity to one existing canonical station. The current reconciliation SQL allows a broad join using `market_id`, `edsm_station_id`, or station name against canonical station rows.[10] Stage 18J must be stricter than that general report. A pilot candidate must require exact `system_id64`, exactly one canonical station row, a stable station identifier, and normalized station name agreement. Name-only matches must not be eligible.
+
+| Rule group | Required rule |
+|---|---|
+| Existing canonical station | The candidate must target an already-existing `stations` row. `candidate_insert_missing_canonical` is never eligible. |
+| Exact match cardinality | The candidate must resolve to exactly one canonical station. Zero matches and multiple matches block. |
+| System identity | Source `system_id64` must be present and equal to canonical `stations.system_id64`/canonical system `id64`. Name-only system identity is insufficient. |
+| Stable station identifier | Prefer `market_id`; allow `edsm_station_id` only if the adapter documents that the value is stable for this source. The approved identifier and value must be recorded. |
+| Station name | Source station name and canonical station name must match after the same canonicalisation rule used by the pilot. Case-only differences may match; punctuation/spacing rules must be deterministic and recorded. |
+| Source station type | Source station type must be present, valid, normalized, and in the approved permanent-station-type allow-list. Unknown, blank, placeholder, carrier, transient, mobile, unsupported, or unrecognized values block. |
+| Current canonical value | Current canonical station type must be missing, blank, unknown, placeholder, or explicitly eligible under a separately approved narrow replacement rule. Existing known types should not be overwritten by default. |
+| Evidence quality | Candidate must have `risk_class = clear` or a Stage 18J-specific equivalent that is stricter than current report-only scoring. It must have no blocking, risky, stale, volatile, source-only, report-only, or unknown labels in the selected apply set. |
+| Source metadata | Candidate must include source name, adapter version, source run key, source file key, source record key/hash, freshness/timestamp state, and immutable source identity. |
+| Duplicate/skip hygiene | Source identity conflicts, malformed/skipped rows, unsupported source linkage, or duplicate identity conflicts block. |
+| Determinism | Candidate must be selected from a deterministic dry-run artifact whose canonical JSON SHA-256 is approved by the operator. |
+| Rollback | Candidate must include canonical primary key, old value, new value, source identity, confidence/risk reasons, rollback pre-image, and audit metadata. |
+
+The current confidence model labels `candidate_update` as `source_only` and risky because it is report-only and not yet a canonical write instruction.[5] A Stage 18J dry-run planner may either produce a new schema with a stricter `station_type_promotion_candidate` action or preserve the old action while adding a separate explicit `canonical_pilot_eligible = true` marker. In either case, the marker must only appear after all Stage 18J rules pass, and the ordinary reconciliation report must still keep `auto_promote_to_canonical = false` and `canonical_writes_planned = 0`.[5]
+
+## Blocking Conditions
+
+The pilot should prefer **block** over **guess**. A block should be explicit, recorded, and safe. A blocked row should remain evidence only and should not be silently omitted from summary counts.
+
+| Blocking condition | Why it blocks |
+|---|---|
+| Stage 18I.5 not accepted | Stage 18J is explicitly gated by the warehouse boundary review.[6] |
+| Dry-run artifact missing or checksum mismatch | Operator approval cannot be tied to immutable evidence. |
+| Artifact schema version unsupported | Apply cannot prove it is reading the intended contract. |
+| Candidate count differs from approval | Prevents broad accidental apply. |
+| Approved table/field/source run mismatch | Prevents a general warehouse recommendation from becoming executable. |
+| Current canonical pre-image changed | Dry-run is stale; operator approval no longer applies. |
+| No canonical match | Would imply station insert or invented row. |
+| More than one canonical match | Identity is ambiguous. |
+| Source `system_id64` missing or different | Exact system identity is not proven. |
+| Name-only station match | Stable station identity is insufficient. |
+| Station name mismatch after canonicalisation | Exact identity is not proven. |
+| Missing, malformed, unsupported, duplicate, or conflicting source identity | Source evidence is not stable enough. |
+| Source station type missing, unknown, invalid, carrier, transient, mobile, or unsupported | No safe permanent station type to promote. |
+| Existing canonical station type known and not explicitly eligible | Avoids overwriting current truth with staged evidence. |
+| Risk class blocked, risky, stale, volatile, source-only, report-only, or unknown | Evidence is not safe for first canonical write. |
+| Freshness missing/undated without explicit operator freshness exception | Avoids silently promoting stale snapshot data. |
+| Any candidate includes non-station-type differences as apply changes | Prevents scope creep. |
+| Any apply SQL targets non-approved table or field | Prevents catastrophic broad write. |
+| Post-apply verification not clean | Blocks wider rollout and requires investigation/rollback decision. |
+
+A dry run may include a dedicated `freshness_exception_requested` or `operator_freshness_exception_required` field for undated source rows. Apply must still block unless the approval artifact explicitly names the exception and the affected candidate IDs. This exception should be rare and should not be available for stale evidence where source timestamps prove the data is older than the accepted policy.
+
+## Dry-Run Artifact Contract
+
+The dry-run artifact should be the center of the pilot. It should be a deterministic JSON document, serialized with stable key ordering, assigned a SHA-256 checksum, and archived before any apply command can run. It should be small enough for a human operator to inspect completely during the pilot.
+
+Recommended schema name: `station_type_canonical_pilot_dry_run/v1`.
+
+| Top-level field | Required content |
+|---|---|
+| `schema_version` | `station_type_canonical_pilot_dry_run/v1`. |
+| `generated_at` | UTC timestamp for artifact generation. |
+| `tool` | Tool/module name, version, git commit, and command arguments excluding secrets. |
+| `dry_run` | Always `true`. |
+| `pilot_scope` | `{ "canonical_table": "stations", "canonical_field": "station_type", "allowed_write_count_max": N }`. |
+| `source_scope` | Source name, adapter version, source run key, source file key, source snapshot timestamp/freshness summary. |
+| `filters` | Candidate filters, limit, explicit source run/file filters, and whether freshness exceptions are allowed. |
+| `summary` | Counts for rows considered, eligible candidates, blocked candidates by reason, warnings, errors, canonical writes planned, approved table/field, and deterministic candidate count. |
+| `eligible_candidates` | Row-level selected candidates, sorted deterministically. |
+| `blocked_candidates` | Row-level rejected candidates with explicit blocking reasons. |
+| `operator_review` | Human-readable notes, risk distributions, freshness exceptions required, and non-scope warnings. |
+| `artifact_integrity` | Canonical JSON SHA-256, source input hashes if available, and artifact generation method. |
+
+Each eligible candidate should include the following row-level fields.
+
+| Candidate field | Required content |
+|---|---|
+| `candidate_id` | Deterministic ID derived from source run/file/hash, canonical station ID, and target field. |
+| `canonical_table` | Always `stations`. |
+| `canonical_pk` | Canonical station primary key. |
+| `canonical_system_id64` | Canonical station/system ID64. |
+| `canonical_station_name` | Current canonical station name. |
+| `field` | Always `station_type`. |
+| `old_value` | Current canonical station type pre-image. |
+| `new_value` | Normalized approved permanent station type. |
+| `source_identity` | `system_id64`, `market_id`, optional approved `edsm_station_id`, station name, station type, source run/file/record keys, and source record hash. |
+| `match_proof` | Exact system match, stable identifier match type, normalized name comparison, canonical match count, duplicate checks. |
+| `eligibility` | Pass/fail booleans for every rule, even for selected candidates. |
+| `confidence` | Confidence/risk labels, reasons, source class, freshness class, timestamp state, and non-volatile field classification. |
+| `rollback_pre_image` | Full pre-image needed to restore this field on this row. |
+| `audit_metadata` | Reason codes, operator-review text, source metadata, and tool version. |
+
+The dry-run artifact should keep `canonical_writes_planned` equal to the count of eligible station-type updates only within this new pilot schema. Existing warehouse reconciliation and coverage reports must continue to report `canonical_writes_planned = 0`, because those report families are not write plans.[4] [5]
+
+## Apply Contract
+
+Apply mode must be separate from dry run and must fail closed. It should never infer approval from a file path alone, and it should never accept general `--apply` flags in existing warehouse loaders. The existing staging loader already rejects `--apply`, `--write`, and `--commit` for canonical writes and requires explicit `--write-staging`, `--dsn`, and `--confirm-staging-db` for staging-only writes.[11] Stage 18J should copy the fail-closed spirit, but not the same command, because canonical apply is a different trust boundary.
+
+Recommended apply schema name: `station_type_canonical_pilot_apply/v1`.
+
+| Apply parameter | Required behavior |
+|---|---|
+| `--artifact PATH` | Required path to dry-run artifact. |
+| `--artifact-sha256 HEX` | Required exact checksum. Recompute and fail if mismatched. |
+| `--expected-candidate-count N` | Required exact count. Fail if artifact count differs. |
+| `--approved-table stations` | Required exact table. |
+| `--approved-field station_type` | Required exact field. |
+| `--approved-source-run KEY` | Required exact source run key. |
+| `--approved-source-file KEY` | Strongly recommended; required for first production pilot unless multiple files are explicitly approved. |
+| `--approval-id TEXT` | Required operator approval reference. |
+| `--confirm-station-type-canonical-pilot` | Required explicit confirmation flag. |
+| `--max-rows N` | Required limit, no greater than the approved artifact count and first-pilot cap. |
+| `--dsn` or environment DSN | Must use canonical apply credentials, not warehouse loader credentials. |
+
+Before updating any row, apply must re-read the current canonical row and prove that the pre-image still matches the dry-run artifact. It must run in one transaction for the bounded pilot batch, write the apply/audit/rollback artifacts before committing where practical, and fail closed if any row fails eligibility revalidation. If the implementation cannot safely write audit artifacts before commit, it must at least write a pre-transaction immutable intent artifact and a post-transaction audit artifact tied by apply run ID.
+
+The only permitted SQL effect is equivalent to updating `stations.station_type` for the approved station primary keys from the recorded old value to the recorded new value. No other columns may be changed. If the database permission model cannot enforce column-level update permissions, the apply code must verify affected columns through pre/post snapshots and tests.
+
+## Audit Trail Contract
+
+Every apply attempt, successful or failed, should emit an audit artifact. The audit artifact should answer who changed what, why, from which source evidence, under which approval, and how to verify or roll it back. Stage 18I requires apply run ID, dry-run artifact checksum, operator approval reference, tool version, source run/file keys, source record hashes, canonical table, primary key, field, old value, new value, confidence/risk metadata, transaction timestamp, planned/applied/skipped/blocked counts, and verification result.[1]
+
+Recommended schema name: `station_type_canonical_pilot_audit/v1`.
+
+| Audit field | Required content |
+|---|---|
+| `apply_run_id` | Unique immutable run ID. |
+| `dry_run_artifact_sha256` | Approved artifact checksum. |
+| `approval` | Approval ID/text, operator identity if available, approved table/field/source/count. |
+| `tool` | Module, version, git commit, command arguments excluding secrets. |
+| `transaction` | Transaction start/end timestamps and success/failure status. |
+| `rows` | For each row: station ID, system ID64, station name, old value, new value, source identity, source record hash, and result. |
+| `blocked_or_skipped` | Any row that was not applied and the exact reason. |
+| `post_apply_verification` | Verification artifact path/checksum and pass/fail state. |
+| `secrets_redaction` | Confirmation that DSNs, API keys, private paths, and secrets were not written. |
+
+Audit artifacts should be retained with canonical operational records rather than treated as disposable warehouse staging output. Stage 18I.5 assigns canonical apply audit and rollback ownership to the canonical apply side, not ordinary warehouse staging.[6]
+
+## Rollback Contract
+
+Rollback must not depend on re-reading mutable warehouse evidence after the fact. The required rollback unit is the canonical pre-image captured at dry-run/apply time. The first pilot can have a simple rollback plan because it touches one field on existing station rows.
+
+Recommended schema name: `station_type_canonical_pilot_rollback_preimage/v1`.
+
+| Rollback field | Required content |
+|---|---|
+| `apply_run_id` | Apply run being protected. |
+| `dry_run_artifact_sha256` | Dry-run artifact that authorized the change. |
+| `canonical_table` | Always `stations`. |
+| `canonical_pk` | Station ID. |
+| `field` | Always `station_type`. |
+| `pre_image_value` | Value before apply, including `NULL`/blank/unknown distinction. |
+| `applied_value` | Value written by apply. |
+| `source_trace` | Source run/file/record hash and candidate ID. |
+| `rollback_sql_preview` | Human-readable rollback intent; not executable by ordinary warehouse loader. |
+| `rollback_verification_rule` | Expected value after rollback and query/check to prove it. |
+
+A rollback command, if implemented, should itself have dry-run and apply phases. It should require artifact checksum, apply run ID, expected row count, approved table/field, and explicit rollback confirmation. If any current value no longer equals the value written by the original apply, rollback must fail closed and require manual review.
+
+## Operator Approval Flow
+
+Operator approval must be deliberate and artifact-specific. A general instruction to apply all warehouse recommendations is not acceptable. The pilot should produce small, reviewable artifacts and require the operator to name exactly what is being approved.
+
+| Step | Operator action | Required gate |
+|---|---|---|
+| 1 | Generate a dry-run artifact from a named source run/file with a small limit. | Artifact must be deterministic and checksumed. |
+| 2 | Review summary, candidate rows, blocked rows, freshness state, duplicate/source conflicts, and non-scope warnings. | No unexpected warnings, no errors, no blocked selected candidates. |
+| 3 | Confirm Stage 18I.5 readiness. | PR/decision accepted, or temporary equivalent boundary explicitly approved. |
+| 4 | Approve the artifact. | Approval names checksum, row count, table `stations`, field `station_type`, source run/file, and maximum rows. |
+| 5 | Run non-production apply rehearsal. | Post-apply verification proves only approved station type changes occurred. |
+| 6 | Archive dry-run, approval, apply audit, rollback pre-image, and verification artifacts together. | No missing artifacts. |
+| 7 | Run production pilot with very small limit. | Same parameters and fail-closed gates. |
+| 8 | Review post-apply verification and decide whether to stop, roll back, or plan a later wider stage. | Any anomaly stops rollout. |
+
+The UI/API should not expose an apply button for Stage 18J. Existing admin endpoints intentionally read sanitized artifacts and do not run importer scripts, Docker, live APIs, or database queries.[9] Stage 18J should preserve that boundary.
+
+## Post-Apply Verification
+
+Post-apply verification must prove both the positive and negative claims: the approved rows changed to the approved values, and no unapproved canonical values changed. Re-running the read-only comparison and seeing the planned updates become no-ops is necessary but not sufficient; the verifier should also compare pre/post canonical snapshots for the approved primary keys and, where possible, an aggregate guard over the canonical table.
+
+| Verification check | Required proof |
+|---|---|
+| Approved rows changed | Each approved station ID has `station_type = new_value`. |
+| Pre-image matched at apply time | Audit artifact records old value exactly as dry-run recorded it. |
+| No unapproved candidate applied | Applied row count equals approved candidate count. |
+| No unapproved field changed | Pre/post snapshot for approved rows differs only in `station_type`. |
+| No unapproved table changed | Apply tool records target table/field and tests prove no other write path. |
+| Reconciliation no-op | A post-apply read-only report for the same source scope no longer proposes those station-type updates. |
+| Artifact integrity | Verification artifact has schema version, checksum, tool version, and links to dry-run/apply artifacts. |
+| Rollback readiness | Rollback pre-image exists for every applied row. |
+
+Recommended verification schema name: `station_type_canonical_pilot_verification/v1`. Any verification failure should stop wider rollout. If a production pilot verification fails, the operator should preserve all artifacts, avoid rerunning apply, and decide whether to execute rollback after inspecting the exact mismatch.
+
+## CLI / Module Placement Recommendation
+
+The apply logic should live in a **dedicated canonical apply module**, with a thin CLI wrapper. It should not be embedded in `enrichment_staging_db_loader.py`, `enrichment_snapshot_loader.py`, `enrichment_warehouse_repository.py`, API routers, UI code, scheduler jobs, or planner code. This placement preserves the current invariant that ordinary warehouse loaders cannot write canonical tables and allows tests to prove the canonical apply path is separate.[3] [8]
+
+| Placement option | Recommendation | Rationale |
+|---|---|---|
+| Existing warehouse staging loader | Reject | It currently rejects canonical flags and is responsible for warehouse-only writes.[11] |
+| Existing snapshot loader | Reject | It is dry-run only, offline, and has no DB/network/write path.[2] |
+| API/admin endpoint | Reject | Current admin endpoints are read-only artifact readers and should remain so.[9] |
+| Production scheduler | Reject | Scheduler wiring is explicitly out of scope for the pilot. |
+| Importer CLI thin wrapper around dedicated module | Accept | Keeps operational location familiar while preserving a separate canonical boundary. |
+| Dedicated maintenance script/module | Prefer | Makes the trust boundary obvious and easier to test. |
+
+A reasonable future shape is a module such as `apps/importer/src/canonical_station_type_pilot.py` with pure artifact-building functions and explicit DB functions, plus a script or module entrypoint that supports `dry-run`, `apply`, `verify`, and optionally `rollback-dry-run`. The names are illustrative; the important requirement is boundary separation, not the exact file path.
+
+## Database Boundary Interaction
+
+Stage 18J must follow the Stage 18I.5 boundary decision. The preferred direction is Option B: `edfinder_enrichment` as a separate warehouse database on the same Postgres stack if feasible, with future Option C compatibility.[6] Under Option B, the warehouse loader writes only to the warehouse database; reconciliation uses canonical snapshots, read-only views, FDW, or immutable exported artifacts; and a separate canonical apply user crosses the boundary only through approved artifacts or a tightly permissioned immutable queue.[6]
+
+| Boundary concern | Stage 18J requirement |
+|---|---|
+| Warehouse database | Source evidence and report/write-plan proposals may live in `edfinder_enrichment`. |
+| Canonical app database | Remains source of trusted current facts. |
+| Warehouse loader user | Must not have canonical write privileges. |
+| Warehouse read/report user | Read-only, or report-artifact write only if separately approved. |
+| Canonical apply user | Separate from app and warehouse users; unavailable by default; scoped to the pilot. |
+| Write-plan transfer | Immutable JSON artifact with checksum or immutable queue row; not executable by ordinary loader. |
+| Audit/rollback ownership | Canonical apply side, not ordinary warehouse staging. |
+
+If Option B has not yet been implemented but the project explicitly accepts a temporary transitional arrangement, that acceptance must be recorded before implementation. The transitional arrangement must still prove equivalent safety controls: separate credentials where practical, deny-listed warehouse code, immutable artifact transfer, read-only reconciliation, explicit apply user boundary, and rollback/audit ownership.
+
+## Non-Production Rehearsal Plan
+
+A production pilot must be preceded by a non-production rehearsal using disposable or staging databases. The rehearsal should exercise the same CLI, artifact checksums, approval gates, transaction behavior, audit output, rollback pre-images, and verification logic planned for production.
+
+| Rehearsal phase | Acceptance criterion |
+|---|---|
+| Fixture dry run | Produces deterministic `station_type_canonical_pilot_dry_run/v1` artifact with expected eligible and blocked rows. |
+| Fixture apply | Applies only the approved `stations.station_type` changes in a disposable canonical database. |
+| Negative fixtures | Ambiguous, insufficient, stale, volatile, source-only, duplicate, carrier/transient, name-only, current-known-type, and pre-image-mismatch cases all block. |
+| Verification | Proves only approved `station_type` fields changed and post-apply reconciliation is clean for the approved rows. |
+| Rollback dry run | Produces a rollback plan from the captured pre-image. |
+| Rollback apply, if implemented | Restores the original values and verifies them. |
+| Artifact archive | Dry-run, approval, apply audit, rollback pre-image, and verification artifacts are complete and secret-free. |
+
+The rehearsal should not use live EDSM/API calls. It should use fixtures and, if needed, an operator-provided offline source snapshot loaded into a disposable warehouse/staging environment.
+
+## Production Pilot Limits
+
+The first production pilot should be deliberately boring. The default limit should be 5 eligible rows, and the first production cap should be no higher than 20 rows. The apply command must require an expected candidate count and should refuse to apply if the artifact contains more rows than the production cap unless a later stage explicitly changes the cap.
+
+| Limit type | Recommendation |
+|---|---|
+| Default dry-run candidate limit | 5 eligible candidates. |
+| First production maximum | 20 eligible candidates. |
+| Source scope | One source run and preferably one source file. |
+| Field scope | `stations.station_type` only. |
+| Table scope | `stations` only. |
+| Apply transaction | One bounded transaction for the pilot batch, unless rehearsal proves a safer per-row transaction model with equivalent audit. |
+| Rollout after success | Stop after the pilot and review artifacts. Do not continue into broad backfill in Stage 18J. |
+
+A larger station-type backfill should be a later stage with separate acceptance criteria, not an automatic continuation of Stage 18J.
+
+## Required Tests
+
+Tests should be written before implementation or alongside the first dry-run-only implementation. They should prove that the pilot is narrower than current reconciliation and that existing warehouse/report-only guarantees remain intact.
+
+| Test category | Required coverage |
+|---|---|
+| Boundary preservation | Ordinary warehouse loaders still cannot write canonical tables; `--apply`, `--write`, and `--commit` remain rejected in current loaders.[11] |
+| Dry-run default | New pilot tool defaults to dry-run and writes no canonical data. |
+| Artifact determinism | Same inputs produce byte-stable canonical JSON and the same SHA-256. |
+| Eligibility acceptance | Exact system ID64, stable identifier, normalized name, valid permanent station type, eligible old value, clear risk state, and complete source metadata produce an eligible candidate. |
+| Identity rejection | Zero matches, multiple matches, name-only matches, mismatched system ID64, mismatched normalized station name, duplicate identity conflict, and malformed/skipped linkage block. |
+| Source type rejection | Missing, unknown, placeholder, unrecognized, carrier, transient, mobile, or unsupported station types block. |
+| Current value rejection | Existing known canonical station types are not overwritten by default. |
+| Evidence-state rejection | Ambiguous, insufficient, source-only, stale, undated without approved exception, risky, blocked, volatile, unknown, and report-only candidates block. |
+| Scope rejection | Distance, body name, services, economies, faction, government, allegiance, systems, bodies, links, rings, scan facts, planner, scoring, optimizer, Simulation Preview, role, and Build Plan mutations block. |
+| Apply gating | Apply requires artifact path, artifact SHA-256, expected count, approved table, approved field, approved source run, approval ID, and confirmation flag. |
+| Pre-image safety | Apply fails if current canonical pre-image differs from dry-run pre-image. |
+| Audit | Audit artifact includes source, pre-image, approval, tool version, row results, and verification metadata. |
+| Rollback | Rollback pre-image can restore old values and fails closed if current values drift. |
+| Verification | Post-apply verification proves only approved `stations.station_type` changed. |
+| API/UI/scheduler absence | No apply endpoint, UI button, Docker invocation, live API crawl, or production scheduler path is introduced. |
+
+Existing tests already provide useful patterns. The warehouse boundary tests prove canonical deny-list behavior and read-only reconciliation SQL enforcement.[8] The staging DB loader tests prove dry-run defaults, explicit staging-only writes, rollback on write failure, and fail-closed parsing for unsupported canonical flags.[11] The existing station enrichment guard tests and wrapper provide operational precedent for persisted artifacts, safety gates, and final dry-run verification, but Stage 18J should not reuse the live EDSM crawl path as its source of truth.[12]
+
+## Failure Modes And Stop Conditions
+
+The catastrophic failures are not subtle. The pilot could corrupt canonical data, overwrite trusted station types with bad snapshot values, turn name-only evidence into false identity, treat stale or source-only evidence as truth, accidentally write broad station metadata, or create a path by which ordinary warehouse loaders become canonical writers. Each of these must be converted into a stop condition.
+
+| Catastrophic risk | Stop condition |
+|---|---|
+| Broad canonical write | Stop if generated SQL, DB permissions, or audit shows any table other than `stations` or any field other than `station_type`. |
+| Wrong station identity | Stop if any candidate lacks exact `system_id64`, stable station identifier, normalized name match, and exactly one canonical match. |
+| Source type pollution | Stop if any selected candidate has missing, unknown, unrecognized, carrier, transient, mobile, or unsupported source type. |
+| Existing truth overwritten | Stop if any selected candidate overwrites a known canonical type without an explicitly approved replacement rule. |
+| Stale artifact | Stop if artifact checksum, row count, source run/file, table, field, or current pre-image differs from approval. |
+| Current reconciliation semantics misused | Stop if ordinary `candidate_update` rows are applied without Stage 18J-specific eligibility marking. |
+| Warehouse loader gains canonical power | Stop if `enrichment_staging_db_loader.py` or warehouse repository code gains canonical write behavior. |
+| Planner or scoring mutation | Stop if implementation touches planner, Build Plan, scoring, Simulation Preview, optimizer, role, or validation behavior. |
+| Live API dependency | Stop if implementation calls EDSM/API, invokes Docker from UI/API, or wires a scheduler. |
+| Missing audit or rollback | Stop if any applied row lacks audit and rollback pre-image. |
+| Verification failure | Stop all rollout; preserve artifacts; do not re-run apply until reviewed. |
+| Non-production rehearsal missing | Stop before production apply. |
+
+Codex or any implementing agent should stop immediately when it discovers that the requested implementation would require migrations, broad permissions, production database creation, UI/API write controls, live API crawling, scheduler wiring, or non-station-type canonical writes unless the user explicitly opens a new stage to approve that broader scope.
+
+## Recommended Codex Implementation Prompt
+
+```md
+You are implementing Stage 18J for ED-Finder. Before changing code, read:
+
+1. docs/colonisation-redesign/README.md
+2. docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+3. docs/colonisation-redesign/enrichment-roadmap.md
+4. docs/colonisation-redesign/enrichment-staging-architecture.md
+5. docs/operations/enrichment-warehouse-runbook.md
+6. docs/colonisation-redesign/stage-18h-warehouse-planner-evidence-bridge.md
+7. docs/colonisation-redesign/stage-18i-canonical-write-design-review.md
+8. docs/colonisation-redesign/stage-18i5-warehouse-database-boundary-review.md
+9. docs/reference/colonisation/README.md
+10. docs/reference/colonisation/source-priority.md
+11. docs/reference/colonisation/codex-reference-prompt-snippet.md
+12. docs/colonisation-redesign/stage-18j-station-type-canonical-pilot-plan.md
+
+Hard scope: implement only exact `stations.station_type` canonical pilot support for existing canonical stations matched by exact trusted station identity. Do not implement station inserts, deletes, systems writes, bodies writes, station_body_links writes, body_rings writes, body_scan_facts writes, distance writes, service/economy/faction/government/allegiance writes, planner mutation, Build Plan mutation, scoring changes, Simulation Preview changes, optimizer changes, role changes, live EDSM/API crawl, UI/API Docker invocation, production scheduler wiring, or broad backfill.
+
+Start with tests and a dry-run-only artifact builder. The dry-run artifact must be deterministic and versioned as `station_type_canonical_pilot_dry_run/v1`. Eligible candidates must require exact `system_id64`, exactly one canonical station match, stable station identifier, normalized station name match, valid permanent source station type, eligible old canonical value, clear risk state, no stale/volatile/source-only/risky/blocked/unknown/report-only selected evidence, source run/file/record metadata, rollback pre-image, and audit metadata.
+
+Do not make ordinary warehouse loaders able to write canonical tables. Do not reuse report-only `candidate_update` rows as executable write instructions. Current reconciliation reports must continue to keep `canonical_writes_planned = 0` and `auto_promote_to_canonical = false`.
+
+Apply mode, if implemented in this stage, must be a separate guarded canonical apply path. It must require artifact path, artifact SHA-256, expected candidate count, approved table `stations`, approved field `station_type`, approved source run, approval reference, and explicit confirmation flag. It must fail closed on any mismatch, stale pre-image, blocked candidate, wrong table, wrong field, or verification failure. It must emit audit, rollback pre-image, and post-apply verification artifacts.
+
+Before any production apply, require non-production rehearsal. First production pilot defaults to 5 rows and must not exceed 20 rows. Stop immediately if implementation requires migrations, broad permissions, live API crawling, UI/API write controls, scheduler wiring, or non-station-type canonical writes.
+```
+
+## Final Recommendation
+
+Stage 18J should proceed only as a **strict station-type-only canonical pilot** after the Stage 18I.5 boundary decision is accepted or an explicit temporary equivalent safety arrangement is approved. The pilot should begin with tests and dry-run-only artifact generation, not with apply. Apply should be introduced only as a separate guarded canonical apply path that requires checksumed artifact approval, exact table/field/source/count parameters, a small candidate cap, audit records, rollback pre-images, and post-apply verification.
+
+The answer to the primary risk question is therefore yes: exact station type promotion is still the safest first canonical write pilot. The answer is conditional, however. It is safe only if the implementation refuses to treat current report-only reconciliation candidates as write instructions, keeps ordinary warehouse loaders unable to write canonical tables, blocks all uncertain evidence states, and proves in non-production that only approved `stations.station_type` values can change.
+
+## References
+
+[1]: ./stage-18i-canonical-write-design-review.md "Stage 18I — Canonical Write Design Review"
+[2]: ./enrichment-staging-architecture.md "Enrichment Staging Architecture"
+[3]: ../../apps/importer/src/enrichment_warehouse.py "enrichment_warehouse.py"
+[4]: ../../apps/importer/src/enrichment_warehouse_repository.py "enrichment_warehouse_repository.py"
+[5]: ../../apps/importer/src/enrichment_reconciliation_scoring.py "enrichment_reconciliation_scoring.py"
+[6]: ./stage-18i5-warehouse-database-boundary-review.md "Stage 18I.5 — Warehouse Database Boundary Review"
+[7]: ./stage-17p-current-state-forward-plan.md "Stage 17P — Current State / Forward Plan Baseline"
+[8]: ../../tests/test_enrichment_warehouse_boundary.py "test_enrichment_warehouse_boundary.py"
+[9]: ../../apps/api/src/routers/admin.py "admin.py"
+[10]: ../../apps/importer/src/enrichment_warehouse_sql.py "enrichment_warehouse_sql.py"
+[11]: ../../tests/test_enrichment_staging_db_loader.py "test_enrichment_staging_db_loader.py"
+[12]: ../../scripts/station_enrichment_guard.py "station_enrichment_guard.py"

--- a/tests/test_station_type_canonical_pilot.py
+++ b/tests/test_station_type_canonical_pilot.py
@@ -284,6 +284,8 @@ def test_cli_apply_requires_full_explicit_approval_contract():
         'run-1',
         '--approval-id',
         'approval-1',
+        '--max-rows',
+        '1',
         '--dsn',
         'postgresql://apply/test',
         '--confirm-station-type-canonical-pilot',
@@ -348,6 +350,17 @@ def test_validate_apply_request_fails_closed_on_mismatched_approval_parameters()
             expected_candidate_count=1,
             approved_table='stations',
             approved_field='body_name',
+            approved_source_run='run-1',
+            approval_id='approval-1',
+            confirmation=True,
+        )
+    with pytest.raises(pilot.Stage18JPlanError, match='max rows'):
+        pilot.validate_apply_request(
+            artifact,
+            artifact_sha256_expected=checksum,
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='station_type',
             approved_source_run='run-1',
             approval_id='approval-1',
             confirmation=True,

--- a/tests/test_station_type_canonical_pilot.py
+++ b/tests/test_station_type_canonical_pilot.py
@@ -56,7 +56,9 @@ def station_candidate(**overrides):
         'canonical': {
             'system_id64': 424242,
             'system_name': 'Test System',
-            'station_id': 1001,
+            'station_id': 900001,
+            'market_id': 1001,
+            'edsm_station_id': None,
             'station_name': 'Harper Plant',
             'station_type': 'Unknown',
         },
@@ -64,7 +66,9 @@ def station_candidate(**overrides):
             {
                 'system_id64': 424242,
                 'system_name': 'Test System',
-                'station_id': 1001,
+                'station_id': 900001,
+                'market_id': 1001,
+                'edsm_station_id': None,
                 'station_name': 'Harper Plant',
                 'station_type': 'Unknown',
             }
@@ -87,7 +91,7 @@ def station_candidate(**overrides):
             'source_updated_at': '2026-05-31T12:00:00Z',
             'freshness_impact': 'timestamped_source',
         },
-        'report_only': True,
+        'report_only': False,
         'canonical_writes_planned': 0,
     }
     _deep_update(candidate, overrides)
@@ -134,8 +138,74 @@ def test_blocks_name_only_or_missing_stable_station_identifier():
     assert artifact['summary']['blocked_by_reason']['stable_station_identifier_matches'] == 1
 
 
+def test_blocks_internal_station_pk_match_without_canonical_external_identity():
+    candidate = station_candidate(
+        source={'market_id': 900001, 'edsm_station_id': None},
+        canonical={'market_id': None, 'edsm_station_id': None},
+        canonical_matches=[{
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'station_id': 900001,
+            'station_name': 'Harper Plant',
+            'station_type': 'Unknown',
+        }],
+    )
+
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(candidate),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['eligible_candidates'] == 0
+    blocked = artifact['blocked_candidates'][0]
+    assert 'stable_station_identifier_matches' in blocked['blocking_reasons']
+    assert blocked['canonical']['station_id'] == 900001
+    assert blocked['canonical']['market_id'] is None
+    assert blocked['match_proof']['source_market_id'] == 900001
+    assert blocked['match_proof']['canonical_market_id'] is None
+
+
+def test_blocks_internal_station_pk_match_when_canonical_external_identity_differs():
+    candidate = station_candidate(
+        source={'market_id': 900001, 'edsm_station_id': None},
+        canonical={'station_id': 900001, 'market_id': 1001, 'edsm_station_id': None},
+        canonical_matches=[{
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'station_id': 900001,
+            'market_id': 1001,
+            'edsm_station_id': None,
+            'station_name': 'Harper Plant',
+            'station_type': 'Unknown',
+        }],
+    )
+
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(candidate),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['eligible_candidates'] == 0
+    blocked = artifact['blocked_candidates'][0]
+    assert 'stable_station_identifier_matches' in blocked['blocking_reasons']
+    assert blocked['match_proof']['source_market_id'] == 900001
+    assert blocked['match_proof']['canonical_market_id'] == 1001
+
+
 def test_allows_edsm_station_id_only_when_explicitly_enabled():
-    candidate = station_candidate(source={'market_id': None, 'edsm_station_id': 1001})
+    candidate = station_candidate(
+        source={'market_id': None, 'edsm_station_id': 1001},
+        canonical={'market_id': None, 'edsm_station_id': 1001},
+        canonical_matches=[{
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'station_id': 900001,
+            'market_id': None,
+            'edsm_station_id': 1001,
+            'station_name': 'Harper Plant',
+            'station_type': 'Unknown',
+        }],
+    )
 
     without_flag = pilot.build_station_type_pilot_dry_run(
         report_with(candidate),
@@ -165,6 +235,8 @@ def test_allows_edsm_station_id_only_when_explicitly_enabled():
         ({'risk_class': 'stale'}, 'risk_class_clear'),
         ({'risk_flags': ['volatile_source_evidence']}, 'no_blocking_risk_flags'),
         ({'review_classifications': ['source_only']}, 'no_blocking_review_classifications'),
+        ({'review_classifications': ['report_only']}, 'no_blocking_review_classifications'),
+        ({'report_only': True}, 'not_report_only_evidence'),
         ({'source_freshness': {'freshness_impact': 'undated_source_review'}}, 'freshness_allowed'),
         ({'differences': [
             {'field': 'station_type', 'staged': 'Orbis Starport', 'canonical': 'Unknown'},
@@ -288,7 +360,7 @@ def test_guarded_apply_updates_only_station_type_and_emits_audit_rollback_and_ve
         generated_at='2026-06-01T00:00:00Z',
     )
     checksum = pilot.artifact_sha256(artifact)
-    conn = FakeApplyConn({(1001, 424242): {'id': 1001, 'system_id64': 424242, 'name': 'Harper Plant', 'station_type': 'Unknown'}})
+    conn = FakeApplyConn({(900001, 424242): {'id': 900001, 'system_id64': 424242, 'name': 'Harper Plant', 'station_type': 'Unknown'}})
 
     audit = pilot.apply_station_type_pilot(
         conn,
@@ -306,7 +378,7 @@ def test_guarded_apply_updates_only_station_type_and_emits_audit_rollback_and_ve
         generated_at='2026-06-01T00:00:00Z',
     )
 
-    assert conn.rows[(1001, 424242)]['station_type'] == 'Orbis'
+    assert conn.rows[(900001, 424242)]['station_type'] == 'Orbis'
     assert conn.commits == 1
     assert conn.rollbacks == 0
     assert audit['schema_version'] == 'station_type_canonical_pilot_apply/v1'
@@ -329,7 +401,7 @@ def test_guarded_apply_rolls_back_when_preimage_changed():
         generated_at='2026-06-01T00:00:00Z',
     )
     checksum = pilot.artifact_sha256(artifact)
-    conn = FakeApplyConn({(1001, 424242): {'id': 1001, 'system_id64': 424242, 'name': 'Harper Plant', 'station_type': 'Coriolis'}})
+    conn = FakeApplyConn({(900001, 424242): {'id': 900001, 'system_id64': 424242, 'name': 'Harper Plant', 'station_type': 'Coriolis'}})
 
     with pytest.raises(pilot.Stage18JPlanError, match='pre-image mismatch'):
         pilot.apply_station_type_pilot(
@@ -347,7 +419,34 @@ def test_guarded_apply_rolls_back_when_preimage_changed():
 
     assert conn.commits == 0
     assert conn.rollbacks == 1
-    assert conn.rows[(1001, 424242)]['station_type'] == 'Coriolis'
+    assert conn.rows[(900001, 424242)]['station_type'] == 'Coriolis'
+
+
+def test_guarded_apply_rolls_back_when_identity_preimage_changed():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(station_candidate()),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+    checksum = pilot.artifact_sha256(artifact)
+    conn = FakeApplyConn({(900001, 424242): {'id': 900001, 'system_id64': 424242, 'name': 'Renamed Plant', 'station_type': 'Unknown'}})
+
+    with pytest.raises(pilot.Stage18JPlanError, match='identity pre-image mismatch'):
+        pilot.apply_station_type_pilot(
+            conn,
+            artifact,
+            artifact_sha256_expected=checksum,
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='station_type',
+            approved_source_run='run-1',
+            approval_id='approval-1',
+            confirmation=True,
+            max_rows=1,
+        )
+
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+    assert conn.rows[(900001, 424242)]['station_type'] == 'Unknown'
 
 
 class FakeApplyConn:

--- a/tests/test_station_type_canonical_pilot.py
+++ b/tests/test_station_type_canonical_pilot.py
@@ -1,0 +1,408 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', '/dev/null')
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_type_canonical_pilot as pilot  # noqa: E402
+
+
+def report_with(*candidates):
+    return {
+        'schema_version': 'enrichment_staging_reconciliation/v1',
+        'dry_run': True,
+        'filters': {
+            'source_run_key': 'run-1',
+            'source_file_key': 'file-1',
+            'source': 'edsm_nightly_stations',
+        },
+        'summary': {
+            'canonical_writes_planned': 0,
+        },
+        'station_candidates': list(candidates),
+    }
+
+
+def station_candidate(**overrides):
+    candidate = {
+        'entity': 'station',
+        'candidate_action': 'candidate_update',
+        'source': {
+            'source_run_key': 'run-1',
+            'source_file_key': 'file-1',
+            'source_record_key': 'record-1',
+            'source_record_hash': 'hash-1',
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'market_id': 1001,
+            'edsm_station_id': None,
+            'station_name': 'Harper Plant',
+            'source': 'edsm_nightly_stations',
+            'source_class': 'semi-stable',
+            'confidence': 'source_station_snapshot',
+            'freshness_class': 'source_updated_at',
+            'source_updated_at': '2026-05-31T12:00:00Z',
+        },
+        'canonical': {
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'station_id': 1001,
+            'station_name': 'Harper Plant',
+            'station_type': 'Unknown',
+        },
+        'canonical_matches': [
+            {
+                'system_id64': 424242,
+                'system_name': 'Test System',
+                'station_id': 1001,
+                'station_name': 'Harper Plant',
+                'station_type': 'Unknown',
+            }
+        ],
+        'differences': [
+            {
+                'field': 'station_type',
+                'staged': 'Orbis Starport',
+                'canonical': 'Unknown',
+            }
+        ],
+        'warnings': [],
+        'confidence': 'high',
+        'risk_class': 'clear',
+        'risk_flags': [],
+        'review_classifications': [],
+        'reconciliation_state': 'confirmed',
+        'source_freshness': {
+            'freshness_class': 'source_updated_at',
+            'source_updated_at': '2026-05-31T12:00:00Z',
+            'freshness_impact': 'timestamped_source',
+        },
+        'report_only': True,
+        'canonical_writes_planned': 0,
+    }
+    _deep_update(candidate, overrides)
+    return candidate
+
+
+def test_dry_run_builds_deterministic_station_type_artifact():
+    report = report_with(station_candidate())
+
+    first = pilot.build_station_type_pilot_dry_run(
+        report,
+        generated_at='2026-06-01T00:00:00Z',
+        git_commit='abc123',
+    )
+    second = pilot.build_station_type_pilot_dry_run(
+        report,
+        generated_at='2026-06-01T00:00:00Z',
+        git_commit='abc123',
+    )
+
+    assert first == second
+    assert first['schema_version'] == 'station_type_canonical_pilot_dry_run/v1'
+    assert first['dry_run'] is True
+    assert first['pilot_scope']['canonical_table'] == 'stations'
+    assert first['pilot_scope']['canonical_field'] == 'station_type'
+    assert first['pilot_scope']['apply_requires_separate_guarded_mode'] is True
+    assert first['summary']['canonical_writes_planned'] == 1
+    candidate = first['eligible_candidates'][0]
+    assert candidate['canonical_table'] == 'stations'
+    assert candidate['field'] == 'station_type'
+    assert candidate['old_value'] == 'Unknown'
+    assert candidate['new_value'] == 'Orbis'
+    assert candidate['match_proof']['identifier_match_type'] == 'market_id'
+    assert candidate['rollback_pre_image']['pre_image_value'] == 'Unknown'
+    assert first['artifact_integrity']['canonical_json_sha256'] == pilot.artifact_sha256(first)
+
+
+def test_blocks_name_only_or_missing_stable_station_identifier():
+    report = report_with(station_candidate(source={'market_id': None, 'edsm_station_id': None}))
+
+    artifact = pilot.build_station_type_pilot_dry_run(report, generated_at='2026-06-01T00:00:00Z')
+
+    assert artifact['summary']['eligible_candidates'] == 0
+    assert artifact['summary']['blocked_by_reason']['stable_station_identifier_matches'] == 1
+
+
+def test_allows_edsm_station_id_only_when_explicitly_enabled():
+    candidate = station_candidate(source={'market_id': None, 'edsm_station_id': 1001})
+
+    without_flag = pilot.build_station_type_pilot_dry_run(
+        report_with(candidate),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+    with_flag = pilot.build_station_type_pilot_dry_run(
+        report_with(candidate),
+        allow_edsm_station_id=True,
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert without_flag['summary']['eligible_candidates'] == 0
+    assert with_flag['summary']['eligible_candidates'] == 1
+    assert with_flag['eligible_candidates'][0]['match_proof']['identifier_match_type'] == 'edsm_station_id'
+
+
+@pytest.mark.parametrize(
+    'overrides,reason',
+    [
+        ({'canonical_matches': []}, 'exactly_one_canonical_match'),
+        ({'canonical_matches': [{'station_id': 1001}, {'station_id': 1002}]}, 'exactly_one_canonical_match'),
+        ({'source': {'system_id64': 999}}, 'system_id64_matches'),
+        ({'source': {'station_name': 'Wrong Name'}}, 'station_name_matches'),
+        ({'differences': [{'field': 'station_type', 'staged': 'Fleet Carrier', 'canonical': 'Unknown'}]}, 'source_station_type_permanent'),
+        ({'differences': [{'field': 'station_type', 'staged': 'Coriolis Logistics', 'canonical': 'Unknown'}]}, 'source_station_type_permanent'),
+        ({'canonical': {'station_type': 'Coriolis'}}, 'canonical_old_value_eligible'),
+        ({'risk_class': 'stale'}, 'risk_class_clear'),
+        ({'risk_flags': ['volatile_source_evidence']}, 'no_blocking_risk_flags'),
+        ({'review_classifications': ['source_only']}, 'no_blocking_review_classifications'),
+        ({'source_freshness': {'freshness_impact': 'undated_source_review'}}, 'freshness_allowed'),
+        ({'differences': [
+            {'field': 'station_type', 'staged': 'Orbis Starport', 'canonical': 'Unknown'},
+            {'field': 'distance_to_arrival', 'staged': 12.0, 'canonical': None},
+        ]}, 'target_difference_is_station_type_only'),
+    ],
+)
+def test_blocks_unsafe_candidate_states(overrides, reason):
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(station_candidate(**overrides)),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['eligible_candidates'] == 0
+    assert artifact['summary']['blocked_by_reason'][reason] == 1
+
+
+def test_cli_rejects_unsupported_write_commit_flags():
+    for flag in ('--write', '--commit'):
+        with pytest.raises(SystemExit):
+            pilot.parse_args([
+                '--reconciliation-report',
+                'report.json',
+                flag,
+            ])
+
+
+def test_cli_apply_requires_full_explicit_approval_contract():
+    with pytest.raises(SystemExit):
+        pilot.parse_args(['--apply', '--artifact', 'artifact.json'])
+
+    args = pilot.parse_args([
+        '--apply',
+        '--artifact',
+        'artifact.json',
+        '--artifact-sha256',
+        'abc',
+        '--expected-candidate-count',
+        '1',
+        '--approved-table',
+        'stations',
+        '--approved-field',
+        'station_type',
+        '--approved-source-run',
+        'run-1',
+        '--approval-id',
+        'approval-1',
+        '--dsn',
+        'postgresql://apply/test',
+        '--confirm-station-type-canonical-pilot',
+    ])
+    assert args.apply is True
+    assert args.confirm_station_type_canonical_pilot is True
+
+
+def test_cli_writes_dry_run_json_artifact(tmp_path):
+    report_path = tmp_path / 'reconciliation.json'
+    output_path = tmp_path / 'stage18j.json'
+    report_path.write_text(json.dumps(report_with(station_candidate())), encoding='utf-8')
+
+    result = pilot.main([
+        '--reconciliation-report',
+        str(report_path),
+        '--output',
+        str(output_path),
+        '--limit',
+        '1',
+    ])
+
+    assert result == 0
+    payload = json.loads(output_path.read_text(encoding='utf-8'))
+    assert payload['schema_version'] == 'station_type_canonical_pilot_dry_run/v1'
+    assert payload['summary']['eligible_candidates'] == 1
+
+
+def test_validate_apply_request_fails_closed_on_mismatched_approval_parameters():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(station_candidate()),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+    checksum = pilot.artifact_sha256(artifact)
+
+    with pytest.raises(pilot.Stage18JPlanError, match='confirmation'):
+        pilot.validate_apply_request(
+            artifact,
+            artifact_sha256_expected=checksum,
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='station_type',
+            approved_source_run='run-1',
+            approval_id='approval-1',
+            confirmation=False,
+        )
+    with pytest.raises(pilot.Stage18JPlanError, match='checksum'):
+        pilot.validate_apply_request(
+            artifact,
+            artifact_sha256_expected='bad-sha',
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='station_type',
+            approved_source_run='run-1',
+            approval_id='approval-1',
+            confirmation=True,
+        )
+    with pytest.raises(pilot.Stage18JPlanError, match='approved field'):
+        pilot.validate_apply_request(
+            artifact,
+            artifact_sha256_expected=checksum,
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='body_name',
+            approved_source_run='run-1',
+            approval_id='approval-1',
+            confirmation=True,
+        )
+
+
+def test_guarded_apply_updates_only_station_type_and_emits_audit_rollback_and_verification():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(station_candidate()),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+    checksum = pilot.artifact_sha256(artifact)
+    conn = FakeApplyConn({(1001, 424242): {'id': 1001, 'system_id64': 424242, 'name': 'Harper Plant', 'station_type': 'Unknown'}})
+
+    audit = pilot.apply_station_type_pilot(
+        conn,
+        artifact,
+        artifact_sha256_expected=checksum,
+        expected_candidate_count=1,
+        approved_table='stations',
+        approved_field='station_type',
+        approved_source_run='run-1',
+        approved_source_file='file-1',
+        approval_id='approval-1',
+        confirmation=True,
+        max_rows=1,
+        apply_run_id='apply-1',
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert conn.rows[(1001, 424242)]['station_type'] == 'Orbis'
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    assert audit['schema_version'] == 'station_type_canonical_pilot_apply/v1'
+    assert audit['summary']['applied'] == 1
+    assert audit['rows'][0]['field'] == 'station_type'
+    assert audit['rollback_preimage']['schema_version'] == 'station_type_canonical_pilot_rollback_preimage/v1'
+    assert audit['rollback_preimage']['rows'][0]['pre_image_value'] == 'Unknown'
+    assert audit['post_apply_verification']['schema_version'] == 'station_type_canonical_pilot_verification/v1'
+    assert audit['post_apply_verification']['summary']['ok'] is True
+    sql_text = '\n'.join(sql for sql, _params in conn.statements)
+    assert 'UPDATE stations' in sql_text
+    assert 'SET station_type' in sql_text
+    assert 'distance_from_star' not in sql_text
+    assert 'station_body_links' not in sql_text
+
+
+def test_guarded_apply_rolls_back_when_preimage_changed():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(station_candidate()),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+    checksum = pilot.artifact_sha256(artifact)
+    conn = FakeApplyConn({(1001, 424242): {'id': 1001, 'system_id64': 424242, 'name': 'Harper Plant', 'station_type': 'Coriolis'}})
+
+    with pytest.raises(pilot.Stage18JPlanError, match='pre-image mismatch'):
+        pilot.apply_station_type_pilot(
+            conn,
+            artifact,
+            artifact_sha256_expected=checksum,
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='station_type',
+            approved_source_run='run-1',
+            approval_id='approval-1',
+            confirmation=True,
+            max_rows=1,
+        )
+
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+    assert conn.rows[(1001, 424242)]['station_type'] == 'Coriolis'
+
+
+class FakeApplyConn:
+    def __init__(self, rows):
+        self.rows = rows
+        self.statements = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self):
+        return FakeApplyCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+class FakeApplyCursor:
+    description = None
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.last_row = None
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        self.conn.statements.append((sql, params or ()))
+        sql_lower = ' '.join(sql.lower().split())
+        if sql_lower.startswith('select id, system_id64'):
+            station_id, system_id64 = params
+            self.last_row = dict(self.conn.rows.get((station_id, system_id64))) if (station_id, system_id64) in self.conn.rows else None
+            return
+        if sql_lower.startswith('update stations'):
+            new_value, station_id, system_id64, old_value = params
+            row = self.conn.rows.get((station_id, system_id64))
+            if row is None or row.get('station_type') != old_value:
+                self.last_row = None
+                return
+            row['station_type'] = new_value
+            self.last_row = dict(row)
+            return
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+    def fetchone(self):
+        return self.last_row
+
+    def close(self):
+        self.closed = True
+
+
+def _deep_update(target, overrides):
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(target.get(key), dict):
+            _deep_update(target[key], value)
+        else:
+            target[key] = value


### PR DESCRIPTION
## What changed

* Adds the Stage 18J station type canonical write pilot plan.
* Adds a dedicated `station_type_canonical_pilot.py` tool for the exact `stations.station_type` pilot.
* Builds deterministic `station_type_canonical_pilot_dry_run/v1` artifacts from read-only warehouse reconciliation reports.
* Keeps dry-run as the default and rejects unsupported broad write/commit aliases.
* Adds a guarded apply path that requires artifact SHA-256, expected count, approved table, approved field, approved source run, approval reference, explicit confirmation, and a bounded max row count.
* Revalidates canonical pre-images before updating only `stations.station_type`.
* Emits apply audit, rollback pre-image, and post-apply verification artifacts.
* Hardens identity matching so source `market_id` / `edsm_station_id` are matched only against explicit canonical external identity fields, never against `canonical.station_id` as an internal primary key fallback.
* Adds focused tests for eligibility, identity mismatch blocking, blocking conditions, CLI gates, apply fail-closed behavior, audit, rollback pre-image, and verification.

## Boundaries

* Stage 18I.5 PR #103 was merged first.
* No migrations.
* No station inserts or deletes.
* No systems, bodies, station_body_links, body_rings, or body_scan_facts writes.
* No distance_from_star / distanceToArrival writes.
* No services/economies/faction/government/allegiance writes.
* No planner, Build Plan, scoring, Simulation Preview, optimiser, or role changes.
* No live EDSM/API crawl.
* No Docker invocation from UI/API.
* No production scheduler wiring.
* Existing warehouse loaders remain separate from the canonical apply path.

## Validation

Requested `python3.11` is not installed in the local review environment (`python3.11: command not found`), so equivalent validation was run with the repo venv interpreter (`Python 3.12.3`).

* `/home/brian/Documents/GitHub/ed-finder/.venv/bin/pytest tests/test_station_type_canonical_pilot.py -q`
  * Result: 26 passed.
* `/home/brian/Documents/GitHub/ed-finder/.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q`
  * Result: 81 passed.
* `/home/brian/Documents/GitHub/ed-finder/.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py`
  * Result: passed.
* `git diff --check`
  * Result: passed.