### PR TITLE
Stage 18T canonical safety test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,66 @@ jobs:
           LOG_LEVEL:    WARNING
         run: python -m pytest tests/integration/ -v
 
+  # ─── Canonical safety tests ────────────────────────────────────────
+  # Stage 18T: keep canonical-write-capable code behind deterministic
+  # unit gates plus a disposable Postgres rehearsal of the guarded apply
+  # path and role boundary.
+  canonical-safety:
+    name: Canonical safety tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER:     edfinder
+          POSTGRES_PASSWORD: edfinder
+          POSTGRES_DB:       edfinder
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s --health-timeout 3s --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            tests/requirements-ci.txt
+            apps/api/requirements.txt
+            apps/importer/requirements.txt
+
+      - name: Install canonical safety test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r tests/requirements-ci.txt
+
+      - name: Run canonical safety suite
+        run: |
+          python -m pytest \
+            tests/test_station_type_canonical_pilot.py \
+            tests/test_enrichment_warehouse_boundary.py \
+            tests/test_enrichment_staging_db_loader.py \
+            tests/test_enrichment_report_contracts.py \
+            tests/test_edsm_station_normalization.py \
+            -q
+
+      - name: Compile canonical safety modules
+        run: |
+          python -m py_compile \
+            apps/importer/src/station_type_canonical_pilot.py \
+            tests/test_station_type_canonical_pilot.py \
+            tests/test_station_type_canonical_pilot_postgres.py
+
+      - name: Run disposable Postgres canonical rehearsal
+        env:
+          DATABASE_URL: postgresql://edfinder:edfinder@localhost:5432/edfinder
+          EDFINDER_CANONICAL_TEST_DSN: postgresql://edfinder:edfinder@localhost:5432/edfinder
+          EDFINDER_CONFIRM_CANONICAL_TEST_DB: "yes"
+        run: python -m pytest tests/test_station_type_canonical_pilot_postgres.py -q
+
 
   # ─── Frontend v2 ────────────────────────────────────────────────────
   # Catches the exact class of "file got swallowed by .gitignore" bug we

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -467,6 +467,13 @@ write-plan transfer, audit ownership, retention, and Stage 18J readiness
 criteria. See
 [`stage-18i5-warehouse-database-boundary-review.md`](./stage-18i5-warehouse-database-boundary-review.md).
 
+Stage 18T hardens the canonical safety test environment for Stage 18J-class
+work. It adds a dedicated CI job, explicit test prerequisites, a one-command
+local runner, and disposable Postgres rehearsal/permission-boundary coverage
+for the guarded station type pilot. It does not authorize production apply,
+artifact approval, production DB access, or wider canonical backfill. See
+[`stage-18t-canonical-safety-test-environment.md`](./stage-18t-canonical-safety-test-environment.md).
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -462,6 +462,40 @@ Acceptance:
 
 - One narrow canonical write path is proven safe, auditable, reversible, and boring before any wider canonical expansion.
 
+Stage 18J delivered the station type canonical pilot as the first
+canonical-write-capable path. Production apply remains unauthorized unless a
+separate future instruction approves the exact artifact, candidate count,
+source run/file, table, field, max row count, and apply DSN context.
+
+### Stage 18T — Canonical Safety Test Environment
+
+Purpose: make canonical-write-capable test coverage repeatable in CI and local
+development before further production dry-run or apply work.
+
+Scope:
+
+- Add a dedicated canonical safety CI job.
+- Install explicit test prerequisites, including `pytest-asyncio`.
+- Add a local one-command canonical safety test runner.
+- Add disposable Postgres rehearsal and permission-boundary tests for the
+  guarded Stage 18J station type apply path.
+
+Non-goals:
+
+- No production apply.
+- No production artifact.
+- No production DB access.
+- No broad canonical backfill.
+- No UI/API apply controls or scheduler wiring.
+
+Acceptance:
+
+- The canonical safety suite runs consistently in CI and locally.
+- Disposable Postgres rehearsal proves the guarded apply path and scoped
+  permissions without touching production.
+
+Environment doc: `stage-18t-canonical-safety-test-environment.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -496,5 +530,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 14. Stage 18I canonical write design review.
 15. Stage 18I.5 warehouse database boundary review.
 16. Stage 18J first narrow canonical write pilot.
+17. Stage 18T canonical safety test environment.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p-station-type-production-dry-run-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-p-station-type-production-dry-run-readiness.md
@@ -237,6 +237,10 @@ approval must name:
 The production cap remains tiny: default 5 and max 20 unless a later stage
 changes it.
 
+Stage 18T adds the canonical safety test-environment gate that should pass
+before any future production dry-run or production apply attempt:
+[`stage-18t-canonical-safety-test-environment.md`](./stage-18t-canonical-safety-test-environment.md).
+
 ## Stop Conditions
 
 Stop before dry-run generation if:

--- a/docs/colonisation-redesign/stage-18t-canonical-safety-test-environment.md
+++ b/docs/colonisation-redesign/stage-18t-canonical-safety-test-environment.md
@@ -1,0 +1,199 @@
+# Stage 18T — Canonical Safety Test Environment
+
+## Purpose
+
+Stage 18T hardens the test environment around canonical-write-capable code.
+The goal is to make the Stage 18J station type pilot repeatable in CI and
+locally, including dependency installation, fail-closed dry-run/apply checks,
+disposable Postgres rehearsal, and permission-boundary coverage.
+
+This stage does not authorize production apply. It creates no production
+artifact, approval record, production database changes, migrations, scheduler
+wiring, UI/API apply controls, or broad canonical backfill.
+
+## Current Gap
+
+Stage 18J and Stage 18J-P proved the station type pilot remains guarded, but
+the safety tests still depended on remembered local commands. The repo also
+configured `asyncio_mode = "auto"` for pytest, which can warn when
+`pytest-asyncio` is not installed in the active test environment.
+
+The missing Stage 18J-R non-production rehearsal document remains a reference
+gap on `origin/main`. Stage 18T fills the executable test-environment gap; it
+does not recreate that missing document.
+
+## CI Gates Added
+
+The CI workflow now has a dedicated `Canonical safety tests` job using Python
+3.12. The job installs explicit canonical test dependencies, then runs:
+
+```sh
+python -m pytest \
+    tests/test_station_type_canonical_pilot.py \
+    tests/test_enrichment_warehouse_boundary.py \
+    tests/test_enrichment_staging_db_loader.py \
+    tests/test_enrichment_report_contracts.py \
+    tests/test_edsm_station_normalization.py \
+    -q
+
+python -m py_compile \
+    apps/importer/src/station_type_canonical_pilot.py \
+    tests/test_station_type_canonical_pilot.py \
+    tests/test_station_type_canonical_pilot_postgres.py
+```
+
+The job also starts a disposable Postgres service container and runs the
+Postgres rehearsal test with:
+
+```sh
+EDFINDER_CANONICAL_TEST_DSN=postgresql://edfinder:edfinder@localhost:5432/edfinder \
+EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes \
+python -m pytest tests/test_station_type_canonical_pilot_postgres.py -q
+```
+
+## Test Dependencies / Prerequisites
+
+CI dependencies are declared in `tests/requirements-ci.txt`. That file pulls
+the API and importer runtime requirements and pins the test runner
+prerequisites:
+
+- `pytest`
+- `pytest-asyncio`
+- the Postgres driver from the importer requirements
+- API and importer runtime dependencies used by imported modules
+
+Adding `pytest-asyncio` to the CI dependency path makes the configured
+`asyncio_mode` option recognized by the canonical safety job instead of relying
+on whatever a local virtualenv already has installed.
+
+## Local Canonical Safety Test Command
+
+Developers can run the non-production canonical safety suite with one command:
+
+```sh
+./scripts/run_canonical_safety_tests.sh
+```
+
+The script uses `.venv/bin/python` when present and otherwise falls back to
+`python`. It runs the Stage 18J pilot tests, warehouse boundary tests, staging
+loader fail-closed tests, report contract tests, station normalization tests,
+and `py_compile` for the pilot module and tests.
+
+Disposable Postgres rehearsal is opt-in locally. To run it, the developer must
+set both variables:
+
+```sh
+EDFINDER_CANONICAL_TEST_DSN=postgresql://edfinder:edfinder@localhost:5432/edfinder \
+EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes \
+./scripts/run_canonical_safety_tests.sh
+```
+
+If `pg_virtualenv` is available, a fully disposable local cluster can be used
+without touching an existing developer database:
+
+```sh
+pg_virtualenv sh -c 'EDFINDER_CANONICAL_TEST_DSN="host=localhost port=$PGPORT dbname=postgres user=$PGUSER" EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes ./scripts/run_canonical_safety_tests.sh'
+```
+
+## Disposable Postgres Rehearsal
+
+`tests/test_station_type_canonical_pilot_postgres.py` is skipped unless
+`EDFINDER_CANONICAL_TEST_DSN` is set and
+`EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes` is present.
+
+The test rejects unsafe DSNs before connecting. It refuses to run when the DSN:
+
+- is missing,
+- lacks the exact confirmation value,
+- uses a host outside `localhost`, `127.0.0.1`, `::1`, or the CI service host
+  name `postgres`,
+- lacks a database name,
+- contains obvious production markers such as `prod`, `production`, `live`, or
+  `hetzner`.
+
+When enabled, the test creates a random disposable schema and disposable test
+roles, then drops them at teardown. It verifies:
+
+- the guarded apply path can update a disposable `stations.station_type` value,
+- only the station type changes,
+- no canonical-like table row counts change,
+- station identity pre-image mismatch fails,
+- station type pre-image mismatch fails,
+- artifact checksum mismatch fails,
+- expected candidate count mismatch fails,
+- approved table mismatch fails,
+- approved field mismatch fails,
+- source run mismatch fails,
+- explicit max row approval is required,
+- rollback pre-image, audit rows, and post-apply verification are emitted.
+
+## Permission Boundary Tests
+
+The disposable Postgres rehearsal creates these test-only roles:
+
+- `warehouse_loader_test_<token>`
+- `canonical_apply_test_<token>`
+- `canonical_read_test_<token>`
+
+The permission-boundary test proves the warehouse loader role cannot update
+`stations`, insert/update/delete canonical-like tables, or touch systems,
+bodies, station-body links, rings, or body scan facts. It also proves the
+canonical apply role can update only `stations.station_type` in the disposable
+schema and cannot update station name, distance fields, systems, bodies,
+station-body links, rings, or scan facts.
+
+These roles are disposable test roles only. Stage 18T does not create or modify
+production users or permissions.
+
+## Tests Required Before Production Dry-Run
+
+Before any future production station-type dry-run, the following gates should
+be green on the candidate branch:
+
+- the `Canonical safety tests` CI job,
+- `./scripts/run_canonical_safety_tests.sh`,
+- the focused Stage 18J pytest suite,
+- the disposable Postgres rehearsal in CI,
+- `git diff --check`.
+
+A production-connected reconciliation command still requires separately
+verified read-only/report-only DSN context. Stage 18T does not authorize that
+command.
+
+## Tests Required Before Production Apply
+
+Before any future production apply, repeat the dry-run gates and additionally
+require:
+
+- the exact dry-run artifact hash to be approved,
+- the exact candidate count to be approved,
+- the exact source run/file to be approved,
+- the table `stations` and field `station_type` to be approved,
+- the bounded max row count to be approved,
+- the apply DSN context to be explicitly approved,
+- the disposable Postgres rehearsal and permission-boundary tests to be green,
+- manual review confirming every candidate is an exact external identity match
+  and no known canonical station type is overwritten by default.
+
+Any future production apply still requires a separate explicit instruction and
+approval. The guarded apply path must remain unavailable to UI/API, scheduler,
+Docker automation, or broad backfill flows.
+
+## Remaining Gaps
+
+- The Stage 18J-R non-production rehearsal document is still absent on
+  `origin/main`.
+- The Postgres rehearsal uses a minimal disposable schema tailored to the
+  station type pilot, not the full production schema.
+- The permission-boundary test proves role behavior in a disposable schema. It
+  does not create or validate production roles.
+- Stage 18T does not generate a production reconciliation artifact or
+  production dry-run artifact.
+
+## Final Recommendation
+
+Keep Stage 18J canonical apply blocked from production until the canonical
+safety CI job is green, the local runner passes, a suitable report-only
+production reconciliation artifact exists, and a separate explicit approval
+names the exact artifact hash, candidate count, source run/file, table, field,
+max row count, and apply DSN context.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -468,6 +468,12 @@ Postgres stack if feasible, with a future path to a separate instance. This
 runbook still describes the current report-only workflow; no database creation,
 migration, permission, or canonical apply step is added by Stage 18I.5.
 
+Stage 18T documents the canonical safety test environment in
+`docs/colonisation-redesign/stage-18t-canonical-safety-test-environment.md`.
+It adds a dedicated CI gate, a local runner, and disposable Postgres rehearsal
+coverage for the guarded Stage 18J station type apply path. This does not
+authorize production apply or production artifact creation.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables

--- a/scripts/run_canonical_safety_tests.sh
+++ b/scripts/run_canonical_safety_tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ -x ".venv/bin/python" ]; then
+    PYTHON=".venv/bin/python"
+else
+    PYTHON="${PYTHON:-python}"
+fi
+
+"$PYTHON" -m pytest \
+    tests/test_station_type_canonical_pilot.py \
+    tests/test_enrichment_warehouse_boundary.py \
+    tests/test_enrichment_staging_db_loader.py \
+    tests/test_enrichment_report_contracts.py \
+    tests/test_edsm_station_normalization.py \
+    -q
+
+"$PYTHON" -m py_compile \
+    apps/importer/src/station_type_canonical_pilot.py \
+    tests/test_station_type_canonical_pilot.py \
+    tests/test_station_type_canonical_pilot_postgres.py
+
+if [ "${EDFINDER_CONFIRM_CANONICAL_TEST_DB:-}" = "yes" ] && [ -n "${EDFINDER_CANONICAL_TEST_DSN:-}" ]; then
+    "$PYTHON" -m pytest tests/test_station_type_canonical_pilot_postgres.py -q
+else
+    echo "Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable."
+fi

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -1,0 +1,10 @@
+# Canonical safety and CI test dependencies.
+#
+# Runtime dependencies are pulled from the app manifests so test imports match
+# CI/runtime behavior instead of depending on whatever happens to be installed
+# in a local virtualenv.
+-r ../apps/api/requirements.txt
+-r ../apps/importer/requirements.txt
+
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/tests/test_station_type_canonical_pilot_postgres.py
+++ b/tests/test_station_type_canonical_pilot_postgres.py
@@ -1,0 +1,430 @@
+import os
+import sys
+import uuid
+from pathlib import Path
+from urllib.parse import quote, urlparse, urlunparse
+
+import pytest
+
+
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', '/dev/null')
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_type_canonical_pilot as pilot  # noqa: E402
+
+
+ALLOWED_TEST_HOSTS = {'localhost', '127.0.0.1', '::1', 'postgres'}
+PRODUCTION_MARKERS = {'prod', 'production', 'live', 'hetzner'}
+
+
+def test_postgres_rehearsal_applies_only_station_type_and_emits_artifacts(pg_env):
+    artifact = pilot.build_station_type_pilot_dry_run(_report_with(_station_candidate()), generated_at='2026-06-01T00:00:00Z')
+    checksum = pilot.artifact_sha256(artifact)
+    before = _table_counts(pg_env.admin_conn, pg_env.schema)
+
+    conn = pg_env.connect_as(pg_env.canonical_apply_role)
+    try:
+        _set_search_path(conn, pg_env.schema)
+        audit = pilot.apply_station_type_pilot(
+            conn,
+            artifact,
+            artifact_sha256_expected=checksum,
+            expected_candidate_count=1,
+            approved_table='stations',
+            approved_field='station_type',
+            approved_source_run='run-1',
+            approved_source_file='file-1',
+            approval_id='stage18t-test-approval',
+            confirmation=True,
+            max_rows=1,
+            apply_run_id='stage18t-test-apply',
+            generated_at='2026-06-01T00:00:00Z',
+        )
+    finally:
+        conn.close()
+
+    station = _station_row(pg_env.admin_conn, pg_env.schema)
+    after = _table_counts(pg_env.admin_conn, pg_env.schema)
+    assert station == {
+        'id': 900001,
+        'system_id64': 424242,
+        'name': 'Harper Plant',
+        'station_type': 'Orbis',
+        'distance_from_star': None,
+    }
+    assert before == after
+    assert audit['schema_version'] == 'station_type_canonical_pilot_apply/v1'
+    assert audit['summary'] == {
+        'planned': 1,
+        'applied': 1,
+        'skipped': 0,
+        'blocked': 0,
+        'canonical_table': 'stations',
+        'canonical_field': 'station_type',
+    }
+    assert audit['rows'][0]['field'] == 'station_type'
+    assert audit['rollback_preimage']['schema_version'] == 'station_type_canonical_pilot_rollback_preimage/v1'
+    assert audit['rollback_preimage']['rows'][0]['pre_image_value'] == 'Unknown'
+    assert audit['post_apply_verification']['schema_version'] == 'station_type_canonical_pilot_verification/v1'
+    assert audit['post_apply_verification']['summary']['ok'] is True
+
+
+@pytest.mark.parametrize(
+    'db_station_name,db_station_type,expected_message',
+    [
+        ('Renamed Plant', 'Unknown', 'identity pre-image mismatch'),
+        ('Harper Plant', 'Coriolis', 'pre-image mismatch'),
+    ],
+)
+def test_postgres_rehearsal_fails_closed_on_preimage_mismatch(pg_env, db_station_name, db_station_type, expected_message):
+    _reset_station(pg_env.admin_conn, pg_env.schema, name=db_station_name, station_type=db_station_type)
+    artifact = pilot.build_station_type_pilot_dry_run(_report_with(_station_candidate()), generated_at='2026-06-01T00:00:00Z')
+    checksum = pilot.artifact_sha256(artifact)
+
+    conn = pg_env.connect_as(pg_env.canonical_apply_role)
+    try:
+        _set_search_path(conn, pg_env.schema)
+        with pytest.raises(pilot.Stage18JPlanError, match=expected_message):
+            pilot.apply_station_type_pilot(
+                conn,
+                artifact,
+                artifact_sha256_expected=checksum,
+                expected_candidate_count=1,
+                approved_table='stations',
+                approved_field='station_type',
+                approved_source_run='run-1',
+                approval_id='stage18t-test-approval',
+                confirmation=True,
+                max_rows=1,
+            )
+    finally:
+        conn.close()
+
+    assert _station_row(pg_env.admin_conn, pg_env.schema)['station_type'] == db_station_type
+
+
+@pytest.mark.parametrize(
+    'overrides,expected_message',
+    [
+        ({'artifact_sha256_expected': 'bad-checksum'}, 'checksum'),
+        ({'expected_candidate_count': 2}, 'expected candidate count'),
+        ({'approved_table': 'bodies'}, 'approved table'),
+        ({'approved_field': 'body_name'}, 'approved field'),
+        ({'approved_source_run': 'wrong-run'}, 'approved source run'),
+        ({'max_rows': None}, 'max rows'),
+    ],
+)
+def test_postgres_rehearsal_approval_mismatches_fail_before_update(pg_env, overrides, expected_message):
+    artifact = pilot.build_station_type_pilot_dry_run(_report_with(_station_candidate()), generated_at='2026-06-01T00:00:00Z')
+    checksum = pilot.artifact_sha256(artifact)
+    kwargs = {
+        'artifact_sha256_expected': checksum,
+        'expected_candidate_count': 1,
+        'approved_table': 'stations',
+        'approved_field': 'station_type',
+        'approved_source_run': 'run-1',
+        'approval_id': 'stage18t-test-approval',
+        'confirmation': True,
+        'max_rows': 1,
+    }
+    kwargs.update(overrides)
+
+    with pytest.raises(pilot.Stage18JPlanError, match=expected_message):
+        pilot.validate_apply_request(artifact, **kwargs)
+
+    assert _station_row(pg_env.admin_conn, pg_env.schema)['station_type'] == 'Unknown'
+
+
+def test_postgres_permission_boundary_roles_are_disposable_and_scoped(pg_env):
+    warehouse_conn = pg_env.connect_as(pg_env.warehouse_loader_role)
+    try:
+        _set_search_path(warehouse_conn, pg_env.schema)
+        _assert_forbidden(warehouse_conn, "UPDATE stations SET station_type = 'Orbis' WHERE id = 900001")
+        _assert_forbidden(warehouse_conn, "INSERT INTO systems (id64, name) VALUES (42, 'Forbidden')")
+        _assert_forbidden(warehouse_conn, "UPDATE bodies SET name = 'Forbidden' WHERE id = 1")
+        _assert_forbidden(warehouse_conn, "DELETE FROM station_body_links WHERE station_id = 900001")
+        _assert_forbidden(warehouse_conn, "UPDATE body_rings SET ring_name = 'Forbidden' WHERE id = 1")
+        _assert_forbidden(warehouse_conn, "UPDATE body_scan_facts SET is_ringed = true WHERE body_id = 1")
+    finally:
+        warehouse_conn.close()
+
+    apply_conn = pg_env.connect_as(pg_env.canonical_apply_role)
+    try:
+        _set_search_path(apply_conn, pg_env.schema)
+        with apply_conn.cursor() as cur:
+            cur.execute("UPDATE stations SET station_type = 'Orbis' WHERE id = 900001")
+        apply_conn.rollback()
+        _assert_forbidden(apply_conn, "UPDATE stations SET name = 'Forbidden' WHERE id = 900001")
+        _assert_forbidden(apply_conn, "UPDATE stations SET distance_from_star = 10 WHERE id = 900001")
+        _assert_forbidden(apply_conn, "UPDATE systems SET name = 'Forbidden' WHERE id64 = 424242")
+        _assert_forbidden(apply_conn, "UPDATE bodies SET name = 'Forbidden' WHERE id = 1")
+        _assert_forbidden(apply_conn, "UPDATE station_body_links SET body_name = 'Forbidden' WHERE station_id = 900001")
+        _assert_forbidden(apply_conn, "UPDATE body_rings SET ring_name = 'Forbidden' WHERE id = 1")
+        _assert_forbidden(apply_conn, "UPDATE body_scan_facts SET is_ringed = true WHERE body_id = 1")
+    finally:
+        apply_conn.close()
+
+
+@pytest.fixture
+def pg_env():
+    psycopg2 = pytest.importorskip('psycopg2')
+    from psycopg2 import sql
+
+    dsn = _canonical_test_dsn_or_skip()
+    token = uuid.uuid4().hex[:12]
+    schema = f'stage18t_{token}'
+    warehouse_loader_role = f'warehouse_loader_test_{token}'
+    canonical_apply_role = f'canonical_apply_test_{token}'
+    canonical_read_role = f'canonical_read_test_{token}'
+    admin_conn = psycopg2.connect(dsn)
+    admin_conn.autocommit = True
+    env = _PgEnv(
+        psycopg2=psycopg2,
+        dsn=dsn,
+        admin_conn=admin_conn,
+        schema=schema,
+        warehouse_loader_role=warehouse_loader_role,
+        canonical_apply_role=canonical_apply_role,
+        canonical_read_role=canonical_read_role,
+        role_password=f'stage18t_{token}',
+    )
+    try:
+        with admin_conn.cursor() as cur:
+            _create_schema(cur, sql, env)
+        yield env
+    finally:
+        with admin_conn.cursor() as cur:
+            cur.execute(sql.SQL('DROP SCHEMA IF EXISTS {} CASCADE').format(sql.Identifier(schema)))
+            for role in (warehouse_loader_role, canonical_apply_role, canonical_read_role):
+                cur.execute(sql.SQL('DROP ROLE IF EXISTS {}').format(sql.Identifier(role)))
+        admin_conn.close()
+
+
+class _PgEnv:
+    def __init__(
+        self,
+        *,
+        psycopg2,
+        dsn,
+        admin_conn,
+        schema,
+        warehouse_loader_role,
+        canonical_apply_role,
+        canonical_read_role,
+        role_password,
+    ):
+        self.psycopg2 = psycopg2
+        self.dsn = dsn
+        self.admin_conn = admin_conn
+        self.schema = schema
+        self.warehouse_loader_role = warehouse_loader_role
+        self.canonical_apply_role = canonical_apply_role
+        self.canonical_read_role = canonical_read_role
+        self.role_password = role_password
+
+    def connect_as(self, role):
+        conn = self.psycopg2.connect(self.dsn, user=role, password=self.role_password)
+        conn.autocommit = False
+        return conn
+
+
+def _canonical_test_dsn_or_skip():
+    dsn = os.getenv('EDFINDER_CANONICAL_TEST_DSN')
+    confirm = os.getenv('EDFINDER_CONFIRM_CANONICAL_TEST_DB')
+    if not dsn:
+        pytest.skip('EDFINDER_CANONICAL_TEST_DSN is not set; skipping disposable canonical Postgres rehearsal')
+    if confirm != 'yes':
+        pytest.skip('EDFINDER_CONFIRM_CANONICAL_TEST_DB must be exactly yes for disposable canonical Postgres rehearsal')
+    _assert_safe_test_dsn(dsn)
+    return dsn
+
+
+def _assert_safe_test_dsn(dsn):
+    parsed = urlparse(dsn)
+    if parsed.scheme:
+        host = parsed.hostname
+        dbname = parsed.path.lstrip('/')
+    else:
+        parts = dict(part.split('=', 1) for part in dsn.split() if '=' in part)
+        host = parts.get('host')
+        dbname = parts.get('dbname')
+    if host not in ALLOWED_TEST_HOSTS:
+        pytest.fail(f'Unsafe canonical test DSN host {host!r}; expected local disposable host')
+    haystack = f'{dsn} {dbname or ""}'.lower()
+    if any(marker in haystack for marker in PRODUCTION_MARKERS):
+        pytest.fail('Unsafe canonical test DSN contains production-like marker')
+    if not dbname:
+        pytest.fail('Unsafe canonical test DSN has no database name')
+
+
+def _create_schema(cur, sql, env):
+    cur.execute(sql.SQL('CREATE SCHEMA {}').format(sql.Identifier(env.schema)))
+    cur.execute(
+        sql.SQL(
+            "CREATE TYPE {} AS ENUM "
+            "('Coriolis', 'Orbis', 'Ocellus', 'Outpost', 'PlanetaryPort', "
+            "'PlanetaryOutpost', 'MegaShip', 'AsteroidBase', 'FleetCarrier', 'Unknown')"
+        ).format(sql.Identifier(env.schema, 'station_type'))
+    )
+    cur.execute(sql.SQL('CREATE TABLE {} (id64 BIGINT PRIMARY KEY, name TEXT NOT NULL)').format(sql.Identifier(env.schema, 'systems')))
+    cur.execute(
+        sql.SQL(
+            'CREATE TABLE {} ('
+            'id BIGINT PRIMARY KEY, '
+            'system_id64 BIGINT NOT NULL, '
+            'name TEXT NOT NULL, '
+            'station_type {} NOT NULL DEFAULT \'Unknown\', '
+            'distance_from_star REAL DEFAULT NULL)'
+        ).format(sql.Identifier(env.schema, 'stations'), sql.Identifier(env.schema, 'station_type'))
+    )
+    cur.execute(sql.SQL('CREATE TABLE {} (id BIGINT PRIMARY KEY, system_id64 BIGINT, name TEXT)').format(sql.Identifier(env.schema, 'bodies')))
+    cur.execute(sql.SQL('CREATE TABLE {} (station_id BIGINT PRIMARY KEY, body_name TEXT)').format(sql.Identifier(env.schema, 'station_body_links')))
+    cur.execute(sql.SQL('CREATE TABLE {} (id BIGINT PRIMARY KEY, ring_name TEXT)').format(sql.Identifier(env.schema, 'body_rings')))
+    cur.execute(sql.SQL('CREATE TABLE {} (body_id BIGINT PRIMARY KEY, is_ringed BOOLEAN)').format(sql.Identifier(env.schema, 'body_scan_facts')))
+    cur.execute(sql.SQL('INSERT INTO {} (id64, name) VALUES (424242, %s)').format(sql.Identifier(env.schema, 'systems')), ('Test System',))
+    cur.execute(
+        sql.SQL('INSERT INTO {} (id, system_id64, name, station_type) VALUES (900001, 424242, %s, %s)').format(
+            sql.Identifier(env.schema, 'stations')
+        ),
+        ('Harper Plant', 'Unknown'),
+    )
+    cur.execute(sql.SQL('INSERT INTO {} (id, system_id64, name) VALUES (1, 424242, %s)').format(sql.Identifier(env.schema, 'bodies')), ('Test 1',))
+    cur.execute(sql.SQL('INSERT INTO {} (station_id, body_name) VALUES (900001, %s)').format(sql.Identifier(env.schema, 'station_body_links')), ('Test 1',))
+    cur.execute(sql.SQL('INSERT INTO {} (id, ring_name) VALUES (1, %s)').format(sql.Identifier(env.schema, 'body_rings')), ('Test Ring',))
+    cur.execute(sql.SQL('INSERT INTO {} (body_id, is_ringed) VALUES (1, false)').format(sql.Identifier(env.schema, 'body_scan_facts')))
+    for role in (env.warehouse_loader_role, env.canonical_apply_role, env.canonical_read_role):
+        cur.execute(sql.SQL('CREATE ROLE {} LOGIN PASSWORD %s').format(sql.Identifier(role)), (env.role_password,))
+        cur.execute(sql.SQL('GRANT USAGE ON SCHEMA {} TO {}').format(sql.Identifier(env.schema), sql.Identifier(role)))
+        cur.execute(sql.SQL('GRANT USAGE ON TYPE {} TO {}').format(sql.Identifier(env.schema, 'station_type'), sql.Identifier(role)))
+        for table in ('systems', 'stations', 'bodies', 'station_body_links', 'body_rings', 'body_scan_facts'):
+            cur.execute(sql.SQL('GRANT SELECT ON {} TO {}').format(sql.Identifier(env.schema, table), sql.Identifier(role)))
+    cur.execute(sql.SQL('GRANT UPDATE (station_type) ON {} TO {}').format(sql.Identifier(env.schema, 'stations'), sql.Identifier(env.canonical_apply_role)))
+
+
+def _set_search_path(conn, schema):
+    from psycopg2 import sql
+
+    with conn.cursor() as cur:
+        cur.execute(sql.SQL('SET search_path TO {}').format(sql.Identifier(schema)))
+
+
+def _reset_station(conn, schema, *, name='Harper Plant', station_type='Unknown'):
+    from psycopg2 import sql
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL('UPDATE {} SET name = %s, station_type = %s, distance_from_star = NULL WHERE id = 900001').format(
+                sql.Identifier(schema, 'stations')
+            ),
+            (name, station_type),
+        )
+
+
+def _station_row(conn, schema):
+    from psycopg2 import sql
+
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL('SELECT id, system_id64, name, station_type::text, distance_from_star FROM {} WHERE id = 900001').format(
+                sql.Identifier(schema, 'stations')
+            )
+        )
+        row = cur.fetchone()
+    return {
+        'id': row[0],
+        'system_id64': row[1],
+        'name': row[2],
+        'station_type': row[3],
+        'distance_from_star': row[4],
+    }
+
+
+def _table_counts(conn, schema):
+    from psycopg2 import sql
+
+    counts = {}
+    with conn.cursor() as cur:
+        for table in ('systems', 'stations', 'bodies', 'station_body_links', 'body_rings', 'body_scan_facts'):
+            cur.execute(sql.SQL('SELECT count(*) FROM {}').format(sql.Identifier(schema, table)))
+            counts[table] = cur.fetchone()[0]
+    return counts
+
+
+def _assert_forbidden(conn, statement):
+    with pytest.raises(Exception):
+        with conn.cursor() as cur:
+            cur.execute(statement)
+    conn.rollback()
+
+
+def _report_with(*candidates):
+    return {
+        'schema_version': 'enrichment_staging_reconciliation/v1',
+        'dry_run': True,
+        'filters': {
+            'source_run_key': 'run-1',
+            'source_file_key': 'file-1',
+            'source': 'edsm_nightly_stations',
+        },
+        'summary': {'canonical_writes_planned': 0},
+        'station_candidates': list(candidates),
+    }
+
+
+def _station_candidate():
+    return {
+        'entity': 'station',
+        'candidate_action': 'candidate_update',
+        'source': {
+            'source_run_key': 'run-1',
+            'source_file_key': 'file-1',
+            'source_record_key': 'record-1',
+            'source_record_hash': 'hash-1',
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'market_id': 1001,
+            'edsm_station_id': None,
+            'station_name': 'Harper Plant',
+            'source_class': 'semi-stable',
+            'confidence': 'source_station_snapshot',
+            'freshness_class': 'source_updated_at',
+            'source_updated_at': '2026-05-31T12:00:00Z',
+        },
+        'canonical': {
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'station_id': 900001,
+            'market_id': 1001,
+            'edsm_station_id': None,
+            'station_name': 'Harper Plant',
+            'station_type': 'Unknown',
+        },
+        'canonical_matches': [{
+            'system_id64': 424242,
+            'system_name': 'Test System',
+            'station_id': 900001,
+            'market_id': 1001,
+            'edsm_station_id': None,
+            'station_name': 'Harper Plant',
+            'station_type': 'Unknown',
+        }],
+        'differences': [{'field': 'station_type', 'staged': 'Orbis Starport', 'canonical': 'Unknown'}],
+        'warnings': [],
+        'confidence': 'high',
+        'risk_class': 'clear',
+        'risk_flags': [],
+        'review_classifications': [],
+        'reconciliation_state': 'confirmed',
+        'source_freshness': {
+            'freshness_class': 'source_updated_at',
+            'source_updated_at': '2026-05-31T12:00:00Z',
+            'freshness_impact': 'timestamped_source',
+        },
+        'report_only': False,
+        'canonical_writes_planned': 0,
+    }


### PR DESCRIPTION
## What changed

* Adds explicit CI/test coverage for Stage 18J canonical safety checks.
* Installs/declares required test prerequisites so canonical safety tests run consistently.
* Adds a local canonical safety test runner.
* Adds or gates disposable Postgres rehearsal coverage for the guarded station-type apply path.
* Adds or gates permission-boundary tests for warehouse loader vs canonical apply behavior.
* Documents required test gates before production dry-run or production apply.

## Boundaries

* No production apply.
* No production artifact.
* No production DB access.
* No broad canonical backfill.
* No UI/API apply controls.
* No scheduler wiring.
* No planner/search/scoring/optimiser changes.
* Any DB/user/permission work is disposable test-only.

## Validation

`./scripts/run_canonical_safety_tests.sh`

```text
........................................................................ [ 88%]
.........                                                                [100%]
81 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.
```

`.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q`

```text
........................................................................ [ 88%]
.........                                                                [100%]
81 passed in 0.15s
```

`.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py tests/test_station_type_canonical_pilot_postgres.py`

```text
(no output; exit 0)
```

`pg_virtualenv sh -c 'EDFINDER_CANONICAL_TEST_DSN="host=localhost port=$PGPORT dbname=postgres user=$PGUSER" EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes .venv/bin/pytest tests/test_station_type_canonical_pilot_postgres.py -q'`

```text
Creating new PostgreSQL cluster 16/regress ...
..........                                                               [100%]
10 passed in 0.93s
Dropping cluster 16/regress ...
```

`git diff --check`

```text
(no output; exit 0)
```

## Notes

Real disposable Postgres rehearsal tests were added and run locally through `pg_virtualenv`. CI also runs them against a Postgres service container with `EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes`. Permission-boundary tests were added and run as part of the same disposable Postgres rehearsal.

The pytest `asyncio_mode` warning is addressed by adding `pytest-asyncio` to the canonical CI test dependency path.