### PR TITLE
Stage 18J-Q4 operator access packet

### DIFF
--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -583,6 +583,29 @@ Current result:
 Report:
 `stage-18j-q3-readonly-production-reconciliation-artifact.md`.
 
+### Stage 18J-Q4 — Operator Access Packet
+
+Purpose: define the safe operator checklist for providing the variables that
+Stage 18J-Q3 lacked.
+
+Scope:
+
+- Document the required read-only/report-only DSN, source run/file keys,
+  operator-managed artifact directory, and mandatory read-only `PGOPTIONS`.
+- Provide a redacted command template that matches the real loader CLI.
+- Define secret handling, sign-off, and rerun criteria without committing real
+  DSNs, credentials, hostnames, or production artifact paths.
+
+Non-goals:
+
+- No production-connected reconciliation command execution.
+- No production artifact generation or approval.
+- No station-type dry-run generation.
+- No production apply or canonical data changes.
+
+Access packet:
+`../operations/stage-18j-q4-operator-access-packet.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -621,5 +644,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 18. Stage 18J-Q production reconciliation artifact readiness.
 19. Stage 18J-Q2 read-only production reconciliation plan.
 20. Stage 18J-Q3 read-only production reconciliation artifact gate.
+21. Stage 18J-Q4 operator access packet.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-q2-readonly-production-reconciliation-plan.md
+++ b/docs/colonisation-redesign/stage-18j-q2-readonly-production-reconciliation-plan.md
@@ -348,3 +348,7 @@ production-connected command because the required verified read-only DSN,
 approved source run/file, read-only session option, and operator-managed output
 path were not available. See
 [`stage-18j-q3-readonly-production-reconciliation-artifact.md`](./stage-18j-q3-readonly-production-reconciliation-artifact.md).
+
+Stage 18J-Q4 defines the operator access packet and redacted sign-off checklist
+needed before Q3 can be retried:
+[`../operations/stage-18j-q4-operator-access-packet.md`](../operations/stage-18j-q4-operator-access-packet.md).

--- a/docs/colonisation-redesign/stage-18j-q3-readonly-production-reconciliation-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-q3-readonly-production-reconciliation-artifact.md
@@ -254,6 +254,10 @@ Before Q3 can be retried, the operator must provide and verify:
 - confirmation that the later command will not invoke live EDSM/API crawling,
   Docker, write-staging, apply, write, commit, confirmation, or rollback flags.
 
+Stage 18J-Q4 provides the operator-facing access packet and sign-off template
+for these missing variables:
+[`../operations/stage-18j-q4-operator-access-packet.md`](../operations/stage-18j-q4-operator-access-packet.md).
+
 Stage 18J-P also remains blocked by the possible missing explicit canonical
 external identity fields in the general reconciliation payload. If a future Q3
 artifact lacks `canonical.market_id` and `canonical.edsm_station_id`, Stage

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -492,6 +492,13 @@ It stopped before any production-connected command because the verified
 read-only DSN, source run/file scope, read-only session option, and
 operator-managed output path were not available.
 
+Stage 18J-Q4 documents the operator access packet in
+`docs/operations/stage-18j-q4-operator-access-packet.md`. It defines the
+missing variables, read-only DSN requirements, source run/file approval, safe
+artifact directory requirements, mandatory `PGOPTIONS`, redacted command
+template, secret handling, and sign-off checklist needed before retrying
+Stage 18J-Q3.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables

--- a/docs/operations/stage-18j-q4-operator-access-packet.md
+++ b/docs/operations/stage-18j-q4-operator-access-packet.md
@@ -1,0 +1,327 @@
+# Stage 18J-Q4 — Operator Access Packet
+
+## Purpose
+
+Stage 18J-Q4 defines the operator packet needed before Stage 18J-Q3 can retry
+the read-only/report-only production reconciliation artifact generation step.
+
+This is documentation/checklist only. It does not authorize or run production
+reconciliation, station-type dry-run generation, approval, apply, database
+mutation, scheduler wiring, UI/API controls, Docker invocation, live EDSM/API
+crawling, Stage 18J-P, Stage 18K, or broader canonical work.
+
+## Current Blocker
+
+Stage 18J-Q3 stopped before any production-connected command because the
+required operator variables were not available:
+
+- `EDFINDER_WAREHOUSE_READ_DSN`
+- `SOURCE_RUN_KEY`
+- `SOURCE_FILE_KEY`
+- `SAFE_ARTIFACT_DIR`
+- `PGOPTIONS='-c default_transaction_read_only=on'`
+
+No production reconciliation artifact was generated. No production artifact was
+approved. Stage 18J-P remains blocked.
+
+## Required Variables
+
+| Variable | Required value | Commit status |
+|---|---|---|
+| `EDFINDER_WAREHOUSE_READ_DSN` | A verified read-only/report-only warehouse DSN. | Never commit. |
+| `SOURCE_RUN_KEY` | The exact approved staged station source run key. | May be summarized only when safe. |
+| `SOURCE_FILE_KEY` | The exact approved staged station source file key. | May be summarized only when safe. |
+| `SAFE_ARTIFACT_DIR` | An operator-managed output directory outside git. | Never commit if it exposes private paths. |
+| `PGOPTIONS` | Exactly `-c default_transaction_read_only=on`. | Safe to document as a literal requirement. |
+
+`EDFINDER_CANONICAL_APPLY_DSN` is not required and must not be provided for
+Stage 18J-Q3.
+
+## How To Provide Variables Safely
+
+Provide the variables only in the approved operator shell, secret manager, or
+deployment secret mechanism for the single approved Stage 18J-Q3 run.
+
+Do not place real values in:
+
+- committed files,
+- `.env` files tracked by git,
+- PR descriptions,
+- issue comments,
+- docs,
+- screenshots,
+- copied terminal transcripts,
+- generated artifacts that will be committed.
+
+Use a private shell session or secret manager injection. Clear the shell
+history or use the operator team's normal no-history secret entry procedure if
+the DSN could be captured by shell history.
+
+## Read-Only DSN Requirements
+
+`EDFINDER_WAREHOUSE_READ_DSN` must be a dedicated read/report credential. It
+must not be:
+
+- the canonical apply user,
+- the application write user,
+- a warehouse staging loader write user,
+- a database owner,
+- a superuser,
+- any role with canonical table write access,
+- any role with broad DDL privileges.
+
+Before Stage 18J-Q3 is retried, the operator must prove outside git that the
+DSN role:
+
+- points at the intended warehouse/report source,
+- can read the staged warehouse tables needed for reconciliation,
+- can read the controlled canonical comparison rows or snapshots needed for
+  reconciliation,
+- cannot write canonical tables such as `systems`, `stations`, `bodies`,
+  `station_body_links`, `body_rings`, or `body_scan_facts`,
+- cannot create, alter, drop, truncate, insert, update, delete, or merge
+  warehouse or canonical tables,
+- does not expose the canonical apply DSN or apply user.
+
+If the deployment still uses the transitional same-database warehouse layout,
+the role review must be stricter because warehouse and canonical tables share a
+database boundary.
+
+## Source Run / Source File Approval
+
+`SOURCE_RUN_KEY` and `SOURCE_FILE_KEY` must identify an approved staged
+`edsm_nightly_stations` source scope.
+
+Before retrying Stage 18J-Q3, the operator must confirm:
+
+- the source run exists in the warehouse/report source,
+- the source file exists or the approved scope explicitly allows a missing
+  file filter,
+- the staged data came from the intended offline snapshot workflow,
+- no live EDSM/API crawl is required,
+- the source run/file is fresh enough for review,
+- the source run/file is narrow enough for a first production reconciliation
+  artifact review,
+- the source run/file approval is not approval for station-type dry-run
+  generation or apply.
+
+## Safe Artifact Directory Requirements
+
+`SAFE_ARTIFACT_DIR` must be:
+
+- outside the git repository,
+- operator-managed,
+- private to the operator or service account,
+- not world-readable,
+- not mounted into public UI/API paths,
+- not a scheduler drop directory,
+- not a location that automatically triggers another job,
+- retained long enough for checksum and contract review.
+
+Use restrictive permissions before writing the artifact:
+
+```bash
+umask 077
+mkdir -p "$SAFE_ARTIFACT_DIR"
+chmod 700 "$SAFE_ARTIFACT_DIR"
+```
+
+Do not commit the raw production artifact unless a later task explicitly
+approves a sanitized version for git.
+
+## Mandatory PGOPTIONS
+
+Stage 18J-Q3 must set:
+
+```bash
+export PGOPTIONS='-c default_transaction_read_only=on'
+```
+
+This is not a substitute for read-only role grants. It is an additional session
+guard. If the target environment does not support this option, stop and document
+the equivalent enforced read-only mechanism before running the reconciliation
+command.
+
+## Pre-Run Verification Checklist
+
+Before retrying Stage 18J-Q3, verify all items:
+
+- The task explicitly authorizes Stage 18J-Q3 retry only.
+- The exact command is printed before execution.
+- The command includes `--report-reconciliation`.
+- The command includes `--source edsm_nightly_stations`.
+- The command includes the approved `--source-run-key`.
+- The command includes the approved `--source-file-key`, unless a separately
+  approved multi-file scope exists.
+- The command includes `--json`.
+- The command writes only to `SAFE_ARTIFACT_DIR` via stdout redirection.
+- `PGOPTIONS` is exactly `-c default_transaction_read_only=on`.
+- `EDFINDER_WAREHOUSE_READ_DSN` is verified read-only/report-only.
+- `EDFINDER_CANONICAL_APPLY_DSN` is not present.
+- No production apply command is invoked.
+- No station-type dry-run command is invoked.
+- No live EDSM/API crawl is invoked.
+- No Docker, UI/API, scheduler, or automation hook is invoked.
+- No real DSN, credential, hostname, private path, or raw artifact content will
+  be committed.
+
+Stop immediately if any checklist item is missing or ambiguous.
+
+## Redacted Command Template
+
+The loader CLI was verified with:
+
+```bash
+.venv/bin/python apps/importer/src/enrichment_staging_db_loader.py --help
+```
+
+The local shell did not provide a `python` command, so the verification used the
+repo virtualenv interpreter. The loader has no `--output` flag; it emits JSON
+to stdout. Use stdout redirection to the operator-managed path.
+
+Template only. Do not paste real values into this document.
+
+```bash
+export PGOPTIONS='-c default_transaction_read_only=on'
+export EDFINDER_WAREHOUSE_READ_DSN='<read-only-warehouse-dsn-not-committed>'
+export SOURCE_RUN_KEY='<approved-source-run-key>'
+export SOURCE_FILE_KEY='<approved-source-file-key>'
+export SAFE_ARTIFACT_DIR='<operator-managed-path-outside-git>'
+export PGAPPNAME='stage18j-q3-readonly-reconciliation'
+
+PYTHON="${PYTHON:-.venv/bin/python}"
+TIMESTAMP='<utc-timestamp>'
+
+umask 077
+mkdir -p "$SAFE_ARTIFACT_DIR"
+chmod 700 "$SAFE_ARTIFACT_DIR"
+
+"$PYTHON" apps/importer/src/enrichment_staging_db_loader.py \
+  --dsn "$EDFINDER_WAREHOUSE_READ_DSN" \
+  --report-reconciliation \
+  --source edsm_nightly_stations \
+  --source-run-key "$SOURCE_RUN_KEY" \
+  --source-file-key "$SOURCE_FILE_KEY" \
+  --limit 1000 \
+  --json \
+  > "$SAFE_ARTIFACT_DIR/enrichment_staging_reconciliation_${TIMESTAMP}.json"
+```
+
+The actual Stage 18J-Q3 retry must print the exact redacted command before
+execution and must not print the real DSN.
+
+## What Must Not Be Done
+
+Do not:
+
+- run production apply,
+- run guarded apply,
+- generate a station-type canonical pilot dry-run artifact,
+- approve any artifact,
+- create an approval record,
+- modify production canonical data,
+- run broad canonical backfill,
+- start Stage 18J-P,
+- start Stage 18K,
+- add UI/API apply controls,
+- add scheduler wiring,
+- run live EDSM/API crawl,
+- use `--write-staging`,
+- use `--apply`,
+- use `--write`,
+- use `--commit`,
+- use confirmation flags,
+- invoke Docker from UI/API,
+- commit real DSNs, credentials, hostnames, secrets, private paths, or raw
+  production artifacts.
+
+## Secret Handling
+
+Treat the DSN and raw production artifact as production-sensitive.
+
+Allowed in git:
+
+- this redacted checklist,
+- variable names,
+- non-secret command shape,
+- non-secret validation notes.
+
+Not allowed in git:
+
+- real DSNs,
+- database usernames or passwords,
+- private hostnames,
+- private artifact paths,
+- API keys or tokens,
+- raw production reconciliation artifacts,
+- raw source payloads,
+- unredacted command history.
+
+If a production artifact is generated in a later task, keep it outside git
+unless the later task explicitly approves a sanitized version for commit.
+
+## Operator Sign-Off Template
+
+Use this outside git before a Stage 18J-Q3 retry. Do not fill real values into
+this repository.
+
+```text
+Stage 18J-Q3 operator access sign-off
+
+Operator:
+Date/time UTC:
+
+Read-only DSN reviewed:
+- DSN stored outside git:
+- Role is dedicated read/report:
+- Role is not app/write/apply/owner/superuser:
+- Role cannot write canonical tables:
+- Role cannot run DDL:
+- PGOPTIONS read-only guard accepted:
+
+Source scope approved:
+- Source: edsm_nightly_stations
+- SOURCE_RUN_KEY:
+- SOURCE_FILE_KEY:
+- Source run/file exists in staged warehouse:
+- No live crawl required:
+
+Artifact output approved:
+- SAFE_ARTIFACT_DIR outside git:
+- Directory is not world-readable:
+- Directory does not trigger scheduler/UI/API:
+
+Execution boundary:
+- No --write-staging:
+- No --apply:
+- No --write:
+- No --commit:
+- No confirmation flags:
+- No station-type dry-run:
+- No artifact approval:
+- No production apply:
+```
+
+## Stage 18J-Q3 Rerun Criteria
+
+Stage 18J-Q3 may be retried only when:
+
+- this packet has been reviewed by the operator,
+- all required variables are available in the approved operator environment,
+- read-only/report-only access has been proven outside git,
+- source run/file scope has been approved,
+- `SAFE_ARTIFACT_DIR` is ready outside git with restrictive permissions,
+- the exact command is printed and reviewed before execution,
+- the Stage 18T canonical safety suite is green on the branch used for the
+  retry.
+
+Even after a successful Q3 artifact generation, Stage 18J-P does not
+automatically proceed. A later explicit task must review the artifact contract,
+checksum, candidate counts, identity fields, and sanitisation state.
+
+## Final Recommendation
+
+Keep Stage 18J-Q3 and Stage 18J-P blocked until the operator provides the
+required variables through a safe channel and completes the sign-off outside
+git. This packet is not an approval to run production reconciliation, generate a
+station-type dry-run artifact, approve an artifact, or apply canonical writes.


### PR DESCRIPTION
## What changed

* Adds the Stage 18J-Q4 operator access packet.
* Documents the missing variables required before read-only production reconciliation can run.
* Defines read-only DSN requirements, source run/file approval, safe artifact directory requirements, mandatory PGOPTIONS, pre-run checklist, redacted command template, secret handling, and operator sign-off.
* Keeps Stage 18J-Q3 execution, production artifact generation, station-type dry-run generation, approval, and apply blocked.

## Boundaries

* Documentation/checklist only.
* No real DSNs, credentials, hostnames, secrets, or production artifact paths committed.
* No production-connected reconciliation command was run.
* No production reconciliation artifact was generated.
* No production station-type dry-run artifact was generated.
* No production apply.
* No production canonical data changes.
* No production approval record.
* No broad canonical backfill.
* No UI/API apply controls.
* No scheduler wiring.
* No planner/search/scoring/optimiser changes.

## Validation

* `python apps/importer/src/enrichment_staging_db_loader.py --help` — failed because the local shell has no `python` command.
* `.venv/bin/python apps/importer/src/enrichment_staging_db_loader.py --help` — passed; confirmed the loader has no `--output` flag and emits JSON to stdout.
* `./scripts/run_canonical_safety_tests.sh` — 81 passed in 0.14s; optional Postgres rehearsal skipped by default because no DSN/confirmation was set.
* `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q` — 81 passed in 0.12s.
* `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py` — passed.
* `pg_virtualenv sh -c 'EDFINDER_CANONICAL_TEST_DSN="host=localhost port=$PGPORT dbname=postgres user=$PGUSER" EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes .venv/bin/pytest tests/test_station_type_canonical_pilot_postgres.py -q'` — 10 passed in 0.31s against a disposable PostgreSQL cluster.
* `git diff --check` — passed.
* `git diff --cached --check` — passed.
* Secret scan of the new packet found no real DSNs or URLs; only generic policy words, placeholders, and variable names were present.