### PR TITLE
Stage 18J-Q5 nested EDSM station snapshot support

### DIFF
--- a/apps/importer/src/enrichment_snapshot_loader.py
+++ b/apps/importer/src/enrichment_snapshot_loader.py
@@ -22,9 +22,11 @@ from enrichment_staging import (
     ADAPTER_VERSION,
     build_enrichment_snapshot_load_plan,
     build_raw_record,
+    classify_station_type_evidence,
     classify_source_adapter,
     classify_source_field,
     first_present,
+    idempotency_key,
     normalise_json_array,
     normalise_edsm_body_ring_snapshot_records,
     normalise_edsm_body_snapshot_record,
@@ -44,6 +46,12 @@ SUPPORTED_SOURCES = {'edsm_nightly_stations', 'edsm_nightly_bodies'}
 DEFAULT_CHUNK_SIZE = 64 * 1024
 SOURCE_FORMAT_VERSION = 'json_snapshot_stream/v1'
 RING_ARRAY_UNKNOWN_STATE = 'unknown_not_false'
+STATION_COLLECTION_FIELDS = ('stations', 'Stations')
+BODY_COLLECTION_FIELDS = ('bodies', 'Bodies')
+SYSTEM_COLLECTION_FIELDS = ('systems', 'Systems')
+SYSTEM_NAME_FIELDS = ('systemName', 'system_name', 'system', 'name')
+SYSTEM_ID64_FIELDS = ('systemId64', 'system_id64', 'systemAddress', 'id64')
+SOURCE_UPDATED_AT_FIELDS = ('updatedAt', 'updated_at', 'updateTime', 'lastUpdate', 'lastUpdated', 'date')
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -127,7 +135,10 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
     conflicts: list[dict[str, Any]] = []
 
     records_seen = 0
-    for record_index, record in enumerate(iter_json_records(source_file), start=1):
+    nested_station_collections = 0
+    nested_station_records_extracted = 0
+    nested_station_records_skipped = 0
+    for record_index, record in enumerate(iter_json_records(source_file, expand_station_collections=False), start=1):
         if limit is not None and records_seen >= limit:
             break
         records_seen += 1
@@ -149,6 +160,98 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             source_updated_at=source_updated_at_from_record(record),
         )
         raw_records.append(raw_record)
+        nested_station_collection = station_collection_from_record(record)
+        if nested_station_collection is not None:
+            nested_station_collections += 1
+            station_collection_field, station_records = nested_station_collection
+            body_warning = unsupported_nested_body_collection_warning(record)
+            if body_warning is not None:
+                raw_record['validation_warnings'] = [*raw_record.get('validation_warnings', []), body_warning]
+                warnings.append({
+                    'record_index': record_index,
+                    'source_record_hash': raw_record['source_record_hash'],
+                    **body_warning,
+                })
+            for station_index, station_record in enumerate(station_records):
+                if not isinstance(station_record, Mapping):
+                    nested_station_records_skipped += 1
+                    station_warning = {
+                        'field': station_collection_field,
+                        'reason': 'nested_station_record_is_not_object',
+                        'station_index': station_index,
+                    }
+                    skipped_rows.append({
+                        'record_index': record_index,
+                        'station_index': station_index,
+                        'source_record_hash': raw_record['source_record_hash'],
+                        'reason': 'nested_station_record_is_not_object',
+                        'warnings': [station_warning],
+                        'raw_payload': station_record,
+                    })
+                    warnings.append({
+                        'record_index': record_index,
+                        'source_record_hash': raw_record['source_record_hash'],
+                        **station_warning,
+                    })
+                    continue
+
+                nested_station_records_extracted += 1
+                station_payload = nested_station_payload(record, station_record)
+                nested_raw_record = nested_station_raw_record(
+                    source=normalised_source,
+                    parent_raw_record=raw_record,
+                    station_payload=station_payload,
+                    station_index=station_index,
+                )
+                row = normalise_edsm_station_snapshot_record(
+                    station_payload,
+                    source=normalised_source,
+                    raw_record=nested_raw_record,
+                )
+                row['provenance'].update({
+                    'source_record_kind': 'nested_station_record',
+                    'parent_source_record_key': raw_record['source_record_key'],
+                    'parent_source_record_hash': raw_record['source_record_hash'],
+                    'source_system_identity': source_system_identity(record),
+                    'station_collection_field': station_collection_field,
+                    'station_index': station_index,
+                    'nested_body_collection_state': (
+                        'unsupported_source_only'
+                        if body_warning is not None
+                        else 'not_present'
+                    ),
+                })
+                validation = validate_staging_record(row, required_fields=('system_name', 'station_name'))
+                row_warnings = station_row_warnings(row, validation=validation)
+                if not validation['valid']:
+                    skipped_rows.append({
+                        'record_index': record_index,
+                        'station_index': station_index,
+                        'source_record_hash': row['source_record_hash'],
+                        'parent_source_record_hash': raw_record['source_record_hash'],
+                        'reason': 'invalid_station_snapshot_record',
+                        'warnings': row_warnings,
+                        'raw_payload': dict(station_payload),
+                    })
+                    for warning in row_warnings:
+                        warnings.append({
+                            'record_index': record_index,
+                            'station_index': station_index,
+                            'source_record_hash': row['source_record_hash'],
+                            **warning,
+                        })
+                    continue
+                row['validation_warnings'] = row_warnings
+                staged_rows.append(row)
+                for warning in row_warnings:
+                    warnings.append({
+                        'record_index': record_index,
+                        'station_index': station_index,
+                        'source_record_hash': row['source_record_hash'],
+                        **warning,
+                    })
+            continue
+
         unsupported_shape = unsupported_source_shape(record, normalised_source)
         if unsupported_shape is not None:
             shape_warning = {
@@ -177,12 +280,7 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             raw_record=raw_record,
         )
         validation = validate_staging_record(row, required_fields=('system_name', 'station_name'))
-        row_warnings = list(validation['warnings'])
-        if row.get('market_id') is None and row.get('edsm_station_id') is None:
-            row_warnings.append({
-                'field': 'market_id',
-                'reason': 'missing_station_source_identity',
-            })
+        row_warnings = station_row_warnings(row, validation=validation)
         if not validation['valid']:
             raw_record['validation_status'] = 'skipped'
             raw_record['validation_warnings'] = row_warnings
@@ -231,6 +329,9 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             'adapter_name': ADAPTER_NAME,
             'records_seen': records_seen,
             'staged_edsm_stations': len(staged_rows),
+            'nested_station_collections': nested_station_collections,
+            'nested_station_records_extracted': nested_station_records_extracted,
+            'nested_station_records_skipped': nested_station_records_skipped,
             'dry_run_only': True,
             'canonical_writes_planned': 0,
             'distance_to_arrival_classification': classify_source_field(normalised_source, 'distanceToArrival'),
@@ -280,7 +381,7 @@ def build_body_ring_snapshot_load_report(
     ring_array_evidence = empty_ring_array_evidence_summary()
 
     records_seen = 0
-    for record_index, record in enumerate(iter_json_records(source_file), start=1):
+    for record_index, record in enumerate(iter_json_records(source_file, expand_station_collections=False), start=1):
         if limit is not None and records_seen >= limit:
             break
         records_seen += 1
@@ -486,6 +587,12 @@ def normalise_edsm_station_snapshot_record(
             if value is not None
         ]
 
+    body_name = first_present(record, 'bodyName', 'body_name')
+    if body_name is None and isinstance(record.get('body'), Mapping):
+        body_name = first_present(record['body'], 'name', 'bodyName', 'body_name')
+    station_type = read_text(first_present(record, 'type', 'stationType', 'station_type'))
+    station_type_evidence = classify_station_type_evidence(station_type)
+
     row = {
         'source_run_key': raw_record.get('source_run_key') if raw_record else None,
         'source_file_key': raw_record.get('source_file_key') if raw_record else None,
@@ -496,7 +603,7 @@ def normalise_edsm_station_snapshot_record(
         'market_id': read_int(first_present(record, 'marketId', 'market_id', 'marketID')),
         'edsm_station_id': read_int(first_present(record, 'id', 'edsmStationId', 'edsm_station_id')),
         'station_name': read_text(first_present(record, 'name', 'stationName', 'station_name')),
-        'station_type': read_text(first_present(record, 'type', 'stationType', 'station_type')),
+        'station_type': station_type,
         'distance_to_arrival': read_float(first_present(
             record,
             'distanceToArrival',
@@ -504,7 +611,7 @@ def normalise_edsm_station_snapshot_record(
             'distanceFromStar',
             'distance_from_star',
         )),
-        'body_name': read_text(first_present(record, 'bodyName', 'body_name')),
+        'body_name': read_text(body_name),
         'services': normalise_json_array(first_present(record, 'services', 'otherServices', 'stationServices')),
         'economies': normalise_json_array(economies),
         'controlling_faction': read_text(controlling_faction),
@@ -519,12 +626,115 @@ def normalise_edsm_station_snapshot_record(
             'source': normalise_source_adapter(source),
             'distance_to_arrival_classification': classify_source_field(source, 'distanceToArrival'),
             'canonical_write_allowed': False,
+            **station_type_evidence,
         },
     }
     return row
 
 
-def iter_json_records(source_file: Path, *, chunk_size: int = DEFAULT_CHUNK_SIZE) -> Iterator[Any]:
+def station_row_warnings(
+    row: Mapping[str, Any],
+    *,
+    validation: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    row_warnings = list(validation['warnings'])
+    if row.get('market_id') is None and row.get('edsm_station_id') is None:
+        row_warnings.append({
+            'field': 'market_id',
+            'reason': 'missing_station_source_identity',
+        })
+    station_type_classification = row.get('provenance', {}).get('station_type_classification')
+    if station_type_classification == 'transient_non_slot':
+        row_warnings.append({
+            'field': 'station_type',
+            'reason': 'transient_non_slot_station_type',
+            'station_type_normalized': row.get('provenance', {}).get('station_type_normalized'),
+        })
+    return row_warnings
+
+
+def station_collection_from_record(record: Mapping[str, Any]) -> tuple[str, list[Any]] | None:
+    for field_name in STATION_COLLECTION_FIELDS:
+        stations = record.get(field_name)
+        if isinstance(stations, list):
+            return field_name, stations
+    return None
+
+
+def nested_station_payload(system_record: Mapping[str, Any], station_record: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(station_record)
+    system_name = read_text(first_present(system_record, *SYSTEM_NAME_FIELDS))
+    system_id64 = read_int(first_present(system_record, *SYSTEM_ID64_FIELDS))
+    source_updated_at = source_updated_at_from_record(system_record)
+
+    if system_name is not None and first_present(payload, 'systemName', 'system_name', 'system') is None:
+        payload['systemName'] = system_name
+    if system_id64 is not None and first_present(payload, *SYSTEM_ID64_FIELDS) is None:
+        payload['systemId64'] = system_id64
+    if source_updated_at is not None and first_present(payload, *SOURCE_UPDATED_AT_FIELDS) is None:
+        payload['updatedAt'] = source_updated_at
+    payload['source_system'] = source_system_identity(system_record)
+    return payload
+
+
+def nested_station_raw_record(
+    *,
+    source: str,
+    parent_raw_record: Mapping[str, Any],
+    station_payload: Mapping[str, Any],
+    station_index: int,
+) -> dict[str, Any]:
+    station_hash = source_record_hash(
+        source,
+        {
+            'parent_source_record_hash': parent_raw_record.get('source_record_hash'),
+            'station_index': station_index,
+            'station': station_payload,
+        },
+    )
+    return {
+        'source_run_key': parent_raw_record.get('source_run_key'),
+        'source_file_key': parent_raw_record.get('source_file_key'),
+        'source_record_key': idempotency_key(
+            'nested_station_source_record_key',
+            parent_raw_record.get('source_record_key'),
+            station_index,
+            station_hash,
+        ),
+        'source_record_hash': station_hash,
+    }
+
+
+def source_system_identity(record: Mapping[str, Any]) -> dict[str, Any]:
+    identity: dict[str, Any] = {
+        'system_name': read_text(first_present(record, *SYSTEM_NAME_FIELDS)),
+        'system_id64': read_int(first_present(record, *SYSTEM_ID64_FIELDS)),
+        'source_system_id': read_int(first_present(record, 'systemId', 'system_id', 'id')),
+    }
+    coords = first_present(record, 'coords', 'coordinates')
+    if isinstance(coords, Mapping):
+        identity['coordinates'] = dict(coords)
+    return {key: value for key, value in identity.items() if value is not None}
+
+
+def unsupported_nested_body_collection_warning(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    for field_name in BODY_COLLECTION_FIELDS:
+        if isinstance(record.get(field_name), list):
+            return {
+                'field': field_name,
+                'reason': 'unsupported_source_shape',
+                'source_shape': 'nested_body_collection',
+                'handling': 'preserved_in_raw_record_only_not_staged',
+            }
+    return None
+
+
+def iter_json_records(
+    source_file: Path,
+    *,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    expand_station_collections: bool = True,
+) -> Iterator[Any]:
     """Yield records from a local JSON array, NDJSON file, or small object wrapper."""
     decoder = json.JSONDecoder()
     with _open_text(source_file) as handle:
@@ -571,7 +781,10 @@ def iter_json_records(source_file: Path, *, chunk_size: int = DEFAULT_CHUNK_SIZE
                     else:
                         eof = True
                     continue
-                yield from _records_from_json_value(value)
+                yield from _records_from_json_value(
+                    value,
+                    expand_station_collections=expand_station_collections,
+                )
                 buffer = buffer[end_index:]
                 continue
 
@@ -581,7 +794,10 @@ def iter_json_records(source_file: Path, *, chunk_size: int = DEFAULT_CHUNK_SIZE
                     if eof:
                         line = buffer.strip()
                         if line:
-                            yield from _records_from_json_value(json.loads(line))
+                            yield from _records_from_json_value(
+                                json.loads(line),
+                                expand_station_collections=expand_station_collections,
+                            )
                         return
                     chunk = handle.read(chunk_size)
                     if chunk:
@@ -592,7 +808,10 @@ def iter_json_records(source_file: Path, *, chunk_size: int = DEFAULT_CHUNK_SIZE
                 line = buffer[:newline].strip()
                 buffer = buffer[newline + 1:]
                 if line:
-                    yield from _records_from_json_value(json.loads(line))
+                    yield from _records_from_json_value(
+                        json.loads(line),
+                        expand_station_collections=expand_station_collections,
+                    )
 
 
 def source_updated_at_from_record(record: Mapping[str, Any]) -> str | None:
@@ -617,8 +836,8 @@ def file_digest(path: Path) -> tuple[str, int]:
     return hasher.hexdigest(), size
 
 
-def _records_from_json_value(value: Any) -> Iterator[Any]:
-    if isinstance(value, Mapping) and isinstance(value.get('stations'), list):
+def _records_from_json_value(value: Any, *, expand_station_collections: bool = True) -> Iterator[Any]:
+    if expand_station_collections and isinstance(value, Mapping) and isinstance(value.get('stations'), list):
         system_context = {
             key: item
             for key, item in value.items()
@@ -655,37 +874,49 @@ def source_file_format_metadata(source_file: Path) -> dict[str, Any]:
 def unsupported_source_shape(record: Mapping[str, Any], source: str) -> dict[str, str] | None:
     normalised_source = normalise_source_adapter(source)
     if normalised_source == 'edsm_nightly_stations':
-        if isinstance(record.get('bodies'), list):
+        body_field = nested_collection_field(record, BODY_COLLECTION_FIELDS)
+        if body_field is not None:
             return {
-                'field': 'bodies',
+                'field': body_field,
                 'source_shape': 'nested_body_collection',
                 'skip_reason': 'unsupported_station_snapshot_source_shape',
             }
-        if isinstance(record.get('systems'), list):
+        system_field = nested_collection_field(record, SYSTEM_COLLECTION_FIELDS)
+        if system_field is not None:
             return {
-                'field': 'systems',
+                'field': system_field,
                 'source_shape': 'nested_system_collection',
                 'skip_reason': 'unsupported_station_snapshot_source_shape',
             }
     if normalised_source == 'edsm_nightly_bodies':
-        if isinstance(record.get('stations'), list):
+        station_field = nested_collection_field(record, STATION_COLLECTION_FIELDS)
+        if station_field is not None:
             return {
-                'field': 'stations',
+                'field': station_field,
                 'source_shape': 'nested_station_collection',
                 'skip_reason': 'unsupported_body_snapshot_source_shape',
             }
-        if isinstance(record.get('systems'), list):
+        system_field = nested_collection_field(record, SYSTEM_COLLECTION_FIELDS)
+        if system_field is not None:
             return {
-                'field': 'systems',
+                'field': system_field,
                 'source_shape': 'nested_system_collection',
                 'skip_reason': 'unsupported_body_snapshot_source_shape',
             }
-        if isinstance(record.get('bodies'), list):
+        body_field = nested_collection_field(record, BODY_COLLECTION_FIELDS)
+        if body_field is not None:
             return {
-                'field': 'bodies',
+                'field': body_field,
                 'source_shape': 'nested_body_collection',
                 'skip_reason': 'unsupported_body_snapshot_source_shape',
             }
+    return None
+
+
+def nested_collection_field(record: Mapping[str, Any], field_names: Sequence[str]) -> str | None:
+    for field_name in field_names:
+        if isinstance(record.get(field_name), list):
+            return field_name
     return None
 
 
@@ -712,8 +943,8 @@ def source_observability_summary(
             'freshness_preserves_unknown': True,
         },
         'unsupported_source_shapes': sum(
-            1 for row in skipped_rows
-            if str(row.get('reason', '')).startswith('unsupported_')
+            1 for warning in warnings
+            if warning.get('reason') == 'unsupported_source_shape'
         ),
         'malformed_rows': sum(
             1 for row in skipped_rows
@@ -723,6 +954,7 @@ def source_observability_summary(
                 'invalid_body_snapshot_record',
                 'invalid_ring_snapshot_record',
                 'ring_record_is_not_object',
+                'nested_station_record_is_not_object',
             }
         ),
         'warning_reason_distribution': field_distribution(warnings, 'reason'),

--- a/apps/importer/src/enrichment_staging.py
+++ b/apps/importer/src/enrichment_staging.py
@@ -78,6 +78,44 @@ SOURCE_CLASS_BY_ADAPTER = {
     'live_edsm_diagnostics': SOURCE_CLASS_DIAGNOSTIC_ONLY,
 }
 
+PERMANENT_COLONY_SLOT_STATION_TYPES = {
+    'Coriolis',
+    'Orbis',
+    'Ocellus',
+    'Outpost',
+    'AsteroidBase',
+    'PlanetaryPort',
+    'PlanetaryOutpost',
+}
+
+TRANSIENT_NON_SLOT_STATION_TYPES = {
+    'FleetCarrier',
+    'MegaShip',
+}
+
+STATION_TYPE_LABELS = {
+    'coriolis': 'Coriolis',
+    'coriolisstarport': 'Coriolis',
+    'orbis': 'Orbis',
+    'orbisstarport': 'Orbis',
+    'ocellus': 'Ocellus',
+    'ocellusstarport': 'Ocellus',
+    'outpost': 'Outpost',
+    'asteroidbase': 'AsteroidBase',
+    'planetaryport': 'PlanetaryPort',
+    'planetaryoutpost': 'PlanetaryOutpost',
+    'planetarysettlement': 'PlanetaryOutpost',
+    'settlement': 'PlanetaryOutpost',
+    'surfacesettlement': 'PlanetaryOutpost',
+    'surfacestation': 'PlanetaryPort',
+    'craterport': 'PlanetaryPort',
+    'crateroutpost': 'PlanetaryOutpost',
+    'fleetcarrier': 'FleetCarrier',
+    'carrier': 'FleetCarrier',
+    'megaship': 'MegaShip',
+    'unknown': 'Unknown',
+}
+
 VOLATILE_FIELDS = {
     'distancetoarrival',
     'distance_to_arrival',
@@ -386,6 +424,31 @@ def read_float(value: Any) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def normalise_station_type_label(station_type: Any) -> str | None:
+    token = ''.join(ch for ch in str(station_type or '').lower() if ch.isalnum())
+    if not token:
+        return None
+    return STATION_TYPE_LABELS.get(token, 'Unknown')
+
+
+def classify_station_type_evidence(station_type: Any) -> dict[str, Any]:
+    normalised = normalise_station_type_label(station_type)
+    if normalised is None:
+        classification = 'missing'
+    elif normalised in TRANSIENT_NON_SLOT_STATION_TYPES:
+        classification = 'transient_non_slot'
+    elif normalised in PERMANENT_COLONY_SLOT_STATION_TYPES:
+        classification = 'permanent_colony_slot'
+    else:
+        classification = 'unknown'
+    return {
+        'station_type_raw': read_text(station_type),
+        'station_type_normalized': normalised,
+        'station_type_classification': classification,
+        'station_type_preserved_as_source_label': True,
+    }
 
 
 def normalise_json_array(value: Any) -> list[Any]:

--- a/apps/importer/src/enrichment_warehouse_repository.py
+++ b/apps/importer/src/enrichment_warehouse_repository.py
@@ -427,11 +427,15 @@ def write_station_snapshot_report(
             batches_attempted += 1
             for station_row in batch:
                 record_hash = str(station_row['source_record_hash'])
+                parent_record_hash = str(
+                    (station_row.get('provenance') or {}).get('parent_source_record_hash')
+                    or ''
+                )
                 staging_id = upsert_staging_station(
                     cur,
                     source_run_id,
                     source_file_id,
-                    raw_ids_by_hash.get(record_hash),
+                    raw_ids_by_hash.get(record_hash) or raw_ids_by_hash.get(parent_record_hash),
                     station_row,
                 )
                 staging_ids_by_hash[record_hash] = staging_id

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -68,9 +68,11 @@ record stream shape, source timestamp summaries, and freshness summaries.
 Skipped rows are counted by explicit reason, exact duplicate source payloads
 are reported by `source_record_hash`, and repeated source identities with
 conflicting payload hashes become report-only conflicts instead of silent
-merges. Unsupported nested source shapes, including future system-with-`bodies`
-inputs, are skipped with explicit unsupported-shape reasons until a dedicated
-adapter exists.
+merges. Stage 18J-Q5 adds support for nested EDSM system records that contain
+`stations`: the full source system record remains raw evidence, extracted
+station rows receive station-specific source hashes, and nested `bodies`
+collections stay warning evidence only until an explicit body adapter supports
+that shape.
 
 ## Source Evidence Classes
 
@@ -240,6 +242,14 @@ evidence with these fields when present:
 
 Missing or invalid required station fields are skipped with warnings. They do
 not crash the loader and do not imply canonical writes.
+
+Nested EDSM system station records are normalized by combining station payloads
+with source system identity (`system_name` / `system_id64`) and parent raw
+record provenance. The station source label is preserved in `station_type`,
+while provenance records a normalized station-type label and classification
+such as `permanent_colony_slot`, `transient_non_slot`, `unknown`, or
+`missing`. Fleet carriers and megaships remain labelled transient/non-slot
+evidence and are not canonical write instructions.
 
 The body/ring adapter normalises body records and source-only ring payloads
 separately. Ring payloads remain `association_status = "source_only"` unless a

--- a/docs/colonisation-redesign/stage-18j-q2-readonly-production-reconciliation-plan.md
+++ b/docs/colonisation-redesign/stage-18j-q2-readonly-production-reconciliation-plan.md
@@ -21,6 +21,15 @@ Stage 18J-Q found no suitable local or configured production
 until an operator produces a verified report-only production reconciliation
 artifact from already staged warehouse data.
 
+Stage 18J-Q5 adds an earlier blocker found during production/server
+inspection: the warehouse schema and read-only role exist, but the warehouse
+tables are empty, and the available `/data/dumps/galaxy_stations.json.gz`
+source shape is nested EDSM system records with station/body collections rather
+than a flat station-only snapshot. The staging load must not be retried until
+the nested station loader support is merged and the operator explicitly
+approves a separate production staging load. This Q2 reconciliation plan still
+starts only after staged warehouse station rows exist.
+
 Additional blocker: the current general reconciliation candidate payload
 appears to expose `canonical.station_id` but not explicit `canonical.market_id`
 or `canonical.edsm_station_id`. Stage 18J identity safety requires explicit

--- a/docs/colonisation-redesign/stage-18j-q3-readonly-production-reconciliation-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-q3-readonly-production-reconciliation-artifact.md
@@ -239,6 +239,14 @@ No valid `enrichment_staging_reconciliation/v1` production artifact was
 generated, no artifact checksum exists, no candidate counts exist, and no
 source run/file scope was verified. Stage 18J-P remains blocked.
 
+Later production/server inspection also found the warehouse tables present but
+empty. The available `/data/dumps/galaxy_stations.json.gz` file appears to be a
+nested EDSM system snapshot with station/body collections, not a flat
+station-only snapshot. Stage 18J-Q5 hardens the loader for that station shape,
+but Q3 remains blocked until Q5 is merged and a separate, explicitly approved
+production staging load is retried. No production load, reconciliation, or
+apply is authorized by Q5 itself.
+
 ## Remaining Blockers
 
 Before Q3 can be retried, the operator must provide and verify:
@@ -251,6 +259,9 @@ Before Q3 can be retried, the operator must provide and verify:
 - approved `SOURCE_FILE_KEY`,
 - operator-managed `SAFE_ARTIFACT_DIR` outside git,
 - confirmation that the staged source run/file already exists,
+- if the intended source file is the nested
+  `/data/dumps/galaxy_stations.json.gz` shape, confirmation that Stage 18J-Q5
+  support is merged and a separate production staging load has succeeded,
 - confirmation that the later command will not invoke live EDSM/API crawling,
   Docker, write-staging, apply, write, commit, confirmation, or rollback flags.
 

--- a/docs/colonisation-redesign/stage-18j-q5-nested-edsm-station-snapshot-support.md
+++ b/docs/colonisation-redesign/stage-18j-q5-nested-edsm-station-snapshot-support.md
@@ -1,0 +1,70 @@
+# Stage 18J-Q5 - Nested EDSM Station Snapshot Support
+
+## Purpose
+
+Stage 18J-Q5 hardens the offline warehouse station loader for the source shape
+observed on the production server:
+
+```text
+/data/dumps/galaxy_stations.json.gz
+```
+
+The file was not inspected or committed in this stage. The production dry-run
+finding was that the file appears to contain nested EDSM system records with
+station/body collections, not a flat station-only snapshot. The previous loader
+reported `unsupported_source_shape` and `nested_body_collection` warnings and
+the warehouse staging tables remained empty.
+
+## Implemented Outcome
+
+Option A was implemented using only small synthetic fixtures.
+
+The `edsm_nightly_stations` loader now supports nested system records with a
+`stations` array:
+
+- each full source system record is preserved as one raw warehouse record,
+- each nested station becomes a deterministic staging station row,
+- each station row receives a station-specific `source_record_hash` and
+  `source_record_key`,
+- station rows retain `source_run_key`, `source_file_key`, and parent raw
+  source provenance,
+- parent raw system hashes are used to link station staging rows back to
+  `enrichment_raw_records` during staging writes,
+- `system_name` and `system_id64` are inherited from the parent system when
+  missing from the station payload,
+- `market_id` and `edsm_station_id` are preserved when present,
+- station type source labels are preserved while provenance records normalized
+  labels and permanent/transient/unknown classification,
+- fleet carriers and megaships remain labelled `transient_non_slot` evidence,
+- nested `bodies` collections remain raw-only unsupported-source-shape warning
+  evidence.
+
+Nested body support was not added. The station source path does not populate
+`staging_edsm_bodies`, `staging_body_rings`, canonical `bodies`, or canonical
+`body_rings`.
+
+## Boundary Confirmations
+
+This stage does not authorize production execution.
+
+- No production data was used or committed.
+- No production source artifact was copied into git.
+- No production load was run.
+- No production reconciliation was run.
+- No production apply was run.
+- No canonical tables are written by the loader.
+- No station-type canonical dry-run was generated.
+- No live EDSM/API crawl was added.
+- Unknown values remain unknown.
+- Source-only nested body evidence remains source-only.
+
+## Production Status
+
+The production warehouse currently has the warehouse tables and read-only role,
+but the staging tables are empty. Stage 18J-Q3 remains blocked until this loader
+support is merged and the production staging load is explicitly retried in a
+separate approved operation.
+
+After a successful separate staging load, Stage 18J-Q3 can retry its read-only
+reconciliation artifact path. Stage 18J-P and Stage 18K remain blocked until
+their own prerequisites are satisfied.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -32,7 +32,7 @@ Current supported source adapters:
 
 | Source | Input file | Current purpose |
 |---|---|---|
-| `edsm_nightly_stations` | Local `.json` or `.json.gz` station snapshot. JSON array, NDJSON, or small object wrapper with a `stations` array. | Station evidence dry-run, staging load, staged-row summary, reconciliation. |
+| `edsm_nightly_stations` | Local `.json` or `.json.gz` station snapshot. JSON array, NDJSON, small object wrapper with a `stations` array, or nested EDSM system records with a `stations` array. | Station evidence dry-run, staging load, staged-row summary, reconciliation. |
 | `edsm_nightly_bodies` | Local `.json` or `.json.gz` body records with optional `rings` arrays. JSON array or NDJSON. | Body/ring evidence dry-run, staging load, staged-row summary, reconciliation. |
 
 The scripts preserve source payloads and future/unknown fields in raw evidence.
@@ -40,6 +40,14 @@ Missing evidence remains unknown. Missing ring arrays are reported as
 `unknown_not_false`; they are not proof that a body has no rings. Source-only
 ring evidence is not trusted local ring truth unless later reconciled to trusted
 `body_rings` evidence.
+
+Nested EDSM system station snapshots are supported only for station extraction.
+The loader preserves each full system record in `enrichment_raw_records`,
+extracts deterministic station staging rows with station-specific source
+hashes, links them back to the parent raw system hash in provenance, and
+reports nested `bodies` collections as raw-only unsupported-source-shape
+warnings. Nested bodies do not populate body/ring staging tables through the
+station source path and do not become canonical truth.
 
 ## Safety Model
 
@@ -143,6 +151,8 @@ A good dry-run has:
 - `schema_version = "enrichment_snapshot_load_plan/v1"`
 - `dry_run = true`
 - expected `records_seen`, `raw_records`, and staged-row counts
+- for nested system station snapshots, expected
+  `nested_station_collections` and `nested_station_records_extracted`
 - `source_format_version = "json_snapshot_stream/v1"` and the expected
   `record_stream_shape`
 - `source_timestamp_summary` and `source_freshness_summary` matching the
@@ -176,8 +186,9 @@ Warnings that block moving to staging load:
 - required identity fields missing across most records
 - unexpected `record_is_not_object` or malformed JSON patterns
 - unsupported source adapter
-- unsupported nested source shape, such as future system-with-`bodies`
-  snapshots, until a dedicated adapter exists
+- unsupported nested source shape that is not the supported nested system
+  station form. Nested `bodies` on a supported station snapshot are warning
+  evidence only and should be reviewed before staging load.
 - `duplicate_source_identity_conflict`
 - non-array `rings` fields or malformed ring rows in body/ring snapshots
 - remote URL used as `--source-file`
@@ -508,6 +519,14 @@ read-only/report-only warehouse DSN in
 `docs/operations/stage-18j-q4c-readonly-warehouse-dsn-provisioning-plan.md`.
 It is docs/ops planning only and does not create roles, change deployment
 config, run reconciliation, generate artifacts, or authorize apply.
+
+Stage 18J-Q5 documents nested EDSM station snapshot support in
+`docs/colonisation-redesign/stage-18j-q5-nested-edsm-station-snapshot-support.md`.
+It hardens the local loader for `/data/dumps/galaxy_stations.json.gz`-style
+nested system records without using production data. Stage 18J-Q3 remains
+blocked until this support is merged and a separate explicitly approved
+production staging load is retried; no production load, reconciliation, or
+apply is authorized by Q5.
 
 ## Optional Postgres Smoke Tests
 

--- a/tests/fixtures/edsm_nested_system_station_snapshot.json
+++ b/tests/fixtures/edsm_nested_system_station_snapshot.json
@@ -1,0 +1,48 @@
+[
+  {
+    "id": 7001,
+    "name": "Nested Alpha",
+    "systemId64": 111111111,
+    "updatedAt": "2026-05-30T00:00:00Z",
+    "stations": [
+      {
+        "id": 1001,
+        "marketId": 9001001,
+        "name": "Alpha Orbital",
+        "type": "Orbis Starport",
+        "distanceToArrival": 101.5,
+        "bodyName": "Nested Alpha 1"
+      },
+      {
+        "id": 1002,
+        "marketId": 9001002,
+        "name": "FC Test",
+        "type": "Fleet Carrier",
+        "distanceToArrival": 2048.0
+      }
+    ],
+    "bodies": [
+      {
+        "id": 1,
+        "name": "Nested Alpha 1",
+        "type": "Planet"
+      }
+    ]
+  },
+  {
+    "systemName": "Nested Beta",
+    "id64": 222222222,
+    "stations": [
+      {
+        "edsmStationId": 1003,
+        "marketId": 9001003,
+        "stationName": "Beta Plant",
+        "stationType": "Planetary Settlement",
+        "services": ["Dock", "Market"],
+        "body": {
+          "name": "Nested Beta A 2"
+        }
+      }
+    ]
+  }
+]

--- a/tests/test_enrichment_snapshot_loader.py
+++ b/tests/test_enrichment_snapshot_loader.py
@@ -19,6 +19,7 @@ import enrichment_snapshot_loader as loader  # noqa: E402
 
 
 FIXTURE = ROOT / 'tests' / 'fixtures' / 'edsm_station_snapshot.json'
+NESTED_FIXTURE = ROOT / 'tests' / 'fixtures' / 'edsm_nested_system_station_snapshot.json'
 
 
 def test_loader_reads_local_edsm_station_snapshot_fixture():
@@ -324,6 +325,115 @@ def test_unsupported_station_source_shape_is_reported_without_guessing(tmp_path)
         },
     }]
     assert report['raw_records_planned'][0]['validation_status'] == 'skipped'
+
+
+def test_nested_system_station_snapshot_extracts_supported_station_rows():
+    report = loader.build_snapshot_load_report(
+        source_file=NESTED_FIXTURE,
+        source='edsm_nightly_stations',
+    )
+
+    assert report['dry_run'] is True
+    assert report['summary']['records_seen'] == 2
+    assert report['summary']['raw_records'] == 2
+    assert report['summary']['staged_rows'] == 3
+    assert report['summary']['staged_edsm_stations'] == 3
+    assert report['summary']['nested_station_collections'] == 2
+    assert report['summary']['nested_station_records_extracted'] == 3
+    assert report['summary']['nested_station_records_skipped'] == 0
+    assert report['summary']['canonical_writes_planned'] == 0
+    assert report['planned_rows'] == []
+    assert 'staged_body_rows' not in report
+
+    raw_hashes = {row['source_record_hash'] for row in report['raw_records_planned']}
+    staged_hashes = {row['source_record_hash'] for row in report['staged_rows']}
+    assert len(raw_hashes) == 2
+    assert len(staged_hashes) == 3
+    assert raw_hashes.isdisjoint(staged_hashes)
+    assert all(row['source_run_key'] == report['source_run']['source_run_key'] for row in report['staged_rows'])
+    assert all(row['source_file_key'] == report['source_file']['source_file_key'] for row in report['staged_rows'])
+    assert {row['provenance']['parent_source_record_hash'] for row in report['staged_rows']} == raw_hashes
+
+    by_name = {row['station_name']: row for row in report['staged_rows']}
+    alpha = by_name['Alpha Orbital']
+    assert alpha['system_name'] == 'Nested Alpha'
+    assert alpha['system_id64'] == 111111111
+    assert alpha['market_id'] == 9001001
+    assert alpha['edsm_station_id'] == 1001
+    assert alpha['station_type'] == 'Orbis Starport'
+    assert alpha['provenance']['station_type_normalized'] == 'Orbis'
+    assert alpha['provenance']['station_type_classification'] == 'permanent_colony_slot'
+    assert alpha['provenance']['source_record_kind'] == 'nested_station_record'
+    assert alpha['provenance']['nested_body_collection_state'] == 'unsupported_source_only'
+    assert alpha['provenance']['canonical_write_allowed'] is False
+
+    beta = by_name['Beta Plant']
+    assert beta['system_name'] == 'Nested Beta'
+    assert beta['system_id64'] == 222222222
+    assert beta['market_id'] == 9001003
+    assert beta['edsm_station_id'] == 1003
+    assert beta['station_type'] == 'Planetary Settlement'
+    assert beta['body_name'] == 'Nested Beta A 2'
+    assert beta['provenance']['station_type_normalized'] == 'PlanetaryOutpost'
+
+
+def test_nested_system_body_collection_remains_warning_not_body_truth():
+    report = loader.build_snapshot_load_report(
+        source_file=NESTED_FIXTURE,
+        source='edsm_nightly_stations',
+    )
+
+    body_warnings = [
+        warning for warning in report['warnings']
+        if warning.get('reason') == 'unsupported_source_shape'
+        and warning.get('source_shape') == 'nested_body_collection'
+    ]
+    assert body_warnings == [{
+        'record_index': 1,
+        'source_record_hash': report['raw_records_planned'][0]['source_record_hash'],
+        'field': 'bodies',
+        'reason': 'unsupported_source_shape',
+        'source_shape': 'nested_body_collection',
+        'handling': 'preserved_in_raw_record_only_not_staged',
+    }]
+    assert report['summary']['unsupported_source_shapes'] == 1
+    assert report['summary']['warning_reason_distribution']['unsupported_source_shape'] == 1
+    assert report['raw_records_planned'][0]['raw_payload']['bodies'][0]['name'] == 'Nested Alpha 1'
+    assert report['raw_records_planned'][0]['validation_status'] == 'accepted'
+    assert report['raw_records_planned'][0]['validation_warnings'] == [
+        {
+            'field': 'bodies',
+            'reason': 'unsupported_source_shape',
+            'source_shape': 'nested_body_collection',
+            'handling': 'preserved_in_raw_record_only_not_staged',
+        },
+    ]
+    assert all('bodies' not in row['raw_payload'] for row in report['staged_rows'])
+    assert report['summary']['canonical_writes_planned'] == 0
+
+
+def test_nested_fleet_carrier_station_type_is_labelled_not_canonical_truth():
+    report = loader.build_snapshot_load_report(
+        source_file=NESTED_FIXTURE,
+        source='edsm_nightly_stations',
+    )
+
+    carrier = {row['station_name']: row for row in report['staged_rows']}['FC Test']
+    assert carrier['station_type'] == 'Fleet Carrier'
+    assert carrier['provenance']['station_type_normalized'] == 'FleetCarrier'
+    assert carrier['provenance']['station_type_classification'] == 'transient_non_slot'
+    assert carrier['validation_warnings'] == [
+        {
+            'field': 'station_type',
+            'reason': 'transient_non_slot_station_type',
+            'station_type_normalized': 'FleetCarrier',
+        },
+    ]
+    assert any(
+        warning.get('reason') == 'transient_non_slot_station_type'
+        and warning.get('source_record_hash') == carrier['source_record_hash']
+        for warning in report['warnings']
+    )
 
 
 def test_conflicting_station_records_with_same_source_identity_are_report_only(tmp_path):

--- a/tests/test_enrichment_staging.py
+++ b/tests/test_enrichment_staging.py
@@ -29,9 +29,11 @@ from enrichment_staging import (  # noqa: E402
     build_mission_intelligence_dry_run,
     build_station_snapshot_enrichment_dry_run,
     canonicalise_json_payload,
+    classify_station_type_evidence,
     classify_source_adapter,
     classify_source_field,
     idempotency_key,
+    normalise_station_type_label,
     normalise_source_file_metadata,
     normalise_source_run_metadata,
     payload_fingerprint,
@@ -121,6 +123,30 @@ def test_source_classification_covers_current_and_future_adapters():
     assert classify_source_field('edsm_nightly_stations', 'distanceToArrival') == 'volatile'
     assert classify_source_field('edsm_nightly_stations', 'distance_from_star') == 'semi-stable'
     assert classify_source_field('live_edsm_diagnostics', 'name') == 'diagnostic-only'
+
+
+def test_station_type_evidence_preserves_source_label_and_classifies_transients():
+    assert normalise_station_type_label('Orbis Starport') == 'Orbis'
+    assert normalise_station_type_label('Planetary Settlement') == 'PlanetaryOutpost'
+    assert normalise_station_type_label('Fleet Carrier') == 'FleetCarrier'
+    assert normalise_station_type_label('Carrier') == 'FleetCarrier'
+    assert normalise_station_type_label('Coriolis Logistics') == 'Unknown'
+    assert normalise_station_type_label(None) is None
+
+    assert classify_station_type_evidence('Orbis Starport') == {
+        'station_type_raw': 'Orbis Starport',
+        'station_type_normalized': 'Orbis',
+        'station_type_classification': 'permanent_colony_slot',
+        'station_type_preserved_as_source_label': True,
+    }
+    assert classify_station_type_evidence('Fleet Carrier') == {
+        'station_type_raw': 'Fleet Carrier',
+        'station_type_normalized': 'FleetCarrier',
+        'station_type_classification': 'transient_non_slot',
+        'station_type_preserved_as_source_label': True,
+    }
+    assert classify_station_type_evidence('Coriolis Logistics')['station_type_classification'] == 'unknown'
+    assert classify_station_type_evidence(None)['station_type_classification'] == 'missing'
 
 
 def test_report_skeletons_are_versioned_and_deterministic():

--- a/tests/test_enrichment_staging_db_loader.py
+++ b/tests/test_enrichment_staging_db_loader.py
@@ -20,6 +20,7 @@ import enrichment_staging_db_loader as db_loader  # noqa: E402
 
 
 FIXTURE = ROOT / 'tests' / 'fixtures' / 'edsm_station_snapshot.json'
+NESTED_FIXTURE = ROOT / 'tests' / 'fixtures' / 'edsm_nested_system_station_snapshot.json'
 CANONICAL_WRITE_RE = re.compile(
     r'\b(insert\s+into|update|delete\s+from|alter\s+table)\s+'
     r'(systems|stations|bodies|body_rings|body_scan_facts|station_body_links)\b',
@@ -382,6 +383,42 @@ def test_gzipped_snapshot_works_through_staging_db_loader(tmp_path):
     assert report['summary']['raw_records_written'] == 3
     assert report['summary']['staging_station_rows_written'] == 2
     assert len([sql for sql, _params in conn.statements if 'INSERT INTO' in sql]) == 7
+    assert_only_safe_sql(conn.statements)
+
+
+def test_nested_system_snapshot_writes_only_supported_station_staging_rows():
+    conn = FakeConn()
+
+    report = db_loader.load_station_snapshot_to_staging_db(
+        source_file=NESTED_FIXTURE,
+        source='edsm_nightly_stations',
+        conn=conn,
+        write_staging=True,
+    )
+
+    assert report['dry_run'] is False
+    assert report['summary']['records_seen'] == 2
+    assert report['summary']['raw_records_written'] == 2
+    assert report['summary']['staging_station_rows_written'] == 3
+    assert report['summary']['staging_body_rows_written'] == 0
+    assert report['summary']['staging_ring_rows_written'] == 0
+    assert report['summary']['canonical_writes_planned'] == 0
+    assert report['summary']['nested_station_records_extracted'] == 3
+    assert len({row['source_record_hash'] for row in report['staged_rows']}) == 3
+    assert all(row['provenance']['source_record_kind'] == 'nested_station_record' for row in report['staged_rows'])
+
+    staging_statements = [
+        (sql, params)
+        for sql, params in conn.statements
+        if 'INSERT INTO staging_edsm_stations' in sql
+    ]
+    assert len(staging_statements) == 3
+    assert all(params[2] is not None for _sql, params in staging_statements)
+    sql_text = '\n'.join(sql for sql, _params in conn.statements)
+    assert 'INSERT INTO staging_edsm_stations' in sql_text
+    assert 'INSERT INTO staging_edsm_bodies' not in sql_text
+    assert 'INSERT INTO staging_body_rings' not in sql_text
+    assert CANONICAL_WRITE_RE.search(sql_text) is None
     assert_only_safe_sql(conn.statements)
 
 


### PR DESCRIPTION
## What changed

- Implemented Option A: nested EDSM system records with `stations` arrays are now supported by the offline `edsm_nightly_stations` loader.
- Preserved each parent system record as raw warehouse evidence while extracting deterministic station staging rows with station-specific source hashes and parent provenance.
- Kept nested `bodies` collections as raw-only unsupported-source-shape warning evidence; they do not populate body/ring staging or canonical truth.
- Added station-type source label preservation plus normalized provenance classification, including `transient_non_slot` labels for fleet carriers/megaships.
- Added a tiny synthetic nested-system fixture and tests for dry-run counts, source keys/hashes/provenance, nested body warnings, transient labels, explicit staging-write boundaries, and no canonical writes.
- Updated the warehouse runbook, staging architecture, Q2/Q3 blocker docs, and added the Q5 stage note.

## Boundary confirmations

- No production data committed.
- No production artifact used or committed.
- No production load run.
- No production reconciliation run.
- No production apply run.
- No production DB touched.
- No canonical tables written by this change.
- No station-type canonical dry-run run.
- No live EDSM/API crawl added or run.
- Unknown values remain unknown.
- Source-only nested body evidence remains source-only.

## Validation

- `./scripts/run_canonical_safety_tests.sh` - passed (`82 passed`; disposable Postgres rehearsal skipped because `EDFINDER_CANONICAL_TEST_DSN` and `EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes` were not set).
- `.venv/bin/pytest tests/test_enrichment_snapshot_loader.py tests/test_enrichment_staging.py tests/test_enrichment_staging_db_loader.py tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q` - passed (`114 passed`).
- `.venv/bin/python -m py_compile apps/importer/src/enrichment_snapshot_loader.py apps/importer/src/enrichment_staging.py apps/importer/src/enrichment_staging_db_loader.py apps/importer/src/station_type_canonical_pilot.py tests/test_enrichment_snapshot_loader.py tests/test_enrichment_staging.py tests/test_enrichment_staging_db_loader.py tests/test_station_type_canonical_pilot.py` - passed.
- `git diff --check` - passed.

## Production status

- Production warehouse schema and read-only role exist, but warehouse tables are currently empty.
- The observed production source candidate `/data/dumps/galaxy_stations.json.gz` appears to be a nested EDSM system station snapshot, not a flat station-only export.
- Stage 18J-Q3 remains blocked until this support is merged and the production load is explicitly retried in a separate approved operation.
- Stage 18J-P remains blocked until a valid read-only production reconciliation artifact exists.
- Stage 18K was not started.