### PR TITLE
Stage 18J-Q6 memory-safe warehouse station load

### DIFF
--- a/apps/importer/src/enrichment_snapshot_loader.py
+++ b/apps/importer/src/enrichment_snapshot_loader.py
@@ -93,18 +93,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     return 0
 
 
-def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | None = None) -> dict[str, Any]:
-    """Build a deterministic dry-run report for a local offline source file."""
+def build_station_snapshot_source_context(*, source_file: Path, source: str) -> dict[str, Any]:
+    """Build deterministic source run/file metadata for station snapshot loading."""
     normalised_source = normalise_source_adapter(source)
-    if normalised_source not in SUPPORTED_SOURCES:
-        raise ValueError(f'unsupported offline source {source!r}; supported sources: {sorted(SUPPORTED_SOURCES)}')
-    if normalised_source == 'edsm_nightly_bodies':
-        return build_body_ring_snapshot_load_report(
-            source_file=source_file,
-            source=normalised_source,
-            limit=limit,
-        )
-
+    if normalised_source != 'edsm_nightly_stations':
+        raise ValueError('station snapshot loading requires source edsm_nightly_stations')
     _assert_local_file(source_file)
 
     file_sha256, file_size_bytes = file_digest(source_file)
@@ -127,6 +120,30 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             **file_format,
         },
     )
+    return {
+        'source': normalised_source,
+        'source_file': source_file_summary,
+        'source_run': source_run,
+        'file_format': file_format,
+    }
+
+
+def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | None = None) -> dict[str, Any]:
+    """Build a deterministic dry-run report for a local offline source file."""
+    normalised_source = normalise_source_adapter(source)
+    if normalised_source not in SUPPORTED_SOURCES:
+        raise ValueError(f'unsupported offline source {source!r}; supported sources: {sorted(SUPPORTED_SOURCES)}')
+    if normalised_source == 'edsm_nightly_bodies':
+        return build_body_ring_snapshot_load_report(
+            source_file=source_file,
+            source=normalised_source,
+            limit=limit,
+        )
+
+    context = build_station_snapshot_source_context(source_file=source_file, source=normalised_source)
+    file_format = context['file_format']
+    source_file_summary = context['source_file']
+    source_run = context['source_run']
 
     raw_records: list[dict[str, Any]] = []
     staged_rows: list[dict[str, Any]] = []
@@ -138,17 +155,93 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
     nested_station_collections = 0
     nested_station_records_extracted = 0
     nested_station_records_skipped = 0
+    for entry in iter_station_snapshot_load_entries(
+        source_file=source_file,
+        source=normalised_source,
+        source_run=source_run,
+        source_file_summary=source_file_summary,
+        limit=limit,
+    ):
+        records_seen += 1
+        raw_record = entry.get('raw_record')
+        if raw_record is not None:
+            raw_records.append(raw_record)
+        staged_rows.extend(entry['staged_rows'])
+        skipped_rows.extend(entry['skipped_rows'])
+        warnings.extend(entry['warnings'])
+        nested_station_collections += int(entry.get('nested_station_collections', 0))
+        nested_station_records_extracted += int(entry.get('nested_station_records_extracted', 0))
+        nested_station_records_skipped += int(entry.get('nested_station_records_skipped', 0))
+
+    conflicts = source_identity_conflicts(staged_rows, entity='station')
+    source_summary = source_observability_summary(
+        raw_records=raw_records,
+        staged_rows=staged_rows,
+        planned_rows=(),
+        skipped_rows=skipped_rows,
+        warnings=warnings,
+        file_format=file_format,
+    )
+    apply_source_observability_metadata(
+        source_run=source_run,
+        source_file=source_file_summary,
+        source_summary=source_summary,
+    )
+
+    return build_enrichment_snapshot_load_plan(
+        source_run=source_run,
+        source_file=source_file_summary,
+        raw_records=raw_records,
+        staged_rows=staged_rows,
+        skipped_rows=skipped_rows,
+        conflicts=conflicts,
+        warnings=warnings,
+        summary_extra={
+            'source': normalised_source,
+            'adapter_name': ADAPTER_NAME,
+            'records_seen': records_seen,
+            'staged_edsm_stations': len(staged_rows),
+            'nested_station_collections': nested_station_collections,
+            'nested_station_records_extracted': nested_station_records_extracted,
+            'nested_station_records_skipped': nested_station_records_skipped,
+            'dry_run_only': True,
+            'canonical_writes_planned': 0,
+            'distance_to_arrival_classification': classify_source_field(normalised_source, 'distanceToArrival'),
+            **source_summary,
+        },
+    )
+
+
+def iter_station_snapshot_load_entries(
+    *,
+    source_file: Path,
+    source: str,
+    source_run: Mapping[str, Any],
+    source_file_summary: Mapping[str, Any],
+    limit: int | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield per-source-record station load entries without accumulating the file."""
+    normalised_source = normalise_source_adapter(source)
+    records_seen = 0
     for record_index, record in enumerate(iter_json_records(source_file, expand_station_collections=False), start=1):
         if limit is not None and records_seen >= limit:
             break
         records_seen += 1
         if not isinstance(record, Mapping):
-            skip = {
+            yield {
                 'record_index': record_index,
-                'reason': 'record_is_not_object',
-                'raw_payload': record,
+                'raw_record': None,
+                'staged_rows': [],
+                'skipped_rows': [{
+                    'record_index': record_index,
+                    'reason': 'record_is_not_object',
+                    'raw_payload': record,
+                }],
+                'warnings': [],
+                'nested_station_collections': 0,
+                'nested_station_records_extracted': 0,
+                'nested_station_records_skipped': 0,
             }
-            skipped_rows.append(skip)
             continue
 
         raw_record = build_raw_record(
@@ -159,10 +252,16 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
             payload=record,
             source_updated_at=source_updated_at_from_record(record),
         )
-        raw_records.append(raw_record)
+        staged_rows: list[dict[str, Any]] = []
+        skipped_rows: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        nested_station_collections = 0
+        nested_station_records_extracted = 0
+        nested_station_records_skipped = 0
+
         nested_station_collection = station_collection_from_record(record)
         if nested_station_collection is not None:
-            nested_station_collections += 1
+            nested_station_collections = 1
             station_collection_field, station_records = nested_station_collection
             body_warning = unsupported_nested_body_collection_warning(record)
             if body_warning is not None:
@@ -250,6 +349,16 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
                         'source_record_hash': row['source_record_hash'],
                         **warning,
                     })
+            yield {
+                'record_index': record_index,
+                'raw_record': raw_record,
+                'staged_rows': staged_rows,
+                'skipped_rows': skipped_rows,
+                'warnings': warnings,
+                'nested_station_collections': nested_station_collections,
+                'nested_station_records_extracted': nested_station_records_extracted,
+                'nested_station_records_skipped': nested_station_records_skipped,
+            }
             continue
 
         unsupported_shape = unsupported_source_shape(record, normalised_source)
@@ -273,7 +382,18 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
                 'source_record_hash': raw_record['source_record_hash'],
                 **shape_warning,
             })
+            yield {
+                'record_index': record_index,
+                'raw_record': raw_record,
+                'staged_rows': staged_rows,
+                'skipped_rows': skipped_rows,
+                'warnings': warnings,
+                'nested_station_collections': 0,
+                'nested_station_records_extracted': 0,
+                'nested_station_records_skipped': 0,
+            }
             continue
+
         row = normalise_edsm_station_snapshot_record(
             record,
             source=normalised_source,
@@ -291,53 +411,25 @@ def build_snapshot_load_report(*, source_file: Path, source: str, limit: int | N
                 'warnings': row_warnings,
                 'raw_payload': dict(record),
             })
-            continue
-        row['validation_warnings'] = row_warnings
-        staged_rows.append(row)
-        for warning in row_warnings:
-            warnings.append({
-                'record_index': record_index,
-                'source_record_hash': raw_record['source_record_hash'],
-                **warning,
-            })
-
-    conflicts = source_identity_conflicts(staged_rows, entity='station')
-    source_summary = source_observability_summary(
-        raw_records=raw_records,
-        staged_rows=staged_rows,
-        planned_rows=(),
-        skipped_rows=skipped_rows,
-        warnings=warnings,
-        file_format=file_format,
-    )
-    apply_source_observability_metadata(
-        source_run=source_run,
-        source_file=source_file_summary,
-        source_summary=source_summary,
-    )
-
-    return build_enrichment_snapshot_load_plan(
-        source_run=source_run,
-        source_file=source_file_summary,
-        raw_records=raw_records,
-        staged_rows=staged_rows,
-        skipped_rows=skipped_rows,
-        conflicts=conflicts,
-        warnings=warnings,
-        summary_extra={
-            'source': normalised_source,
-            'adapter_name': ADAPTER_NAME,
-            'records_seen': records_seen,
-            'staged_edsm_stations': len(staged_rows),
-            'nested_station_collections': nested_station_collections,
-            'nested_station_records_extracted': nested_station_records_extracted,
-            'nested_station_records_skipped': nested_station_records_skipped,
-            'dry_run_only': True,
-            'canonical_writes_planned': 0,
-            'distance_to_arrival_classification': classify_source_field(normalised_source, 'distanceToArrival'),
-            **source_summary,
-        },
-    )
+        else:
+            row['validation_warnings'] = row_warnings
+            staged_rows.append(row)
+            for warning in row_warnings:
+                warnings.append({
+                    'record_index': record_index,
+                    'source_record_hash': raw_record['source_record_hash'],
+                    **warning,
+                })
+        yield {
+            'record_index': record_index,
+            'raw_record': raw_record,
+            'staged_rows': staged_rows,
+            'skipped_rows': skipped_rows,
+            'warnings': warnings,
+            'nested_station_collections': 0,
+            'nested_station_records_extracted': 0,
+            'nested_station_records_skipped': 0,
+        }
 
 
 def build_body_ring_snapshot_load_report(

--- a/apps/importer/src/enrichment_staging_db_loader.py
+++ b/apps/importer/src/enrichment_staging_db_loader.py
@@ -14,13 +14,19 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from enrichment_snapshot_loader import build_snapshot_load_report
-from enrichment_staging import normalise_source_adapter
+from enrichment_snapshot_loader import (
+    apply_source_observability_metadata,
+    build_snapshot_load_report,
+    build_station_snapshot_source_context,
+    iter_station_snapshot_load_entries,
+)
+from enrichment_staging import classify_source_field, normalise_source_adapter
 from enrichment_warehouse import (
     WAREHOUSE_BASE_TABLES,
     WAREHOUSE_BODY_RING_WRITE_TABLES,
@@ -48,6 +54,8 @@ STATION_TARGET_TABLES = WAREHOUSE_STATION_WRITE_TABLES
 BODY_RING_TARGET_TABLES = WAREHOUSE_BODY_RING_WRITE_TABLES
 TARGET_TABLES = STATION_TARGET_TABLES
 SUPPORTED_SOURCES = {'edsm_nightly_stations', 'edsm_nightly_bodies'}
+DEFAULT_STREAMING_WRITE_BATCH_SIZE = 500
+MAX_TRACKED_UNIQUE_TIMESTAMPS = 10_000
 PREFLIGHT_SCHEMA_VERSION = 'enrichment_staging_schema_preflight/v1'
 STAGED_ROWS_REPORT_SCHEMA_VERSION = 'enrichment_staged_rows_summary/v1'
 RECONCILIATION_REPORT_SCHEMA_VERSION = 'enrichment_staging_reconciliation/v1'
@@ -69,6 +77,12 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         help='Offline source adapter. Supported: edsm_nightly_stations, edsm_nightly_bodies.',
     )
     parser.add_argument('--limit', type=int, default=None, help='Maximum local records to inspect.')
+    parser.add_argument(
+        '--batch-size',
+        type=int,
+        default=DEFAULT_STREAMING_WRITE_BATCH_SIZE,
+        help='Maximum source records per station streaming write batch. Applies to --write-staging station loads.',
+    )
     parser.add_argument('--json', action='store_true', help='Emit JSON. Output is always JSON.')
     parser.add_argument('--dry-run', action='store_true', default=True, help='Dry-run/no-write mode. This is the default.')
     parser.add_argument(
@@ -108,6 +122,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         parser.error('canonical apply/write flags are not available; use --write-staging for warehouse staging only')
     if args.limit is not None and args.limit < 0:
         parser.error('--limit must be >= 0')
+    if args.batch_size < 1:
+        parser.error('--batch-size must be >= 1')
     if args.write_staging and not args.dsn:
         parser.error('--write-staging requires an explicit non-production --dsn')
     if args.write_staging and not args.confirm_staging_db:
@@ -177,6 +193,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     conn=conn,
                     limit=args.limit,
                     write_staging=True,
+                    batch_size=args.batch_size,
                 )
         else:
             report = build_staging_loader_report(
@@ -330,20 +347,34 @@ def load_station_snapshot_to_staging_db(
     conn: Any | None = None,
     limit: int | None = None,
     write_staging: bool = False,
+    batch_size: int = DEFAULT_STREAMING_WRITE_BATCH_SIZE,
 ) -> dict[str, Any]:
     """Optionally write one local station snapshot report to staging tables."""
+    if batch_size < 1:
+        raise ValueError('batch_size must be >= 1')
+    normalised_source = normalise_source_adapter(source)
+    if normalised_source not in SUPPORTED_SOURCES:
+        raise ValueError(f'unsupported offline source {source!r}; supported sources: {sorted(SUPPORTED_SOURCES)}')
+    if write_staging and conn is None:
+        raise ValueError('write_staging requires an explicit database connection')
+    if write_staging and normalised_source == 'edsm_nightly_stations':
+        return stream_station_snapshot_to_staging_db(
+            source_file=source_file,
+            source=normalised_source,
+            conn=conn,
+            limit=limit,
+            batch_size=batch_size,
+        )
     report = build_staging_loader_report(
         source_file=source_file,
-        source=source,
+        source=normalised_source,
         limit=limit,
         write_staging=write_staging,
     )
     if not write_staging:
         return report
-    if conn is None:
-        raise ValueError('write_staging requires an explicit database connection')
 
-    preflight = check_staging_schema(conn, source=source)
+    preflight = check_staging_schema(conn, source=normalised_source)
     if not preflight['ok']:
         _rollback(conn)
         raise ValueError(
@@ -359,6 +390,383 @@ def load_station_snapshot_to_staging_db(
         _rollback(conn)
         raise
     return build_report_from_staged_rows(report, write_summary)
+
+
+def stream_station_snapshot_to_staging_db(
+    *,
+    source_file: Path,
+    source: str,
+    conn: Any,
+    limit: int | None = None,
+    batch_size: int = DEFAULT_STREAMING_WRITE_BATCH_SIZE,
+) -> dict[str, Any]:
+    """Stream a station snapshot into staging rows without retaining the full plan."""
+    if batch_size < 1:
+        raise ValueError('batch_size must be >= 1')
+    context = build_station_snapshot_source_context(source_file=source_file, source=source)
+    normalised_source = context['source']
+    source_run = deepcopy(context['source_run'])
+    source_file_summary = deepcopy(context['source_file'])
+    file_format = context['file_format']
+    source_run['dry_run'] = False
+
+    preflight = check_staging_schema(conn, source=normalised_source)
+    if not preflight['ok']:
+        _rollback(conn)
+        raise ValueError(
+            'enrichment staging schema preflight failed: '
+            f"missing_tables={preflight['missing_tables']} "
+            f"missing_columns={preflight['missing_columns']}"
+        )
+
+    source_run_id: int | None = None
+    source_file_id: int | None = None
+    batch_raw_records: list[Mapping[str, Any]] = []
+    batch_station_rows: list[Mapping[str, Any]] = []
+    batch_source_records = 0
+    stats = _new_station_streaming_stats(file_format=file_format)
+
+    try:
+        source_run_id, source_file_id = _upsert_source_context(conn, source_run, source_file_summary)
+
+        for entry in iter_station_snapshot_load_entries(
+            source_file=source_file,
+            source=normalised_source,
+            source_run=source_run,
+            source_file_summary=source_file_summary,
+            limit=limit,
+        ):
+            _record_station_streaming_entry(stats, entry)
+            raw_record = entry.get('raw_record')
+            if raw_record is not None:
+                batch_raw_records.append(raw_record)
+            batch_station_rows.extend(entry['staged_rows'])
+            batch_source_records += 1
+
+            if batch_source_records >= batch_size:
+                _flush_station_streaming_batch(
+                    conn,
+                    source_run_id=source_run_id,
+                    source_file_id=source_file_id,
+                    raw_records=batch_raw_records,
+                    station_rows=batch_station_rows,
+                    stats=stats,
+                )
+                _commit(conn)
+                batch_raw_records = []
+                batch_station_rows = []
+                batch_source_records = 0
+
+        if batch_source_records:
+            _flush_station_streaming_batch(
+                conn,
+                source_run_id=source_run_id,
+                source_file_id=source_file_id,
+                raw_records=batch_raw_records,
+                station_rows=batch_station_rows,
+                stats=stats,
+            )
+            _commit(conn)
+
+        source_summary = _station_streaming_source_summary(stats, file_format=file_format)
+        apply_source_observability_metadata(
+            source_run=source_run,
+            source_file=source_file_summary,
+            source_summary=source_summary,
+        )
+        final_source_run_id, final_source_file_id = _upsert_source_context(conn, source_run, source_file_summary)
+        source_run_id = source_run_id or final_source_run_id
+        source_file_id = source_file_id or final_source_file_id
+        _commit(conn)
+    except Exception:
+        _rollback(conn)
+        raise
+
+    source_run['db_id'] = source_run_id
+    source_file_summary['db_id'] = source_file_id
+    return _build_station_streaming_write_report(
+        source_run=source_run,
+        source_file=source_file_summary,
+        source_summary=source_summary,
+        stats=stats,
+        batch_size=batch_size,
+        target_tables=target_tables_for_source(normalised_source),
+    )
+
+
+def _upsert_source_context(
+    conn: Any,
+    source_run: Mapping[str, Any],
+    source_file: Mapping[str, Any],
+) -> tuple[int, int]:
+    cur = conn.cursor()
+    try:
+        source_run_id = upsert_source_run(cur, source_run)
+        source_file_id = upsert_source_file(cur, source_run_id, source_file)
+        return source_run_id, source_file_id
+    finally:
+        _close_cursor(cur)
+
+
+def _flush_station_streaming_batch(
+    conn: Any,
+    *,
+    source_run_id: int,
+    source_file_id: int,
+    raw_records: Sequence[Mapping[str, Any]],
+    station_rows: Sequence[Mapping[str, Any]],
+    stats: dict[str, Any],
+) -> None:
+    if not raw_records and not station_rows:
+        return
+    cur = conn.cursor()
+    try:
+        raw_ids_by_hash: dict[str, int] = {}
+        for raw_record in raw_records:
+            raw_record_id = upsert_raw_record(cur, source_run_id, source_file_id, raw_record)
+            raw_ids_by_hash[str(raw_record['source_record_hash'])] = raw_record_id
+            stats['raw_records_written'] += 1
+
+        for station_row in station_rows:
+            record_hash = str(station_row['source_record_hash'])
+            parent_record_hash = str(
+                (station_row.get('provenance') or {}).get('parent_source_record_hash')
+                or ''
+            )
+            upsert_staging_edsm_station(
+                cur,
+                source_run_id,
+                source_file_id,
+                raw_ids_by_hash.get(record_hash) or raw_ids_by_hash.get(parent_record_hash),
+                station_row,
+            )
+            stats['staging_station_rows_written'] += 1
+        stats['batches_written'] += 1
+    finally:
+        _close_cursor(cur)
+
+
+def _new_station_streaming_stats(*, file_format: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'records_seen': 0,
+        'raw_records': 0,
+        'staged_edsm_stations': 0,
+        'skipped_rows': 0,
+        'warnings': 0,
+        'nested_station_collections': 0,
+        'nested_station_records_extracted': 0,
+        'nested_station_records_skipped': 0,
+        'raw_records_written': 0,
+        'staging_station_rows_written': 0,
+        'batches_written': 0,
+        'unsupported_source_shapes': 0,
+        'malformed_rows': 0,
+        'records_with_source_updated_at': 0,
+        'records_without_source_updated_at': 0,
+        'earliest_source_updated_at': None,
+        'latest_source_updated_at': None,
+        'unique_source_updated_at_values': set(),
+        'unique_source_updated_at_values_is_lower_bound': False,
+        'warning_reason_distribution': Counter(),
+        'skipped_row_reason_distribution': Counter(),
+        'confidence_distribution': Counter(),
+        'freshness_distribution': Counter(),
+        'source_class_distribution': Counter(),
+        'source_format': file_format.get('source_format'),
+        'source_format_version': file_format.get('source_format_version'),
+        'record_stream_shape': file_format.get('record_stream_shape'),
+    }
+
+
+def _record_station_streaming_entry(stats: dict[str, Any], entry: Mapping[str, Any]) -> None:
+    stats['records_seen'] += 1
+    raw_record = entry.get('raw_record')
+    if raw_record is not None:
+        stats['raw_records'] += 1
+        _record_source_updated_at(stats, raw_record.get('source_updated_at'))
+
+    staged_rows = entry.get('staged_rows') or ()
+    skipped_rows = entry.get('skipped_rows') or ()
+    warnings = entry.get('warnings') or ()
+    stats['staged_edsm_stations'] += len(staged_rows)
+    stats['skipped_rows'] += len(skipped_rows)
+    stats['warnings'] += len(warnings)
+    stats['nested_station_collections'] += int(entry.get('nested_station_collections', 0))
+    stats['nested_station_records_extracted'] += int(entry.get('nested_station_records_extracted', 0))
+    stats['nested_station_records_skipped'] += int(entry.get('nested_station_records_skipped', 0))
+
+    for warning in warnings:
+        reason = warning.get('reason')
+        if reason is not None:
+            stats['warning_reason_distribution'][str(reason)] += 1
+            if reason == 'unsupported_source_shape':
+                stats['unsupported_source_shapes'] += 1
+    for skipped_row in skipped_rows:
+        reason = skipped_row.get('reason')
+        if reason is not None:
+            stats['skipped_row_reason_distribution'][str(reason)] += 1
+            if reason in {
+                'record_is_not_object',
+                'invalid_station_snapshot_record',
+                'invalid_body_snapshot_record',
+                'invalid_ring_snapshot_record',
+                'ring_record_is_not_object',
+                'nested_station_record_is_not_object',
+            }:
+                stats['malformed_rows'] += 1
+    for row in staged_rows:
+        _count_field(stats['confidence_distribution'], row.get('confidence'))
+        _count_field(stats['freshness_distribution'], row.get('freshness_class'))
+        _count_field(stats['source_class_distribution'], row.get('source_class'))
+
+
+def _record_source_updated_at(stats: dict[str, Any], source_updated_at: Any) -> None:
+    if source_updated_at is None:
+        stats['records_without_source_updated_at'] += 1
+        return
+    timestamp = str(source_updated_at)
+    stats['records_with_source_updated_at'] += 1
+    earliest = stats['earliest_source_updated_at']
+    latest = stats['latest_source_updated_at']
+    if earliest is None or timestamp < earliest:
+        stats['earliest_source_updated_at'] = timestamp
+    if latest is None or timestamp > latest:
+        stats['latest_source_updated_at'] = timestamp
+    unique_values: set[str] = stats['unique_source_updated_at_values']
+    if timestamp in unique_values or len(unique_values) < MAX_TRACKED_UNIQUE_TIMESTAMPS:
+        unique_values.add(timestamp)
+    else:
+        stats['unique_source_updated_at_values_is_lower_bound'] = True
+
+
+def _station_streaming_source_summary(
+    stats: Mapping[str, Any],
+    *,
+    file_format: Mapping[str, Any],
+) -> dict[str, Any]:
+    timestamp_summary = _station_streaming_timestamp_summary(stats)
+    freshness_distribution = _counter_dict(stats['freshness_distribution'])
+    return {
+        'source_format': file_format.get('source_format'),
+        'source_format_version': file_format.get('source_format_version'),
+        'record_stream_shape': file_format.get('record_stream_shape'),
+        'source_timestamp_summary': timestamp_summary,
+        'source_freshness_summary': {
+            'freshness_distribution': freshness_distribution,
+            'records_with_source_updated_at': timestamp_summary['records_with_source_updated_at'],
+            'records_without_source_updated_at': timestamp_summary['records_without_source_updated_at'],
+            'freshness_preserves_unknown': True,
+        },
+        'unsupported_source_shapes': stats['unsupported_source_shapes'],
+        'malformed_rows': stats['malformed_rows'],
+        'warning_reason_distribution': _counter_dict(stats['warning_reason_distribution']),
+        'skipped_row_reason_distribution': _counter_dict(stats['skipped_row_reason_distribution']),
+    }
+
+
+def _station_streaming_timestamp_summary(stats: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'records_with_source_updated_at': stats['records_with_source_updated_at'],
+        'records_without_source_updated_at': stats['records_without_source_updated_at'],
+        'unique_source_updated_at_values': len(stats['unique_source_updated_at_values']),
+        'unique_source_updated_at_values_is_lower_bound': bool(
+            stats['unique_source_updated_at_values_is_lower_bound']
+        ),
+        'earliest_source_updated_at': stats['earliest_source_updated_at'],
+        'latest_source_updated_at': stats['latest_source_updated_at'],
+    }
+
+
+def _build_station_streaming_write_report(
+    *,
+    source_run: Mapping[str, Any],
+    source_file: Mapping[str, Any],
+    source_summary: Mapping[str, Any],
+    stats: Mapping[str, Any],
+    batch_size: int,
+    target_tables: Sequence[str],
+) -> dict[str, Any]:
+    summary = {
+        'source_runs': 1,
+        'source_files': 1,
+        'raw_records': stats['raw_records'],
+        'raw_records_written': stats['raw_records_written'],
+        'staged_rows': stats['staged_edsm_stations'],
+        'staged_edsm_stations': stats['staged_edsm_stations'],
+        'planned_rows': 0,
+        'skipped_rows': stats['skipped_rows'],
+        'conflicts': 0,
+        'warnings': stats['warnings'],
+        'errors': 0,
+        'records_seen': stats['records_seen'],
+        'nested_station_collections': stats['nested_station_collections'],
+        'nested_station_records_extracted': stats['nested_station_records_extracted'],
+        'nested_station_records_skipped': stats['nested_station_records_skipped'],
+        'staging_station_rows_written': stats['staging_station_rows_written'],
+        'staging_body_rows_written': 0,
+        'staging_ring_rows_written': 0,
+        'batches_written': stats['batches_written'],
+        'write_batches_attempted': stats['batches_written'],
+        'batch_size': batch_size,
+        'write_mode': 'staging_only',
+        'dry_run_only': False,
+        'staging_writes_enabled': True,
+        'target_tables': list(target_tables),
+        'canonical_writes_planned': 0,
+        'compact_write_summary': True,
+        'output_records_materialized': False,
+        'raw_records_materialized': 0,
+        'staged_rows_materialized': 0,
+        'duplicate_source_record_tracking': (
+            'not_accumulated_in_streaming_write; '
+            'warehouse_upsert_keys_are_idempotent'
+        ),
+        'idempotency_model': (
+            'source_run_key/source_file_key/source_record_hash upserts make '
+            'reruns idempotent; an interrupted batch may leave committed '
+            'warehouse staging evidence for retry'
+        ),
+        'distance_to_arrival_classification': classify_source_field(
+            source_run.get('source'),
+            'distanceToArrival',
+        ),
+        'confidence_distribution': _counter_dict(stats['confidence_distribution']),
+        'freshness_distribution': _counter_dict(stats['freshness_distribution']),
+        'source_class_distribution': _counter_dict(stats['source_class_distribution']),
+        'skipped_row_reasons': _counter_dict(stats['skipped_row_reason_distribution']),
+        'warning_reasons': _counter_dict(stats['warning_reason_distribution']),
+        'duplicate_source_record_hashes': None,
+        'duplicate_source_records': None,
+        **dict(source_summary),
+    }
+    return {
+        'schema_version': 'enrichment_snapshot_load_plan/v1',
+        'dry_run': False,
+        'source_run': dict(source_run),
+        'source_file': dict(source_file),
+        'summary': summary,
+        'raw_records_planned': [],
+        'staged_rows': [],
+        'planned_rows': [],
+        'skipped_rows': [],
+        'conflicts': [],
+        'warnings': [],
+        'errors': [],
+        'source_record_duplicate_groups': [],
+        'compact_write_summary': True,
+    }
+
+
+def _counter_dict(counter: Mapping[Any, int]) -> dict[str, int]:
+    return {
+        str(key): int(counter[key])
+        for key in sorted(counter, key=str)
+    }
+
+
+def _count_field(counter: Counter, value: Any) -> None:
+    if value is not None:
+        counter[str(value)] += 1
 
 
 def write_station_snapshot_report(conn: Any, report: Mapping[str, Any]) -> dict[str, Any]:
@@ -446,6 +854,12 @@ def _rollback(conn: Any) -> None:
     rollback = getattr(conn, 'rollback', None)
     if callable(rollback):
         rollback()
+
+
+def _close_cursor(cur: Any) -> None:
+    close = getattr(cur, 'close', None)
+    if callable(close):
+        close()
 
 
 if __name__ == '__main__':

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -495,6 +495,23 @@ operator-managed output path were not available. Stage 18J-P remains blocked.
 See
 [`stage-18j-q3-readonly-production-reconciliation-artifact.md`](./stage-18j-q3-readonly-production-reconciliation-artifact.md).
 
+Stage 18J-Q5 added support for the nested EDSM system station snapshot shape
+observed on the production server. It extracts deterministic station staging
+rows from nested `stations` arrays while preserving parent system raw records
+and keeping nested `bodies` collections as warning evidence only. See
+[`stage-18j-q5-nested-edsm-station-snapshot-support.md`](./stage-18j-q5-nested-edsm-station-snapshot-support.md).
+
+Stage 18J-Q6 follows the failed full warehouse station staging load attempt.
+It makes explicit station write-staging memory-safe by streaming source-record
+batches and emitting a compact write summary rather than retaining all raw and
+staged rows in memory. After Q6 merges, the next server action is a controlled
+retry of the warehouse station staging load. If that succeeds, move to
+read-only reconciliation artifact generation. Stage 18J-P remains blocked
+until a valid reconciliation artifact exists. Stage 19 should expand the
+warehouse broadly and design freshness/scheduler support, but no cron/scheduler
+implementation is allowed in Q6. See
+[`stage-18j-q6-memory-safe-warehouse-station-load.md`](./stage-18j-q6-memory-safe-warehouse-station-load.md).
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.
@@ -533,6 +550,10 @@ treated as a separate proposal.
   quality checks across staged station, body, and ring evidence while
   preserving `distanceToArrival` as volatile evidence instead of a churn
   source.
+* **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
+  staging retry and read-only artifact path are boring, Stage 19 should broaden
+  warehouse source coverage and design freshness/scheduler support. Scheduler
+  or cron implementation is not part of Q6.
 * **Report-only analytics maturation**: improve confidence/risk explanations,
   source coverage summaries, colonisation signals, and mission-density signals
   without writing canonical data.

--- a/docs/colonisation-redesign/enrichment-staging-architecture.md
+++ b/docs/colonisation-redesign/enrichment-staging-architecture.md
@@ -74,6 +74,14 @@ station rows receive station-specific source hashes, and nested `bodies`
 collections stay warning evidence only until an explicit body adapter supports
 that shape.
 
+Stage 18J-Q6 hardens the `edsm_nightly_stations` write-staging path for large
+nested station snapshots. Dry-run mode still materializes deterministic
+small-file reports for inspection. Explicit station write-staging mode streams
+source records, writes raw and station rows in batches, and emits a compact
+summary instead of retaining every raw/staged row in memory. Source run/file
+keys, source record hashes, parent raw provenance, nested body warnings, and
+`canonical_writes_planned = 0` remain unchanged.
+
 ## Source Evidence Classes
 
 The foundation tracks source stability without treating any source as canonical
@@ -110,6 +118,16 @@ and pure signal helpers emit report-only analytics contracts such as
 summary counts, staged/planned rows, skipped rows, conflicts, warnings,
 confidence/freshness/source-class distributions, candidate confidence/risk
 fields, and deterministic sorting for stable diffs.
+
+Station write-staging reports are a compact variant of
+`enrichment_snapshot_load_plan/v1`: they preserve source run/file metadata and
+summary counters, but leave `raw_records_planned`, `staged_rows`,
+`planned_rows`, `skipped_rows`, and `warnings` empty to avoid large final JSON
+payloads. The summary records `records_seen`, `raw_records`,
+`raw_records_written`, `staged_edsm_stations`,
+`staging_station_rows_written`, nested-station extraction counts,
+`batches_written`, warning/error distributions, target tables, idempotency
+notes, and `canonical_writes_planned = 0`.
 
 The snapshot load plan also includes source-normalisation observability:
 `source_timestamp_summary`, `source_freshness_summary`,
@@ -207,6 +225,8 @@ The staging DB loader remains explicitly opt-in. Staging writes require
 `--write-staging`, `--dsn`, and `--confirm-staging-db`; read-only schema,
 staged-row, and reconciliation report modes require a DSN but do not require
 the staging-write confirmation flag. Canonical flags continue to fail closed.
+For station snapshots, `--batch-size` controls source-record batches during
+write-staging mode. The default remains dry-run/no-write.
 The Stage 18C operator workflow and exact command examples are documented in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 The repository writes only to:

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -636,6 +636,62 @@ Operator note:
 Provisioning plan:
 `../operations/stage-18j-q4c-readonly-warehouse-dsn-provisioning-plan.md`.
 
+### Stage 18J-Q5 — Nested EDSM Station Snapshot Support
+
+Purpose: support the nested EDSM system station snapshot shape observed on the
+server without committing production data or running production loads.
+
+Scope:
+
+- Preserve full source system records as raw warehouse evidence.
+- Extract deterministic station staging rows from nested `stations` arrays.
+- Preserve source run/file keys, station source hashes, parent raw provenance,
+  station identity, and station-type labels.
+- Keep nested `bodies` collections as raw-only unsupported-source-shape
+  warning evidence.
+
+Non-goals:
+
+- No production load.
+- No production reconciliation.
+- No station-type dry-run.
+- No canonical apply.
+- No Stage 18J-P or Stage 18K work.
+
+Support doc:
+`stage-18j-q5-nested-edsm-station-snapshot-support.md`.
+
+### Stage 18J-Q6 — Memory-Safe Warehouse Station Load
+
+Purpose: make the explicit station warehouse staging load safe for the large
+nested EDSM station snapshot after the post-Q5 full load attempt was killed.
+
+Scope:
+
+- Stream `edsm_nightly_stations` source records in write-staging mode.
+- Add source-record batch sizing for station writes.
+- Keep dry-run as the default/no-write full report path.
+- Emit compact write summaries instead of materializing every raw/staged row
+  in the final JSON output.
+- Document idempotent retry expectations for interrupted staging loads.
+
+Non-goals:
+
+- No production load during the development stage.
+- No production reconciliation or artifact generation.
+- No station-type dry-run.
+- No canonical apply.
+- No scheduler/cron implementation.
+- No Stage 18J-P or Stage 18K work.
+
+After Q6 merges, the next server action is a controlled retry of the warehouse
+station staging load. If that succeeds, move to read-only reconciliation
+artifact generation. Stage 18J-P remains blocked until a valid reconciliation
+artifact exists.
+
+Support doc:
+`stage-18j-q6-memory-safe-warehouse-station-load.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -676,5 +732,7 @@ Do not add another large planner feature immediately. The healthiest next sequen
 20. Stage 18J-Q3 read-only production reconciliation artifact gate.
 21. Stage 18J-Q4 operator access packet.
 22. Stage 18J-Q4b/Q4c read-only warehouse DSN operator prep.
+23. Stage 18J-Q5 nested EDSM station snapshot support.
+24. Stage 18J-Q6 memory-safe warehouse station load.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-q5-nested-edsm-station-snapshot-support.md
+++ b/docs/colonisation-redesign/stage-18j-q5-nested-edsm-station-snapshot-support.md
@@ -68,3 +68,17 @@ separate approved operation.
 After a successful separate staging load, Stage 18J-Q3 can retry its read-only
 reconciliation artifact path. Stage 18J-P and Stage 18K remain blocked until
 their own prerequisites are satisfied.
+
+## Q6 Follow-Up
+
+After Q5 merged, a full warehouse station staging load was attempted separately
+by an operator using the warehouse loader role. The process was killed before
+completion, the failed output files were empty, and the safety check showed no
+canonical station-count change and no warehouse rows persisted.
+
+Stage 18J-Q6 is the follow-up hardening stage. It keeps Q5 nested station
+extraction, but changes the explicit `edsm_nightly_stations` write-staging path
+to stream source-record batches and return a compact write summary. Q5 does not
+authorize a production retry by itself; after Q6 merges, the next server action
+is a controlled warehouse staging load retry only. Read-only reconciliation
+artifact generation comes after that retry succeeds.

--- a/docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md
+++ b/docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md
@@ -1,0 +1,234 @@
+# Stage 18J-Q6 — Memory-Safe Warehouse Station Load
+
+## Purpose
+
+Stage 18J-Q6 makes the warehouse station staging loader safe for very large
+nested EDSM station snapshots while preserving the Stage 18J-Q5 source-shape
+support.
+
+The stage is implementation and documentation only. It does not run production
+load, production reconciliation, station-type dry-run, canonical apply, or any
+Stage 18J-P/18K work.
+
+## Production Failure Summary
+
+After Stage 18J-Q5 merged, an operator attempted a full warehouse staging load
+of the server-local station dump:
+
+```text
+/data/dumps/galaxy_stations.json.gz
+```
+
+The loader process was killed before completion while processing the large
+source file. Kernel logs did not show an obvious out-of-memory message, but the
+failure mode is consistent with the pre-Q6 write path building a complete
+in-memory output plan before database writes.
+
+## Safety Check After Failure
+
+The post-failure safety check found:
+
+- canonical station count: `284763`
+- `enrichment_source_runs`: `0`
+- `enrichment_source_files`: `0`
+- `enrichment_raw_records`: `0`
+- `staging_edsm_stations`: `0`
+- failed output artifact files were `0` bytes
+- no production reconciliation was run
+- no station-type dry-run was run
+- no canonical apply was run
+- Stage 18J-P remained blocked
+- Stage 18K remained untouched
+
+## Root Cause Hypothesis
+
+Stage 18J-Q5 correctly extracted station rows from nested EDSM system records,
+but write-staging still reused the full dry-run report shape. For a
+galaxy-sized nested station snapshot, that meant accumulating every raw system
+record and every staged station row in memory, then serializing a very large
+final JSON report.
+
+The likely fix is not more host memory. The loader needs to stream source
+records, write bounded batches, and keep only counters plus source metadata for
+the write-mode summary.
+
+## Loader Changes
+
+Q6 keeps dry-run as the default/no-write path. Small dry-runs still return the
+full deterministic `enrichment_snapshot_load_plan/v1` report, including raw
+records, staged rows, skipped rows, and warnings.
+
+For `edsm_nightly_stations` with explicit `--write-staging`, Q6 adds a
+streaming station write path:
+
+- source run and source file keys remain deterministic,
+- top-level source records stream from `.json` or `.json.gz`,
+- nested EDSM system station records are extracted using the Q5 logic,
+- full parent system records are written to `enrichment_raw_records`,
+- extracted stations are written to `staging_edsm_stations`,
+- nested body collections remain raw-only unsupported-source-shape warning
+  evidence,
+- target tables remain limited to warehouse/staging tables,
+- `canonical_writes_planned` remains `0`.
+
+## Batching / Streaming Model
+
+The station write path accepts `--batch-size`, defaulting to 500 source
+records. Each batch keeps only:
+
+- raw source records for that batch,
+- station rows extracted from those source records,
+- counters and distributions for the final summary.
+
+After a batch writes successfully, the transaction is committed and the batch
+lists are discarded. A final metadata update records source timestamp and
+freshness summaries on the source run/file rows.
+
+Body/ring staging keeps its existing report-backed write path. Q6 is scoped to
+the station source shape that failed in production.
+
+## Output Summary Model
+
+Write-staging station output remains JSON, but it is compact. It does not
+materialize all `raw_records_planned`, `staged_rows`, `planned_rows`,
+`skipped_rows`, or warning payloads in the final output.
+
+The compact summary includes the operational counters needed for review:
+
+- `records_seen`
+- `source_runs`
+- `source_files`
+- `raw_records`
+- `raw_records_written`
+- `staged_edsm_stations`
+- `staging_station_rows_written`
+- `nested_station_records_extracted`
+- `nested_station_records_skipped`
+- `batches_written`
+- `warnings`
+- `errors`
+- `canonical_writes_planned`
+- `target_tables`
+- `staging_writes_enabled`
+- `write_mode`
+
+Use dry-run mode with `--limit` for payload-level inspection before a full
+warehouse staging load.
+
+## Idempotency / Duplicate Protection
+
+Warehouse writes use deterministic source identity and upsert keys:
+
+- `source_run_key`
+- `source_file_key`
+- `source_record_key`
+- `source_record_hash`
+
+Raw records upsert by source run/file/hash. Station staging rows upsert by
+source run/hash. Retrying the same source file with the same source adapter
+updates existing warehouse evidence instead of duplicating it.
+
+Because batches commit independently, an interrupted process may leave a
+partial staging load if it is killed after at least one batch commit. The safe
+recovery expectation is to retry the same staging load and verify the compact
+summary plus staged-row counts before running read-only reconciliation. Do not
+use a failed or incomplete staging run as reconciliation input.
+
+## Production Retry Criteria
+
+After Q6 merges, the next server action is a controlled retry of the warehouse
+station staging load only.
+
+Before retry:
+
+- main must include Q6,
+- the warehouse loader role must be scoped to warehouse/staging tables only,
+- the source file must be present on the server,
+- the output path must be outside git and operator-managed,
+- canonical station count must be captured before the run,
+- warehouse row counts must be captured before the run,
+- `--write-staging`, `--dsn`, `--confirm-staging-db`, and a reviewed
+  `--batch-size` must be explicit.
+
+After retry:
+
+- loader summary must report `errors = 0`,
+- target tables must be warehouse/staging only,
+- `canonical_writes_planned = 0`,
+- warehouse row counts must match the summary,
+- canonical station count must be unchanged.
+
+If the staging load succeeds, move to read-only reconciliation artifact
+generation. Stage 18J-P remains blocked until a valid reconciliation artifact
+exists.
+
+## Boundaries
+
+Q6 does not authorize:
+
+- production data committed to git,
+- production artifacts committed to git,
+- production load during the development stage,
+- production reconciliation during the development stage,
+- station-type dry-run,
+- canonical apply,
+- production DB access from development,
+- scheduler or cron wiring,
+- UI/API apply controls,
+- live EDSM/API crawl,
+- broad canonical backfill,
+- Stage 18J-P,
+- Stage 18K.
+
+Unknown values remain unknown. Source-only evidence remains source-only.
+
+## Validation
+
+Required local validation:
+
+```sh
+./scripts/run_canonical_safety_tests.sh
+
+.venv/bin/pytest \
+  tests/test_enrichment_snapshot_loader.py \
+  tests/test_enrichment_staging.py \
+  tests/test_enrichment_staging_db_loader.py \
+  tests/test_station_type_canonical_pilot.py \
+  tests/test_enrichment_warehouse_boundary.py \
+  tests/test_enrichment_report_contracts.py \
+  tests/test_edsm_station_normalization.py \
+  -q
+
+.venv/bin/python -m py_compile \
+  apps/importer/src/enrichment_snapshot_loader.py \
+  apps/importer/src/enrichment_staging.py \
+  apps/importer/src/enrichment_staging_db_loader.py \
+  apps/importer/src/station_type_canonical_pilot.py \
+  tests/test_enrichment_snapshot_loader.py \
+  tests/test_enrichment_staging.py \
+  tests/test_enrichment_staging_db_loader.py \
+  tests/test_station_type_canonical_pilot.py
+
+git diff --check
+```
+
+Disposable Postgres rehearsal remains optional and must use explicit
+non-production confirmation only.
+
+## Roadmap Impact
+
+After Q6 merges, the next server action is a controlled retry of the warehouse
+station staging load. If that succeeds, move to read-only reconciliation
+artifact generation. Stage 18J-P remains blocked until a valid reconciliation
+artifact exists.
+
+Stage 19 should expand the warehouse broadly and design freshness/scheduler
+support, but no cron/scheduler implementation is allowed in Q6.
+
+## Final Recommendation
+
+Merge Q6 before retrying the full station staging load. Use the compact summary
+and staged-row counts to verify the retry. If the retry succeeds cleanly,
+generate the read-only reconciliation artifact next. Do not start Stage 18J-P,
+Stage 18K, or any canonical apply path until their documented prerequisites are
+satisfied.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -201,7 +201,7 @@ Set the DSN only in your shell or secret manager. Do not paste real DSNs into
 docs, PRs, issue comments, or committed files.
 
 ```sh
-export EDFINDER_STAGING_DSN='postgresql://USER:PASSWORD@HOST:PORT/DBNAME'
+export EDFINDER_STAGING_DSN="<private-staging-warehouse-dsn>"
 ```
 
 Read-only schema/preflight check:
@@ -237,6 +237,7 @@ python3 apps/importer/src/enrichment_staging_db_loader.py \
     --limit 1000 \
     --write-staging \
     --dsn "$EDFINDER_STAGING_DSN" \
+    --batch-size 500 \
     --confirm-staging-db \
     --json
 ```
@@ -263,6 +264,24 @@ A good staging load has:
   input contains valid records
 - target tables limited to the warehouse table family
 - `summary.canonical_writes_planned = 0`
+
+For `edsm_nightly_stations`, write-staging mode streams the source file and
+flushes warehouse rows by source-record batch. The default `--batch-size` is
+500 source records. The station write report is a compact summary: it keeps
+counts such as `records_seen`, `raw_records_written`,
+`staging_station_rows_written`, `nested_station_records_extracted`,
+`batches_written`, warnings, errors, target tables, and
+`canonical_writes_planned`, but it does not materialize every raw or staged
+row in the final JSON output. Use dry-run mode when exact row payloads are
+needed for small-file inspection.
+
+Station staging writes are idempotent at the warehouse evidence layer. Source
+runs/files and raw/station rows use deterministic keys and `source_record_hash`
+upserts. If a streaming station load is interrupted after one or more batches
+commit, retry the same source file with the same source adapter; committed
+warehouse evidence is updated in place rather than duplicated. Do not proceed
+to read-only reconciliation until the retry completes with zero errors and the
+operator has verified the staged-row counts.
 
 Staging-load warnings that block progress:
 
@@ -528,6 +547,15 @@ blocked until this support is merged and a separate explicitly approved
 production staging load is retried; no production load, reconciliation, or
 apply is authorized by Q5.
 
+Stage 18J-Q6 documents memory-safe station warehouse loading in
+`docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md`.
+It changes the `edsm_nightly_stations` write-staging path to stream and commit
+source-record batches with compact output. After Q6 merges, the next server
+action is a controlled retry of the warehouse station staging load. If that
+succeeds, move to read-only reconciliation artifact generation. Stage 18J-P
+remains blocked until a valid reconciliation artifact exists, and Stage 18K is
+not started by Q6.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables
@@ -574,6 +602,16 @@ If reconciliation shows conflicts or warnings:
   `body_rings` rows support it.
 - Station/body association candidates remain report-only until a separate
   canonical write design exists.
+
+If a station staging load is interrupted:
+
+- Do not run reconciliation against an incomplete or failed load.
+- Confirm the canonical station count did not change.
+- Confirm warehouse row counts and the compact loader output before retrying.
+- Retry only the warehouse staging load with the same source file/source
+  adapter and explicit staging flags.
+- Treat the retry as a staging-only operation. It must not run station-type
+  dry-run, reconciliation apply, canonical apply, or scheduler work.
 
 ## What Not To Do
 

--- a/tests/test_enrichment_staging_db_loader.py
+++ b/tests/test_enrichment_staging_db_loader.py
@@ -170,8 +170,11 @@ def test_explicit_staging_write_targets_only_enrichment_warehouse_tables():
     assert report['summary']['canonical_writes_planned'] == 0
     assert report['source_run']['db_id'] == 1001
     assert report['source_file']['db_id'] == 1002
+    assert report['compact_write_summary'] is True
+    assert report['raw_records_planned'] == []
+    assert report['staged_rows'] == []
     assert conn.cursors[-1].closed is True
-    assert conn.commits == 1
+    assert conn.commits == 2
     assert conn.rollbacks == 0
 
     assert_only_safe_sql(conn.statements)
@@ -313,10 +316,22 @@ def test_parse_args_requires_explicit_staging_write_and_rejects_apply_flags():
         '--dsn',
         'postgresql://test/test',
         '--confirm-staging-db',
+        '--batch-size',
+        '25',
     ])
     assert write_args.write_staging is True
     assert write_args.confirm_staging_db is True
     assert write_args.dry_run is False
+    assert write_args.batch_size == 25
+    with pytest.raises(SystemExit):
+        db_loader.parse_args([
+            '--source-file',
+            str(FIXTURE),
+            '--source',
+            'edsm_nightly_stations',
+            '--batch-size',
+            '0',
+        ])
     check_args = db_loader.parse_args([
         '--check-staging-schema',
         '--dsn',
@@ -382,7 +397,7 @@ def test_gzipped_snapshot_works_through_staging_db_loader(tmp_path):
     assert report['source_file']['compression'] == 'gzip'
     assert report['summary']['raw_records_written'] == 3
     assert report['summary']['staging_station_rows_written'] == 2
-    assert len([sql for sql, _params in conn.statements if 'INSERT INTO' in sql]) == 7
+    assert len([sql for sql, _params in conn.statements if 'INSERT INTO' in sql]) == 9
     assert_only_safe_sql(conn.statements)
 
 
@@ -404,8 +419,10 @@ def test_nested_system_snapshot_writes_only_supported_station_staging_rows():
     assert report['summary']['staging_ring_rows_written'] == 0
     assert report['summary']['canonical_writes_planned'] == 0
     assert report['summary']['nested_station_records_extracted'] == 3
-    assert len({row['source_record_hash'] for row in report['staged_rows']}) == 3
-    assert all(row['provenance']['source_record_kind'] == 'nested_station_record' for row in report['staged_rows'])
+    assert report['summary']['unsupported_source_shapes'] > 0
+    assert report['summary']['warning_reason_distribution']['unsupported_source_shape'] > 0
+    assert report['staged_rows'] == []
+    assert report['raw_records_planned'] == []
 
     staging_statements = [
         (sql, params)
@@ -414,6 +431,21 @@ def test_nested_system_snapshot_writes_only_supported_station_staging_rows():
     ]
     assert len(staging_statements) == 3
     assert all(params[2] is not None for _sql, params in staging_statements)
+    assert len({params[4] for _sql, params in staging_statements}) == 3
+    assert all(
+        json.loads(params[23])['source_record_kind'] == 'nested_station_record'
+        for _sql, params in staging_statements
+    )
+    raw_warning_payloads = [
+        json.loads(params[8])
+        for sql, params in conn.statements
+        if 'INSERT INTO enrichment_raw_records' in sql
+    ]
+    assert any(
+        warning.get('reason') == 'unsupported_source_shape'
+        for warnings in raw_warning_payloads
+        for warning in warnings
+    )
     sql_text = '\n'.join(sql for sql, _params in conn.statements)
     assert 'INSERT INTO staging_edsm_stations' in sql_text
     assert 'INSERT INTO staging_edsm_bodies' not in sql_text
@@ -442,16 +474,93 @@ def test_duplicate_records_keep_stable_hashes_and_idempotent_upsert_sql(tmp_path
         conn=conn,
         write_staging=True,
     )
+    dry_run_report = db_loader.build_staging_loader_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+        write_staging=False,
+    )
 
-    raw_hashes = [row['source_record_hash'] for row in report['raw_records_planned']]
-    staging_hashes = [row['source_record_hash'] for row in report['staged_rows']]
+    raw_hashes = [row['source_record_hash'] for row in dry_run_report['raw_records_planned']]
+    staging_hashes = [row['source_record_hash'] for row in dry_run_report['staged_rows']]
     assert len(set(raw_hashes)) == 1
     assert len(set(staging_hashes)) == 1
-    assert len({row['source_record_key'] for row in report['raw_records_planned']}) == 2
-    assert len({row['db_id'] for row in report['staged_rows']}) == 1
+    assert len({row['source_record_key'] for row in dry_run_report['raw_records_planned']}) == 2
+    assert report['source_run']['source_run_key'] == dry_run_report['source_run']['source_run_key']
+    assert report['source_file']['source_file_key'] == dry_run_report['source_file']['source_file_key']
+    assert report['raw_records_planned'] == []
+    assert report['staged_rows'] == []
+    assert report['summary']['duplicate_source_record_hashes'] is None
+    assert report['summary']['duplicate_source_records'] is None
+    assert 'upserts make reruns idempotent' in report['summary']['idempotency_model']
     sql_text = '\n'.join(sql for sql, _params in conn.statements)
     assert 'ON CONFLICT (source_run_id, source_file_id, source_record_hash)' in sql_text
     assert 'ON CONFLICT (source_run_id, source_record_hash)' in sql_text
+
+
+def test_large_nested_station_snapshot_streams_in_source_record_batches(tmp_path):
+    records = []
+    for index in range(6):
+        records.append({
+            'name': f'Batch System {index}',
+            'id64': 9_000 + index,
+            'updatedAt': f'2026-01-{index + 1:02d} 00:00:00+00',
+            'stations': [
+                {
+                    'id': 10_000 + (index * 2),
+                    'marketId': 20_000 + (index * 2),
+                    'name': f'Batch Port {index}A',
+                    'type': 'Outpost',
+                    'distanceToArrival': 100 + index,
+                },
+                {
+                    'id': 10_001 + (index * 2),
+                    'marketId': 20_001 + (index * 2),
+                    'name': f'Batch Port {index}B',
+                    'type': 'FleetCarrier' if index == 5 else 'Coriolis',
+                    'distanceToArrival': 200 + index,
+                },
+            ],
+            'bodies': [{'name': f'Batch Body {index}', 'bodyId': index}],
+        })
+    source_file = tmp_path / 'large-ish-nested-stations.json'
+    source_file.write_text(json.dumps(records), encoding='utf-8')
+    conn = FakeConn()
+
+    report = db_loader.load_station_snapshot_to_staging_db(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+        conn=conn,
+        write_staging=True,
+        batch_size=2,
+    )
+
+    assert report['dry_run'] is False
+    assert report['compact_write_summary'] is True
+    assert report['raw_records_planned'] == []
+    assert report['staged_rows'] == []
+    assert report['summary']['records_seen'] == 6
+    assert report['summary']['raw_records'] == 6
+    assert report['summary']['raw_records_written'] == 6
+    assert report['summary']['staged_edsm_stations'] == 12
+    assert report['summary']['staging_station_rows_written'] == 12
+    assert report['summary']['nested_station_records_extracted'] == 12
+    assert report['summary']['batches_written'] == 3
+    assert report['summary']['write_batches_attempted'] == 3
+    assert report['summary']['batch_size'] == 2
+    assert report['summary']['target_tables'] == list(db_loader.TARGET_TABLES)
+    assert report['summary']['canonical_writes_planned'] == 0
+    assert report['summary']['warning_reason_distribution']['unsupported_source_shape'] == 6
+    assert report['summary']['warning_reason_distribution']['transient_non_slot_station_type'] == 1
+    assert conn.commits == 4
+    assert len([
+        sql for sql, _params in conn.statements
+        if 'INSERT INTO enrichment_raw_records' in sql
+    ]) == 6
+    assert len([
+        sql for sql, _params in conn.statements
+        if 'INSERT INTO staging_edsm_stations' in sql
+    ]) == 12
+    assert_only_safe_sql(conn.statements)
 
 
 def test_malformed_records_are_skipped_and_not_written_as_staging_success(tmp_path):
@@ -477,10 +586,15 @@ def test_malformed_records_are_skipped_and_not_written_as_staging_success(tmp_pa
     assert report['summary']['raw_records_written'] == 2
     assert report['summary']['staging_station_rows_written'] == 1
     assert report['summary']['skipped_rows'] == 2
-    assert [row['reason'] for row in report['skipped_rows']] == [
-        'record_is_not_object',
-        'invalid_station_snapshot_record',
-    ]
+    assert report['summary']['skipped_row_reasons'] == {
+        'invalid_station_snapshot_record': 1,
+        'record_is_not_object': 1,
+    }
+    assert report['summary']['skipped_row_reason_distribution'] == {
+        'invalid_station_snapshot_record': 1,
+        'record_is_not_object': 1,
+    }
+    assert report['skipped_rows'] == []
     staging_statements = [
         (sql, params)
         for sql, params in conn.statements
@@ -627,7 +741,7 @@ def test_main_write_requires_confirmation_and_can_write_with_fake_db(monkeypatch
     assert payload['summary']['write_mode'] == 'staging_only'
     assert payload['summary']['raw_records_written'] == 3
     assert payload['summary']['staging_station_rows_written'] == 2
-    assert conn.commits == 1
+    assert conn.commits == 2
     assert conn.rollbacks == 0
     assert_only_safe_sql(conn.statements)
 


### PR DESCRIPTION
## What changed

- Added a streaming/batched `edsm_nightly_stations` write-staging path for large nested station snapshots.
- Kept dry-run/no-write as the default full-report mode for small-file inspection.
- Added `--batch-size` for station write-staging batches.
- Preserved Q5 nested station extraction, parent raw-record provenance, deterministic source keys/hashes, and nested body warnings as raw/source-only evidence.
- Made station write-staging output compact so it reports counts and batch status without materializing every raw/staged row in the final JSON payload.
- Added synthetic batch tests and updated docs/runbook/roadmap for Q6 retry criteria and idempotency expectations.

## Boundary confirmations

- No production data committed.
- No production artifact committed.
- No production load run.
- No production reconciliation run.
- No station-type dry-run run.
- No canonical apply run.
- No production DB touched.
- Target tables remain warehouse/staging only.
- `canonical_writes_planned` remains `0`.
- Stage 18J-P remains blocked.
- Stage 18K not started.

## Validation

- `./scripts/run_canonical_safety_tests.sh` passed: 83 tests passed; disposable Postgres rehearsal skipped because explicit non-production env vars were not set.
- `.venv/bin/pytest tests/test_enrichment_snapshot_loader.py tests/test_enrichment_staging.py tests/test_enrichment_staging_db_loader.py tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q` passed: 115 tests passed.
- `.venv/bin/python -m py_compile apps/importer/src/enrichment_snapshot_loader.py apps/importer/src/enrichment_staging.py apps/importer/src/enrichment_staging_db_loader.py apps/importer/src/station_type_canonical_pilot.py tests/test_enrichment_snapshot_loader.py tests/test_enrichment_staging.py tests/test_enrichment_staging_db_loader.py tests/test_station_type_canonical_pilot.py` passed.
- `git diff --check` passed.
- Secret scan command for changed Q6 docs/runbook/roadmap returned no matches.
- Extra guard: `.venv/bin/pytest tests/test_enrichment_body_ring_staging_loader.py tests/test_enrichment_warehouse_repository.py -q` passed: 28 tests passed.

## Production status

- This PR does not use or commit the production dump.
- This PR does not generate or approve a production artifact.
- This PR does not run production warehouse load, production reconciliation, station-type dry-run, or canonical apply.
- After Q6 merges, the next server action is a controlled retry of the warehouse station staging load.
- If that staging retry succeeds, the next step is read-only reconciliation artifact generation.
- Stage 18J-P remains blocked until a valid reconciliation artifact exists.
- Stage 18K and broader canonical work remain untouched.
