### PR TITLE
Stage 18J-Q7 reconciliation JSON serialization fix

### DIFF
--- a/apps/importer/src/enrichment_staging.py
+++ b/apps/importer/src/enrichment_staging.py
@@ -141,6 +141,11 @@ def canonicalise_json_payload(payload: Any) -> str:
     )
 
 
+def json_safe_value(value: Any) -> Any:
+    """Return a JSON-native copy while preserving deterministic report content."""
+    return _canonical_json_value(value)
+
+
 def payload_fingerprint(payload: Any, *, algorithm: str = 'sha256') -> str:
     """Hash a JSON-compatible payload after stable canonicalisation."""
     hasher = hashlib.new(algorithm)

--- a/apps/importer/src/enrichment_staging_db_loader.py
+++ b/apps/importer/src/enrichment_staging_db_loader.py
@@ -26,7 +26,7 @@ from enrichment_snapshot_loader import (
     build_station_snapshot_source_context,
     iter_station_snapshot_load_entries,
 )
-from enrichment_staging import classify_source_field, normalise_source_adapter
+from enrichment_staging import classify_source_field, json_safe_value, normalise_source_adapter
 from enrichment_warehouse import (
     WAREHOUSE_BASE_TABLES,
     WAREHOUSE_BODY_RING_WRITE_TABLES,
@@ -162,7 +162,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.check_staging_schema:
             with connect_staging_db(args.dsn) as conn:
                 report = check_staging_schema(conn, source=args.source)
-            print(json.dumps(report, sort_keys=True, indent=2))
+            print(json_dumps_report(report))
             return 0 if report['ok'] else 2
         if args.report_staged_run:
             with connect_staging_db(args.dsn) as conn:
@@ -172,7 +172,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     source_file_key=args.source_file_key,
                     source=args.source,
                 )
-            print(json.dumps(report, sort_keys=True, indent=2))
+            print(json_dumps_report(report))
             return 0
         if args.report_reconciliation:
             with connect_staging_db(args.dsn) as conn:
@@ -183,7 +183,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     source=args.source,
                     limit=args.limit,
                 )
-            print(json.dumps(report, sort_keys=True, indent=2))
+            print(json_dumps_report(report))
             return 0
         if args.write_staging:
             with connect_staging_db(args.dsn) as conn:
@@ -206,7 +206,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f'enrichment staging DB loader failed: {exc}', file=sys.stderr)
         return 2
 
-    print(json.dumps(report, sort_keys=True, indent=2))
+    print(json_dumps_report(report))
     return 0
 
 
@@ -251,12 +251,18 @@ def build_reconciliation_report(
     limit: int | None = None,
 ) -> dict[str, Any]:
     """Read-only comparison of staged warehouse evidence against canonical rows."""
-    return EnrichmentWarehouseRepository(conn).build_reconciliation_report(
+    report = EnrichmentWarehouseRepository(conn).build_reconciliation_report(
         source_run_key=source_run_key,
         source_file_key=source_file_key,
         source=source,
         limit=limit,
     )
+    return json_safe_value(report)
+
+
+def json_dumps_report(report: Mapping[str, Any]) -> str:
+    """Dump deterministic report JSON after converting DB-native scalar values."""
+    return json.dumps(json_safe_value(report), sort_keys=True, indent=2)
 
 
 def fetch_station_reconciliation_rows(

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -512,6 +512,15 @@ warehouse broadly and design freshness/scheduler support, but no cron/scheduler
 implementation is allowed in Q6. See
 [`stage-18j-q6-memory-safe-warehouse-station-load.md`](./stage-18j-q6-memory-safe-warehouse-station-load.md).
 
+Stage 18J-Q7 fixes the next read-only artifact blocker. After the successful
+Q6 staging load, reconciliation report generation failed while printing JSON
+because DB-native datetime values were not serializable. The artifact file was
+0 bytes and canonical data remained unchanged. Q7 makes
+`enrichment_staging_reconciliation/v1` output JSON-safe and deterministic
+before retrying Stage 18J-Q3. Stage 18J-P remains blocked until a valid
+reconciliation artifact exists. See
+[`stage-18j-q7-reconciliation-json-serialization-fix.md`](./stage-18j-q7-reconciliation-json-serialization-fix.md).
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -692,6 +692,35 @@ artifact exists.
 Support doc:
 `stage-18j-q6-memory-safe-warehouse-station-load.md`.
 
+### Stage 18J-Q7 — Reconciliation JSON Serialization Fix
+
+Purpose: fix the read-only reconciliation artifact path after the first
+post-Q6 reconciliation attempt failed while printing JSON.
+
+Scope:
+
+- Convert DB-native reconciliation report values such as datetimes, dates, and
+  decimals into deterministic JSON-safe values.
+- Preserve `enrichment_staging_reconciliation/v1` content and deterministic
+  `sort_keys=True` output.
+- Keep station candidates and `canonical_writes_planned = 0` visible.
+- Document the 0-byte artifact failure and the blocked Stage 18J-P state.
+
+Non-goals:
+
+- No production reconciliation run from development.
+- No production artifact generation or approval.
+- No station-type dry-run.
+- No canonical apply.
+- No production DB access.
+- No Stage 18J-P or Stage 18K work.
+
+Q7 fixes serialization only. Stage 18J-P remains blocked until a valid
+read-only reconciliation artifact exists.
+
+Support doc:
+`stage-18j-q7-reconciliation-json-serialization-fix.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -734,5 +763,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 22. Stage 18J-Q4b/Q4c read-only warehouse DSN operator prep.
 23. Stage 18J-Q5 nested EDSM station snapshot support.
 24. Stage 18J-Q6 memory-safe warehouse station load.
+25. Stage 18J-Q7 reconciliation JSON serialization fix.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md
+++ b/docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md
@@ -232,3 +232,16 @@ and staged-row counts to verify the retry. If the retry succeeds cleanly,
 generate the read-only reconciliation artifact next. Do not start Stage 18J-P,
 Stage 18K, or any canonical apply path until their documented prerequisites are
 satisfied.
+
+## Q7 Follow-Up
+
+After Q6 merged, the controlled warehouse station staging load succeeded and
+canonical station count remained unchanged. The next read-only reconciliation
+attempt failed before artifact generation because the report contained
+DB-native datetime values that the CLI JSON printer could not serialize. The
+artifact file was 0 bytes, no station-type dry-run was generated, no canonical
+apply was run, and Stage 18J-P remained blocked.
+
+Stage 18J-Q7 fixes reconciliation report serialization before retrying the
+Stage 18J-Q3 read-only artifact path. Q7 does not authorize station-type
+dry-run, canonical apply, Stage 18J-P, Stage 18K, or scheduler work.

--- a/docs/colonisation-redesign/stage-18j-q7-reconciliation-json-serialization-fix.md
+++ b/docs/colonisation-redesign/stage-18j-q7-reconciliation-json-serialization-fix.md
@@ -1,0 +1,104 @@
+# Stage 18J-Q7 — Reconciliation JSON Serialization Fix
+
+## Purpose
+
+Stage 18J-Q7 fixes the read-only reconciliation artifact path after the first
+post-Q6 production attempt failed while printing JSON.
+
+This stage is a serialization fix only. It does not run production
+reconciliation, generate or approve a production artifact, run a station-type
+dry-run, apply canonical writes, touch the production DB, start Stage 18J-P, or
+start Stage 18K.
+
+## Production Finding
+
+After Stage 18J-Q6 merged, the controlled warehouse station staging load
+succeeded. Warehouse row counts were populated, canonical station count
+remained unchanged, and no reconciliation/apply/station-type dry-run/canonical
+write was run during the staging load.
+
+The next read-only reconciliation attempt failed while printing JSON:
+
+```text
+TypeError: Object of type datetime is not JSON serializable
+```
+
+The failure occurred in the `--report-reconciliation` CLI path while calling
+`json.dumps(report, sort_keys=True, indent=2)`.
+
+## Safety State
+
+The failed reconciliation attempt produced a 0-byte artifact and did not alter
+canonical data.
+
+- no canonical data changed,
+- canonical station count remained `284763`,
+- warehouse staging rows remained loaded,
+- no station-type dry-run artifact was generated,
+- no canonical apply was run,
+- Stage 18J-P remained blocked,
+- Stage 18K remained untouched.
+
+## Fix
+
+Q7 makes report output JSON-safe before printing. DB-native scalar values are
+converted without dropping fields:
+
+- `datetime` and `date` values serialize to ISO-8601 strings,
+- `Decimal` values serialize to strings, matching the existing deterministic
+  canonical JSON convention,
+- mappings, sequences, tuples, and sets are recursively converted to
+  JSON-native structures,
+- deterministic `sort_keys=True` output is preserved.
+
+The fix is applied to the read-only reconciliation report wrapper and CLI JSON
+printing path. It does not introduce a write path.
+
+## Boundaries
+
+Q7 does not authorize:
+
+- production data committed to git,
+- production artifacts committed to git,
+- production reconciliation from development,
+- station-type dry-run,
+- canonical apply,
+- production DB access from development,
+- UI/API apply controls,
+- scheduler or cron wiring,
+- live EDSM/API crawl,
+- broad canonical work,
+- Stage 18J-P,
+- Stage 18K.
+
+`canonical_writes_planned` remains `0`, and reconciliation remains
+read-only/report-only.
+
+## Retry Criteria
+
+After Q7 merges, Stage 18J-Q3 may retry the read-only reconciliation artifact
+generation only through the approved operator path.
+
+The retry must confirm:
+
+- output artifact is non-empty valid JSON,
+- schema is `enrichment_staging_reconciliation/v1`,
+- `canonical_writes_planned = 0`,
+- station candidates remain present,
+- no production apply or station-type dry-run is run.
+
+Stage 18J-P remains blocked until a valid reconciliation artifact exists and is
+explicitly reviewed.
+
+## Validation
+
+Q7 validation must include canonical safety tests, reconciliation tests with
+DB-native timestamp/decimal values, report contract tests, `py_compile`,
+`git diff --check`, and a changed-doc secret scan.
+
+## Final Recommendation
+
+Merge Q7 before retrying the read-only reconciliation artifact generation.
+Treat any JSON serialization failure or 0-byte artifact as a hard stop. Do not
+start Stage 18J-P, Stage 18K, station-type dry-run, or canonical apply until
+their documented prerequisites are satisfied.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -556,6 +556,20 @@ succeeds, move to read-only reconciliation artifact generation. Stage 18J-P
 remains blocked until a valid reconciliation artifact exists, and Stage 18K is
 not started by Q6.
 
+Stage 18J-Q7 documents the read-only reconciliation JSON serialization fix in
+`docs/colonisation-redesign/stage-18j-q7-reconciliation-json-serialization-fix.md`.
+The first post-Q6 reconciliation attempt failed before artifact generation
+because DB-native timestamp values were not JSON serializable. The failed
+artifact was 0 bytes, canonical data was unchanged, and Stage 18J-P remained
+blocked. Q7 makes report output JSON-safe before retrying the Stage 18J-Q3
+read-only artifact path.
+
+When generating reconciliation artifacts, the CLI converts DB-native report
+values such as timestamps and decimals into deterministic JSON-safe values
+before printing. Datetimes and dates are emitted as ISO-8601 strings; decimals
+are emitted as strings. If JSON printing fails, treat the artifact as invalid,
+keep Stage 18J-P blocked, and do not proceed to station-type dry-run or apply.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables

--- a/tests/test_enrichment_report_contracts.py
+++ b/tests/test_enrichment_report_contracts.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -101,6 +102,11 @@ class FakeConn:
             'controlling_faction': None,
             'allegiance': None,
             'government': None,
+            'source': 'edsm_nightly_stations',
+            'source_class': 'semi-stable',
+            'confidence': 'source_station_snapshot',
+            'freshness_class': 'source_updated_at',
+            'source_updated_at': datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc),
             'canonical_system_id64': 42,
             'canonical_system_name': 'Contract System',
             'canonical_station_id': None,
@@ -213,6 +219,7 @@ def test_reconciliation_report_contract_is_stable_and_read_only():
         'source': 'edsm_nightly_stations',
         'limit': 1,
     }
+    assert first['station_candidates'][0]['source']['source_updated_at'] == '2026-01-02T00:00:00+00:00'
     assert first['summary']['staged_station_rows_considered'] == 1
     assert first['summary']['canonical_writes_planned'] == 0
     assert_no_writes(first_conn)

--- a/tests/test_enrichment_staging_reconciliation.py
+++ b/tests/test_enrichment_staging_reconciliation.py
@@ -2,6 +2,8 @@ import json
 import os
 import re
 import sys
+from datetime import date, datetime, timezone
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -911,8 +913,60 @@ def test_reconciliation_report_is_deterministic():
     assert_read_only_sql(conn_two)
 
 
+def test_reconciliation_report_serializes_db_native_values():
+    conn = FakeConn(
+        station_rows=[station_row(
+            source_updated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        )],
+        ring_rows=[ring_row(
+            source_updated_at=date(2026, 1, 3),
+            mass_mt=Decimal('1001.5'),
+            canonical_mass_mt=Decimal('1000.0'),
+        )],
+        source_coverage_rows=[{
+            'source_run_key': 'run-stations',
+            'source_file_key': 'file-stations',
+            'source_file_name': 'stations.json',
+            'source': 'edsm_nightly_stations',
+            'source_class': 'semi-stable',
+            'source_format': 'json',
+            'source_format_version': 'json_snapshot_stream/v1',
+            'record_stream_shape': 'json_array',
+            'raw_records': Decimal('2'),
+            'accepted_raw_records': Decimal('2'),
+            'skipped_raw_records': 0,
+            'invalid_raw_records': 0,
+            'conflict_raw_records': 0,
+            'duplicate_source_record_hashes': 0,
+            'duplicate_source_records': 0,
+            'records_with_source_updated_at': 2,
+            'records_without_source_updated_at': 0,
+            'latest_source_updated_at': datetime(2026, 1, 4, 0, 0, tzinfo=timezone.utc),
+            'warning_reason_distribution': {},
+        }],
+    )
+
+    report = db_loader.build_reconciliation_report(conn)
+    dumped = json.dumps(report, sort_keys=True)
+    payload = json.loads(dumped)
+
+    assert payload['schema_version'] == 'enrichment_staging_reconciliation/v1'
+    assert payload['summary']['canonical_writes_planned'] == 0
+    assert payload['station_candidates'][0]['source']['source_updated_at'] == '2026-01-02T03:04:05+00:00'
+    assert payload['ring_candidates'][0]['source']['source_updated_at'] == '2026-01-03'
+    assert payload['ring_candidates'][0]['differences'] == [{
+        'field': 'mass_mt',
+        'staged': '1001.5',
+        'canonical': '1000.0',
+    }]
+    assert payload['station_candidates']
+    assert_read_only_sql(conn)
+
+
 def test_reconciliation_main_outputs_json_without_writes(monkeypatch, capsys):
-    conn = FakeConn(station_rows=[station_row()])
+    conn = FakeConn(station_rows=[station_row(
+        source_updated_at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+    )])
     monkeypatch.setattr(db_loader, 'connect_staging_db', lambda _dsn: conn)
 
     exit_code = db_loader.main([
@@ -929,4 +983,5 @@ def test_reconciliation_main_outputs_json_without_writes(monkeypatch, capsys):
     assert payload['schema_version'] == 'enrichment_staging_reconciliation/v1'
     assert payload['summary']['staged_station_rows_considered'] == 1
     assert payload['summary']['canonical_writes_planned'] == 0
+    assert payload['station_candidates'][0]['source']['source_updated_at'] == '2026-01-02T03:04:05+00:00'
     assert_read_only_sql(conn)


### PR DESCRIPTION
## What changed

- Added a shared JSON-safe report value conversion helper using the existing deterministic canonical JSON conventions.
- Updated the staging DB loader JSON output path to convert DB-native values before printing reports.
- Made `build_reconciliation_report` return JSON-native `enrichment_staging_reconciliation/v1` report content for datetimes, dates, decimals, and nested structures.
- Added synthetic tests for reconciliation reports and the `--report-reconciliation --json` CLI path with datetime/date/Decimal values.
- Updated Q7 docs/runbook/roadmap notes for the 0-byte production artifact failure and retry boundary.

## Boundary confirmations

- No production data committed.
- No production artifact committed.
- No production reconciliation run from Codex.
- No station-type dry-run run.
- No canonical apply run.
- No production DB touched.
- No UI/API apply controls added.
- No scheduler wiring added.
- No live EDSM/API crawl added.
- No broad canonical work added.
- `canonical_writes_planned` remains `0`.
- Stage 18J-P remains blocked.
- Stage 18K not started.

## Validation

- `./scripts/run_canonical_safety_tests.sh` passed: 83 tests passed; disposable Postgres rehearsal skipped because explicit non-production env vars were not set.
- `.venv/bin/pytest tests/test_enrichment_staging_reconciliation.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_edsm_station_normalization.py -q` passed: 103 tests passed.
- `.venv/bin/python -m py_compile apps/importer/src/enrichment_staging_db_loader.py apps/importer/src/enrichment_reconciliation.py apps/importer/src/enrichment_warehouse_repository.py apps/importer/src/station_type_canonical_pilot.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_staging_reconciliation.py tests/test_enrichment_report_contracts.py tests/test_station_type_canonical_pilot.py` passed.
- Extra compile guard: `.venv/bin/python -m py_compile apps/importer/src/enrichment_staging.py` passed.
- `git diff --check` passed.
- Changed-doc secret scan returned no matches.

## Production status

- The production read-only reconciliation attempt failed before artifact generation because datetime values were not JSON serializable.
- The failed artifact was 0 bytes and was not committed.
- No canonical data changed.
- Warehouse staging rows remain loaded from the Q6 server action.
- No station-type dry-run artifact was generated.
- No canonical apply was run.
- This PR does not retry production reconciliation; it only fixes local/report serialization before the operator retry.
- Stage 18J-P remains blocked until a valid reconciliation artifact exists.
- Stage 18K and broader canonical work remain untouched.
