### PR TITLE
Stage 18J-Q8 compact reconciliation summary

### DIFF
--- a/apps/importer/src/reconciliation_artifact_summary.py
+++ b/apps/importer/src/reconciliation_artifact_summary.py
@@ -1,0 +1,622 @@
+#!/usr/bin/env python3
+"""Build a compact, bounded-memory summary of reconciliation JSON artifacts."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import ijson
+from ijson.common import ObjectBuilder
+
+
+SUMMARY_SCHEMA_VERSION = 'enrichment_reconciliation_artifact_summary/v1'
+RECONCILIATION_SCHEMA_VERSION = 'enrichment_staging_reconciliation/v1'
+HASH_CHUNK_SIZE = 1024 * 1024
+TOP_LIST_LIMIT = 20
+CANDIDATE_SECTIONS = (
+    'station_candidates',
+    'body_candidates',
+    'ring_candidates',
+    'station_body_association_candidates',
+)
+TOP_OBJECTS = {
+    'summary',
+    'source_coverage_summary',
+    'warehouse_coverage_report',
+    'confidence_risk_summary',
+}
+BLOCKING_ACTIONS = {'ambiguous_match', 'insufficient_evidence'}
+SCALAR_EVENTS = {'string', 'number', 'boolean', 'null'}
+SENSITIVE_KEY_RE = re.compile(r'(dsn|password|secret|token|credential|source_path|path)\b', re.IGNORECASE)
+SENSITIVE_TEXT_RE = re.compile(
+    r'(^/|[A-Za-z]:\\|postgres(?:ql)?://|'
+    r'pass' r'word=|'
+    r'PG' r'PASSWORD=|'
+    r'SEC' r'RET=|'
+    r'TOK' r'EN=)',
+    re.IGNORECASE,
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Build a compact report-only summary of a reconciliation artifact without DB access.',
+    )
+    parser.add_argument('--artifact', required=True, help='Path to the reconciliation JSON artifact.')
+    parser.add_argument('--output', required=True, help='Path for the compact summary JSON.')
+    parser.add_argument(
+        '--max-candidate-samples',
+        type=int,
+        default=50,
+        help='Maximum sanitized candidate samples to include. Default: 50.',
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        summary = build_compact_summary(
+            Path(args.artifact),
+            max_candidate_samples=args.max_candidate_samples,
+        )
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(summary, sort_keys=True, indent=2) + '\n',
+            encoding='utf-8',
+        )
+    except (OSError, ValueError, ijson.JSONError) as exc:
+        print(f'reconciliation artifact summary failed: {exc}', file=sys.stderr)
+        return 2
+    return 0
+
+
+def build_compact_summary(artifact_path: Path, *, max_candidate_samples: int = 50) -> dict[str, Any]:
+    if max_candidate_samples < 0:
+        raise ValueError('--max-candidate-samples must be >= 0')
+    artifact_size = artifact_path.stat().st_size
+    artifact_sha256 = _sha256_file(artifact_path)
+
+    parsed = _stream_reconciliation_artifact(
+        artifact_path,
+        max_candidate_samples=max_candidate_samples,
+    )
+    artifact_schema_version = parsed['artifact_schema_version']
+    if artifact_schema_version != RECONCILIATION_SCHEMA_VERSION:
+        raise ValueError(
+            f'unsupported reconciliation artifact schema {artifact_schema_version!r}; '
+            f'expected {RECONCILIATION_SCHEMA_VERSION!r}'
+        )
+
+    summary_counts = _summary_counts(parsed['top_objects'].get('summary', {}))
+    canonical_writes_planned = parsed['canonical_writes_planned']
+    if canonical_writes_planned is None:
+        canonical_writes_planned = summary_counts.get('canonical_writes_planned')
+
+    candidate_action_counts = {
+        section: _counter_dict(parsed['candidate_action_counts'][section])
+        for section in CANDIDATE_SECTIONS
+    }
+    candidate_action_counts['all'] = _counter_dict(parsed['candidate_action_counts']['all'])
+
+    return _json_safe_value({
+        'schema_version': SUMMARY_SCHEMA_VERSION,
+        'safe_for_git': False,
+        'source_artifact_basename': artifact_path.name,
+        'source_artifact_sha256': artifact_sha256,
+        'source_artifact_size_bytes': artifact_size,
+        'artifact_schema_version': artifact_schema_version,
+        'canonical_writes_planned': canonical_writes_planned,
+        'artifact_summary_counts': summary_counts,
+        'station_candidate_count': parsed['candidate_counts']['station_candidates'],
+        'candidate_counts': {
+            section: parsed['candidate_counts'][section]
+            for section in CANDIDATE_SECTIONS
+        },
+        'candidate_action_counts': candidate_action_counts,
+        'candidate_update_counts': _action_count_summary(parsed['candidate_action_counts'], 'candidate_update'),
+        'candidate_insert_missing_canonical_counts': _action_count_summary(
+            parsed['candidate_action_counts'],
+            'candidate_insert_missing_canonical',
+        ),
+        'top_blocking_reasons': _top_counter(parsed['blocking_reasons'], label='reason'),
+        'top_confidence_counts': _top_counter(parsed['confidence_counts']),
+        'top_confidence_level_counts': _top_counter(parsed['confidence_level_counts']),
+        'top_risk_class_counts': _top_counter(parsed['risk_class_counts']),
+        'top_reconciliation_state_counts': _top_counter(parsed['reconciliation_state_counts']),
+        'confidence_risk_counts': _confidence_risk_counts(
+            parsed['top_objects'].get('confidence_risk_summary', {}),
+        ),
+        'source_coverage_summary_counts': _source_coverage_counts(
+            parsed['top_objects'].get('source_coverage_summary', {}),
+        ),
+        'warehouse_coverage_summary_counts': _warehouse_coverage_counts(
+            parsed['top_objects'].get('warehouse_coverage_report', {}),
+        ),
+        'candidate_samples': {
+            'max_samples': max_candidate_samples,
+            'samples_included': len(parsed['candidate_samples']),
+            'samples': parsed['candidate_samples'],
+        },
+    })
+
+
+def _stream_reconciliation_artifact(artifact_path: Path, *, max_candidate_samples: int) -> dict[str, Any]:
+    candidate_counts = Counter({section: 0 for section in CANDIDATE_SECTIONS})
+    candidate_action_counts: dict[str, Counter[str]] = {
+        section: Counter()
+        for section in CANDIDATE_SECTIONS
+    }
+    candidate_action_counts['all'] = Counter()
+
+    parsed: dict[str, Any] = {
+        'artifact_schema_version': None,
+        'canonical_writes_planned': None,
+        'top_objects': {},
+        'candidate_counts': candidate_counts,
+        'candidate_action_counts': candidate_action_counts,
+        'blocking_reasons': Counter(),
+        'confidence_counts': Counter(),
+        'confidence_level_counts': Counter(),
+        'risk_class_counts': Counter(),
+        'reconciliation_state_counts': Counter(),
+        'candidate_samples': [],
+    }
+
+    candidate_builder: ObjectBuilder | None = None
+    candidate_section: str | None = None
+    candidate_depth = 0
+    top_object_builder: ObjectBuilder | None = None
+    top_object_name: str | None = None
+    top_object_depth = 0
+
+    with artifact_path.open('rb') as handle:
+        for prefix, event, value in ijson.parse(handle):
+            if candidate_builder is not None:
+                candidate_builder.event(event, value)
+                candidate_depth = _updated_depth(candidate_depth, event)
+                if candidate_depth == 0:
+                    _record_candidate(
+                        parsed,
+                        section=str(candidate_section),
+                        candidate=candidate_builder.value,
+                        max_candidate_samples=max_candidate_samples,
+                    )
+                    candidate_builder = None
+                    candidate_section = None
+                continue
+
+            if top_object_builder is not None:
+                top_object_builder.event(event, value)
+                top_object_depth = _updated_depth(top_object_depth, event)
+                if top_object_depth == 0:
+                    parsed['top_objects'][str(top_object_name)] = top_object_builder.value
+                    top_object_builder = None
+                    top_object_name = None
+                continue
+
+            if event == 'start_map' and prefix in TOP_OBJECTS:
+                top_object_builder = ObjectBuilder()
+                top_object_name = prefix
+                top_object_depth = 0
+                top_object_builder.event(event, value)
+                top_object_depth = _updated_depth(top_object_depth, event)
+                continue
+
+            if event == 'start_map':
+                section = _candidate_section_for_prefix(prefix)
+                if section is not None:
+                    candidate_builder = ObjectBuilder()
+                    candidate_section = section
+                    candidate_depth = 0
+                    candidate_builder.event(event, value)
+                    candidate_depth = _updated_depth(candidate_depth, event)
+                    continue
+
+            if prefix == 'schema_version' and event in SCALAR_EVENTS:
+                parsed['artifact_schema_version'] = value
+                if value != RECONCILIATION_SCHEMA_VERSION:
+                    raise ValueError(
+                        f'unsupported reconciliation artifact schema {value!r}; '
+                        f'expected {RECONCILIATION_SCHEMA_VERSION!r}'
+                    )
+                continue
+
+            if prefix in {'canonical_writes_planned', 'summary.canonical_writes_planned'} and event in SCALAR_EVENTS:
+                parsed['canonical_writes_planned'] = value
+
+    return parsed
+
+
+def _record_candidate(
+    parsed: dict[str, Any],
+    *,
+    section: str,
+    candidate: Any,
+    max_candidate_samples: int,
+) -> None:
+    if not isinstance(candidate, Mapping):
+        return
+
+    parsed['candidate_counts'][section] += 1
+    action = _safe_counter_key(candidate.get('candidate_action'))
+    if action is not None:
+        parsed['candidate_action_counts'][section][action] += 1
+        parsed['candidate_action_counts']['all'][action] += 1
+
+    for source_key, counter_name in (
+        ('confidence', 'confidence_counts'),
+        ('confidence_level', 'confidence_level_counts'),
+        ('risk_class', 'risk_class_counts'),
+        ('reconciliation_state', 'reconciliation_state_counts'),
+    ):
+        counter_key = _safe_counter_key(candidate.get(source_key))
+        if counter_key is not None:
+            parsed[counter_name][counter_key] += 1
+
+    if _is_blocked_candidate(candidate):
+        reasons = _safe_string_list(candidate.get('risk_flags'))
+        if not reasons and action is not None:
+            reasons = [action]
+        if not reasons:
+            state = _safe_counter_key(candidate.get('reconciliation_state'))
+            reasons = [state] if state is not None else ['blocked_unknown_reason']
+        for reason in reasons:
+            parsed['blocking_reasons'][reason] += 1
+
+    if len(parsed['candidate_samples']) < max_candidate_samples:
+        parsed['candidate_samples'].append(_candidate_sample(section, candidate))
+
+
+def _candidate_sample(section: str, candidate: Mapping[str, Any]) -> dict[str, Any]:
+    sample: dict[str, Any] = {
+        'section': section,
+    }
+    for key in (
+        'entity',
+        'candidate_action',
+        'reconciliation_state',
+        'confidence',
+        'confidence_level',
+        'risk_class',
+        'evidence_quality',
+        'identifier_quality',
+    ):
+        value = _safe_scalar(candidate.get(key), key=key)
+        if value is not None:
+            sample[key] = value
+
+    source = candidate.get('source')
+    if isinstance(source, Mapping):
+        source_identity = _sanitized_source_identity(source)
+        if source_identity:
+            sample['source_identity'] = source_identity
+
+    for key in ('risk_flags', 'review_classifications'):
+        values = _safe_string_list(candidate.get(key))
+        if values:
+            sample[key] = values
+
+    differences = candidate.get('differences')
+    fields = _difference_fields(differences)
+    if fields:
+        sample['difference_fields'] = fields
+
+    warnings = candidate.get('warnings')
+    warning_reasons = _warning_reasons(warnings)
+    if warning_reasons:
+        sample['warning_reasons'] = warning_reasons
+
+    canonical_matches = candidate.get('canonical_matches')
+    if isinstance(canonical_matches, Sequence) and not isinstance(canonical_matches, (str, bytes, bytearray)):
+        sample['canonical_match_count'] = len(canonical_matches)
+
+    review_marker = _future_review_marker(candidate.get('future_canonical_review_candidate'))
+    if review_marker:
+        sample['future_canonical_review_candidate'] = review_marker
+
+    return sample
+
+
+def _sanitized_source_identity(source: Mapping[str, Any]) -> dict[str, Any]:
+    allowed_keys = (
+        'system_id64',
+        'system_name',
+        'market_id',
+        'edsm_station_id',
+        'station_name',
+        'source_body_id',
+        'body_name',
+        'ring_name',
+        'source',
+        'source_class',
+        'confidence',
+        'freshness_class',
+        'source_updated_at',
+        'source_record_hash',
+    )
+    sanitized: dict[str, Any] = {}
+    for key in allowed_keys:
+        value = _safe_scalar(source.get(key), key=key)
+        if value is not None:
+            sanitized[key] = value
+    return sanitized
+
+
+def _summary_counts(summary: Any) -> dict[str, Any]:
+    if not isinstance(summary, Mapping):
+        return {}
+    return {
+        str(key): _json_safe_value(value)
+        for key, value in sorted(summary.items())
+        if _is_safe_key(str(key)) and _is_compact_scalar(value)
+    }
+
+
+def _confidence_risk_counts(summary: Any) -> dict[str, Any]:
+    if not isinstance(summary, Mapping):
+        return {}
+    count_keys = (
+        'schema_version',
+        'canonical_writes_planned',
+        'confidence_distribution',
+        'confidence_level_distribution',
+        'evidence_quality_distribution',
+        'identifier_quality_distribution',
+        'reconciliation_state_distribution',
+        'risk_class_distribution',
+        'risk_flag_distribution',
+        'review_classification_distribution',
+        'source_freshness_impact_distribution',
+        'future_canonical_review_candidates',
+    )
+    return _known_key_summary(summary, count_keys)
+
+
+def _source_coverage_counts(summary: Any) -> dict[str, Any]:
+    if not isinstance(summary, Mapping):
+        return {}
+    result = _known_key_summary(summary, ('schema_version', 'canonical_writes_planned', 'warnings'))
+    entities = summary.get('entities')
+    if isinstance(entities, Mapping):
+        result['entities'] = {}
+        for entity_name in ('station', 'body', 'ring'):
+            entity = entities.get(entity_name)
+            if not isinstance(entity, Mapping):
+                continue
+            result['entities'][entity_name] = _known_key_summary(
+                entity,
+                (
+                    'candidates',
+                    'candidate_actions',
+                    'confidence',
+                    'missing_system_identifiers',
+                    'volatile_warnings',
+                ),
+            )
+    ring_evidence = summary.get('ring_evidence')
+    if isinstance(ring_evidence, Mapping):
+        result['ring_evidence'] = _known_key_summary(
+            ring_evidence,
+            (
+                'staged_ring_candidates',
+                'trusted_local_matched_ring_candidates',
+                'missing_ring_arrays_state',
+                'ringed_truth_requires_trusted_body_rings',
+            ),
+        )
+    return result
+
+
+def _warehouse_coverage_counts(report: Any) -> dict[str, Any]:
+    if not isinstance(report, Mapping):
+        return {}
+    result = _known_key_summary(report, ('schema_version', 'canonical_writes_planned'))
+    summary = report.get('summary')
+    if isinstance(summary, Mapping):
+        result['summary'] = {
+            str(key): _json_safe_value(value)
+            for key, value in sorted(summary.items())
+            if _is_safe_key(str(key)) and _is_compact_scalar(value)
+        }
+    operator_review = report.get('operator_review')
+    if isinstance(operator_review, Mapping):
+        needs_attention = operator_review.get('needs_attention_buckets')
+        if isinstance(needs_attention, Mapping):
+            result['needs_attention_buckets'] = {
+                str(key): _json_safe_value(value)
+                for key, value in sorted(needs_attention.items())
+                if _is_safe_key(str(key)) and _is_compact_scalar(value)
+            }
+    return result
+
+
+def _known_key_summary(source: Mapping[str, Any], keys: Sequence[str]) -> dict[str, Any]:
+    return {
+        key: _json_safe_value(source[key])
+        for key in keys
+        if key in source and _is_safe_key(key) and _is_compact_summary_value(source[key])
+    }
+
+
+def _action_count_summary(action_counts: Mapping[str, Counter[str]], action: str) -> dict[str, int]:
+    result = {
+        section: int(action_counts[section].get(action, 0))
+        for section in CANDIDATE_SECTIONS
+    }
+    result['all'] = int(action_counts['all'].get(action, 0))
+    return result
+
+
+def _candidate_section_for_prefix(prefix: str) -> str | None:
+    for section in CANDIDATE_SECTIONS:
+        if prefix == f'{section}.item':
+            return section
+    return None
+
+
+def _updated_depth(depth: int, event: str) -> int:
+    if event in {'start_map', 'start_array'}:
+        return depth + 1
+    if event in {'end_map', 'end_array'}:
+        return depth - 1
+    return depth
+
+
+def _is_blocked_candidate(candidate: Mapping[str, Any]) -> bool:
+    action = candidate.get('candidate_action')
+    risk_class = candidate.get('risk_class')
+    classifications = set(_safe_string_list(candidate.get('review_classifications')))
+    return risk_class == 'blocked' or action in BLOCKING_ACTIONS or 'blocked' in classifications
+
+
+def _difference_fields(differences: Any) -> list[str]:
+    if not isinstance(differences, Sequence) or isinstance(differences, (str, bytes, bytearray)):
+        return []
+    fields = {
+        str(difference.get('field'))
+        for difference in differences
+        if isinstance(difference, Mapping)
+        and _safe_counter_key(difference.get('field')) is not None
+    }
+    return sorted(fields)
+
+
+def _warning_reasons(warnings: Any) -> list[str]:
+    if not isinstance(warnings, Sequence) or isinstance(warnings, (str, bytes, bytearray)):
+        return []
+    reasons = {
+        _safe_counter_key(warning.get('reason'))
+        for warning in warnings
+        if isinstance(warning, Mapping)
+    }
+    return sorted(reason for reason in reasons if reason is not None)
+
+
+def _future_review_marker(review: Any) -> dict[str, Any]:
+    if not isinstance(review, Mapping):
+        return {}
+    result = _known_key_summary(
+        review,
+        (
+            'marker',
+            'auto_promote_to_canonical',
+            'canonical_writes_planned',
+        ),
+    )
+    return result
+
+
+def _counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return {key: int(counter[key]) for key in sorted(counter)}
+
+
+def _top_counter(
+    counter: Counter[str],
+    *,
+    limit: int = TOP_LIST_LIMIT,
+    label: str = 'value',
+) -> list[dict[str, Any]]:
+    return [
+        {label: key, 'count': int(count)}
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:limit]
+    ]
+
+
+def _safe_string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    values = {
+        key
+        for key in (_safe_counter_key(item) for item in value)
+        if key is not None
+    }
+    return sorted(values)
+
+
+def _safe_counter_key(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    if _looks_sensitive_text(text):
+        return '[redacted]'
+    return text
+
+
+def _safe_scalar(value: Any, *, key: str) -> Any:
+    if value is None:
+        return None
+    if not _is_safe_key(key):
+        return None
+    if isinstance(value, (str, int, float, bool, Decimal)):
+        if isinstance(value, str) and _looks_sensitive_text(value):
+            return None
+        return _json_safe_value(value)
+    return None
+
+
+def _is_compact_scalar(value: Any) -> bool:
+    return value is None or isinstance(value, (str, int, float, bool, Decimal))
+
+
+def _is_compact_summary_value(value: Any) -> bool:
+    if _is_compact_scalar(value):
+        return True
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str)
+            and _is_safe_key(key)
+            and _is_compact_summary_value(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return all(_is_compact_scalar(item) for item in value)
+    return False
+
+
+def _is_safe_key(key: str) -> bool:
+    return SENSITIVE_KEY_RE.search(key) is None
+
+
+def _looks_sensitive_text(text: str) -> bool:
+    return SENSITIVE_TEXT_RE.search(text) is not None
+
+
+def _json_safe_value(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_safe_value(item)
+            for key, item in sorted(value.items(), key=lambda item: str(item[0]))
+            if _is_safe_key(str(key))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_safe_value(item) for item in value]
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open('rb') as handle:
+        while True:
+            chunk = handle.read(HASH_CHUNK_SIZE)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -521,6 +521,16 @@ before retrying Stage 18J-Q3. Stage 18J-P remains blocked until a valid
 reconciliation artifact exists. See
 [`stage-18j-q7-reconciliation-json-serialization-fix.md`](./stage-18j-q7-reconciliation-json-serialization-fix.md).
 
+Stage 18J-Q8 adds an offline compact summary tool for very large
+`enrichment_staging_reconciliation/v1` artifacts. It streams an existing JSON
+artifact without DB access, records the source basename, file size, SHA-256,
+schema, candidate counts, update/insert counts, blocking reasons,
+confidence/risk counts, coverage counts, and capped sanitized candidate
+samples. It does not run production reconciliation, station-type dry-run,
+canonical apply, or Stage 18J-P/18K work. Stage 18J-P remains blocked until a
+compact review output exists and has been reviewed. See
+[`stage-18j-q8-compact-reconciliation-summary.md`](./stage-18j-q8-compact-reconciliation-summary.md).
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.
@@ -560,9 +570,10 @@ treated as a separate proposal.
   preserving `distanceToArrival` as volatile evidence instead of a churn
   source.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
-  staging retry and read-only artifact path are boring, Stage 19 should broaden
-  warehouse source coverage and design freshness/scheduler support. Scheduler
-  or cron implementation is not part of Q6.
+  staging retry, read-only artifact path, and compact reconciliation review are
+  boring, Stage 19 should broaden warehouse source coverage and design
+  freshness/scheduler support. Scheduler or cron implementation is not part of
+  Q6/Q8.
 * **Report-only analytics maturation**: improve confidence/risk explanations,
   source coverage summaries, colonisation signals, and mission-density signals
   without writing canonical data.

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -35,6 +35,9 @@ Current merged direction, based on the latest roadmap trail:
 - Stage 17N.2c recovered trust around unknown coordinates, unknown distances, stale/saturated ratings, and legacy rationale language.
 - Stage 17N.2d/17N.2d-H moved existing-infrastructure awareness and station/body association toward backend-backed trust metadata.
 - Stage 17N.2d-P and the enrichment roadmap introduced a safer offline/staging warehouse direction for repeatable enrichment evidence and report-only reconciliation.
+- Stage 18J-Q8 keeps the first production-scale reconciliation review offline
+  and compact: large artifacts must be summarized before Stage 18J-P can
+  proceed, and production summaries remain non-git by default.
 
 ## Read-Order For Future Work
 
@@ -721,6 +724,38 @@ read-only reconciliation artifact exists.
 Support doc:
 `stage-18j-q7-reconciliation-json-serialization-fix.md`.
 
+### Stage 18J-Q8 - Compact Reconciliation Summary
+
+Purpose: make the valid large reconciliation artifact reviewable without
+loading or committing the full production artifact.
+
+Scope:
+
+- Add an offline CLI that streams an existing
+  `enrichment_staging_reconciliation/v1` JSON artifact in bounded memory.
+- Output source basename only, SHA-256, file size, schema,
+  `canonical_writes_planned`, candidate counts, update/insert counts, blocking
+  reasons, confidence/risk counts, coverage counts, and capped sanitized
+  candidate samples.
+- Exclude raw payloads, private paths, DSNs, and secrets from the compact
+  output.
+- Mark compact output `safe_for_git = false` by default.
+
+Non-goals:
+
+- No production reconciliation run from development.
+- No production data or artifact commits.
+- No station-type dry-run.
+- No canonical apply.
+- No production DB access.
+- No Stage 18J-P or Stage 18K work.
+
+Q8 is a review-enabling extraction step only. Stage 18J-P remains blocked until
+a compact review output exists and is explicitly reviewed.
+
+Support doc:
+`stage-18j-q8-compact-reconciliation-summary.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -764,5 +799,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 23. Stage 18J-Q5 nested EDSM station snapshot support.
 24. Stage 18J-Q6 memory-safe warehouse station load.
 25. Stage 18J-Q7 reconciliation JSON serialization fix.
+26. Stage 18J-Q8 compact reconciliation summary.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md
+++ b/docs/colonisation-redesign/stage-18j-q6-memory-safe-warehouse-station-load.md
@@ -245,3 +245,21 @@ apply was run, and Stage 18J-P remained blocked.
 Stage 18J-Q7 fixes reconciliation report serialization before retrying the
 Stage 18J-Q3 read-only artifact path. Q7 does not authorize station-type
 dry-run, canonical apply, Stage 18J-P, Stage 18K, or scheduler work.
+
+## Q8 Follow-Up
+
+After Q7 merged, the controlled read-only reconciliation artifact was generated
+successfully and validated outside git. Its size makes direct review
+impractical, so Stage 18J-Q8 adds an offline, memory-safe compact summary tool.
+
+Q8 reads an existing `enrichment_staging_reconciliation/v1` artifact from an
+operator-managed path and writes a compact deterministic extract with the source
+basename, file size, SHA-256, schema, candidate counts, update/insert counts,
+blocking reasons, confidence/risk counts, coverage counts, and capped sanitized
+candidate samples.
+
+Q8 does not authorize production data commits, production artifact commits,
+production reconciliation from development, station-type dry-run, canonical
+apply, production DB access from development, Stage 18J-P, Stage 18K, or
+scheduler work. Stage 18J-P remains blocked until a compact review output
+exists and is explicitly reviewed.

--- a/docs/colonisation-redesign/stage-18j-q8-compact-reconciliation-summary.md
+++ b/docs/colonisation-redesign/stage-18j-q8-compact-reconciliation-summary.md
@@ -1,0 +1,135 @@
+# Stage 18J-Q8 - Compact Reconciliation Summary
+
+## Purpose
+
+Stage 18J-Q8 adds an offline, memory-safe compact summary tool for large
+read-only reconciliation artifacts.
+
+The current valid reconciliation artifact exists outside git in an
+operator-managed location. It has schema
+`enrichment_staging_reconciliation/v1`, `canonical_writes_planned = 0`,
+zero-byte stderr, clean JSON termination, and no canonical station count
+change. The artifact is too large for normal review, so the next safe step is a
+bounded compact extract.
+
+## Tool
+
+CLI:
+
+```sh
+python3 apps/importer/src/reconciliation_artifact_summary.py \
+    --artifact /operator/artifacts/enrichment_staging_reconciliation_YYYYMMDDTHHMMSSZ.json \
+    --output /operator/artifacts/enrichment_staging_reconciliation_summary_YYYYMMDDTHHMMSSZ.json \
+    --max-candidate-samples 50
+```
+
+The tool:
+
+- reads only the supplied local JSON artifact,
+- computes source file size and SHA-256 by streaming bytes,
+- parses the JSON with `ijson`,
+- streams candidate arrays one candidate at a time,
+- keeps only counters, top distributions, and capped sanitized samples,
+- writes deterministic JSON with `sort_keys=True`,
+- does not import warehouse DB modules or connect to Postgres.
+
+## Compact Output
+
+The compact summary includes:
+
+- summary schema `enrichment_reconciliation_artifact_summary/v1`,
+- `safe_for_git = false`,
+- source artifact basename only,
+- source artifact SHA-256,
+- source artifact size in bytes,
+- artifact schema version,
+- `canonical_writes_planned`,
+- station candidate count,
+- candidate counts by section,
+- candidate action counts,
+- candidate update and missing-canonical insert counts,
+- top blocking reasons,
+- top confidence/risk/reconciliation-state counts,
+- available confidence/risk summary distributions,
+- available source coverage summary counts,
+- available warehouse coverage summary counts,
+- capped sanitized candidate samples.
+
+Samples deliberately exclude raw payloads, full canonical payloads, difference
+values, full private paths, DSNs, passwords, tokens, and secrets. Production
+summary output still defaults to `safe_for_git = false` because sampled
+candidate identities can be production evidence even after sanitization.
+
+## Boundaries
+
+Q8 does not authorize:
+
+- production data committed to git,
+- production artifact committed to git,
+- production summary committed unless separately synthetic or sanitized,
+- production reconciliation from development,
+- station-type dry-run,
+- canonical apply,
+- production DB access from development,
+- scheduler or cron wiring,
+- Stage 18J-P,
+- Stage 18K.
+
+The tool is an extract/review aid only. It does not change the reconciliation
+artifact and does not turn report candidates into a write plan.
+
+## Review Gate
+
+Stage 18J-P remains blocked until:
+
+- the compact summary is generated from the valid read-only artifact by an
+  operator-approved offline command,
+- the compact summary confirms `schema_version =
+  enrichment_staging_reconciliation/v1`,
+- `canonical_writes_planned = 0`,
+- station candidate counts and update/insert counts are understood,
+- blocking reasons and confidence/risk distributions are reviewed,
+- source and warehouse coverage counts are reviewed,
+- no production artifact or production summary is committed to git.
+
+Only after that review may a separate prompt decide whether Stage 18J-P should
+generate a station-type production dry-run. Q8 itself does not start Stage
+18J-P.
+
+## Validation
+
+Local validation uses synthetic fixtures only:
+
+```sh
+./scripts/run_canonical_safety_tests.sh
+
+.venv/bin/pytest \
+  tests/test_enrichment_staging_reconciliation.py \
+  tests/test_enrichment_staging_db_loader.py \
+  tests/test_enrichment_report_contracts.py \
+  tests/test_station_type_canonical_pilot.py \
+  tests/test_enrichment_warehouse_boundary.py \
+  tests/test_edsm_station_normalization.py \
+  tests/test_reconciliation_artifact_summary.py \
+  -q
+
+.venv/bin/python -m py_compile \
+  apps/importer/src/enrichment_staging_db_loader.py \
+  apps/importer/src/enrichment_reconciliation.py \
+  apps/importer/src/enrichment_warehouse_repository.py \
+  apps/importer/src/station_type_canonical_pilot.py \
+  apps/importer/src/reconciliation_artifact_summary.py \
+  tests/test_reconciliation_artifact_summary.py
+
+git diff --check
+```
+
+Changed docs and code should also be scanned for DSNs/secrets before opening
+the PR.
+
+## Final Recommendation
+
+Merge Q8 before any Stage 18J-P decision. Generate and review a compact
+operator-managed summary from the existing valid reconciliation artifact, keep
+production outputs out of git, and do not run station-type dry-run, canonical
+apply, Stage 18J-P, or Stage 18K from this stage.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -570,6 +570,31 @@ before printing. Datetimes and dates are emitted as ISO-8601 strings; decimals
 are emitted as strings. If JSON printing fails, treat the artifact as invalid,
 keep Stage 18J-P blocked, and do not proceed to station-type dry-run or apply.
 
+Stage 18J-Q8 documents the compact reconciliation summary tool in
+`docs/colonisation-redesign/stage-18j-q8-compact-reconciliation-summary.md`.
+It exists because the valid read-only reconciliation artifact is too large for
+normal review. The Q8 tool reads an existing artifact offline, streams candidate
+arrays in bounded memory, and emits a compact deterministic JSON extract with
+the source basename, file size, SHA-256, schema, candidate counts,
+confidence/risk distributions, coverage counts, and capped sanitized candidate
+samples.
+
+Compact summary command:
+
+```sh
+python3 apps/importer/src/reconciliation_artifact_summary.py \
+    --artifact /operator/artifacts/enrichment_staging_reconciliation_YYYYMMDDTHHMMSSZ.json \
+    --output /operator/artifacts/enrichment_staging_reconciliation_summary_YYYYMMDDTHHMMSSZ.json \
+    --max-candidate-samples 50
+```
+
+The summary tool does not connect to a database, run reconciliation, run
+station-type dry-run, or apply canonical writes. Its output sets
+`safe_for_git = false` by default because production candidate samples may
+still contain production identities even after payload/path sanitization. Do
+not commit production summaries unless a separate review explicitly marks a
+synthetic or sanitized output safe.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables

--- a/tests/test_reconciliation_artifact_summary.py
+++ b/tests/test_reconciliation_artifact_summary.py
@@ -1,0 +1,207 @@
+import builtins
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import reconciliation_artifact_summary as summary_tool  # noqa: E402
+
+
+def write_artifact(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload, sort_keys=True, indent=2), encoding='utf-8')
+    return path
+
+
+def candidate(index: int, **overrides):
+    row = {
+        'entity': 'station',
+        'candidate_action': 'no_change',
+        'confidence': 'high',
+        'confidence_level': 'high',
+        'risk_class': 'clear',
+        'reconciliation_state': 'confirmed',
+        'review_classifications': ['confirmed', 'report_only'],
+        'risk_flags': [],
+        'source': {
+            'system_id64': 1000 + index,
+            'system_name': f'Synthetic System {index}',
+            'station_name': f'Synthetic Port {index}',
+            'source': 'synthetic_fixture',
+            'source_record_hash': f'hash-{index}',
+            'source_path': f'/home/example/private/source-{index}.json',
+        },
+        'canonical': {
+            'station_id': index,
+            'password': 'must-not-leak',
+        },
+        'canonical_matches': [{'station_id': index}],
+        'differences': [],
+        'warnings': [],
+        'raw_payload': {'secret': 'must-not-leak'},
+    }
+    row.update(overrides)
+    return row
+
+
+def artifact(**overrides):
+    payload = {
+        'schema_version': 'enrichment_staging_reconciliation/v1',
+        'dry_run': True,
+        'summary': {
+            'schema_version': 'nested-schema-must-not-win',
+            'staged_station_rows_considered': 1,
+            'canonical_writes_planned': 0,
+            'candidate_station_updates': 0,
+            'errors': 0,
+        },
+        'station_candidates': [candidate(1)],
+        'body_candidates': [],
+        'ring_candidates': [],
+        'station_body_association_candidates': [],
+        'source_coverage_summary': {
+            'schema_version': 'enrichment_source_coverage_summary/v1',
+            'canonical_writes_planned': 0,
+            'entities': {
+                'station': {
+                    'candidates': 1,
+                    'candidate_actions': {'no_change': 1},
+                    'confidence': {'high': 1},
+                    'source_runs': ['/home/example/private/run'],
+                    'source_files': ['/home/example/private/file.json'],
+                    'missing_system_identifiers': 0,
+                    'volatile_warnings': 0,
+                },
+            },
+            'ring_evidence': {
+                'staged_ring_candidates': 0,
+                'trusted_local_matched_ring_candidates': 0,
+                'missing_ring_arrays_state': 'unknown_not_false',
+                'ringed_truth_requires_trusted_body_rings': True,
+            },
+        },
+        'warehouse_coverage_report': {
+            'schema_version': 'enrichment_warehouse_coverage_report/v1',
+            'canonical_writes_planned': 0,
+            'summary': {
+                'systems_with_station_evidence': 1,
+                'source_files_considered': 1,
+                'canonical_writes_planned': 0,
+            },
+            'operator_review': {
+                'needs_attention_buckets': {'unresolved_stations': 0},
+            },
+        },
+        'confidence_risk_summary': {
+            'schema_version': 'enrichment_confidence_risk_summary/v1',
+            'canonical_writes_planned': 0,
+            'confidence_distribution': {'high': 1},
+            'risk_class_distribution': {'clear': 1},
+            'risk_flag_distribution': {},
+            'future_canonical_review_candidates': 0,
+        },
+        'warnings': [],
+        'errors': [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_top_level_schema_version_detection_ignores_nested_schema_versions(tmp_path):
+    path = write_artifact(tmp_path / 'synthetic-reconciliation.json', artifact())
+
+    summary = summary_tool.build_compact_summary(path)
+
+    assert summary['artifact_schema_version'] == 'enrichment_staging_reconciliation/v1'
+    assert summary['artifact_summary_counts']['schema_version'] == 'nested-schema-must-not-win'
+    assert summary['canonical_writes_planned'] == 0
+
+
+def test_candidate_samples_are_capped_and_station_count_is_streamed(tmp_path):
+    rows = [
+        candidate(1, candidate_action='candidate_update'),
+        candidate(2, candidate_action='candidate_insert_missing_canonical', canonical=None, canonical_matches=[]),
+        candidate(3),
+    ]
+    path = write_artifact(tmp_path / 'synthetic-reconciliation.json', artifact(station_candidates=rows))
+
+    summary = summary_tool.build_compact_summary(path, max_candidate_samples=2)
+
+    assert summary['station_candidate_count'] == 3
+    assert summary['candidate_samples']['samples_included'] == 2
+    assert summary['candidate_update_counts']['station_candidates'] == 1
+    assert summary['candidate_insert_missing_canonical_counts']['station_candidates'] == 1
+
+
+def test_raw_payloads_and_private_paths_are_excluded(tmp_path):
+    path = write_artifact(
+        tmp_path / 'synthetic-reconciliation.json',
+        artifact(filters={'source_file': '/home/example/private/full-path.json'}),
+    )
+
+    summary = summary_tool.build_compact_summary(path)
+    dumped = json.dumps(summary, sort_keys=True)
+
+    assert 'must-not-leak' not in dumped
+    assert 'raw_payload' not in dumped
+    assert '/home/example/private' not in dumped
+    assert str(path.parent) not in dumped
+    assert summary['source_artifact_basename'] == path.name
+
+
+def test_unsupported_schema_is_rejected(tmp_path):
+    path = write_artifact(
+        tmp_path / 'synthetic-reconciliation.json',
+        artifact(schema_version='enrichment_snapshot_load_plan/v1'),
+    )
+
+    with pytest.raises(ValueError, match='unsupported reconciliation artifact schema'):
+        summary_tool.build_compact_summary(path)
+
+
+def test_output_is_deterministic(tmp_path):
+    path = write_artifact(
+        tmp_path / 'synthetic-reconciliation.json',
+        artifact(station_candidates=[
+            candidate(2, candidate_action='candidate_update', risk_flags=['canonical_difference_review']),
+            candidate(1, candidate_action='candidate_update', risk_flags=['canonical_difference_review']),
+        ]),
+    )
+
+    first = summary_tool.build_compact_summary(path)
+    second = summary_tool.build_compact_summary(path)
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_tool_runs_without_db_access(tmp_path, monkeypatch):
+    path = write_artifact(tmp_path / 'synthetic-reconciliation.json', artifact())
+    output = tmp_path / 'summary.json'
+    real_import = builtins.__import__
+
+    def fail_on_db_import(name, *args, **kwargs):
+        if name.startswith('psycopg2'):
+            raise AssertionError('summary tool must not import DB drivers')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', fail_on_db_import)
+
+    exit_code = summary_tool.main([
+        '--artifact',
+        str(path),
+        '--output',
+        str(output),
+        '--max-candidate-samples',
+        '1',
+    ])
+
+    assert exit_code == 0
+    payload = json.loads(output.read_text(encoding='utf-8'))
+    assert payload['candidate_samples']['samples_included'] == 1
+    assert payload['safe_for_git'] is False


### PR DESCRIPTION
## Summary

- Add `apps/importer/src/reconciliation_artifact_summary.py`, an offline `ijson`-based compact summary CLI for large `enrichment_staging_reconciliation/v1` artifacts.
- Add synthetic-only tests for schema detection, nested schema handling, capped samples, payload/path exclusion, unsupported schema rejection, deterministic output, and no DB-driver access.
- Update the warehouse runbook, enrichment roadmap, Q6 follow-up, Stage 17P baseline, and add the Stage 18J-Q8 stage document.

## Validation

- `./scripts/run_canonical_safety_tests.sh` - 83 passed; disposable Postgres rehearsal skipped because no explicit canonical test DSN confirmation was set.
- `.venv/bin/pytest tests/test_enrichment_staging_reconciliation.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_edsm_station_normalization.py tests/test_reconciliation_artifact_summary.py -q` - 109 passed.
- `.venv/bin/python -m py_compile apps/importer/src/enrichment_staging_db_loader.py apps/importer/src/enrichment_reconciliation.py apps/importer/src/enrichment_warehouse_repository.py apps/importer/src/station_type_canonical_pilot.py apps/importer/src/reconciliation_artifact_summary.py tests/test_reconciliation_artifact_summary.py` - passed.
- `git diff --check` and `git diff --cached --check` - passed.
- Requested docs secret scan for DSNs/secrets - no matches.

## Safety Confirmations

- No production data committed.
- No production artifact committed.
- No production summary committed unless synthetic/sanitized; this PR commits no production summary output.
- No production reconciliation run from Codex.
- No station-type dry-run run.
- No canonical apply run.
- No production DB touched.
- Stage 18J-P remains blocked until compact review output exists.
- Stage 18K not started.