### PR TITLE
Stage 19A warehouse artifact taxonomy and chunked roadmap

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -531,6 +531,16 @@ canonical apply, or Stage 18J-P/18K work. Stage 18J-P remains blocked until a
 compact review output exists and has been reviewed. See
 [`stage-18j-q8-compact-reconciliation-summary.md`](./stage-18j-q8-compact-reconciliation-summary.md).
 
+Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
+the warehouse broadens beyond the station reconciliation path. It separates
+stations, bodies, rings, station/body links, markets, services, economies,
+colonisation, freshness, coverage, analytics, and future write-plan artifacts;
+standardizes domain-qualified names; and requires source inventory, load,
+reconciliation, compact summary, dry-run, approval packet, and manual apply to
+remain separate chunks. Scheduler work remains design-only and disabled by
+default; scheduled jobs must never run canonical apply. See
+[`stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`](./stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md).
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.
@@ -569,11 +579,15 @@ treated as a separate proposal.
   quality checks across staged station, body, and ring evidence while
   preserving `distanceToArrival` as volatile evidence instead of a churn
   source.
+* **Warehouse artifact taxonomy**: Stage 19A fixes the naming and chunking
+  contract before broader warehouse domains are added. Keep load,
+  reconciliation, compact summary, dry-run, approval, and apply artifacts
+  separate.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
-  staging retry, read-only artifact path, and compact reconciliation review are
-  boring, Stage 19 should broaden warehouse source coverage and design
-  freshness/scheduler support. Scheduler or cron implementation is not part of
-  Q6/Q8.
+  staging retry, read-only artifact path, compact reconciliation review, and
+  Stage 19A taxonomy are boring, Stage 19 should broaden warehouse source
+  coverage and design freshness/scheduler support. Scheduler or cron
+  implementation is not part of Q6/Q8/19A.
 * **Report-only analytics maturation**: improve confidence/risk explanations,
   source coverage summaries, colonisation signals, and mission-density signals
   without writing canonical data.

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -756,6 +756,39 @@ a compact review output exists and is explicitly reviewed.
 Support doc:
 `stage-18j-q8-compact-reconciliation-summary.md`.
 
+### Stage 19A - Warehouse Artifact Taxonomy and Chunked Roadmap
+
+Purpose: define how warehouse artifacts are named, separated, reviewed, and
+sequenced before Stage 19 broadens beyond station reconciliation.
+
+Scope:
+
+- Separate artifact families for stations, bodies, rings, station/body links,
+  markets, services, economies, colonisation, freshness, coverage, analytics,
+  and future write plans.
+- Standardize domain-qualified artifact names for loads, reconciliation,
+  compact summaries, freshness status, operator status, and future write plans.
+- Require source inventory before load, load before reconciliation,
+  reconciliation before compact summary, compact summary before dry-run,
+  dry-run before approval packet, approval packet before apply, and manual
+  apply only.
+- State that scheduler work must remain disabled by default and must never run
+  canonical apply.
+- Preserve the Stage 18J continuation path: Q9 compact review, 18J-P dry-run
+  retry only, 18J-P2 review packet, 18J-P3 tiny approval packet, and 18J-P4
+  tiny apply only if explicitly approved.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No imports, reconciliation, station-type dry-run, or apply.
+- No cron/scheduler wiring.
+- No Stage 18J-P or Stage 18K work.
+
+Support doc:
+`stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -800,5 +833,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 24. Stage 18J-Q6 memory-safe warehouse station load.
 25. Stage 18J-Q7 reconciliation JSON serialization fix.
 26. Stage 18J-Q8 compact reconciliation summary.
+27. Stage 19A warehouse artifact taxonomy and chunked roadmap.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-q8-compact-reconciliation-summary.md
+++ b/docs/colonisation-redesign/stage-18j-q8-compact-reconciliation-summary.md
@@ -133,3 +133,18 @@ Merge Q8 before any Stage 18J-P decision. Generate and review a compact
 operator-managed summary from the existing valid reconciliation artifact, keep
 production outputs out of git, and do not run station-type dry-run, canonical
 apply, Stage 18J-P, or Stage 18K from this stage.
+
+## Stage 19A Follow-Up
+
+Stage 19A defines the artifact taxonomy and chunked roadmap that should govern
+any broader warehouse expansion after Q8. The station compact summary remains a
+station-domain artifact and should use the domain-qualified naming direction
+from Stage 19A, such as
+`reconciliation_compact_summary_stations_<timestamp>.json`, for future operator
+outputs.
+
+Do not use Stage 19A to skip the Stage 18J continuation gates. The next station
+steps remain Q9 compact summary review / station-type dry-run readiness, then
+18J-P production dry-run retry only if explicitly approved, followed by review
+and tiny manual apply approval packets if the dry-run is boring. Stage 19A does
+not start Stage 18J-P, Stage 18K, scheduler wiring, or any canonical apply.

--- a/docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md
+++ b/docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md
@@ -1,0 +1,160 @@
+# Stage 19A - Warehouse Artifact Taxonomy and Chunked Roadmap
+
+## Purpose
+
+Stage 19A defines the artifact taxonomy and chunked roadmap for broadening the
+offline enrichment warehouse after the Stage 18J-Q station reconciliation path.
+
+This stage is documentation and planning only. It does not run production
+commands, connect to production databases, run imports, run reconciliation, run
+station-type dry-run, run canonical apply, implement scheduler wiring, start
+Stage 18J-P, or start Stage 18K.
+
+## Artifact Families
+
+Warehouse artifacts must stay split by domain and lifecycle step so review can
+advance in small, auditable chunks. A station artifact must not silently become
+a body, market, colonisation, or canonical-write artifact.
+
+| Family | Domain scope | Purpose | Write authority |
+|---|---|---|---|
+| Stations | Station snapshot and staged station rows | Stage, reconcile, compact, and review station evidence such as station type and station body name. | Warehouse staging only until a separately approved canonical station write plan exists. |
+| Bodies | Body snapshot and staged body rows | Stage and reconcile body names, body identifiers, body classes, landability, terraformability, and scan-value evidence. | Warehouse staging/report-only. |
+| Rings | Ring arrays and staged ring rows | Preserve source-only ring evidence, trusted ring matches, and unknown-not-false ring semantics. | Warehouse staging/report-only. |
+| Station/body links | Association evidence between stations and bodies | Review confirmed, inferred/verify, ambiguous, unresolved, and missing association evidence. | Report-only until a dedicated canonical link write design is approved. |
+| Markets | Market and commodity source evidence | Inventory source shape, freshness, and future market staging without changing planner economics. | Warehouse staging/report-only. |
+| Services | Station service and facility source evidence | Inventory services separately from station identity and market evidence. | Warehouse staging/report-only. |
+| Economies | Economy/source classification evidence | Preserve economy observations and conflicts as evidence without changing scoring or planner mechanics. | Warehouse staging/report-only. |
+| Colonisation | Construction, colonisation, and related system evidence | Track colonisation/construction source records and review signals separately from canonical system truth. | Warehouse staging/report-only. |
+| Freshness | Source age, source update coverage, and stale/undated signals | Explain whether evidence is current enough to review, without wall-clock write decisions. | Status/report-only. |
+| Coverage | Source, warehouse, and domain completeness reports | Show what evidence exists, what is absent, and what remains unknown. | Status/report-only. |
+| Analytics | Confidence/risk, mission-density, and colonisation signals | Summarize review signals from staged evidence without mutating planner state. | Report-only. |
+| Future write plans | Narrow canonical write candidates after explicit review | Carry pre-images, counts, approvals, rollback expectations, and field/table limits. | Manual apply only after separate approval. |
+
+## Naming Pattern
+
+Use domain-qualified artifact names. The `<domain>` token should be stable and
+short, for example `stations`, `bodies`, `rings`, `station_body_links`,
+`markets`, `services`, `economies`, `colonisation`, `freshness`, `coverage`,
+`analytics`, or a narrower approved domain.
+
+| Pattern | Meaning |
+|---|---|
+| `warehouse_<domain>_load_<timestamp>.json` | Loader output for one domain, source, and run. |
+| `enrichment_staging_reconciliation_<domain>_<timestamp>.json` | Read-only reconciliation artifact for one domain. |
+| `reconciliation_compact_summary_<domain>_<timestamp>.json` | Compact summary derived from an existing reconciliation artifact. |
+| `warehouse_<domain>_freshness_status_<timestamp>.json` | Freshness/source-age status for one domain. |
+| `warehouse_operator_status_<timestamp>.json` | Operator-facing aggregate status assembled from reviewed artifacts. |
+| `canonical_write_plan_<domain>_<timestamp>.json` | Future manual write-plan candidate packet for one explicitly approved domain. |
+
+Timestamps should be UTC and sortable, normally `YYYYMMDDTHHMMSSZ`. Artifacts
+created from production evidence stay outside git by default. Committed
+examples must be synthetic or explicitly sanitized.
+
+## Chunking Rules
+
+Every domain follows the same order. Do not skip ahead because a later step has
+a familiar command name from a different domain.
+
+1. Source inventory before load.
+2. Load before reconciliation.
+3. Reconciliation before compact summary.
+4. Compact summary before dry-run.
+5. Dry-run before approval packet.
+6. Approval packet before apply.
+7. Apply manual only.
+8. Scheduler never runs canonical apply.
+
+Additional rules:
+
+- Each chunk names its domain, source, artifact basename, expected schema, and
+  explicit non-goals.
+- Each load summary must keep `canonical_writes_planned = 0`.
+- Reconciliation remains read-only/report-only and must not create a write
+  plan by implication.
+- Compact summaries are review aids and default to non-git production handling.
+- Dry-runs are not approvals.
+- Approval packets must name exact candidate count, table, field, source scope,
+  rollback/pre-image expectations, max row count, operator, and stop
+  conditions.
+- Any canonical apply must be a separate manual command with explicit approval.
+- Scheduled jobs may refresh warehouse artifacts only after a disabled-by-
+  default scheduler design lands; they must not apply canonical writes.
+
+## Stage 18J Continuation
+
+Stage 18J remains a narrow station-type path. It must continue separately from
+the broader Stage 19 warehouse roadmap.
+
+1. **Q8 compact station reconciliation summary**: generate an offline compact
+   summary from the valid station reconciliation artifact. Do not commit
+   production output.
+2. **Q9 compact summary review / station-type dry-run readiness**: review the
+   compact station summary, decide whether station-type dry-run is ready, and
+   keep Stage 18J-P blocked if counts, blockers, or risk classes are not
+   understood.
+3. **18J-P retry station-type production dry-run only**: generate only the
+   station-type production dry-run from reviewed reconciliation evidence. Do
+   not apply.
+4. **18J-P2 dry-run review packet**: review dry-run candidates, pre-images,
+   row counts, table/field scope, and stop conditions.
+5. **18J-P3 tiny apply approval packet**: prepare a tiny manually approved
+   apply packet if the dry-run review is boring and bounded.
+6. **18J-P4 tiny apply only if explicitly approved**: run a manual tiny apply
+   only after explicit approval. Scheduler never runs this apply.
+
+Stage 18K remains untouched until a separate prompt starts it. Stage 19 does
+not broaden canonical apply authority.
+
+## Stage 19 Roadmap
+
+Stage 19 expands warehouse observability and coverage in chunks. Each stage is
+expected to preserve report-only boundaries unless it explicitly says otherwise.
+
+| Stage | Name | Scope |
+|---|---|---|
+| 19A | Taxonomy and chunked roadmap | Define artifact families, naming, ordering, and Stage 18J/19 sequencing. |
+| 19B | Freshness/scheduler design | Design freshness status and disabled-by-default scheduler boundaries; no cron wiring. |
+| 19C | Source inventory | Inventory available source files, domains, shapes, retention needs, and review risks. |
+| 19D | Body source shape inspection | Inspect body source shapes with synthetic/local evidence only and define loader contract. |
+| 19E | Body warehouse staging loader | Implement body staging loader changes after source-shape inspection. |
+| 19F | Body load/reconciliation/summary | Plan and review body load, read-only reconciliation, and compact summary chunks. |
+| 19G | Ring source shape inspection | Inspect ring source arrays and trusted/unknown semantics before loader changes. |
+| 19H | Ring warehouse staging loader | Implement ring staging loader changes after source-shape inspection. |
+| 19I | Ring load/reconciliation/summary | Plan and review ring load, read-only reconciliation, and compact summary chunks. |
+| 19J | Station/body association evidence | Broaden association evidence reporting without creating canonical link writes. |
+| 19K | Market/services/economy inventory | Inventory source shapes and authority boundaries for market, service, and economy evidence. |
+| 19L | Market/services warehouse staging | Stage market/service/economy evidence as warehouse/report-only data. |
+| 19M | Colonisation/construction evidence inventory | Inventory colonisation and construction source evidence before staging. |
+| 19N | Colonisation/construction warehouse staging | Stage colonisation/construction evidence as warehouse/report-only data. |
+| 19O | Dashboard coverage/freshness v2 | Improve operator dashboard coverage and freshness views from reviewed artifacts. |
+| 19P | Retention/cleanup policy | Define retention, cleanup, compression, checksums, and artifact storage rules. |
+| 19Q | Scheduled warehouse dry-run jobs disabled by default | Define dry-run refresh jobs that are off unless explicitly enabled. |
+| 19R | Maintenance-container scheduler wiring disabled by default | Wire scheduler mechanics in a maintenance container, still disabled by default. |
+| 19S | Operator-controlled scheduled refresh pilot | Pilot operator-controlled scheduled warehouse refreshes with no canonical apply. |
+| 19T | Full warehouse coverage report v2 | Produce a cross-domain coverage/freshness/report-only status model from reviewed artifacts. |
+
+## Non-Goals
+
+Stage 19A does not authorize:
+
+- production commands,
+- production DB access,
+- imports,
+- reconciliation,
+- station-type dry-run,
+- production summary generation,
+- canonical write plans,
+- canonical apply,
+- cron or scheduler wiring,
+- Stage 18J-P,
+- Stage 18K.
+
+## Final Recommendation
+
+Use this taxonomy before opening any broader warehouse stage. Keep each domain
+artifact family separate, advance through the chunking rules in order, and keep
+canonical apply manual-only behind explicit approval. Stage 18J station-type
+work should finish its compact-summary and dry-run review sequence before any
+tiny apply is considered; Stage 19 should broaden warehouse evidence without
+quietly starting Stage 18K or scheduler-driven writes.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -595,6 +595,29 @@ still contain production identities even after payload/path sanitization. Do
 not commit production summaries unless a separate review explicitly marks a
 synthetic or sanitized output safe.
 
+Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
+`docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
+Use domain-qualified artifact families for stations, bodies, rings,
+station/body links, markets, services, economies, colonisation, freshness,
+coverage, analytics, and future write plans. Do not mix lifecycle steps in one
+artifact: source inventory comes before load, load before reconciliation,
+reconciliation before compact summary, compact summary before dry-run, dry-run
+before approval packet, and approval packet before any manual apply.
+
+Preferred naming patterns:
+
+```text
+warehouse_<domain>_load_<timestamp>.json
+enrichment_staging_reconciliation_<domain>_<timestamp>.json
+reconciliation_compact_summary_<domain>_<timestamp>.json
+warehouse_<domain>_freshness_status_<timestamp>.json
+warehouse_operator_status_<timestamp>.json
+canonical_write_plan_<domain>_<timestamp>.json
+```
+
+Scheduler work must stay disabled by default until a later approved stage, and
+scheduler jobs must never run canonical apply.
+
 ## Optional Postgres Smoke Tests
 
 These tests are skipped by default. They write only to warehouse staging tables


### PR DESCRIPTION
## Summary

- Add `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
- Document warehouse artifact families for stations, bodies, rings, station/body links, markets, services, economies, colonisation, freshness, coverage, analytics, and future write plans.
- Define domain-qualified naming patterns, chunking rules, Stage 18J continuation, and the Stage 19A-19T roadmap.
- Update the enrichment roadmap, warehouse runbook, Stage 17P baseline, and Q8 compact summary doc with Stage 19A references.

## Validation

- `git diff --check` - passed.
- `git diff --cached --check` - passed after staging so the new doc was included.
- `./scripts/run_canonical_safety_tests.sh` - 83 passed; disposable Postgres rehearsal skipped because no explicit canonical test DSN confirmation was set.
- `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q` - 83 passed.
- `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py` - passed.
- Requested changed-doc secret scan - no matches.

## Safety Confirmations

- Docs/planning only.
- No production commands run.
- No production DB touched.
- No imports run.
- No reconciliation run.
- No station-type dry-run run.
- No canonical apply run.
- No cron/scheduler wiring implemented.
- Stage 18J-P not started.
- Stage 18K not started.