### PR TITLE
Stage 19A.1 operator path guardrails

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -541,6 +541,15 @@ remain separate chunks. Scheduler work remains design-only and disabled by
 default; scheduled jobs must never run canonical apply. See
 [`stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`](./stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md).
 
+Stage 19A.1 adds operator path guardrails after Codex/local and Hetzner command
+contexts were repeatedly confused. It adds a reusable Hetzner environment guard,
+a Stage 18J compact-summary operator wrapper, and
+`docs/operations/operator-command-contexts.md`. Codex remains for repo/code/docs
+and PR work; `/opt/ed-finder`, `/var/lib/ed-finder`, Docker Compose production
+services, production Postgres containers, and production artifacts belong in
+the Hetzner operator shell. The scripts are tooling/docs only and do not start
+Stage 18J-P, Stage 18K, scheduler wiring, or canonical apply.
+
 The operator workflow and current command examples live in
 [`../operations/enrichment-warehouse-runbook.md`](../operations/enrichment-warehouse-runbook.md).
 Use that runbook before loading any local snapshot into staging tables.
@@ -583,11 +592,14 @@ treated as a separate proposal.
   contract before broader warehouse domains are added. Keep load,
   reconciliation, compact summary, dry-run, approval, and apply artifacts
   separate.
+* **Operator path guardrails**: Stage 19A.1 keeps Codex/local work separate
+  from Hetzner operator commands and adds fail-fast guards for server-only
+  scripts.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
-  Stage 19A taxonomy are boring, Stage 19 should broaden warehouse source
-  coverage and design freshness/scheduler support. Scheduler or cron
-  implementation is not part of Q6/Q8/19A.
+  Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse
+  source coverage and design freshness/scheduler support. Scheduler or cron
+  implementation is not part of Q6/Q8/19A/19A.1.
 * **Report-only analytics maturation**: improve confidence/risk explanations,
   source coverage summaries, colonisation signals, and mission-density signals
   without writing canonical data.

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -789,6 +789,33 @@ Non-goals:
 Support doc:
 `stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 
+### Stage 19A.1 - Operator Path Guardrails
+
+Purpose: prevent Codex/local prompts from accidentally running Hetzner
+production operator commands.
+
+Scope:
+
+- Add a reusable shell guard that checks the Hetzner host, `/opt/ed-finder`,
+  Docker Compose availability, and required operator artifact directories.
+- Add a Stage 18J compact-summary operator wrapper that calls the guard before
+  reading production artifacts.
+- Document Codex, DAVE2/local dev, and Hetzner production operator command
+  contexts.
+- Keep operator scripts fail-fast outside the production operator shell.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No cron/scheduler wiring.
+- No Stage 18J-P or Stage 18K work.
+
+Support doc:
+`../operations/operator-command-contexts.md`.
+
 ## Historical Docs Status
 
 Older docs should not be deleted by default. They contain useful context, rationale, boundaries, and acceptance criteria. Treat them as historical/reference unless this file points to them as active.
@@ -834,5 +861,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 25. Stage 18J-Q7 reconciliation JSON serialization fix.
 26. Stage 18J-Q8 compact reconciliation summary.
 27. Stage 19A warehouse artifact taxonomy and chunked roadmap.
+28. Stage 19A.1 operator path guardrails.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md
+++ b/docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md
@@ -158,3 +158,21 @@ canonical apply manual-only behind explicit approval. Stage 18J station-type
 work should finish its compact-summary and dry-run review sequence before any
 tiny apply is considered; Stage 19 should broaden warehouse evidence without
 quietly starting Stage 18K or scheduler-driven writes.
+
+## Stage 19A.1 Follow-Up
+
+Stage 19A.1 adds operator path guardrails for this taxonomy. The key rule is
+that Codex/local repo work and Hetzner operator work are separate command
+contexts:
+
+- Codex/local: edit scripts and docs, run local tests, open PRs.
+- Hetzner operator shell: run `/opt/ed-finder`, `/var/lib/ed-finder`, Docker
+  Compose production service checks, production artifact reads, and
+  operator-approved production commands.
+
+Stage 19A.1 adds `scripts/operator/require_hetzner_operator_env.sh` and
+`scripts/operator/stage18j_run_compact_summary.sh`. Server-only scripts should
+call the shared guard and fail fast outside the expected Hetzner host/path.
+This does not run production commands from Codex, touch production DBs, run
+imports, run reconciliation, run station-type dry-run, run apply, implement
+scheduler wiring, start Stage 18J-P, or start Stage 18K.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -595,6 +595,23 @@ still contain production identities even after payload/path sanitization. Do
 not commit production summaries unless a separate review explicitly marks a
 synthetic or sanitized output safe.
 
+Stage 19A.1 documents operator command contexts in
+`docs/operations/operator-command-contexts.md` and adds fail-fast operator
+scripts under `scripts/operator/`. Codex/local development should edit and
+validate these scripts, but Hetzner-only commands must run from the production
+operator shell. The Stage 18J compact summary operator wrapper is:
+
+```sh
+cd /opt/ed-finder
+scripts/operator/stage18j_run_compact_summary.sh
+```
+
+That wrapper checks the expected host, `/opt/ed-finder`, Docker Compose
+availability, and the Stage 18J artifact directory before reading production
+artifacts. It never runs reconciliation, station-type dry-run, or apply. The
+optional canonical station count check is disabled unless the operator sets
+`CHECK_CANONICAL_COUNT=yes`.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/docs/operations/operator-command-contexts.md
+++ b/docs/operations/operator-command-contexts.md
@@ -1,0 +1,203 @@
+# Operator Command Contexts
+
+## Purpose
+
+This document separates ED-Finder command contexts so production-only operator
+commands are not accidentally run from Codex, DAVE2 local development, or any
+other non-Hetzner shell.
+
+Codex is for repo, code, docs, tests, commits, and PR work. The Hetzner
+production operator shell is for `/opt/ed-finder`, `/var/lib/ed-finder`,
+Docker/Postgres production containers, production artifacts, and operator
+commands. DAVE2/local development is not production.
+
+## The Three Environments
+
+ED-Finder currently has three common command contexts:
+
+| Environment | Typical path | Purpose |
+|---|---|---|
+| Codex / repo environment | A checked-out repo under a local workspace | Code, docs, tests, validation, commits, and PRs. |
+| DAVE2 local dev environment | A developer checkout or local services | Local development and non-production validation. |
+| Hetzner production operator shell | `/opt/ed-finder` | Production operator artifacts, Docker Compose services, and production-only checks. |
+
+If a command depends on `/opt/ed-finder`, `/var/lib/ed-finder`, production
+Docker services, or production Postgres containers, it belongs in the Hetzner
+operator shell.
+
+## Codex / Repo Environment
+
+Use Codex for:
+
+- editing code and docs,
+- writing tests,
+- running local test suites,
+- running local syntax checks,
+- opening and updating PRs,
+- documenting operator commands without executing them.
+
+Codex must not run production operator commands. If a pasted command starts
+with `cd /opt/ed-finder`, reads `/var/lib/ed-finder`, calls production Docker
+Compose services, or reads production artifacts, treat it as a Hetzner operator
+command and do not run it from Codex.
+
+## DAVE2 Local Dev Environment
+
+DAVE2/local dev is useful for local builds, local services, and non-production
+experiments. It is not the production operator shell.
+
+Do not treat a local checkout, local Docker stack, or local Postgres instance
+as proof that a production operator command is safe. Production artifact paths
+and production Docker service names still belong on Hetzner.
+
+## Hetzner Production Operator Shell
+
+The Hetzner production operator shell is the only place for commands that need:
+
+- `/opt/ed-finder`,
+- `/var/lib/ed-finder/operator-artifacts`,
+- production Docker Compose services,
+- production Postgres containers,
+- operator-managed production artifacts.
+
+Operator commands must be explicit, bounded, and reviewed. They should print
+clear stop messages when the host, path, artifact directory, or Docker context
+is wrong.
+
+## Commands Codex Must Not Run
+
+Codex must not run commands that:
+
+- change into `/opt/ed-finder`,
+- read or write `/var/lib/ed-finder/operator-artifacts`,
+- invoke production Docker Compose services,
+- query production Postgres containers,
+- run imports or warehouse loads against production inputs,
+- run production reconciliation,
+- run the compact summarizer against production artifacts,
+- run station-type dry-run against production artifacts,
+- run canonical apply,
+- install or wire cron/scheduler jobs on production.
+
+Codex may edit scripts and docs that describe these workflows, and may run
+local syntax/tests against those scripts.
+
+## Commands That Must Run Only On Hetzner
+
+Run these only from the Hetzner production operator shell:
+
+- Stage 18J compact summary generation from production artifacts,
+- production artifact file permission changes,
+- production artifact checksum or size inspection,
+- Docker Compose production service inspection,
+- read-only production station count checks,
+- any future operator-approved production dry-run,
+- any future explicitly approved manual canonical apply.
+
+Scheduled jobs must never run canonical apply.
+
+## Required Hetzner Paths
+
+Required production paths include:
+
+- `/opt/ed-finder`
+- `/var/lib/ed-finder/operator-artifacts/stage-18j`
+
+If these paths do not exist, the command is not running in the expected
+operator context.
+
+## Artifact Directory Rules
+
+Production artifacts are private operator files. They should not be committed
+to git.
+
+Rules:
+
+- Keep production artifacts under operator-managed directories.
+- Commit only synthetic fixtures or explicitly sanitized examples.
+- Compact summaries generated from production evidence default to
+  `safe_for_git = false`.
+- Use domain-qualified artifact names from Stage 19A for new outputs.
+- Keep load, reconciliation, compact summary, dry-run, approval packet, and
+  apply artifacts separate.
+
+## Secret Handling
+
+Never paste real DSNs/passwords/secrets into chat or Git. Do not commit private
+environment files. Operator scripts must not source private environment files
+unless a later reviewed stage explicitly adds that behavior.
+
+When sharing output, prefer schema versions, counts, basenames, file sizes, and
+hashes. Do not share full production artifact paths if a basename is enough.
+
+## How To Recognise The Right Prompt
+
+Use Codex when the prompt asks for repo edits, docs, tests, validation, commits,
+or PRs.
+
+Use Hetzner when the prompt asks to operate on `/opt/ed-finder`,
+`/var/lib/ed-finder`, production Docker services, production Postgres
+containers, or production artifacts.
+
+Use DAVE2/local dev when the prompt asks for local application development or
+non-production service checks.
+
+If the prompt mixes contexts, split it. Codex can prepare the PR; the Hetzner
+operator terminal runs the production command.
+
+## How To Use Operator Scripts
+
+Operator scripts live under `scripts/operator`.
+
+For Stage 18J compact summary generation, run from Hetzner only:
+
+```sh
+cd /opt/ed-finder
+scripts/operator/stage18j_run_compact_summary.sh
+```
+
+Optional environment overrides:
+
+- `ART_DIR`
+- `RECON_ARTIFACT`
+- `COMPACT_SUMMARY`
+- `MAX_CANDIDATE_SAMPLES`
+- `CHECK_CANONICAL_COUNT=yes`
+
+The compact summary script calls the shared environment guard first. It fails
+fast outside the expected host/path/Docker/artifact context.
+
+## Stage 18J Current Operator Artifacts
+
+Stage 18J currently uses an operator-managed reconciliation artifact basename:
+
+```text
+enrichment_staging_reconciliation_20260602T112948Z.json
+```
+
+The compact summary output basename is:
+
+```text
+reconciliation_compact_summary_20260602T112948Z.json
+```
+
+Both are production/operator artifacts and must stay out of git unless a future
+review explicitly produces a synthetic or sanitized example.
+
+## Stage 19 Roadmap Impact
+
+Stage 19A.1 adds guardrails before broader warehouse work continues. Future
+Stage 19 chunks should keep Codex/repo work separate from Hetzner operator
+work, and server-only scripts should fail fast outside Hetzner.
+
+Stage 19 scheduler planning remains disabled by default. Scheduler jobs may
+refresh warehouse artifacts only after explicit approval and must never run
+canonical apply.
+
+## Final Recommendation
+
+Use Codex for repository work and PRs. Use DAVE2/local dev for non-production
+development. Use the Hetzner production operator shell for `/opt/ed-finder`,
+`/var/lib/ed-finder`, Docker/Postgres production services, and production
+artifacts. Keep operator artifacts private, keep secrets out of chat and Git,
+and rely on fail-fast operator scripts for server-only commands.

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -1,0 +1,25 @@
+# Operator Scripts
+
+Scripts in this directory are for the Hetzner production operator shell unless
+their own header says otherwise. They are not Codex/local development commands.
+
+Run them from:
+
+```sh
+cd /opt/ed-finder
+```
+
+The shared guard `require_hetzner_operator_env.sh` checks the host, working
+directory, Docker Compose availability, and required artifact directories before
+server-only workflows proceed. It does not source private environment files and
+does not touch the database.
+
+Current scripts:
+
+- `require_hetzner_operator_env.sh`: reusable fail-fast guard for
+  Hetzner-only commands.
+- `stage18j_run_compact_summary.sh`: generates the Stage 18J compact
+  reconciliation summary from an existing operator-managed artifact. It never
+  runs reconciliation, station-type dry-run, or apply.
+
+Production artifacts are private operator files and should not be committed.

--- a/scripts/operator/require_hetzner_operator_env.sh
+++ b/scripts/operator/require_hetzner_operator_env.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_HOSTNAME="ed-finder"
+EXPECTED_REPO_DIR="/opt/ed-finder"
+STAGE18J_ARTIFACT_DIR="${ART_DIR:-/var/lib/ed-finder/operator-artifacts/stage-18j}"
+ALLOW_NON_HETZNER="${EDFINDER_ALLOW_NON_HETZNER_OPERATOR_ENV:-no}"
+REQUIRE_STAGE18J_ARTIFACT_DIR="${REQUIRE_STAGE18J_ARTIFACT_DIR:-no}"
+
+stop() {
+  printf 'STOP: %s\n' "$*" >&2
+  printf 'This command is for the Hetzner production operator shell only.\n' >&2
+  printf 'Run repo/code/docs/PR work in Codex or local dev, and run operator artifact commands from %s on host %s.\n' \
+    "$EXPECTED_REPO_DIR" "$EXPECTED_HOSTNAME" >&2
+  exit 1
+}
+
+actual_hostname="$(hostname 2>/dev/null || true)"
+if [[ "$actual_hostname" != "$EXPECTED_HOSTNAME" && "$ALLOW_NON_HETZNER" != "yes" ]]; then
+  stop "wrong host '${actual_hostname:-unknown}'. Expected '$EXPECTED_HOSTNAME'. Set EDFINDER_ALLOW_NON_HETZNER_OPERATOR_ENV=yes only for an explicitly approved operator exception."
+fi
+
+current_dir="$(pwd -P)"
+if [[ "$current_dir" != "$EXPECTED_REPO_DIR" ]]; then
+  stop "wrong working directory '$current_dir'. Expected '$EXPECTED_REPO_DIR'."
+fi
+
+if [[ ! -f docker-compose.yml ]]; then
+  stop "docker-compose.yml was not found in '$current_dir'."
+fi
+
+if [[ "$REQUIRE_STAGE18J_ARTIFACT_DIR" == "yes" && ! -d "$STAGE18J_ARTIFACT_DIR" ]]; then
+  stop "required Stage 18J artifact directory is missing: $STAGE18J_ARTIFACT_DIR"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  stop "docker CLI is not available in this shell."
+fi
+
+if ! docker compose ps >/dev/null 2>&1; then
+  stop "docker compose ps failed. Confirm this is the production operator shell and Docker Compose services are available."
+fi
+
+printf 'OK: Hetzner operator environment guard passed for %s on host %s.\n' "$current_dir" "$actual_hostname"

--- a/scripts/operator/stage18j_run_compact_summary.sh
+++ b/scripts/operator/stage18j_run_compact_summary.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +H
+
+ART_DIR="${ART_DIR:-/var/lib/ed-finder/operator-artifacts/stage-18j}"
+RECON_ARTIFACT="${RECON_ARTIFACT:-$ART_DIR/enrichment_staging_reconciliation_20260602T112948Z.json}"
+COMPACT_SUMMARY="${COMPACT_SUMMARY:-$ART_DIR/reconciliation_compact_summary_20260602T112948Z.json}"
+MAX_CANDIDATE_SAMPLES="${MAX_CANDIDATE_SAMPLES:-50}"
+CHECK_CANONICAL_COUNT="${CHECK_CANONICAL_COUNT:-no}"
+
+stop() {
+  printf 'STOP: %s\n' "$*" >&2
+  exit 1
+}
+
+REQUIRE_STAGE18J_ARTIFACT_DIR=yes ART_DIR="$ART_DIR" \
+  scripts/operator/require_hetzner_operator_env.sh
+
+if [[ ! "$MAX_CANDIDATE_SAMPLES" =~ ^[0-9]+$ ]]; then
+  stop "MAX_CANDIDATE_SAMPLES must be a non-negative integer."
+fi
+
+if [[ ! -s "$RECON_ARTIFACT" ]]; then
+  stop "reconciliation artifact is missing or empty: $RECON_ARTIFACT"
+fi
+
+if ! python3 -c 'import ijson' >/dev/null 2>&1; then
+  stop "Python module ijson is missing. Install importer Python requirements or install the OS package, for example: sudo apt-get update && sudo apt-get install -y python3-ijson"
+fi
+
+python3 apps/importer/src/reconciliation_artifact_summary.py \
+  --artifact "$RECON_ARTIFACT" \
+  --output "$COMPACT_SUMMARY" \
+  --max-candidate-samples "$MAX_CANDIDATE_SAMPLES"
+
+chmod 600 "$COMPACT_SUMMARY"
+
+echo "== Compact summary file =="
+ls -lh "$COMPACT_SUMMARY"
+
+echo "== Compact summary validation =="
+python3 - "$COMPACT_SUMMARY" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding='utf-8') as handle:
+    payload = json.load(handle)
+
+candidate_samples = payload.get('candidate_samples') or {}
+if isinstance(candidate_samples, dict):
+    sample_count = candidate_samples.get('samples_included')
+    if sample_count is None:
+        sample_count = len(candidate_samples.get('samples') or [])
+else:
+    sample_count = len(candidate_samples)
+
+for key in (
+    'schema_version',
+    'safe_for_git',
+    'source_artifact_basename',
+    'source_artifact_sha256',
+    'source_artifact_size_bytes',
+    'canonical_writes_planned',
+    'station_candidate_count',
+):
+    print(f'{key}:', payload.get(key))
+print('candidate_samples:', sample_count)
+PY
+
+echo "== Secret/path sanity check =="
+sensitive_pattern='postgre''sql://|post''gres://|pass''word=|PG''PASSWORD|SEC''RET|TOK''EN|/var/lib/ed-finder|/root/'
+if grep -Eq "$sensitive_pattern" "$COMPACT_SUMMARY"; then
+  stop "compact summary may contain credentials or private paths. Review the operator artifact out of band; do not commit it."
+fi
+echo "OK: no obvious credential/private path markers found"
+
+if [[ "$CHECK_CANONICAL_COUNT" == "yes" ]]; then
+  echo "== Canonical station count =="
+  docker compose exec -T postgres psql -U edfinder -d edfinder -t -A -v ON_ERROR_STOP=1 -c "SELECT count(*) FROM stations;"
+else
+  echo "== Canonical station count =="
+  echo "SKIPPED: set CHECK_CANONICAL_COUNT=yes to run the read-only Docker/Postgres count check."
+fi
+
+echo "OK: compact reconciliation summary generated."
+echo "OK: no reconciliation, station-type dry-run, or apply was run by this script."


### PR DESCRIPTION
## What changed

* Adds operator environment guardrails for Hetzner-only commands.
* Adds a reusable compact-summary operator script.
* Documents Codex vs DAVE2 vs Hetzner command contexts.
* Updates roadmap/runbook docs.

## Boundary confirmations

* Tooling/docs only.
* No production commands run.
* No production DB touched.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No cron/scheduler wiring implemented.
* Stage 18J-P not started.
* Stage 18K not started.

## Validation

* `git diff --check` - passed.
* `git diff --cached --check` - passed.
* `bash -n scripts/operator/require_hetzner_operator_env.sh` - passed.
* `bash -n scripts/operator/stage18j_run_compact_summary.sh` - passed.
* `./scripts/run_canonical_safety_tests.sh` - 83 passed; disposable Postgres rehearsal skipped because no explicit canonical test DSN confirmation was set.
* `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q` - 83 passed.
* `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py` - passed.
* Secret scan: `grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' scripts/operator docs/operations/operator-command-contexts.md docs/operations/enrichment-warehouse-runbook.md docs/colonisation-redesign/enrichment-roadmap.md docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md 2>/dev/null || true` - no matches.