### PR TITLE
Stage 18J-P-filter strict station-type dry-run filter

### DIFF
--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -49,21 +49,14 @@ APPROVED_FIELD = 'station_type'
 DEFAULT_LIMIT = 5
 MAX_FIRST_PILOT_LIMIT = 20
 ELIGIBLE_OLD_TYPE_LABELS = {None, '', 'Unknown'}
-BLOCKING_RISK_CLASSES = {'blocked', 'risky', 'stale', 'volatile', 'unknown'}
-BLOCKING_RECONCILIATION_STATES = {'blocked', 'source_only', 'unresolved', 'unknown'}
-BLOCKING_REVIEW_CLASSIFICATIONS = {
-    'blocked',
-    'report_only',
-    'risky',
-    'stale',
-    'volatile',
-    'source_only',
-    'unknown',
-}
+VOLATILE_RISK_FLAGS = {'volatile_source_class', 'volatile_source_evidence'}
+SOURCE_ONLY_RISK_FLAGS = {'source_only_evidence'}
+AMBIGUOUS_RISK_FLAGS = {'ambiguous_canonical_match'}
+STATION_BODY_LINK_ONLY_RISK_FLAGS = {'missing_station_body_name'}
+REPORT_ONLY_STATION_TYPE_REVIEW_FLAGS = {'canonical_difference_review'}
 BLOCKING_RISK_FLAGS = {
     'ambiguous_canonical_match',
     'ambiguous_staged_body_evidence',
-    'canonical_difference_review',
     'insufficient_identifiers',
     'missing_staged_body_evidence',
     'missing_station_body_name',
@@ -74,6 +67,23 @@ BLOCKING_RISK_FLAGS = {
     'volatile_source_class',
     'volatile_source_evidence',
 }
+STATION_TYPE_DRY_RUN_ALLOWED_RISK_FLAGS = (
+    STATION_BODY_LINK_ONLY_RISK_FLAGS
+    | REPORT_ONLY_STATION_TYPE_REVIEW_FLAGS
+)
+STATION_TYPE_DRY_RUN_REJECTION_REASONS = (
+    'rejected_ambiguous_identity',
+    'rejected_source_only_insert',
+    'rejected_missing_external_identity',
+    'rejected_volatile_evidence',
+    'rejected_transient_non_slot',
+    'rejected_non_station_type_change',
+    'rejected_missing_station_type_delta',
+    'rejected_ineligible_canonical_old_value',
+    'rejected_missing_provenance',
+    'rejected_freshness',
+    'rejected_by_max_row_bound',
+)
 
 
 class Stage18JPlanError(ValueError):
@@ -96,18 +106,28 @@ def build_station_type_pilot_dry_run(
     reconciliation_report: Mapping[str, Any],
     *,
     limit: int | None = DEFAULT_LIMIT,
-    allow_edsm_station_id: bool = False,
+    allow_edsm_station_id: bool = True,
     allow_undated_source_exception: bool = False,
+    reconciliation_artifact_sha256: str | None = None,
+    reconciliation_artifact_basename: str | None = None,
+    reconciliation_artifact_size_bytes: int | None = None,
     generated_at: str | None = None,
     git_commit: str | None = None,
 ) -> dict[str, Any]:
     """Build a deterministic dry-run artifact for exact station type promotion."""
-    if limit is not None and limit < 0:
+    if limit is None:
+        raise Stage18JPlanError('explicit max-row bound is required')
+    if limit < 0:
         raise Stage18JPlanError('limit must be >= 0')
-    if limit is not None and limit > MAX_FIRST_PILOT_LIMIT:
+    if limit > MAX_FIRST_PILOT_LIMIT:
         raise Stage18JPlanError(f'limit must be <= {MAX_FIRST_PILOT_LIMIT} for the first Stage 18J pilot')
 
-    source_scope = _source_scope(reconciliation_report)
+    source_scope = _source_scope(
+        reconciliation_report,
+        reconciliation_artifact_sha256=reconciliation_artifact_sha256,
+        reconciliation_artifact_basename=reconciliation_artifact_basename,
+        reconciliation_artifact_size_bytes=reconciliation_artifact_size_bytes,
+    )
     eligible: list[dict[str, Any]] = []
     blocked: list[dict[str, Any]] = []
     rows_considered = 0
@@ -121,14 +141,15 @@ def build_station_type_pilot_dry_run(
             allow_edsm_station_id=allow_edsm_station_id,
             allow_undated_source_exception=allow_undated_source_exception,
         )
-        if decision['eligible'] and (limit is None or len(eligible) < limit):
+        if decision['eligible'] and len(eligible) < limit:
             eligible.append(decision['candidate'])
         elif decision['eligible']:
             blocked.append({
                 'candidate_id': decision['candidate']['candidate_id'],
                 'source_identity': decision['candidate']['source_identity'],
                 'canonical': decision['candidate']['canonical'],
-                'blocking_reasons': ['pilot_limit_excluded'],
+                'rejection_reasons': ['rejected_by_max_row_bound'],
+                'blocking_reasons': ['rejected_by_max_row_bound'],
                 'eligible_if_limit_allows': True,
             })
         else:
@@ -136,7 +157,8 @@ def build_station_type_pilot_dry_run(
 
     eligible = sorted(eligible, key=canonical_json)
     blocked = sorted(blocked, key=canonical_json)
-    blocked_by_reason = _blocked_reason_distribution(blocked)
+    rejection_reason_counts = _blocked_reason_distribution(blocked)
+    rejection_summary = _rejection_summary(rejection_reason_counts)
     now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
     artifact: dict[str, Any] = {
         'schema_version': DRY_RUN_SCHEMA_VERSION,
@@ -153,19 +175,35 @@ def build_station_type_pilot_dry_run(
             'default_limit': DEFAULT_LIMIT,
             'max_first_pilot_limit': MAX_FIRST_PILOT_LIMIT,
             'apply_requires_separate_guarded_mode': True,
+            'dry_run_only': True,
+            'canonical_writes_planned': 0,
         },
         'source_scope': source_scope,
         'filters': {
             'limit': limit,
+            'max_row_bound': limit,
             'allow_edsm_station_id': allow_edsm_station_id,
             'allow_undated_source_exception': allow_undated_source_exception,
+            'requires_external_identity_proof': True,
+            'requires_update_only_candidate_action': True,
+            'requires_station_type_only_delta': True,
+            'excludes_station_body_association_writes': True,
+            'excludes_volatile_evidence': True,
+            'excludes_transient_non_slot_station_types': True,
         },
         'summary': {
+            **rejection_summary,
+            'total_candidates_seen': rows_considered,
             'station_candidates_considered': rows_considered,
+            'eligible_station_type_updates': len(eligible),
             'eligible_candidates': len(eligible),
             'blocked_candidates': len(blocked),
-            'blocked_by_reason': blocked_by_reason,
-            'canonical_writes_planned': len(eligible),
+            'rejection_reason_counts': rejection_reason_counts,
+            'blocked_by_reason': rejection_reason_counts,
+            'canonical_writes_planned': 0,
+            'dry_run_only': True,
+            'apply_run': False,
+            'approval_record_created': False,
             'approved_table': APPROVED_TABLE,
             'approved_field': APPROVED_FIELD,
             'errors': 0,
@@ -177,10 +215,13 @@ def build_station_type_pilot_dry_run(
             'manual_approval_required': True,
             'apply_requires_separate_guarded_tool': True,
             'ordinary_warehouse_loaders_must_remain_canonical_read_only': True,
+            'production_artifact_approved': False,
+            'approval_record_created': False,
             'review_guidance': [
                 'Approve only a checksumed dry-run artifact with a small row count.',
                 'Apply must be table-specific, field-specific, source-run-specific, and fail closed.',
-                'Source-only, stale, volatile, risky, blocked, unknown, and report-only evidence remains non-canonical.',
+                'Source-only inserts, ambiguous identity, volatile evidence, transient station types, and non-station-type deltas remain blocked.',
+                'Missing station_body_name remains a blocker for station/body-link work, not for externally proven station-type comparison.',
             ],
         },
     }
@@ -195,7 +236,7 @@ def build_station_type_pilot_dry_run(
 def evaluate_station_type_candidate(
     candidate: Mapping[str, Any],
     *,
-    allow_edsm_station_id: bool = False,
+    allow_edsm_station_id: bool = True,
     allow_undated_source_exception: bool = False,
 ) -> dict[str, Any]:
     """Evaluate one reconciliation station candidate against Stage 18J rules."""
@@ -216,51 +257,53 @@ def evaluate_station_type_candidate(
     canonical_edsm_station_id = _read_int(canonical.get('edsm_station_id'))
     source_name = source.get('station_name')
     canonical_name = canonical.get('station_name')
+    candidate_action = candidate.get('candidate_action')
+    risk_flags = set(candidate.get('risk_flags') or [])
+    review_classifications = set(candidate.get('review_classifications') or [])
+
+    identifier_match_type = _station_external_identifier_match_type(
+        source_market_id=source_market_id,
+        canonical_market_id=canonical_market_id,
+        source_edsm_station_id=source_edsm_station_id,
+        canonical_edsm_station_id=canonical_edsm_station_id,
+        allow_edsm_station_id=allow_edsm_station_id,
+    )
 
     checks = {
         'entity_is_station': candidate.get('entity') == 'station',
         'target_difference_is_station_type_only': _has_only_station_type_difference(differences),
-        'exactly_one_canonical_match': len(canonical_matches) == 1 and bool(canonical),
+        'has_no_non_station_type_difference': not _has_non_station_type_difference(differences),
+        'candidate_action_is_update': candidate_action == 'candidate_update',
+        'not_source_only_insert': candidate_action != 'candidate_insert_missing_canonical',
+        'not_ambiguous_identity': candidate_action != 'ambiguous_match' and len(canonical_matches) == 1 and bool(canonical),
         'canonical_station_exists': canonical_station_id is not None,
         'source_system_id64_present': source_system_id64 is not None,
         'system_id64_matches': source_system_id64 is not None and source_system_id64 == canonical_system_id64,
-        'stable_station_identifier_matches': False,
+        'external_station_identifier_matches': identifier_match_type is not None,
+        'internal_primary_key_not_identity_proof': True,
         'station_name_matches': _normalise_name(source_name) is not None and _normalise_name(source_name) == _normalise_name(canonical_name),
         'source_station_type_present': source_station_type not in (None, ''),
         'source_station_type_normalised': new_value is not None,
+        'station_type_delta_present': _station_type_delta_present(old_value, new_value),
         'source_station_type_permanent': bool(new_value) and is_permanent_colony_slot_station_type(new_value),
         'source_station_type_not_transient': bool(new_value) and not is_transient_non_slot_station_type(new_value),
         'canonical_old_value_eligible': _canonical_old_value_eligible(old_value),
-        'risk_class_clear': candidate.get('risk_class') == 'clear',
-        'reconciliation_state_allowed': candidate.get('reconciliation_state') == 'confirmed',
-        'no_blocking_risk_flags': not (set(candidate.get('risk_flags') or []) & BLOCKING_RISK_FLAGS),
-        'no_blocking_review_classifications': not (set(candidate.get('review_classifications') or []) & BLOCKING_REVIEW_CLASSIFICATIONS),
-        'not_report_only_evidence': candidate.get('report_only') is not True,
+        'no_volatile_evidence': not _has_volatile_evidence(candidate, source=source, warnings=warnings),
+        'no_unhandled_blocking_risk_flags': not _unhandled_station_type_blocking_risk_flags(risk_flags),
         'source_record_hash_present': bool(source.get('source_record_hash')),
         'source_run_key_present': bool(source.get('source_run_key')),
         'source_file_key_present': bool(source.get('source_file_key')),
-        'source_not_volatile': source.get('source_class') != 'volatile',
-        'no_volatile_warnings': not any(warning.get('reason') == 'volatile_source_evidence_not_canonical_update' for warning in warnings),
         'freshness_allowed': _freshness_allowed(candidate, allow_undated_source_exception=allow_undated_source_exception),
+        'no_station_body_association_write': True,
+        'canonical_writes_planned_zero': _mapping(candidate).get('canonical_writes_planned', 0) in (0, None),
     }
 
-    identifier_match_type = None
-    # canonical.station_id is the database update target. It is not accepted as
-    # external identity proof unless the canonical payload also exposes the
-    # matching external identity field.
-    if source_market_id is not None and canonical_market_id is not None and source_market_id == canonical_market_id:
-        checks['stable_station_identifier_matches'] = True
-        identifier_match_type = 'market_id'
-    elif (
-        allow_edsm_station_id
-        and source_edsm_station_id is not None
-        and canonical_edsm_station_id is not None
-        and source_edsm_station_id == canonical_edsm_station_id
-    ):
-        checks['stable_station_identifier_matches'] = True
-        identifier_match_type = 'edsm_station_id'
-
-    blocking_reasons = [name for name, passed in checks.items() if not passed]
+    rejection_reasons = _station_type_rejection_reasons(
+        candidate=candidate,
+        checks=checks,
+        risk_flags=risk_flags,
+        review_classifications=review_classifications,
+    )
     candidate_id = _candidate_id(source=source, canonical_station_id=canonical_station_id, new_value=new_value)
     common = {
         'candidate_id': candidate_id,
@@ -300,6 +343,8 @@ def evaluate_station_type_candidate(
             'canonical_system_id64': canonical_system_id64,
             'normalised_source_station_name': _normalise_name(source_name),
             'normalised_canonical_station_name': _normalise_name(canonical_name),
+            'external_identity_proof_required': True,
+            'internal_primary_key_is_not_identity_proof': True,
             'allow_edsm_station_id': allow_edsm_station_id,
         },
         'eligibility_checks': checks,
@@ -316,12 +361,13 @@ def evaluate_station_type_candidate(
         },
     }
 
-    if blocking_reasons:
+    if rejection_reasons:
         return {
             'eligible': False,
             'blocked_candidate': {
                 **common,
-                'blocking_reasons': blocking_reasons,
+                'rejection_reasons': rejection_reasons,
+                'blocking_reasons': rejection_reasons,
             },
         }
 
@@ -631,8 +677,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Stage 18J station-type canonical pilot tooling.')
     parser.add_argument('--reconciliation-report', default=None, help='Path to read-only warehouse reconciliation JSON for dry-run mode.')
     parser.add_argument('--output', default=None, help='Optional output path. Defaults to stdout only.')
-    parser.add_argument('--limit', type=int, default=DEFAULT_LIMIT, help='Maximum eligible candidates to include.')
-    parser.add_argument('--allow-edsm-station-id', action='store_true', help='Allow edsm_station_id as a reviewed stable identifier.')
+    parser.add_argument('--limit', type=int, default=DEFAULT_LIMIT, help='Explicit max-row bound for eligible dry-run candidates.')
+    parser.add_argument('--allow-edsm-station-id', action='store_true', help='Compatibility flag; edsm_station_id is allowed as external identity by the strict filter.')
     parser.add_argument('--allow-undated-source-exception', action='store_true', help='Allow otherwise eligible undated/file-snapshot rows in dry-run review.')
     parser.add_argument('--json', action='store_true', help='Accepted for compatibility; output is always JSON.')
     parser.add_argument('--dry-run', action='store_true', default=True, help='Dry-run mode. This is the default.')
@@ -653,6 +699,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if args.write or args.commit:
         parser.error('--write/--commit are not supported; use --apply with explicit Stage 18J approval parameters')
+    if not args.apply and args.limit is None:
+        parser.error('dry-run mode requires an explicit --limit max-row bound')
     if args.apply:
         required = {
             '--artifact': args.artifact,
@@ -672,6 +720,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             parser.error('apply mode requires --confirm-station-type-canonical-pilot')
     elif not args.reconciliation_report:
         parser.error('--reconciliation-report is required in dry-run mode')
+    elif args.dsn:
+        parser.error('--dsn is only valid in apply mode')
     return args
 
 
@@ -696,13 +746,17 @@ def main(argv: Sequence[str] | None = None) -> int:
                 max_rows=args.max_rows,
             )
         else:
-            with open(args.reconciliation_report, 'r', encoding='utf-8') as handle:
+            reconciliation_report_path = Path(args.reconciliation_report)
+            with open(reconciliation_report_path, 'r', encoding='utf-8') as handle:
                 reconciliation_report = json.load(handle)
             artifact = build_station_type_pilot_dry_run(
                 reconciliation_report,
                 limit=args.limit,
-                allow_edsm_station_id=args.allow_edsm_station_id,
+                allow_edsm_station_id=True,
                 allow_undated_source_exception=args.allow_undated_source_exception,
+                reconciliation_artifact_sha256=_file_sha256(reconciliation_report_path),
+                reconciliation_artifact_basename=reconciliation_report_path.name,
+                reconciliation_artifact_size_bytes=reconciliation_report_path.stat().st_size,
             )
     except (OSError, ValueError, TypeError) as exc:
         print(f'Stage 18J station type pilot failed: {exc}', file=sys.stderr)
@@ -721,6 +775,14 @@ def _connect_postgres(dsn: str) -> Any:
     except ImportError as exc:  # pragma: no cover - exercised only in real apply environments
         raise Stage18JPlanError('psycopg2 is required for guarded apply mode') from exc
     return psycopg2.connect(dsn)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, 'rb') as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _fetchone_mapping(cur: Any) -> dict[str, Any] | None:
@@ -750,16 +812,138 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
 
 
-def _source_scope(report: Mapping[str, Any]) -> dict[str, Any]:
+def _source_scope(
+    report: Mapping[str, Any],
+    *,
+    reconciliation_artifact_sha256: str | None = None,
+    reconciliation_artifact_basename: str | None = None,
+    reconciliation_artifact_size_bytes: int | None = None,
+) -> dict[str, Any]:
     filters = _mapping(report.get('filters'))
     return {
         'input_schema_version': report.get('schema_version'),
         'input_dry_run': report.get('dry_run'),
+        'input_artifact_basename': reconciliation_artifact_basename,
+        'input_artifact_sha256': reconciliation_artifact_sha256,
+        'input_artifact_size_bytes': reconciliation_artifact_size_bytes,
         'source_run_key': filters.get('source_run_key'),
         'source_file_key': filters.get('source_file_key'),
         'source': filters.get('source'),
         'input_canonical_writes_planned': _mapping(report.get('summary')).get('canonical_writes_planned'),
     }
+
+
+def _station_external_identifier_match_type(
+    *,
+    source_market_id: int | None,
+    canonical_market_id: int | None,
+    source_edsm_station_id: int | None,
+    canonical_edsm_station_id: int | None,
+    allow_edsm_station_id: bool,
+) -> str | None:
+    # canonical.station_id is the database update target. It is not accepted as
+    # external identity proof unless the canonical payload also exposes the
+    # matching external identity field.
+    if source_market_id is not None and canonical_market_id is not None and source_market_id == canonical_market_id:
+        return 'market_id'
+    if (
+        allow_edsm_station_id
+        and source_edsm_station_id is not None
+        and canonical_edsm_station_id is not None
+        and source_edsm_station_id == canonical_edsm_station_id
+    ):
+        return 'edsm_station_id'
+    return None
+
+
+def _station_type_rejection_reasons(
+    *,
+    candidate: Mapping[str, Any],
+    checks: Mapping[str, bool],
+    risk_flags: set[Any],
+    review_classifications: set[Any],
+) -> list[str]:
+    reasons: set[str] = set()
+    action = candidate.get('candidate_action')
+    if action == 'ambiguous_match' or not checks.get('not_ambiguous_identity'):
+        reasons.add('rejected_ambiguous_identity')
+    if action == 'candidate_insert_missing_canonical' or risk_flags & SOURCE_ONLY_RISK_FLAGS:
+        reasons.add('rejected_source_only_insert')
+    if (
+        not checks.get('canonical_station_exists')
+        or not checks.get('source_system_id64_present')
+        or not checks.get('external_station_identifier_matches')
+        or not checks.get('system_id64_matches')
+        or not checks.get('station_name_matches')
+    ):
+        reasons.add('rejected_missing_external_identity')
+    if not checks.get('no_volatile_evidence') or 'volatile' in review_classifications:
+        reasons.add('rejected_volatile_evidence')
+    if not checks.get('source_station_type_permanent') or not checks.get('source_station_type_not_transient'):
+        reasons.add('rejected_transient_non_slot')
+    if not checks.get('entity_is_station') or not checks.get('has_no_non_station_type_difference'):
+        reasons.add('rejected_non_station_type_change')
+    if (
+        action not in {'candidate_update', 'candidate_insert_missing_canonical', 'ambiguous_match'}
+        or not checks.get('source_station_type_present')
+        or not checks.get('source_station_type_normalised')
+        or not checks.get('station_type_delta_present')
+    ):
+        reasons.add('rejected_missing_station_type_delta')
+    if not checks.get('canonical_old_value_eligible'):
+        reasons.add('rejected_ineligible_canonical_old_value')
+    if (
+        not checks.get('source_record_hash_present')
+        or not checks.get('source_run_key_present')
+        or not checks.get('source_file_key_present')
+    ):
+        reasons.add('rejected_missing_provenance')
+    if not checks.get('freshness_allowed'):
+        reasons.add('rejected_freshness')
+
+    unhandled_risk_flags = _unhandled_station_type_blocking_risk_flags(risk_flags)
+    if unhandled_risk_flags:
+        if unhandled_risk_flags & AMBIGUOUS_RISK_FLAGS:
+            reasons.add('rejected_ambiguous_identity')
+        elif unhandled_risk_flags & SOURCE_ONLY_RISK_FLAGS:
+            reasons.add('rejected_source_only_insert')
+        elif unhandled_risk_flags & VOLATILE_RISK_FLAGS:
+            reasons.add('rejected_volatile_evidence')
+        else:
+            reasons.add('rejected_non_station_type_change')
+    if not checks.get('canonical_writes_planned_zero'):
+        reasons.add('rejected_non_station_type_change')
+    return sorted(reasons)
+
+
+def _unhandled_station_type_blocking_risk_flags(risk_flags: set[Any]) -> set[str]:
+    normalized = {str(flag) for flag in risk_flags}
+    return normalized - STATION_TYPE_DRY_RUN_ALLOWED_RISK_FLAGS
+
+
+def _has_volatile_evidence(
+    candidate: Mapping[str, Any],
+    *,
+    source: Mapping[str, Any],
+    warnings: Sequence[Mapping[str, Any]],
+) -> bool:
+    risk_flags = {str(flag) for flag in candidate.get('risk_flags') or []}
+    review_classifications = {str(item) for item in candidate.get('review_classifications') or []}
+    if source.get('source_class') == 'volatile':
+        return True
+    if candidate.get('risk_class') == 'volatile':
+        return True
+    if risk_flags & VOLATILE_RISK_FLAGS:
+        return True
+    if 'volatile' in review_classifications:
+        return True
+    return any(warning.get('reason') == 'volatile_source_evidence_not_canonical_update' for warning in warnings)
+
+
+def _station_type_delta_present(old_value: Any, new_value: Any) -> bool:
+    if new_value is None:
+        return False
+    return _normalise_station_type_value(old_value) != new_value
 
 
 def _station_type_difference_value(differences: Sequence[Mapping[str, Any]]) -> Any:
@@ -771,6 +955,10 @@ def _station_type_difference_value(differences: Sequence[Mapping[str, Any]]) -> 
 
 def _has_only_station_type_difference(differences: Sequence[Mapping[str, Any]]) -> bool:
     return len(differences) == 1 and differences[0].get('field') == APPROVED_FIELD
+
+
+def _has_non_station_type_difference(differences: Sequence[Mapping[str, Any]]) -> bool:
+    return any(difference.get('field') != APPROVED_FIELD for difference in differences)
 
 
 def _canonical_old_value_eligible(value: Any) -> bool:
@@ -807,9 +995,17 @@ def _candidate_id(*, source: Mapping[str, Any], canonical_station_id: int | None
 def _blocked_reason_distribution(blocked: Sequence[Mapping[str, Any]]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for row in blocked:
-        for reason in row.get('blocking_reasons', []) or []:
+        reasons = row.get('rejection_reasons') or row.get('blocking_reasons') or []
+        for reason in reasons:
             counts[str(reason)] = counts.get(str(reason), 0) + 1
     return dict(sorted(counts.items()))
+
+
+def _rejection_summary(rejection_reason_counts: Mapping[str, int]) -> dict[str, int]:
+    return {
+        reason: int(rejection_reason_counts.get(reason, 0))
+        for reason in STATION_TYPE_DRY_RUN_REJECTION_REASONS
+    }
 
 
 def _normalise_name(value: Any) -> str | None:

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -543,6 +543,17 @@ non-ambiguous, non-volatile, permanent station-type candidates with an explicit
 max-row bound. See
 [`stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md`](./stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md).
 
+Stage 18J-P-filter hardens the station-type dry-run filter before any
+production dry-run retry. The pilot now requires external station identity via
+matching `market_id` or matching `edsm_station_id`, rejects internal
+primary-key-only identity proof, excludes ambiguous/source-only/volatile/
+transient/non-station-type candidates, keeps missing `station_body_name` as a
+station/body-link blocker only, requires an explicit max-row bound, records the
+input reconciliation artifact checksum, and keeps dry-run
+`canonical_writes_planned = 0`. It does not run Stage 18J-P or authorize apply.
+See
+[`stage-18j-p-filter-strict-station-type-dry-run-filter.md`](./stage-18j-p-filter-strict-station-type-dry-run-filter.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -610,6 +621,9 @@ treated as a separate proposal.
 * **Station-type dry-run readiness**: Stage 18J-Q9 allows only a filtered
   station-type dry-run readiness path. Do not run Stage 18J-P against the full
   station reconciliation candidate set.
+* **Strict station-type filter hardening**: Stage 18J-P-filter implements the
+  strict filter and synthetic tests. A future Stage 18J-P production dry-run
+  can proceed only as a separate operator step after this hardening merges.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -817,6 +817,37 @@ Non-goals:
 Support doc:
 `stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md`.
 
+### Stage 18J-P-filter - Strict Station-Type Dry-Run Filter Hardening
+
+Purpose: harden the station-type dry-run eligibility filter before any future
+Stage 18J-P production dry-run retry.
+
+Scope:
+
+- Require explicit external station identity proof by matching `market_id` or
+  matching `edsm_station_id`; internal canonical `station_id` is not identity
+  proof.
+- Reject ambiguous identity, source-only inserts, volatile evidence,
+  transient/non-slot station types, non-station-type changes, missing
+  station-type deltas, and candidates outside the explicit max-row bound.
+- Preserve `missing_station_body_name` as a station/body-link blocker while
+  allowing externally proven station-type comparisons.
+- Keep dry-run output at `canonical_writes_planned = 0`, record the input
+  reconciliation artifact checksum, and report explicit rejection counts.
+- Add synthetic tests only.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No imports, reconciliation, production summarizer run, production
+  station-type dry-run, or canonical apply.
+- No approval record.
+- No Stage 18J-P or Stage 18K work.
+
+Support doc:
+`stage-18j-p-filter-strict-station-type-dry-run-filter.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -891,5 +922,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 27. Stage 19A warehouse artifact taxonomy and chunked roadmap.
 28. Stage 19A.1 operator path guardrails.
 29. Stage 18J-Q9 compact summary review / station-type dry-run readiness.
+30. Stage 18J-P-filter strict station-type dry-run filter hardening.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
+++ b/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
@@ -1,0 +1,150 @@
+# Stage 18J-P-filter - Strict Station-Type Dry-Run Filter
+
+## Purpose
+
+Stage 18J-P-filter hardens the station-type dry-run candidate filter before any
+future Stage 18J-P production dry-run retry. It converts the Stage 18J-Q9
+readiness verdict, `Ready only with strict filter`, into code-level dry-run
+eligibility rules and synthetic test coverage.
+
+This stage does not run production commands, touch the production DB, run
+imports, run reconciliation, run the summarizer against production artifacts,
+run a production station-type dry-run, run canonical apply, create approval
+records, start Stage 18J-P, or start Stage 18K.
+
+## Inputs
+
+Stage 18J-Q9 reviewed the compact reconciliation summary and found:
+
+- `298177` station candidates,
+- `163722` station candidate updates,
+- `35340` source-only missing-canonical candidates,
+- `98857` no-change candidates,
+- `258` ambiguous matches,
+- `298177` station/body association candidates blocked by missing body names,
+- volatile evidence present,
+- `15014` high-confidence rows.
+
+Those counts show that the full station reconciliation candidate set is too
+broad for a production station-type dry-run. The future retry must be bounded
+and filtered before an operator runs it.
+
+## Filter Contract
+
+The station-type dry-run planner now requires:
+
+- explicit external station identity proof by matching `source.market_id` to
+  `canonical.market_id`, or matching `source.edsm_station_id` to
+  `canonical.edsm_station_id`;
+- no identity proof from internal canonical `station_id` or primary-key
+  equality alone;
+- exactly one canonical station match;
+- `candidate_action = candidate_update`;
+- `stations.station_type` as the only target field;
+- a present station-type delta;
+- a permanent colony-slot station type;
+- no fleet carrier, megaship, transient, mobile, or non-slot station type;
+- no source-only insert candidate;
+- no volatile evidence;
+- no station/body association writes;
+- no non-station-type canonical writes;
+- a required explicit max-row bound.
+
+Missing `station_body_name` remains a station/body-link blocker, but it no
+longer blocks an otherwise externally proven station-type comparison. This
+keeps station-type comparison separate from station/body association work.
+
+## Rejection Reasons
+
+Every excluded station candidate receives machine-readable rejection reasons.
+The dry-run summary includes these counts:
+
+- `total_candidates_seen`
+- `eligible_station_type_updates`
+- `rejected_ambiguous_identity`
+- `rejected_source_only_insert`
+- `rejected_missing_external_identity`
+- `rejected_volatile_evidence`
+- `rejected_transient_non_slot`
+- `rejected_non_station_type_change`
+- `rejected_missing_station_type_delta`
+- `rejected_ineligible_canonical_old_value`
+- `rejected_missing_provenance`
+- `rejected_freshness`
+- `rejected_by_max_row_bound`
+
+The artifact keeps `rejection_reason_counts` and the legacy
+`blocked_by_reason` map aligned so existing review flows can still inspect the
+distribution.
+
+## Dry-Run Output
+
+The dry-run artifact remains `station_type_canonical_pilot_dry_run/v1` and is
+still deterministic. It now records the input reconciliation artifact basename,
+size, and SHA-256 when invoked through the CLI, so a future operator review can
+tie the dry-run to the exact read-only reconciliation artifact.
+
+The dry-run output explicitly records:
+
+- `dry_run = true`,
+- `summary.canonical_writes_planned = 0`,
+- `summary.apply_run = false`,
+- `summary.approval_record_created = false`,
+- `operator_review.production_artifact_approved = false`.
+
+Eligible rows are reported as `eligible_station_type_updates`; they are not
+canonical writes, approval records, or apply instructions.
+
+## Tests
+
+Synthetic tests cover:
+
+- market ID external identity qualifies;
+- EDSM station ID external identity qualifies;
+- internal primary-key-only matching does not qualify;
+- ambiguous matches are rejected;
+- source-only insert candidates are rejected;
+- missing `station_body_name` does not block externally proven station-type
+  comparison;
+- missing `station_body_name` remains blocked for station/body-link candidates;
+- volatile evidence is rejected;
+- fleet carriers and megaships are rejected as transient/non-slot;
+- non-station-type changes are rejected;
+- an explicit max-row bound is required;
+- rejection reason counts are present;
+- `canonical_writes_planned` remains `0`;
+- the dry-run path does not invoke apply.
+
+## Boundaries
+
+This stage does not authorize Stage 18J-P. It only hardens the local code and
+tests so a future operator command can be reviewed against the strict filter.
+
+Still blocked:
+
+- production station-type dry-run,
+- canonical apply,
+- approval record creation,
+- station/body association writes,
+- Stage 18J-P,
+- Stage 18K.
+
+## Future Stage 18J-P Effect
+
+After this stage merges, a future Stage 18J-P production dry-run can proceed
+only when separately prompted in the Hetzner operator shell and only with:
+
+- the reviewed production reconciliation artifact,
+- the explicit max-row bound,
+- the recorded source artifact checksum,
+- compact/reviewable dry-run output,
+- no approval record,
+- no canonical apply.
+
+Stage 18J-P remains blocked until that separate operator step is requested.
+
+## Final Recommendation
+
+Merge the strict filter hardening before retrying Stage 18J-P. After merge, the
+future production dry-run is technically eligible to proceed as a separate
+operator step, but it is not started or approved by this stage.

--- a/docs/colonisation-redesign/stage-18j-p-station-type-production-dry-run-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-p-station-type-production-dry-run-readiness.md
@@ -162,8 +162,7 @@ must show:
 - `field = "station_type"`.
 - `canonical.station_type` is unknown/empty/eligible under the narrow rule.
 - `new_value` is an approved permanent station type.
-- `match_proof.identifier_match_type` is `market_id`, or `edsm_station_id`
-  only when explicitly allowed.
+- `match_proof.identifier_match_type` is `market_id` or `edsm_station_id`.
 - The source and canonical external identity values match on explicit fields.
 - The candidate count is small enough for complete manual review.
 
@@ -182,8 +181,7 @@ report-only evidence must remain blocked.
 The merged Stage 18J pilot code enforces the important identity boundary:
 
 - `source.market_id` matches explicit `canonical.market_id` only.
-- `source.edsm_station_id` matches explicit `canonical.edsm_station_id` only
-  when the EDSM flag is used.
+- `source.edsm_station_id` matches explicit `canonical.edsm_station_id`.
 - `canonical.station_id` is treated as the internal database primary key and
   update target, not as external identity proof.
 - Internal primary key equality alone cannot satisfy stable identity.
@@ -207,11 +205,12 @@ No production source freshness, risk, or blocking distribution was available.
 
 Future review must confirm:
 
-- `risk_class = clear` for every eligible candidate.
-- `reconciliation_state = confirmed` for every eligible candidate.
-- `report_only` evidence is not selected.
-- stale, volatile, risky, source-only, unknown, and blocked classifications are
-  not selected.
+- Stage 18J-specific eligibility passes for every candidate.
+- Source-only inserts, ambiguous identity, stale/undated evidence without
+  exception, volatile evidence, transient/non-slot station types, unknown
+  station-type deltas, and non-station-type changes are not selected.
+- Report-only reconciliation rows are not write instructions; they may feed the
+  dry-run only after the strict filter passes.
 - source run key, source file key, source record key/hash, and source freshness
   are present.
 - missing or undated source evidence is either blocked or covered by a
@@ -278,8 +277,8 @@ Stop before any future apply if:
 - approved table/field/source run/source file mismatches,
 - max row count is missing or too high,
 - current canonical pre-image differs,
-- any selected candidate is source-only, stale, volatile, risky, blocked,
-  unknown, report-only, ambiguous, or identity-unsafe,
+- any selected candidate is source-only insert, stale, volatile, blocked,
+  unknown, ambiguous, transient/non-slot, non-station-type, or identity-unsafe,
 - any write would target a table or field outside `stations.station_type`,
 - post-apply verification cannot be emitted and reviewed.
 
@@ -308,3 +307,27 @@ access. Once that artifact exists, rerun the Stage 18J dry-run command with
 `--limit 5`, review every eligible candidate manually, and approve nothing
 until the exact artifact hash, candidate count, table, field, source run/file,
 and max row count are explicitly accepted.
+
+## Stage 18J-P-filter Follow-Up
+
+Stage 18J-Q9 later reviewed the compact reconciliation summary and set the
+verdict to `Ready only with strict filter`. Stage 18J-P-filter hardens that
+filter in code before any production dry-run retry:
+
+- external identity proof requires matching `market_id` or matching
+  `edsm_station_id`;
+- internal canonical `station_id` / primary-key equality alone cannot prove
+  identity;
+- ambiguous matches, source-only inserts, volatile evidence, transient/non-slot
+  station types, and non-station-type changes are rejected;
+- missing `station_body_name` remains a station/body-link blocker but does not
+  block an otherwise externally proven station-type comparison;
+- dry-run output keeps `canonical_writes_planned = 0` and reports eligible
+  rows separately as `eligible_station_type_updates`;
+- the input reconciliation artifact checksum is recorded in the dry-run
+  output.
+
+See
+[`stage-18j-p-filter-strict-station-type-dry-run-filter.md`](./stage-18j-p-filter-strict-station-type-dry-run-filter.md).
+This does not start Stage 18J-P, approve an artifact, or authorize canonical
+apply.

--- a/docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md
@@ -278,12 +278,14 @@ must not be committed to git.
 Stage 18J should continue with a narrow station-type dry-run readiness path:
 
 1. Q9 records this review and the strict filter.
-2. Stage 18J-P may retry station-type production dry-run only if separately
+2. Stage 18J-P-filter hardens the strict dry-run eligibility filter in code
+   and synthetic tests without running production commands.
+3. Stage 18J-P may retry station-type production dry-run only if separately
    prompted and if the strict filter is implemented or reconfirmed.
-3. Stage 18J-P2 reviews the filtered dry-run artifact.
-4. Stage 18J-P3 prepares a tiny apply approval packet only if the dry-run is
+4. Stage 18J-P2 reviews the filtered dry-run artifact.
+5. Stage 18J-P3 prepares a tiny apply approval packet only if the dry-run is
    boring and bounded.
-5. Stage 18J-P4 performs a tiny manual apply only if explicitly approved.
+6. Stage 18J-P4 performs a tiny manual apply only if explicitly approved.
 
 Stage 19 warehouse expansion remains separate and report-only. Stage 18K is not
 started by Q9.
@@ -296,3 +298,6 @@ station-type-only dry-run filter, an explicit max-row bound, and compact
 reviewable output. Keep station/body association work blocked, keep canonical
 apply unauthorized, and keep Stage 18J-P blocked until a separate prompt
 implements or reconfirms the filtered dry-run scope.
+
+Stage 18J-P-filter is the implementation hardening step for that filter. It
+does not run the production dry-run or approve any artifact.

--- a/docs/colonisation-redesign/stage-18j-station-type-canonical-pilot-plan.md
+++ b/docs/colonisation-redesign/stage-18j-station-type-canonical-pilot-plan.md
@@ -63,7 +63,7 @@ The pilot may read warehouse staging evidence, source-run metadata, source-file 
 | Canonical field | `station_type` only. |
 | Canonical row requirement | Existing row only; exactly one row matched. |
 | Evidence source | Offline staged station snapshot evidence, preferably from a named source run/file. |
-| Identity keys | Exact `system_id64`, normalized station name, and stable station identifier. Prefer `market_id`; allow `edsm_station_id` only when the source adapter proves stability. |
+| Identity keys | Exact `system_id64`, normalized station name, and explicit external station identifier: matching `market_id` or matching `edsm_station_id`. |
 | Artifact outputs | Dry-run artifact, approval record, apply artifact, audit record, rollback pre-image, post-apply verification artifact. |
 | Limits | Very small bounded pilot; default 5 rows and first-production maximum 20 rows. |
 
@@ -100,11 +100,11 @@ The core eligibility rule is that the source row must prove exact identity to on
 | Existing canonical station | The candidate must target an already-existing `stations` row. `candidate_insert_missing_canonical` is never eligible. |
 | Exact match cardinality | The candidate must resolve to exactly one canonical station. Zero matches and multiple matches block. |
 | System identity | Source `system_id64` must be present and equal to canonical `stations.system_id64`/canonical system `id64`. Name-only system identity is insufficient. |
-| Stable station identifier | Prefer `market_id`; allow `edsm_station_id` only if the adapter documents that the value is stable for this source. The approved identifier and value must be recorded. |
+| Stable station identifier | Require an explicit external match: source `market_id` to canonical `market_id`, or source `edsm_station_id` to canonical `edsm_station_id`. Internal canonical `station_id`/primary-key equality is never identity proof. |
 | Station name | Source station name and canonical station name must match after the same canonicalisation rule used by the pilot. Case-only differences may match; punctuation/spacing rules must be deterministic and recorded. |
 | Source station type | Source station type must be present, valid, normalized, and in the approved permanent-station-type allow-list. Unknown, blank, placeholder, carrier, transient, mobile, unsupported, or unrecognized values block. |
 | Current canonical value | Current canonical station type must be missing, blank, unknown, placeholder, or explicitly eligible under a separately approved narrow replacement rule. Existing known types should not be overwritten by default. |
-| Evidence quality | Candidate must have `risk_class = clear` or a Stage 18J-specific equivalent that is stricter than current report-only scoring. It must have no blocking, risky, stale, volatile, source-only, report-only, or unknown labels in the selected apply set. |
+| Evidence quality | Candidate must satisfy the Stage 18J-specific strict filter. Source-only inserts, ambiguous identity, stale/undated evidence without exception, volatile evidence, non-station-type deltas, and transient/non-slot station types block. `missing_station_body_name` remains a station/body-link blocker but does not block an externally proven station-type comparison. |
 | Source metadata | Candidate must include source name, adapter version, source run key, source file key, source record key/hash, freshness/timestamp state, and immutable source identity. |
 | Duplicate/skip hygiene | Source identity conflicts, malformed/skipped rows, unsupported source linkage, or duplicate identity conflicts block. |
 | Determinism | Candidate must be selected from a deterministic dry-run artifact whose canonical JSON SHA-256 is approved by the operator. |
@@ -132,7 +132,7 @@ The pilot should prefer **block** over **guess**. A block should be explicit, re
 | Missing, malformed, unsupported, duplicate, or conflicting source identity | Source evidence is not stable enough. |
 | Source station type missing, unknown, invalid, carrier, transient, mobile, or unsupported | No safe permanent station type to promote. |
 | Existing canonical station type known and not explicitly eligible | Avoids overwriting current truth with staged evidence. |
-| Risk class blocked, risky, stale, volatile, source-only, report-only, or unknown | Evidence is not safe for first canonical write. |
+| Risk class blocked, stale, volatile, source-only insert, or unknown | Evidence is not safe for first canonical write. Report-only candidate updates may feed a dry-run only after Stage 18J-specific eligibility passes; they are still not write instructions. |
 | Freshness missing/undated without explicit operator freshness exception | Avoids silently promoting stale snapshot data. |
 | Any candidate includes non-station-type differences as apply changes | Prevents scope creep. |
 | Any apply SQL targets non-approved table or field | Prevents catastrophic broad write. |
@@ -173,14 +173,19 @@ Each eligible candidate should include the following row-level fields.
 | `field` | Always `station_type`. |
 | `old_value` | Current canonical station type pre-image. |
 | `new_value` | Normalized approved permanent station type. |
-| `source_identity` | `system_id64`, `market_id`, optional approved `edsm_station_id`, station name, station type, source run/file/record keys, and source record hash. |
+| `source_identity` | `system_id64`, `market_id`, `edsm_station_id` when available, station name, station type, source run/file/record keys, and source record hash. |
 | `match_proof` | Exact system match, stable identifier match type, normalized name comparison, canonical match count, duplicate checks. |
 | `eligibility` | Pass/fail booleans for every rule, even for selected candidates. |
 | `confidence` | Confidence/risk labels, reasons, source class, freshness class, timestamp state, and non-volatile field classification. |
 | `rollback_pre_image` | Full pre-image needed to restore this field on this row. |
 | `audit_metadata` | Reason codes, operator-review text, source metadata, and tool version. |
 
-The dry-run artifact should keep `canonical_writes_planned` equal to the count of eligible station-type updates only within this new pilot schema. Existing warehouse reconciliation and coverage reports must continue to report `canonical_writes_planned = 0`, because those report families are not write plans.[4] [5]
+The dry-run artifact must keep `canonical_writes_planned = 0`; eligible rows are
+reported separately as `eligible_station_type_updates`. Existing warehouse
+reconciliation and coverage reports also continue to report
+`canonical_writes_planned = 0`, because these report families are not canonical
+apply instructions.[4] [5] Stage 18J-P-filter records the hardened filter in
+[`stage-18j-p-filter-strict-station-type-dry-run-filter.md`](./stage-18j-p-filter-strict-station-type-dry-run-filter.md).
 
 ## Apply Contract
 
@@ -357,7 +362,7 @@ Tests should be written before implementation or alongside the first dry-run-onl
 | Identity rejection | Zero matches, multiple matches, name-only matches, mismatched system ID64, mismatched normalized station name, duplicate identity conflict, and malformed/skipped linkage block. |
 | Source type rejection | Missing, unknown, placeholder, unrecognized, carrier, transient, mobile, or unsupported station types block. |
 | Current value rejection | Existing known canonical station types are not overwritten by default. |
-| Evidence-state rejection | Ambiguous, insufficient, source-only, stale, undated without approved exception, risky, blocked, volatile, unknown, and report-only candidates block. |
+| Evidence-state rejection | Ambiguous, insufficient, source-only inserts, stale, undated without approved exception, volatile, unknown, and non-station-type candidates block. Report-only reconciliation rows may feed the dry-run only after Stage 18J-specific eligibility passes; they are never canonical write instructions by themselves. |
 | Scope rejection | Distance, body name, services, economies, faction, government, allegiance, systems, bodies, links, rings, scan facts, planner, scoring, optimizer, Simulation Preview, role, and Build Plan mutations block. |
 | Apply gating | Apply requires artifact path, artifact SHA-256, expected count, approved table, approved field, approved source run, approval ID, and confirmation flag. |
 | Pre-image safety | Apply fails if current canonical pre-image differs from dry-run pre-image. |
@@ -409,7 +414,7 @@ You are implementing Stage 18J for ED-Finder. Before changing code, read:
 
 Hard scope: implement only exact `stations.station_type` canonical pilot support for existing canonical stations matched by exact trusted station identity. Do not implement station inserts, deletes, systems writes, bodies writes, station_body_links writes, body_rings writes, body_scan_facts writes, distance writes, service/economy/faction/government/allegiance writes, planner mutation, Build Plan mutation, scoring changes, Simulation Preview changes, optimizer changes, role changes, live EDSM/API crawl, UI/API Docker invocation, production scheduler wiring, or broad backfill.
 
-Start with tests and a dry-run-only artifact builder. The dry-run artifact must be deterministic and versioned as `station_type_canonical_pilot_dry_run/v1`. Eligible candidates must require exact `system_id64`, exactly one canonical station match, stable station identifier, normalized station name match, valid permanent source station type, eligible old canonical value, clear risk state, no stale/volatile/source-only/risky/blocked/unknown/report-only selected evidence, source run/file/record metadata, rollback pre-image, and audit metadata.
+Start with tests and a dry-run-only artifact builder. The dry-run artifact must be deterministic and versioned as `station_type_canonical_pilot_dry_run/v1`. Eligible candidates must require exact `system_id64`, exactly one canonical station match, external station identity by matching `market_id` or `edsm_station_id`, normalized station name match, valid permanent source station type, eligible old canonical value, no ambiguous/source-only-insert/stale/volatile/transient/non-station-type selected evidence, source run/file/record metadata, rollback pre-image, and audit metadata.
 
 Do not make ordinary warehouse loaders able to write canonical tables. Do not reuse report-only `candidate_update` rows as executable write instructions. Current reconciliation reports must continue to keep `canonical_writes_planned = 0` and `auto_promote_to_canonical = false`.
 

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -626,6 +626,17 @@ externally proven. A dry-run retry still requires a separate prompt, an
 explicit max-row bound, recorded reconciliation checksum, compact output, and
 no canonical apply.
 
+Stage 18J-P-filter hardens the station-type dry-run eligibility code before
+any future operator retry. The filter accepts only update-only station-type
+candidates with external identity proof by matching `market_id` or
+`edsm_station_id`; internal canonical `station_id` is never identity proof.
+It emits explicit rejection counts for ambiguous identity, source-only inserts,
+missing external identity, volatile evidence, transient/non-slot station types,
+non-station-type changes, missing station-type deltas, and max-row exclusions.
+Dry-run output keeps `canonical_writes_planned = 0`, records the input
+reconciliation artifact checksum, creates no approval record, and does not run
+apply. This hardening does not itself authorize or run Stage 18J-P.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/tests/test_station_type_canonical_pilot.py
+++ b/tests/test_station_type_canonical_pilot.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ if str(IMPORTER_SRC) not in sys.path:
     sys.path.insert(0, str(IMPORTER_SRC))
 
 import station_type_canonical_pilot as pilot  # noqa: E402
+from enrichment_reconciliation import station_body_association_candidates  # noqa: E402
 
 
 def report_with(*candidates):
@@ -91,7 +93,7 @@ def station_candidate(**overrides):
             'source_updated_at': '2026-05-31T12:00:00Z',
             'freshness_impact': 'timestamped_source',
         },
-        'report_only': False,
+        'report_only': True,
         'canonical_writes_planned': 0,
     }
     _deep_update(candidate, overrides)
@@ -118,7 +120,12 @@ def test_dry_run_builds_deterministic_station_type_artifact():
     assert first['pilot_scope']['canonical_table'] == 'stations'
     assert first['pilot_scope']['canonical_field'] == 'station_type'
     assert first['pilot_scope']['apply_requires_separate_guarded_mode'] is True
-    assert first['summary']['canonical_writes_planned'] == 1
+    assert first['summary']['total_candidates_seen'] == 1
+    assert first['summary']['eligible_station_type_updates'] == 1
+    assert first['summary']['canonical_writes_planned'] == 0
+    assert first['summary']['dry_run_only'] is True
+    assert first['summary']['apply_run'] is False
+    assert first['summary']['approval_record_created'] is False
     candidate = first['eligible_candidates'][0]
     assert candidate['canonical_table'] == 'stations'
     assert candidate['field'] == 'station_type'
@@ -135,7 +142,8 @@ def test_blocks_name_only_or_missing_stable_station_identifier():
     artifact = pilot.build_station_type_pilot_dry_run(report, generated_at='2026-06-01T00:00:00Z')
 
     assert artifact['summary']['eligible_candidates'] == 0
-    assert artifact['summary']['blocked_by_reason']['stable_station_identifier_matches'] == 1
+    assert artifact['summary']['rejected_missing_external_identity'] == 1
+    assert artifact['summary']['rejection_reason_counts']['rejected_missing_external_identity'] == 1
 
 
 def test_blocks_internal_station_pk_match_without_canonical_external_identity():
@@ -158,7 +166,7 @@ def test_blocks_internal_station_pk_match_without_canonical_external_identity():
 
     assert artifact['summary']['eligible_candidates'] == 0
     blocked = artifact['blocked_candidates'][0]
-    assert 'stable_station_identifier_matches' in blocked['blocking_reasons']
+    assert 'rejected_missing_external_identity' in blocked['rejection_reasons']
     assert blocked['canonical']['station_id'] == 900001
     assert blocked['canonical']['market_id'] is None
     assert blocked['match_proof']['source_market_id'] == 900001
@@ -187,12 +195,12 @@ def test_blocks_internal_station_pk_match_when_canonical_external_identity_diffe
 
     assert artifact['summary']['eligible_candidates'] == 0
     blocked = artifact['blocked_candidates'][0]
-    assert 'stable_station_identifier_matches' in blocked['blocking_reasons']
+    assert 'rejected_missing_external_identity' in blocked['rejection_reasons']
     assert blocked['match_proof']['source_market_id'] == 900001
     assert blocked['match_proof']['canonical_market_id'] == 1001
 
 
-def test_allows_edsm_station_id_only_when_explicitly_enabled():
+def test_allows_edsm_station_id_external_identity_match():
     candidate = station_candidate(
         source={'market_id': None, 'edsm_station_id': 1001},
         canonical={'market_id': None, 'edsm_station_id': 1001},
@@ -207,41 +215,35 @@ def test_allows_edsm_station_id_only_when_explicitly_enabled():
         }],
     )
 
-    without_flag = pilot.build_station_type_pilot_dry_run(
+    artifact = pilot.build_station_type_pilot_dry_run(
         report_with(candidate),
-        generated_at='2026-06-01T00:00:00Z',
-    )
-    with_flag = pilot.build_station_type_pilot_dry_run(
-        report_with(candidate),
-        allow_edsm_station_id=True,
         generated_at='2026-06-01T00:00:00Z',
     )
 
-    assert without_flag['summary']['eligible_candidates'] == 0
-    assert with_flag['summary']['eligible_candidates'] == 1
-    assert with_flag['eligible_candidates'][0]['match_proof']['identifier_match_type'] == 'edsm_station_id'
+    assert artifact['summary']['eligible_candidates'] == 1
+    assert artifact['eligible_candidates'][0]['match_proof']['identifier_match_type'] == 'edsm_station_id'
 
 
 @pytest.mark.parametrize(
     'overrides,reason',
     [
-        ({'canonical_matches': []}, 'exactly_one_canonical_match'),
-        ({'canonical_matches': [{'station_id': 1001}, {'station_id': 1002}]}, 'exactly_one_canonical_match'),
-        ({'source': {'system_id64': 999}}, 'system_id64_matches'),
-        ({'source': {'station_name': 'Wrong Name'}}, 'station_name_matches'),
-        ({'differences': [{'field': 'station_type', 'staged': 'Fleet Carrier', 'canonical': 'Unknown'}]}, 'source_station_type_permanent'),
-        ({'differences': [{'field': 'station_type', 'staged': 'Coriolis Logistics', 'canonical': 'Unknown'}]}, 'source_station_type_permanent'),
-        ({'canonical': {'station_type': 'Coriolis'}}, 'canonical_old_value_eligible'),
-        ({'risk_class': 'stale'}, 'risk_class_clear'),
-        ({'risk_flags': ['volatile_source_evidence']}, 'no_blocking_risk_flags'),
-        ({'review_classifications': ['source_only']}, 'no_blocking_review_classifications'),
-        ({'review_classifications': ['report_only']}, 'no_blocking_review_classifications'),
-        ({'report_only': True}, 'not_report_only_evidence'),
-        ({'source_freshness': {'freshness_impact': 'undated_source_review'}}, 'freshness_allowed'),
+        ({'canonical_matches': []}, 'rejected_ambiguous_identity'),
+        ({'canonical_matches': [{'station_id': 1001}, {'station_id': 1002}]}, 'rejected_ambiguous_identity'),
+        ({'candidate_action': 'ambiguous_match'}, 'rejected_ambiguous_identity'),
+        ({'candidate_action': 'candidate_insert_missing_canonical'}, 'rejected_source_only_insert'),
+        ({'source': {'system_id64': 999}}, 'rejected_missing_external_identity'),
+        ({'source': {'station_name': 'Wrong Name'}}, 'rejected_missing_external_identity'),
+        ({'differences': [{'field': 'station_type', 'staged': 'Fleet Carrier', 'canonical': 'Unknown'}]}, 'rejected_transient_non_slot'),
+        ({'differences': [{'field': 'station_type', 'staged': 'MegaShip', 'canonical': 'Unknown'}]}, 'rejected_transient_non_slot'),
+        ({'canonical': {'station_type': 'Coriolis'}}, 'rejected_ineligible_canonical_old_value'),
+        ({'risk_flags': ['volatile_source_evidence']}, 'rejected_volatile_evidence'),
+        ({'source': {'source_class': 'volatile'}}, 'rejected_volatile_evidence'),
+        ({'source_freshness': {'freshness_impact': 'undated_source_review'}}, 'rejected_freshness'),
+        ({'differences': []}, 'rejected_missing_station_type_delta'),
         ({'differences': [
             {'field': 'station_type', 'staged': 'Orbis Starport', 'canonical': 'Unknown'},
             {'field': 'distance_to_arrival', 'staged': 12.0, 'canonical': None},
-        ]}, 'target_difference_is_station_type_only'),
+        ]}, 'rejected_non_station_type_change'),
     ],
 )
 def test_blocks_unsafe_candidate_states(overrides, reason):
@@ -252,6 +254,80 @@ def test_blocks_unsafe_candidate_states(overrides, reason):
 
     assert artifact['summary']['eligible_candidates'] == 0
     assert artifact['summary']['blocked_by_reason'][reason] == 1
+    assert artifact['blocked_candidates'][0]['rejection_reasons'][0].startswith('rejected_')
+
+
+def test_missing_station_body_name_does_not_block_external_station_type_update():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(station_candidate(
+            risk_class='blocked',
+            risk_flags=['missing_station_body_name', 'canonical_difference_review'],
+            review_classifications=['blocked', 'report_only', 'source_only', 'unknown'],
+        )),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['eligible_station_type_updates'] == 1
+    assert artifact['eligible_candidates'][0]['source_reconciliation']['risk_flags'] == [
+        'canonical_difference_review',
+        'missing_station_body_name',
+    ]
+    assert artifact['summary']['canonical_writes_planned'] == 0
+
+
+def test_missing_station_body_name_remains_station_body_link_blocker():
+    association_candidates = station_body_association_candidates([station_candidate()], [])
+
+    assert len(association_candidates) == 1
+    candidate = association_candidates[0]
+    assert candidate['entity'] == 'station_body_association'
+    assert candidate['candidate_action'] == 'station_body_name_missing'
+    assert candidate['canonical_link_writes_planned'] == 0
+    assert 'missing_station_body_name' in candidate['risk_flags']
+    assert 'blocked' in candidate['review_classifications']
+
+
+def test_requires_explicit_max_row_bound():
+    with pytest.raises(pilot.Stage18JPlanError, match='max-row bound'):
+        pilot.build_station_type_pilot_dry_run(
+            report_with(station_candidate()),
+            limit=None,
+            generated_at='2026-06-01T00:00:00Z',
+        )
+
+
+def test_summary_contains_strict_rejection_reason_counts():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(source={'market_id': None, 'edsm_station_id': None}),
+            station_candidate(candidate_action='candidate_insert_missing_canonical'),
+            station_candidate(risk_flags=['volatile_source_evidence']),
+        ),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['total_candidates_seen'] == 3
+    assert artifact['summary']['eligible_station_type_updates'] == 0
+    assert artifact['summary']['canonical_writes_planned'] == 0
+    assert artifact['summary']['rejected_missing_external_identity'] == 1
+    assert artifact['summary']['rejected_source_only_insert'] == 1
+    assert artifact['summary']['rejected_volatile_evidence'] == 1
+    assert artifact['summary']['rejection_reason_counts']['rejected_missing_external_identity'] == 1
+
+
+def test_limit_exclusion_is_reported_as_rejection_reason():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(source={'source_record_key': 'record-1', 'source_record_hash': 'hash-1'}),
+            station_candidate(source={'source_record_key': 'record-2', 'source_record_hash': 'hash-2'}),
+        ),
+        limit=1,
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['eligible_station_type_updates'] == 1
+    assert artifact['summary']['rejected_by_max_row_bound'] == 1
+    assert artifact['blocked_candidates'][0]['eligible_if_limit_allows'] is True
 
 
 def test_cli_rejects_unsupported_write_commit_flags():
@@ -312,6 +388,37 @@ def test_cli_writes_dry_run_json_artifact(tmp_path):
     payload = json.loads(output_path.read_text(encoding='utf-8'))
     assert payload['schema_version'] == 'station_type_canonical_pilot_dry_run/v1'
     assert payload['summary']['eligible_candidates'] == 1
+    assert payload['summary']['canonical_writes_planned'] == 0
+    assert payload['source_scope']['input_artifact_basename'] == 'reconciliation.json'
+    assert payload['source_scope']['input_artifact_sha256'] == _file_sha256(report_path)
+    assert payload['source_scope']['input_artifact_size_bytes'] == report_path.stat().st_size
+
+
+def test_cli_dry_run_rejects_dsn_and_does_not_invoke_apply(tmp_path, monkeypatch):
+    report_path = tmp_path / 'reconciliation.json'
+    output_path = tmp_path / 'stage18j.json'
+    report_path.write_text(json.dumps(report_with(station_candidate())), encoding='utf-8')
+
+    def fail_apply(*_args, **_kwargs):
+        raise AssertionError('apply path must not be invoked during dry-run')
+
+    monkeypatch.setattr(pilot, 'apply_station_type_pilot', fail_apply)
+
+    assert pilot.main([
+        '--reconciliation-report',
+        str(report_path),
+        '--output',
+        str(output_path),
+        '--limit',
+        '1',
+    ]) == 0
+    with pytest.raises(SystemExit):
+        pilot.parse_args([
+            '--reconciliation-report',
+            str(report_path),
+            '--dsn',
+            'postgresql://dry-run/test',
+        ])
 
 
 def test_validate_apply_request_fails_closed_on_mismatched_approval_parameters():
@@ -518,3 +625,7 @@ def _deep_update(target, overrides):
             _deep_update(target[key], value)
         else:
             target[key] = value
+
+
+def _file_sha256(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()


### PR DESCRIPTION
## What changed

* Inspects/hardens station-type dry-run eligibility.
* Enforces external identity proof.
* Excludes ambiguous/source-only/volatile/transient candidates.
* Preserves missing station_body_name as station-body-link blocker while allowing externally proven station-type comparisons.
* Keeps canonical_writes_planned at 0.
* Adds tests and docs.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No production station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18J-P not started.
* Stage 18K not started.

## Validation

```text
./scripts/run_canonical_safety_tests.sh
89 passed in 0.18s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q
89 passed in 0.18s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py
PASS

git diff --check
PASS

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' apps/importer/src/station_type_canonical_pilot.py docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md docs/colonisation-redesign/stage-18j-station-type-canonical-pilot-plan.md docs/colonisation-redesign/stage-18j-p-station-type-production-dry-run-readiness.md docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md docs/colonisation-redesign/enrichment-roadmap.md docs/operations/enrichment-warehouse-runbook.md 2>/dev/null || true
No matches

Additional scan of changed Stage 17P doc:
grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' docs/colonisation-redesign/stage-17p-current-state-forward-plan.md 2>/dev/null || true
No matches

git diff --cached --check
PASS
```
