### PR TITLE
Stage 18J-P dry-run operator-safe wrapper

### DIFF
--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -48,6 +48,7 @@ APPROVED_TABLE = 'stations'
 APPROVED_FIELD = 'station_type'
 DEFAULT_LIMIT = 5
 MAX_FIRST_PILOT_LIMIT = 20
+DEFAULT_BLOCKED_CANDIDATE_SAMPLE_LIMIT = 100
 ELIGIBLE_OLD_TYPE_LABELS = {None, '', 'Unknown'}
 VOLATILE_RISK_FLAGS = {'volatile_source_class', 'volatile_source_evidence'}
 SOURCE_ONLY_RISK_FLAGS = {'source_only_evidence'}
@@ -111,6 +112,7 @@ def build_station_type_pilot_dry_run(
     reconciliation_artifact_sha256: str | None = None,
     reconciliation_artifact_basename: str | None = None,
     reconciliation_artifact_size_bytes: int | None = None,
+    blocked_candidate_sample_limit: int | None = DEFAULT_BLOCKED_CANDIDATE_SAMPLE_LIMIT,
     generated_at: str | None = None,
     git_commit: str | None = None,
 ) -> dict[str, Any]:
@@ -121,6 +123,7 @@ def build_station_type_pilot_dry_run(
         raise Stage18JPlanError('limit must be >= 0')
     if limit > MAX_FIRST_PILOT_LIMIT:
         raise Stage18JPlanError(f'limit must be <= {MAX_FIRST_PILOT_LIMIT} for the first Stage 18J pilot')
+    blocked_sample_limit = _validate_blocked_candidate_sample_limit(blocked_candidate_sample_limit)
 
     source_scope = _source_scope(
         reconciliation_report,
@@ -129,7 +132,9 @@ def build_station_type_pilot_dry_run(
         reconciliation_artifact_size_bytes=reconciliation_artifact_size_bytes,
     )
     eligible: list[dict[str, Any]] = []
-    blocked: list[dict[str, Any]] = []
+    blocked_samples: list[dict[str, Any]] = []
+    blocked_count = 0
+    rejection_reason_counts: dict[str, int] = {}
     rows_considered = 0
 
     for candidate in reconciliation_report.get('station_candidates', []) or []:
@@ -144,20 +149,32 @@ def build_station_type_pilot_dry_run(
         if decision['eligible'] and len(eligible) < limit:
             eligible.append(decision['candidate'])
         elif decision['eligible']:
-            blocked.append({
-                'candidate_id': decision['candidate']['candidate_id'],
-                'source_identity': decision['candidate']['source_identity'],
-                'canonical': decision['candidate']['canonical'],
-                'rejection_reasons': ['rejected_by_max_row_bound'],
-                'blocking_reasons': ['rejected_by_max_row_bound'],
-                'eligible_if_limit_allows': True,
-            })
+            blocked_count = _record_blocked_candidate(
+                {
+                    'candidate_id': decision['candidate']['candidate_id'],
+                    'source_identity': decision['candidate']['source_identity'],
+                    'canonical': decision['candidate']['canonical'],
+                    'rejection_reasons': ['rejected_by_max_row_bound'],
+                    'blocking_reasons': ['rejected_by_max_row_bound'],
+                    'eligible_if_limit_allows': True,
+                },
+                blocked_samples=blocked_samples,
+                blocked_count=blocked_count,
+                rejection_reason_counts=rejection_reason_counts,
+                sample_limit=blocked_sample_limit,
+            )
         else:
-            blocked.append(decision['blocked_candidate'])
+            blocked_count = _record_blocked_candidate(
+                decision['blocked_candidate'],
+                blocked_samples=blocked_samples,
+                blocked_count=blocked_count,
+                rejection_reason_counts=rejection_reason_counts,
+                sample_limit=blocked_sample_limit,
+            )
 
     eligible = sorted(eligible, key=canonical_json)
-    blocked = sorted(blocked, key=canonical_json)
-    rejection_reason_counts = _blocked_reason_distribution(blocked)
+    blocked = sorted(blocked_samples, key=canonical_json)
+    rejection_reason_counts = dict(sorted(rejection_reason_counts.items()))
     rejection_summary = _rejection_summary(rejection_reason_counts)
     now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
     artifact: dict[str, Any] = {
@@ -182,6 +199,7 @@ def build_station_type_pilot_dry_run(
         'filters': {
             'limit': limit,
             'max_row_bound': limit,
+            'blocked_candidate_sample_limit': blocked_sample_limit,
             'allow_edsm_station_id': allow_edsm_station_id,
             'allow_undated_source_exception': allow_undated_source_exception,
             'requires_external_identity_proof': True,
@@ -197,7 +215,10 @@ def build_station_type_pilot_dry_run(
             'station_candidates_considered': rows_considered,
             'eligible_station_type_updates': len(eligible),
             'eligible_candidates': len(eligible),
-            'blocked_candidates': len(blocked),
+            'blocked_candidates': blocked_count,
+            'blocked_candidate_samples_included': len(blocked),
+            'blocked_candidate_sample_limit': blocked_sample_limit,
+            'blocked_candidate_samples_omitted': max(blocked_count - len(blocked), 0),
             'rejection_reason_counts': rejection_reason_counts,
             'blocked_by_reason': rejection_reason_counts,
             'canonical_writes_planned': 0,
@@ -210,6 +231,14 @@ def build_station_type_pilot_dry_run(
             'warnings': 0,
         },
         'eligible_candidates': eligible,
+        'blocked_candidate_output': {
+            'sampled': True,
+            'sample_limit': blocked_sample_limit,
+            'samples_included': len(blocked),
+            'total_blocked_candidates': blocked_count,
+            'samples_omitted': max(blocked_count - len(blocked), 0),
+            'sampling': 'first_n_by_input_order_sorted_for_output',
+        },
         'blocked_candidates': blocked,
         'operator_review': {
             'manual_approval_required': True,
@@ -678,9 +707,11 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--reconciliation-report', default=None, help='Path to read-only warehouse reconciliation JSON for dry-run mode.')
     parser.add_argument('--output', default=None, help='Optional output path. Defaults to stdout only.')
     parser.add_argument('--limit', type=int, default=DEFAULT_LIMIT, help='Explicit max-row bound for eligible dry-run candidates.')
+    parser.add_argument('--blocked-candidate-sample-limit', type=int, default=DEFAULT_BLOCKED_CANDIDATE_SAMPLE_LIMIT, help='Maximum blocked candidate samples to include in dry-run output.')
     parser.add_argument('--allow-edsm-station-id', action='store_true', help='Compatibility flag; edsm_station_id is allowed as external identity by the strict filter.')
     parser.add_argument('--allow-undated-source-exception', action='store_true', help='Allow otherwise eligible undated/file-snapshot rows in dry-run review.')
     parser.add_argument('--json', action='store_true', help='Accepted for compatibility; output is always JSON.')
+    parser.add_argument('--quiet', action='store_true', help='When --output is set, do not also print the JSON artifact to stdout.')
     parser.add_argument('--dry-run', action='store_true', default=True, help='Dry-run mode. This is the default.')
     parser.add_argument('--apply', action='store_true', help='Run guarded apply mode from a checksumed dry-run artifact.')
     parser.add_argument('--artifact', default=None, help='Dry-run artifact path for apply mode.')
@@ -701,6 +732,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         parser.error('--write/--commit are not supported; use --apply with explicit Stage 18J approval parameters')
     if not args.apply and args.limit is None:
         parser.error('dry-run mode requires an explicit --limit max-row bound')
+    if not args.apply and args.blocked_candidate_sample_limit is not None and args.blocked_candidate_sample_limit < 0:
+        parser.error('--blocked-candidate-sample-limit must be >= 0')
     if args.apply:
         required = {
             '--artifact': args.artifact,
@@ -757,6 +790,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 reconciliation_artifact_sha256=_file_sha256(reconciliation_report_path),
                 reconciliation_artifact_basename=reconciliation_report_path.name,
                 reconciliation_artifact_size_bytes=reconciliation_report_path.stat().st_size,
+                blocked_candidate_sample_limit=args.blocked_candidate_sample_limit,
             )
     except (OSError, ValueError, TypeError) as exc:
         print(f'Stage 18J station type pilot failed: {exc}', file=sys.stderr)
@@ -765,7 +799,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     output = json.dumps(artifact, sort_keys=True, indent=2)
     if args.output:
         Path(args.output).write_text(output + '\n', encoding='utf-8')
-    print(output)
+    if not args.quiet or not args.output:
+        print(output)
     return 0
 
 
@@ -990,6 +1025,31 @@ def _candidate_id(*, source: Mapping[str, Any], canonical_station_id: int | None
         APPROVED_FIELD,
         new_value,
     ]).encode('utf-8')).hexdigest()
+
+
+def _validate_blocked_candidate_sample_limit(value: int | None) -> int | None:
+    if value is None:
+        return None
+    if value < 0:
+        raise Stage18JPlanError('blocked candidate sample limit must be >= 0')
+    return value
+
+
+def _record_blocked_candidate(
+    candidate: Mapping[str, Any],
+    *,
+    blocked_samples: list[dict[str, Any]],
+    blocked_count: int,
+    rejection_reason_counts: dict[str, int],
+    sample_limit: int | None,
+) -> int:
+    row = dict(candidate)
+    for reason in row.get('rejection_reasons') or row.get('blocking_reasons') or []:
+        key = str(reason)
+        rejection_reason_counts[key] = rejection_reason_counts.get(key, 0) + 1
+    if sample_limit is None or len(blocked_samples) < sample_limit:
+        blocked_samples.append(row)
+    return blocked_count + 1
 
 
 def _blocked_reason_distribution(blocked: Sequence[Mapping[str, Any]]) -> dict[str, int]:

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -554,6 +554,14 @@ input reconciliation artifact checksum, and keeps dry-run
 See
 [`stage-18j-p-filter-strict-station-type-dry-run-filter.md`](./stage-18j-p-filter-strict-station-type-dry-run-filter.md).
 
+Stage 18J-P-dryrun-ops adds the Hetzner-only wrapper for the future strict
+station-type dry-run. The wrapper verifies the validated reconciliation
+artifact SHA-256, requires bounded `MAX_ROWS` and refuses values above `20`,
+passes compact blocked-candidate output options, writes the dry-run artifact
+under the operator artifact directory, and prints compact summary fields. It
+does not run from Codex, touch the DB, create approvals, or run apply. See
+[`stage-18j-p-dryrun-operator-safe-wrapper.md`](./stage-18j-p-dryrun-operator-safe-wrapper.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -624,6 +632,9 @@ treated as a separate proposal.
 * **Strict station-type filter hardening**: Stage 18J-P-filter implements the
   strict filter and synthetic tests. A future Stage 18J-P production dry-run
   can proceed only as a separate operator step after this hardening merges.
+* **Operator-safe station-type dry-run wrapper**: Stage 18J-P-dryrun-ops adds
+  the Hetzner-only wrapper, checksum guard, max-row cap, and compact blocked
+  output required before the future production dry-run operator step.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -848,6 +848,34 @@ Non-goals:
 Support doc:
 `stage-18j-p-filter-strict-station-type-dry-run-filter.md`.
 
+### Stage 18J-P-dryrun-ops - Operator-Safe Station-Type Dry-Run Wrapper
+
+Purpose: add the Hetzner-only wrapper and compact-output controls required
+before any future Stage 18J-P production station-type dry-run.
+
+Scope:
+
+- Add `scripts/operator/stage18j_run_station_type_dry_run.sh`.
+- Require the shared Hetzner operator environment guard.
+- Verify the validated reconciliation artifact checksum before dry-run.
+- Require bounded `MAX_ROWS`, with first-pilot refusal above `20`.
+- Write the dry-run artifact under the operator artifact directory.
+- Cap blocked candidate samples while preserving full rejection counts and
+  total candidate counts.
+- Print compact summary fields and artifact checksum.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access.
+- No imports, reconciliation, production summarizer run, production
+  station-type dry-run, or canonical apply.
+- No approval record.
+- No Stage 18J-P or Stage 18K work.
+
+Support doc:
+`stage-18j-p-dryrun-operator-safe-wrapper.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -923,5 +951,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 28. Stage 19A.1 operator path guardrails.
 29. Stage 18J-Q9 compact summary review / station-type dry-run readiness.
 30. Stage 18J-P-filter strict station-type dry-run filter hardening.
+31. Stage 18J-P-dryrun-ops operator-safe station-type dry-run wrapper.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p-dryrun-operator-safe-wrapper.md
+++ b/docs/colonisation-redesign/stage-18j-p-dryrun-operator-safe-wrapper.md
@@ -1,0 +1,144 @@
+# Stage 18J-P-dryrun-ops - Operator-Safe Station-Type Dry-Run Wrapper
+
+## Purpose
+
+Stage 18J-P-dryrun-ops adds an operator-safe wrapper for the strict
+station-type dry-run after Stage 18J-P-filter hardened eligibility. The wrapper
+is for the Hetzner production operator shell only and keeps the dry-run bounded,
+checksumed, compact, and outside git.
+
+This stage does not run production commands, touch the production DB, run
+imports, run reconciliation, run the summarizer against production artifacts,
+run a production station-type dry-run, run canonical apply, create approval
+records, start Stage 18J-P, or start Stage 18K.
+
+## Operator Wrapper
+
+New script:
+
+```text
+scripts/operator/stage18j_run_station_type_dry_run.sh
+```
+
+The script calls `scripts/operator/require_hetzner_operator_env.sh` before it
+can operate. It requires the Hetzner host/path/Docker context, defaults to the
+Stage 18J operator artifact directory, and writes the dry-run artifact under:
+
+```text
+/var/lib/ed-finder/operator-artifacts/stage-18j
+```
+
+Default input artifact basename:
+
+```text
+enrichment_staging_reconciliation_20260602T112948Z.json
+```
+
+Default expected SHA-256:
+
+```text
+0bacd62b7de0adf749b3c0de59ac3eebd4f67a6bea18eb96510d29f999935802
+```
+
+The wrapper verifies that checksum before running the dry-run tool. A checksum
+mismatch stops the script.
+
+## Bounded Dry-Run Controls
+
+The wrapper uses `MAX_ROWS`, defaulting to the conservative first-pilot value
+of `5`, and refuses values above `20`.
+
+The wrapper never passes apply-mode or database connection arguments. It runs
+the pilot tool in dry-run mode only and prints:
+
+- output path,
+- output artifact SHA-256,
+- schema version,
+- `dry_run`,
+- `canonical_writes_planned`,
+- total candidates seen,
+- eligible station-type updates,
+- eligible candidate count,
+- blocked candidate count,
+- rejection reason counts,
+- artifact integrity checksum,
+- source reconciliation artifact basename,
+- source reconciliation artifact SHA-256,
+- max-row bound,
+- apply/approval flags.
+
+## Compact Blocked-Candidate Output
+
+`station_type_canonical_pilot.py` now supports:
+
+```text
+--blocked-candidate-sample-limit N
+--quiet
+```
+
+The dry-run artifact keeps full counts and rejection reason distributions, but
+only emits a capped sample of blocked candidates. Eligible candidates remain
+included up to the explicit `--limit`.
+
+The default blocked sample limit is `100`; the operator wrapper passes
+`BLOCKED_CANDIDATE_SAMPLE_LIMIT`, also defaulting to `100`.
+
+## Output Contract
+
+Dry-run output remains:
+
+```text
+station_type_canonical_pilot_dry_run/v1
+```
+
+The artifact records:
+
+- `summary.canonical_writes_planned = 0`,
+- `summary.apply_run = false`,
+- `summary.approval_record_created = false`,
+- `summary.total_candidates_seen`,
+- `summary.eligible_station_type_updates`,
+- `summary.blocked_candidates`,
+- `summary.rejection_reason_counts`,
+- `summary.blocked_candidate_samples_included`,
+- `summary.blocked_candidate_samples_omitted`,
+- `source_scope.input_artifact_basename`,
+- `source_scope.input_artifact_sha256`,
+- `artifact_integrity.canonical_json_sha256`.
+
+Eligible rows are still dry-run review rows. They are not approval records and
+not canonical apply instructions.
+
+## Boundaries
+
+The wrapper does not authorize Stage 18J-P from Codex or local dev. It is a
+server-only operator script. Production artifacts remain private and must not
+be committed.
+
+Still not allowed in this stage:
+
+- production dry-run execution from Codex,
+- production DB access,
+- imports,
+- reconciliation,
+- summarizer execution against production artifacts,
+- canonical apply,
+- approval record creation,
+- Stage 18J-P,
+- Stage 18K.
+
+## Future Stage 18J-P Effect
+
+After this stage merges, the future Stage 18J-P production dry-run can proceed
+only when separately prompted for the Hetzner operator shell. That future step
+must use the wrapper, the validated reconciliation checksum, an explicit
+`MAX_ROWS` no greater than `20`, and compact blocked-candidate output.
+
+This stage does not run that command.
+
+## Final Recommendation
+
+Merge this wrapper before asking the Hetzner operator to run the production
+station-type dry-run. Then run Stage 18J-P only as a separate operator step and
+review the resulting compact dry-run artifact before any approval packet or
+apply discussion.

--- a/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
+++ b/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
@@ -88,12 +88,21 @@ The dry-run output explicitly records:
 
 - `dry_run = true`,
 - `summary.canonical_writes_planned = 0`,
+- `summary.total_candidates_seen`,
+- `summary.eligible_station_type_updates`,
+- `summary.rejection_reason_counts`,
 - `summary.apply_run = false`,
 - `summary.approval_record_created = false`,
 - `operator_review.production_artifact_approved = false`.
 
 Eligible rows are reported as `eligible_station_type_updates`; they are not
 canonical writes, approval records, or apply instructions.
+
+Stage 18J-P-dryrun-ops adds compact blocked-candidate output controls so the
+future operator dry-run does not emit every blocked row from the large
+production reconciliation artifact. The dry-run artifact keeps all counts and
+rejection distributions, includes eligible rows up to the explicit limit, and
+caps blocked row samples through `--blocked-candidate-sample-limit`.
 
 ## Tests
 
@@ -132,7 +141,8 @@ Still blocked:
 ## Future Stage 18J-P Effect
 
 After this stage merges, a future Stage 18J-P production dry-run can proceed
-only when separately prompted in the Hetzner operator shell and only with:
+only when separately prompted in the Hetzner operator shell, after the
+operator-safe wrapper has merged, and only with:
 
 - the reviewed production reconciliation artifact,
 - the explicit max-row bound,

--- a/docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md
@@ -280,12 +280,14 @@ Stage 18J should continue with a narrow station-type dry-run readiness path:
 1. Q9 records this review and the strict filter.
 2. Stage 18J-P-filter hardens the strict dry-run eligibility filter in code
    and synthetic tests without running production commands.
-3. Stage 18J-P may retry station-type production dry-run only if separately
+3. Stage 18J-P-dryrun-ops adds the Hetzner-only wrapper, reconciliation
+   checksum verification, max-row guard, and compact blocked-candidate output.
+4. Stage 18J-P may retry station-type production dry-run only if separately
    prompted and if the strict filter is implemented or reconfirmed.
-4. Stage 18J-P2 reviews the filtered dry-run artifact.
-5. Stage 18J-P3 prepares a tiny apply approval packet only if the dry-run is
+5. Stage 18J-P2 reviews the filtered dry-run artifact.
+6. Stage 18J-P3 prepares a tiny apply approval packet only if the dry-run is
    boring and bounded.
-6. Stage 18J-P4 performs a tiny manual apply only if explicitly approved.
+7. Stage 18J-P4 performs a tiny manual apply only if explicitly approved.
 
 Stage 19 warehouse expansion remains separate and report-only. Stage 18K is not
 started by Q9.
@@ -300,4 +302,5 @@ apply unauthorized, and keep Stage 18J-P blocked until a separate prompt
 implements or reconfirms the filtered dry-run scope.
 
 Stage 18J-P-filter is the implementation hardening step for that filter. It
-does not run the production dry-run or approve any artifact.
+does not run the production dry-run or approve any artifact. Stage
+18J-P-dryrun-ops adds the operator wrapper needed before that future dry-run.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -637,6 +637,17 @@ Dry-run output keeps `canonical_writes_planned = 0`, records the input
 reconciliation artifact checksum, creates no approval record, and does not run
 apply. This hardening does not itself authorize or run Stage 18J-P.
 
+Stage 18J-P-dryrun-ops adds the Hetzner-only wrapper for the future
+station-type dry-run:
+`scripts/operator/stage18j_run_station_type_dry_run.sh`. The wrapper calls the
+shared operator environment guard, verifies the known reconciliation artifact
+checksum before running, requires bounded `MAX_ROWS` with a hard first-pilot cap
+of `20`, passes the compact blocked-candidate sample limit to the pilot tool,
+and writes the dry-run artifact under the operator artifact directory. It never
+passes apply-mode or database connection arguments, creates no approval record,
+and keeps `canonical_writes_planned = 0`. This wrapper must be run only from
+the Hetzner operator shell and only after a separate Stage 18J-P prompt.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/docs/operations/operator-command-contexts.md
+++ b/docs/operations/operator-command-contexts.md
@@ -167,6 +167,29 @@ Optional environment overrides:
 The compact summary script calls the shared environment guard first. It fails
 fast outside the expected host/path/Docker/artifact context.
 
+For a future Stage 18J-P station-type dry-run, after the operator has been
+separately prompted, run from Hetzner only:
+
+```sh
+cd /opt/ed-finder
+MAX_ROWS=5 scripts/operator/stage18j_run_station_type_dry_run.sh
+```
+
+Optional environment overrides:
+
+- `ART_DIR`
+- `RECON_ARTIFACT`
+- `EXPECTED_RECON_SHA256`
+- `DRY_RUN_ARTIFACT`
+- `MAX_ROWS`
+- `BLOCKED_CANDIDATE_SAMPLE_LIMIT`
+
+The station-type dry-run wrapper calls the shared environment guard, verifies
+the reconciliation artifact checksum, refuses `MAX_ROWS > 20`, writes output
+under the operator artifact directory, and prints only compact summary fields.
+It does not connect to the database, create approval records, or run canonical
+apply.
+
 ## Stage 18J Current Operator Artifacts
 
 Stage 18J currently uses an operator-managed reconciliation artifact basename:
@@ -179,6 +202,12 @@ The compact summary output basename is:
 
 ```text
 reconciliation_compact_summary_20260602T112948Z.json
+```
+
+The future station-type dry-run wrapper defaults to this output basename:
+
+```text
+station_type_canonical_pilot_dry_run_20260602T112948Z.json
 ```
 
 Both are production/operator artifacts and must stay out of git unless a future

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -21,5 +21,10 @@ Current scripts:
 - `stage18j_run_compact_summary.sh`: generates the Stage 18J compact
   reconciliation summary from an existing operator-managed artifact. It never
   runs reconciliation, station-type dry-run, or apply.
+- `stage18j_run_station_type_dry_run.sh`: generates the Stage 18J-P
+  station-type dry-run artifact from the validated reconciliation artifact
+  after verifying its SHA-256. It requires bounded `MAX_ROWS`, caps blocked
+  candidate samples, writes under the operator artifact directory, and never
+  touches the database, creates approval records, or runs canonical apply.
 
 Production artifacts are private operator files and should not be committed.

--- a/scripts/operator/stage18j_run_station_type_dry_run.sh
+++ b/scripts/operator/stage18j_run_station_type_dry_run.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +H
+
+ART_DIR="${ART_DIR:-/var/lib/ed-finder/operator-artifacts/stage-18j}"
+RECON_ARTIFACT="${RECON_ARTIFACT:-$ART_DIR/enrichment_staging_reconciliation_20260602T112948Z.json}"
+EXPECTED_RECON_SHA256="${EXPECTED_RECON_SHA256:-0bacd62b7de0adf749b3c0de59ac3eebd4f67a6bea18eb96510d29f999935802}"
+DRY_RUN_ARTIFACT="${DRY_RUN_ARTIFACT:-$ART_DIR/station_type_canonical_pilot_dry_run_20260602T112948Z.json}"
+MAX_ROWS="${MAX_ROWS:-5}"
+BLOCKED_CANDIDATE_SAMPLE_LIMIT="${BLOCKED_CANDIDATE_SAMPLE_LIMIT:-100}"
+
+stop() {
+  printf 'STOP: %s\n' "$*" >&2
+  exit 1
+}
+
+REQUIRE_STAGE18J_ARTIFACT_DIR=yes ART_DIR="$ART_DIR" \
+  scripts/operator/require_hetzner_operator_env.sh
+
+if [[ "${MAX_ROWS}" == "" || ! "${MAX_ROWS}" =~ ^[0-9]+$ ]]; then
+  stop "MAX_ROWS must be a non-negative integer."
+fi
+
+if (( MAX_ROWS > 20 )); then
+  stop "MAX_ROWS must be <= 20 for the first Stage 18J-P station-type dry-run."
+fi
+
+if [[ "${BLOCKED_CANDIDATE_SAMPLE_LIMIT}" == "" || ! "${BLOCKED_CANDIDATE_SAMPLE_LIMIT}" =~ ^[0-9]+$ ]]; then
+  stop "BLOCKED_CANDIDATE_SAMPLE_LIMIT must be a non-negative integer."
+fi
+
+if [[ ! -s "$RECON_ARTIFACT" ]]; then
+  stop "reconciliation artifact is missing or empty: $RECON_ARTIFACT"
+fi
+
+case "$DRY_RUN_ARTIFACT" in
+  "$ART_DIR"/*) ;;
+  *) stop "DRY_RUN_ARTIFACT must be written under ART_DIR: $ART_DIR" ;;
+esac
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+  stop "sha256sum is required to verify the reconciliation artifact."
+fi
+
+read -r actual_recon_sha _ < <(sha256sum "$RECON_ARTIFACT")
+if [[ "$actual_recon_sha" != "$EXPECTED_RECON_SHA256" ]]; then
+  stop "reconciliation artifact checksum mismatch. Expected $EXPECTED_RECON_SHA256, got $actual_recon_sha"
+fi
+
+echo "== Stage 18J-P station-type dry-run =="
+echo "DRY-RUN ONLY: no database connection, no approval record, no canonical apply."
+echo "ART_DIR: $ART_DIR"
+echo "RECON_ARTIFACT: $RECON_ARTIFACT"
+echo "RECON_SHA256: $actual_recon_sha"
+echo "DRY_RUN_ARTIFACT: $DRY_RUN_ARTIFACT"
+echo "MAX_ROWS: $MAX_ROWS"
+echo "BLOCKED_CANDIDATE_SAMPLE_LIMIT: $BLOCKED_CANDIDATE_SAMPLE_LIMIT"
+
+python3 apps/importer/src/station_type_canonical_pilot.py \
+  --reconciliation-report "$RECON_ARTIFACT" \
+  --output "$DRY_RUN_ARTIFACT" \
+  --limit "$MAX_ROWS" \
+  --blocked-candidate-sample-limit "$BLOCKED_CANDIDATE_SAMPLE_LIMIT" \
+  --json \
+  --quiet
+
+chmod 600 "$DRY_RUN_ARTIFACT"
+
+read -r dry_run_sha _ < <(sha256sum "$DRY_RUN_ARTIFACT")
+
+echo "== Station-type dry-run file =="
+ls -lh "$DRY_RUN_ARTIFACT"
+echo "dry_run_artifact_sha256: $dry_run_sha"
+
+echo "== Station-type dry-run validation =="
+python3 - "$DRY_RUN_ARTIFACT" "$EXPECTED_RECON_SHA256" "$MAX_ROWS" <<'PY'
+import json
+import sys
+
+path, expected_source_sha, expected_max_rows = sys.argv[1:4]
+with open(path, encoding='utf-8') as handle:
+    payload = json.load(handle)
+
+summary = payload.get('summary') or {}
+source_scope = payload.get('source_scope') or {}
+filters = payload.get('filters') or {}
+integrity = payload.get('artifact_integrity') or {}
+
+checks = {
+    'dry_run': payload.get('dry_run') is True,
+    'canonical_writes_planned_zero': summary.get('canonical_writes_planned') == 0,
+    'apply_run_false': summary.get('apply_run') is False,
+    'approval_record_created_false': summary.get('approval_record_created') is False,
+    'source_sha_matches': source_scope.get('input_artifact_sha256') == expected_source_sha,
+    'max_rows_matches': str(filters.get('max_row_bound')) == str(expected_max_rows),
+}
+
+for name, ok in checks.items():
+    if not ok:
+        raise SystemExit(f'STOP: dry-run validation failed: {name}')
+
+for key, value in (
+    ('schema_version', payload.get('schema_version')),
+    ('dry_run', payload.get('dry_run')),
+    ('canonical_writes_planned', summary.get('canonical_writes_planned')),
+    ('total_candidates_seen', summary.get('total_candidates_seen')),
+    ('eligible_station_type_updates', summary.get('eligible_station_type_updates')),
+    ('eligible_candidates', summary.get('eligible_candidates')),
+    ('blocked_candidates', summary.get('blocked_candidates')),
+    ('blocked_candidate_samples_included', summary.get('blocked_candidate_samples_included')),
+    ('blocked_candidate_sample_limit', summary.get('blocked_candidate_sample_limit')),
+    ('source_reconciliation_artifact_basename', source_scope.get('input_artifact_basename')),
+    ('source_reconciliation_artifact_sha256', source_scope.get('input_artifact_sha256')),
+    ('max_row_bound', filters.get('max_row_bound')),
+    ('artifact_integrity_sha256', integrity.get('canonical_json_sha256')),
+    ('apply_run', summary.get('apply_run')),
+    ('approval_record_created', summary.get('approval_record_created')),
+):
+    print(f'{key}: {value}')
+
+print('rejection_reason_counts:', json.dumps(summary.get('rejection_reason_counts') or {}, sort_keys=True))
+PY
+
+echo "== Secret/path sanity check =="
+sensitive_pattern='postgre''sql://|post''gres://|pass''word=|PG''PASSWORD|SEC''RET|TOK''EN|/var/lib/ed-finder|/root/'
+if grep -Eq "$sensitive_pattern" "$DRY_RUN_ARTIFACT"; then
+  stop "station-type dry-run artifact may contain credentials or private paths. Review the operator artifact out of band; do not commit it."
+fi
+echo "OK: no obvious credential/private path markers found"
+
+echo "OK: Stage 18J-P station-type dry-run artifact generated."
+echo "OK: dry-run only; no database access, no approval record, and no canonical apply."

--- a/tests/test_station_type_canonical_pilot.py
+++ b/tests/test_station_type_canonical_pilot.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import hashlib
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -315,6 +316,67 @@ def test_summary_contains_strict_rejection_reason_counts():
     assert artifact['summary']['rejection_reason_counts']['rejected_missing_external_identity'] == 1
 
 
+def test_compact_mode_caps_blocked_samples_but_keeps_full_counts():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(source={'source_record_key': 'record-eligible', 'source_record_hash': 'hash-eligible'}),
+            station_candidate(source={'source_record_key': 'record-missing-id', 'source_record_hash': 'hash-missing-id', 'market_id': None, 'edsm_station_id': None}),
+            station_candidate(source={'source_record_key': 'record-volatile', 'source_record_hash': 'hash-volatile'}, risk_flags=['volatile_source_evidence']),
+            station_candidate(source={'source_record_key': 'record-source-only', 'source_record_hash': 'hash-source-only'}, candidate_action='candidate_insert_missing_canonical'),
+        ),
+        limit=1,
+        blocked_candidate_sample_limit=2,
+        reconciliation_artifact_sha256='source-sha',
+        reconciliation_artifact_basename='reconciliation.json',
+        reconciliation_artifact_size_bytes=123,
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['total_candidates_seen'] == 4
+    assert artifact['summary']['eligible_station_type_updates'] == 1
+    assert artifact['summary']['eligible_candidates'] == 1
+    assert len(artifact['eligible_candidates']) == 1
+    assert artifact['summary']['blocked_candidates'] == 3
+    assert artifact['summary']['blocked_candidate_samples_included'] == 2
+    assert artifact['summary']['blocked_candidate_sample_limit'] == 2
+    assert artifact['summary']['blocked_candidate_samples_omitted'] == 1
+    assert len(artifact['blocked_candidates']) == 2
+    assert artifact['summary']['rejected_missing_external_identity'] == 1
+    assert artifact['summary']['rejected_volatile_evidence'] == 1
+    assert artifact['summary']['rejected_source_only_insert'] == 1
+    assert artifact['source_scope']['input_artifact_sha256'] == 'source-sha'
+    assert artifact['source_scope']['input_artifact_basename'] == 'reconciliation.json'
+    assert artifact['source_scope']['input_artifact_size_bytes'] == 123
+
+
+def test_blocked_candidate_sample_limit_zero_keeps_counts_without_samples():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(source={'market_id': None, 'edsm_station_id': None}),
+            station_candidate(risk_flags=['volatile_source_evidence']),
+        ),
+        limit=1,
+        blocked_candidate_sample_limit=0,
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['blocked_candidates'] == 2
+    assert artifact['summary']['blocked_candidate_samples_included'] == 0
+    assert artifact['summary']['blocked_candidate_samples_omitted'] == 2
+    assert artifact['blocked_candidates'] == []
+    assert artifact['summary']['rejected_missing_external_identity'] == 1
+    assert artifact['summary']['rejected_volatile_evidence'] == 1
+
+
+def test_blocked_candidate_sample_limit_must_be_non_negative():
+    with pytest.raises(pilot.Stage18JPlanError, match='sample limit'):
+        pilot.build_station_type_pilot_dry_run(
+            report_with(station_candidate(source={'market_id': None, 'edsm_station_id': None})),
+            blocked_candidate_sample_limit=-1,
+            generated_at='2026-06-01T00:00:00Z',
+        )
+
+
 def test_limit_exclusion_is_reported_as_rejection_reason():
     artifact = pilot.build_station_type_pilot_dry_run(
         report_with(
@@ -389,9 +451,39 @@ def test_cli_writes_dry_run_json_artifact(tmp_path):
     assert payload['schema_version'] == 'station_type_canonical_pilot_dry_run/v1'
     assert payload['summary']['eligible_candidates'] == 1
     assert payload['summary']['canonical_writes_planned'] == 0
+    assert payload['summary']['blocked_candidate_sample_limit'] == 100
     assert payload['source_scope']['input_artifact_basename'] == 'reconciliation.json'
     assert payload['source_scope']['input_artifact_sha256'] == _file_sha256(report_path)
     assert payload['source_scope']['input_artifact_size_bytes'] == report_path.stat().st_size
+
+
+def test_cli_quiet_writes_without_stdout_and_respects_blocked_sample_limit(tmp_path, capsys):
+    report_path = tmp_path / 'reconciliation.json'
+    output_path = tmp_path / 'stage18j.json'
+    report_path.write_text(json.dumps(report_with(
+        station_candidate(source={'market_id': None, 'edsm_station_id': None}),
+        station_candidate(risk_flags=['volatile_source_evidence']),
+    )), encoding='utf-8')
+
+    result = pilot.main([
+        '--reconciliation-report',
+        str(report_path),
+        '--output',
+        str(output_path),
+        '--limit',
+        '1',
+        '--blocked-candidate-sample-limit',
+        '1',
+        '--quiet',
+    ])
+
+    captured = capsys.readouterr()
+    payload = json.loads(output_path.read_text(encoding='utf-8'))
+    assert result == 0
+    assert captured.out == ''
+    assert payload['summary']['blocked_candidates'] == 2
+    assert payload['summary']['blocked_candidate_samples_included'] == 1
+    assert len(payload['blocked_candidates']) == 1
 
 
 def test_cli_dry_run_rejects_dsn_and_does_not_invoke_apply(tmp_path, monkeypatch):
@@ -419,6 +511,23 @@ def test_cli_dry_run_rejects_dsn_and_does_not_invoke_apply(tmp_path, monkeypatch
             '--dsn',
             'postgresql://dry-run/test',
         ])
+
+
+def test_operator_station_type_dry_run_script_is_syntax_valid_and_guarded():
+    script = ROOT / 'scripts' / 'operator' / 'stage18j_run_station_type_dry_run.sh'
+
+    subprocess.run(['bash', '-n', str(script)], check=True)
+    text = script.read_text(encoding='utf-8')
+    assert 'scripts/operator/require_hetzner_operator_env.sh' in text
+    assert '--apply' not in text
+    assert '--dsn' not in text
+    assert '--limit "$MAX_ROWS"' in text
+    assert '--blocked-candidate-sample-limit "$BLOCKED_CANDIDATE_SAMPLE_LIMIT"' in text
+    assert 'MAX_ROWS > 20' in text
+    assert '[[ ! -s "$RECON_ARTIFACT" ]]' in text
+    assert 'checksum mismatch' in text
+    assert 'canonical_writes_planned_zero' in text
+    assert 'approval_record_created_false' in text
 
 
 def test_validate_apply_request_fails_closed_on_mismatched_approval_parameters():


### PR DESCRIPTION
## What changed

* Adds Hetzner-only operator wrapper for the strict station-type dry-run.
* Verifies reconciliation artifact checksum before dry-run.
* Requires explicit bounded max rows.
* Prevents apply/DB access.
* Adds compact blocked-candidate output if implemented.
* Updates docs/roadmap.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No production station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18J-P not started.
* Stage 18K not started.

## Validation

```text
git diff --check
PASS

bash -n scripts/operator/require_hetzner_operator_env.sh
PASS

bash -n scripts/operator/stage18j_run_compact_summary.sh
PASS

bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
PASS

./scripts/run_canonical_safety_tests.sh
94 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q
94 passed in 0.15s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py
PASS

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' scripts/operator apps/importer/src/station_type_canonical_pilot.py docs/operations/enrichment-warehouse-runbook.md docs/operations/operator-command-contexts.md docs/colonisation-redesign/enrichment-roadmap.md docs/colonisation-redesign/stage-18j-p-dryrun-operator-safe-wrapper.md 2>/dev/null || true
No matches

Additional scan of changed Stage 18J/17P docs:
grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md docs/colonisation-redesign/stage-17p-current-state-forward-plan.md 2>/dev/null || true
No matches

git diff --cached --check
PASS
```
