### PR TITLE
Stage 18J-P2 station-type identity coverage diagnostics

### DIFF
--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -135,12 +135,14 @@ def build_station_type_pilot_dry_run(
     blocked_samples: list[dict[str, Any]] = []
     blocked_count = 0
     rejection_reason_counts: dict[str, int] = {}
+    identity_coverage_summary = _new_identity_coverage_summary()
     rows_considered = 0
 
     for candidate in reconciliation_report.get('station_candidates', []) or []:
         if not isinstance(candidate, Mapping):
             continue
         rows_considered += 1
+        _record_identity_coverage(identity_coverage_summary, candidate, allow_edsm_station_id=allow_edsm_station_id)
         decision = evaluate_station_type_candidate(
             candidate,
             allow_edsm_station_id=allow_edsm_station_id,
@@ -231,6 +233,7 @@ def build_station_type_pilot_dry_run(
             'warnings': 0,
         },
         'eligible_candidates': eligible,
+        'identity_coverage_summary': identity_coverage_summary,
         'blocked_candidate_output': {
             'sampled': True,
             'sample_limit': blocked_sample_limit,
@@ -1050,6 +1053,175 @@ def _record_blocked_candidate(
     if sample_limit is None or len(blocked_samples) < sample_limit:
         blocked_samples.append(row)
     return blocked_count + 1
+
+
+def _new_identity_coverage_summary() -> dict[str, int]:
+    return {
+        'total_candidates_seen': 0,
+        'source_market_id_present': 0,
+        'source_market_id_missing': 0,
+        'canonical_market_id_present': 0,
+        'canonical_market_id_missing': 0,
+        'market_id_both_present': 0,
+        'market_id_both_missing': 0,
+        'market_id_source_only': 0,
+        'market_id_canonical_only': 0,
+        'market_id_match': 0,
+        'market_id_mismatch': 0,
+        'source_edsm_station_id_present': 0,
+        'source_edsm_station_id_missing': 0,
+        'canonical_edsm_station_id_present': 0,
+        'canonical_edsm_station_id_missing': 0,
+        'edsm_station_id_both_present': 0,
+        'edsm_station_id_both_missing': 0,
+        'edsm_station_id_source_only': 0,
+        'edsm_station_id_canonical_only': 0,
+        'edsm_station_id_match': 0,
+        'edsm_station_id_mismatch': 0,
+        'source_system_id64_present': 0,
+        'source_system_id64_missing': 0,
+        'canonical_system_id64_present': 0,
+        'canonical_system_id64_missing': 0,
+        'system_id64_both_present': 0,
+        'system_id64_match': 0,
+        'system_id64_mismatch': 0,
+        'source_station_name_present': 0,
+        'source_station_name_missing': 0,
+        'canonical_station_name_present': 0,
+        'canonical_station_name_missing': 0,
+        'station_name_both_present': 0,
+        'station_name_match': 0,
+        'station_name_mismatch': 0,
+        'canonical_match_count_exactly_one': 0,
+        'canonical_match_count_not_one': 0,
+        'canonical_match_count_zero': 0,
+        'canonical_match_count_multiple': 0,
+        'canonical_station_present': 0,
+        'canonical_station_missing': 0,
+        'canonical_station_present_but_external_ids_missing_in_payload': 0,
+        'possible_canonical_external_ids_omitted_from_reconciliation_payload': 0,
+        'external_identity_proof_present': 0,
+        'external_identity_proof_absent': 0,
+        'internal_primary_key_only_not_identity_proof': 0,
+    }
+
+
+def _record_identity_coverage(
+    counts: dict[str, int],
+    candidate: Mapping[str, Any],
+    *,
+    allow_edsm_station_id: bool,
+) -> None:
+    source = _mapping(candidate.get('source'))
+    canonical = _mapping(candidate.get('canonical'))
+    canonical_matches = _sequence_of_mappings(candidate.get('canonical_matches'))
+
+    source_market_id = _read_int(source.get('market_id'))
+    canonical_market_id = _read_int(canonical.get('market_id'))
+    source_edsm_station_id = _read_int(source.get('edsm_station_id'))
+    canonical_edsm_station_id = _read_int(canonical.get('edsm_station_id'))
+    source_system_id64 = _read_int(source.get('system_id64'))
+    canonical_system_id64 = _read_int(canonical.get('system_id64'))
+    canonical_station_id = _read_int(canonical.get('station_id'))
+    source_name = _normalise_name(source.get('station_name'))
+    canonical_name = _normalise_name(canonical.get('station_name'))
+
+    counts['total_candidates_seen'] += 1
+
+    _record_pair_coverage(
+        counts,
+        prefix='market_id',
+        source_value=source_market_id,
+        canonical_value=canonical_market_id,
+    )
+    _record_pair_coverage(
+        counts,
+        prefix='edsm_station_id',
+        source_value=source_edsm_station_id,
+        canonical_value=canonical_edsm_station_id,
+    )
+    _record_pair_coverage(
+        counts,
+        prefix='system_id64',
+        source_value=source_system_id64,
+        canonical_value=canonical_system_id64,
+        include_source_only=False,
+    )
+    _record_pair_coverage(
+        counts,
+        prefix='station_name',
+        source_value=source_name,
+        canonical_value=canonical_name,
+        include_source_only=False,
+    )
+
+    match_count = len(canonical_matches)
+    if match_count == 1:
+        counts['canonical_match_count_exactly_one'] += 1
+    else:
+        counts['canonical_match_count_not_one'] += 1
+        if match_count == 0:
+            counts['canonical_match_count_zero'] += 1
+        else:
+            counts['canonical_match_count_multiple'] += 1
+
+    if canonical_station_id is None:
+        counts['canonical_station_missing'] += 1
+    else:
+        counts['canonical_station_present'] += 1
+        if canonical_market_id is None and canonical_edsm_station_id is None:
+            counts['canonical_station_present_but_external_ids_missing_in_payload'] += 1
+            counts['possible_canonical_external_ids_omitted_from_reconciliation_payload'] += 1
+
+    identifier_match_type = _station_external_identifier_match_type(
+        source_market_id=source_market_id,
+        canonical_market_id=canonical_market_id,
+        source_edsm_station_id=source_edsm_station_id,
+        canonical_edsm_station_id=canonical_edsm_station_id,
+        allow_edsm_station_id=allow_edsm_station_id,
+    )
+    if identifier_match_type is None:
+        counts['external_identity_proof_absent'] += 1
+    else:
+        counts['external_identity_proof_present'] += 1
+
+    if (
+        identifier_match_type is None
+        and canonical_station_id is not None
+        and canonical_station_id in {source_market_id, source_edsm_station_id}
+    ):
+        counts['internal_primary_key_only_not_identity_proof'] += 1
+
+
+def _record_pair_coverage(
+    counts: dict[str, int],
+    *,
+    prefix: str,
+    source_value: Any,
+    canonical_value: Any,
+    include_source_only: bool = True,
+) -> None:
+    if source_value is None:
+        counts[f'source_{prefix}_missing'] += 1
+    else:
+        counts[f'source_{prefix}_present'] += 1
+    if canonical_value is None:
+        counts[f'canonical_{prefix}_missing'] += 1
+    else:
+        counts[f'canonical_{prefix}_present'] += 1
+
+    if source_value is not None and canonical_value is not None:
+        counts[f'{prefix}_both_present'] += 1
+        if source_value == canonical_value:
+            counts[f'{prefix}_match'] += 1
+        else:
+            counts[f'{prefix}_mismatch'] += 1
+    elif include_source_only and source_value is None and canonical_value is None:
+        counts[f'{prefix}_both_missing'] += 1
+    elif include_source_only and source_value is None:
+        counts[f'{prefix}_canonical_only'] += 1
+    elif include_source_only and canonical_value is None:
+        counts[f'{prefix}_source_only'] += 1
 
 
 def _blocked_reason_distribution(blocked: Sequence[Mapping[str, Any]]) -> dict[str, int]:

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -562,6 +562,15 @@ under the operator artifact directory, and prints compact summary fields. It
 does not run from Codex, touch the DB, create approvals, or run apply. See
 [`stage-18j-p-dryrun-operator-safe-wrapper.md`](./stage-18j-p-dryrun-operator-safe-wrapper.md).
 
+Stage 18J-P2 adds identity coverage diagnostics after the first bounded
+Hetzner/operator station-type dry-run safely produced zero eligible candidates.
+The dry-run artifact now records compact counts for source/canonical
+`market_id`, `edsm_station_id`, `system_id64`, station-name, canonical match
+count, and possible missing canonical external IDs in the reconciliation
+payload. The strict filter is unchanged, `canonical_writes_planned` stays `0`,
+and the next operator action is diagnostic rerun only. See
+[`stage-18j-p2-station-type-identity-coverage-diagnostics.md`](./stage-18j-p2-station-type-identity-coverage-diagnostics.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -876,6 +876,36 @@ Non-goals:
 Support doc:
 `stage-18j-p-dryrun-operator-safe-wrapper.md`.
 
+### Stage 18J-P2 - Station-Type Identity Coverage Diagnostics
+
+Purpose: explain why the first bounded operator station-type dry-run produced
+zero eligible update candidates after every candidate failed external identity
+proof.
+
+Scope:
+
+- Add count-only `identity_coverage_summary` to the strict station-type dry-run
+  artifact.
+- Count source/canonical `market_id` and `edsm_station_id` presence, matches,
+  and mismatches.
+- Count `system_id64` and station-name matches and mismatches.
+- Count canonical match distribution and canonical station rows whose external
+  IDs are absent from the reconciliation payload.
+- Keep the strict filter unchanged and keep `canonical_writes_planned = 0`.
+- Support a future bounded Hetzner/operator diagnostic rerun.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access.
+- No imports, reconciliation, production summarizer run, production
+  station-type dry-run, or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p2-station-type-identity-coverage-diagnostics.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -952,5 +982,6 @@ Do not add another large planner feature immediately. The healthiest next sequen
 29. Stage 18J-Q9 compact summary review / station-type dry-run readiness.
 30. Stage 18J-P-filter strict station-type dry-run filter hardening.
 31. Stage 18J-P-dryrun-ops operator-safe station-type dry-run wrapper.
+32. Stage 18J-P2 station-type identity coverage diagnostics.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p-dryrun-operator-safe-wrapper.md
+++ b/docs/colonisation-redesign/stage-18j-p-dryrun-operator-safe-wrapper.md
@@ -83,6 +83,18 @@ included up to the explicit `--limit`.
 The default blocked sample limit is `100`; the operator wrapper passes
 `BLOCKED_CANDIDATE_SAMPLE_LIMIT`, also defaulting to `100`.
 
+## Identity Coverage Diagnostics
+
+Stage 18J-P2 adds `identity_coverage_summary` to future dry-run artifacts. The
+summary is count-only and explains external identity coverage without including
+raw payloads. It records source/canonical `market_id`, `edsm_station_id`,
+`system_id64`, station-name, canonical match count, canonical station presence,
+and possible missing canonical external IDs in the reconciliation payload.
+
+The diagnostics do not relax the strict filter. They are intended to explain
+why the bounded operator dry-run can produce zero eligible station-type updates
+while still keeping `canonical_writes_planned = 0`.
+
 ## Output Contract
 
 Dry-run output remains:
@@ -102,6 +114,7 @@ The artifact records:
 - `summary.rejection_reason_counts`,
 - `summary.blocked_candidate_samples_included`,
 - `summary.blocked_candidate_samples_omitted`,
+- `identity_coverage_summary`,
 - `source_scope.input_artifact_basename`,
 - `source_scope.input_artifact_sha256`,
 - `artifact_integrity.canonical_json_sha256`.

--- a/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
+++ b/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
@@ -104,6 +104,13 @@ production reconciliation artifact. The dry-run artifact keeps all counts and
 rejection distributions, includes eligible rows up to the explicit limit, and
 caps blocked row samples through `--blocked-candidate-sample-limit`.
 
+Stage 18J-P2 adds `identity_coverage_summary` to future dry-run artifacts. It
+counts source/canonical external ID presence, external ID matches and
+mismatches, `system_id64` and station-name mismatches, canonical match count
+distribution, and possible canonical external IDs missing from the
+reconciliation payload. These diagnostics explain rejection causes without
+relaxing the strict filter or changing `canonical_writes_planned = 0`.
+
 ## Tests
 
 Synthetic tests cover:

--- a/docs/colonisation-redesign/stage-18j-p2-station-type-identity-coverage-diagnostics.md
+++ b/docs/colonisation-redesign/stage-18j-p2-station-type-identity-coverage-diagnostics.md
@@ -1,0 +1,128 @@
+# Stage 18J-P2 - Station-Type Identity Coverage Diagnostics
+
+## Purpose
+
+Stage 18J-P2 adds compact identity coverage diagnostics to the strict
+station-type dry-run output. The first bounded Hetzner/operator dry-run was
+safe and compact, but it found zero eligible station-type update candidates
+because every station candidate failed external identity proof.
+
+This stage is diagnostic/review tooling only. It does not run production
+commands, touch the production DB, run imports, run reconciliation, run the
+summarizer against production artifacts, run production station-type dry-run,
+run canonical apply, create approval records, or start Stage 18K.
+
+## Input Dry-Run Result
+
+The operator dry-run artifact reported:
+
+- schema: `station_type_canonical_pilot_dry_run/v1`
+- dry-run artifact SHA-256:
+  `29a95f910d86707d90ef4b1cbd393ca37831ed2cca9e320446ab0101fef3d4e7`
+- source reconciliation artifact SHA-256:
+  `0bacd62b7de0adf749b3c0de59ac3eebd4f67a6bea18eb96510d29f999935802`
+- `canonical_writes_planned`: `0`
+- `total_candidates_seen`: `298177`
+- `eligible_station_type_updates`: `0`
+- `blocked_candidates`: `298177`
+- `blocked_candidate_samples_included`: `100`
+- `max_row_bound`: `5`
+- `apply_run`: `false`
+- `approval_record_created`: `false`
+
+The leading rejection count was:
+
+- `rejected_missing_external_identity`: `298177`
+
+That means the strict filter behaved safely, but it did not explain whether
+the failure came from missing source IDs, missing canonical IDs, mismatched IDs,
+system/name mismatches, ambiguous match counts, or omitted canonical external
+IDs in the reconciliation payload.
+
+## Diagnostic Output
+
+`station_type_canonical_pilot.py` now emits
+`identity_coverage_summary` in dry-run artifacts. The summary is compact,
+deterministic, and count-only. It does not include raw payloads and does not
+change candidate eligibility.
+
+The summary records:
+
+- source and canonical `market_id` presence,
+- `market_id` matches and mismatches when both sides are present,
+- source and canonical `edsm_station_id` presence,
+- `edsm_station_id` matches and mismatches when both sides are present,
+- source and canonical `system_id64` presence and mismatch counts,
+- source and canonical station-name presence and mismatch counts,
+- canonical match count distribution,
+- canonical station presence,
+- canonical station present while external IDs are absent from the
+  reconciliation payload,
+- possible omitted canonical external IDs in reconciliation payload,
+- internal primary-key-only cases that remain insufficient identity proof,
+- external identity proof present/absent counts.
+
+## Eligibility Boundary
+
+The diagnostics do not relax the strict filter. A candidate is still eligible
+only when the existing Stage 18J-P-filter rules pass:
+
+- update-only station candidate,
+- station-type delta only,
+- `source.market_id == canonical.market_id`, or
+  `source.edsm_station_id == canonical.edsm_station_id`,
+- exactly one canonical match,
+- matching `system_id64`,
+- matching normalized station name,
+- no volatile evidence,
+- no transient/non-slot station type,
+- eligible canonical old value,
+- explicit max-row bound.
+
+Internal canonical `station_id` remains only the update target. It is never
+accepted as identity proof.
+
+## What The Next Diagnostic Rerun Should Answer
+
+After this change merges, a separate Hetzner/operator bounded dry-run can
+produce the new identity coverage summary. That rerun should answer:
+
+- whether source `market_id` values are absent,
+- whether canonical `market_id` values are absent from reconciliation output,
+- whether both sides have `market_id` values but disagree,
+- whether source `edsm_station_id` values are absent,
+- whether canonical `edsm_station_id` values are absent from reconciliation
+  output,
+- whether both sides have `edsm_station_id` values but disagree,
+- whether `system_id64` or station names fail the identity guard,
+- whether canonical match counts are not exactly one,
+- whether canonical station rows are present but external IDs are missing from
+  the reconciliation payload.
+
+## Boundaries
+
+This stage creates no approval record and authorizes no apply. The dry-run
+artifact remains review input only. `canonical_writes_planned` remains `0`,
+`apply_run` remains `false`, and `approval_record_created` remains `false`.
+
+Production rerun, if requested later, must still use the Hetzner operator
+wrapper, the known reconciliation checksum, bounded `MAX_ROWS`, compact blocked
+samples, and no apply arguments.
+
+## Roadmap Impact
+
+Stage 18J-P is not ready for any apply path. The next appropriate step after
+merge is a separate bounded Hetzner/operator dry-run rerun for diagnostics
+only. If the new identity coverage summary shows canonical external IDs are
+missing from the reconciliation payload, the follow-up should inspect and
+repair reconciliation identity payload coverage before considering any apply
+approval packet.
+
+Stage 18K remains not started.
+
+## Final Recommendation
+
+Merge the identity coverage diagnostics, then rerun the bounded Hetzner
+station-type dry-run only as a separate operator-shell diagnostic step. Do not
+create an approval packet or apply plan until the identity coverage summary is
+reviewed and the source of the missing external identity proof is understood.

--- a/docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md
@@ -284,10 +284,13 @@ Stage 18J should continue with a narrow station-type dry-run readiness path:
    checksum verification, max-row guard, and compact blocked-candidate output.
 4. Stage 18J-P may retry station-type production dry-run only if separately
    prompted and if the strict filter is implemented or reconfirmed.
-5. Stage 18J-P2 reviews the filtered dry-run artifact.
-6. Stage 18J-P3 prepares a tiny apply approval packet only if the dry-run is
-   boring and bounded.
-7. Stage 18J-P4 performs a tiny manual apply only if explicitly approved.
+5. Stage 18J-P2 adds identity coverage diagnostics if the filtered dry-run
+   finds zero eligible station-type updates because external identity proof is
+   missing.
+6. A separate bounded operator rerun may collect those diagnostics for review.
+7. Stage 18J-P3 prepares a tiny apply approval packet only if a later dry-run
+   is boring, bounded, externally identity-proven, and explicitly reviewed.
+8. Stage 18J-P4 performs a tiny manual apply only if explicitly approved.
 
 Stage 19 warehouse expansion remains separate and report-only. Stage 18K is not
 started by Q9.
@@ -304,3 +307,5 @@ implements or reconfirms the filtered dry-run scope.
 Stage 18J-P-filter is the implementation hardening step for that filter. It
 does not run the production dry-run or approve any artifact. Stage
 18J-P-dryrun-ops adds the operator wrapper needed before that future dry-run.
+Stage 18J-P2 adds identity coverage diagnostics so a zero-eligible bounded
+dry-run can be understood before any approval-packet discussion.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -648,6 +648,16 @@ passes apply-mode or database connection arguments, creates no approval record,
 and keeps `canonical_writes_planned = 0`. This wrapper must be run only from
 the Hetzner operator shell and only after a separate Stage 18J-P prompt.
 
+The first bounded operator dry-run succeeded safely but found zero eligible
+station-type update candidates because all `298177` candidates failed external
+identity proof. Stage 18J-P2 adds `identity_coverage_summary` to future dry-run
+artifacts so a diagnostic rerun can show whether the missing proof comes from
+absent source IDs, absent canonical IDs in the reconciliation payload, ID
+mismatches, system/name mismatches, or non-exact canonical match counts. The
+diagnostic summary does not relax eligibility, does not create approvals, and
+keeps `canonical_writes_planned = 0`. Any rerun for these diagnostics is still
+a separate Hetzner/operator step and must not run apply.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/tests/test_station_type_canonical_pilot.py
+++ b/tests/test_station_type_canonical_pilot.py
@@ -127,6 +127,11 @@ def test_dry_run_builds_deterministic_station_type_artifact():
     assert first['summary']['dry_run_only'] is True
     assert first['summary']['apply_run'] is False
     assert first['summary']['approval_record_created'] is False
+    assert first['identity_coverage_summary'] == second['identity_coverage_summary']
+    assert first['identity_coverage_summary']['total_candidates_seen'] == 1
+    assert first['identity_coverage_summary']['market_id_match'] == 1
+    assert first['identity_coverage_summary']['external_identity_proof_present'] == 1
+    assert all(isinstance(value, int) for value in first['identity_coverage_summary'].values())
     candidate = first['eligible_candidates'][0]
     assert candidate['canonical_table'] == 'stations'
     assert candidate['field'] == 'station_type'
@@ -145,6 +150,7 @@ def test_blocks_name_only_or_missing_stable_station_identifier():
     assert artifact['summary']['eligible_candidates'] == 0
     assert artifact['summary']['rejected_missing_external_identity'] == 1
     assert artifact['summary']['rejection_reason_counts']['rejected_missing_external_identity'] == 1
+    assert artifact['identity_coverage_summary']['external_identity_proof_absent'] == 1
 
 
 def test_blocks_internal_station_pk_match_without_canonical_external_identity():
@@ -172,6 +178,9 @@ def test_blocks_internal_station_pk_match_without_canonical_external_identity():
     assert blocked['canonical']['market_id'] is None
     assert blocked['match_proof']['source_market_id'] == 900001
     assert blocked['match_proof']['canonical_market_id'] is None
+    assert artifact['identity_coverage_summary']['internal_primary_key_only_not_identity_proof'] == 1
+    assert artifact['identity_coverage_summary']['canonical_station_present_but_external_ids_missing_in_payload'] == 1
+    assert artifact['identity_coverage_summary']['possible_canonical_external_ids_omitted_from_reconciliation_payload'] == 1
 
 
 def test_blocks_internal_station_pk_match_when_canonical_external_identity_differs():
@@ -223,6 +232,114 @@ def test_allows_edsm_station_id_external_identity_match():
 
     assert artifact['summary']['eligible_candidates'] == 1
     assert artifact['eligible_candidates'][0]['match_proof']['identifier_match_type'] == 'edsm_station_id'
+
+
+def test_identity_coverage_summary_counts_market_id_presence_and_match_states():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(),
+            station_candidate(source={'market_id': None}),
+            station_candidate(canonical={'market_id': None}),
+            station_candidate(source={'market_id': 2002}),
+        ),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    summary = artifact['identity_coverage_summary']
+    assert summary['total_candidates_seen'] == 4
+    assert summary['source_market_id_present'] == 3
+    assert summary['source_market_id_missing'] == 1
+    assert summary['canonical_market_id_present'] == 3
+    assert summary['canonical_market_id_missing'] == 1
+    assert summary['market_id_both_present'] == 2
+    assert summary['market_id_match'] == 1
+    assert summary['market_id_mismatch'] == 1
+    assert summary['market_id_canonical_only'] == 1
+    assert summary['market_id_source_only'] == 1
+
+
+def test_identity_coverage_summary_counts_edsm_station_id_presence_and_match_states():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(source={'market_id': None}, canonical={'market_id': None}),
+            station_candidate(source={'market_id': None}, canonical={'market_id': None, 'edsm_station_id': 7001}),
+            station_candidate(source={'market_id': None, 'edsm_station_id': 7002}, canonical={'market_id': None}),
+            station_candidate(source={'market_id': None, 'edsm_station_id': 7003}, canonical={'market_id': None, 'edsm_station_id': 7003}),
+            station_candidate(source={'market_id': None, 'edsm_station_id': 7004}, canonical={'market_id': None, 'edsm_station_id': 7005}),
+        ),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    summary = artifact['identity_coverage_summary']
+    assert summary['total_candidates_seen'] == 5
+    assert summary['source_edsm_station_id_present'] == 3
+    assert summary['source_edsm_station_id_missing'] == 2
+    assert summary['canonical_edsm_station_id_present'] == 3
+    assert summary['canonical_edsm_station_id_missing'] == 2
+    assert summary['edsm_station_id_both_missing'] == 1
+    assert summary['edsm_station_id_canonical_only'] == 1
+    assert summary['edsm_station_id_source_only'] == 1
+    assert summary['edsm_station_id_both_present'] == 2
+    assert summary['edsm_station_id_match'] == 1
+    assert summary['edsm_station_id_mismatch'] == 1
+
+
+def test_identity_coverage_summary_counts_system_id64_and_station_name_mismatches():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(),
+            station_candidate(source={'system_id64': 999999}),
+            station_candidate(source={'station_name': 'Renamed Plant'}),
+        ),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    summary = artifact['identity_coverage_summary']
+    assert summary['source_system_id64_present'] == 3
+    assert summary['canonical_system_id64_present'] == 3
+    assert summary['system_id64_both_present'] == 3
+    assert summary['system_id64_match'] == 2
+    assert summary['system_id64_mismatch'] == 1
+    assert summary['source_station_name_present'] == 3
+    assert summary['canonical_station_name_present'] == 3
+    assert summary['station_name_both_present'] == 3
+    assert summary['station_name_match'] == 2
+    assert summary['station_name_mismatch'] == 1
+
+
+def test_identity_coverage_summary_counts_ambiguous_canonical_match_counts():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(),
+            station_candidate(canonical_matches=[]),
+            station_candidate(canonical_matches=[{'station_id': 1001}, {'station_id': 1002}]),
+        ),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    summary = artifact['identity_coverage_summary']
+    assert summary['canonical_match_count_exactly_one'] == 1
+    assert summary['canonical_match_count_not_one'] == 2
+    assert summary['canonical_match_count_zero'] == 1
+    assert summary['canonical_match_count_multiple'] == 1
+    assert artifact['summary']['blocked_by_reason']['rejected_ambiguous_identity'] == 2
+
+
+def test_zero_eligible_candidates_remains_valid_when_external_identity_is_absent():
+    artifact = pilot.build_station_type_pilot_dry_run(
+        report_with(
+            station_candidate(source={'market_id': None, 'edsm_station_id': None}),
+            station_candidate(source={'market_id': None, 'edsm_station_id': None}, risk_flags=['volatile_source_evidence']),
+        ),
+        generated_at='2026-06-01T00:00:00Z',
+    )
+
+    assert artifact['summary']['eligible_candidates'] == 0
+    assert artifact['summary']['canonical_writes_planned'] == 0
+    assert artifact['summary']['apply_run'] is False
+    assert artifact['summary']['approval_record_created'] is False
+    assert artifact['identity_coverage_summary']['external_identity_proof_absent'] == 2
+    assert artifact['identity_coverage_summary']['external_identity_proof_present'] == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

* Adds identity coverage diagnostics for strict station-type dry-run filtering.
* Explains why candidates fail external identity proof.
* Keeps strict filter unchanged.
* Keeps canonical_writes_planned at 0.
* Adds tests and docs.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No production station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18J-P apply not started.
* Stage 18K not started.

## Validation

```text
git diff --check
passed

bash -n scripts/operator/require_hetzner_operator_env.sh
passed

bash -n scripts/operator/stage18j_run_compact_summary.sh
passed

bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
passed

./scripts/run_canonical_safety_tests.sh
99 passed in 0.18s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py -q
99 passed in 0.15s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py
passed

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' apps/importer/src/station_type_canonical_pilot.py docs/colonisation-redesign/stage-18j-p2-station-type-identity-coverage-diagnostics.md docs/colonisation-redesign/stage-18j-p-dryrun-operator-safe-wrapper.md docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md docs/colonisation-redesign/stage-18j-q9-compact-summary-review-station-type-dry-run-readiness.md docs/colonisation-redesign/enrichment-roadmap.md docs/operations/enrichment-warehouse-runbook.md docs/colonisation-redesign/stage-17p-current-state-forward-plan.md 2>/dev/null || true
no matches
```