### PR TITLE
Stage 18J-P3 canonical external station identity model

### DIFF
--- a/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
+++ b/docs/colonisation-redesign/stage-18j-p-filter-strict-station-type-dry-run-filter.md
@@ -2,15 +2,9 @@
 
 ## Purpose
 
-Stage 18J-P-filter hardens the station-type dry-run candidate filter before any
-future Stage 18J-P production dry-run retry. It converts the Stage 18J-Q9
-readiness verdict, `Ready only with strict filter`, into code-level dry-run
-eligibility rules and synthetic test coverage.
+Stage 18J-P-filter hardens the station-type dry-run candidate filter before any future Stage 18J-P production dry-run retry. It converts the Stage 18J-Q9 readiness verdict, `Ready only with strict filter`, into code-level dry-run eligibility rules and synthetic test coverage.
 
-This stage does not run production commands, touch the production DB, run
-imports, run reconciliation, run the summarizer against production artifacts,
-run a production station-type dry-run, run canonical apply, create approval
-records, start Stage 18J-P, or start Stage 18K.
+This stage does not run production commands, touch the production DB, run imports, run reconciliation, run the summarizer against production artifacts, run a production station-type dry-run, run canonical apply, create approval records, start Stage 18J-P, or start Stage 18K.
 
 ## Inputs
 
@@ -25,19 +19,14 @@ Stage 18J-Q9 reviewed the compact reconciliation summary and found:
 - volatile evidence present,
 - `15014` high-confidence rows.
 
-Those counts show that the full station reconciliation candidate set is too
-broad for a production station-type dry-run. The future retry must be bounded
-and filtered before an operator runs it.
+Those counts show that the full station reconciliation candidate set is too broad for a production station-type dry-run. The future retry must be bounded and filtered before an operator runs it.
 
 ## Filter Contract
 
 The station-type dry-run planner now requires:
 
-- explicit external station identity proof by matching `source.market_id` to
-  `canonical.market_id`, or matching `source.edsm_station_id` to
-  `canonical.edsm_station_id`;
-- no identity proof from internal canonical `station_id` or primary-key
-  equality alone;
+- explicit external station identity proof by matching `source.market_id` to `canonical.market_id`, or matching `source.edsm_station_id` to `canonical.edsm_station_id`;
+- no identity proof from internal canonical `station_id` or primary-key equality alone;
 - exactly one canonical station match;
 - `candidate_action = candidate_update`;
 - `stations.station_type` as the only target field;
@@ -50,14 +39,11 @@ The station-type dry-run planner now requires:
 - no non-station-type canonical writes;
 - a required explicit max-row bound.
 
-Missing `station_body_name` remains a station/body-link blocker, but it no
-longer blocks an otherwise externally proven station-type comparison. This
-keeps station-type comparison separate from station/body association work.
+Missing `station_body_name` remains a station/body-link blocker, but it no longer blocks an otherwise externally proven station-type comparison. This keeps station-type comparison separate from station/body association work.
 
 ## Rejection Reasons
 
-Every excluded station candidate receives machine-readable rejection reasons.
-The dry-run summary includes these counts:
+Every excluded station candidate receives machine-readable rejection reasons. The dry-run summary includes these counts:
 
 - `total_candidates_seen`
 - `eligible_station_type_updates`
@@ -73,16 +59,11 @@ The dry-run summary includes these counts:
 - `rejected_freshness`
 - `rejected_by_max_row_bound`
 
-The artifact keeps `rejection_reason_counts` and the legacy
-`blocked_by_reason` map aligned so existing review flows can still inspect the
-distribution.
+The artifact keeps `rejection_reason_counts` and the legacy `blocked_by_reason` map aligned so existing review flows can still inspect the distribution.
 
 ## Dry-Run Output
 
-The dry-run artifact remains `station_type_canonical_pilot_dry_run/v1` and is
-still deterministic. It now records the input reconciliation artifact basename,
-size, and SHA-256 when invoked through the CLI, so a future operator review can
-tie the dry-run to the exact read-only reconciliation artifact.
+The dry-run artifact remains `station_type_canonical_pilot_dry_run/v1` and is still deterministic. It records the input reconciliation artifact basename, size, and SHA-256 when invoked through the CLI, so a future operator review can tie the dry-run to the exact read-only reconciliation artifact.
 
 The dry-run output explicitly records:
 
@@ -95,21 +76,27 @@ The dry-run output explicitly records:
 - `summary.approval_record_created = false`,
 - `operator_review.production_artifact_approved = false`.
 
-Eligible rows are reported as `eligible_station_type_updates`; they are not
-canonical writes, approval records, or apply instructions.
+Eligible rows are reported as `eligible_station_type_updates`; they are not canonical writes, approval records, or apply instructions.
 
-Stage 18J-P-dryrun-ops adds compact blocked-candidate output controls so the
-future operator dry-run does not emit every blocked row from the large
-production reconciliation artifact. The dry-run artifact keeps all counts and
-rejection distributions, includes eligible rows up to the explicit limit, and
-caps blocked row samples through `--blocked-candidate-sample-limit`.
+Stage 18J-P-dryrun-ops adds compact blocked-candidate output controls so the future operator dry-run does not emit every blocked row from the large production reconciliation artifact. The dry-run artifact keeps all counts and rejection distributions, includes eligible rows up to the explicit limit, and caps blocked row samples through `--blocked-candidate-sample-limit`.
 
-Stage 18J-P2 adds `identity_coverage_summary` to future dry-run artifacts. It
-counts source/canonical external ID presence, external ID matches and
-mismatches, `system_id64` and station-name mismatches, canonical match count
-distribution, and possible canonical external IDs missing from the
-reconciliation payload. These diagnostics explain rejection causes without
-relaxing the strict filter or changing `canonical_writes_planned = 0`.
+Stage 18J-P2 adds `identity_coverage_summary` to future dry-run artifacts. It counts source/canonical external ID presence, external ID matches and mismatches, `system_id64` and station-name mismatches, canonical match count distribution, and possible canonical external IDs missing from the reconciliation payload. These diagnostics explain rejection causes without relaxing the strict filter or changing `canonical_writes_planned = 0`.
+
+## Stage 18J-P3 Identity Model Implication
+
+The bounded P2 dry-run found source EDSM station IDs present but canonical `market_id` and `edsm_station_id` absent. The production schema check confirmed that `stations` does not contain those external identity columns.
+
+That result does not weaken the filter. It proves the canonical identity model is incomplete for strict station-type promotion. The filter must continue to reject all candidates until read-only reconciliation can expose confirmed canonical external station identity from a modeled source such as a future `station_external_identity` table.
+
+Do not change the filter to accept:
+
+- internal `stations.id` equality,
+- station-name-only matches,
+- system/name matches without external ID equality,
+- source-only EDSM IDs,
+- candidate or conflicted identity evidence.
+
+Only confirmed canonical external identity should satisfy this filter.
 
 ## Tests
 
@@ -120,8 +107,7 @@ Synthetic tests cover:
 - internal primary-key-only matching does not qualify;
 - ambiguous matches are rejected;
 - source-only insert candidates are rejected;
-- missing `station_body_name` does not block externally proven station-type
-  comparison;
+- missing `station_body_name` does not block externally proven station-type comparison;
 - missing `station_body_name` remains blocked for station/body-link candidates;
 - volatile evidence is rejected;
 - fleet carriers and megaships are rejected as transient/non-slot;
@@ -129,12 +115,12 @@ Synthetic tests cover:
 - an explicit max-row bound is required;
 - rejection reason counts are present;
 - `canonical_writes_planned` remains `0`;
-- the dry-run path does not invoke apply.
+- the dry-run path does not invoke apply;
+- identity coverage counts explain why missing canonical external IDs produce zero eligible rows.
 
 ## Boundaries
 
-This stage does not authorize Stage 18J-P. It only hardens the local code and
-tests so a future operator command can be reviewed against the strict filter.
+This stage does not authorize Stage 18J-P. It only hardens the local code and tests so a future operator command can be reviewed against the strict filter.
 
 Still blocked:
 
@@ -147,21 +133,18 @@ Still blocked:
 
 ## Future Stage 18J-P Effect
 
-After this stage merges, a future Stage 18J-P production dry-run can proceed
-only when separately prompted in the Hetzner operator shell, after the
-operator-safe wrapper has merged, and only with:
+After this stage merges, a future Stage 18J-P production dry-run can proceed only when separately prompted in the Hetzner operator shell, after the operator-safe wrapper has merged, and only with:
 
 - the reviewed production reconciliation artifact,
 - the explicit max-row bound,
 - the recorded source artifact checksum,
 - compact/reviewable dry-run output,
+- confirmed canonical external identity available in reconciliation output,
 - no approval record,
 - no canonical apply.
 
-Stage 18J-P remains blocked until that separate operator step is requested.
+Stage 18J-P remains blocked until that separate operator step is requested and canonical external identity is modeled.
 
 ## Final Recommendation
 
-Merge the strict filter hardening before retrying Stage 18J-P. After merge, the
-future production dry-run is technically eligible to proceed as a separate
-operator step, but it is not started or approved by this stage.
+Keep the strict filter hardening. The P2 zero-eligible result is not a reason to loosen it. The next step is the Stage 18J-P3 external station identity model, followed by a separate schema/evidence-loader stage before any station-type dry-run retry can produce eligible rows.

--- a/docs/colonisation-redesign/stage-18j-p2-station-type-identity-coverage-diagnostics.md
+++ b/docs/colonisation-redesign/stage-18j-p2-station-type-identity-coverage-diagnostics.md
@@ -2,25 +2,17 @@
 
 ## Purpose
 
-Stage 18J-P2 adds compact identity coverage diagnostics to the strict
-station-type dry-run output. The first bounded Hetzner/operator dry-run was
-safe and compact, but it found zero eligible station-type update candidates
-because every station candidate failed external identity proof.
+Stage 18J-P2 adds compact identity coverage diagnostics to the strict station-type dry-run output. The first bounded Hetzner/operator dry-run was safe and compact, but it found zero eligible station-type update candidates because every station candidate failed external identity proof.
 
-This stage is diagnostic/review tooling only. It does not run production
-commands, touch the production DB, run imports, run reconciliation, run the
-summarizer against production artifacts, run production station-type dry-run,
-run canonical apply, create approval records, or start Stage 18K.
+This stage is diagnostic/review tooling only. It does not run production commands, touch the production DB, run imports, run reconciliation, run the summarizer against production artifacts, run production station-type dry-run, run canonical apply, create approval records, or start Stage 18K.
 
 ## Input Dry-Run Result
 
 The operator dry-run artifact reported:
 
 - schema: `station_type_canonical_pilot_dry_run/v1`
-- dry-run artifact SHA-256:
-  `29a95f910d86707d90ef4b1cbd393ca37831ed2cca9e320446ab0101fef3d4e7`
-- source reconciliation artifact SHA-256:
-  `0bacd62b7de0adf749b3c0de59ac3eebd4f67a6bea18eb96510d29f999935802`
+- dry-run artifact SHA-256: `29a95f910d86707d90ef4b1cbd393ca37831ed2cca9e320446ab0101fef3d4e7`
+- source reconciliation artifact SHA-256: `0bacd62b7de0adf749b3c0de59ac3eebd4f67a6bea18eb96510d29f999935802`
 - `canonical_writes_planned`: `0`
 - `total_candidates_seen`: `298177`
 - `eligible_station_type_updates`: `0`
@@ -34,17 +26,11 @@ The leading rejection count was:
 
 - `rejected_missing_external_identity`: `298177`
 
-That means the strict filter behaved safely, but it did not explain whether
-the failure came from missing source IDs, missing canonical IDs, mismatched IDs,
-system/name mismatches, ambiguous match counts, or omitted canonical external
-IDs in the reconciliation payload.
+That means the strict filter behaved safely, but it did not explain whether the failure came from missing source IDs, missing canonical IDs, mismatched IDs, system/name mismatches, ambiguous match counts, or omitted canonical external IDs in the reconciliation payload.
 
 ## Diagnostic Output
 
-`station_type_canonical_pilot.py` now emits
-`identity_coverage_summary` in dry-run artifacts. The summary is compact,
-deterministic, and count-only. It does not include raw payloads and does not
-change candidate eligibility.
+`station_type_canonical_pilot.py` now emits `identity_coverage_summary` in dry-run artifacts. The summary is compact, deterministic, and count-only. It does not include raw payloads and does not change candidate eligibility.
 
 The summary records:
 
@@ -56,21 +42,32 @@ The summary records:
 - source and canonical station-name presence and mismatch counts,
 - canonical match count distribution,
 - canonical station presence,
-- canonical station present while external IDs are absent from the
-  reconciliation payload,
+- canonical station present while external IDs are absent from the reconciliation payload,
 - possible omitted canonical external IDs in reconciliation payload,
 - internal primary-key-only cases that remain insufficient identity proof,
 - external identity proof present/absent counts.
 
+## Production Finding After P2
+
+The follow-up Hetzner/operator finding confirmed that canonical `stations` has no `market_id` or `edsm_station_id` columns. The attempted coverage query failed on missing `market_id`, and the P2 identity coverage reported:
+
+- `source_edsm_station_id_present`: `298177`
+- `canonical_edsm_station_id_present`: `0`
+- `canonical_market_id_present`: `0`
+- `external_identity_proof_present`: `0`
+- `external_identity_proof_absent`: `298177`
+- `canonical_station_present_but_external_ids_missing_in_payload`: `262579`
+- `possible_canonical_external_ids_omitted_from_reconciliation_payload`: `262579`
+
+The updated conclusion is that Stage 18J-P cannot produce eligible station-type update candidates until external station identity is modeled and populated safely. Re-running the same strict dry-run without canonical external identity available should continue to produce zero eligible rows.
+
 ## Eligibility Boundary
 
-The diagnostics do not relax the strict filter. A candidate is still eligible
-only when the existing Stage 18J-P-filter rules pass:
+The diagnostics do not relax the strict filter. A candidate is still eligible only when the existing Stage 18J-P-filter rules pass:
 
 - update-only station candidate,
 - station-type delta only,
-- `source.market_id == canonical.market_id`, or
-  `source.edsm_station_id == canonical.edsm_station_id`,
+- `source.market_id == canonical.market_id`, or `source.edsm_station_id == canonical.edsm_station_id`,
 - exactly one canonical match,
 - matching `system_id64`,
 - matching normalized station name,
@@ -79,50 +76,26 @@ only when the existing Stage 18J-P-filter rules pass:
 - eligible canonical old value,
 - explicit max-row bound.
 
-Internal canonical `station_id` remains only the update target. It is never
-accepted as identity proof.
+Internal canonical `station_id` remains only the update target. It is never accepted as identity proof.
 
-## What The Next Diagnostic Rerun Should Answer
+## What The Diagnostics Answered
 
-After this change merges, a separate Hetzner/operator bounded dry-run can
-produce the new identity coverage summary. That rerun should answer:
+The P2 diagnostics answered the core question: the missing identity proof is not primarily source-side absence. Source EDSM station IDs are present in the source payload, but canonical external station IDs are absent from the canonical payload because canonical `stations` does not model them.
 
-- whether source `market_id` values are absent,
-- whether canonical `market_id` values are absent from reconciliation output,
-- whether both sides have `market_id` values but disagree,
-- whether source `edsm_station_id` values are absent,
-- whether canonical `edsm_station_id` values are absent from reconciliation
-  output,
-- whether both sides have `edsm_station_id` values but disagree,
-- whether `system_id64` or station names fail the identity guard,
-- whether canonical match counts are not exactly one,
-- whether canonical station rows are present but external IDs are missing from
-  the reconciliation payload.
+This shifts the next step from dry-run retry to identity-model design. See `stage-18j-p3-canonical-external-station-identity-model.md`.
 
 ## Boundaries
 
-This stage creates no approval record and authorizes no apply. The dry-run
-artifact remains review input only. `canonical_writes_planned` remains `0`,
-`apply_run` remains `false`, and `approval_record_created` remains `false`.
+This stage creates no approval record and authorizes no apply. The dry-run artifact remains review input only. `canonical_writes_planned` remains `0`, `apply_run` remains `false`, and `approval_record_created` remains `false`.
 
-Production rerun, if requested later, must still use the Hetzner operator
-wrapper, the known reconciliation checksum, bounded `MAX_ROWS`, compact blocked
-samples, and no apply arguments.
+No follow-up should relax the identity filter or reinterpret internal primary keys as external proof. Production reruns, if requested later, must still use the Hetzner operator wrapper, the known reconciliation checksum, bounded `MAX_ROWS`, compact blocked samples, and no apply arguments.
 
 ## Roadmap Impact
 
-Stage 18J-P is not ready for any apply path. The next appropriate step after
-merge is a separate bounded Hetzner/operator dry-run rerun for diagnostics
-only. If the new identity coverage summary shows canonical external IDs are
-missing from the reconciliation payload, the follow-up should inspect and
-repair reconciliation identity payload coverage before considering any apply
-approval packet.
+Stage 18J-P is not ready for any apply path. The next appropriate step is Stage 18J-P3: design canonical external station identity evidence. If a later identity table is added and populated, a future read-only identity coverage artifact should prove that canonical `market_id` or `edsm_station_id` values are available before retrying the station-type dry-run.
 
 Stage 18K remains not started.
 
 ## Final Recommendation
 
-Merge the identity coverage diagnostics, then rerun the bounded Hetzner
-station-type dry-run only as a separate operator-shell diagnostic step. Do not
-create an approval packet or apply plan until the identity coverage summary is
-reviewed and the source of the missing external identity proof is understood.
+Keep the strict filter. Do not create an approval packet or apply plan from the zero-eligible P2 result. Model external station identity separately, preserve provenance and conflict status, and retry station-type dry-run only after canonical external identity is available in read-only reconciliation output.

--- a/docs/colonisation-redesign/stage-18j-p3-canonical-external-station-identity-model.md
+++ b/docs/colonisation-redesign/stage-18j-p3-canonical-external-station-identity-model.md
@@ -1,0 +1,246 @@
+# Stage 18J-P3 - Canonical External Station Identity Model
+
+## Purpose
+
+Stage 18J-P3 records the follow-up investigation after the bounded Stage 18J-P station-type dry-run proved safe but produced zero eligible rows. The goal is to identify the safest way to model station external identity evidence so the strict station-type filter can stay strict, without writing station types or weakening identity proof.
+
+This stage is investigation/design/tooling only. It does not run production commands, touch the production database, run imports, run reconciliation, run the summarizer against production artifacts, run a production station-type dry-run, run canonical apply, create approval records, or start Stage 18K.
+
+## Production Finding
+
+The Hetzner/operator schema check confirmed that canonical `stations` currently includes:
+
+- `id`
+- `system_id64`
+- `name`
+- `station_type`
+- `has_market`
+- `has_black_market`
+- `station_type_source`
+- `station_type_confidence`
+- `station_type_updated_at`
+
+The same check confirmed that canonical `stations` does not include:
+
+- `market_id`
+- `edsm_station_id`
+
+The attempted identity coverage query failed because `market_id` does not exist on `stations`.
+
+The Stage 18J-P2 dry-run identity coverage then reported:
+
+- `source_edsm_station_id_present`: `298177`
+- `canonical_edsm_station_id_present`: `0`
+- `canonical_market_id_present`: `0`
+- `external_identity_proof_present`: `0`
+- `external_identity_proof_absent`: `298177`
+- `canonical_station_present_but_external_ids_missing_in_payload`: `262579`
+- `possible_canonical_external_ids_omitted_from_reconciliation_payload`: `262579`
+
+## Why Stage 18J-P Has Zero Eligible Rows
+
+The strict station-type filter requires explicit external identity equality:
+
+- `source.market_id == canonical.market_id`, or
+- `source.edsm_station_id == canonical.edsm_station_id`.
+
+The source side has EDSM station identifiers, but the canonical side cannot expose matching `market_id` or `edsm_station_id` because those fields are not modeled on `stations` or joined from another canonical identity table. As a result, every candidate fails `external_station_identifier_matches` and is rejected as `rejected_missing_external_identity`.
+
+That is the correct fail-closed result. The zero-candidate outcome means the model is incomplete, not that the filter is too strict.
+
+## Current Canonical Station Schema
+
+`sql/001_schema.sql` defines `stations.id` as the primary key and includes station attributes, service flags, economy fields, government/faction fields, and provenance columns for selected mutable fields. It does not define a separate external `market_id` or `edsm_station_id` column.
+
+`sql/023_station_data_provenance.sql` adds provenance columns for station distance, station type, and body name. It does not add external identity fields.
+
+`sql/021_station_body_links.sql` creates `station_body_links` as a separate association table and includes a nullable `market_id`, but that table models station/body occupied-slot association. It is not a general station external identity registry, and not every station/body link is confirmed.
+
+The API and existing importer paths often project `s.id AS market_id` for compatibility. The EDSM station enrichment probe also selects `id, id AS market_id` from canonical `stations`. That alias is useful for legacy payloads and diagnostics, but it is not modeled external identity proof. Existing docs already warn not to assume `stations.id == market_id` forever.
+
+## Existing Identity / Provenance Options
+
+There is no current canonical/provenance table that stores general station external identity with both `market_id` and `edsm_station_id` evidence.
+
+Existing options and limits:
+
+- `stations.id`: canonical update target and historical import identifier, not explicit external identity proof.
+- `station_body_links.market_id`: scoped to station/body association, nullable, and not sufficient as the general external station identity registry.
+- `staging_edsm_stations.market_id` and `staging_edsm_stations.edsm_station_id`: source evidence only. These are valuable inputs for backfill, but cannot become canonical proof without a separate verified mapping stage.
+- `enrichment_raw_records.raw_payload` and `source_record_hash`: provenance inputs, not direct canonical identity.
+- `station_type_source`, `station_type_confidence`, `station_type_updated_at`: field provenance for station type only, not identity proof.
+
+Because no existing table safely carries canonical station external IDs, read-only reconciliation cannot currently join a trusted mapping table and include canonical `market_id` / `edsm_station_id` in `candidate.canonical`.
+
+## Recommended Identity Model
+
+Prefer a separate evidence/provenance-backed mapping table rather than adding external IDs directly to `stations` in this stage.
+
+Reasons:
+
+- External IDs are identity evidence, not ordinary station attributes.
+- Source evidence can conflict across snapshots, adapters, and historical imports.
+- The warehouse needs to retain provenance: source run, source file, raw record hash, confidence, freshness, and status.
+- Canonical `stations` should remain the core application truth table; adding source-only evidence directly there risks making provisional evidence look authoritative.
+- The existing `station_body_links` precedent already keeps uncertain association metadata out of the main `stations` row.
+
+The recommended table name is `station_external_identity`.
+
+## Why Not Relax The Filter
+
+Do not accept name-only matches, system/name matches, or `stations.id == source.market_id` as station-type write eligibility.
+
+The strict filter is protecting a canonical write-capable path. Station names can collide, drift, or be ambiguous inside historical import data. Internal primary keys are update targets, not external identity proof. Treating internal ID equality as market identity would hide exactly the schema gap P2 exposed.
+
+The right fix is to model and populate external station identity safely, then let the existing filter pass only when explicit canonical external IDs match the source IDs.
+
+## Proposed External Identity Table
+
+Design sketch for a later additive migration:
+
+```sql
+CREATE TABLE IF NOT EXISTS station_external_identity (
+    id BIGSERIAL PRIMARY KEY,
+    canonical_station_id BIGINT NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    system_id64 BIGINT NOT NULL REFERENCES systems(id64) ON DELETE CASCADE,
+    station_name TEXT NOT NULL,
+    source TEXT NOT NULL,
+    source_class TEXT NOT NULL CHECK (source_class IN (
+        'stable',
+        'semi-stable',
+        'volatile',
+        'diagnostic-only'
+    )),
+    market_id BIGINT DEFAULT NULL,
+    edsm_station_id BIGINT DEFAULT NULL,
+    source_run_key TEXT DEFAULT NULL,
+    source_file_key TEXT DEFAULT NULL,
+    source_record_hash TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    identity_status TEXT NOT NULL DEFAULT 'candidate' CHECK (identity_status IN (
+        'candidate',
+        'confirmed',
+        'conflict',
+        'retired'
+    )),
+    match_method TEXT NOT NULL,
+    source_updated_at TIMESTAMPTZ DEFAULT NULL,
+    first_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    evidence JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+    CHECK (market_id IS NOT NULL OR edsm_station_id IS NOT NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_source_market
+    ON station_external_identity (source, market_id)
+    WHERE market_id IS NOT NULL AND identity_status IN ('candidate', 'confirmed');
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_source_edsm
+    ON station_external_identity (source, edsm_station_id)
+    WHERE edsm_station_id IS NOT NULL AND identity_status IN ('candidate', 'confirmed');
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_station
+    ON station_external_identity (canonical_station_id, identity_status);
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_system_name
+    ON station_external_identity (system_id64, station_name);
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_source_run
+    ON station_external_identity (source_run_key, source_file_key);
+```
+
+The table is intended to store canonical-station-to-external-ID mapping evidence. It should not store volatile station facts such as distance, market price, demand, supply, services, or station type changes. Those stay in staging, report-only intelligence, or their own observation tables.
+
+Recommended status semantics:
+
+- `candidate`: one source snapshot suggests the mapping; not yet enough for canonical write eligibility.
+- `confirmed`: mapping has passed the identity evidence stage's rules and can be used by read-only reconciliation as canonical external identity.
+- `conflict`: source evidence disagrees with an existing active mapping or maps one external ID to multiple canonical stations.
+- `retired`: old mapping retained for audit/history but not used as active proof.
+
+## Backfill Strategy
+
+Backfill should be its own stage and must be separate from station-type dry-run/apply.
+
+Recommended backfill path:
+
+1. Read warehouse station evidence from staged, already reviewed offline snapshots.
+2. Match to canonical stations conservatively inside the same `system_id64`.
+3. Prefer source rows with explicit `market_id` and/or `edsm_station_id`, station name, source run/file keys, and source record hash.
+4. Require exactly one canonical station candidate by strict criteria before creating a `candidate` or `confirmed` identity row.
+5. Detect conflicts before writes:
+   - one external ID mapping to multiple canonical stations,
+   - one canonical station mapping to multiple active external IDs for the same source identity kind,
+   - source system/name disagreement,
+   - stale or undated evidence when the stage requires current evidence.
+6. Emit a versioned identity coverage artifact before any table write.
+7. In a non-production/staging rehearsal, load only identity rows, never station type rows.
+8. Only after review, run a bounded production identity evidence load if explicitly approved.
+
+The backfill must retain raw provenance fields and never mark failed or ambiguous rows as confirmed.
+
+## Reconciliation Integration
+
+After the identity table exists and is populated, read-only reconciliation can join it to canonical station matches and include canonical external IDs in `candidate.canonical`:
+
+- `canonical.market_id`
+- `canonical.edsm_station_id`
+- `canonical.external_identity_status`
+- `canonical.external_identity_source`
+- `canonical.external_identity_confidence`
+- `canonical.external_identity_source_record_hash`
+
+Only `identity_status = 'confirmed'` should count as strict proof for station-type dry-run eligibility. `candidate`, `conflict`, and `retired` rows should be visible in diagnostics but not accepted by the strict filter.
+
+The Stage 18J station-type dry-run filter should remain unchanged in spirit: explicit external ID match, exactly one canonical station, matching `system_id64`, matching normalized station name, station-type-only delta, no volatile evidence, no transient type, and `canonical_writes_planned = 0` in dry-run output.
+
+## Dry-Run Impact
+
+Before the identity model exists, a zero-eligible Stage 18J-P dry-run is expected and safe.
+
+After a confirmed identity table exists, the read-only reconciliation artifact should be able to report canonical external identity coverage. Only then should the station-type dry-run be retried. That retry should remain a dry-run and should still produce:
+
+- `canonical_writes_planned = 0`
+- `apply_run = false`
+- `approval_record_created = false`
+- explicit identity coverage counts
+- rejected candidates for missing, candidate-only, conflict, or stale identity mappings
+
+A non-zero eligible count would still not authorize apply. It would only support a later review packet.
+
+## Boundaries
+
+This stage does not:
+
+- run production commands,
+- touch production DB,
+- run imports,
+- run reconciliation,
+- run summarizer against production artifacts,
+- run production station-type dry-run,
+- run canonical apply,
+- create approval records,
+- start Stage 18K,
+- apply or create a production migration,
+- populate station external identity rows,
+- alter the strict filter to accept weaker proof,
+- allow station-type writes.
+
+## Recommended Next Stages
+
+- Stage 18J-P4 - External station identity model design review.
+- Stage 18J-P5 - External identity schema migration, not applied to production yet.
+- Stage 18J-P6 - Warehouse-to-identity evidence loader/reconciliation, non-canonical station-type.
+- Stage 18J-P7 - Read-only identity coverage artifact.
+- Stage 18J-P8 - Retry station-type dry-run with canonical external identity available.
+- Stage 18J-P9 - Dry-run review packet.
+- Only later: tiny apply approval packet, if any candidates pass.
+
+## Final Recommendation
+
+Do not add `market_id` or `edsm_station_id` directly to `stations` in the next implementation stage unless an app-level need is separately proven. The safer path is a separate `station_external_identity` table populated by a dedicated identity evidence stage, with provenance and conflict status preserved.
+
+Keep the strict station-type filter exactly as strict as it is now. Stage 18J-P cannot produce eligible station-type updates until canonical external station identity is modeled, populated, and exposed through read-only reconciliation. The smallest next stage that unblocks progress is a design-reviewed additive identity schema migration plus a report-only identity evidence loader plan, not station-type apply.


### PR DESCRIPTION
## What changed

- Added `docs/colonisation-redesign/stage-18j-p3-canonical-external-station-identity-model.md`.
- Updated the Stage 18J-P2 diagnostics doc to record the confirmed schema gap: source EDSM station IDs are present, but canonical `market_id` / `edsm_station_id` are unavailable.
- Updated the strict station-type filter doc to state that the zero-eligible result is a modeling gap, not a reason to relax identity proof.

## Findings

- Canonical `stations` currently has no modeled `market_id` or `edsm_station_id` columns.
- Existing code and API paths sometimes project `s.id AS market_id`, but that is a compatibility alias/update target, not explicit external identity proof.
- `station_body_links.market_id` exists, but it is scoped to occupied-slot association and is not a general station external identity registry.
- Warehouse staging has source-side `market_id` and `edsm_station_id`; read-only reconciliation cannot currently expose proven canonical external IDs because no canonical/provenance identity table exists.
- Stage 18J-P therefore correctly has zero eligible station-type candidates under the strict filter.

## Recommendation

Prefer a separate provenance-backed `station_external_identity` table over adding external IDs directly to `stations` in the next stage. Populate it through a dedicated identity evidence/load/reconciliation stage, preserving source run/file/hash, confidence, freshness, and conflict status. Only confirmed identity rows should be accepted by read-only reconciliation as canonical external identity proof.

Do not relax the strict station-type filter. Do not accept name-only matches or internal `stations.id` equality as proof.

## Boundary confirmations

- Docs/design only.
- No production commands run.
- No production DB touched.
- No imports run.
- No reconciliation run.
- No summarizer run against production artifacts.
- No production station-type dry-run run.
- No canonical apply run.
- No approval record created.
- Stage 18K not started.

## Validation

- GitHub compare from `main` confirms a docs-only branch with three changed docs.
- Requested local validation commands were not run because this local checkout is behind current `main`, `git fetch` cannot reach GitHub from the sandbox, and `gh auth status` reports an invalid token. Running those checks locally would validate stale files, not this PR branch.
- Secret scan result: no private DSNs, passwords, tokens, or API secrets were introduced in the authored docs content.

Not run for the reason above:

- `git diff --check`
- shell syntax checks for the operator scripts
- `./scripts/run_canonical_safety_tests.sh`
- targeted pytest suite
- `py_compile`