### PR TITLE
Stage 18J-P5 external station identity migration draft

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -589,6 +589,16 @@ migration, run production commands, run imports, run reconciliation, run
 station-type dry-run, or authorize apply. See
 [`stage-18j-p4-external-station-identity-schema-design.md`](./stage-18j-p4-external-station-identity-schema-design.md).
 
+Stage 18J-P5 drafts the additive external identity migration in
+`sql/027_station_external_identity.sql` and adds synthetic migration contract
+tests. The migration creates `station_external_identity`, requires at least one
+external ID, constrains identity statuses, preserves source run/file/hash
+provenance, adds partial unique indexes for confirmed identities, and adds
+lookup indexes for station, system, external IDs, source run/file, and status.
+It is not applied to production, does not update `stations`, does not backfill
+identity rows, and does not authorize station-type dry-run or apply. See
+[`stage-18j-p5-external-station-identity-migration-draft.md`](./stage-18j-p5-external-station-identity-migration-draft.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -666,10 +676,14 @@ treated as a separate proposal.
   design a separate provenance-backed `station_external_identity` table. Do not
   relax the strict station-type filter or reuse `stations.id` as external
   proof.
-* **External identity follow-up sequence**: continue with P5 migration draft
-  not applied to production, P6 non-canonical evidence extraction, P7 read-only
-  coverage, P8 confirmed identity integration into reconciliation, P9 dry-run
-  retry, and P10 dry-run review packet before any later apply approval packet.
+* **External identity migration draft**: Stage 18J-P5 adds
+  `sql/027_station_external_identity.sql` and migration contract tests. This is
+  a draft only; production application requires a later readiness review.
+* **External identity follow-up sequence**: continue with P6 evidence
+  loader/reconciliation design, P7 production readiness review, P8 schema-only
+  migration apply if approved, P9 identity evidence load/reconciliation with no
+  station-type writes, and P10 strict station-type dry-run retry with confirmed
+  external identity.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -776,10 +776,11 @@ Scope:
   canonical apply.
 - Preserve the Stage 18J continuation path: Q9 compact review, strict-filter
   hardening, operator-safe dry-run wrapper, P2 identity diagnostics, P3/P4
-  external identity design, P5 migration draft, P6 evidence extraction, P7
-  read-only coverage, P8 confirmed identity reconciliation integration, P9
-  dry-run retry, P10 review packet, and only later a tiny apply approval packet
-  if candidates pass.
+  external identity design, P5 migration draft, P6 evidence loader/
+  reconciliation design, P7 production readiness review, P8 schema-only
+  migration apply if approved, P9 identity evidence load/reconciliation with no
+  station-type writes, and P10 strict station-type dry-run retry with confirmed
+  external identity.
 
 Non-goals:
 
@@ -955,8 +956,9 @@ Scope:
 - Allow only `confirmed` rows to serve as read-only reconciliation proof.
 - Keep station-type writes blocked until confirmed external identity is
   available.
-- Recommend P5 through P10 follow-up stages before any later apply approval
-  packet.
+- Recommend a draft migration first, then a separate production readiness
+  review before any schema application, identity evidence load, or dry-run
+  retry.
 
 Non-goals:
 
@@ -970,6 +972,40 @@ Non-goals:
 
 Support doc:
 `stage-18j-p4-external-station-identity-schema-design.md`.
+
+### Stage 18J-P5 - External Station Identity Migration Draft
+
+Purpose: draft the additive schema migration for the external station identity
+model without applying it to production.
+
+Scope:
+
+- Add `sql/027_station_external_identity.sql`.
+- Create `station_external_identity` with canonical station reference,
+  `system_id64`, station name, source, nullable `market_id`, nullable
+  `edsm_station_id`, source run/file/hash provenance, source update time,
+  evidence first/last seen timestamps, confidence, freshness, identity status,
+  conflict reason, and timestamps.
+- Require at least one external ID.
+- Allow identity statuses `proposed`, `confirmed`, `conflicting`, `rejected`,
+  and `superseded`.
+- Add partial unique indexes for confirmed external identities and lookup
+  indexes for station, system, external IDs, source run/file, and status.
+- Add migration contract tests for constraints, indexes, status behavior,
+  additive scope, and no station-type write implication.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No production migration apply.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p5-external-station-identity-migration-draft.md`.
 
 ### Stage 19A.1 - Operator Path Guardrails
 
@@ -1051,10 +1087,10 @@ Do not add another large planner feature immediately. The healthiest next sequen
 33. Stage 18J-P3 canonical external station identity model.
 34. Stage 18J-P4 external station identity schema design.
 35. Stage 18J-P5 external station identity migration draft, not applied to production.
-36. Stage 18J-P6 identity evidence extraction/reconciliation from warehouse.
-37. Stage 18J-P7 read-only external identity coverage artifact.
-38. Stage 18J-P8 confirmed identity integration into reconciliation output.
-39. Stage 18J-P9 station-type dry-run retry with confirmed external identity.
-40. Stage 18J-P10 dry-run review packet.
+36. Stage 18J-P6 external identity evidence loader/reconciliation design.
+37. Stage 18J-P7 external identity migration production readiness review.
+38. Stage 18J-P8 apply external identity schema migration only, if approved.
+39. Stage 18J-P9 load/reconcile identity evidence, no station-type writes.
+40. Stage 18J-P10 retry strict station-type dry-run with confirmed external identity.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p3-canonical-external-station-identity-model.md
+++ b/docs/colonisation-redesign/stage-18j-p3-canonical-external-station-identity-model.md
@@ -88,6 +88,9 @@ The recommended table name is `station_external_identity`.
 
 Stage 18J-P4 refines this recommendation into the explicit schema design:
 `stage-18j-p4-external-station-identity-schema-design.md`.
+Stage 18J-P5 then drafts the additive migration as
+`sql/027_station_external_identity.sql` without applying it to production or
+backfilling identity evidence.
 
 ## Why Not Relax The Filter
 
@@ -120,11 +123,12 @@ CREATE TABLE IF NOT EXISTS station_external_identity (
     source_file_key TEXT DEFAULT NULL,
     source_record_hash TEXT NOT NULL,
     confidence TEXT NOT NULL,
-    identity_status TEXT NOT NULL DEFAULT 'candidate' CHECK (identity_status IN (
-        'candidate',
+    identity_status TEXT NOT NULL DEFAULT 'proposed' CHECK (identity_status IN (
+        'proposed',
         'confirmed',
-        'conflict',
-        'retired'
+        'conflicting',
+        'rejected',
+        'superseded'
     )),
     match_method TEXT NOT NULL,
     source_updated_at TIMESTAMPTZ DEFAULT NULL,
@@ -139,11 +143,11 @@ CREATE TABLE IF NOT EXISTS station_external_identity (
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_source_market
     ON station_external_identity (source, market_id)
-    WHERE market_id IS NOT NULL AND identity_status IN ('candidate', 'confirmed');
+    WHERE market_id IS NOT NULL AND identity_status = 'confirmed';
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_source_edsm
     ON station_external_identity (source, edsm_station_id)
-    WHERE edsm_station_id IS NOT NULL AND identity_status IN ('candidate', 'confirmed');
+    WHERE edsm_station_id IS NOT NULL AND identity_status = 'confirmed';
 
 CREATE INDEX IF NOT EXISTS idx_station_external_identity_station
     ON station_external_identity (canonical_station_id, identity_status);
@@ -159,14 +163,13 @@ The table is intended to store canonical-station-to-external-ID mapping evidence
 
 Recommended status semantics:
 
-- `candidate`: one source snapshot suggests the mapping; not yet enough for canonical write eligibility.
+- `proposed`: one source snapshot suggests the mapping; not yet enough for canonical write eligibility.
 - `confirmed`: mapping has passed the identity evidence stage's rules and can be used by read-only reconciliation as canonical external identity.
-- `conflict`: source evidence disagrees with an existing active mapping or maps one external ID to multiple canonical stations.
-- `retired`: old mapping retained for audit/history but not used as active proof.
+- `conflicting`: source evidence disagrees with an existing active mapping or maps one external ID to multiple canonical stations.
+- `rejected`: evidence was reviewed or classified as not acceptable proof.
+- `superseded`: old mapping retained for audit/history but not used as active proof.
 
-Stage 18J-P4 renames and expands this status model to `proposed`,
-`confirmed`, `conflicting`, `rejected`, and `superseded` so failed and
-historical evidence are visible without being accepted as proof.
+Stage 18J-P5 drafts this status model in `sql/027_station_external_identity.sql`.
 
 ## Backfill Strategy
 
@@ -177,7 +180,7 @@ Recommended backfill path:
 1. Read warehouse station evidence from staged, already reviewed offline snapshots.
 2. Match to canonical stations conservatively inside the same `system_id64`.
 3. Prefer source rows with explicit `market_id` and/or `edsm_station_id`, station name, source run/file keys, and source record hash.
-4. Require exactly one canonical station candidate by strict criteria before creating a `candidate` or `confirmed` identity row.
+4. Require exactly one canonical station candidate by strict criteria before creating a `proposed` or `confirmed` identity row.
 5. Detect conflicts before writes:
    - one external ID mapping to multiple canonical stations,
    - one canonical station mapping to multiple active external IDs for the same source identity kind,
@@ -200,7 +203,10 @@ After the identity table exists and is populated, read-only reconciliation can j
 - `canonical.external_identity_confidence`
 - `canonical.external_identity_source_record_hash`
 
-Only `identity_status = 'confirmed'` should count as strict proof for station-type dry-run eligibility. `candidate`, `conflict`, and `retired` rows should be visible in diagnostics but not accepted by the strict filter.
+Only `identity_status = 'confirmed'` should count as strict proof for
+station-type dry-run eligibility. `proposed`, `conflicting`, `rejected`, and
+`superseded` rows should be visible in diagnostics but not accepted by the
+strict filter.
 
 The Stage 18J station-type dry-run filter should remain unchanged in spirit: explicit external ID match, exactly one canonical station, matching `system_id64`, matching normalized station name, station-type-only delta, no volatile evidence, no transient type, and `canonical_writes_planned = 0` in dry-run output.
 
@@ -214,7 +220,7 @@ After a confirmed identity table exists, the read-only reconciliation artifact s
 - `apply_run = false`
 - `approval_record_created = false`
 - explicit identity coverage counts
-- rejected candidates for missing, candidate-only, conflict, or stale identity mappings
+- rejected candidates for missing, proposed-only, conflicting, or stale identity mappings
 
 A non-zero eligible count would still not authorize apply. It would only support a later review packet.
 
@@ -240,12 +246,11 @@ This stage does not:
 
 - Stage 18J-P4 - External station identity schema design.
 - Stage 18J-P5 - External station identity migration draft, not applied to production.
-- Stage 18J-P6 - Identity evidence extraction/reconciliation from warehouse, non-canonical station-type.
-- Stage 18J-P7 - Read-only external identity coverage artifact.
-- Stage 18J-P8 - Confirmed identity integration into reconciliation output.
-- Stage 18J-P9 - Retry station-type dry-run with confirmed external identity.
-- Stage 18J-P10 - Dry-run review packet.
-- Later only: tiny apply approval packet, if candidates pass.
+- Stage 18J-P6 - External identity evidence loader/reconciliation design.
+- Stage 18J-P7 - External identity migration production readiness review.
+- Stage 18J-P8 - Apply external identity schema migration only, if approved.
+- Stage 18J-P9 - Load/reconcile identity evidence, no station-type writes.
+- Stage 18J-P10 - Retry strict station-type dry-run with confirmed external identity.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p4-external-station-identity-schema-design.md
+++ b/docs/colonisation-redesign/stage-18j-p4-external-station-identity-schema-design.md
@@ -144,6 +144,10 @@ Recommended constraints for a later migration draft:
 The final migration draft should choose exact index names, timestamp defaults,
 and trigger/update mechanics. P4 intentionally does not add that migration.
 
+Stage 18J-P5 follows this design with the draft additive migration
+`sql/027_station_external_identity.sql`. P5 does not apply the migration to
+production and does not backfill identity evidence.
+
 ## Identity Status Model
 
 Recommended statuses:
@@ -328,6 +332,9 @@ Recommended migration-draft rules:
 The migration draft should remain separate from evidence extraction and
 separate from any station-type dry-run retry.
 
+Stage 18J-P5 implements this draft step in repo only. Production application is
+still deferred to a later explicit readiness review and approval stage.
+
 ## Production Safety Gates
 
 Before any production identity load or station-type dry-run retry, require:
@@ -348,13 +355,12 @@ Before any production identity load or station-type dry-run retry, require:
 
 - Stage 18J-P5 - External station identity migration draft, not applied to
   production.
-- Stage 18J-P6 - Identity evidence extraction/reconciliation from warehouse,
-  non-canonical station-type.
-- Stage 18J-P7 - Read-only external identity coverage artifact.
-- Stage 18J-P8 - Confirmed identity integration into reconciliation output.
-- Stage 18J-P9 - Retry station-type dry-run with confirmed external identity.
-- Stage 18J-P10 - Dry-run review packet.
-- Later only: tiny apply approval packet if candidates pass.
+- Stage 18J-P6 - External identity evidence loader/reconciliation design.
+- Stage 18J-P7 - External identity migration production readiness review.
+- Stage 18J-P8 - Apply external identity schema migration only, if approved.
+- Stage 18J-P9 - Load/reconcile identity evidence, no station-type writes.
+- Stage 18J-P10 - Retry strict station-type dry-run with confirmed external
+  identity.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md
+++ b/docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md
@@ -1,0 +1,259 @@
+# Stage 18J-P5 — External Station Identity Migration Draft
+
+## Purpose
+
+Stage 18J-P5 drafts the additive schema migration for the external station
+identity model recommended by Stage 18J-P4.
+
+The migration creates a provenance-backed `station_external_identity` table so
+future stages can store explicit external station identity evidence separately
+from canonical `stations` rows and separately from station/body association
+evidence.
+
+This stage drafts and tests the migration only. It does not apply the migration
+to production, run production commands, touch the production database, run
+imports, run reconciliation, run the summarizer against production artifacts,
+run station-type dry-run, run canonical apply, create approval records, or
+start Stage 18K.
+
+## Migration Scope
+
+Migration file:
+
+- `sql/027_station_external_identity.sql`
+
+Test file:
+
+- `tests/test_station_external_identity_migration.py`
+
+The migration is additive and idempotent. It creates one new table and its
+indexes. It does not update `stations`, add `market_id` or `edsm_station_id`
+columns to `stations`, alter `station_body_links`, backfill identity rows, or
+create any station-type approval or apply path.
+
+## Table Shape
+
+The drafted table is:
+
+```sql
+CREATE TABLE IF NOT EXISTS station_external_identity (
+    id                          BIGSERIAL       PRIMARY KEY,
+    canonical_station_id        BIGINT          NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    system_id64                 BIGINT          NOT NULL REFERENCES systems(id64) ON DELETE CASCADE,
+    station_name                TEXT            NOT NULL,
+    source                      TEXT            NOT NULL,
+    market_id                   BIGINT          DEFAULT NULL,
+    edsm_station_id             BIGINT          DEFAULT NULL,
+    source_run_key              TEXT            NOT NULL,
+    source_file_key             TEXT            NOT NULL,
+    source_record_hash          TEXT            NOT NULL,
+    source_updated_at           TIMESTAMPTZ     DEFAULT NULL,
+    evidence_first_seen_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    evidence_last_seen_at       TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    confidence                  TEXT            NOT NULL,
+    freshness_class             TEXT            NOT NULL,
+    identity_status             TEXT            NOT NULL DEFAULT 'proposed',
+    conflict_reason             TEXT            DEFAULT NULL,
+    created_at                  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ     NOT NULL DEFAULT NOW()
+);
+```
+
+`canonical_station_id` is the ED-Finder station update target. It is not an
+external `market_id`. External identity proof must come from `market_id` and/or
+`edsm_station_id` evidence preserved with source provenance.
+
+## Constraints
+
+The migration adds check constraints for:
+
+- at least one external ID: `market_id IS NOT NULL OR edsm_station_id IS NOT NULL`;
+- identity status values:
+  - `proposed`,
+  - `confirmed`,
+  - `conflicting`,
+  - `rejected`,
+  - `superseded`;
+- confidence labels aligned with current station/enrichment conventions:
+  - `exact_station_identity`,
+  - `source_station_snapshot`,
+  - `high`,
+  - `medium`,
+  - `low`,
+  - `unresolved`;
+- freshness labels aligned with warehouse and P4 terminology:
+  - `source_updated_at`,
+  - `file_snapshot`,
+  - `current`,
+  - `recent`,
+  - `stale`,
+  - `undated`,
+  - `unknown`;
+- `conflicting` rows must have `conflict_reason`;
+- `evidence_last_seen_at` must be greater than or equal to
+  `evidence_first_seen_at`.
+
+These constraints make the table suitable for evidence review while keeping all
+non-confirmed statuses representable.
+
+## Indexes
+
+The migration adds unique partial indexes for confirmed identities:
+
+- `idx_station_external_identity_confirmed_source_market`
+- `idx_station_external_identity_confirmed_source_edsm`
+- `idx_station_external_identity_confirmed_station_source_market`
+- `idx_station_external_identity_confirmed_station_source_edsm`
+
+These indexes block duplicate confirmed external ID mappings while leaving
+`proposed`, `conflicting`, `rejected`, and `superseded` rows available for
+review and audit.
+
+The migration also adds lookup indexes for:
+
+- `canonical_station_id`;
+- `system_id64`;
+- `market_id`;
+- `edsm_station_id`;
+- `source_run_key, source_file_key`;
+- `identity_status`.
+
+## Provenance Requirements
+
+Every identity row must preserve source provenance:
+
+- `source`;
+- `source_run_key`;
+- `source_file_key`;
+- `source_record_hash`;
+- `source_updated_at` when available;
+- evidence first/last seen timestamps.
+
+Warehouse source-only evidence is still not canonical identity by default. A
+future loader/reconciliation stage must decide whether evidence remains
+`proposed`, becomes `confirmed`, or is marked `conflicting`, `rejected`, or
+`superseded`.
+
+## Conflict Handling
+
+The table represents conflict state directly with:
+
+- `identity_status = 'conflicting'`;
+- a required `conflict_reason`.
+
+Conflicting evidence is retained for visibility and audit. It is blocked from
+canonical external identity proof, blocked from strict station-type dry-run
+eligibility, and should appear in future coverage/reconciliation artifacts.
+
+Examples that should be represented as conflicts in later evidence stages:
+
+- one `market_id` maps to multiple canonical stations;
+- one `edsm_station_id` maps to multiple canonical stations;
+- one canonical station receives multiple active external IDs for the same
+  source identity kind;
+- source system/name evidence disagrees with the canonical station;
+- repeated source evidence disagrees by source record hash.
+
+## What This Does Not Do
+
+This stage does not:
+
+- apply the migration to production;
+- update or rewrite `stations`;
+- add `market_id` or `edsm_station_id` directly to `stations`;
+- reuse `station_body_links` as a general identity table;
+- backfill identity evidence;
+- load warehouse evidence;
+- run imports;
+- run reconciliation;
+- run summarizer against production artifacts;
+- run station-type dry-run;
+- run canonical apply;
+- create approval records;
+- relax the strict station-type filter;
+- start Stage 18K.
+
+## Production Application Status
+
+The migration is drafted only. It is not applied to production in this stage.
+
+Production application requires a later explicit readiness review and approval
+stage. That later stage must verify the migration against a disposable or
+staging database, confirm rollback expectations before any identity data exists,
+and keep station-type writes blocked.
+
+## Reconciliation Impact
+
+No reconciliation code is changed in P5. Current reconciliation output remains
+unchanged.
+
+After a later approved schema application and evidence load, read-only
+reconciliation can be extended to join only `identity_status = 'confirmed'`
+rows and expose canonical external identity fields such as:
+
+- `canonical.market_id`;
+- `canonical.edsm_station_id`;
+- `canonical.external_identity_status`;
+- `canonical.external_identity_source`;
+- `canonical.external_identity_confidence`;
+- `canonical.external_identity_freshness_class`;
+- `canonical.external_identity_source_run_key`;
+- `canonical.external_identity_source_file_key`;
+- `canonical.external_identity_source_record_hash`.
+
+## Station-Type Dry-Run Impact
+
+P5 does not run or change station-type dry-run.
+
+The strict station-type filter remains unchanged. Until confirmed external
+identity is available through read-only reconciliation, the Stage 18J-P
+station-type dry-run should continue to reject candidates that lack canonical
+external identity proof.
+
+The new table does not imply station-type approval. Even after the schema is
+applied and evidence is loaded, only confirmed external identity should satisfy
+the identity proof portion of the strict filter, and any non-zero dry-run result
+still requires a separate review packet before apply can be discussed.
+
+## Validation
+
+Validation for this stage should include:
+
+- `git diff --check`;
+- shell syntax checks for the Stage 18J operator guard/wrappers;
+- canonical safety tests;
+- targeted station-type and enrichment tests;
+- py_compile for the station-type pilot and tests;
+- `tests/test_station_external_identity_migration.py`;
+- secret/DSN scan across changed docs, code, and SQL.
+
+The migration tests verify:
+
+- the table is created;
+- required columns and foreign-key references are present;
+- at least one external ID is required;
+- valid identity statuses are represented while older P3 draft names are not;
+- confidence and freshness checks use local conventions;
+- duplicate confirmed identity indexes exist;
+- non-confirmed statuses remain representable;
+- lookup indexes exist;
+- the migration is additive and does not write canonical station data.
+
+## Recommended Next Stages
+
+- Stage 18J-P6 - External identity evidence loader/reconciliation design.
+- Stage 18J-P7 - External identity migration production readiness review.
+- Stage 18J-P8 - Apply external identity schema migration only, if approved.
+- Stage 18J-P9 - Load/reconcile identity evidence, no station-type writes.
+- Stage 18J-P10 - Retry strict station-type dry-run with confirmed external
+  identity.
+
+## Final Recommendation
+
+Keep `sql/027_station_external_identity.sql` as a draft additive migration
+until a later production readiness review approves applying only the schema.
+
+Do not backfill identity evidence, alter the strict station-type filter, or
+start any station-type dry-run/apply path in P5. The correct next step is an
+external identity evidence loader/reconciliation design that can populate and
+review the table safely after the schema has been separately approved.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -676,6 +676,15 @@ identity proof in read-only reconciliation. Do not treat warehouse source-only
 evidence, station-name matches, internal `stations.id` equality, or
 station/body link association evidence as station-type proof.
 
+Stage 18J-P5 drafts that schema migration in
+`sql/027_station_external_identity.sql` and documents it in
+`docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md`.
+The migration is additive and creates only `station_external_identity` plus
+indexes and constraints. It is not applied to production by P5, does not load
+or reconcile identity evidence, does not update `stations`, and does not
+authorize station-type dry-run or apply. Any production schema application
+requires a later explicit readiness review and approval stage.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/sql/027_station_external_identity.sql
+++ b/sql/027_station_external_identity.sql
@@ -1,0 +1,126 @@
+-- =============================================================================
+-- Stage 18J-P5 - external station identity migration draft
+-- =============================================================================
+-- Additive/idempotent migration. This table stores provenance-backed external
+-- station identity evidence for canonical stations. It does not modify canonical
+-- station rows, backfill evidence, approve station-type writes, or create an
+-- apply path.
+
+CREATE TABLE IF NOT EXISTS station_external_identity (
+    id                          BIGSERIAL       PRIMARY KEY,
+    canonical_station_id        BIGINT          NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
+    system_id64                 BIGINT          NOT NULL REFERENCES systems(id64) ON DELETE CASCADE,
+    station_name                TEXT            NOT NULL,
+    source                      TEXT            NOT NULL,
+    market_id                   BIGINT          DEFAULT NULL,
+    edsm_station_id             BIGINT          DEFAULT NULL,
+    source_run_key              TEXT            NOT NULL,
+    source_file_key             TEXT            NOT NULL,
+    source_record_hash          TEXT            NOT NULL,
+    source_updated_at           TIMESTAMPTZ     DEFAULT NULL,
+    evidence_first_seen_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    evidence_last_seen_at       TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    confidence                  TEXT            NOT NULL,
+    freshness_class             TEXT            NOT NULL,
+    identity_status             TEXT            NOT NULL DEFAULT 'proposed',
+    conflict_reason             TEXT            DEFAULT NULL,
+    created_at                  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_station_external_identity_external_id
+        CHECK (market_id IS NOT NULL OR edsm_station_id IS NOT NULL),
+    CONSTRAINT chk_station_external_identity_status
+        CHECK (identity_status IN (
+            'proposed',
+            'confirmed',
+            'conflicting',
+            'rejected',
+            'superseded'
+        )),
+    CONSTRAINT chk_station_external_identity_confidence
+        CHECK (confidence IN (
+            'exact_station_identity',
+            'source_station_snapshot',
+            'high',
+            'medium',
+            'low',
+            'unresolved'
+        )),
+    CONSTRAINT chk_station_external_identity_freshness
+        CHECK (freshness_class IN (
+            'source_updated_at',
+            'file_snapshot',
+            'current',
+            'recent',
+            'stale',
+            'undated',
+            'unknown'
+        )),
+    CONSTRAINT chk_station_external_identity_conflict_reason
+        CHECK (identity_status <> 'conflicting' OR conflict_reason IS NOT NULL),
+    CONSTRAINT chk_station_external_identity_seen_window
+        CHECK (evidence_last_seen_at >= evidence_first_seen_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_confirmed_source_market
+    ON station_external_identity (source, market_id)
+    WHERE market_id IS NOT NULL AND identity_status = 'confirmed';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_confirmed_source_edsm
+    ON station_external_identity (source, edsm_station_id)
+    WHERE edsm_station_id IS NOT NULL AND identity_status = 'confirmed';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_confirmed_station_source_market
+    ON station_external_identity (canonical_station_id, source, market_id)
+    WHERE market_id IS NOT NULL AND identity_status = 'confirmed';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_station_external_identity_confirmed_station_source_edsm
+    ON station_external_identity (canonical_station_id, source, edsm_station_id)
+    WHERE edsm_station_id IS NOT NULL AND identity_status = 'confirmed';
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_station
+    ON station_external_identity (canonical_station_id);
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_system
+    ON station_external_identity (system_id64);
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_market_id
+    ON station_external_identity (market_id)
+    WHERE market_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_edsm_station_id
+    ON station_external_identity (edsm_station_id)
+    WHERE edsm_station_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_source_run_file
+    ON station_external_identity (source_run_key, source_file_key);
+
+CREATE INDEX IF NOT EXISTS idx_station_external_identity_status
+    ON station_external_identity (identity_status);
+
+COMMENT ON TABLE station_external_identity
+    IS 'Provenance-backed external station identity evidence. Only confirmed rows may later be used by read-only reconciliation as canonical external identity proof.';
+
+COMMENT ON COLUMN station_external_identity.canonical_station_id
+    IS 'ED-Finder canonical stations.id update target; not an external market identifier.';
+
+COMMENT ON COLUMN station_external_identity.market_id
+    IS 'Nullable external market identifier observed from source evidence.';
+
+COMMENT ON COLUMN station_external_identity.edsm_station_id
+    IS 'Nullable external EDSM station identifier observed from source evidence.';
+
+COMMENT ON COLUMN station_external_identity.source_run_key
+    IS 'Warehouse source run key that produced this identity evidence.';
+
+COMMENT ON COLUMN station_external_identity.source_file_key
+    IS 'Warehouse source file key that produced this identity evidence.';
+
+COMMENT ON COLUMN station_external_identity.source_record_hash
+    IS 'Deterministic hash of the source station record backing this identity evidence.';
+
+COMMENT ON COLUMN station_external_identity.identity_status
+    IS 'Identity review status. Only confirmed rows can serve as canonical external identity proof.';
+
+COMMENT ON COLUMN station_external_identity.conflict_reason
+    IS 'Required explanation for conflicting rows; conflicting evidence is visible but blocked from proof use.';

--- a/tests/test_station_external_identity_migration.py
+++ b/tests/test_station_external_identity_migration.py
@@ -1,0 +1,159 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / 'sql' / '027_station_external_identity.sql'
+
+
+def _migration_text() -> str:
+    return MIGRATION.read_text(encoding='utf-8')
+
+
+def _table_sql(migration: str, table_name: str = 'station_external_identity') -> str:
+    match = re.search(
+        rf'CREATE TABLE IF NOT EXISTS {re.escape(table_name)} \((.*?)\n\);',
+        migration,
+        flags=re.DOTALL,
+    )
+    assert match is not None, f'{table_name} table definition missing'
+    return match.group(1)
+
+
+def _normalise_sql(sql: str) -> str:
+    return re.sub(r'\s+', ' ', sql).strip()
+
+
+def test_station_external_identity_migration_creates_expected_table_shape():
+    migration = _migration_text()
+    table = _table_sql(migration)
+
+    assert 'CREATE TABLE IF NOT EXISTS station_external_identity' in migration
+    for column_name in (
+        'id',
+        'canonical_station_id',
+        'system_id64',
+        'station_name',
+        'source',
+        'market_id',
+        'edsm_station_id',
+        'source_run_key',
+        'source_file_key',
+        'source_record_hash',
+        'source_updated_at',
+        'evidence_first_seen_at',
+        'evidence_last_seen_at',
+        'confidence',
+        'freshness_class',
+        'identity_status',
+        'conflict_reason',
+        'created_at',
+        'updated_at',
+    ):
+        assert re.search(rf'\b{re.escape(column_name)}\b', table), f'{column_name} missing'
+
+    assert 'canonical_station_id        BIGINT          NOT NULL REFERENCES stations(id)' in table
+    assert 'system_id64                 BIGINT          NOT NULL REFERENCES systems(id64)' in table
+    assert 'station_type' not in table
+
+
+def test_station_external_identity_requires_external_id_and_valid_status_values():
+    migration = _migration_text()
+    table = _table_sql(migration)
+    normalised = _normalise_sql(table)
+
+    assert 'CONSTRAINT chk_station_external_identity_external_id' in table
+    assert 'CHECK (market_id IS NOT NULL OR edsm_station_id IS NOT NULL)' in normalised
+
+    assert 'CONSTRAINT chk_station_external_identity_status' in table
+    for status in ('proposed', 'confirmed', 'conflicting', 'rejected', 'superseded'):
+        assert f"'{status}'" in table
+    assert "'candidate'" not in table
+    assert "'conflict'" not in table
+    assert "'retired'" not in table
+
+
+def test_station_external_identity_uses_project_confidence_and_freshness_labels():
+    table = _table_sql(_migration_text())
+
+    assert 'CONSTRAINT chk_station_external_identity_confidence' in table
+    for confidence in (
+        'exact_station_identity',
+        'source_station_snapshot',
+        'high',
+        'medium',
+        'low',
+        'unresolved',
+    ):
+        assert f"'{confidence}'" in table
+
+    assert 'CONSTRAINT chk_station_external_identity_freshness' in table
+    for freshness_class in (
+        'source_updated_at',
+        'file_snapshot',
+        'current',
+        'recent',
+        'stale',
+        'undated',
+        'unknown',
+    ):
+        assert f"'{freshness_class}'" in table
+
+
+def test_station_external_identity_blocks_duplicate_confirmed_external_ids():
+    migration = _migration_text()
+    normalised = _normalise_sql(migration)
+
+    for index_name, external_id in (
+        ('idx_station_external_identity_confirmed_source_market', 'market_id'),
+        ('idx_station_external_identity_confirmed_source_edsm', 'edsm_station_id'),
+        ('idx_station_external_identity_confirmed_station_source_market', 'market_id'),
+        ('idx_station_external_identity_confirmed_station_source_edsm', 'edsm_station_id'),
+    ):
+        assert f'CREATE UNIQUE INDEX IF NOT EXISTS {index_name}' in migration
+        assert f'{external_id} IS NOT NULL AND identity_status = \'confirmed\'' in normalised
+
+
+def test_station_external_identity_non_confirmed_statuses_remain_representable():
+    migration = _migration_text()
+    table = _table_sql(migration)
+    normalised = _normalise_sql(migration)
+
+    for status in ('proposed', 'conflicting', 'rejected', 'superseded'):
+        assert f"'{status}'" in table
+    assert "identity_status = 'confirmed'" in normalised
+    assert "identity_status <> 'conflicting' OR conflict_reason IS NOT NULL" in normalised
+    assert "identity_status IN ('confirmed'" not in normalised
+
+
+def test_station_external_identity_has_required_lookup_indexes():
+    migration = _migration_text()
+
+    for index_name in (
+        'idx_station_external_identity_station',
+        'idx_station_external_identity_system',
+        'idx_station_external_identity_market_id',
+        'idx_station_external_identity_edsm_station_id',
+        'idx_station_external_identity_source_run_file',
+        'idx_station_external_identity_status',
+    ):
+        assert f'CREATE INDEX IF NOT EXISTS {index_name}' in migration
+
+
+def test_station_external_identity_migration_is_additive_and_write_safe():
+    migration = _migration_text()
+    normalised = _normalise_sql(migration.upper())
+
+    forbidden_patterns = (
+        r'\bDROP\s+TABLE\b',
+        r'\bTRUNCATE\b',
+        r'\bDELETE\s+FROM\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|BODY_SCAN_FACTS|STATION_BODY_LINKS)\b',
+        r'\bUPDATE\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|BODY_SCAN_FACTS|STATION_BODY_LINKS)\b',
+        r'\bALTER\s+TABLE\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|BODY_SCAN_FACTS|STATION_BODY_LINKS)\b',
+        r'\bINSERT\s+INTO\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|BODY_SCAN_FACTS|STATION_BODY_LINKS)\b',
+    )
+    for pattern in forbidden_patterns:
+        assert re.search(pattern, normalised) is None
+
+    assert 'CREATE TABLE IF NOT EXISTS STATION_EXTERNAL_IDENTITY' in normalised
+    assert 'STATION_TYPE' not in normalised


### PR DESCRIPTION
## What changed

* Adds draft `station_external_identity` schema migration.
* Adds tests for constraints/indexes/status behaviour.
* Updates docs/roadmap.
* Does not apply migration to production.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* Migration drafted only, not applied to production.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

```text
$ git diff --check
(no output)

$ bash -n scripts/operator/require_hetzner_operator_env.sh
(no output)

$ bash -n scripts/operator/stage18j_run_compact_summary.sh
(no output)

$ bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
(no output)

$ ./scripts/run_canonical_safety_tests.sh
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.17s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

$ .venv/bin/pytest \
  tests/test_station_type_canonical_pilot.py \
  tests/test_enrichment_warehouse_boundary.py \
  tests/test_enrichment_staging_db_loader.py \
  tests/test_enrichment_report_contracts.py \
  tests/test_edsm_station_normalization.py \
  -q
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.15s

$ .venv/bin/pytest tests/test_station_external_identity_migration.py -q
.......                                                                  [100%]
7 passed in 0.02s

$ .venv/bin/python -m py_compile \
  apps/importer/src/station_type_canonical_pilot.py \
  tests/test_station_type_canonical_pilot.py
(no output)

$ grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' \
  sql \
  docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md \
  docs/colonisation-redesign/stage-18j-p4-external-station-identity-schema-design.md \
  docs/colonisation-redesign/enrichment-roadmap.md \
  docs/operations/enrichment-warehouse-runbook.md \
  docs/colonisation-redesign/stage-17p-current-state-forward-plan.md \
  2>/dev/null || true
(no matches)

$ git diff --cached --check
(no output)
```