### PR TITLE
Stage 18J-P6 external identity migration production readiness

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -599,6 +599,15 @@ It is not applied to production, does not update `stations`, does not backfill
 identity rows, and does not authorize station-type dry-run or apply. See
 [`stage-18j-p5-external-station-identity-migration-draft.md`](./stage-18j-p5-external-station-identity-migration-draft.md).
 
+Stage 18J-P6 reviews the P5 migration for production readiness. The verdict is
+`Ready for schema-only production application`, limited to a later Hetzner
+operator stage that creates the empty table and indexes only. P6 defines
+required preflight checks, post-apply checks, rollback expectations, and
+forbidden follow-on actions. It does not apply the migration, touch production
+DB, load identity evidence, run reconciliation, run station-type dry-run, or
+authorize apply. See
+[`stage-18j-p6-external-identity-migration-production-readiness.md`](./stage-18j-p6-external-identity-migration-production-readiness.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -679,11 +688,14 @@ treated as a separate proposal.
 * **External identity migration draft**: Stage 18J-P5 adds
   `sql/027_station_external_identity.sql` and migration contract tests. This is
   a draft only; production application requires a later readiness review.
-* **External identity follow-up sequence**: continue with P6 evidence
-  loader/reconciliation design, P7 production readiness review, P8 schema-only
-  migration apply if approved, P9 identity evidence load/reconciliation with no
-  station-type writes, and P10 strict station-type dry-run retry with confirmed
-  external identity.
+* **External identity migration readiness**: Stage 18J-P6 reviews migration 027
+  and finds it ready for a later schema-only production application stage with
+  explicit preflight and post-apply checks.
+* **External identity follow-up sequence**: continue with P7 schema-only
+  application packet, P8 schema-only migration apply if approved, P9 evidence
+  loader/reconciliation design, P10 identity evidence load/reconciliation with
+  no station-type writes, and only later retry strict station-type dry-run with
+  confirmed external identity.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -776,11 +776,11 @@ Scope:
   canonical apply.
 - Preserve the Stage 18J continuation path: Q9 compact review, strict-filter
   hardening, operator-safe dry-run wrapper, P2 identity diagnostics, P3/P4
-  external identity design, P5 migration draft, P6 evidence loader/
-  reconciliation design, P7 production readiness review, P8 schema-only
-  migration apply if approved, P9 identity evidence load/reconciliation with no
-  station-type writes, and P10 strict station-type dry-run retry with confirmed
-  external identity.
+  external identity design, P5 migration draft, P6 production readiness review,
+  P7 schema-only application packet, P8 schema-only migration apply if
+  approved, P9 evidence loader/reconciliation design, P10 identity evidence
+  load/reconciliation with no station-type writes, and only later a strict
+  station-type dry-run retry with confirmed external identity.
 
 Non-goals:
 
@@ -1007,6 +1007,35 @@ Non-goals:
 Support doc:
 `stage-18j-p5-external-station-identity-migration-draft.md`.
 
+### Stage 18J-P6 - External Identity Migration Production Readiness Review
+
+Purpose: review `sql/027_station_external_identity.sql` before any production
+schema application stage.
+
+Scope:
+
+- Confirm the migration is additive and schema-only.
+- Confirm it does not alter `stations`.
+- Confirm it does not write canonical station-type data.
+- Review constraints, indexes, provenance fields, conflict handling, rollback
+  expectations, preflight checks, and post-apply checks.
+- Record the readiness verdict for a future schema-only Hetzner operator stage.
+- Keep identity evidence loading, reconciliation, station-type dry-run, and
+  canonical apply blocked.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No production migration apply.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p6-external-identity-migration-production-readiness.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1087,10 +1116,11 @@ Do not add another large planner feature immediately. The healthiest next sequen
 33. Stage 18J-P3 canonical external station identity model.
 34. Stage 18J-P4 external station identity schema design.
 35. Stage 18J-P5 external station identity migration draft, not applied to production.
-36. Stage 18J-P6 external identity evidence loader/reconciliation design.
-37. Stage 18J-P7 external identity migration production readiness review.
+36. Stage 18J-P6 external identity migration production readiness review.
+37. Stage 18J-P7 schema-only external identity migration application packet.
 38. Stage 18J-P8 apply external identity schema migration only, if approved.
-39. Stage 18J-P9 load/reconcile identity evidence, no station-type writes.
-40. Stage 18J-P10 retry strict station-type dry-run with confirmed external identity.
+39. Stage 18J-P9 external identity evidence loader/reconciliation design.
+40. Stage 18J-P10 load/reconcile identity evidence, no station-type writes.
+41. Later: retry strict station-type dry-run with confirmed external identity.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p4-external-station-identity-schema-design.md
+++ b/docs/colonisation-redesign/stage-18j-p4-external-station-identity-schema-design.md
@@ -334,6 +334,8 @@ separate from any station-type dry-run retry.
 
 Stage 18J-P5 implements this draft step in repo only. Production application is
 still deferred to a later explicit readiness review and approval stage.
+Stage 18J-P6 records that readiness review and limits its approval to a future
+schema-only production application stage.
 
 ## Production Safety Gates
 
@@ -355,12 +357,13 @@ Before any production identity load or station-type dry-run retry, require:
 
 - Stage 18J-P5 - External station identity migration draft, not applied to
   production.
-- Stage 18J-P6 - External identity evidence loader/reconciliation design.
-- Stage 18J-P7 - External identity migration production readiness review.
+- Stage 18J-P6 - External identity migration production readiness review.
+- Stage 18J-P7 - Schema-only external identity migration application packet.
 - Stage 18J-P8 - Apply external identity schema migration only, if approved.
-- Stage 18J-P9 - Load/reconcile identity evidence, no station-type writes.
-- Stage 18J-P10 - Retry strict station-type dry-run with confirmed external
-  identity.
+- Stage 18J-P9 - External identity evidence loader/reconciliation design.
+- Stage 18J-P10 - Load/reconcile identity evidence, no station-type writes.
+- Later: retry strict station-type dry-run only after confirmed external
+  identity appears in read-only reconciliation output.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md
+++ b/docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md
@@ -182,6 +182,11 @@ stage. That later stage must verify the migration against a disposable or
 staging database, confirm rollback expectations before any identity data exists,
 and keep station-type writes blocked.
 
+Stage 18J-P6 performs that readiness review in
+`stage-18j-p6-external-identity-migration-production-readiness.md` and finds the
+migration ready for a future schema-only production application stage, provided
+the required preflight and post-apply checks pass.
+
 ## Reconciliation Impact
 
 No reconciliation code is changed in P5. Current reconciliation output remains
@@ -241,12 +246,13 @@ The migration tests verify:
 
 ## Recommended Next Stages
 
-- Stage 18J-P6 - External identity evidence loader/reconciliation design.
-- Stage 18J-P7 - External identity migration production readiness review.
+- Stage 18J-P6 - External identity migration production readiness review.
+- Stage 18J-P7 - Schema-only external identity migration application packet.
 - Stage 18J-P8 - Apply external identity schema migration only, if approved.
-- Stage 18J-P9 - Load/reconcile identity evidence, no station-type writes.
-- Stage 18J-P10 - Retry strict station-type dry-run with confirmed external
-  identity.
+- Stage 18J-P9 - External identity evidence loader/reconciliation design.
+- Stage 18J-P10 - Load/reconcile identity evidence, no station-type writes.
+- Later: retry strict station-type dry-run only after confirmed external
+  identity appears in read-only reconciliation output.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md
@@ -1,0 +1,325 @@
+# Stage 18J-P6 — External Identity Migration Production Readiness
+
+## Purpose
+
+Stage 18J-P6 reviews whether the Stage 18J-P5 external station identity
+migration draft is safe and complete enough for a later schema-only production
+application stage.
+
+This stage is docs/review only. It does not run production commands, touch the
+production database, apply the migration to production, run imports, run
+reconciliation, run the summarizer against production artifacts, run
+station-type dry-run, run canonical apply, create approval records, or start
+Stage 18K.
+
+## Migration Reviewed
+
+Reviewed migration:
+
+- `sql/027_station_external_identity.sql`
+
+Reviewed supporting material:
+
+- `tests/test_station_external_identity_migration.py`
+- `docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md`
+- `docs/colonisation-redesign/stage-18j-p4-external-station-identity-schema-design.md`
+- `docs/operations/enrichment-warehouse-runbook.md`
+- `docs/colonisation-redesign/enrichment-roadmap.md`
+- `docs/colonisation-redesign/stage-17p-current-state-forward-plan.md`
+- `scripts/operator/require_hetzner_operator_env.sh`
+
+The migration creates `station_external_identity` as a separate
+provenance-backed identity table. It does not add `market_id` or
+`edsm_station_id` to `stations`.
+
+## Readiness Verdict
+
+Ready for schema-only production application.
+
+This verdict is limited to a future schema-only stage that creates the empty
+`station_external_identity` table and indexes. It does not approve any identity
+data load, backfill, reconciliation run, station-type dry-run, canonical apply,
+or approval record.
+
+The verdict depends on the required preflight checks passing and on the
+operator applying only `sql/027_station_external_identity.sql` from the Hetzner
+production operator shell.
+
+## Additive Safety Review
+
+The migration is additive:
+
+- `CREATE TABLE IF NOT EXISTS station_external_identity`;
+- `CREATE INDEX IF NOT EXISTS ...`;
+- `CREATE UNIQUE INDEX IF NOT EXISTS ...`;
+- comments on the new table and new columns only.
+
+The migration does not:
+
+- alter `stations`;
+- alter `systems`;
+- alter `station_body_links`;
+- insert, update, delete, or backfill data;
+- create station-type write paths;
+- create views or procedures that imply canonical write eligibility;
+- create approval records.
+
+The table references `stations(id)` and `systems(id64)`, but those references do
+not rewrite existing rows because the new table starts empty.
+
+## Constraint Review
+
+The migration requires at least one external station identifier:
+
+- `market_id IS NOT NULL OR edsm_station_id IS NOT NULL`
+
+Identity status is constrained to:
+
+- `proposed`;
+- `confirmed`;
+- `conflicting`;
+- `rejected`;
+- `superseded`.
+
+Confidence and freshness are constrained to the current project vocabulary used
+by station identity, warehouse staging, and P4:
+
+- confidence: `exact_station_identity`, `source_station_snapshot`, `high`,
+  `medium`, `low`, `unresolved`;
+- freshness: `source_updated_at`, `file_snapshot`, `current`, `recent`,
+  `stale`, `undated`, `unknown`.
+
+Conflicting rows require `conflict_reason`, and evidence timestamps must satisfy
+`evidence_last_seen_at >= evidence_first_seen_at`.
+
+These constraints are sufficient for schema-only application. Later loader
+logic must still enforce higher-level confirmation rules, such as rejecting
+name-only matches and internal `stations.id` equality as external identity
+proof.
+
+## Index Review
+
+The migration adds lookup indexes for future reconciliation paths:
+
+- `canonical_station_id`;
+- `system_id64`;
+- `market_id`;
+- `edsm_station_id`;
+- `source_run_key, source_file_key`;
+- `identity_status`.
+
+The migration adds partial unique indexes for confirmed identities:
+
+- `(source, market_id)` when `market_id` is present and status is `confirmed`;
+- `(source, edsm_station_id)` when `edsm_station_id` is present and status is
+  `confirmed`;
+- `(canonical_station_id, source, market_id)` for confirmed market identity;
+- `(canonical_station_id, source, edsm_station_id)` for confirmed EDSM identity.
+
+The uniqueness rules are safe for schema-only application because the table is
+empty and because only `confirmed` rows are constrained. Non-confirmed
+`proposed`, `conflicting`, `rejected`, and `superseded` evidence remains
+representable.
+
+The rules are intentionally conservative: a confirmed external ID should not map
+to multiple canonical stations for the same source. Later evidence-loader logic
+must still detect semantic conflicts such as one canonical station receiving
+multiple active external IDs for the same identity kind.
+
+## Provenance Review
+
+The migration preserves the provenance fields needed for review:
+
+- `source`;
+- `source_run_key`;
+- `source_file_key`;
+- `source_record_hash`;
+- `source_updated_at`;
+- `evidence_first_seen_at`;
+- `evidence_last_seen_at`;
+- `confidence`;
+- `freshness_class`.
+
+These fields are sufficient for a future identity evidence loader and read-only
+coverage artifact to explain where an identity row came from. Warehouse
+source-only evidence remains source evidence until a later loader/reconciliation
+stage promotes it to `confirmed`.
+
+## Conflict Handling Review
+
+Conflict states are representable through:
+
+- `identity_status = 'conflicting'`;
+- required `conflict_reason`;
+- nullable external IDs so market and EDSM conflicts can be represented
+  independently;
+- non-confirmed rows remaining outside the confirmed unique-index constraints.
+
+The migration does not resolve conflicts by itself. Later stages must classify
+and report conflicts before any identity row is accepted as canonical external
+identity proof.
+
+## Rollback / Reversibility Considerations
+
+Before any identity rows are loaded, rollback is straightforward: remove the
+new table and indexes. Because the table is new and empty after schema-only
+application, rollback does not require restoring canonical station data.
+
+After identity evidence is loaded, rollback becomes a data-retention decision
+and must be handled by a separate evidence rollback plan. P6 does not approve
+loading evidence, so this readiness verdict applies only to the empty-table
+schema step.
+
+The operator should verify that `station_external_identity` does not already
+exist before applying the migration. If it does exist, stop and inspect the
+table definition instead of relying on `CREATE TABLE IF NOT EXISTS` to repair a
+partial or divergent table.
+
+## Required Preflight Checks
+
+Before any future schema-only production application stage, the operator must:
+
+- confirm the shell is the Hetzner production operator shell on host
+  `ed-finder`;
+- confirm the working directory is `/opt/ed-finder`;
+- run the Hetzner operator environment guard;
+- confirm `git` main includes PR #126 and `sql/027_station_external_identity.sql`;
+- confirm the production database is reachable;
+- confirm migration 027 has not already been applied;
+- confirm `station_external_identity` does not already exist;
+- confirm a backup/snapshot exists, or the operator explicitly accepts the risk
+  of a schema-only additive migration;
+- confirm no imports are running;
+- confirm no reconciliation jobs are running;
+- confirm no canonical apply jobs are running;
+- confirm no station-type dry-run is running;
+- confirm Docker services are healthy;
+- check SQL syntax against a disposable or local PostgreSQL database first.
+
+If any preflight check fails or is ambiguous, stop before applying the schema.
+
+## Required Post-Apply Checks
+
+After a future schema-only production application stage, the operator must
+verify:
+
+- `station_external_identity` exists;
+- all expected constraints exist;
+- all expected indexes exist;
+- `stations` row count is unchanged from the preflight snapshot;
+- `station_external_identity` row count is `0`;
+- no station-type data changed;
+- no approval record was created;
+- app containers and Docker services are still healthy;
+- no imports, reconciliation jobs, station-type dry-runs, or canonical apply
+  jobs were started by the schema application.
+
+If any post-apply check fails, stop and preserve logs/output for review.
+
+## Production Application Boundaries
+
+A later schema application stage must be schema-only:
+
+- applying the schema must not load identity data;
+- applying the schema must not backfill;
+- applying the schema must not run imports;
+- applying the schema must not run reconciliation;
+- applying the schema must not run station-type dry-run;
+- applying the schema must not run canonical apply;
+- applying the schema must not create approval records;
+- identity evidence load/reconciliation remains a later stage.
+
+The migration only creates the place where identity evidence can later be
+stored. It does not make any station-type candidate eligible.
+
+## What This Still Does Not Enable
+
+Even after a future schema-only application:
+
+- canonical `stations` still has no `market_id` or `edsm_station_id` columns;
+- `stations.id` remains an update target, not external identity proof;
+- `station_body_links.market_id` remains association-scoped;
+- no identity rows exist yet;
+- no confirmed external identity coverage exists yet;
+- strict station-type dry-run remains blocked by missing confirmed canonical
+  external identity;
+- station-type canonical writes remain blocked.
+
+## Risks / Open Questions
+
+Known risks and follow-up questions:
+
+- `CREATE TABLE IF NOT EXISTS` will not fix a partially existing divergent
+  table; preflight must require the table to be absent.
+- The current indexes are sufficient for the first confirmed-identity join
+  shape, but later high-volume reconciliation may need an additional composite
+  index such as `(canonical_station_id, identity_status)`.
+- The migration constrains common confidence and freshness labels. If a later
+  loader needs additional labels, that stage must explicitly extend the
+  constraint before using them.
+- The migration does not include an automatic `updated_at` trigger. Current
+  repo migrations commonly use timestamp defaults without a generic update
+  trigger; later loader code must update `updated_at` explicitly.
+- Foreign keys use `ON DELETE CASCADE` for stations/systems. That is acceptable
+  for identity evidence tied to canonical rows, but evidence archival policy
+  should be revisited before any large identity load.
+
+None of these risks blocks a schema-only production application, provided the
+preflight and post-apply checks are followed.
+
+## Recommended Operator Command Shape
+
+This is a recommended shape for a later explicitly approved Hetzner operator
+stage. Do not run it from Codex/local development.
+
+```sh
+cd /opt/ed-finder
+scripts/operator/require_hetzner_operator_env.sh
+
+git fetch origin main
+git status --short --branch
+git log --oneline -5
+
+# Preflight examples:
+# - verify PR #126 merge is present on main
+# - verify database connectivity through the operator-managed DB environment
+# - verify station_external_identity does not already exist
+# - capture stations row count
+# - verify no imports/reconciliation/dry-run/apply jobs are active
+# - verify Docker services are healthy
+
+psql "$EDFINDER_PRODUCTION_DSN" \
+  -v ON_ERROR_STOP=1 \
+  -f sql/027_station_external_identity.sql
+
+# Post-apply examples:
+# - verify station_external_identity exists
+# - verify constraints and indexes
+# - verify station_external_identity row count is 0
+# - verify stations row count is unchanged
+# - verify station_type data is unchanged
+# - verify app containers remain healthy
+```
+
+The real operator prompt should replace the comments with concrete read-only
+preflight/post-apply SQL checks and should record the exact outputs.
+
+## Recommended Next Stages
+
+- Stage 18J-P7 - Schema-only external identity migration application packet.
+- Stage 18J-P8 - Apply external identity schema migration only, if approved.
+- Stage 18J-P9 - External identity evidence loader/reconciliation design.
+- Stage 18J-P10 - Load/reconcile identity evidence, no station-type writes.
+- Later: retry strict station-type dry-run only after confirmed external
+  identity appears in read-only reconciliation output.
+
+## Final Recommendation
+
+`sql/027_station_external_identity.sql` is ready for a future schema-only
+production application stage after this readiness review merges.
+
+Do not combine that schema application with evidence loading, reconciliation,
+station-type dry-run, canonical apply, or approval-record creation. The next
+stage should be a narrow operator packet for applying only the empty
+`station_external_identity` schema on Hetzner with explicit preflight and
+post-apply checks.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -685,6 +685,18 @@ or reconcile identity evidence, does not update `stations`, and does not
 authorize station-type dry-run or apply. Any production schema application
 requires a later explicit readiness review and approval stage.
 
+Stage 18J-P6 records that readiness review in
+`docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md`.
+The verdict is `Ready for schema-only production application`, limited to a
+future operator stage that applies only `sql/027_station_external_identity.sql`.
+The P6 review requires Hetzner `/opt/ed-finder` preflight checks, proof that PR
+#126 is present on main, confirmation that `station_external_identity` does not
+already exist, a backup/snapshot or explicit schema-only risk acceptance, no
+active imports/reconciliation/apply jobs, disposable/local SQL syntax testing,
+and post-apply verification that the new table is empty and `stations` is
+unchanged. Applying this schema later must still not load identity data,
+backfill, run station-type dry-run, or run canonical apply.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,


### PR DESCRIPTION
## What changed

* Adds production readiness review for `sql/027_station_external_identity.sql`.
* Records readiness verdict.
* Defines preflight and post-apply checks.
* Confirms schema-only boundaries.
* Updates roadmap/runbook docs.

## Boundary confirmations

* Docs/review only.
* No production commands run.
* No production DB touched.
* Migration not applied to production.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

`git diff --check`

```text
(no output)
```

`bash -n scripts/operator/require_hetzner_operator_env.sh`

```text
(no output)
```

`bash -n scripts/operator/stage18j_run_compact_summary.sh`

```text
(no output)
```

`bash -n scripts/operator/stage18j_run_station_type_dry_run.sh`

```text
(no output)
```

`./scripts/run_canonical_safety_tests.sh`

```text
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.
```

`.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py -q`

```text
........................................................................ [ 67%]
..................................                                       [100%]
106 passed in 0.15s
```

`.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py`

```text
(no output)
```

Secret/DSN scan over `sql/027_station_external_identity.sql` and changed docs:

```text
(no matches)
```

Additional staged-file whitespace check, so the new P6 doc was included:

`git diff --cached --check`

```text
(no output)
```