### PR TITLE
Stage 18J-P7 external identity schema production apply closeout

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -608,6 +608,14 @@ DB, load identity evidence, run reconciliation, run station-type dry-run, or
 authorize apply. See
 [`stage-18j-p6-external-identity-migration-production-readiness.md`](./stage-18j-p6-external-identity-migration-production-readiness.md).
 
+Stage 18J-P7 records the schema-only production application closeout for
+`sql/027_station_external_identity.sql`. The `station_external_identity` table
+now exists on Hetzner with the expected constraints and indexes, has row count
+`0`, and the recorded canonical `stations` count stayed unchanged at `284763`. No
+identity evidence was loaded, no reconciliation/import/summarizer/station-type
+dry-run/apply was run, and no station-type data changed. See
+[`stage-18j-p7-external-identity-schema-production-apply-closeout.md`](./stage-18j-p7-external-identity-schema-production-apply-closeout.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -691,11 +699,14 @@ treated as a separate proposal.
 * **External identity migration readiness**: Stage 18J-P6 reviews migration 027
   and finds it ready for a later schema-only production application stage with
   explicit preflight and post-apply checks.
-* **External identity follow-up sequence**: continue with P7 schema-only
-  application packet, P8 schema-only migration apply if approved, P9 evidence
-  loader/reconciliation design, P10 identity evidence load/reconciliation with
-  no station-type writes, and only later retry strict station-type dry-run with
-  confirmed external identity.
+* **External identity schema closeout**: Stage 18J-P7 records that migration
+  027 has been applied on Hetzner as schema-only. The identity table exists but
+  is empty, so strict station-type dry-run remains blocked.
+* **External identity follow-up sequence**: after the P7 schema closeout,
+  continue with P8 evidence loader/reconciliation design, P9 evidence load
+  dry-run, P10 write-staging/load with no station-type writes, P11 identity
+  coverage artifact, P12 reconciliation integration with confirmed identity,
+  and P13 strict station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -777,10 +777,11 @@ Scope:
 - Preserve the Stage 18J continuation path: Q9 compact review, strict-filter
   hardening, operator-safe dry-run wrapper, P2 identity diagnostics, P3/P4
   external identity design, P5 migration draft, P6 production readiness review,
-  P7 schema-only application packet, P8 schema-only migration apply if
-  approved, P9 evidence loader/reconciliation design, P10 identity evidence
-  load/reconciliation with no station-type writes, and only later a strict
-  station-type dry-run retry with confirmed external identity.
+  P7 schema production apply closeout, P8 evidence loader/reconciliation
+  design, P9 evidence load dry-run, P10 evidence write-staging/load with no
+  station-type writes, P11 identity coverage artifact, P12 reconciliation
+  integration with confirmed identity, and P13 strict station-type dry-run
+  retry.
 
 Non-goals:
 
@@ -1036,6 +1037,37 @@ Non-goals:
 Support doc:
 `stage-18j-p6-external-identity-migration-production-readiness.md`.
 
+### Stage 18J-P7 - External Identity Schema Production Apply Closeout
+
+Purpose: record that `sql/027_station_external_identity.sql` has been applied
+on Hetzner as a schema-only migration after the P6 readiness review.
+
+Scope:
+
+- Record that `station_external_identity` exists in production.
+- Record that `station_external_identity` row count is `0`.
+- Record that canonical `stations` count after apply is `284763`.
+- Record the verified constraints and indexes.
+- Confirm no identity evidence was loaded.
+- Confirm no imports, reconciliation, production summarizer run, station-type
+  dry-run, or canonical apply were run.
+- Confirm no station-type data changed.
+- Keep strict station-type dry-run blocked until confirmed identity evidence is
+  loaded and integrated into read-only reconciliation.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No production migration reapply.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p7-external-identity-schema-production-apply-closeout.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1117,10 +1149,12 @@ Do not add another large planner feature immediately. The healthiest next sequen
 34. Stage 18J-P4 external station identity schema design.
 35. Stage 18J-P5 external station identity migration draft, not applied to production.
 36. Stage 18J-P6 external identity migration production readiness review.
-37. Stage 18J-P7 schema-only external identity migration application packet.
-38. Stage 18J-P8 apply external identity schema migration only, if approved.
-39. Stage 18J-P9 external identity evidence loader/reconciliation design.
-40. Stage 18J-P10 load/reconcile identity evidence, no station-type writes.
-41. Later: retry strict station-type dry-run with confirmed external identity.
+37. Stage 18J-P7 external identity schema production apply closeout.
+38. Stage 18J-P8 external identity evidence loader/reconciliation design.
+39. Stage 18J-P9 external identity evidence load dry-run.
+40. Stage 18J-P10 external identity evidence write-staging/load, no station-type writes.
+41. Stage 18J-P11 identity coverage artifact.
+42. Stage 18J-P12 reconciliation integration with confirmed identity.
+43. Stage 18J-P13 retry strict station-type dry-run.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md
+++ b/docs/colonisation-redesign/stage-18j-p5-external-station-identity-migration-draft.md
@@ -187,14 +187,20 @@ Stage 18J-P6 performs that readiness review in
 migration ready for a future schema-only production application stage, provided
 the required preflight and post-apply checks pass.
 
+Stage 18J-P7 later records the schema-only production apply closeout in
+`stage-18j-p7-external-identity-schema-production-apply-closeout.md`. The
+schema is now present on Hetzner, `station_external_identity` has row count `0`,
+and no identity evidence, reconciliation, station-type dry-run, or canonical
+apply was run.
+
 ## Reconciliation Impact
 
 No reconciliation code is changed in P5. Current reconciliation output remains
 unchanged.
 
-After a later approved schema application and evidence load, read-only
-reconciliation can be extended to join only `identity_status = 'confirmed'`
-rows and expose canonical external identity fields such as:
+Now that P7 records the schema as present, a later approved evidence load can
+let read-only reconciliation join only `identity_status = 'confirmed'` rows and
+expose canonical external identity fields such as:
 
 - `canonical.market_id`;
 - `canonical.edsm_station_id`;
@@ -247,19 +253,22 @@ The migration tests verify:
 ## Recommended Next Stages
 
 - Stage 18J-P6 - External identity migration production readiness review.
-- Stage 18J-P7 - Schema-only external identity migration application packet.
-- Stage 18J-P8 - Apply external identity schema migration only, if approved.
-- Stage 18J-P9 - External identity evidence loader/reconciliation design.
-- Stage 18J-P10 - Load/reconcile identity evidence, no station-type writes.
-- Later: retry strict station-type dry-run only after confirmed external
-  identity appears in read-only reconciliation output.
+- Stage 18J-P7 - External identity schema production apply closeout.
+- Stage 18J-P8 - External identity evidence loader/reconciliation design.
+- Stage 18J-P9 - External identity evidence load dry-run.
+- Stage 18J-P10 - External identity evidence write-staging/load, no
+  station-type writes.
+- Stage 18J-P11 - Identity coverage artifact.
+- Stage 18J-P12 - Reconciliation integration with confirmed identity.
+- Stage 18J-P13 - Retry strict station-type dry-run.
 
 ## Final Recommendation
 
-Keep `sql/027_station_external_identity.sql` as a draft additive migration
-until a later production readiness review approves applying only the schema.
+P5 correctly kept `sql/027_station_external_identity.sql` as a draft additive
+migration. P6 approved schema-only application, and P7 records that the schema
+is now present but empty.
 
 Do not backfill identity evidence, alter the strict station-type filter, or
-start any station-type dry-run/apply path in P5. The correct next step is an
-external identity evidence loader/reconciliation design that can populate and
-review the table safely after the schema has been separately approved.
+start any station-type dry-run/apply path from this migration. The correct next
+step is an external identity evidence loader/reconciliation design that can
+populate and review the table safely without station-type writes.

--- a/docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md
@@ -232,9 +232,12 @@ A later schema application stage must be schema-only:
 The migration only creates the place where identity evidence can later be
 stored. It does not make any station-type candidate eligible.
 
+Stage 18J-P7 later records that this schema-only application has completed on
+Hetzner and that `station_external_identity` exists with row count `0`.
+
 ## What This Still Does Not Enable
 
-Even after a future schema-only application:
+Even after the Stage 18J-P7 schema-only application closeout:
 
 - canonical `stations` still has no `market_id` or `edsm_station_id` columns;
 - `stations.id` remains an update target, not external identity proof;
@@ -269,8 +272,10 @@ preflight and post-apply checks are followed.
 
 ## Recommended Operator Command Shape
 
-This is a recommended shape for a later explicitly approved Hetzner operator
-stage. Do not run it from Codex/local development.
+This was the recommended shape for the later explicitly approved Hetzner
+operator stage. Stage 18J-P7 records that the schema-only application has now
+completed, so do not re-run this command shape as part of P7 closeout. Do not
+run it from Codex/local development.
 
 ```sh
 cd /opt/ed-finder
@@ -306,20 +311,21 @@ preflight/post-apply SQL checks and should record the exact outputs.
 
 ## Recommended Next Stages
 
-- Stage 18J-P7 - Schema-only external identity migration application packet.
-- Stage 18J-P8 - Apply external identity schema migration only, if approved.
-- Stage 18J-P9 - External identity evidence loader/reconciliation design.
-- Stage 18J-P10 - Load/reconcile identity evidence, no station-type writes.
-- Later: retry strict station-type dry-run only after confirmed external
-  identity appears in read-only reconciliation output.
+- Stage 18J-P7 - External identity schema production apply closeout.
+- Stage 18J-P8 - External identity evidence loader/reconciliation design.
+- Stage 18J-P9 - External identity evidence load dry-run.
+- Stage 18J-P10 - External identity evidence write-staging/load, no
+  station-type writes.
+- Stage 18J-P11 - Identity coverage artifact.
+- Stage 18J-P12 - Reconciliation integration with confirmed identity.
+- Stage 18J-P13 - Retry strict station-type dry-run.
 
 ## Final Recommendation
 
-`sql/027_station_external_identity.sql` is ready for a future schema-only
-production application stage after this readiness review merges.
+`sql/027_station_external_identity.sql` was ready for schema-only production
+application after this readiness review, and Stage 18J-P7 records that the
+schema is now present with no identity evidence rows.
 
-Do not combine that schema application with evidence loading, reconciliation,
-station-type dry-run, canonical apply, or approval-record creation. The next
-stage should be a narrow operator packet for applying only the empty
-`station_external_identity` schema on Hetzner with explicit preflight and
-post-apply checks.
+Do not combine the now-present schema with station-type writes. The next work
+should design evidence loading and reconciliation while keeping strict
+station-type dry-run blocked until confirmed identity coverage exists.

--- a/docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md
+++ b/docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md
@@ -1,0 +1,175 @@
+# Stage 18J-P7 — External Identity Schema Production Apply Closeout
+
+## Purpose
+
+Stage 18J-P7 records the closeout for the schema-only production application of
+`sql/027_station_external_identity.sql` after the Stage 18J-P6 readiness
+review.
+
+This is documentation/closeout only. Codex did not run production commands,
+touch the production database, reapply the migration, run imports, run
+reconciliation, run the summarizer against production artifacts, run
+station-type dry-run, run canonical apply, create approval records, or start
+Stage 18K.
+
+## Production Action Recorded
+
+The Hetzner operator flow has already applied the schema-only migration:
+
+- migration applied: `sql/027_station_external_identity.sql`;
+- environment: Hetzner production operator context;
+- scope: schema creation only;
+- identity evidence load: not run;
+- station-type write path: not run.
+
+This closeout records the supplied operator result. It does not re-run or
+verify production commands from Codex.
+
+## Migration Applied
+
+Applied migration:
+
+- `sql/027_station_external_identity.sql`
+
+The migration creates the separate provenance-backed
+`station_external_identity` table with constraints and indexes. It does not add
+`market_id` or `edsm_station_id` columns to canonical `stations`, and it does
+not update canonical station rows.
+
+## Post-Apply Checks
+
+Recorded post-apply checks:
+
+- `station_external_identity` exists;
+- `station_external_identity` row count is `0`;
+- canonical `stations` count after apply is `284763`;
+- expected constraints are present;
+- expected indexes are present;
+- no imports were run;
+- no reconciliation was run;
+- no summarizer was run;
+- no station-type dry-run was run;
+- no canonical apply was run;
+- no identity evidence was loaded;
+- no station-type data changed.
+
+## Table State
+
+`station_external_identity` is now present in production, but it is empty.
+
+Current recorded row count:
+
+```text
+station_external_identity: 0
+```
+
+The empty table means the schema is available for later evidence-loading
+stages, but no canonical external station identity proof exists yet.
+
+## Constraint Verification
+
+The following constraints were reported present:
+
+- `chk_station_external_identity_confidence`;
+- `chk_station_external_identity_conflict_reason`;
+- `chk_station_external_identity_external_id`;
+- `chk_station_external_identity_freshness`;
+- `chk_station_external_identity_seen_window`;
+- `chk_station_external_identity_status`;
+- `station_external_identity_canonical_station_id_fkey`;
+- `station_external_identity_pkey`;
+- `station_external_identity_system_id64_fkey`.
+
+These constraints preserve the P5/P6 contract: at least one external ID is
+required, identity status/confidence/freshness values are constrained,
+conflicting rows require a reason, evidence seen windows are valid, and the
+table remains tied to canonical station/system rows.
+
+## Index Verification
+
+The following indexes were reported present:
+
+- `idx_station_external_identity_confirmed_source_edsm`;
+- `idx_station_external_identity_confirmed_source_market`;
+- `idx_station_external_identity_confirmed_station_source_edsm`;
+- `idx_station_external_identity_confirmed_station_source_market`;
+- `idx_station_external_identity_edsm_station_id`;
+- `idx_station_external_identity_market_id`;
+- `idx_station_external_identity_source_run_file`;
+- `idx_station_external_identity_station`;
+- `idx_station_external_identity_status`;
+- `idx_station_external_identity_system`;
+- `station_external_identity_pkey`.
+
+These indexes support the initial reconciliation join shape and confirmed
+identity uniqueness checks. They do not load evidence or make station-type
+updates eligible by themselves.
+
+## Canonical Station Count Verification
+
+The supplied post-apply result records canonical `stations` count stayed
+unchanged at:
+
+```text
+stations: 284763
+```
+
+The closeout result also records that no station-type data changed. Because
+Codex did not query production, this document records the supplied operator
+verification rather than independently rechecking the production database.
+
+## What Was Not Run
+
+The schema-only apply did not run:
+
+- imports;
+- reconciliation;
+- summarizer against production artifacts;
+- station-type dry-run;
+- canonical apply;
+- identity evidence load;
+- station-type data writes.
+
+Codex did not run production commands, touch the production database, or
+reapply the migration while creating this closeout.
+
+## Safety Outcome
+
+The schema-only production application completed with the expected empty table,
+expected constraints, expected indexes, and no recorded data-load or
+station-type write activity.
+
+This satisfies the Stage 18J-P6 readiness boundary for applying only the
+external identity schema. It does not satisfy the identity-proof requirement
+for strict station-type dry-run eligibility.
+
+## Remaining Blocker
+
+The schema is now present, but it contains no identity evidence yet. Stage
+18J-P station-type dry-run remains blocked from producing eligible candidates
+until identity evidence is loaded, reconciled, and confirmed.
+
+Only `identity_status = 'confirmed'` rows should later be eligible for
+read-only reconciliation as canonical external identity proof. Name-only
+matches, warehouse source-only evidence, internal `stations.id` equality, and
+station/body link association evidence remain insufficient.
+
+## Recommended Next Stages
+
+- Stage 18J-P8 - External identity evidence loader/reconciliation design.
+- Stage 18J-P9 - External identity evidence load dry-run.
+- Stage 18J-P10 - External identity evidence write-staging/load, no
+  station-type writes.
+- Stage 18J-P11 - Identity coverage artifact.
+- Stage 18J-P12 - Reconciliation integration with confirmed identity.
+- Stage 18J-P13 - Retry strict station-type dry-run.
+
+## Final Recommendation
+
+Treat the external identity schema as present but empty. The next work should
+design and validate identity evidence loading/reconciliation without creating
+station-type writes.
+
+Do not retry the strict station-type dry-run until confirmed external identity
+coverage exists in read-only reconciliation output. Do not run canonical apply
+or create approval records as part of identity evidence loading.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -697,6 +697,17 @@ and post-apply verification that the new table is empty and `stations` is
 unchanged. Applying this schema later must still not load identity data,
 backfill, run station-type dry-run, or run canonical apply.
 
+Stage 18J-P7 records the schema-only production apply closeout in
+`docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md`.
+The migration `sql/027_station_external_identity.sql` has been applied on
+Hetzner. `station_external_identity` exists with the expected constraints and
+indexes, its row count is `0`, and the recorded canonical `stations` count
+stayed unchanged at `284763`. No identity evidence was loaded, no imports,
+reconciliation, summarizer, station-type dry-run, or canonical apply were run,
+and no station-type data changed. The table is present but empty, so
+station-type dry-run remains blocked until confirmed external identity evidence
+is loaded and integrated into read-only reconciliation.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,


### PR DESCRIPTION
## What changed

* Records schema-only production application of `sql/027_station_external_identity.sql`.
* Records post-apply checks.
* Confirms the identity table is empty.
* Confirms canonical station count stayed unchanged.
* Confirms no imports/reconciliation/summarizer/station-type dry-run/apply were run.
* Updates roadmap/runbook docs.

## Boundary confirmations

* Docs/closeout only.
* No production commands run from Codex.
* No production DB touched from Codex.
* Migration was already applied separately on Hetzner.
* No migration reapply.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

`git diff --check`

```text
(no output)
```

`./scripts/run_canonical_safety_tests.sh`

```text
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.14s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.
```

`.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py -q`

```text
........................................................................ [ 67%]
..................................                                       [100%]
106 passed in 0.15s
```

`.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py`

```text
(no output)
```

Secret/DSN scan over changed docs:

```text
(no matches)
```

Additional staged-file whitespace check, so the new P7 doc was included:

`git diff --cached --check`

```text
(no output)
```