### PR TITLE
Stage 18J-P8 external identity evidence loader reconciliation design

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -616,6 +616,16 @@ identity evidence was loaded, no reconciliation/import/summarizer/station-type
 dry-run/apply was run, and no station-type data changed. See
 [`stage-18j-p7-external-identity-schema-production-apply-closeout.md`](./stage-18j-p7-external-identity-schema-production-apply-closeout.md).
 
+Stage 18J-P8 designs the external identity evidence loader/reconciliation
+workflow. It selects existing `edsm_nightly_stations` warehouse rows as the
+first evidence source, maps `staging_edsm_stations` fields to
+`station_external_identity`, defines read-only candidate matching/status rules,
+and requires a dry-run identity candidate artifact before any identity evidence
+load. It keeps station-type writes blocked and does not run production
+commands, load identity evidence, run reconciliation, run station-type dry-run,
+or run apply. See
+[`stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md`](./stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -702,11 +712,13 @@ treated as a separate proposal.
 * **External identity schema closeout**: Stage 18J-P7 records that migration
   027 has been applied on Hetzner as schema-only. The identity table exists but
   is empty, so strict station-type dry-run remains blocked.
-* **External identity follow-up sequence**: after the P7 schema closeout,
-  continue with P8 evidence loader/reconciliation design, P9 evidence load
-  dry-run, P10 write-staging/load with no station-type writes, P11 identity
-  coverage artifact, P12 reconciliation integration with confirmed identity,
-  and P13 strict station-type dry-run retry.
+* **External identity loader design**: Stage 18J-P8 requires a read-only
+  identity candidate artifact from staged EDSM station evidence before any
+  writes to `station_external_identity`.
+* **External identity follow-up sequence**: after the P8 design, continue with
+  P9 evidence load dry-run, P10 write-staging/load with no station-type writes,
+  P11 identity coverage artifact, P12 reconciliation integration with confirmed
+  identity, and P13 strict station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -1068,6 +1068,40 @@ Non-goals:
 Support doc:
 `stage-18j-p7-external-identity-schema-production-apply-closeout.md`.
 
+### Stage 18J-P8 - External Identity Evidence Loader / Reconciliation Design
+
+Purpose: design how external station identity evidence will be loaded and
+reconciled into the now-present `station_external_identity` table.
+
+Scope:
+
+- Identify `edsm_nightly_stations` warehouse evidence as the first identity
+  source candidate.
+- Map `staging_edsm_stations` fields to `station_external_identity`.
+- Define candidate matching rules using external IDs, source provenance,
+  `system_id64`, normalized station name, and exactly one canonical station
+  match.
+- Define `proposed`, `confirmed`, `conflicting`, `rejected`, and `superseded`
+  status rules.
+- Define a read-only identity candidate artifact before any identity writes.
+- Define future write-staging/load boundaries for `station_external_identity`
+  only.
+- Keep strict station-type dry-run blocked until confirmed identity coverage is
+  reviewed and exposed through read-only reconciliation.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No identity evidence load.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner

--- a/docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md
+++ b/docs/colonisation-redesign/stage-18j-p6-external-identity-migration-production-readiness.md
@@ -326,6 +326,11 @@ preflight/post-apply SQL checks and should record the exact outputs.
 application after this readiness review, and Stage 18J-P7 records that the
 schema is now present with no identity evidence rows.
 
+Stage 18J-P8 designs the later identity evidence candidate artifact and
+write-staging/load workflow. That design keeps identity loading separate from
+reconciliation integration, station-type dry-run, canonical apply, and approval
+record creation.
+
 Do not combine the now-present schema with station-type writes. The next work
 should design evidence loading and reconciliation while keeping strict
 station-type dry-run blocked until confirmed identity coverage exists.

--- a/docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md
+++ b/docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md
@@ -154,9 +154,12 @@ read-only reconciliation as canonical external identity proof. Name-only
 matches, warehouse source-only evidence, internal `stations.id` equality, and
 station/body link association evidence remain insufficient.
 
+Stage 18J-P8 designs the next step: a read-only external identity evidence
+candidate artifact and later write-staging/load workflow that preserves
+provenance while keeping station-type writes blocked.
+
 ## Recommended Next Stages
 
-- Stage 18J-P8 - External identity evidence loader/reconciliation design.
 - Stage 18J-P9 - External identity evidence load dry-run.
 - Stage 18J-P10 - External identity evidence write-staging/load, no
   station-type writes.

--- a/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
+++ b/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
@@ -1,0 +1,395 @@
+# Stage 18J-P8 — External Identity Evidence Loader / Reconciliation Design
+
+## Purpose
+
+Stage 18J-P8 designs how external station identity evidence should be loaded
+and reconciled into `station_external_identity` after the Stage 18J-P7
+schema-only production apply closeout.
+
+This stage is docs/design only. It does not run production commands, touch the
+production database, load identity evidence, run imports, run reconciliation,
+run the summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Current Production State
+
+Known operator state after Stage 18J-P7:
+
+- `station_external_identity` exists in production.
+- `station_external_identity` row count is `0`.
+- canonical `stations` count after schema apply stayed unchanged at `284763`.
+- no imports were run.
+- no reconciliation was run.
+- no summarizer was run.
+- no station-type dry-run was run.
+- no canonical apply was run.
+- no identity evidence was loaded.
+- no station-type data changed.
+
+The schema is present but empty. It does not yet provide canonical external
+identity proof for Stage 18J-P station-type filtering.
+
+## Source Evidence Candidates
+
+Use existing `edsm_nightly_stations` warehouse evidence first, specifically
+accepted rows from `staging_edsm_stations` joined to their source run/file/raw
+record metadata.
+
+This is the preferred first source because it already carries the fields needed
+by `station_external_identity`:
+
+- `system_id64`;
+- `system_name`;
+- `station_name`;
+- `market_id`;
+- `edsm_station_id`;
+- `source_run_key`;
+- `source_file_key`;
+- `source_record_hash`;
+- `source_updated_at`;
+- `confidence`;
+- `freshness_class`;
+- `source`;
+- `source_class`;
+- raw/provenance payload.
+
+Do not use live EDSM calls for this first design. Do not use station/body link
+evidence as a general station identity source. Body-link evidence can become
+supporting context later, but identity and association must remain separate.
+
+## Target Table
+
+Target table:
+
+- `station_external_identity`
+
+Field mapping from `staging_edsm_stations` and source metadata:
+
+| Target field | Proposed source |
+|---|---|
+| `canonical_station_id` | matched canonical `stations.id`, only after candidate matching |
+| `system_id64` | `staging_edsm_stations.system_id64` |
+| `station_name` | `staging_edsm_stations.station_name` |
+| `source` | `enrichment_source_runs.source`, expected `edsm_nightly_stations` |
+| `market_id` | `staging_edsm_stations.market_id` |
+| `edsm_station_id` | `staging_edsm_stations.edsm_station_id` |
+| `source_run_key` | `enrichment_source_runs.source_run_key` |
+| `source_file_key` | `enrichment_source_files.source_file_key` |
+| `source_record_hash` | `staging_edsm_stations.source_record_hash` |
+| `source_updated_at` | `staging_edsm_stations.source_updated_at` |
+| `evidence_first_seen_at` | loader timestamp or preserved existing first-seen value |
+| `evidence_last_seen_at` | loader timestamp for the reviewed evidence batch |
+| `confidence` | `exact_station_identity` for confirmed reviewed rows, otherwise existing source confidence such as `source_station_snapshot` |
+| `freshness_class` | `staging_edsm_stations.freshness_class` |
+| `identity_status` | status decision from the candidate artifact |
+| `conflict_reason` | required reason for `conflicting` rows |
+
+The loader must preserve `source_run_key`, `source_file_key`, and
+`source_record_hash` for every row. Rows without complete provenance are not
+eligible for confirmed identity.
+
+## Candidate Matching Strategy
+
+The first implementation should produce a read-only identity candidate artifact
+before writing any identity evidence. The artifact should classify each
+candidate with enough detail for operator review.
+
+Candidate matching should:
+
+- start from accepted `staging_edsm_stations` rows with at least one external
+  ID (`market_id` or `edsm_station_id`);
+- require `system_id64` to resolve to exactly one canonical system;
+- require a normalized station-name match within that system;
+- require exactly one canonical station candidate;
+- preserve source `market_id` and `edsm_station_id` without treating them as
+  canonical proof until the candidate is reviewed;
+- report rows with zero or multiple canonical station matches as blocked from
+  confirmation;
+- report rows where the same external ID maps to multiple canonical stations;
+- report rows where one canonical station receives multiple active external
+  IDs from the same source identity kind.
+
+Do not use name-only matching as confirmed identity proof. Normalized station
+name can support a match only when paired with `system_id64`, source external
+ID evidence, complete provenance, and a single canonical station match.
+
+Do not treat internal `stations.id` equality as external identity proof. The
+current reconciliation SQL has compatibility joins where staged `market_id` or
+`edsm_station_id` may equal `stations.id`; that behavior must not be promoted
+to identity confirmation without the explicit external identity model.
+
+## Identity Status Decision Rules
+
+Recommended status rules:
+
+- `proposed`: source row has at least one external ID, complete provenance, and
+  a plausible single canonical match, but it has not been reviewed or accepted
+  as confirmed identity.
+- `confirmed`: source row has complete provenance, at least one external ID,
+  `system_id64` matches the canonical system, normalized station name matches
+  exactly one canonical station, no same-source external ID conflict exists,
+  no canonical-station external ID conflict exists, and the reviewed dry-run
+  artifact approves the row for identity load.
+- `conflicting`: evidence is internally or externally contradictory and must
+  remain visible but blocked from proof use.
+- `rejected`: evidence is malformed, missing required provenance, missing both
+  external IDs, attached to an unsupported source, or cannot be made useful for
+  identity review.
+- `superseded`: a previously loaded non-current evidence row has been replaced
+  by a newer reviewed row for the same canonical station/source/external ID.
+
+Do not mark warehouse source-only evidence as `confirmed` automatically.
+Confirmation is a reviewed identity decision, not just the presence of a staged
+row.
+
+Rejected evidence that lacks both external IDs or required provenance cannot be
+inserted into `station_external_identity` because the table requires those
+fields. Keep those rows in the dry-run artifact as artifact-only rejects. Only
+schema-valid rejected evidence should be loaded with
+`identity_status = 'rejected'`.
+
+## Conflict Handling
+
+Conflicts must be stored or reported as `conflicting`, not overwritten.
+
+Block confirmed identity when:
+
+- `market_id` is associated with multiple canonical stations for the same
+  source;
+- `edsm_station_id` is associated with multiple canonical stations for the same
+  source;
+- one canonical station receives multiple active `market_id` values for the
+  same source without an explicit supersession decision;
+- one canonical station receives multiple active `edsm_station_id` values for
+  the same source without an explicit supersession decision;
+- source rows with the same `source_record_hash` or external ID disagree on
+  `system_id64` or normalized `station_name`;
+- staged evidence matches zero canonical stations;
+- staged evidence matches multiple canonical stations;
+- source `system_id64` conflicts with the matched canonical station system;
+- normalized source and canonical station names do not match;
+- provenance is incomplete;
+- the row would rely only on internal `stations.id` equality.
+
+Every conflicting row needs a `conflict_reason` that is specific enough for
+later review, for example `external_id_maps_to_multiple_canonical_stations`,
+`canonical_station_has_multiple_market_ids`, `system_id64_mismatch`,
+`station_name_mismatch`, or `missing_source_provenance`.
+
+## Proposed Loader Workflow
+
+P8 does not implement the loader. The recommended workflow for later stages is:
+
+1. Select an explicit `source_run_key` and optional `source_file_key`.
+2. Read only accepted `edsm_nightly_stations` staged rows.
+3. Build identity candidates from rows with at least one external ID.
+4. Join candidates to canonical systems by `system_id64`.
+5. Match canonical stations within the system by normalized station name.
+6. Classify candidates into `proposed`, `confirmed_candidate`,
+   `conflicting_candidate`, `rejected_candidate`, or `superseded_candidate` in
+   a read-only artifact.
+7. Include all source provenance and match proof in the artifact.
+8. Record aggregate counts by status, external ID type, source run/file, and
+   conflict reason.
+9. Require operator review of the artifact before any write-stage/load step.
+
+The first loader implementation should be report-only by default and should
+reject any canonical write flag.
+
+## Proposed Dry-Run Artifact
+
+Stage 18J-P9 should produce an identity evidence dry-run artifact only.
+
+Suggested artifact schema:
+
+- `schema_version`: `station_external_identity_candidates/v1`;
+- `dry_run`: `true`;
+- `report_only`: `true`;
+- `canonical_writes_planned`: `0`;
+- `identity_rows_planned`: count by status;
+- `filters`: source run/file and source;
+- `source_summary`: staged rows considered, rows with external IDs, rows with
+  complete provenance, rows skipped;
+- `candidate_summary`: counts for proposed/confirmable/conflicting/rejected;
+- `conflict_summary`: counts by conflict reason;
+- `confirmed_candidate_samples`;
+- `conflicting_candidate_samples`;
+- `rejected_candidate_samples`;
+- `proposed_candidate_samples`;
+- `artifact_integrity`: canonical JSON hash.
+
+Each candidate row should include:
+
+- source run/file/hash;
+- source record key;
+- source `market_id`;
+- source `edsm_station_id`;
+- source `system_id64`;
+- source `station_name`;
+- normalized source station name;
+- matched canonical station ID;
+- matched canonical system ID64;
+- normalized canonical station name;
+- canonical match count;
+- proposed `identity_status`;
+- proposed confidence/freshness;
+- `conflict_reason` when applicable;
+- explicit statement that `stations.id` was not used as external proof.
+
+## Proposed Write-Staging / Load Workflow
+
+Stage 18J-P10 should be a separate write-staging/load stage after the P9
+artifact is reviewed. It should write only to `station_external_identity`.
+
+Recommended load behavior:
+
+- require an artifact hash from the reviewed P9 candidate artifact;
+- require exact source run/file filters to match the artifact;
+- write no canonical tables;
+- write no station-type data;
+- insert reviewed `confirmed`, `conflicting`, schema-valid `rejected`,
+  `proposed`, and `superseded` rows as explicitly selected by the load plan;
+- keep conflicting evidence visible with `conflict_reason`;
+- update `evidence_last_seen_at` and `updated_at` for existing matching rows;
+- preserve previous `evidence_first_seen_at` when refreshing the same evidence;
+- mark old rows `superseded` only through an explicit reviewed supersession
+  decision;
+- run inside a transaction;
+- emit a post-load identity evidence report.
+
+The load should not be combined with read-only reconciliation integration or
+station-type dry-run.
+
+## Required Operator Preflight Checks
+
+Before any future identity evidence dry-run or load stage, require:
+
+- confirm the shell context is correct for the intended action;
+- confirm Codex/local prompts are not running production commands;
+- confirm `station_external_identity` exists;
+- confirm current row count before the action;
+- confirm `stations` count snapshot before the action;
+- confirm target source run/file exists in warehouse staging;
+- confirm source rows are from `edsm_nightly_stations`;
+- confirm no imports are running;
+- confirm no reconciliation jobs are running;
+- confirm no summarizer jobs are running;
+- confirm no station-type dry-run is running;
+- confirm no canonical apply is running;
+- confirm no approval-record creation is part of the workflow;
+- for write-load only, confirm the reviewed P9 artifact hash and source filters
+  match exactly;
+- for write-load only, confirm backup/snapshot or explicit identity-table load
+  risk acceptance.
+
+## Required Post-Load Checks
+
+After a future identity evidence load, require:
+
+- `station_external_identity` row count matches the load report;
+- counts by `identity_status` match the reviewed plan;
+- conflicts have non-null `conflict_reason`;
+- no row lacks `source_run_key`, `source_file_key`, or `source_record_hash`;
+- no row lacks both `market_id` and `edsm_station_id`;
+- `stations` row count is unchanged;
+- station-type data is unchanged;
+- no canonical write plan was produced;
+- no imports, reconciliation, summarizer, station-type dry-run, or canonical
+  apply started as part of the load;
+- a follow-up coverage artifact can be produced from the identity table.
+
+## Reconciliation Integration
+
+Stage 18J-P12 should integrate confirmed external identity into read-only
+station reconciliation output.
+
+Recommended read-only join shape:
+
+- join canonical station matches to `station_external_identity` by
+  `canonical_station_id`;
+- restrict proof rows to `identity_status = 'confirmed'`;
+- preserve source/provenance fields in the reconciliation output;
+- expose canonical external identity fields such as `canonical.market_id`,
+  `canonical.edsm_station_id`, `canonical.external_identity_status`,
+  `canonical.external_identity_source`,
+  `canonical.external_identity_confidence`,
+  `canonical.external_identity_freshness_class`,
+  `canonical.external_identity_source_run_key`,
+  `canonical.external_identity_source_file_key`, and
+  `canonical.external_identity_source_record_hash`;
+- keep ambiguous or conflicting identity rows out of proof use while reporting
+  them in coverage.
+
+Reconciliation integration must remain read-only and must preserve
+`canonical_writes_planned = 0`.
+
+## Station-Type Dry-Run Impact
+
+P8 does not run or unblock station-type dry-run.
+
+The strict station-type filter should remain unchanged until:
+
+- identity evidence has been loaded in a separate reviewed stage;
+- an identity coverage artifact shows confirmed identity coverage;
+- read-only reconciliation exposes confirmed canonical external IDs;
+- strict station-type dry-run is retried in Stage 18J-P13.
+
+Station-type writes remain blocked. Non-zero dry-run candidates still require a
+separate review packet before canonical apply can be discussed.
+
+## What This Does Not Enable
+
+P8 does not enable:
+
+- production commands from Codex;
+- production DB access from Codex;
+- identity evidence loading;
+- imports;
+- reconciliation runs;
+- summarizer runs against production artifacts;
+- station-type dry-run;
+- canonical apply;
+- approval-record creation;
+- changes to `stations`;
+- changes to `station_type`;
+- Stage 18K.
+
+## Risks / Open Questions
+
+Open questions for P9/P10 design:
+
+- whether the first candidate artifact should emit only confirmable/conflicting
+  rows or all staged external-ID rows;
+- whether `edsm_station_id` and `market_id` are always identical in current
+  EDSM station snapshots, and how to classify rows where they diverge;
+- whether later high-volume reads need an additional
+  `(canonical_station_id, identity_status)` index;
+- how to handle station renames where source external ID stays stable but
+  normalized station name changes;
+- whether supersession should be modeled as a load-time status transition or as
+  separate historical rows only;
+- whether future body-link evidence should be included as secondary context in
+  coverage reports without affecting identity confirmation.
+
+## Recommended Next Stages
+
+- Stage 18J-P9 - External identity evidence load dry-run.
+- Stage 18J-P10 - External identity evidence write-staging/load, no
+  station-type writes.
+- Stage 18J-P11 - Identity coverage artifact.
+- Stage 18J-P12 - Reconciliation integration with confirmed identity.
+- Stage 18J-P13 - Retry strict station-type dry-run.
+
+## Final Recommendation
+
+Proceed with a read-only identity candidate artifact before any writes to
+`station_external_identity`.
+
+Use `staging_edsm_stations` as the first source of external station identity
+evidence, but do not confirm identity from source evidence alone. Confirmation
+must require complete provenance, at least one external ID, `system_id64`, a
+single normalized station-name match to canonical, no conflicts, and explicit
+review of the dry-run artifact.
+
+Keep station-type dry-run and canonical apply blocked until confirmed identity
+coverage exists and has been reviewed through read-only reconciliation.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -708,6 +708,17 @@ and no station-type data changed. The table is present but empty, so
 station-type dry-run remains blocked until confirmed external identity evidence
 is loaded and integrated into read-only reconciliation.
 
+Stage 18J-P8 designs the identity evidence loader/reconciliation workflow in
+`docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md`.
+Use existing `edsm_nightly_stations` warehouse evidence as the first candidate
+source, but produce a read-only identity candidate artifact before writing
+anything to `station_external_identity`. Candidate confirmation must not rely
+on name-only matching, internal `stations.id` equality, or source-only evidence
+by default. Future identity loading must write only the identity table, preserve
+source run/file/hash provenance, keep conflicts visible, leave `stations` and
+`station_type` unchanged, and keep station-type dry-run blocked until confirmed
+identity coverage is reviewed.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,


### PR DESCRIPTION
## What changed

* Adds Stage 18J-P8 external identity evidence loader/reconciliation design.
* Defines source evidence, matching strategy, identity statuses, conflict handling, dry-run artifact, and future write-staging workflow.
* Keeps station-type writes blocked.
* Updates roadmap/runbook docs.

## Boundary confirmations

* Docs/design only.
* No production commands run.
* No production DB touched.
* No identity evidence loaded.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

`git diff --check`

```text
(no output)
```

`./scripts/run_canonical_safety_tests.sh`

```text
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.14s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.
```

`.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py -q`

```text
........................................................................ [ 67%]
..................................                                       [100%]
106 passed in 0.15s
```

`.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py`

```text
(no output)
```

Secret/DSN scan over changed docs:

```text
(no matches)
```

Additional staged-file whitespace check, so the new P8 doc was included:

`git diff --cached --check`

```text
(no output)
```