### PR TITLE
Stage 18J-P9 read-only external identity candidate artifact

### DIFF
--- a/apps/importer/src/station_external_identity_candidates.py
+++ b/apps/importer/src/station_external_identity_candidates.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Read-only external station identity candidate artifact generator.
+
+This tool reads staged EDSM station evidence and produces deterministic JSON
+candidate rows for later review. It never writes to ``station_external_identity``
+or any canonical table.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from enrichment_staging import json_safe_value
+from enrichment_warehouse import assert_reconciliation_sql_is_read_only
+
+
+SCHEMA_VERSION = 'station_external_identity_candidates/v1'
+TOOL_NAME = 'station_external_identity_candidates'
+TOOL_VERSION = 'v1'
+DEFAULT_SAMPLE_LIMIT = 100
+SOURCE = 'edsm_nightly_stations'
+CONFIRMED_CANDIDATE_CONFIDENCE = {'exact_station_identity', 'source_station_snapshot', 'high'}
+CONFIRMED_CANDIDATE_FRESHNESS = {'source_updated_at', 'file_snapshot', 'current', 'recent'}
+CANDIDATE_STATUSES = ('proposed', 'confirmed_candidate', 'conflicting', 'rejected')
+
+
+class IdentityCandidateError(ValueError):
+    """Raised when an identity candidate artifact cannot be built safely."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Build a read-only external station identity candidate artifact from staged EDSM station evidence.',
+    )
+    parser.add_argument('--dsn', required=True, help='Read-only warehouse/staging Postgres DSN.')
+    parser.add_argument('--source-run-key', required=True, help='Required staged source run key filter.')
+    parser.add_argument('--source-file-key', default=None, help='Optional staged source file key filter.')
+    parser.add_argument('--limit', type=int, default=None, help='Maximum staged station rows to inspect.')
+    parser.add_argument(
+        '--sample-limit',
+        type=int,
+        default=DEFAULT_SAMPLE_LIMIT,
+        help='Maximum sample candidates to include in the artifact.',
+    )
+    parser.add_argument('--json', action='store_true', help='Emit JSON to stdout. Output is JSON by default.')
+    parser.add_argument('--output', default=None, help='Optional path to write the JSON artifact.')
+    parser.add_argument('--apply', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--write', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--write-staging', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--commit', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--load', action='store_true', help='Unsupported; this tool is read-only.')
+    args = parser.parse_args(argv)
+
+    if args.apply or args.write or args.write_staging or args.commit or args.load:
+        parser.error('write/apply/load flags are not available; this tool only emits a read-only candidate artifact')
+    if args.limit is not None and args.limit < 0:
+        parser.error('--limit must be >= 0')
+    if args.sample_limit < 0:
+        parser.error('--sample-limit must be >= 0')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        with connect_read_only_db(args.dsn) as conn:
+            artifact = build_candidate_artifact_from_db(
+                conn,
+                source_run_key=args.source_run_key,
+                source_file_key=args.source_file_key,
+                limit=args.limit,
+                sample_limit=args.sample_limit,
+            )
+    except (OSError, ValueError) as exc:
+        print(f'station external identity candidate generation failed: {exc}', file=sys.stderr)
+        return 2
+
+    output = json_dumps_artifact(artifact)
+    if args.output:
+        Path(args.output).write_text(output + '\n', encoding='utf-8')
+    if args.json or not args.output:
+        print(output)
+    return 0
+
+
+def connect_read_only_db(dsn: str):
+    """Connect lazily so tests and imports do not require Postgres."""
+    import psycopg2  # noqa: PLC0415
+
+    conn = psycopg2.connect(dsn)
+    set_session = getattr(conn, 'set_session', None)
+    if callable(set_session):
+        set_session(readonly=True, autocommit=False)
+    return conn
+
+
+def build_candidate_artifact_from_db(
+    conn: Any,
+    *,
+    source_run_key: str,
+    source_file_key: str | None = None,
+    limit: int | None = None,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    rows = fetch_candidate_rows(
+        conn,
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        limit=limit,
+    )
+    return build_candidate_artifact_from_rows(
+        rows,
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        limit=limit,
+        sample_limit=sample_limit,
+        generated_at=generated_at,
+    )
+
+
+def fetch_candidate_rows(
+    conn: Any,
+    *,
+    source_run_key: str,
+    source_file_key: str | None,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    sql, params = candidate_rows_query(
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        limit=limit,
+    )
+    assert_reconciliation_sql_is_read_only(sql)
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, params)
+        return _fetchall_dicts(cur)
+    finally:
+        close = getattr(cur, 'close', None)
+        if callable(close):
+            close()
+
+
+def candidate_rows_query(
+    *,
+    source_run_key: str,
+    source_file_key: str | None,
+    limit: int | None,
+) -> tuple[str, list[Any]]:
+    limit_clause = 'LIMIT %s' if limit is not None else ''
+    params: list[Any] = [SOURCE, source_run_key, source_file_key, source_file_key]
+    if limit is not None:
+        params.append(limit)
+    return (
+        f"""
+        WITH staged AS (
+            SELECT
+                ss.id AS staging_station_id,
+                ss.source_record_key,
+                ss.source_record_hash,
+                ss.system_id64,
+                ss.system_name,
+                ss.market_id,
+                ss.edsm_station_id,
+                ss.station_name,
+                ss.source_class,
+                ss.confidence,
+                ss.freshness_class,
+                ss.source_updated_at,
+                sr.source_run_key,
+                sr.source,
+                sf.source_file_key
+            FROM staging_edsm_stations ss
+            JOIN enrichment_source_runs sr ON sr.id = ss.source_run_id
+            LEFT JOIN enrichment_source_files sf ON sf.id = ss.source_file_id
+            WHERE sr.source = %s
+              AND sr.source_run_key = %s
+              AND (%s IS NULL OR sf.source_file_key = %s)
+            ORDER BY ss.system_id64 NULLS LAST, ss.station_name NULLS LAST, ss.id
+            {limit_clause}
+        )
+        SELECT
+            staged.*,
+            sys.id64 AS canonical_system_id64,
+            sys.name AS canonical_system_name,
+            st.id AS canonical_station_id,
+            st.name AS canonical_station_name,
+            st.station_type AS canonical_station_type,
+            COUNT(st.id) OVER (PARTITION BY staged.staging_station_id)::integer AS canonical_station_match_count
+        FROM staged
+        LEFT JOIN systems sys
+          ON staged.system_id64 IS NOT NULL
+         AND sys.id64 = staged.system_id64
+        LEFT JOIN stations st
+          ON st.system_id64 = sys.id64
+         AND staged.station_name IS NOT NULL
+         AND lower(btrim(st.name)) = lower(btrim(staged.station_name))
+        ORDER BY staged.system_id64 NULLS LAST, staged.station_name NULLS LAST,
+                 staged.staging_station_id, st.id NULLS LAST
+        """,
+        params,
+    )
+
+
+def build_candidate_artifact_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    source_run_key: str,
+    source_file_key: str | None = None,
+    limit: int | None = None,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    if limit is not None and limit < 0:
+        raise IdentityCandidateError('limit must be >= 0')
+    if sample_limit < 0:
+        raise IdentityCandidateError('sample_limit must be >= 0')
+
+    groups = _group_by_staging_station(rows)
+    candidates: list[dict[str, Any]] = []
+    status_counts = Counter({status: 0 for status in CANDIDATE_STATUSES})
+    conflict_reason_counts: Counter[str] = Counter()
+    match_basis_counts: Counter[str] = Counter()
+    source_identity_coverage = Counter({
+        'source_market_id_present': 0,
+        'source_edsm_station_id_present': 0,
+        'source_station_name_present': 0,
+        'source_system_id64_present': 0,
+        'source_market_id_missing': 0,
+        'source_edsm_station_id_missing': 0,
+        'source_station_name_missing': 0,
+        'source_system_id64_missing': 0,
+    })
+    canonical_match_coverage = Counter({
+        'canonical_station_match_count_0': 0,
+        'canonical_station_match_count_1': 0,
+        'canonical_station_match_count_multiple': 0,
+    })
+
+    for group in groups:
+        candidate = build_candidate(group)
+        candidates.append(candidate)
+        status = str(candidate['candidate_status'])
+        status_counts[status] += 1
+        match_basis_counts[str(candidate['match_basis'])] += 1
+        if status == 'conflicting':
+            conflict_reason_counts[str(candidate['conflict_reason'])] += 1
+        _record_source_coverage(source_identity_coverage, candidate)
+        match_count = int(candidate['match_proof']['canonical_station_match_count'])
+        if match_count == 0:
+            canonical_match_coverage['canonical_station_match_count_0'] += 1
+        elif match_count == 1:
+            canonical_match_coverage['canonical_station_match_count_1'] += 1
+        else:
+            canonical_match_coverage['canonical_station_match_count_multiple'] += 1
+
+    candidates = sorted(candidates, key=canonical_json)
+    sampled = candidates[:sample_limit]
+    now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    artifact: dict[str, Any] = {
+        'schema_version': SCHEMA_VERSION,
+        'generated_at': now,
+        'tool': {
+            'name': TOOL_NAME,
+            'version': TOOL_VERSION,
+        },
+        'dry_run': True,
+        'read_only': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_written': 0,
+        'filters': {
+            'source': SOURCE,
+            'source_run_key': source_run_key,
+            'source_file_key': source_file_key,
+            'limit': limit,
+            'sample_limit': sample_limit,
+        },
+        'summary': {
+            'total_staged_rows_inspected': len(groups),
+            'sample_candidates_included': len(sampled),
+            'candidate_status_counts': _ordered_counts(status_counts, CANDIDATE_STATUSES),
+            'conflict_reason_counts': dict(sorted(conflict_reason_counts.items())),
+            'match_basis_counts': dict(sorted(match_basis_counts.items())),
+            'source_identity_coverage': _ordered_counts(
+                source_identity_coverage,
+                (
+                    'source_market_id_present',
+                    'source_edsm_station_id_present',
+                    'source_station_name_present',
+                    'source_system_id64_present',
+                    'source_market_id_missing',
+                    'source_edsm_station_id_missing',
+                    'source_station_name_missing',
+                    'source_system_id64_missing',
+                ),
+            ),
+            'canonical_match_coverage': _ordered_counts(
+                canonical_match_coverage,
+                (
+                    'canonical_station_match_count_0',
+                    'canonical_station_match_count_1',
+                    'canonical_station_match_count_multiple',
+                ),
+            ),
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': 0,
+        },
+        'sample_candidates': sampled,
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+        'canonicalization': 'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False) excluding artifact_integrity',
+    }
+    return json_safe_value(artifact)
+
+
+def build_candidate(group: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    if not group:
+        raise IdentityCandidateError('candidate group is empty')
+    first = dict(group[0])
+    canonical_matches = _canonical_matches(group)
+    match_count = len(canonical_matches)
+    source = _source_identity(first)
+    normalized_source_name = _normalise_name(source.get('station_name'))
+    external_ids_present = source.get('market_id') is not None or source.get('edsm_station_id') is not None
+    provenance_complete = all(source.get(field) for field in ('source_run_key', 'source_file_key', 'source_record_hash'))
+
+    status = 'proposed'
+    conflict_reason = None
+    rejection_reason = None
+    if not external_ids_present:
+        status = 'rejected'
+        rejection_reason = 'missing_external_station_id'
+        match_basis = 'missing_external_station_id'
+    elif not provenance_complete:
+        status = 'rejected'
+        rejection_reason = 'missing_source_provenance'
+        match_basis = 'missing_source_provenance'
+    elif source.get('system_id64') is None:
+        status = 'rejected'
+        rejection_reason = 'missing_system_id64'
+        match_basis = 'missing_system_id64'
+    elif normalized_source_name is None:
+        status = 'rejected'
+        rejection_reason = 'missing_station_name'
+        match_basis = 'missing_station_name'
+    elif match_count == 0:
+        status = 'rejected'
+        rejection_reason = 'source_only_no_canonical_station_match'
+        match_basis = 'no_canonical_station_match'
+    elif match_count > 1:
+        status = 'conflicting'
+        conflict_reason = 'ambiguous_canonical_station_match'
+        match_basis = 'ambiguous_system_id64_normalized_station_name'
+    else:
+        canonical = canonical_matches[0]
+        normalized_canonical_name = _normalise_name(canonical.get('station_name'))
+        if _read_int(source.get('system_id64')) != _read_int(canonical.get('system_id64')):
+            status = 'conflicting'
+            conflict_reason = 'system_id64_mismatch'
+            match_basis = 'system_id64_mismatch'
+        elif normalized_source_name != normalized_canonical_name:
+            status = 'conflicting'
+            conflict_reason = 'station_name_mismatch'
+            match_basis = 'station_name_mismatch'
+        elif _confirmed_candidate_source_quality(source):
+            status = 'confirmed_candidate'
+            match_basis = 'system_id64_normalized_station_name'
+        else:
+            status = 'proposed'
+            match_basis = 'system_id64_normalized_station_name_needs_review'
+
+    canonical_match = canonical_matches[0] if len(canonical_matches) == 1 else None
+    candidate = {
+        'candidate_id': _candidate_id(source, canonical_match),
+        'candidate_status': status,
+        'proposed_identity_status': _proposed_identity_status(status),
+        'match_basis': match_basis,
+        'source_identity': source,
+        'canonical_match': canonical_match,
+        'canonical_matches': canonical_matches,
+        'match_proof': {
+            'required_match_basis': 'system_id64_normalized_station_name',
+            'canonical_station_match_count': match_count,
+            'normalised_source_station_name': normalized_source_name,
+            'external_identity_proof_required_for_station_type': True,
+            'internal_station_id_not_used_as_external_proof': True,
+            'station_body_links_not_used_as_identity_proof': True,
+        },
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_written': 0,
+    }
+    if conflict_reason is not None:
+        candidate['conflict_reason'] = conflict_reason
+    if rejection_reason is not None:
+        candidate['rejection_reason'] = rejection_reason
+    return json_safe_value(candidate)
+
+
+def json_dumps_artifact(artifact: Mapping[str, Any]) -> str:
+    return canonical_json(json_safe_value(artifact))
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(json_safe_value(value), sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def artifact_sha256(value: Mapping[str, Any]) -> str:
+    payload = deepcopy(dict(value))
+    payload.pop('artifact_integrity', None)
+    return hashlib.sha256(canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def _fetchall_dicts(cur: Any) -> list[dict[str, Any]]:
+    rows = cur.fetchall()
+    if not rows:
+        return []
+    first = rows[0]
+    if isinstance(first, Mapping):
+        return [dict(row) for row in rows]
+    description = getattr(cur, 'description', None)
+    if not description:
+        raise IdentityCandidateError('cursor returned positional rows without column descriptions')
+    columns = [str(item[0]) for item in description]
+    return [dict(zip(columns, row, strict=False)) for row in rows]
+
+
+def _group_by_staging_station(rows: Sequence[Mapping[str, Any]]) -> list[list[Mapping[str, Any]]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for index, row in enumerate(rows):
+        key = row.get('staging_station_id')
+        if key is None:
+            key = f'row:{index}'
+        grouped.setdefault(str(key), []).append(row)
+    return [
+        grouped[key]
+        for key in sorted(
+            grouped,
+            key=lambda item: (
+                _sort_value(grouped[item][0].get('system_id64')),
+                _sort_value(grouped[item][0].get('station_name')),
+                _sort_value(grouped[item][0].get('staging_station_id')),
+            ),
+        )
+    ]
+
+
+def _source_identity(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'staging_station_id': row.get('staging_station_id'),
+        'source': row.get('source'),
+        'source_run_key': row.get('source_run_key'),
+        'source_file_key': row.get('source_file_key'),
+        'source_record_key': row.get('source_record_key'),
+        'source_record_hash': row.get('source_record_hash'),
+        'source_updated_at': row.get('source_updated_at'),
+        'system_id64': _read_int(row.get('system_id64')),
+        'system_name': row.get('system_name'),
+        'station_name': row.get('station_name'),
+        'normalised_station_name': _normalise_name(row.get('station_name')),
+        'market_id': _read_int(row.get('market_id')),
+        'edsm_station_id': _read_int(row.get('edsm_station_id')),
+        'confidence': row.get('confidence'),
+        'freshness_class': row.get('freshness_class'),
+        'source_class': row.get('source_class'),
+    }
+
+
+def _canonical_matches(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    matches: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        station_id = _read_int(row.get('canonical_station_id'))
+        if station_id is None:
+            continue
+        matches[str(station_id)] = {
+            'canonical_station_id': station_id,
+            'system_id64': _read_int(row.get('canonical_system_id64')),
+            'system_name': row.get('canonical_system_name'),
+            'station_name': row.get('canonical_station_name'),
+            'normalised_station_name': _normalise_name(row.get('canonical_station_name')),
+            'station_type': row.get('canonical_station_type'),
+        }
+    return sorted(matches.values(), key=canonical_json)
+
+
+def _confirmed_candidate_source_quality(source: Mapping[str, Any]) -> bool:
+    return (
+        source.get('confidence') in CONFIRMED_CANDIDATE_CONFIDENCE
+        and source.get('freshness_class') in CONFIRMED_CANDIDATE_FRESHNESS
+    )
+
+
+def _proposed_identity_status(candidate_status: str) -> str:
+    if candidate_status == 'confirmed_candidate':
+        return 'confirmed'
+    if candidate_status == 'conflicting':
+        return 'conflicting'
+    if candidate_status == 'rejected':
+        return 'rejected'
+    return 'proposed'
+
+
+def _candidate_id(source: Mapping[str, Any], canonical_match: Mapping[str, Any] | None) -> str:
+    return hashlib.sha256(canonical_json([
+        'station_external_identity_candidate',
+        source.get('source_run_key'),
+        source.get('source_file_key'),
+        source.get('source_record_hash'),
+        source.get('market_id'),
+        source.get('edsm_station_id'),
+        source.get('system_id64'),
+        _normalise_name(source.get('station_name')),
+        _read_int((canonical_match or {}).get('canonical_station_id')),
+    ]).encode('utf-8')).hexdigest()
+
+
+def _record_source_coverage(counts: Counter[str], candidate: Mapping[str, Any]) -> None:
+    source = candidate.get('source_identity') or {}
+    _record_present_missing(counts, 'source_market_id', source.get('market_id'))
+    _record_present_missing(counts, 'source_edsm_station_id', source.get('edsm_station_id'))
+    _record_present_missing(counts, 'source_station_name', source.get('station_name'))
+    _record_present_missing(counts, 'source_system_id64', source.get('system_id64'))
+
+
+def _record_present_missing(counts: Counter[str], prefix: str, value: Any) -> None:
+    suffix = 'missing' if _missing(value) else 'present'
+    counts[f'{prefix}_{suffix}'] += 1
+
+
+def _ordered_counts(counts: Mapping[str, int], keys: Sequence[str]) -> dict[str, int]:
+    return {key: int(counts.get(key, 0)) for key in keys}
+
+
+def _normalise_name(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = re.sub(r'\s+', ' ', str(value).strip().lower())
+    return text or None
+
+
+def _read_int(value: Any) -> int | None:
+    if value is None or value == '':
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _missing(value: Any) -> bool:
+    return value is None or value == ''
+
+
+def _sort_value(value: Any) -> tuple[int, str]:
+    if value is None:
+        return (1, '')
+    return (0, str(value))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -626,6 +626,14 @@ commands, load identity evidence, run reconciliation, run station-type dry-run,
 or run apply. See
 [`stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md`](./stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md).
 
+Stage 18J-P9 adds the read-only external identity candidate artifact generator
+in `apps/importer/src/station_external_identity_candidates.py`. It reads staged
+EDSM station evidence through an explicit read-only DSN, matches by
+`system_id64` plus normalized station name, preserves source run/file/hash
+provenance, emits compact deterministic JSON with capped samples and integrity
+hash, and writes no identity or canonical rows. See
+[`stage-18j-p9-readonly-external-identity-candidate-artifact.md`](./stage-18j-p9-readonly-external-identity-candidate-artifact.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -715,10 +723,13 @@ treated as a separate proposal.
 * **External identity loader design**: Stage 18J-P8 requires a read-only
   identity candidate artifact from staged EDSM station evidence before any
   writes to `station_external_identity`.
-* **External identity follow-up sequence**: after the P8 design, continue with
-  P9 evidence load dry-run, P10 write-staging/load with no station-type writes,
-  P11 identity coverage artifact, P12 reconciliation integration with confirmed
-  identity, and P13 strict station-type dry-run retry.
+* **External identity candidate artifact**: Stage 18J-P9 implements the
+  read-only candidate artifact generator. It proposes reviewable identities but
+  writes nothing to `station_external_identity`.
+* **External identity follow-up sequence**: after the P9 artifact, continue
+  with P10 write-staging/load with no station-type writes, P11 identity coverage
+  artifact, P12 reconciliation integration with confirmed identity, and P13
+  strict station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -778,10 +778,10 @@ Scope:
   hardening, operator-safe dry-run wrapper, P2 identity diagnostics, P3/P4
   external identity design, P5 migration draft, P6 production readiness review,
   P7 schema production apply closeout, P8 evidence loader/reconciliation
-  design, P9 evidence load dry-run, P10 evidence write-staging/load with no
-  station-type writes, P11 identity coverage artifact, P12 reconciliation
-  integration with confirmed identity, and P13 strict station-type dry-run
-  retry.
+  design, P9 read-only identity candidate artifact, P10 evidence
+  write-staging/load with no station-type writes, P11 identity coverage
+  artifact, P12 reconciliation integration with confirmed identity, and P13
+  strict station-type dry-run retry.
 
 Non-goals:
 
@@ -1102,6 +1102,39 @@ Non-goals:
 Support doc:
 `stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md`.
 
+### Stage 18J-P9 - Read-only External Identity Candidate Artifact
+
+Purpose: implement a read-only artifact generator that proposes external
+station identity candidates from staged EDSM station evidence.
+
+Scope:
+
+- Add `apps/importer/src/station_external_identity_candidates.py`.
+- Read staged EDSM station evidence through an explicit read-only DSN.
+- Require `--source-run-key` and support `--source-file-key`, `--limit`,
+  `--sample-limit`, `--json`, and `--output`.
+- Match candidates by source `system_id64` and normalized station name.
+- Emit candidate statuses `confirmed_candidate`, `proposed`, `conflicting`,
+  and `rejected`.
+- Preserve source run/file/hash provenance and source external IDs.
+- Emit compact deterministic JSON with capped samples and an integrity hash.
+- Add synthetic tests for status classification, provenance, no-write SQL,
+  deterministic JSON, sample caps, and write/apply flag rejection.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No writes to `station_external_identity`.
+- No identity evidence load.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p9-readonly-external-identity-candidate-artifact.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1185,7 +1218,7 @@ Do not add another large planner feature immediately. The healthiest next sequen
 36. Stage 18J-P6 external identity migration production readiness review.
 37. Stage 18J-P7 external identity schema production apply closeout.
 38. Stage 18J-P8 external identity evidence loader/reconciliation design.
-39. Stage 18J-P9 external identity evidence load dry-run.
+39. Stage 18J-P9 read-only external identity candidate artifact.
 40. Stage 18J-P10 external identity evidence write-staging/load, no station-type writes.
 41. Stage 18J-P11 identity coverage artifact.
 42. Stage 18J-P12 reconciliation integration with confirmed identity.

--- a/docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md
+++ b/docs/colonisation-redesign/stage-18j-p7-external-identity-schema-production-apply-closeout.md
@@ -157,10 +157,11 @@ station/body link association evidence remain insufficient.
 Stage 18J-P8 designs the next step: a read-only external identity evidence
 candidate artifact and later write-staging/load workflow that preserves
 provenance while keeping station-type writes blocked.
+Stage 18J-P9 implements the read-only candidate artifact generator without
+writing to `station_external_identity`.
 
 ## Recommended Next Stages
 
-- Stage 18J-P9 - External identity evidence load dry-run.
 - Stage 18J-P10 - External identity evidence write-staging/load, no
   station-type writes.
 - Stage 18J-P11 - Identity coverage artifact.

--- a/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
+++ b/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
@@ -199,6 +199,9 @@ reject any canonical write flag.
 ## Proposed Dry-Run Artifact
 
 Stage 18J-P9 should produce an identity evidence dry-run artifact only.
+Stage 18J-P9 implements this as
+`apps/importer/src/station_external_identity_candidates.py`, a read-only JSON
+artifact generator.
 
 Suggested artifact schema:
 
@@ -373,7 +376,6 @@ Open questions for P9/P10 design:
 
 ## Recommended Next Stages
 
-- Stage 18J-P9 - External identity evidence load dry-run.
 - Stage 18J-P10 - External identity evidence write-staging/load, no
   station-type writes.
 - Stage 18J-P11 - Identity coverage artifact.

--- a/docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md
@@ -1,0 +1,193 @@
+# Stage 18J-P9 — Read-only External Identity Candidate Artifact
+
+## Purpose
+
+Stage 18J-P9 adds a read-only external station identity candidate artifact
+generator. It proposes reviewable identity rows from staged EDSM station
+evidence without writing to `station_external_identity`.
+
+This stage is read-only artifact/tooling work. It does not run production
+commands, touch the production database, write to `station_external_identity`,
+load identity evidence, run production imports, run production reconciliation,
+run the summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Input Evidence
+
+The artifact generator reads staged EDSM station evidence through an explicit
+read-only DSN:
+
+- `staging_edsm_stations`;
+- `enrichment_source_runs`;
+- `enrichment_source_files`;
+- canonical `systems`;
+- canonical `stations`.
+
+The first source is `edsm_nightly_stations`, as selected by Stage 18J-P8.
+Source run filtering is required through `--source-run-key`, with optional
+`--source-file-key` and `--limit`.
+
+The current known production state remains:
+
+- `station_external_identity` exists;
+- `station_external_identity` row count is `0`;
+- canonical `stations` count is `284763`;
+- staged EDSM station evidence exists;
+- no identity evidence has been loaded.
+
+## Matching Strategy
+
+The candidate query intentionally does not use `station_external_identity` and
+does not use `station_body_links`.
+
+Candidate canonical matching requires:
+
+- staged source is `edsm_nightly_stations`;
+- source row is within the requested source run/file filters;
+- source `system_id64` matches canonical `systems.id64`;
+- normalized staged `station_name` matches normalized canonical `stations.name`
+  within that system.
+
+The artifact classifies:
+
+- exactly one canonical station match as reviewable;
+- zero canonical station matches as rejected/source-only;
+- multiple canonical station matches as conflicting/ambiguous.
+
+The tool preserves source `market_id` and `edsm_station_id` values from staged
+evidence. It does not infer external IDs from `stations.id`, and it does not
+use `station_body_links.market_id` as general station identity proof.
+
+## Candidate Statuses
+
+Artifact statuses are:
+
+- `confirmed_candidate`: one canonical station matches by `system_id64` and
+  normalized station name, source provenance is complete, at least one external
+  source ID is present, and source confidence/freshness are reviewable.
+- `proposed`: one canonical station matches, but source confidence/freshness
+  requires review before it can be treated as a confirmed identity candidate.
+- `conflicting`: multiple canonical station matches or direct match proof
+  conflict, such as system/name mismatch.
+- `rejected`: missing external source ID, missing provenance, missing
+  `system_id64`, missing station name, or no canonical station match.
+
+These statuses are artifact review statuses. P9 does not insert table rows and
+does not mark any identity as confirmed in production.
+
+## Artifact Contract
+
+Tool:
+
+- `apps/importer/src/station_external_identity_candidates.py`
+
+The CLI supports:
+
+- `--dsn`;
+- `--source-run-key`;
+- `--source-file-key`;
+- `--limit`;
+- `--sample-limit`;
+- `--json`;
+- `--output`.
+
+The emitted JSON includes:
+
+- `schema_version = station_external_identity_candidates/v1`;
+- `generated_at`;
+- `dry_run = true`;
+- `read_only = true`;
+- `report_only = true`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_written = 0`;
+- source run/file filters;
+- total staged rows inspected;
+- candidate counts by status;
+- conflict reason counts;
+- match basis counts;
+- source identity coverage counts;
+- canonical match coverage counts;
+- capped sample candidates;
+- artifact checksum/integrity block.
+
+Sample candidates omit raw payload dumps. They include source run/file/hash
+provenance, external source IDs, source/canonical match proof, and explicit
+flags that internal `stations.id` and `station_body_links` were not used as
+identity proof.
+
+## Safety Boundaries
+
+The tool is read-only:
+
+- its SQL is SELECT-only;
+- it rejects `--apply`, `--write`, `--write-staging`, `--commit`, and `--load`;
+- it does not write to `station_external_identity`;
+- it does not write canonical tables;
+- it does not run station-type dry-run;
+- it emits deterministic JSON for review.
+
+Tests use synthetic rows and fake DB cursors. They do not require production
+credentials.
+
+## What This Does Not Write
+
+P9 writes nothing to:
+
+- `station_external_identity`;
+- `stations`;
+- `station_type`;
+- warehouse staging tables;
+- approval records;
+- production artifact directories.
+
+It also does not load identity evidence, run imports, run reconciliation, run
+summarizer, run station-type dry-run, or run canonical apply.
+
+## Operator Workflow
+
+After merge, a future Hetzner operator may run the tool as a read-only artifact
+step with explicit source filters and an operator-managed read-only DSN.
+
+Operator workflow requirements:
+
+- run from the approved Hetzner operator context only;
+- use a read-only DB role/DSN;
+- provide `--source-run-key`;
+- provide `--source-file-key` when narrowing to the known staged source file;
+- write output to an operator artifact path;
+- preserve the artifact checksum;
+- do not combine this artifact run with identity evidence load,
+  reconciliation integration, station-type dry-run, or apply.
+
+## Review Requirements
+
+Before any Stage 18J-P10 write-staging/load stage:
+
+- review candidate status counts;
+- review conflict reason counts;
+- inspect capped samples;
+- confirm source run/file filters;
+- confirm raw payloads are not dumped;
+- confirm `canonical_writes_planned`, `station_type_writes_planned`, and
+  `identity_rows_written` are all `0`;
+- confirm source provenance is present for reviewable candidates;
+- confirm rejected/source-only and conflicting/ambiguous candidates are not
+  treated as confirmed identity.
+
+## Recommended Next Stages
+
+- Stage 18J-P10 - External identity evidence write-staging/load, no
+  station-type writes.
+- Stage 18J-P11 - Identity coverage artifact.
+- Stage 18J-P12 - Reconciliation integration with confirmed identity.
+- Stage 18J-P13 - Retry strict station-type dry-run.
+
+## Final Recommendation
+
+Use the P9 artifact as the review gate before any writes to
+`station_external_identity`.
+
+Do not load identity evidence until the candidate artifact has been generated,
+reviewed, and accepted with exact source filters and artifact checksum. Keep
+station-type dry-run and canonical apply blocked.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -719,6 +719,16 @@ source run/file/hash provenance, keep conflicts visible, leave `stations` and
 `station_type` unchanged, and keep station-type dry-run blocked until confirmed
 identity coverage is reviewed.
 
+Stage 18J-P9 adds that read-only artifact generator in
+`apps/importer/src/station_external_identity_candidates.py` and documents it in
+`docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md`.
+It requires an explicit read-only DSN plus `--source-run-key`, supports
+`--source-file-key`, `--limit`, `--sample-limit`, `--json`, and `--output`, and
+rejects write/apply/load flags. The artifact is review-only: it writes nothing
+to `station_external_identity`, does not update `stations` or `station_type`,
+and must not be combined with imports, reconciliation, station-type dry-run, or
+canonical apply.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/tests/test_station_external_identity_candidates.py
+++ b/tests/test_station_external_identity_candidates.py
@@ -1,0 +1,231 @@
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', '/dev/null')
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_external_identity_candidates as candidates  # noqa: E402
+
+
+WRITE_SQL_RE = re.compile(r'\b(INSERT|UPDATE|DELETE|MERGE|TRUNCATE|DROP|ALTER)\b', re.IGNORECASE)
+GENERATED_AT = '2026-01-02T00:00:00Z'
+
+
+class FakeCursor:
+    def __init__(self, conn) -> None:
+        self.conn = conn
+
+    def execute(self, sql, params=None):
+        self.conn.statements.append((sql, tuple(params or ())))
+
+    def fetchall(self):
+        return list(self.conn.rows)
+
+    def close(self):
+        pass
+
+
+class FakeConn:
+    def __init__(self, rows) -> None:
+        self.rows = list(rows)
+        self.statements: list[tuple[str, tuple[object, ...]]] = []
+
+    def cursor(self):
+        return FakeCursor(self)
+
+
+def station_candidate_row(**overrides):
+    row = {
+        'staging_station_id': 1,
+        'source_run_key': 'run-stations',
+        'source_file_key': 'file-stations',
+        'source_record_key': 'station-record-key',
+        'source_record_hash': 'station-hash',
+        'system_id64': 42,
+        'system_name': 'Test System',
+        'market_id': 1001,
+        'edsm_station_id': 1001,
+        'station_name': 'Test Port',
+        'source': 'edsm_nightly_stations',
+        'source_class': 'semi-stable',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'source_updated_at': datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc),
+        'canonical_system_id64': 42,
+        'canonical_system_name': 'Test System',
+        'canonical_station_id': 2001,
+        'canonical_station_name': 'Test Port',
+        'canonical_station_type': 'Orbis',
+        'canonical_station_match_count': 1,
+    }
+    row.update(overrides)
+    return row
+
+
+def build_artifact(rows, *, sample_limit=100):
+    return candidates.build_candidate_artifact_from_rows(
+        rows,
+        source_run_key='run-stations',
+        source_file_key='file-stations',
+        sample_limit=sample_limit,
+        generated_at=GENERATED_AT,
+    )
+
+
+def test_single_canonical_match_yields_reviewable_confirmed_candidate():
+    artifact = build_artifact([station_candidate_row()])
+
+    assert artifact['schema_version'] == 'station_external_identity_candidates/v1'
+    assert artifact['dry_run'] is True
+    assert artifact['read_only'] is True
+    assert artifact['canonical_writes_planned'] == 0
+    assert artifact['station_type_writes_planned'] == 0
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['summary']['candidate_status_counts']['confirmed_candidate'] == 1
+    assert artifact['summary']['canonical_match_coverage']['canonical_station_match_count_1'] == 1
+
+    sample = artifact['sample_candidates'][0]
+    assert sample['candidate_status'] == 'confirmed_candidate'
+    assert sample['proposed_identity_status'] == 'confirmed'
+    assert sample['match_basis'] == 'system_id64_normalized_station_name'
+    assert sample['canonical_match']['canonical_station_id'] == 2001
+    assert sample['match_proof']['internal_station_id_not_used_as_external_proof'] is True
+    assert sample['match_proof']['station_body_links_not_used_as_identity_proof'] is True
+
+
+def test_zero_canonical_matches_yields_rejected_source_only_candidate():
+    artifact = build_artifact([
+        station_candidate_row(
+            canonical_station_id=None,
+            canonical_station_name=None,
+            canonical_station_type=None,
+            canonical_station_match_count=0,
+        ),
+    ])
+
+    sample = artifact['sample_candidates'][0]
+    assert sample['candidate_status'] == 'rejected'
+    assert sample['proposed_identity_status'] == 'rejected'
+    assert sample['rejection_reason'] == 'source_only_no_canonical_station_match'
+    assert artifact['summary']['candidate_status_counts']['rejected'] == 1
+    assert artifact['summary']['canonical_match_coverage']['canonical_station_match_count_0'] == 1
+
+
+def test_multiple_canonical_matches_yields_conflicting_ambiguous_candidate():
+    rows = [
+        station_candidate_row(staging_station_id=1, canonical_station_id=2001, canonical_station_name='Test Port'),
+        station_candidate_row(staging_station_id=1, canonical_station_id=2002, canonical_station_name='Test Port'),
+    ]
+
+    artifact = build_artifact(rows)
+
+    sample = artifact['sample_candidates'][0]
+    assert sample['candidate_status'] == 'conflicting'
+    assert sample['proposed_identity_status'] == 'conflicting'
+    assert sample['conflict_reason'] == 'ambiguous_canonical_station_match'
+    assert len(sample['canonical_matches']) == 2
+    assert artifact['summary']['candidate_status_counts']['conflicting'] == 1
+    assert artifact['summary']['conflict_reason_counts'] == {'ambiguous_canonical_station_match': 1}
+    assert artifact['summary']['canonical_match_coverage']['canonical_station_match_count_multiple'] == 1
+
+
+def test_source_external_ids_and_provenance_are_preserved():
+    artifact = build_artifact([
+        station_candidate_row(
+            market_id=987654,
+            edsm_station_id=123456,
+            source_record_hash='stable-hash',
+            source_updated_at='2026-02-03T00:00:00Z',
+        ),
+    ])
+
+    source = artifact['sample_candidates'][0]['source_identity']
+    assert source['market_id'] == 987654
+    assert source['edsm_station_id'] == 123456
+    assert source['source_run_key'] == 'run-stations'
+    assert source['source_file_key'] == 'file-stations'
+    assert source['source_record_hash'] == 'stable-hash'
+    assert source['source_updated_at'] == '2026-02-03T00:00:00Z'
+    assert artifact['summary']['source_identity_coverage']['source_market_id_present'] == 1
+    assert artifact['summary']['source_identity_coverage']['source_edsm_station_id_present'] == 1
+    assert artifact['summary']['source_identity_coverage']['source_station_name_present'] == 1
+    assert artifact['summary']['source_identity_coverage']['source_system_id64_present'] == 1
+
+
+def test_build_candidate_artifact_from_db_is_read_only():
+    conn = FakeConn([station_candidate_row()])
+
+    artifact = candidates.build_candidate_artifact_from_db(
+        conn,
+        source_run_key='run-stations',
+        source_file_key='file-stations',
+        generated_at=GENERATED_AT,
+    )
+
+    assert artifact['summary']['candidate_status_counts']['confirmed_candidate'] == 1
+    assert conn.statements
+    for sql, _params in conn.statements:
+        assert WRITE_SQL_RE.search(sql) is None
+        assert 'station_external_identity' not in sql
+
+
+def test_sample_candidates_are_capped():
+    rows = [
+        station_candidate_row(staging_station_id=1, source_record_hash='hash-1', canonical_station_id=2001),
+        station_candidate_row(staging_station_id=2, source_record_hash='hash-2', canonical_station_id=2002),
+        station_candidate_row(staging_station_id=3, source_record_hash='hash-3', canonical_station_id=2003),
+    ]
+
+    artifact = build_artifact(rows, sample_limit=2)
+
+    assert artifact['summary']['total_staged_rows_inspected'] == 3
+    assert artifact['summary']['sample_candidates_included'] == 2
+    assert len(artifact['sample_candidates']) == 2
+
+
+def test_candidate_json_is_deterministic_and_compact():
+    rows = [station_candidate_row()]
+
+    first = build_artifact(rows)
+    second = build_artifact(rows)
+    first_json = candidates.json_dumps_artifact(first)
+    second_json = candidates.json_dumps_artifact(second)
+
+    assert first_json == second_json
+    assert json.loads(first_json) == first
+    assert '\n' not in first_json
+    assert 'artifact_integrity' in first
+    assert first['artifact_integrity']['canonical_json_sha256']
+
+
+@pytest.mark.parametrize('flag', ['--apply', '--write', '--write-staging', '--commit', '--load'])
+def test_cli_rejects_write_apply_commit_aliases(flag):
+    with pytest.raises(SystemExit):
+        candidates.parse_args([
+            '--dsn',
+            'read-only-dsn',
+            '--source-run-key',
+            'run-stations',
+            flag,
+        ])
+
+
+def test_synthetic_read_only_artifact_build_does_not_require_production_credentials():
+    artifact = build_artifact([station_candidate_row()])
+
+    assert artifact['filters']['source_run_key'] == 'run-stations'
+    assert artifact['summary']['canonical_writes_planned'] == 0
+    assert artifact['summary']['station_type_writes_planned'] == 0
+    assert artifact['summary']['identity_rows_written'] == 0


### PR DESCRIPTION
## What changed

* Adds read-only external station identity candidate artifact tooling.
* Produces reviewable identity candidates from staged EDSM station evidence.
* Preserves provenance.
* Emits compact deterministic JSON.
* Adds tests and docs.
* Does not write to `station_external_identity`.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No identity evidence loaded.
* No writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

`git diff --check`

```text
(no output)
```

`bash -n scripts/operator/require_hetzner_operator_env.sh`

```text
(no output)
```

`bash -n scripts/operator/stage18j_run_compact_summary.sh`

```text
(no output)
```

`bash -n scripts/operator/stage18j_run_station_type_dry_run.sh`

```text
(no output)
```

`./scripts/run_canonical_safety_tests.sh`

```text
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.14s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.
```

`.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py -q`

```text
........................................................................ [ 60%]
...............................................                          [100%]
119 passed in 0.17s
```

`.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py tests/test_station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py tests/test_station_external_identity_candidates.py`

```text
(no output)
```

Secret/DSN scan over changed docs/code:

```text
(no matches)
```

Additional staged-file whitespace check, so new files were included:

`git diff --cached --check`

```text
(no output)
```