### PR TITLE
Stage 18J-P10 external identity candidate artifact review

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -634,6 +634,15 @@ provenance, emits compact deterministic JSON with capped samples and integrity
 hash, and writes no identity or canonical rows. See
 [`stage-18j-p9-readonly-external-identity-candidate-artifact.md`](./stage-18j-p9-readonly-external-identity-candidate-artifact.md).
 
+Stage 18J-P10 reviews the first Hetzner read-only external identity candidate
+artifact. The artifact inspected `298177` staged EDSM station rows and reported
+`261938` `confirmed_candidate` rows, `258` conflicting rows, and `35981`
+rejected/source-only rows with no identity or canonical writes. The verdict is
+`Ready only for bounded identity load dry-run`: candidates are promising, but
+the next step must be a bounded no-write load-plan artifact before any insert
+into `station_external_identity`. See
+[`stage-18j-p10-external-identity-candidate-artifact-review.md`](./stage-18j-p10-external-identity-candidate-artifact-review.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -726,10 +735,14 @@ treated as a separate proposal.
 * **External identity candidate artifact**: Stage 18J-P9 implements the
   read-only candidate artifact generator. It proposes reviewable identities but
   writes nothing to `station_external_identity`.
-* **External identity follow-up sequence**: after the P9 artifact, continue
-  with P10 write-staging/load with no station-type writes, P11 identity coverage
-  artifact, P12 reconciliation integration with confirmed identity, and P13
-  strict station-type dry-run retry.
+* **External identity artifact review**: Stage 18J-P10 reviews the first
+  Hetzner candidate artifact and finds it ready only for a bounded no-write
+  identity load-plan dry-run.
+* **External identity follow-up sequence**: after P10 review, continue with
+  P11 bounded load-plan artifact with no DB writes, P12 load-plan review, P13
+  controlled identity load with no station-type writes, P14 identity coverage
+  artifact, P15 read-only reconciliation integration with confirmed identity,
+  and P16 strict station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -778,9 +778,10 @@ Scope:
   hardening, operator-safe dry-run wrapper, P2 identity diagnostics, P3/P4
   external identity design, P5 migration draft, P6 production readiness review,
   P7 schema production apply closeout, P8 evidence loader/reconciliation
-  design, P9 read-only identity candidate artifact, P10 evidence
-  write-staging/load with no station-type writes, P11 identity coverage
-  artifact, P12 reconciliation integration with confirmed identity, and P13
+  design, P9 read-only identity candidate artifact, P10 candidate artifact
+  review, P11 bounded no-write load-plan artifact, P12 load-plan review, P13
+  controlled identity load with no station-type writes, P14 identity coverage
+  artifact, P15 reconciliation integration with confirmed identity, and P16
   strict station-type dry-run retry.
 
 Non-goals:
@@ -1135,6 +1136,43 @@ Non-goals:
 Support doc:
 `stage-18j-p9-readonly-external-identity-candidate-artifact.md`.
 
+### Stage 18J-P10 - External Identity Candidate Artifact Review
+
+Purpose: review the first Hetzner read-only external station identity candidate
+artifact and decide whether the result is ready for a future identity evidence
+load path.
+
+Scope:
+
+- Record artifact
+  `station_external_identity_candidates_20260603T002504Z.json`, its path, size,
+  SHA-256, integrity SHA-256, source run/file filters, and schema version.
+- Record read-only safety fields: `dry_run = true`, `read_only = true`,
+  `report_only = true`, `canonical_writes_planned = 0`,
+  `station_type_writes_planned = 0`, and `identity_rows_written = 0`.
+- Record candidate counts: `261938` `confirmed_candidate`, `258`
+  conflicting, `35981` rejected/source-only, and `0` proposed.
+- Record source identity coverage and canonical match coverage.
+- Interpret `confirmed_candidate` as reviewable artifact evidence only, not as
+  production-confirmed external identity.
+- Set readiness verdict to `Ready only for bounded identity load dry-run`.
+- Require the next stage to produce a bounded no-write load-plan artifact before
+  any controlled insert into `station_external_identity`.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No identity evidence load.
+- No writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p10-external-identity-candidate-artifact-review.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1219,9 +1257,12 @@ Do not add another large planner feature immediately. The healthiest next sequen
 37. Stage 18J-P7 external identity schema production apply closeout.
 38. Stage 18J-P8 external identity evidence loader/reconciliation design.
 39. Stage 18J-P9 read-only external identity candidate artifact.
-40. Stage 18J-P10 external identity evidence write-staging/load, no station-type writes.
-41. Stage 18J-P11 identity coverage artifact.
-42. Stage 18J-P12 reconciliation integration with confirmed identity.
-43. Stage 18J-P13 retry strict station-type dry-run.
+40. Stage 18J-P10 external identity candidate artifact review.
+41. Stage 18J-P11 bounded external identity load-plan artifact, no DB writes.
+42. Stage 18J-P12 review bounded identity load plan.
+43. Stage 18J-P13 controlled identity evidence load, no station-type writes.
+44. Stage 18J-P14 identity coverage artifact after load.
+45. Stage 18J-P15 reconciliation integration with confirmed identity.
+46. Stage 18J-P16 retry strict station-type dry-run.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
+++ b/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
@@ -1,0 +1,257 @@
+# Stage 18J-P10 — External Identity Candidate Artifact Review
+
+## Purpose
+
+Stage 18J-P10 reviews the read-only external station identity candidate
+artifact generated on Hetzner from staged EDSM station evidence.
+
+This stage is docs/review only. It does not run production commands from
+Codex, touch the production database from Codex, load identity evidence, write
+to `station_external_identity`, run imports, run reconciliation, run the
+summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Artifact Reviewed
+
+Reviewed artifact:
+
+- artifact: `station_external_identity_candidates_20260603T002504Z.json`;
+- path:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_candidates_20260603T002504Z.json`;
+- size: `178K`;
+- artifact SHA-256:
+  `c306321e5bc22b864c9bfe09e92b407c3b407e25e2d4dce4b822e9613aa3b834`;
+- artifact integrity SHA-256:
+  `23f8208acef617249d1bd7d831834eb84a2a35deac103114b8940039a65efc65`;
+- schema: `station_external_identity_candidates/v1`;
+- source: `edsm_nightly_stations`;
+- source run key:
+  `6ad44d1ad04d53c958ba7f5877b01752a22e29d9e905627c7feba5bb9eca2db1`;
+- source file key:
+  `76f5c8aa5e55d267c96c16da026ff5cbfae58f1d63575d47759c9bf3aaa37c19`;
+- total staged rows inspected: `298177`;
+- sample candidates included: `100`.
+
+## Read-only Safety Result
+
+The artifact reports:
+
+- `dry_run = true`;
+- `read_only = true`;
+- `report_only = true`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_written = 0`.
+
+Post-checks recorded:
+
+- `station_external_identity` row count before artifact generation: `0`;
+- `station_external_identity` row count after artifact generation: `0`;
+- no obvious credential/private path markers were found;
+- no identity rows were loaded;
+- no station-type dry-run was run;
+- no canonical apply was run.
+
+## Candidate Status Counts
+
+The artifact classified candidates as:
+
+| Status | Count |
+|---|---:|
+| `confirmed_candidate` | `261938` |
+| `conflicting` | `258` |
+| `rejected` | `35981` |
+| `proposed` | `0` |
+
+`confirmed_candidate` is a read-only artifact status. It means exactly one
+canonical station matched by `system_id64` plus normalized station name and the
+source evidence was complete enough for review. It does not mean the identity
+has been approved, written, or made available as canonical external identity
+proof.
+
+## Source Identity Coverage
+
+Source evidence coverage:
+
+| Field | Count |
+|---|---:|
+| `source_edsm_station_id_present` | `298177` |
+| `source_edsm_station_id_missing` | `0` |
+| `source_market_id_present` | `0` |
+| `source_market_id_missing` | `298177` |
+| `source_station_name_present` | `298177` |
+| `source_station_name_missing` | `0` |
+| `source_system_id64_present` | `298177` |
+| `source_system_id64_missing` | `0` |
+
+Every staged row includes `edsm_station_id`, `station_name`, and `system_id64`.
+No staged row includes `market_id`, so future load planning must preserve
+`market_id = NULL` rather than inferring it from `stations.id` or
+`station_body_links.market_id`.
+
+## Canonical Match Coverage
+
+Canonical match coverage:
+
+| Match count bucket | Count |
+|---|---:|
+| `canonical_station_match_count_1` | `261938` |
+| `canonical_station_match_count_0` | `35981` |
+| `canonical_station_match_count_multiple` | `258` |
+
+Match basis counts:
+
+| Match basis | Count |
+|---|---:|
+| `system_id64_normalized_station_name` | `261938` |
+| `no_canonical_station_match` | `35981` |
+| `ambiguous_system_id64_normalized_station_name` | `258` |
+
+## Conflict Findings
+
+The artifact found `258` conflicting rows.
+
+Conflict reason counts:
+
+| Conflict reason | Count |
+|---|---:|
+| `ambiguous_canonical_station_match` | `258` |
+
+These rows must remain blocked from confirmed identity use until a later review
+resolves the ambiguity. They must not be overwritten by a bulk load and must
+not be used as station-type proof.
+
+## Rejected / Source-only Findings
+
+The artifact found `35981` rejected rows with
+`no_canonical_station_match`.
+
+These rows have source identity evidence but no matching canonical station by
+the required `system_id64` plus normalized station-name rule. They remain
+source-only for this workflow. They are not eligible for confirmed identity and
+must not be used to loosen the strict station-type filter.
+
+## Interpretation
+
+The artifact is useful and internally consistent as a review gate:
+
+- it inspected the full staged EDSM station source scope;
+- it found a large set of reviewable `confirmed_candidate` rows;
+- it preserved source run/file/hash provenance and source `edsm_station_id`;
+- it did not infer external identity from internal `stations.id`;
+- it did not use `station_body_links.market_id` as general station identity;
+- it surfaced ambiguous matches and source-only rows instead of silently
+  promoting them.
+
+The result is not sufficient to authorize a bulk identity evidence load yet.
+The next step should translate the reviewed artifact into a bounded no-write
+load-plan artifact before any insert into `station_external_identity`.
+
+## Load Readiness Verdict
+
+Ready only for bounded identity load dry-run.
+
+The `261938` `confirmed_candidate` rows are promising, but they are still
+artifact candidates. A future stage should first produce a bounded identity
+load-plan artifact, preferably with a small explicit max-row sample and no
+database writes, before any controlled insert into `station_external_identity`
+is considered.
+
+## Required Future Load Scope
+
+The next load-planning stage should:
+
+- use only the reviewed artifact hash and integrity hash recorded above;
+- require the exact `source_run_key` and `source_file_key`;
+- select a bounded max-row sample, not the full `261938` candidate set;
+- plan writes only to `station_external_identity`;
+- plan no writes to `stations`, `station_type`, or any canonical apply table;
+- map `confirmed_candidate` to planned `identity_status = 'confirmed'` only
+  in the load plan, not in production;
+- keep `conflicting` rows blocked or explicitly planned as
+  `identity_status = 'conflicting'` with `conflict_reason`;
+- keep rejected/source-only rows out of confirmed identity;
+- preserve source run/file/hash provenance for every planned row;
+- keep `canonical_writes_planned = 0`;
+- keep `station_type_writes_planned = 0`;
+- keep `identity_rows_written = 0`.
+
+## Required Operator Preconditions
+
+Before any future bounded load-plan or controlled load stage, require:
+
+- confirm the operation is a separately approved stage;
+- confirm Codex/local prompts are not running production commands;
+- confirm the Hetzner operator context and artifact path;
+- confirm `station_external_identity` exists and record its row count;
+- confirm the artifact SHA-256 and integrity SHA-256 match this review;
+- confirm the source run/file filters match this review exactly;
+- confirm no imports are running;
+- confirm no reconciliation jobs are running;
+- confirm no summarizer jobs are running;
+- confirm no station-type dry-run is running;
+- confirm no canonical apply is running;
+- confirm no approval-record creation is part of the workflow;
+- for any write stage, confirm backup/snapshot or explicit identity-table load
+  risk acceptance.
+
+## Required Post-load Checks
+
+After a future controlled identity evidence load, require:
+
+- `station_external_identity` row count matches the reviewed load report;
+- counts by `identity_status` match the load report;
+- all loaded rows preserve `source_run_key`, `source_file_key`, and
+  `source_record_hash`;
+- no loaded row lacks both `market_id` and `edsm_station_id`;
+- conflicting rows have non-null `conflict_reason`;
+- `stations` row count is unchanged;
+- `station_type` data is unchanged;
+- no imports, reconciliation, summarizer, station-type dry-run, or canonical
+  apply were run as part of the load;
+- no approval record was created;
+- a follow-up identity coverage artifact can be generated from the identity
+  table.
+
+## What This Still Does Not Enable
+
+P10 does not enable:
+
+- production commands from Codex;
+- production DB access from Codex;
+- identity evidence loading;
+- writes to `station_external_identity`;
+- imports;
+- reconciliation runs;
+- summarizer runs against production artifacts;
+- station-type dry-run;
+- canonical apply;
+- approval-record creation;
+- changes to `stations`;
+- changes to `station_type`;
+- Stage 18K.
+
+Strict station-type dry-run remains blocked until confirmed external identity
+evidence is loaded in a later approved stage, reviewed through a coverage
+artifact, and integrated into read-only reconciliation.
+
+## Recommended Next Stages
+
+- Stage 18J-P11 - Bounded external identity load-plan artifact, no DB writes.
+- Stage 18J-P12 - Review bounded identity load plan.
+- Stage 18J-P13 - Controlled identity evidence load into
+  `station_external_identity`, no station-type writes.
+- Stage 18J-P14 - Identity coverage artifact after load.
+- Stage 18J-P15 - Read-only reconciliation integration with confirmed
+  identity.
+- Stage 18J-P16 - Retry strict station-type dry-run.
+
+## Final Recommendation
+
+Use the reviewed P9 artifact as the basis for a bounded no-write load-plan
+artifact only.
+
+Do not bulk load the `261938` `confirmed_candidate` rows yet. Do not treat
+`confirmed_candidate` as production-confirmed identity, and do not use it for
+station-type writes. Proceed next with Stage 18J-P11 as a bounded identity
+load-plan artifact with no database writes.

--- a/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
+++ b/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
@@ -241,8 +241,13 @@ Each candidate row should include:
 
 ## Proposed Write-Staging / Load Workflow
 
-Stage 18J-P10 should be a separate write-staging/load stage after the P9
-artifact is reviewed. It should write only to `station_external_identity`.
+Stage 18J-P10 reviews the first read-only candidate artifact and records the
+verdict `Ready only for bounded identity load dry-run`. The next implementation
+step should be a bounded no-write load-plan artifact before any write-staging
+or load stage.
+
+A later controlled write-staging/load stage should write only to
+`station_external_identity`.
 
 Recommended load behavior:
 
@@ -303,7 +308,7 @@ After a future identity evidence load, require:
 
 ## Reconciliation Integration
 
-Stage 18J-P12 should integrate confirmed external identity into read-only
+Stage 18J-P15 should integrate confirmed external identity into read-only
 station reconciliation output.
 
 Recommended read-only join shape:
@@ -335,7 +340,7 @@ The strict station-type filter should remain unchanged until:
 - identity evidence has been loaded in a separate reviewed stage;
 - an identity coverage artifact shows confirmed identity coverage;
 - read-only reconciliation exposes confirmed canonical external IDs;
-- strict station-type dry-run is retried in Stage 18J-P13.
+- strict station-type dry-run is retried in Stage 18J-P16.
 
 Station-type writes remain blocked. Non-zero dry-run candidates still require a
 separate review packet before canonical apply can be discussed.
@@ -359,7 +364,7 @@ P8 does not enable:
 
 ## Risks / Open Questions
 
-Open questions for P9/P10 design:
+Open questions for the load-plan and controlled-load design:
 
 - whether the first candidate artifact should emit only confirmable/conflicting
   rows or all staged external-ID rows;
@@ -376,11 +381,15 @@ Open questions for P9/P10 design:
 
 ## Recommended Next Stages
 
-- Stage 18J-P10 - External identity evidence write-staging/load, no
-  station-type writes.
-- Stage 18J-P11 - Identity coverage artifact.
-- Stage 18J-P12 - Reconciliation integration with confirmed identity.
-- Stage 18J-P13 - Retry strict station-type dry-run.
+- Stage 18J-P10 - External identity candidate artifact review.
+- Stage 18J-P11 - Bounded external identity load-plan artifact, no DB writes.
+- Stage 18J-P12 - Review bounded identity load plan.
+- Stage 18J-P13 - Controlled identity evidence load into
+  `station_external_identity`, no station-type writes.
+- Stage 18J-P14 - Identity coverage artifact after load.
+- Stage 18J-P15 - Read-only reconciliation integration with confirmed
+  identity.
+- Stage 18J-P16 - Retry strict station-type dry-run.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md
@@ -162,7 +162,7 @@ Operator workflow requirements:
 
 ## Review Requirements
 
-Before any Stage 18J-P10 write-staging/load stage:
+Before any bounded load-plan or write-staging/load stage:
 
 - review candidate status counts;
 - review conflict reason counts;
@@ -175,13 +175,23 @@ Before any Stage 18J-P10 write-staging/load stage:
 - confirm rejected/source-only and conflicting/ambiguous candidates are not
   treated as confirmed identity.
 
+Stage 18J-P10 reviews the first Hetzner read-only artifact. It records
+`261938` `confirmed_candidate` rows, `258` conflicting rows, and `35981`
+rejected/source-only rows. The readiness verdict is `Ready only for bounded
+identity load dry-run`; `confirmed_candidate` remains an artifact status, not a
+production-confirmed identity status.
+
 ## Recommended Next Stages
 
-- Stage 18J-P10 - External identity evidence write-staging/load, no
-  station-type writes.
-- Stage 18J-P11 - Identity coverage artifact.
-- Stage 18J-P12 - Reconciliation integration with confirmed identity.
-- Stage 18J-P13 - Retry strict station-type dry-run.
+- Stage 18J-P10 - External identity candidate artifact review.
+- Stage 18J-P11 - Bounded external identity load-plan artifact, no DB writes.
+- Stage 18J-P12 - Review bounded identity load plan.
+- Stage 18J-P13 - Controlled identity evidence load into
+  `station_external_identity`, no station-type writes.
+- Stage 18J-P14 - Identity coverage artifact after load.
+- Stage 18J-P15 - Read-only reconciliation integration with confirmed
+  identity.
+- Stage 18J-P16 - Retry strict station-type dry-run.
 
 ## Final Recommendation
 

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -729,6 +729,19 @@ to `station_external_identity`, does not update `stations` or `station_type`,
 and must not be combined with imports, reconciliation, station-type dry-run, or
 canonical apply.
 
+Stage 18J-P10 reviews the first Hetzner read-only external identity candidate
+artifact in
+`docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md`.
+The artifact
+`station_external_identity_candidates_20260603T002504Z.json` inspected
+`298177` staged EDSM station rows and reported `261938`
+`confirmed_candidate` rows, `258` conflicting rows, and `35981`
+rejected/source-only rows. It kept `dry_run`, `read_only`, and `report_only`
+true, with `canonical_writes_planned = 0`, `station_type_writes_planned = 0`,
+and `identity_rows_written = 0`. The verdict is `Ready only for bounded
+identity load dry-run`; the next operator step must be a bounded no-write
+load-plan artifact, not a bulk insert into `station_external_identity`.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,


### PR DESCRIPTION
## What changed

* Records the read-only external identity candidate artifact result.
* Records candidate status counts, coverage counts, conflict counts, and safety checks.
* Records readiness verdict: ready only for bounded identity load dry-run.
* Keeps station-type writes blocked.
* Updates roadmap/runbook docs.

## Boundary confirmations

* Docs/review only.
* No production commands run from Codex.
* No production DB touched from Codex.
* No identity evidence loaded.
* No writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

* `git diff --check`: passed.
* `./scripts/run_canonical_safety_tests.sh`: passed, `99 passed in 0.24s`; disposable Postgres rehearsal skipped because `EDFINDER_CANONICAL_TEST_DSN` and `EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes` were not set.
* `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py -q`: passed, `119 passed in 0.18s`.
* `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py`: passed.
* Secret scan changed docs: no matches.
* `git diff --cached --check`: passed before commit.