### PR TITLE
Stage 18J-P11 bounded external identity load-plan artifact

### DIFF
--- a/apps/importer/src/station_external_identity_load_plan.py
+++ b/apps/importer/src/station_external_identity_load_plan.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Bounded no-write external station identity load-plan artifact generator.
+
+This tool reads staged EDSM station evidence through the Stage 18J-P9
+candidate matcher and produces reviewable ``station_external_identity`` insert
+plans. It never writes to ``station_external_identity`` or canonical tables.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from enrichment_staging import json_safe_value
+
+import station_external_identity_candidates as candidates
+
+
+SCHEMA_VERSION = 'station_external_identity_load_plan/v1'
+TOOL_NAME = 'station_external_identity_load_plan'
+TOOL_VERSION = 'v1'
+DEFAULT_SAMPLE_LIMIT = 20
+MAX_ROWS_CAP = 20
+WRITE_FLAG_ERROR = 'write/apply/load flags are not available; this tool only emits a bounded no-write load plan'
+
+
+class IdentityLoadPlanError(ValueError):
+    """Raised when an identity load-plan artifact cannot be built safely."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Build a bounded no-write station_external_identity load-plan artifact.',
+    )
+    parser.add_argument('--dsn', required=True, help='Read-only warehouse/staging Postgres DSN.')
+    parser.add_argument('--source-run-key', required=True, help='Required staged source run key filter.')
+    parser.add_argument('--source-file-key', default=None, help='Optional staged source file key filter.')
+    parser.add_argument('--max-rows', type=int, required=True, help=f'Required planned row cap, maximum {MAX_ROWS_CAP}.')
+    parser.add_argument(
+        '--sample-limit',
+        type=int,
+        default=DEFAULT_SAMPLE_LIMIT,
+        help='Maximum rejected/conflicting samples to include in the artifact.',
+    )
+    parser.add_argument(
+        '--input-candidate-artifact-sha256',
+        default=None,
+        help='Optional SHA-256 of the reviewed P9 candidate artifact.',
+    )
+    parser.add_argument('--json', action='store_true', help='Emit JSON to stdout. Output is JSON by default.')
+    parser.add_argument('--output', default=None, help='Optional path to write the JSON artifact.')
+    parser.add_argument('--apply', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--write', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--write-staging', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--commit', action='store_true', help='Unsupported; this tool is read-only.')
+    parser.add_argument('--load', action='store_true', help='Unsupported; this tool is read-only.')
+    args = parser.parse_args(argv)
+
+    if args.apply or args.write or args.write_staging or args.commit or args.load:
+        parser.error(WRITE_FLAG_ERROR)
+    if args.max_rows < 1:
+        parser.error('--max-rows must be >= 1')
+    if args.max_rows > MAX_ROWS_CAP:
+        parser.error(f'--max-rows must be <= {MAX_ROWS_CAP} for the first bounded load-plan stage')
+    if args.sample_limit < 0:
+        parser.error('--sample-limit must be >= 0')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        with candidates.connect_read_only_db(args.dsn) as conn:
+            artifact = build_load_plan_artifact_from_db(
+                conn,
+                source_run_key=args.source_run_key,
+                source_file_key=args.source_file_key,
+                max_rows=args.max_rows,
+                sample_limit=args.sample_limit,
+                input_candidate_artifact_sha256=args.input_candidate_artifact_sha256,
+            )
+    except (OSError, ValueError) as exc:
+        print(f'station external identity load-plan generation failed: {exc}', file=sys.stderr)
+        return 2
+
+    output = json_dumps_artifact(artifact)
+    if args.output:
+        Path(args.output).write_text(output + '\n', encoding='utf-8')
+    if args.json or not args.output:
+        print(output)
+    return 0
+
+
+def build_load_plan_artifact_from_db(
+    conn: Any,
+    *,
+    source_run_key: str,
+    source_file_key: str | None = None,
+    max_rows: int,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    input_candidate_artifact_sha256: str | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    rows = candidates.fetch_candidate_rows(
+        conn,
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        limit=None,
+    )
+    return build_load_plan_artifact_from_rows(
+        rows,
+        source_run_key=source_run_key,
+        source_file_key=source_file_key,
+        max_rows=max_rows,
+        sample_limit=sample_limit,
+        input_candidate_artifact_sha256=input_candidate_artifact_sha256,
+        generated_at=generated_at,
+    )
+
+
+def build_load_plan_artifact_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    source_run_key: str,
+    source_file_key: str | None = None,
+    max_rows: int,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    input_candidate_artifact_sha256: str | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    if max_rows < 1:
+        raise IdentityLoadPlanError('max_rows must be >= 1')
+    if max_rows > MAX_ROWS_CAP:
+        raise IdentityLoadPlanError(f'max_rows must be <= {MAX_ROWS_CAP}')
+    if sample_limit < 0:
+        raise IdentityLoadPlanError('sample_limit must be >= 0')
+
+    candidate_rows = [
+        candidates.build_candidate(group)
+        for group in candidates._group_by_staging_station(rows)  # noqa: SLF001 - reuse P9 grouping contract.
+    ]
+    candidate_rows = sorted(candidate_rows, key=canonical_json)
+
+    status_counts = Counter({status: 0 for status in candidates.CANDIDATE_STATUSES})
+    skipped_reason_counts: Counter[str] = Counter()
+    rejected_reason_counts: Counter[str] = Counter()
+    conflicting_reason_counts: Counter[str] = Counter()
+    eligible_confirmed_candidates_seen = 0
+    planned_rows: list[dict[str, Any]] = []
+    sample_rejected_candidates: list[dict[str, Any]] = []
+    sample_conflicting_candidates: list[dict[str, Any]] = []
+
+    for candidate in candidate_rows:
+        status = str(candidate.get('candidate_status'))
+        status_counts[status] += 1
+        skip_reason = _skip_reason(candidate)
+        if skip_reason is None:
+            eligible_confirmed_candidates_seen += 1
+            if len(planned_rows) < max_rows:
+                planned_rows.append(_planned_row(candidate))
+            else:
+                skipped_reason_counts['eligible_beyond_max_rows'] += 1
+            continue
+
+        skipped_reason_counts[skip_reason] += 1
+        if status == 'rejected':
+            rejected_reason_counts[skip_reason] += 1
+            if len(sample_rejected_candidates) < sample_limit:
+                sample_rejected_candidates.append(_sample_candidate(candidate, reason=skip_reason))
+        elif status == 'conflicting':
+            conflicting_reason_counts[skip_reason] += 1
+            if len(sample_conflicting_candidates) < sample_limit:
+                sample_conflicting_candidates.append(_sample_candidate(candidate, reason=skip_reason))
+
+    now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    artifact: dict[str, Any] = {
+        'schema_version': SCHEMA_VERSION,
+        'generated_at': now,
+        'tool': {
+            'name': TOOL_NAME,
+            'version': TOOL_VERSION,
+        },
+        'dry_run': True,
+        'read_only': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_planned': len(planned_rows),
+        'identity_rows_written': 0,
+        'max_rows': max_rows,
+        'filters': {
+            'source': candidates.SOURCE,
+            'source_run_key': source_run_key,
+            'source_file_key': source_file_key,
+            'sample_limit': sample_limit,
+        },
+        'input_candidate_artifact_sha256': input_candidate_artifact_sha256,
+        'summary': {
+            'total_candidates_seen': len(candidate_rows),
+            'eligible_confirmed_candidates_seen': eligible_confirmed_candidates_seen,
+            'planned_rows_count': len(planned_rows),
+            'candidate_status_counts': _ordered_counts(status_counts, candidates.CANDIDATE_STATUSES),
+            'skipped_reason_counts': dict(sorted(skipped_reason_counts.items())),
+            'rejected_reason_counts': dict(sorted(rejected_reason_counts.items())),
+            'conflicting_reason_counts': dict(sorted(conflicting_reason_counts.items())),
+            'sample_rejected_candidates_included': len(sample_rejected_candidates),
+            'sample_conflicting_candidates_included': len(sample_conflicting_candidates),
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': 0,
+        },
+        'planned_db_defaults': {
+            'evidence_first_seen_at': 'DEFAULT now()',
+            'evidence_last_seen_at': 'DEFAULT now()',
+            'created_at': 'DEFAULT now()',
+            'updated_at': 'DEFAULT now()',
+        },
+        'planned_rows': planned_rows,
+        'sample_rejected_candidates': sample_rejected_candidates,
+        'sample_conflicting_candidates': sample_conflicting_candidates,
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+        'canonicalization': 'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False) excluding artifact_integrity',
+    }
+    return json_safe_value(artifact)
+
+
+def json_dumps_artifact(artifact: Mapping[str, Any]) -> str:
+    return canonical_json(json_safe_value(artifact))
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(json_safe_value(value), sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def artifact_sha256(value: Mapping[str, Any]) -> str:
+    payload = deepcopy(dict(value))
+    payload.pop('artifact_integrity', None)
+    return hashlib.sha256(canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def _skip_reason(candidate: Mapping[str, Any]) -> str | None:
+    status = str(candidate.get('candidate_status'))
+    if status == 'rejected':
+        return str(candidate.get('rejection_reason') or 'rejected_candidate')
+    if status == 'conflicting':
+        return str(candidate.get('conflict_reason') or 'conflicting_candidate')
+    if status == 'proposed':
+        return 'proposed_candidate_not_planned'
+    if status != 'confirmed_candidate':
+        return f'{status}_candidate_not_planned'
+    if candidate.get('match_basis') != 'system_id64_normalized_station_name':
+        return 'unsupported_match_basis'
+
+    source = _mapping(candidate.get('source_identity'))
+    canonical_match = _mapping(candidate.get('canonical_match'))
+    match_proof = _mapping(candidate.get('match_proof'))
+    if int(match_proof.get('canonical_station_match_count') or 0) != 1:
+        return 'not_exactly_one_canonical_station_match'
+    if not canonical_match.get('canonical_station_id'):
+        return 'missing_canonical_station_match'
+    if source.get('market_id') is None and source.get('edsm_station_id') is None:
+        return 'missing_external_station_id'
+    if not all(source.get(field) for field in ('source_run_key', 'source_file_key', 'source_record_hash')):
+        return 'missing_source_provenance'
+    return None
+
+
+def _planned_row(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    source = _mapping(candidate.get('source_identity'))
+    canonical_match = _mapping(candidate.get('canonical_match'))
+    row = {
+        'plan_row_id': _plan_row_id(candidate),
+        'candidate_id': candidate.get('candidate_id'),
+        'canonical_station_id': canonical_match.get('canonical_station_id'),
+        'system_id64': source.get('system_id64'),
+        'station_name': source.get('station_name'),
+        'source': source.get('source'),
+        'market_id': source.get('market_id'),
+        'edsm_station_id': source.get('edsm_station_id'),
+        'source_run_key': source.get('source_run_key'),
+        'source_file_key': source.get('source_file_key'),
+        'source_record_hash': source.get('source_record_hash'),
+        'source_updated_at': source.get('source_updated_at'),
+        'confidence': source.get('confidence'),
+        'freshness_class': source.get('freshness_class'),
+        'identity_status': 'confirmed',
+        'conflict_reason': None,
+        'match_basis': candidate.get('match_basis'),
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_written': 0,
+    }
+    return json_safe_value(row)
+
+
+def _sample_candidate(candidate: Mapping[str, Any], *, reason: str) -> dict[str, Any]:
+    return json_safe_value({
+        'candidate_id': candidate.get('candidate_id'),
+        'candidate_status': candidate.get('candidate_status'),
+        'proposed_identity_status': candidate.get('proposed_identity_status'),
+        'skip_reason': reason,
+        'match_basis': candidate.get('match_basis'),
+        'conflict_reason': candidate.get('conflict_reason'),
+        'rejection_reason': candidate.get('rejection_reason'),
+        'source_identity': candidate.get('source_identity'),
+        'canonical_match': candidate.get('canonical_match'),
+        'canonical_matches': candidate.get('canonical_matches'),
+        'match_proof': candidate.get('match_proof'),
+    })
+
+
+def _plan_row_id(candidate: Mapping[str, Any]) -> str:
+    row = {
+        'candidate_id': candidate.get('candidate_id'),
+        'source_identity': candidate.get('source_identity'),
+        'canonical_match': candidate.get('canonical_match'),
+        'identity_status': 'confirmed',
+    }
+    return hashlib.sha256(canonical_json(['station_external_identity_load_plan_row', row]).encode('utf-8')).hexdigest()
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _ordered_counts(counts: Mapping[str, int], keys: Sequence[str]) -> dict[str, int]:
+    return {key: int(counts.get(key, 0)) for key in keys}
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -643,6 +643,14 @@ the next step must be a bounded no-write load-plan artifact before any insert
 into `station_external_identity`. See
 [`stage-18j-p10-external-identity-candidate-artifact-review.md`](./stage-18j-p10-external-identity-candidate-artifact-review.md).
 
+Stage 18J-P11 adds the bounded no-write external identity load-plan artifact
+generator in `apps/importer/src/station_external_identity_load_plan.py`. It
+reads staged EDSM station evidence through the same read-only matching path,
+requires explicit source filters and `--max-rows`, rejects bounds above `20`,
+plans only eligible `confirmed_candidate` rows, preserves provenance, rejects
+write/apply/load flags, and keeps `identity_rows_written = 0`. See
+[`stage-18j-p11-bounded-external-identity-load-plan-artifact.md`](./stage-18j-p11-bounded-external-identity-load-plan-artifact.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -738,11 +746,15 @@ treated as a separate proposal.
 * **External identity artifact review**: Stage 18J-P10 reviews the first
   Hetzner candidate artifact and finds it ready only for a bounded no-write
   identity load-plan dry-run.
+* **External identity bounded load-plan**: Stage 18J-P11 implements the
+  no-write load-plan artifact. It proposes at most an explicit bounded set of
+  identity rows for review and still writes nothing to
+  `station_external_identity`.
 * **External identity follow-up sequence**: after P10 review, continue with
-  P11 bounded load-plan artifact with no DB writes, P12 load-plan review, P13
-  controlled identity load with no station-type writes, P14 identity coverage
-  artifact, P15 read-only reconciliation integration with confirmed identity,
-  and P16 strict station-type dry-run retry.
+  P11 bounded load-plan artifact with no DB writes, then P12 load-plan review,
+  P13 controlled identity load with no station-type writes, P14 identity
+  coverage artifact, P15 read-only reconciliation integration with confirmed
+  identity, and P16 strict station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -1173,6 +1173,43 @@ Non-goals:
 Support doc:
 `stage-18j-p10-external-identity-candidate-artifact-review.md`.
 
+### Stage 18J-P11 - Bounded External Identity Load-Plan Artifact
+
+Purpose: implement a bounded no-write artifact generator that proposes a
+small, reviewable set of `station_external_identity` insert rows.
+
+Scope:
+
+- Add `apps/importer/src/station_external_identity_load_plan.py`.
+- Reuse the Stage 18J-P9 read-only staged EDSM station matching path.
+- Require explicit `--source-run-key` and `--max-rows`.
+- Reject `--max-rows` values above `20` for the first bounded plan.
+- Support optional `--source-file-key`, `--sample-limit`,
+  `--input-candidate-artifact-sha256`, `--json`, and `--output`.
+- Reject `--apply`, `--write`, `--write-staging`, `--load`, and `--commit`.
+- Emit `station_external_identity_load_plan/v1` with `dry_run = true`,
+  `read_only = true`, `report_only = true`, `canonical_writes_planned = 0`,
+  `station_type_writes_planned = 0`, and `identity_rows_written = 0`.
+- Plan only eligible `confirmed_candidate` rows, preserving
+  `source_run_key`, `source_file_key`, and `source_record_hash`.
+- Add synthetic tests for planned rows, skipped rejected/conflicting/proposed
+  candidates, max-row guardrails, no-write SQL, deterministic JSON, and sample
+  caps.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No identity evidence load.
+- No writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p11-bounded-external-identity-load-plan-artifact.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner

--- a/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
+++ b/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
@@ -176,6 +176,12 @@ The next load-planning stage should:
 - keep `station_type_writes_planned = 0`;
 - keep `identity_rows_written = 0`.
 
+Stage 18J-P11 implements this as
+`apps/importer/src/station_external_identity_load_plan.py`, emitting
+`station_external_identity_load_plan/v1` artifacts. The tool requires
+`--max-rows`, rejects values above `20`, rejects write/apply/load flags, and
+writes no database rows.
+
 ## Required Operator Preconditions
 
 Before any future bounded load-plan or controlled load stage, require:

--- a/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
@@ -1,0 +1,218 @@
+# Stage 18J-P11 — Bounded External Identity Load-Plan Artifact
+
+## Purpose
+
+Stage 18J-P11 adds a bounded no-write external station identity load-plan
+artifact generator.
+
+The tool proposes a small, reviewable set of `station_external_identity` insert
+rows from staged EDSM station evidence, but it does not execute the inserts.
+This stage is no-write tooling/test/docs work only. It does not run production
+commands, touch the production database, write to `station_external_identity`,
+load identity evidence, run production imports, run production reconciliation,
+run the summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Inputs
+
+Primary tool:
+
+- `apps/importer/src/station_external_identity_load_plan.py`
+
+Required runtime inputs:
+
+- read-only warehouse/staging DSN through `--dsn`;
+- explicit `--source-run-key`;
+- optional `--source-file-key`;
+- explicit `--max-rows`;
+- optional `--sample-limit`;
+- optional reviewed P9 artifact checksum through
+  `--input-candidate-artifact-sha256`.
+
+The current reviewed production artifact context from Stage 18J-P10 is:
+
+- candidate artifact:
+  `station_external_identity_candidates_20260603T002504Z.json`;
+- artifact SHA-256:
+  `c306321e5bc22b864c9bfe09e92b407c3b407e25e2d4dce4b822e9613aa3b834`;
+- schema: `station_external_identity_candidates/v1`;
+- total staged rows inspected: `298177`;
+- `confirmed_candidate`: `261938`;
+- `conflicting`: `258`;
+- `rejected`: `35981`;
+- `proposed`: `0`;
+- `identity_rows_written`: `0`.
+
+## Load-Plan Scope
+
+The load-plan artifact uses the same read-only staged EDSM station matching
+logic as Stage 18J-P9. It reads staged evidence and canonical station matches,
+classifies candidates, and plans at most the requested bounded number of
+eligible `confirmed_candidate` rows.
+
+The first-run cap is `20` planned rows. The CLI rejects `--max-rows` values
+above that cap.
+
+The artifact schema is:
+
+- `station_external_identity_load_plan/v1`
+
+The artifact includes:
+
+- `dry_run = true`;
+- `read_only = true`;
+- `report_only = true`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_written = 0`;
+- `identity_rows_planned`;
+- `max_rows`;
+- source filters;
+- optional input candidate artifact checksum;
+- total candidates seen;
+- eligible confirmed candidates seen;
+- planned row count;
+- skipped/rejected/conflicting reason counts;
+- capped rejected/conflicting samples;
+- planned rows capped by `max_rows`;
+- artifact integrity hash.
+
+## Planned Row Contract
+
+Each planned row aligns with `station_external_identity` insert fields:
+
+- `canonical_station_id`;
+- `system_id64`;
+- `station_name`;
+- `source`;
+- nullable `market_id`;
+- nullable `edsm_station_id`;
+- `source_run_key`;
+- `source_file_key`;
+- `source_record_hash`;
+- nullable `source_updated_at`;
+- `confidence`;
+- `freshness_class`;
+- `identity_status = 'confirmed'`;
+- `conflict_reason = null`.
+
+The plan omits `evidence_first_seen_at`, `evidence_last_seen_at`,
+`created_at`, and `updated_at` as insert values because the table defaults are
+intended for a later controlled load stage. The artifact records those planned
+database defaults separately.
+
+## Eligibility Rules
+
+A candidate can become a planned row only when:
+
+- candidate status is `confirmed_candidate`;
+- exactly one canonical station matched;
+- match basis is `system_id64_normalized_station_name`;
+- source has at least one external identifier, `edsm_station_id` or
+  `market_id`;
+- source provenance includes `source_run_key`, `source_file_key`, and
+  `source_record_hash`;
+- the candidate is not conflicting;
+- the candidate is not rejected/source-only;
+- the candidate is within the explicit `--max-rows` bound.
+
+This planning step uses `system_id64` plus normalized station name to select
+candidate identity rows for review. It does not promote station-type canonical
+truth and it does not prove station-type writes.
+
+## Rejection Rules
+
+The plan skips:
+
+- rejected/source-only candidates;
+- conflicting/ambiguous candidates;
+- proposed candidates;
+- candidates without exactly one canonical station match;
+- candidates without source external ID evidence;
+- candidates without complete source provenance;
+- otherwise eligible candidates beyond `--max-rows`.
+
+Skipped candidates are counted by reason. Rejected and conflicting samples are
+capped by `--sample-limit`.
+
+## Safety Boundaries
+
+The load-plan tool is no-write:
+
+- it uses a read-only DB connection/session;
+- its DB SQL is SELECT-only;
+- it asserts the SQL is read-only;
+- it never inserts, updates, or deletes rows;
+- it never writes to `station_external_identity`;
+- it never updates `stations`;
+- it never changes `station_type`;
+- it never runs station-type dry-run;
+- it rejects `--apply`, `--write`, `--write-staging`, `--load`, and
+  `--commit`.
+
+## Operator Workflow
+
+A future Hetzner operator run is appropriate after this PR merges, limited to a
+bounded read-only load-plan artifact:
+
+1. Run from the approved Hetzner operator context.
+2. Use a read-only DB role/DSN.
+3. Provide the reviewed `source_run_key`.
+4. Provide the reviewed `source_file_key`.
+5. Provide an explicit `--max-rows` value no greater than `20`.
+6. Provide the reviewed P9 artifact SHA-256 when available.
+7. Write the JSON artifact under the operator artifact directory.
+8. Preserve the artifact checksum.
+9. Do not combine this with identity evidence load, reconciliation,
+   summarizer, station-type dry-run, or canonical apply.
+
+## Review Requirements
+
+Before any controlled identity evidence load:
+
+- review the load-plan artifact checksum;
+- confirm `dry_run`, `read_only`, and `report_only` are true;
+- confirm `canonical_writes_planned = 0`;
+- confirm `station_type_writes_planned = 0`;
+- confirm `identity_rows_written = 0`;
+- confirm `identity_rows_planned` is within the explicit bound;
+- inspect every planned row;
+- confirm every planned row preserves source run/file/hash provenance;
+- confirm every planned row has at least one external source ID;
+- confirm skipped rejected/source-only candidates are not planned;
+- confirm skipped conflicting/ambiguous candidates are not planned;
+- confirm the plan does not imply station-type writes.
+
+## What This Does Not Write
+
+P11 writes nothing to:
+
+- `station_external_identity`;
+- `stations`;
+- `station_type`;
+- warehouse staging tables;
+- approval records;
+- production artifact directories from Codex.
+
+It also does not load identity evidence, run imports, run reconciliation, run
+the summarizer, run station-type dry-run, run canonical apply, or start Stage
+18K.
+
+## Recommended Next Stages
+
+- Stage 18J-P12 - Review bounded identity load-plan artifact.
+- Stage 18J-P13 - Controlled identity evidence load into
+  `station_external_identity`, no station-type writes.
+- Stage 18J-P14 - Identity coverage artifact after load.
+- Stage 18J-P15 - Read-only reconciliation integration with confirmed
+  identity.
+- Stage 18J-P16 - Retry strict station-type dry-run.
+
+## Final Recommendation
+
+Use the P11 tool to produce a bounded no-write load-plan artifact after merge.
+
+Do not load identity evidence until the bounded plan has been generated,
+reviewed, and accepted with exact source filters, artifact checksum, and a
+small explicit max-row bound. Keep station-type dry-run and canonical apply
+blocked.

--- a/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
+++ b/docs/colonisation-redesign/stage-18j-p8-external-identity-evidence-loader-reconciliation-design.md
@@ -246,6 +246,12 @@ verdict `Ready only for bounded identity load dry-run`. The next implementation
 step should be a bounded no-write load-plan artifact before any write-staging
 or load stage.
 
+Stage 18J-P11 implements that bounded no-write load-plan artifact as
+`apps/importer/src/station_external_identity_load_plan.py`. It emits
+`station_external_identity_load_plan/v1`, requires an explicit `--max-rows`
+bound no greater than `20`, rejects write/apply/load flags, and keeps
+`identity_rows_written = 0`.
+
 A later controlled write-staging/load stage should write only to
 `station_external_identity`.
 

--- a/docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p9-readonly-external-identity-candidate-artifact.md
@@ -181,6 +181,12 @@ rejected/source-only rows. The readiness verdict is `Ready only for bounded
 identity load dry-run`; `confirmed_candidate` remains an artifact status, not a
 production-confirmed identity status.
 
+Stage 18J-P11 adds the bounded no-write load-plan tool
+`apps/importer/src/station_external_identity_load_plan.py`. It converts a
+small bounded set of eligible `confirmed_candidate` rows into reviewable
+planned `station_external_identity` insert rows while keeping
+`identity_rows_written = 0`.
+
 ## Recommended Next Stages
 
 - Stage 18J-P10 - External identity candidate artifact review.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -742,6 +742,18 @@ and `identity_rows_written = 0`. The verdict is `Ready only for bounded
 identity load dry-run`; the next operator step must be a bounded no-write
 load-plan artifact, not a bulk insert into `station_external_identity`.
 
+Stage 18J-P11 adds that bounded no-write load-plan artifact generator in
+`apps/importer/src/station_external_identity_load_plan.py` and documents it in
+`docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md`.
+The tool requires a read-only DSN, explicit `--source-run-key`, optional
+`--source-file-key`, and explicit `--max-rows`; it rejects `--max-rows` above
+`20` for the first bounded plan. It emits
+`station_external_identity_load_plan/v1`, plans only eligible
+`confirmed_candidate` rows, preserves source run/file/hash provenance, rejects
+write/apply/load flags, and keeps `identity_rows_written = 0`. This is still a
+review artifact and must not be combined with identity evidence load,
+reconciliation, summarizer, station-type dry-run, or canonical apply.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/tests/test_station_external_identity_load_plan.py
+++ b/tests/test_station_external_identity_load_plan.py
@@ -1,0 +1,284 @@
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', '/dev/null')
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_external_identity_load_plan as load_plan  # noqa: E402
+
+
+WRITE_SQL_RE = re.compile(r'\b(INSERT|UPDATE|DELETE|MERGE|TRUNCATE|DROP|ALTER)\b', re.IGNORECASE)
+GENERATED_AT = '2026-01-02T00:00:00Z'
+
+
+class FakeCursor:
+    def __init__(self, conn) -> None:
+        self.conn = conn
+
+    def execute(self, sql, params=None):
+        self.conn.statements.append((sql, tuple(params or ())))
+
+    def fetchall(self):
+        return list(self.conn.rows)
+
+    def close(self):
+        pass
+
+
+class FakeConn:
+    def __init__(self, rows) -> None:
+        self.rows = list(rows)
+        self.statements: list[tuple[str, tuple[object, ...]]] = []
+
+    def cursor(self):
+        return FakeCursor(self)
+
+
+def station_candidate_row(**overrides):
+    row = {
+        'staging_station_id': 1,
+        'source_run_key': 'run-stations',
+        'source_file_key': 'file-stations',
+        'source_record_key': 'station-record-key',
+        'source_record_hash': 'station-hash',
+        'system_id64': 42,
+        'system_name': 'Test System',
+        'market_id': None,
+        'edsm_station_id': 1001,
+        'station_name': 'Test Port',
+        'source': 'edsm_nightly_stations',
+        'source_class': 'semi-stable',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'source_updated_at': datetime(2026, 1, 2, 0, 0, tzinfo=timezone.utc),
+        'canonical_system_id64': 42,
+        'canonical_system_name': 'Test System',
+        'canonical_station_id': 2001,
+        'canonical_station_name': 'Test Port',
+        'canonical_station_type': 'Orbis',
+        'canonical_station_match_count': 1,
+    }
+    row.update(overrides)
+    return row
+
+
+def build_plan(rows, *, max_rows=20, sample_limit=20, candidate_sha='candidate-sha'):
+    return load_plan.build_load_plan_artifact_from_rows(
+        rows,
+        source_run_key='run-stations',
+        source_file_key='file-stations',
+        max_rows=max_rows,
+        sample_limit=sample_limit,
+        input_candidate_artifact_sha256=candidate_sha,
+        generated_at=GENERATED_AT,
+    )
+
+
+def test_confirmed_candidate_becomes_planned_identity_row():
+    artifact = build_plan([station_candidate_row()], max_rows=1)
+
+    assert artifact['schema_version'] == 'station_external_identity_load_plan/v1'
+    assert artifact['dry_run'] is True
+    assert artifact['read_only'] is True
+    assert artifact['report_only'] is True
+    assert artifact['canonical_writes_planned'] == 0
+    assert artifact['station_type_writes_planned'] == 0
+    assert artifact['identity_rows_planned'] == 1
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['summary']['eligible_confirmed_candidates_seen'] == 1
+    assert artifact['summary']['planned_rows_count'] == 1
+
+    row = artifact['planned_rows'][0]
+    assert row['canonical_station_id'] == 2001
+    assert row['system_id64'] == 42
+    assert row['station_name'] == 'Test Port'
+    assert row['source'] == 'edsm_nightly_stations'
+    assert row['identity_status'] == 'confirmed'
+    assert row['conflict_reason'] is None
+    assert row['canonical_writes_planned'] == 0
+    assert row['station_type_writes_planned'] == 0
+    assert row['identity_rows_written'] == 0
+
+
+def test_rejected_source_only_candidate_is_skipped():
+    artifact = build_plan([
+        station_candidate_row(
+            canonical_station_id=None,
+            canonical_station_name=None,
+            canonical_station_type=None,
+            canonical_station_match_count=0,
+        ),
+    ])
+
+    assert artifact['identity_rows_planned'] == 0
+    assert artifact['planned_rows'] == []
+    assert artifact['summary']['candidate_status_counts']['rejected'] == 1
+    assert artifact['summary']['skipped_reason_counts'] == {'source_only_no_canonical_station_match': 1}
+    assert artifact['summary']['rejected_reason_counts'] == {'source_only_no_canonical_station_match': 1}
+    assert artifact['sample_rejected_candidates'][0]['skip_reason'] == 'source_only_no_canonical_station_match'
+
+
+def test_conflicting_ambiguous_candidate_is_skipped():
+    rows = [
+        station_candidate_row(staging_station_id=1, canonical_station_id=2001, canonical_station_name='Test Port'),
+        station_candidate_row(staging_station_id=1, canonical_station_id=2002, canonical_station_name='Test Port'),
+    ]
+
+    artifact = build_plan(rows)
+
+    assert artifact['identity_rows_planned'] == 0
+    assert artifact['summary']['candidate_status_counts']['conflicting'] == 1
+    assert artifact['summary']['skipped_reason_counts'] == {'ambiguous_canonical_station_match': 1}
+    assert artifact['summary']['conflicting_reason_counts'] == {'ambiguous_canonical_station_match': 1}
+    assert artifact['sample_conflicting_candidates'][0]['skip_reason'] == 'ambiguous_canonical_station_match'
+
+
+def test_proposed_candidate_is_skipped_for_first_bounded_load_plan():
+    artifact = build_plan([station_candidate_row(confidence='medium')])
+
+    assert artifact['identity_rows_planned'] == 0
+    assert artifact['summary']['candidate_status_counts']['proposed'] == 1
+    assert artifact['summary']['skipped_reason_counts'] == {'proposed_candidate_not_planned': 1}
+
+
+def test_planned_row_preserves_provenance_and_edsm_station_id():
+    artifact = build_plan([
+        station_candidate_row(
+            market_id=None,
+            edsm_station_id=123456,
+            source_record_hash='stable-hash',
+            source_updated_at='2026-02-03T00:00:00Z',
+        ),
+    ])
+
+    row = artifact['planned_rows'][0]
+    assert row['source_run_key'] == 'run-stations'
+    assert row['source_file_key'] == 'file-stations'
+    assert row['source_record_hash'] == 'stable-hash'
+    assert row['source_updated_at'] == '2026-02-03T00:00:00Z'
+    assert row['market_id'] is None
+    assert row['edsm_station_id'] == 123456
+    assert row['confidence'] == 'source_station_snapshot'
+    assert row['freshness_class'] == 'source_updated_at'
+
+
+def test_planned_row_includes_market_id_when_present():
+    artifact = build_plan([station_candidate_row(market_id=987654, edsm_station_id=None)])
+
+    row = artifact['planned_rows'][0]
+    assert row['market_id'] == 987654
+    assert row['edsm_station_id'] is None
+
+
+def test_max_rows_is_required_by_cli():
+    with pytest.raises(SystemExit):
+        load_plan.parse_args([
+            '--dsn',
+            'read-only-dsn',
+            '--source-run-key',
+            'run-stations',
+        ])
+
+
+def test_max_rows_above_first_run_cap_is_rejected():
+    with pytest.raises(SystemExit):
+        load_plan.parse_args([
+            '--dsn',
+            'read-only-dsn',
+            '--source-run-key',
+            'run-stations',
+            '--max-rows',
+            str(load_plan.MAX_ROWS_CAP + 1),
+        ])
+
+
+def test_max_rows_bounds_planned_rows_without_writes():
+    rows = [
+        station_candidate_row(staging_station_id=1, source_record_hash='hash-1', canonical_station_id=2001),
+        station_candidate_row(staging_station_id=2, source_record_hash='hash-2', canonical_station_id=2002),
+        station_candidate_row(staging_station_id=3, source_record_hash='hash-3', canonical_station_id=2003),
+    ]
+
+    artifact = build_plan(rows, max_rows=2)
+
+    assert artifact['summary']['eligible_confirmed_candidates_seen'] == 3
+    assert artifact['identity_rows_planned'] == 2
+    assert len(artifact['planned_rows']) == 2
+    assert artifact['summary']['skipped_reason_counts']['eligible_beyond_max_rows'] == 1
+    assert artifact['identity_rows_written'] == 0
+
+
+def test_build_load_plan_artifact_from_db_is_read_only_and_does_not_target_identity_table():
+    conn = FakeConn([station_candidate_row()])
+
+    artifact = load_plan.build_load_plan_artifact_from_db(
+        conn,
+        source_run_key='run-stations',
+        source_file_key='file-stations',
+        max_rows=1,
+        generated_at=GENERATED_AT,
+    )
+
+    assert artifact['identity_rows_planned'] == 1
+    assert conn.statements
+    for sql, _params in conn.statements:
+        assert WRITE_SQL_RE.search(sql) is None
+        assert 'station_external_identity' not in sql
+
+
+@pytest.mark.parametrize('flag', ['--apply', '--write', '--write-staging', '--commit', '--load'])
+def test_cli_rejects_write_apply_load_commit_aliases(flag):
+    with pytest.raises(SystemExit):
+        load_plan.parse_args([
+            '--dsn',
+            'read-only-dsn',
+            '--source-run-key',
+            'run-stations',
+            '--max-rows',
+            '1',
+            flag,
+        ])
+
+
+def test_load_plan_json_is_deterministic_and_compact():
+    rows = [station_candidate_row()]
+
+    first = build_plan(rows)
+    second = build_plan(rows)
+    first_json = load_plan.json_dumps_artifact(first)
+    second_json = load_plan.json_dumps_artifact(second)
+
+    assert first_json == second_json
+    assert json.loads(first_json) == first
+    assert '\n' not in first_json
+    assert first['artifact_integrity']['canonical_json_sha256']
+
+
+def test_rejected_and_conflicting_samples_are_capped():
+    rows = [
+        station_candidate_row(staging_station_id=1, canonical_station_id=None, canonical_station_name=None),
+        station_candidate_row(staging_station_id=2, canonical_station_id=None, canonical_station_name=None),
+        station_candidate_row(staging_station_id=3, canonical_station_id=3001),
+        station_candidate_row(staging_station_id=3, canonical_station_id=3002),
+        station_candidate_row(staging_station_id=4, canonical_station_id=4001),
+        station_candidate_row(staging_station_id=4, canonical_station_id=4002),
+    ]
+
+    artifact = build_plan(rows, sample_limit=1)
+
+    assert artifact['summary']['sample_rejected_candidates_included'] == 1
+    assert artifact['summary']['sample_conflicting_candidates_included'] == 1
+    assert len(artifact['sample_rejected_candidates']) == 1
+    assert len(artifact['sample_conflicting_candidates']) == 1


### PR DESCRIPTION
## What changed

* Adds bounded no-write external identity load-plan artifact tooling.
* Produces reviewable planned `station_external_identity` rows.
* Requires explicit max-row bound.
* Preserves provenance.
* Rejects writes/apply/load flags.
* Adds tests and docs.
* Does not write to `station_external_identity`.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No identity evidence loaded.
* No writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

* `git diff --check`: passed.
* `bash -n scripts/operator/require_hetzner_operator_env.sh`: passed.
* `bash -n scripts/operator/stage18j_run_compact_summary.sh`: passed.
* `bash -n scripts/operator/stage18j_run_station_type_dry_run.sh`: passed.
* `./scripts/run_canonical_safety_tests.sh`: passed, `99 passed in 0.14s`; disposable Postgres rehearsal skipped because `EDFINDER_CANONICAL_TEST_DSN` and `EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes` were not set.
* `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py -q`: passed, `136 passed in 0.18s`.
* `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py`: passed.
* Secret scan changed docs/code: no matches.
* `git diff --cached --check`: passed before commit.