### PR TITLE
Stage 18J-P12 bounded external identity load-plan review

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -651,6 +651,14 @@ plans only eligible `confirmed_candidate` rows, preserves provenance, rejects
 write/apply/load flags, and keeps `identity_rows_written = 0`. See
 [`stage-18j-p11-bounded-external-identity-load-plan-artifact.md`](./stage-18j-p11-bounded-external-identity-load-plan-artifact.md).
 
+Stage 18J-P12 reviews the first Hetzner bounded load-plan artifact. The
+artifact is `station_external_identity_load_plan/v1`, planned `20` rows, wrote
+`0` rows, and kept canonical and station-type writes at `0`. The verdict is
+`Ready only after extra review`: the plan is safe as a no-write artifact, but
+the planned rows must be manually reviewed before any controlled insert into
+`station_external_identity`. See
+[`stage-18j-p12-bounded-external-identity-load-plan-review.md`](./stage-18j-p12-bounded-external-identity-load-plan-review.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -750,11 +758,14 @@ treated as a separate proposal.
   no-write load-plan artifact. It proposes at most an explicit bounded set of
   identity rows for review and still writes nothing to
   `station_external_identity`.
-* **External identity follow-up sequence**: after P10 review, continue with
-  P11 bounded load-plan artifact with no DB writes, then P12 load-plan review,
-  P13 controlled identity load with no station-type writes, P14 identity
-  coverage artifact, P15 read-only reconciliation integration with confirmed
-  identity, and P16 strict station-type dry-run retry.
+* **External identity load-plan review**: Stage 18J-P12 reviews the first
+  bounded load-plan artifact and finds it ready only after extra planned-row
+  review.
+* **External identity follow-up sequence**: after P12 review, continue with
+  P13 planned identity row manual review packet, P14 controlled identity load
+  of reviewed rows only, P15 post-load identity coverage artifact, P16
+  reconciliation integration with confirmed identity, and P17 strict
+  station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -780,8 +780,9 @@ Scope:
   P7 schema production apply closeout, P8 evidence loader/reconciliation
   design, P9 read-only identity candidate artifact, P10 candidate artifact
   review, P11 bounded no-write load-plan artifact, P12 load-plan review, P13
-  controlled identity load with no station-type writes, P14 identity coverage
-  artifact, P15 reconciliation integration with confirmed identity, and P16
+  planned identity row manual review packet, P14 controlled identity load of
+  reviewed rows only, P15 post-load identity coverage artifact, P16
+  reconciliation integration with confirmed identity, and P17
   strict station-type dry-run retry.
 
 Non-goals:
@@ -1210,6 +1211,42 @@ Non-goals:
 Support doc:
 `stage-18j-p11-bounded-external-identity-load-plan-artifact.md`.
 
+### Stage 18J-P12 - Bounded External Identity Load-Plan Review
+
+Purpose: review the first Hetzner bounded no-write external identity load-plan
+artifact before any identity evidence is written.
+
+Scope:
+
+- Record artifact
+  `station_external_identity_load_plan_20260603T071913Z.json`, its path, size,
+  SHA-256, integrity SHA-256, source run/file filters, and schema version.
+- Record safety fields: `dry_run = true`, `read_only = true`,
+  `report_only = true`, `canonical_writes_planned = 0`,
+  `station_type_writes_planned = 0`, `identity_rows_planned = 20`, and
+  `identity_rows_written = 0`.
+- Record load-plan counts: `298177` total candidates, `261938` eligible
+  confirmed candidates, `20` planned rows, and `0` written rows.
+- Record skipped/rejected counts: `261918` eligible rows beyond max rows,
+  `35981` source-only rows, and `258` ambiguous canonical matches.
+- Set readiness verdict to `Ready only after extra review`.
+- Require a planned identity row manual review packet before any controlled
+  insert into `station_external_identity`.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No identity evidence load.
+- No writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p12-bounded-external-identity-load-plan-review.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1297,9 +1334,10 @@ Do not add another large planner feature immediately. The healthiest next sequen
 40. Stage 18J-P10 external identity candidate artifact review.
 41. Stage 18J-P11 bounded external identity load-plan artifact, no DB writes.
 42. Stage 18J-P12 review bounded identity load plan.
-43. Stage 18J-P13 controlled identity evidence load, no station-type writes.
-44. Stage 18J-P14 identity coverage artifact after load.
-45. Stage 18J-P15 reconciliation integration with confirmed identity.
-46. Stage 18J-P16 retry strict station-type dry-run.
+43. Stage 18J-P13 planned identity row manual review packet.
+44. Stage 18J-P14 controlled identity evidence load of reviewed rows only.
+45. Stage 18J-P15 post-load identity coverage artifact.
+46. Stage 18J-P16 reconciliation integration with confirmed identity.
+47. Stage 18J-P17 retry strict station-type dry-run.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
+++ b/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
@@ -245,12 +245,11 @@ artifact, and integrated into read-only reconciliation.
 
 - Stage 18J-P11 - Bounded external identity load-plan artifact, no DB writes.
 - Stage 18J-P12 - Review bounded identity load plan.
-- Stage 18J-P13 - Controlled identity evidence load into
-  `station_external_identity`, no station-type writes.
-- Stage 18J-P14 - Identity coverage artifact after load.
-- Stage 18J-P15 - Read-only reconciliation integration with confirmed
-  identity.
-- Stage 18J-P16 - Retry strict station-type dry-run.
+- Stage 18J-P13 - Planned identity row manual review packet.
+- Stage 18J-P14 - Controlled identity evidence load of reviewed rows only.
+- Stage 18J-P15 - Post-load identity coverage artifact.
+- Stage 18J-P16 - Reconciliation integration with confirmed identity.
+- Stage 18J-P17 - Retry strict station-type dry-run.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
@@ -183,6 +183,11 @@ Before any controlled identity evidence load:
 - confirm skipped conflicting/ambiguous candidates are not planned;
 - confirm the plan does not imply station-type writes.
 
+Stage 18J-P12 reviews the first Hetzner bounded load-plan artifact. It records
+`20` planned rows, `0` written rows, and the verdict `Ready only after extra
+review`; every planned row still needs manual review before any controlled
+insert into `station_external_identity`.
+
 ## What This Does Not Write
 
 P11 writes nothing to:
@@ -201,12 +206,11 @@ the summarizer, run station-type dry-run, run canonical apply, or start Stage
 ## Recommended Next Stages
 
 - Stage 18J-P12 - Review bounded identity load-plan artifact.
-- Stage 18J-P13 - Controlled identity evidence load into
-  `station_external_identity`, no station-type writes.
-- Stage 18J-P14 - Identity coverage artifact after load.
-- Stage 18J-P15 - Read-only reconciliation integration with confirmed
-  identity.
-- Stage 18J-P16 - Retry strict station-type dry-run.
+- Stage 18J-P13 - Planned identity row manual review packet.
+- Stage 18J-P14 - Controlled identity evidence load of reviewed rows only.
+- Stage 18J-P15 - Post-load identity coverage artifact.
+- Stage 18J-P16 - Reconciliation integration with confirmed identity.
+- Stage 18J-P17 - Retry strict station-type dry-run.
 
 ## Final Recommendation
 

--- a/docs/colonisation-redesign/stage-18j-p12-bounded-external-identity-load-plan-review.md
+++ b/docs/colonisation-redesign/stage-18j-p12-bounded-external-identity-load-plan-review.md
@@ -1,0 +1,205 @@
+# Stage 18J-P12 — Bounded External Identity Load-Plan Review
+
+## Purpose
+
+Stage 18J-P12 reviews the bounded no-write external station identity load-plan
+artifact generated on Hetzner after Stage 18J-P11.
+
+This stage is docs/review only. It does not run production commands from
+Codex, touch the production database from Codex, load identity evidence, write
+to `station_external_identity`, run imports, run reconciliation, run the
+summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Artifact Reviewed
+
+Reviewed artifact:
+
+- artifact type: `station_external_identity_load_plan/v1`;
+- path:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_load_plan_20260603T071913Z.json`;
+- size: `349K`;
+- artifact SHA-256:
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- artifact integrity SHA-256:
+  `f8cf7260425ba82b1fc476d3cd239dbf41e2b246040ad9b461750ae4322a544f`;
+- source: `edsm_nightly_stations`;
+- source run key:
+  `6ad44d1ad04d53c958ba7f5877b01752a22e29d9e905627c7feba5bb9eca2db1`;
+- source file key:
+  `76f5c8aa5e55d267c96c16da026ff5cbfae58f1d63575d47759c9bf3aaa37c19`;
+- max rows: `20`.
+
+## Safety Result
+
+The artifact reports:
+
+- `dry_run = true`;
+- `read_only = true`;
+- `report_only = true`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_planned = 20`;
+- `identity_rows_written = 0`.
+
+Post-checks recorded:
+
+- secret/path sanity check: clean;
+- `station_external_identity` row count after artifact generation: `0`;
+- no identity rows were loaded;
+- no station-type dry-run was run;
+- no canonical apply was run.
+
+The artifact is safe as a no-write planning artifact. It does not approve or
+perform any insert into `station_external_identity`.
+
+## Load-Plan Counts
+
+Summary counts:
+
+| Field | Count |
+|---|---:|
+| `total_candidates_seen` | `298177` |
+| `eligible_confirmed_candidates_seen` | `261938` |
+| `planned_rows_count` | `20` |
+| `identity_rows_written` | `0` |
+
+The bounded plan selected only the first `20` eligible confirmed candidates for
+review. It did not plan the full eligible candidate set.
+
+## Planned Row Scope
+
+The planned row scope is intentionally small:
+
+- planned rows in artifact: `20`;
+- sample non-planned candidates in artifact: `100`;
+- `max_rows = 20`;
+- source is restricted to `edsm_nightly_stations`;
+- source run/file filters match the reviewed Stage 18J-P10 candidate artifact;
+- planned rows are intended as candidate `station_external_identity` inserts
+  for manual review only;
+- planned rows do not imply station-type canonical truth;
+- planned rows do not authorize station-type writes.
+
+The artifact can support a later manual review packet, but it is not itself
+the approval packet for a controlled insert.
+
+## Skipped / Rejected Counts
+
+Skipped and rejected reason counts:
+
+| Reason | Count |
+|---|---:|
+| `eligible_beyond_max_rows` | `261918` |
+| `source_only_no_canonical_station_match` | `35981` |
+| `ambiguous_canonical_station_match` | `258` |
+
+The `eligible_beyond_max_rows` rows remain unplanned only because of the
+bounded first-review cap. The source-only and ambiguous rows remain blocked
+from confirmed identity use.
+
+## Candidate Status Counts
+
+Candidate status counts:
+
+| Status | Count |
+|---|---:|
+| `confirmed_candidate` | `261938` |
+| `conflicting` | `258` |
+| `proposed` | `0` |
+| `rejected` | `35981` |
+
+`confirmed_candidate` remains a planning status from the read-only matching
+workflow. It is not a production-confirmed external identity row until a later
+controlled load writes reviewed rows to `station_external_identity`.
+
+## Artifact Integrity
+
+The artifact includes both file-level and internal integrity checks:
+
+- file SHA-256:
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- artifact integrity SHA-256:
+  `f8cf7260425ba82b1fc476d3cd239dbf41e2b246040ad9b461750ae4322a544f`.
+
+Any future review or load stage must reference these exact hashes and source
+filters. A mismatch means the planned rows are not the reviewed P12 rows.
+
+## What Was Not Run
+
+P12 records that:
+
+- no production commands were run from Codex;
+- no production DB was touched from Codex;
+- no identity evidence was loaded;
+- no writes to `station_external_identity` occurred;
+- no imports were run;
+- no reconciliation was run;
+- no summarizer was run against production artifacts;
+- no station-type dry-run was run;
+- no canonical apply was run;
+- no approval record was created;
+- Stage 18K was not started.
+
+## Readiness Verdict
+
+Ready only after extra review.
+
+The artifact safely planned only `20` rows and wrote `0` rows. That is enough
+to proceed to a manual planned-row review packet, but it is not enough to
+authorize loading those rows. The planned rows themselves must be reviewed
+before any future insert into `station_external_identity`.
+
+## Required Manual Review
+
+Before any controlled identity evidence load, require a manual review packet
+that checks every planned row:
+
+- canonical station ID is the intended station;
+- `system_id64` matches the intended canonical system;
+- station name is the intended source/canonical station;
+- source is `edsm_nightly_stations`;
+- at least one external ID is present;
+- no `market_id` is inferred from `stations.id`;
+- no `station_body_links.market_id` is used as general identity proof;
+- source run/file/hash provenance is present;
+- `identity_status = 'confirmed'` is appropriate for the selected row;
+- `conflict_reason = null` is appropriate;
+- no row implies station-type truth;
+- no row is ambiguous, rejected, proposed, or source-only.
+
+## Required Future Load Boundaries
+
+A future controlled load stage must:
+
+- be separately approved after manual planned-row review;
+- reference this artifact path and both recorded hashes;
+- load only reviewed planned rows;
+- write only to `station_external_identity`;
+- preserve source run/file/hash provenance;
+- keep `stations` unchanged;
+- keep `station_type` unchanged;
+- create no approval record unless a later explicit stage asks for one;
+- run no imports;
+- run no reconciliation;
+- run no summarizer;
+- run no station-type dry-run;
+- run no canonical apply;
+- produce post-load row-count and status-count checks.
+
+## Recommended Next Stages
+
+- Stage 18J-P13 - Planned identity row manual review packet.
+- Stage 18J-P14 - Controlled identity evidence load of reviewed rows only.
+- Stage 18J-P15 - Post-load identity coverage artifact.
+- Stage 18J-P16 - Reconciliation integration with confirmed identity.
+- Stage 18J-P17 - Retry strict station-type dry-run.
+
+## Final Recommendation
+
+Proceed only to a planned-row manual review packet.
+
+Do not load the `20` planned rows yet. The load-plan artifact is safe and
+bounded, but the row contents must be manually reviewed before any controlled
+insert into `station_external_identity`. Keep station-type dry-run and
+canonical apply blocked.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -754,6 +754,17 @@ write/apply/load flags, and keeps `identity_rows_written = 0`. This is still a
 review artifact and must not be combined with identity evidence load,
 reconciliation, summarizer, station-type dry-run, or canonical apply.
 
+Stage 18J-P12 reviews the first bounded no-write load-plan artifact in
+`docs/colonisation-redesign/stage-18j-p12-bounded-external-identity-load-plan-review.md`.
+The artifact
+`station_external_identity_load_plan_20260603T071913Z.json` planned `20` rows,
+wrote `0` rows, and reported `261938` eligible confirmed candidates, `261918`
+eligible rows beyond the `max_rows` cap, `35981` source-only rows, and `258`
+ambiguous rows. The verdict is `Ready only after extra review`; every planned
+row still needs manual review before any controlled insert into
+`station_external_identity`. Do not load identity rows, run reconciliation,
+summarizer, station-type dry-run, or canonical apply from the P12 review.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,


### PR DESCRIPTION
## What changed

* Records the bounded no-write external identity load-plan artifact.
* Records planned rows, skipped/rejected counts, candidate status counts, and safety checks.
* Records readiness verdict: ready only after extra review.
* Keeps identity writes blocked until planned rows are manually reviewed.
* Keeps station-type writes blocked.
* Updates roadmap/runbook docs.

## Boundary confirmations

* Docs/review only.
* No production commands run from Codex.
* No production DB touched from Codex.
* No identity evidence loaded.
* No writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

* `git diff --check`: passed.
* `./scripts/run_canonical_safety_tests.sh`: passed, `99 passed in 0.18s`; disposable Postgres rehearsal skipped because `EDFINDER_CANONICAL_TEST_DSN` and `EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes` were not set.
* `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py -q`: passed, `136 passed in 0.23s`.
* `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py`: passed.
* Secret scan changed docs: no matches.
* `git diff --cached --check`: passed before commit.