### PR TITLE
Stage 18J-P identity evidence execution board

### DIFF
--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -651,6 +651,15 @@ plans only eligible `confirmed_candidate` rows, preserves provenance, rejects
 write/apply/load flags, and keeps `identity_rows_written = 0`. See
 [`stage-18j-p11-bounded-external-identity-load-plan-artifact.md`](./stage-18j-p11-bounded-external-identity-load-plan-artifact.md).
 
+Stage 18J-P-OPT adds the identity evidence execution board. It keeps Hetzner
+production actions tiny and single-purpose while bundling repo work into larger
+safe chunks that include tooling, tests, operator scripts, docs, and roadmap
+updates where appropriate. It tracks Chunk A P12/P13 review pack, Chunk B P14
+controlled identity load tooling, Chunk C P15 post-load identity coverage,
+Chunk D P16 read-only reconciliation integration, and Chunk E P17 strict
+station-type dry-run retry. See
+[`stage-18j-p-identity-evidence-execution-board.md`](./stage-18j-p-identity-evidence-execution-board.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -750,11 +759,13 @@ treated as a separate proposal.
   no-write load-plan artifact. It proposes at most an explicit bounded set of
   identity rows for review and still writes nothing to
   `station_external_identity`.
-* **External identity follow-up sequence**: after P10 review, continue with
-  P11 bounded load-plan artifact with no DB writes, then P12 load-plan review,
-  P13 controlled identity load with no station-type writes, P14 identity
-  coverage artifact, P15 read-only reconciliation integration with confirmed
-  identity, and P16 strict station-type dry-run retry.
+* **External identity execution board**: Stage 18J-P-OPT groups remaining
+  repo work into larger safe chunks while keeping Hetzner production actions
+  tiny and single-purpose.
+* **External identity follow-up sequence**: use the execution board for Chunk A
+  P12/P13 review pack, Chunk B P14 controlled identity load tooling, Chunk C
+  P15 post-load identity coverage, Chunk D P16 read-only reconciliation
+  integration, and Chunk E P17 strict station-type dry-run retry.
 * **Warehouse expansion and freshness design**: after the Stage 18J-Q6 station
   staging retry, read-only artifact path, compact reconciliation review, and
   Stage 19A/19A.1 guardrails are boring, Stage 19 should broaden warehouse

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -779,10 +779,11 @@ Scope:
   external identity design, P5 migration draft, P6 production readiness review,
   P7 schema production apply closeout, P8 evidence loader/reconciliation
   design, P9 read-only identity candidate artifact, P10 candidate artifact
-  review, P11 bounded no-write load-plan artifact, P12 load-plan review, P13
-  controlled identity load with no station-type writes, P14 identity coverage
-  artifact, P15 reconciliation integration with confirmed identity, and P16
-  strict station-type dry-run retry.
+  review, P11 bounded no-write load-plan artifact, P-OPT execution board,
+  Chunk A P12/P13 review pack, Chunk B P14 controlled identity load tooling,
+  Chunk C P15 post-load identity coverage, Chunk D P16 reconciliation
+  integration with confirmed identity, and Chunk E P17 strict station-type
+  dry-run retry.
 
 Non-goals:
 
@@ -1210,6 +1211,42 @@ Non-goals:
 Support doc:
 `stage-18j-p11-bounded-external-identity-load-plan-artifact.md`.
 
+### Stage 18J-P-OPT - Identity Evidence Execution Board
+
+Purpose: optimise the remaining external identity evidence workflow into
+larger safe repo chunks while preserving tiny Hetzner production actions.
+
+Scope:
+
+- Add `stage-18j-p-identity-evidence-execution-board.md`.
+- Record current state: `station_external_identity` exists, row count is `0`,
+  read-only candidate artifact exists, bounded no-write load-plan exists, and
+  the load plan saw `298177` candidates, `261938` eligible confirmed
+  candidates, `20` planned rows, and `0` written rows.
+- Define what must stay small: Hetzner operator actions, controlled loads,
+  coverage generation, reconciliation generation, strict dry-run retry,
+  approval packets, and apply.
+- Define what can be bundled: tool, tests, operator script, docs, and roadmap
+  updates when they share one safety boundary.
+- Define Chunk A through Chunk E for the remaining Stage 18J-P identity work.
+- Define the standard operator action shape: pre-check row counts, guarded
+  script, artifact path, checksum, compact summary, post-check row counts, and
+  explicit no-forbidden-actions confirmation.
+
+Non-goals:
+
+- No production commands.
+- No production DB access.
+- No identity evidence load.
+- No writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p-identity-evidence-execution-board.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1296,10 +1333,11 @@ Do not add another large planner feature immediately. The healthiest next sequen
 39. Stage 18J-P9 read-only external identity candidate artifact.
 40. Stage 18J-P10 external identity candidate artifact review.
 41. Stage 18J-P11 bounded external identity load-plan artifact, no DB writes.
-42. Stage 18J-P12 review bounded identity load plan.
-43. Stage 18J-P13 controlled identity evidence load, no station-type writes.
-44. Stage 18J-P14 identity coverage artifact after load.
-45. Stage 18J-P15 reconciliation integration with confirmed identity.
-46. Stage 18J-P16 retry strict station-type dry-run.
+42. Stage 18J-P-OPT identity evidence execution board.
+43. Chunk A: Stage 18J-P12/P13 review pack, no DB writes.
+44. Chunk B: Stage 18J-P14 controlled identity load tooling.
+45. Chunk C: Stage 18J-P15 post-load identity coverage.
+46. Chunk D: Stage 18J-P16 reconciliation integration with confirmed identity.
+47. Chunk E: Stage 18J-P17 retry strict station-type dry-run.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
+++ b/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
@@ -1,0 +1,283 @@
+# Stage 18J-P Identity Evidence Execution Board
+
+## Purpose
+
+This board optimises the remaining Stage 18J-P external station identity
+evidence workflow.
+
+Stage 18J-P has deliberately used small safe chunks while it proved the
+identity model, schema, read-only candidate artifact, and bounded load-plan
+artifact. The remaining repo work can now be grouped into larger safe chunks
+without relaxing production/operator boundaries.
+
+This stage is docs/planning only. It does not run production commands, touch
+the production database, load identity evidence, write to
+`station_external_identity`, run imports, run reconciliation, run the
+summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Current State
+
+Known state:
+
+- `station_external_identity` exists on Hetzner.
+- `station_external_identity` row count is `0`.
+- The read-only identity candidate artifact exists.
+- The bounded no-write load-plan artifact exists.
+- The load-plan artifact reported:
+  - `total_candidates_seen = 298177`;
+  - `eligible_confirmed_candidates_seen = 261938`;
+  - `planned_rows_count = 20`;
+  - `identity_rows_written = 0`;
+  - `station_external_identity` row count remained `0`.
+- Stage 18J-P10 verdict: `Ready only for bounded identity load dry-run`.
+- Stage 18J-P11 produced the bounded no-write load-plan tool/artifact path.
+- Stage 18K remains untouched.
+
+## Why We Are Optimising
+
+The earlier tiny chunks were correct while the risk was unknown:
+
+- canonical `stations` had no `market_id` or `edsm_station_id`;
+- the strict station-type dry-run correctly yielded zero eligible rows;
+- external identity needed a separate schema and proof model;
+- the first candidate and load-plan artifacts needed to prove they were
+  read-only and bounded.
+
+That risk is now better understood. Continuing with one docs-only PR per small
+decision would add review overhead without improving production safety. Repo
+work can be bundled when the bundle is still testable, no-write, and bounded.
+
+## What Must Stay Small
+
+Hetzner production actions must stay tiny and single-purpose:
+
+- planned-row review packet generation;
+- controlled load of exactly reviewed rows;
+- post-load row-count and status-count checks;
+- identity coverage artifact generation;
+- read-only reconciliation artifact generation;
+- strict station-type dry-run retry;
+- any future approval packet;
+- any future canonical apply.
+
+Never combine identity load with station-type dry-run. Never combine
+station-type dry-run with canonical apply.
+
+## What Can Be Bundled
+
+Repo work can be bundled where the bundle shares one goal and one safety
+boundary:
+
+- tool;
+- tests;
+- operator script;
+- docs;
+- roadmap/runbook updates.
+
+Avoid docs-only PRs unless they unblock a risky action, clarify a safety gate,
+or record an operator result that must be preserved before the next action.
+
+## Remaining Workstreams
+
+Remaining workstreams are:
+
+- planned-row review packet generation;
+- controlled identity evidence load tooling;
+- identity coverage artifact after load;
+- read-only reconciliation integration with confirmed identity;
+- strict station-type dry-run retry using confirmed identity;
+- review/approval packet only if a future dry-run produces acceptable
+  station-type candidates;
+- later apply only if a separate approval packet explicitly authorizes it.
+
+## Proposed Chunked PR Plan
+
+### Chunk A - P12/P13 Review Pack
+
+Goal: review the bounded load-plan artifact and generate a planned-row review
+packet.
+
+Bundle:
+
+- review bounded load-plan artifact;
+- add planned-row review packet tooling if needed;
+- add tests for review packet extraction and safety fields;
+- add docs/runbook updates;
+- no DB writes.
+
+Exit criteria:
+
+- exact load-plan artifact path and checksum recorded;
+- each of the `20` planned rows can be inspected in a compact review packet;
+- rejected/source-only and ambiguous rows remain non-loadable;
+- `identity_rows_written = 0`;
+- station-type writes remain blocked.
+
+### Chunk B - P14 Controlled Identity Load Tooling
+
+Goal: add controlled load tooling for reviewed rows only.
+
+Bundle:
+
+- add controlled load tool;
+- add operator script;
+- enforce reviewed artifact checksum;
+- enforce exact source run/file filters;
+- enforce exact reviewed row IDs/hashes;
+- enforce max rows;
+- run inside a transaction;
+- add tests for refusal modes and no accidental canonical writes;
+- update docs/runbook.
+
+Repo work must not run production. The Hetzner production load remains a
+separate tiny operator action after review.
+
+### Chunk C - P15 Post-load Identity Coverage
+
+Goal: prove what changed after the controlled identity load.
+
+Bundle:
+
+- coverage artifact tool;
+- tests;
+- operator script;
+- docs/runbook updates.
+
+Coverage must show:
+
+- `station_external_identity` row count;
+- counts by `identity_status`;
+- source run/file/hash preservation;
+- no rows without external IDs;
+- no station-type writes;
+- no canonical apply.
+
+### Chunk D - P16 Reconciliation Integration
+
+Goal: expose confirmed identity in read-only reconciliation.
+
+Bundle:
+
+- read-only reconciliation includes confirmed external identity fields;
+- tests;
+- docs/runbook updates;
+- no canonical writes.
+
+Confirmed identity may support read-only station identity proof. It is not
+station-type truth.
+
+### Chunk E - P17 Strict Station-Type Dry-Run Retry
+
+Goal: retry the strict station-type dry-run using confirmed identity evidence.
+
+Bundle:
+
+- use confirmed identity in the strict filter/reconciliation input;
+- keep the dry-run bounded;
+- keep `canonical_writes_planned = 0`;
+- no apply;
+- add docs/runbook updates and tests as needed.
+
+Any non-zero candidates still require a separate review packet before canonical
+apply can be discussed.
+
+## Proposed Hetzner Operator Actions
+
+Use tiny, single-purpose Hetzner actions:
+
+1. Run planned-row review packet.
+2. Only after review, run controlled load of the exact reviewed `20` rows.
+3. Generate identity coverage artifact.
+4. Generate read-only reconciliation with confirmed identity.
+5. Retry strict station-type dry-run only if identity coverage is acceptable.
+
+Each action should use this standard command shape:
+
+- pre-check row counts;
+- run guarded script;
+- output artifact path;
+- output checksum;
+- output compact summary;
+- post-check row counts;
+- explicit no-forbidden-actions confirmation.
+
+## Stop / Go Gates
+
+Stop if:
+
+- artifact checksum mismatches;
+- source run/file filters mismatch;
+- planned rows are not the reviewed rows;
+- `station_external_identity` row count is unexpected;
+- any planned row lacks source run/file/hash provenance;
+- any planned row lacks both `market_id` and `edsm_station_id`;
+- any row depends on internal `stations.id` as external identity proof;
+- any row uses `station_body_links.market_id` as general identity proof;
+- conflicting or source-only evidence is treated as confirmed;
+- imports, reconciliation, summarizer, dry-run, or apply are accidentally
+  coupled to identity loading;
+- Stage 18K appears in scope.
+
+Go only when:
+
+- exact artifacts and checksums are recorded;
+- row counts match expectations;
+- every planned row in scope has been reviewed;
+- operator action is tiny and single-purpose;
+- forbidden actions remain blocked.
+
+## Artifact Rules
+
+Artifacts must:
+
+- use versioned schema names;
+- include `generated_at`;
+- include `dry_run`, `read_only`, and/or `report_only` flags when applicable;
+- include source run/file filters;
+- include input artifact checksums when derived from prior artifacts;
+- include output artifact checksum or integrity block;
+- include compact counts and bounded samples;
+- avoid raw payload dumps unless a later explicit review stage requires them;
+- record `canonical_writes_planned = 0` until a separate apply packet exists;
+- record `station_type_writes_planned = 0` until strict dry-run review permits
+  otherwise;
+- preserve source run/file/hash provenance for identity evidence.
+
+## Production Safety Rules
+
+Production safety rules:
+
+- Keep Hetzner production actions tiny and single-purpose.
+- Never combine identity load with station-type dry-run.
+- Never combine station-type dry-run with canonical apply.
+- Never run apply without a separate approval packet.
+- Never let scheduler/cron run canonical apply.
+- Unknown remains unknown.
+- Source-only remains source-only.
+- Confirmed identity is identity evidence, not station-type truth.
+- Conflicting evidence remains visible and blocked.
+- Stage 18K remains out of scope.
+
+## Recommended Next Actions
+
+Recommended next actions:
+
+1. Use this execution board as the remaining Stage 18J-P tracker.
+2. Proceed with Chunk A as one repo PR: load-plan review plus planned-row review
+   packet tooling/tests/docs, no DB writes.
+3. Run the planned-row review packet as a tiny Hetzner action after Chunk A
+   merges.
+4. Proceed with Chunk B only after the planned rows are accepted.
+5. Keep station-type dry-run blocked until post-load coverage and read-only
+   reconciliation prove confirmed identity coverage.
+
+## Final Recommendation
+
+Move from one-stage-per-sentence to larger repo chunks, but keep every Hetzner
+action small and explicit.
+
+Use this board to track Stage 18J-P through identity evidence load, coverage,
+read-only reconciliation integration, and the strict station-type dry-run
+retry. Do not start Stage 18K, and do not discuss canonical apply until a
+future bounded dry-run and separate approval packet justify it.

--- a/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
+++ b/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
@@ -244,13 +244,13 @@ artifact, and integrated into read-only reconciliation.
 ## Recommended Next Stages
 
 - Stage 18J-P11 - Bounded external identity load-plan artifact, no DB writes.
-- Stage 18J-P12 - Review bounded identity load plan.
-- Stage 18J-P13 - Controlled identity evidence load into
-  `station_external_identity`, no station-type writes.
-- Stage 18J-P14 - Identity coverage artifact after load.
-- Stage 18J-P15 - Read-only reconciliation integration with confirmed
-  identity.
-- Stage 18J-P16 - Retry strict station-type dry-run.
+- Stage 18J-P-OPT - Identity evidence execution board.
+- Chunk A - P12/P13 review pack: review bounded load-plan artifact and
+  generate planned-row review packet, no DB writes.
+- Chunk B - P14 controlled identity load tooling.
+- Chunk C - P15 post-load identity coverage.
+- Chunk D - P16 read-only reconciliation integration with confirmed identity.
+- Chunk E - P17 strict station-type dry-run retry.
 
 ## Final Recommendation
 
@@ -261,3 +261,6 @@ Do not bulk load the `261938` `confirmed_candidate` rows yet. Do not treat
 `confirmed_candidate` as production-confirmed identity, and do not use it for
 station-type writes. Proceed next with Stage 18J-P11 as a bounded identity
 load-plan artifact with no database writes.
+
+After P11, use the Stage 18J-P execution board to bundle repo work safely while
+keeping each Hetzner production action tiny, explicit, and single-purpose.

--- a/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
@@ -200,13 +200,13 @@ the summarizer, run station-type dry-run, run canonical apply, or start Stage
 
 ## Recommended Next Stages
 
-- Stage 18J-P12 - Review bounded identity load-plan artifact.
-- Stage 18J-P13 - Controlled identity evidence load into
-  `station_external_identity`, no station-type writes.
-- Stage 18J-P14 - Identity coverage artifact after load.
-- Stage 18J-P15 - Read-only reconciliation integration with confirmed
-  identity.
-- Stage 18J-P16 - Retry strict station-type dry-run.
+- Stage 18J-P-OPT - Identity evidence execution board.
+- Chunk A - P12/P13 review pack: review bounded load-plan artifact and
+  generate planned-row review packet, no DB writes.
+- Chunk B - P14 controlled identity load tooling.
+- Chunk C - P15 post-load identity coverage.
+- Chunk D - P16 read-only reconciliation integration with confirmed identity.
+- Chunk E - P17 strict station-type dry-run retry.
 
 ## Final Recommendation
 
@@ -216,3 +216,7 @@ Do not load identity evidence until the bounded plan has been generated,
 reviewed, and accepted with exact source filters, artifact checksum, and a
 small explicit max-row bound. Keep station-type dry-run and canonical apply
 blocked.
+
+Use `stage-18j-p-identity-evidence-execution-board.md` as the remaining
+Stage 18J-P tracker so repo work can be bundled safely while Hetzner actions
+stay tiny and single-purpose.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -754,6 +754,17 @@ write/apply/load flags, and keeps `identity_rows_written = 0`. This is still a
 review artifact and must not be combined with identity evidence load,
 reconciliation, summarizer, station-type dry-run, or canonical apply.
 
+Stage 18J-P-OPT documents the identity evidence execution board in
+`docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md`.
+Use it as the remaining Stage 18J-P tracker. Repo work may be bundled into
+larger chunks when the bundle has one safety boundary and includes tool, tests,
+operator script, docs, and roadmap updates. Hetzner actions remain tiny:
+pre-check row counts, run a guarded script, output artifact path/checksum and
+compact summary, post-check row counts, and explicitly confirm no forbidden
+actions. Never combine identity load with station-type dry-run, never combine
+station-type dry-run with canonical apply, and never run apply without a
+separate approval packet.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,


### PR DESCRIPTION
## What changed

* Adds an identity evidence execution board.
* Groups remaining Stage 18J-P work into larger safe chunks.
* Defines what must stay as tiny Hetzner-only actions.
* Defines standard operator action shape.
* Keeps station-type writes and canonical apply blocked.

## Boundary confirmations

* Docs/planning only.
* No production commands run.
* No production DB touched.
* No identity evidence loaded.
* No writes to station_external_identity.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

* `git diff --check`: passed.
* `./scripts/run_canonical_safety_tests.sh`: passed, `99 passed in 0.15s`; disposable Postgres rehearsal skipped because `EDFINDER_CANONICAL_TEST_DSN` and `EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes` were not set.
* `.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py -q`: passed, `136 passed in 0.20s`.
* `.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py`: passed.
* Secret scan changed docs: no matches.
* `git diff --cached --check`: passed before commit.