### PR TITLE
Stage 18J-P12-P13 load-plan review packet

### DIFF
--- a/apps/importer/src/station_external_identity_review_packet.py
+++ b/apps/importer/src/station_external_identity_review_packet.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Offline planned-row review packet generator for external station identity.
+
+This tool reads a local ``station_external_identity_load_plan/v1`` JSON
+artifact and emits a deterministic manual review packet for the bounded
+planned rows. It does not accept a DSN and never connects to a database.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 'station_external_identity_review_packet/v1'
+SOURCE_SCHEMA_VERSION = 'station_external_identity_load_plan/v1'
+TOOL_NAME = 'station_external_identity_review_packet'
+TOOL_VERSION = 'v1'
+MAX_PLANNED_ROWS_CAP = 20
+WRITE_FLAG_ERROR = 'write/apply/load/commit flags are not available; this tool only emits an offline review packet'
+MANUAL_REVIEW_STATUS = 'needs_manual_review'
+REVIEW_CHECKS: tuple[tuple[str, str], ...] = (
+    (
+        'canonical_station_match',
+        'Confirm the planned canonical_station_id is the intended station for the source system/name evidence.',
+    ),
+    (
+        'external_identifier_present',
+        'Confirm the planned row has at least one source external identifier, edsm_station_id or market_id.',
+    ),
+    (
+        'source_provenance_present',
+        'Confirm source_run_key, source_file_key, and source_record_hash are present and match the reviewed load plan.',
+    ),
+    (
+        'identity_status_confirmed_only',
+        "Confirm identity_status is 'confirmed' and conflict_reason is null for this bounded row.",
+    ),
+    (
+        'no_station_type_or_canonical_write',
+        'Confirm the row does not plan station_type writes, canonical writes, imports, reconciliation, or apply.',
+    ),
+)
+
+
+class IdentityReviewPacketError(ValueError):
+    """Raised when a review packet cannot be built safely."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Build an offline manual review packet from a bounded station_external_identity load-plan artifact.',
+    )
+    parser.add_argument('--load-plan-artifact', required=True, help='Local station_external_identity_load_plan/v1 JSON file.')
+    parser.add_argument('--expected-load-plan-sha256', required=True, help='Expected SHA-256 of the load-plan artifact file.')
+    parser.add_argument('--output', default=None, help='Optional path to write the JSON review packet.')
+    parser.add_argument('--json', action='store_true', help='Emit JSON to stdout. Output is JSON by default.')
+    parser.add_argument(
+        '--max-planned-rows',
+        type=int,
+        default=MAX_PLANNED_ROWS_CAP,
+        help=f'Maximum planned rows to include, capped at {MAX_PLANNED_ROWS_CAP}.',
+    )
+    parser.add_argument('--apply', action='store_true', help='Unsupported; this tool is offline review-only.')
+    parser.add_argument('--write', action='store_true', help='Unsupported; this tool is offline review-only.')
+    parser.add_argument('--write-staging', action='store_true', help='Unsupported; this tool is offline review-only.')
+    parser.add_argument('--load', action='store_true', help='Unsupported; this tool is offline review-only.')
+    parser.add_argument('--commit', action='store_true', help='Unsupported; this tool is offline review-only.')
+    args = parser.parse_args(argv)
+
+    if args.apply or args.write or args.write_staging or args.load or args.commit:
+        parser.error(WRITE_FLAG_ERROR)
+    if args.max_planned_rows < 1:
+        parser.error('--max-planned-rows must be >= 1')
+    if args.max_planned_rows > MAX_PLANNED_ROWS_CAP:
+        parser.error(f'--max-planned-rows must be <= {MAX_PLANNED_ROWS_CAP}')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        artifact = build_review_packet_from_file(
+            args.load_plan_artifact,
+            expected_load_plan_sha256=args.expected_load_plan_sha256,
+            max_planned_rows=args.max_planned_rows,
+        )
+    except (OSError, ValueError) as exc:
+        print(f'station external identity review packet generation failed: {exc}', file=sys.stderr)
+        return 2
+
+    output = json_dumps_artifact(artifact)
+    if args.output:
+        Path(args.output).write_text(output + '\n', encoding='utf-8')
+    if args.json or not args.output:
+        print(output)
+    return 0
+
+
+def build_review_packet_from_file(
+    load_plan_artifact: str | Path,
+    *,
+    expected_load_plan_sha256: str,
+    max_planned_rows: int = MAX_PLANNED_ROWS_CAP,
+) -> dict[str, Any]:
+    if max_planned_rows < 1:
+        raise IdentityReviewPacketError('max_planned_rows must be >= 1')
+    if max_planned_rows > MAX_PLANNED_ROWS_CAP:
+        raise IdentityReviewPacketError(f'max_planned_rows must be <= {MAX_PLANNED_ROWS_CAP}')
+
+    path = Path(load_plan_artifact)
+    if not path.is_file():
+        raise IdentityReviewPacketError(f'load-plan artifact is missing: {path}')
+
+    payload = path.read_bytes()
+    actual_sha256 = hashlib.sha256(payload).hexdigest()
+    if actual_sha256 != expected_load_plan_sha256.lower():
+        raise IdentityReviewPacketError(
+            f'load-plan artifact checksum mismatch. Expected {expected_load_plan_sha256}, got {actual_sha256}',
+        )
+
+    try:
+        load_plan = json.loads(payload.decode('utf-8'))
+    except json.JSONDecodeError as exc:
+        raise IdentityReviewPacketError(f'load-plan artifact is not valid JSON: {exc}') from exc
+    if not isinstance(load_plan, Mapping):
+        raise IdentityReviewPacketError('load-plan artifact must be a JSON object')
+
+    return build_review_packet(
+        load_plan,
+        source_artifact_basename=path.name,
+        source_artifact_size_bytes=len(payload),
+        source_artifact_sha256=actual_sha256,
+        max_planned_rows=max_planned_rows,
+    )
+
+
+def build_review_packet(
+    load_plan: Mapping[str, Any],
+    *,
+    source_artifact_basename: str,
+    source_artifact_size_bytes: int,
+    source_artifact_sha256: str,
+    max_planned_rows: int = MAX_PLANNED_ROWS_CAP,
+) -> dict[str, Any]:
+    if max_planned_rows < 1:
+        raise IdentityReviewPacketError('max_planned_rows must be >= 1')
+    if max_planned_rows > MAX_PLANNED_ROWS_CAP:
+        raise IdentityReviewPacketError(f'max_planned_rows must be <= {MAX_PLANNED_ROWS_CAP}')
+    if load_plan.get('schema_version') != SOURCE_SCHEMA_VERSION:
+        raise IdentityReviewPacketError(f'load-plan artifact schema_version must be {SOURCE_SCHEMA_VERSION}')
+    _assert_load_plan_is_no_write(load_plan)
+
+    planned_rows_raw = load_plan.get('planned_rows')
+    if not isinstance(planned_rows_raw, list):
+        raise IdentityReviewPacketError('load-plan artifact planned_rows must be a list')
+
+    planned_rows = [_json_clone(row) for row in planned_rows_raw[:max_planned_rows]]
+    source_summary = _mapping(load_plan.get('summary'))
+    filters = _mapping(load_plan.get('filters'))
+    source_integrity = _mapping(load_plan.get('artifact_integrity'))
+    manual_review_items = [
+        _manual_review_item(row, index=index, source_artifact_sha256=source_artifact_sha256)
+        for index, row in enumerate(planned_rows, start=1)
+    ]
+
+    artifact: dict[str, Any] = {
+        'schema_version': SCHEMA_VERSION,
+        'tool': {
+            'name': TOOL_NAME,
+            'version': TOOL_VERSION,
+        },
+        'dry_run': True,
+        'read_only': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_planned': len(planned_rows),
+        'identity_rows_written': 0,
+        'approval_record_created': False,
+        'max_planned_rows': max_planned_rows,
+        'source_artifact': {
+            'artifact_type': SOURCE_SCHEMA_VERSION,
+            'basename': source_artifact_basename,
+            'size_bytes': source_artifact_size_bytes,
+            'sha256': source_artifact_sha256,
+            'artifact_integrity_sha256': source_integrity.get('canonical_json_sha256'),
+        },
+        'source_scope': {
+            'source': filters.get('source'),
+            'source_run_key': filters.get('source_run_key'),
+            'source_file_key': filters.get('source_file_key'),
+            'source_max_rows': load_plan.get('max_rows'),
+            'source_identity_rows_planned': load_plan.get('identity_rows_planned'),
+            'source_planned_rows_count': source_summary.get('planned_rows_count'),
+            'total_candidates_seen': source_summary.get('total_candidates_seen'),
+            'eligible_confirmed_candidates_seen': source_summary.get('eligible_confirmed_candidates_seen'),
+            'eligible_beyond_max_rows': _count(source_summary, 'skipped_reason_counts', 'eligible_beyond_max_rows'),
+            'source_only_no_canonical_station_match': _count(
+                source_summary,
+                'rejected_reason_counts',
+                'source_only_no_canonical_station_match',
+            ),
+            'ambiguous_canonical_station_match': _count(
+                source_summary,
+                'conflicting_reason_counts',
+                'ambiguous_canonical_station_match',
+            ),
+            'candidate_status_counts': _json_clone(source_summary.get('candidate_status_counts') or {}),
+        },
+        'summary': {
+            'planned_rows_available': len(planned_rows_raw),
+            'planned_rows_included': len(planned_rows),
+            'planned_rows_capped': len(planned_rows_raw) > len(planned_rows),
+            'manual_review_items_count': len(manual_review_items),
+            'manual_review_status_counts': {MANUAL_REVIEW_STATUS: len(manual_review_items)},
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': 0,
+            'approval_record_created': False,
+        },
+        'planned_rows': planned_rows,
+        'manual_review_items': manual_review_items,
+        'safety_boundaries': {
+            'db_connections_allowed': False,
+            'dsn_accepted': False,
+            'identity_load_allowed': False,
+            'station_type_dry_run_allowed': False,
+            'canonical_apply_allowed': False,
+            'approval_record_allowed': False,
+        },
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+        'canonicalization': 'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False) excluding artifact_integrity',
+    }
+    return artifact
+
+
+def json_dumps_artifact(artifact: Mapping[str, Any]) -> str:
+    return canonical_json(artifact)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def artifact_sha256(value: Mapping[str, Any]) -> str:
+    payload = deepcopy(dict(value))
+    payload.pop('artifact_integrity', None)
+    return hashlib.sha256(canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def _manual_review_item(
+    planned_row: Mapping[str, Any],
+    *,
+    index: int,
+    source_artifact_sha256: str,
+) -> dict[str, Any]:
+    row = _json_clone(planned_row)
+    item = {
+        'review_item_id': hashlib.sha256(
+            canonical_json([
+                'station_external_identity_review_packet_item',
+                source_artifact_sha256,
+                index,
+                row.get('plan_row_id'),
+                row,
+            ]).encode('utf-8'),
+        ).hexdigest(),
+        'planned_row_index': index,
+        'plan_row_id': row.get('plan_row_id'),
+        'candidate_id': row.get('candidate_id'),
+        'canonical_station_id': row.get('canonical_station_id'),
+        'source_record_hash': row.get('source_record_hash'),
+        'review_status': MANUAL_REVIEW_STATUS,
+        'review_checks': [
+            {
+                'check_id': check_id,
+                'prompt': prompt,
+                'review_status': MANUAL_REVIEW_STATUS,
+            }
+            for check_id, prompt in REVIEW_CHECKS
+        ],
+    }
+    return item
+
+
+def _assert_load_plan_is_no_write(load_plan: Mapping[str, Any]) -> None:
+    required_true = ('dry_run', 'read_only', 'report_only')
+    for key in required_true:
+        if load_plan.get(key) is not True:
+            raise IdentityReviewPacketError(f'load-plan artifact must have {key} = true')
+
+    required_zero = ('canonical_writes_planned', 'station_type_writes_planned', 'identity_rows_written')
+    for key in required_zero:
+        if load_plan.get(key) != 0:
+            raise IdentityReviewPacketError(f'load-plan artifact must have {key} = 0')
+
+    summary = _mapping(load_plan.get('summary'))
+    for key in required_zero:
+        value = summary.get(key)
+        if value is not None and value != 0:
+            raise IdentityReviewPacketError(f'load-plan artifact summary must have {key} = 0')
+
+
+def _count(parent: Mapping[str, Any], child_key: str, key: str) -> int:
+    child = parent.get(child_key)
+    if isinstance(child, Mapping):
+        value = child.get(key, 0)
+        if isinstance(value, int):
+            return value
+    return 0
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _json_clone(value: Any) -> Any:
+    return json.loads(canonical_json(value))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -660,6 +660,17 @@ Chunk D P16 read-only reconciliation integration, and Chunk E P17 strict
 station-type dry-run retry. See
 [`stage-18j-p-identity-evidence-execution-board.md`](./stage-18j-p-identity-evidence-execution-board.md).
 
+Stage 18J-P12/P13 implements Chunk A from that board. It records the bounded
+load-plan artifact review and adds the offline planned-row review packet
+generator in `apps/importer/src/station_external_identity_review_packet.py`,
+plus a Hetzner-only wrapper in
+`scripts/operator/stage18j_run_identity_review_packet.sh`. The packet tool
+verifies the exact load-plan artifact SHA-256, reads only local JSON, accepts
+no DSN, caps planned rows at `20`, and defaults every row review item to
+`needs_manual_review`. The readiness verdict is
+`Ready only after planned-row manual review`. See
+[`stage-18j-p12-p13-load-plan-review-packet.md`](./stage-18j-p12-p13-load-plan-review-packet.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -762,6 +773,10 @@ treated as a separate proposal.
 * **External identity execution board**: Stage 18J-P-OPT groups remaining
   repo work into larger safe chunks while keeping Hetzner production actions
   tiny and single-purpose.
+* **External identity planned-row review packet**: Stage 18J-P12/P13 records
+  the bounded load-plan review and adds an offline packet generator for manual
+  review of the `20` planned rows. It writes no identity rows and keeps
+  station-type dry-run and canonical apply blocked.
 * **External identity follow-up sequence**: use the execution board for Chunk A
   P12/P13 review pack, Chunk B P14 controlled identity load tooling, Chunk C
   P15 post-load identity coverage, Chunk D P16 read-only reconciliation

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -1247,6 +1247,50 @@ Non-goals:
 Support doc:
 `stage-18j-p-identity-evidence-execution-board.md`.
 
+### Stage 18J-P12/P13 - Load-Plan Review + Planned Row Review Packet
+
+Purpose: implement Chunk A from the identity evidence execution board by
+recording the bounded load-plan review and adding offline planned-row review
+packet tooling.
+
+Scope:
+
+- Record the reviewed `station_external_identity_load_plan/v1` operator
+  artifact path, file checksum, internal integrity checksum, source run/file
+  keys, candidate counts, and no-write result.
+- Add `apps/importer/src/station_external_identity_review_packet.py`.
+- Accept `--load-plan-artifact`, `--expected-load-plan-sha256`, `--output`,
+  `--json`, and `--max-planned-rows`.
+- Reject `--max-planned-rows` above `20`.
+- Verify the source artifact file checksum before parsing.
+- Parse only local JSON and accept no DSN.
+- Reject write/apply/load/commit flags.
+- Emit `station_external_identity_review_packet/v1`.
+- Include capped planned rows and one manual review item per row, defaulting
+  to `needs_manual_review`.
+- Keep `canonical_writes_planned = 0`,
+  `station_type_writes_planned = 0`, `identity_rows_written = 0`, and
+  `approval_record_created = false`.
+- Add `scripts/operator/stage18j_run_identity_review_packet.sh` as a
+  Hetzner-only offline wrapper guarded by
+  `scripts/operator/require_hetzner_operator_env.sh`.
+- Add synthetic tests for checksum enforcement, missing artifacts, row caps,
+  refusal flags, review defaults, safety fields, and deterministic JSON.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No identity evidence load.
+- No writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p12-p13-load-plan-review-packet.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1334,7 +1378,7 @@ Do not add another large planner feature immediately. The healthiest next sequen
 40. Stage 18J-P10 external identity candidate artifact review.
 41. Stage 18J-P11 bounded external identity load-plan artifact, no DB writes.
 42. Stage 18J-P-OPT identity evidence execution board.
-43. Chunk A: Stage 18J-P12/P13 review pack, no DB writes.
+43. Stage 18J-P12/P13 load-plan review packet, no DB writes.
 44. Chunk B: Stage 18J-P14 controlled identity load tooling.
 45. Chunk C: Stage 18J-P15 post-load identity coverage.
 46. Chunk D: Stage 18J-P16 reconciliation integration with confirmed identity.

--- a/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
+++ b/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
@@ -32,6 +32,9 @@ Known state:
   - `station_external_identity` row count remained `0`.
 - Stage 18J-P10 verdict: `Ready only for bounded identity load dry-run`.
 - Stage 18J-P11 produced the bounded no-write load-plan tool/artifact path.
+- Stage 18J-P12/P13 records the bounded load-plan artifact review and adds an
+  offline planned-row review packet generator.
+- Stage 18J-P12/P13 verdict: `Ready only after planned-row manual review`.
 - Stage 18K remains untouched.
 
 ## Why We Are Optimising
@@ -110,8 +113,10 @@ Exit criteria:
 
 - exact load-plan artifact path and checksum recorded;
 - each of the `20` planned rows can be inspected in a compact review packet;
+- every review item defaults to `needs_manual_review`;
 - rejected/source-only and ambiguous rows remain non-loadable;
 - `identity_rows_written = 0`;
+- `approval_record_created = false`;
 - station-type writes remain blocked.
 
 ### Chunk B - P14 Controlled Identity Load Tooling
@@ -264,11 +269,11 @@ Production safety rules:
 Recommended next actions:
 
 1. Use this execution board as the remaining Stage 18J-P tracker.
-2. Proceed with Chunk A as one repo PR: load-plan review plus planned-row review
-   packet tooling/tests/docs, no DB writes.
-3. Run the planned-row review packet as a tiny Hetzner action after Chunk A
-   merges.
-4. Proceed with Chunk B only after the planned rows are accepted.
+2. Use `stage-18j-p12-p13-load-plan-review-packet.md` as the Chunk A review
+   record.
+3. Run the planned-row review packet as a tiny Hetzner offline action after
+   Chunk A merges.
+4. Proceed with Chunk B only after the planned rows are manually accepted.
 5. Keep station-type dry-run blocked until post-load coverage and read-only
    reconciliation prove confirmed identity coverage.
 

--- a/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
+++ b/docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md
@@ -182,6 +182,14 @@ Stage 18J-P11 implements this as
 `--max-rows`, rejects values above `20`, rejects write/apply/load flags, and
 writes no database rows.
 
+Stage 18J-P12/P13 then records the first bounded load-plan artifact review and
+adds `apps/importer/src/station_external_identity_review_packet.py`. The
+review packet tool verifies the exact load-plan artifact checksum, reads only
+local JSON, accepts no DSN, caps planned rows at `20`, and emits
+`station_external_identity_review_packet/v1` with each row defaulting to
+`needs_manual_review`. The P12/P13 verdict is
+`Ready only after planned-row manual review`.
+
 ## Required Operator Preconditions
 
 Before any future bounded load-plan or controlled load stage, require:

--- a/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md
@@ -183,6 +183,30 @@ Before any controlled identity evidence load:
 - confirm skipped conflicting/ambiguous candidates are not planned;
 - confirm the plan does not imply station-type writes.
 
+## P12/P13 Follow-up Review
+
+Stage 18J-P12/P13 records the first bounded operator load-plan artifact and
+adds the offline planned-row review packet tool.
+
+Reviewed load-plan artifact:
+
+- path:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_load_plan_20260603T071913Z.json`;
+- artifact SHA-256:
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- artifact integrity SHA-256:
+  `f8cf7260425ba82b1fc476d3cd239dbf41e2b246040ad9b461750ae4322a544f`;
+- planned rows: `20`;
+- identity rows written: `0`;
+- `station_external_identity` row count after: `0`.
+
+P12/P13 readiness verdict:
+
+`Ready only after planned-row manual review`
+
+See
+[`stage-18j-p12-p13-load-plan-review-packet.md`](./stage-18j-p12-p13-load-plan-review-packet.md).
+
 ## What This Does Not Write
 
 P11 writes nothing to:
@@ -210,12 +234,13 @@ the summarizer, run station-type dry-run, run canonical apply, or start Stage
 
 ## Final Recommendation
 
-Use the P11 tool to produce a bounded no-write load-plan artifact after merge.
+Use the P11 tool to produce bounded no-write load-plan artifacts, then use the
+P12/P13 offline review packet flow to manually review the planned rows.
 
 Do not load identity evidence until the bounded plan has been generated,
-reviewed, and accepted with exact source filters, artifact checksum, and a
-small explicit max-row bound. Keep station-type dry-run and canonical apply
-blocked.
+reviewed as a packet, and accepted with exact source filters, artifact
+checksum, reviewed row identifiers, and a small explicit max-row bound. Keep
+station-type dry-run and canonical apply blocked.
 
 Use `stage-18j-p-identity-evidence-execution-board.md` as the remaining
 Stage 18J-P tracker so repo work can be bundled safely while Hetzner actions

--- a/docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md
+++ b/docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md
@@ -1,0 +1,246 @@
+# Stage 18J-P12/P13 — Load-Plan Review + Planned Row Review Packet
+
+## Purpose
+
+Stage 18J-P12/P13 implements Chunk A from the Stage 18J-P identity evidence
+execution board.
+
+This stage records the bounded no-write identity load-plan artifact review and
+adds an offline planned-row review packet generator. It does not run
+production commands, touch the production database, load identity evidence,
+write to `station_external_identity`, run imports, run reconciliation, run the
+summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create approval records, or start Stage 18K.
+
+## Inputs
+
+Reviewed operator artifact:
+
+- artifact type: `station_external_identity_load_plan/v1`;
+- path:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_load_plan_20260603T071913Z.json`;
+- size: `349K`;
+- artifact SHA-256:
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- artifact integrity SHA-256:
+  `f8cf7260425ba82b1fc476d3cd239dbf41e2b246040ad9b461750ae4322a544f`;
+- schema version: `station_external_identity_load_plan/v1`;
+- source: `edsm_nightly_stations`;
+- source run key:
+  `6ad44d1ad04d53c958ba7f5877b01752a22e29d9e905627c7feba5bb9eca2db1`;
+- source file key:
+  `76f5c8aa5e55d267c96c16da026ff5cbfae58f1d63575d47759c9bf3aaa37c19`.
+
+The artifact reports:
+
+- `dry_run = true`;
+- `read_only = true`;
+- `report_only = true`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_planned = 20`;
+- `identity_rows_written = 0`;
+- `max_rows = 20`;
+- `total_candidates_seen = 298177`;
+- `eligible_confirmed_candidates_seen = 261938`;
+- `planned_rows_count = 20`;
+- `eligible_beyond_max_rows = 261918`;
+- `source_only_no_canonical_station_match = 35981`;
+- `ambiguous_canonical_station_match = 258`;
+- `confirmed_candidate = 261938`;
+- `conflicting = 258`;
+- `proposed = 0`;
+- `rejected = 35981`.
+
+Post-checks recorded:
+
+- `station_external_identity` row count after artifact generation: `0`;
+- no identity rows loaded;
+- no station-type dry-run run;
+- no canonical apply run.
+
+## P12 Load-Plan Review Result
+
+The load-plan artifact is internally consistent as a bounded no-write review
+artifact:
+
+- it uses the expected versioned schema,
+  `station_external_identity_load_plan/v1`;
+- the artifact file checksum and internal integrity checksum are recorded;
+- the source scope matches the reviewed EDSM nightly station run/file keys;
+- the plan is capped at `20` rows;
+- the plan reports no identity rows written;
+- rejected/source-only rows remain excluded from planned confirmed identity;
+- ambiguous canonical station matches remain excluded from planned confirmed
+  identity;
+- no canonical station writes are planned;
+- no station-type writes are planned.
+
+The result is not an authorization to load identity evidence. It is only ready
+to produce a compact manual review packet for the exact planned rows.
+
+## Readiness Verdict
+
+`Ready only after planned-row manual review`
+
+The bounded load-plan artifact can be used as the input to an offline
+planned-row review packet. It does not authorize a controlled insert into
+`station_external_identity`.
+
+## P13 Review Packet Tool
+
+P13 adds:
+
+- `apps/importer/src/station_external_identity_review_packet.py`;
+- `scripts/operator/stage18j_run_identity_review_packet.sh`;
+- synthetic tests in
+  `tests/test_station_external_identity_review_packet.py`.
+
+The Python tool:
+
+- accepts `--load-plan-artifact`;
+- accepts `--expected-load-plan-sha256`;
+- accepts `--output`;
+- supports `--json`;
+- supports `--max-planned-rows`, defaulting to `20`;
+- refuses `--max-planned-rows` above `20`;
+- verifies the load-plan artifact file SHA-256 before parsing;
+- parses only local JSON;
+- never accepts `--dsn`;
+- rejects write/apply/load/commit flags;
+- emits deterministic JSON with schema
+  `station_external_identity_review_packet/v1`;
+- includes planned rows capped by `--max-planned-rows`;
+- includes one manual review item per included planned row;
+- defaults each review item and each row check to `needs_manual_review`;
+- keeps `canonical_writes_planned = 0`;
+- keeps `station_type_writes_planned = 0`;
+- keeps `identity_rows_written = 0`;
+- keeps `approval_record_created = false`.
+
+The generated packet is an offline manual review artifact. It is not a load
+artifact and it is not an approval record.
+
+## Planned Row Review Requirements
+
+Each planned row must be manually reviewed before any future controlled load
+tooling may use it.
+
+Required row checks:
+
+- confirm the planned `canonical_station_id` is the intended station for the
+  source `system_id64` and station-name evidence;
+- confirm at least one source external identifier is present,
+  `edsm_station_id` or `market_id`;
+- confirm `source_run_key`, `source_file_key`, and `source_record_hash` are
+  present and match the reviewed load plan;
+- confirm `identity_status = 'confirmed'`;
+- confirm `conflict_reason = null`;
+- confirm the row does not plan canonical writes;
+- confirm the row does not plan station-type writes;
+- confirm the row does not depend on internal `stations.id` as external
+  identity proof;
+- confirm the row does not use `station_body_links.market_id` as general
+  station identity proof.
+
+Rows that remain `needs_manual_review` are not loadable. Conflicting,
+ambiguous, rejected, or source-only rows remain blocked.
+
+## Operator Workflow
+
+After this PR merges, a future Hetzner operator action may run the offline
+review packet wrapper:
+
+```sh
+scripts/operator/stage18j_run_identity_review_packet.sh
+```
+
+The wrapper:
+
+- calls `scripts/operator/require_hetzner_operator_env.sh`;
+- defaults `ART_DIR` to
+  `/var/lib/ed-finder/operator-artifacts/stage-18j`;
+- defaults `LOAD_PLAN_ARTIFACT` to the reviewed P11 load-plan path;
+- requires the expected load-plan SHA-256
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- writes the review packet under the same artifact directory;
+- applies mode `600` to the output packet;
+- prints the packet path, output checksum, and compact summary fields.
+
+This wrapper does not source DB environment variables, does not connect to a
+database, and does not run imports, reconciliation, summarizer,
+station-type dry-run, identity load, approval-record creation, or canonical
+apply.
+
+## Safety Boundaries
+
+Safety boundaries for P12/P13:
+
+- no production commands from Codex;
+- no production DB access from Codex;
+- no identity evidence load;
+- no writes to `station_external_identity`;
+- no imports;
+- no reconciliation;
+- no summarizer run against production artifacts;
+- no station-type dry-run;
+- no canonical apply;
+- no approval record;
+- no Stage 18K work.
+
+The only future production action enabled by this repo work is a tiny
+Hetzner-only offline review-packet generation step after merge.
+
+## What This Does Not Approve
+
+P12/P13 does not approve:
+
+- loading the `20` planned rows;
+- loading all `261938` eligible confirmed candidates;
+- writing to `station_external_identity`;
+- treating `confirmed_candidate` as production-confirmed identity;
+- using identity candidates as station-type proof;
+- running reconciliation against production artifacts;
+- retrying station-type dry-run;
+- creating an approval record;
+- running canonical apply;
+- starting Stage 18K.
+
+## Required Future Load Boundaries
+
+A later controlled identity load stage, if approved separately, must:
+
+- consume only a manually reviewed packet;
+- require exact source artifact checksum verification;
+- require exact reviewed row identifiers/hashes;
+- enforce a small max-row bound;
+- write only to `station_external_identity`;
+- write no canonical station fields;
+- write no station-type fields;
+- run in a transaction;
+- report row counts before and after;
+- preserve source run/file/hash provenance;
+- create no approval record unless a separate approval stage explicitly
+  defines that record.
+
+No load stage may be combined with reconciliation, summarizer,
+station-type dry-run, or canonical apply.
+
+## Recommended Next Stages
+
+Recommended sequence after this PR:
+
+- run the P12/P13 review packet wrapper as a tiny Hetzner offline action;
+- manually review every planned row in the generated packet;
+- proceed to Chunk B / Stage 18J-P14 controlled identity load tooling only
+  after the planned-row review is accepted;
+- keep Chunk C, Chunk D, and Chunk E blocked until the controlled load is
+  separately implemented, run, and reviewed.
+
+## Final Recommendation
+
+Accept the bounded load-plan artifact only as input to offline planned-row
+manual review.
+
+Do not load identity evidence yet. Keep identity writes, station-type writes,
+canonical apply, approval-record creation, and Stage 18K blocked.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -765,6 +765,21 @@ actions. Never combine identity load with station-type dry-run, never combine
 station-type dry-run with canonical apply, and never run apply without a
 separate approval packet.
 
+Stage 18J-P12/P13 records the bounded no-write identity load-plan review and
+adds the offline planned-row review packet generator in
+`apps/importer/src/station_external_identity_review_packet.py`. The
+Hetzner-only wrapper is
+`scripts/operator/stage18j_run_identity_review_packet.sh`. It calls the
+operator environment guard, verifies the exact load-plan artifact SHA-256
+`3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`, writes
+the review packet under
+`/var/lib/ed-finder/operator-artifacts/stage-18j`, applies mode `600`, and
+prints the packet path, checksum, and summary fields. It does not source DB
+environment, connect to Postgres, load identity evidence, run imports,
+reconciliation, summarizer, station-type dry-run, approval-record creation, or
+canonical apply. The verdict remains
+`Ready only after planned-row manual review`.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/scripts/operator/stage18j_run_identity_review_packet.sh
+++ b/scripts/operator/stage18j_run_identity_review_packet.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +H
+
+ART_DIR="${ART_DIR:-/var/lib/ed-finder/operator-artifacts/stage-18j}"
+LOAD_PLAN_ARTIFACT="${LOAD_PLAN_ARTIFACT:-$ART_DIR/station_external_identity_load_plan_20260603T071913Z.json}"
+EXPECTED_LOAD_PLAN_SHA256="${EXPECTED_LOAD_PLAN_SHA256:-3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1}"
+MAX_PLANNED_ROWS="${MAX_PLANNED_ROWS:-20}"
+REVIEW_PACKET="${REVIEW_PACKET:-$ART_DIR/station_external_identity_review_packet_$(date -u +%Y%m%dT%H%M%SZ).json}"
+
+stop() {
+  printf 'STOP: %s\n' "$*" >&2
+  exit 1
+}
+
+REQUIRE_STAGE18J_ARTIFACT_DIR=yes ART_DIR="$ART_DIR" \
+  scripts/operator/require_hetzner_operator_env.sh
+
+if [[ "${MAX_PLANNED_ROWS}" == "" || ! "${MAX_PLANNED_ROWS}" =~ ^[0-9]+$ ]]; then
+  stop "MAX_PLANNED_ROWS must be a positive integer."
+fi
+
+if (( MAX_PLANNED_ROWS < 1 || MAX_PLANNED_ROWS > 20 )); then
+  stop "MAX_PLANNED_ROWS must be between 1 and 20 for Stage 18J-P12/P13 review."
+fi
+
+if [[ ! -s "$LOAD_PLAN_ARTIFACT" ]]; then
+  stop "load-plan artifact is missing or empty: $LOAD_PLAN_ARTIFACT"
+fi
+
+case "$LOAD_PLAN_ARTIFACT" in
+  "$ART_DIR"/*) ;;
+  *) stop "LOAD_PLAN_ARTIFACT must be read from ART_DIR: $ART_DIR" ;;
+esac
+
+case "$REVIEW_PACKET" in
+  "$ART_DIR"/*) ;;
+  *) stop "REVIEW_PACKET must be written under ART_DIR: $ART_DIR" ;;
+esac
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+  stop "sha256sum is required to verify the load-plan artifact."
+fi
+
+read -r actual_load_plan_sha _ < <(sha256sum "$LOAD_PLAN_ARTIFACT")
+if [[ "$actual_load_plan_sha" != "$EXPECTED_LOAD_PLAN_SHA256" ]]; then
+  stop "load-plan artifact checksum mismatch. Expected $EXPECTED_LOAD_PLAN_SHA256, got $actual_load_plan_sha"
+fi
+
+echo "== Stage 18J-P12/P13 identity review packet =="
+echo "OFFLINE REVIEW ONLY: no database connection, no identity load, no station-type dry-run, no canonical apply."
+echo "ART_DIR: $ART_DIR"
+echo "LOAD_PLAN_ARTIFACT: $LOAD_PLAN_ARTIFACT"
+echo "LOAD_PLAN_SHA256: $actual_load_plan_sha"
+echo "REVIEW_PACKET: $REVIEW_PACKET"
+echo "MAX_PLANNED_ROWS: $MAX_PLANNED_ROWS"
+
+python3 apps/importer/src/station_external_identity_review_packet.py \
+  --load-plan-artifact "$LOAD_PLAN_ARTIFACT" \
+  --expected-load-plan-sha256 "$EXPECTED_LOAD_PLAN_SHA256" \
+  --output "$REVIEW_PACKET" \
+  --max-planned-rows "$MAX_PLANNED_ROWS"
+
+chmod 600 "$REVIEW_PACKET"
+
+read -r review_packet_sha _ < <(sha256sum "$REVIEW_PACKET")
+
+echo "== Review packet file =="
+ls -lh "$REVIEW_PACKET"
+echo "review_packet_sha256: $review_packet_sha"
+
+echo "== Review packet summary =="
+python3 - "$REVIEW_PACKET" "$EXPECTED_LOAD_PLAN_SHA256" "$MAX_PLANNED_ROWS" <<'PY'
+import json
+import sys
+
+path, expected_source_sha, expected_max_rows = sys.argv[1:4]
+with open(path, encoding='utf-8') as handle:
+    payload = json.load(handle)
+
+summary = payload.get('summary') or {}
+source_artifact = payload.get('source_artifact') or {}
+source_scope = payload.get('source_scope') or {}
+
+checks = {
+    'schema_version': payload.get('schema_version') == 'station_external_identity_review_packet/v1',
+    'dry_run': payload.get('dry_run') is True,
+    'read_only': payload.get('read_only') is True,
+    'report_only': payload.get('report_only') is True,
+    'source_sha_matches': source_artifact.get('sha256') == expected_source_sha,
+    'max_planned_rows_matches': str(payload.get('max_planned_rows')) == str(expected_max_rows),
+    'canonical_writes_planned_zero': payload.get('canonical_writes_planned') == 0,
+    'station_type_writes_planned_zero': payload.get('station_type_writes_planned') == 0,
+    'identity_rows_written_zero': payload.get('identity_rows_written') == 0,
+    'approval_record_created_false': payload.get('approval_record_created') is False,
+}
+
+for name, ok in checks.items():
+    if not ok:
+        raise SystemExit(f'STOP: review packet validation failed: {name}')
+
+for key, value in (
+    ('schema_version', payload.get('schema_version')),
+    ('source_artifact_basename', source_artifact.get('basename')),
+    ('source_artifact_sha256', source_artifact.get('sha256')),
+    ('source_artifact_integrity_sha256', source_artifact.get('artifact_integrity_sha256')),
+    ('source_run_key', source_scope.get('source_run_key')),
+    ('source_file_key', source_scope.get('source_file_key')),
+    ('total_candidates_seen', source_scope.get('total_candidates_seen')),
+    ('eligible_confirmed_candidates_seen', source_scope.get('eligible_confirmed_candidates_seen')),
+    ('source_planned_rows_count', source_scope.get('source_planned_rows_count')),
+    ('planned_rows_included', summary.get('planned_rows_included')),
+    ('manual_review_items_count', summary.get('manual_review_items_count')),
+    ('manual_review_status_counts', json.dumps(summary.get('manual_review_status_counts') or {}, sort_keys=True)),
+    ('canonical_writes_planned', payload.get('canonical_writes_planned')),
+    ('station_type_writes_planned', payload.get('station_type_writes_planned')),
+    ('identity_rows_written', payload.get('identity_rows_written')),
+    ('approval_record_created', payload.get('approval_record_created')),
+):
+    print(f'{key}: {value}')
+PY
+
+echo "== Secret/path sanity check =="
+sensitive_pattern='postgre''sql://|post''gres://|pass''word=|PG''PASSWORD|SEC''RET|TOK''EN'
+if grep -Eq "$sensitive_pattern" "$REVIEW_PACKET"; then
+  stop "review packet may contain credentials. Review the operator artifact out of band; do not commit it."
+fi
+echo "OK: no obvious credential markers found"
+
+echo "OK: Stage 18J-P12/P13 review packet generated."
+echo "OK: offline review only; no DB access, no identity load, no imports, no reconciliation, no summarizer, no station-type dry-run, no approval record, and no canonical apply."

--- a/tests/test_station_external_identity_review_packet.py
+++ b/tests/test_station_external_identity_review_packet.py
@@ -1,0 +1,243 @@
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_external_identity_review_packet as review_packet  # noqa: E402
+
+
+def planned_row(index: int) -> dict[str, object]:
+    return {
+        'plan_row_id': f'plan-row-{index}',
+        'candidate_id': f'candidate-{index}',
+        'canonical_station_id': 2000 + index,
+        'system_id64': 420000 + index,
+        'station_name': f'Test Port {index}',
+        'source': 'edsm_nightly_stations',
+        'market_id': None,
+        'edsm_station_id': 1000 + index,
+        'source_run_key': 'run-key',
+        'source_file_key': 'file-key',
+        'source_record_hash': f'source-hash-{index}',
+        'source_updated_at': '2026-01-02T00:00:00Z',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'identity_status': 'confirmed',
+        'conflict_reason': None,
+        'match_basis': 'system_id64_normalized_station_name',
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_written': 0,
+    }
+
+
+def load_plan_artifact(rows: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        'schema_version': 'station_external_identity_load_plan/v1',
+        'generated_at': '2026-01-02T00:00:00Z',
+        'tool': {
+            'name': 'station_external_identity_load_plan',
+            'version': 'v1',
+        },
+        'dry_run': True,
+        'read_only': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_planned': len(rows),
+        'identity_rows_written': 0,
+        'max_rows': 20,
+        'filters': {
+            'source': 'edsm_nightly_stations',
+            'source_run_key': 'run-key',
+            'source_file_key': 'file-key',
+            'sample_limit': 20,
+        },
+        'summary': {
+            'total_candidates_seen': 298177,
+            'eligible_confirmed_candidates_seen': 261938,
+            'planned_rows_count': len(rows),
+            'candidate_status_counts': {
+                'proposed': 0,
+                'confirmed_candidate': 261938,
+                'conflicting': 258,
+                'rejected': 35981,
+            },
+            'skipped_reason_counts': {
+                'eligible_beyond_max_rows': 261918,
+                'source_only_no_canonical_station_match': 35981,
+                'ambiguous_canonical_station_match': 258,
+            },
+            'rejected_reason_counts': {
+                'source_only_no_canonical_station_match': 35981,
+            },
+            'conflicting_reason_counts': {
+                'ambiguous_canonical_station_match': 258,
+            },
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': 0,
+        },
+        'planned_rows': rows,
+        'artifact_integrity': {
+            'hash_algorithm': 'sha256',
+            'canonical_json_sha256': 'internal-integrity-sha',
+        },
+    }
+
+
+def write_load_plan(tmp_path: Path, artifact: dict[str, object]) -> tuple[Path, str]:
+    path = tmp_path / 'load-plan.json'
+    payload = json.dumps(artifact, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+    path.write_text(payload + '\n', encoding='utf-8')
+    return path, hashlib.sha256((payload + '\n').encode('utf-8')).hexdigest()
+
+
+def test_review_packet_verifies_source_artifact_sha(tmp_path):
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+
+    assert artifact['schema_version'] == 'station_external_identity_review_packet/v1'
+    assert artifact['source_artifact']['sha256'] == expected_sha
+    assert artifact['source_artifact']['basename'] == 'load-plan.json'
+    assert artifact['source_artifact']['artifact_integrity_sha256'] == 'internal-integrity-sha'
+
+
+def test_checksum_mismatch_fails(tmp_path):
+    path, _expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    with pytest.raises(review_packet.IdentityReviewPacketError, match='checksum mismatch'):
+        review_packet.build_review_packet_from_file(path, expected_load_plan_sha256='0' * 64)
+
+
+def test_missing_artifact_fails(tmp_path):
+    missing_path = tmp_path / 'missing.json'
+
+    with pytest.raises(review_packet.IdentityReviewPacketError, match='missing'):
+        review_packet.build_review_packet_from_file(missing_path, expected_load_plan_sha256='0' * 64)
+
+
+def test_max_planned_rows_over_20_fails():
+    with pytest.raises(SystemExit):
+        review_packet.parse_args([
+            '--load-plan-artifact',
+            'load-plan.json',
+            '--expected-load-plan-sha256',
+            '0' * 64,
+            '--max-planned-rows',
+            '21',
+        ])
+
+
+def test_dsn_is_rejected():
+    with pytest.raises(SystemExit):
+        review_packet.parse_args([
+            '--load-plan-artifact',
+            'load-plan.json',
+            '--expected-load-plan-sha256',
+            '0' * 64,
+            '--dsn',
+            'not-accepted',
+        ])
+
+
+@pytest.mark.parametrize('flag', ['--apply', '--write', '--write-staging', '--load', '--commit'])
+def test_write_apply_load_commit_flags_are_rejected(flag):
+    with pytest.raises(SystemExit):
+        review_packet.parse_args([
+            '--load-plan-artifact',
+            'load-plan.json',
+            '--expected-load-plan-sha256',
+            '0' * 64,
+            flag,
+        ])
+
+
+def test_planned_rows_are_capped(tmp_path):
+    rows = [planned_row(1), planned_row(2), planned_row(3)]
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact(rows))
+
+    artifact = review_packet.build_review_packet_from_file(
+        path,
+        expected_load_plan_sha256=expected_sha,
+        max_planned_rows=2,
+    )
+
+    assert artifact['identity_rows_planned'] == 2
+    assert artifact['summary']['planned_rows_available'] == 3
+    assert artifact['summary']['planned_rows_included'] == 2
+    assert artifact['summary']['planned_rows_capped'] is True
+    assert [row['plan_row_id'] for row in artifact['planned_rows']] == ['plan-row-1', 'plan-row-2']
+
+
+def test_review_items_default_to_needs_manual_review(tmp_path):
+    rows = [planned_row(1), planned_row(2)]
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact(rows))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+
+    assert artifact['summary']['manual_review_status_counts'] == {'needs_manual_review': 2}
+    for item in artifact['manual_review_items']:
+        assert item['review_status'] == 'needs_manual_review'
+        for check in item['review_checks']:
+            assert check['review_status'] == 'needs_manual_review'
+
+
+def test_review_checks_are_populated_correctly(tmp_path):
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+    review_item = artifact['manual_review_items'][0]
+
+    assert review_item['planned_row_index'] == 1
+    assert review_item['plan_row_id'] == 'plan-row-1'
+    assert review_item['candidate_id'] == 'candidate-1'
+    assert review_item['canonical_station_id'] == 2001
+    assert review_item['source_record_hash'] == 'source-hash-1'
+    assert [check['check_id'] for check in review_item['review_checks']] == [
+        'canonical_station_match',
+        'external_identifier_present',
+        'source_provenance_present',
+        'identity_status_confirmed_only',
+        'no_station_type_or_canonical_write',
+    ]
+
+
+def test_safety_fields_remain_zero_or_false(tmp_path):
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+
+    assert artifact['canonical_writes_planned'] == 0
+    assert artifact['station_type_writes_planned'] == 0
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['approval_record_created'] is False
+    assert artifact['summary']['canonical_writes_planned'] == 0
+    assert artifact['summary']['station_type_writes_planned'] == 0
+    assert artifact['summary']['identity_rows_written'] == 0
+    assert artifact['summary']['approval_record_created'] is False
+    assert artifact['safety_boundaries']['db_connections_allowed'] is False
+    assert artifact['safety_boundaries']['canonical_apply_allowed'] is False
+
+
+def test_deterministic_json_output(tmp_path):
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    first = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+    second = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+    first_json = review_packet.json_dumps_artifact(first)
+    second_json = review_packet.json_dumps_artifact(second)
+
+    assert first_json == second_json
+    assert json.loads(first_json) == first
+    assert '\n' not in first_json
+    assert first['artifact_integrity']['canonical_json_sha256']


### PR DESCRIPTION
## What changed

* Records the bounded load-plan review.
* Adds offline planned-row review packet tooling.
* Adds Hetzner-only operator script.
* Requires source artifact checksum verification.
* Requires manual review before any identity load.
* Keeps identity writes blocked.
* Keeps station-type writes blocked.
* Adds tests and docs.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No identity evidence loaded.
* No writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

```text
git diff --check
(no output; exit 0)

git diff --cached --check
(no output; exit 0)

bash -n scripts/operator/require_hetzner_operator_env.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_compact_summary.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_identity_review_packet.sh
(no output; exit 0)

./scripts/run_canonical_safety_tests.sh
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py -q
........................................................................ [ 47%]
........................................................................ [ 95%]
.......                                                                  [100%]
151 passed in 0.23s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py apps/importer/src/station_external_identity_review_packet.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py
(no output; exit 0)

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' apps/importer/src/station_external_identity_review_packet.py apps/importer/src/station_external_identity_load_plan.py scripts/operator/stage18j_run_identity_review_packet.sh docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md docs/colonisation-redesign/stage-18j-p11-bounded-external-identity-load-plan-artifact.md docs/colonisation-redesign/stage-18j-p10-external-identity-candidate-artifact-review.md docs/colonisation-redesign/enrichment-roadmap.md docs/operations/enrichment-warehouse-runbook.md docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
(no matches; grep exit 1, equivalent to requested scan with `|| true`)
```