### PR TITLE
Stage 18J-P13A review packet contract hardening

### DIFF
--- a/apps/importer/src/station_external_identity_review_packet.py
+++ b/apps/importer/src/station_external_identity_review_packet.py
@@ -24,27 +24,17 @@ TOOL_VERSION = 'v1'
 MAX_PLANNED_ROWS_CAP = 20
 WRITE_FLAG_ERROR = 'write/apply/load/commit flags are not available; this tool only emits an offline review packet'
 MANUAL_REVIEW_STATUS = 'needs_manual_review'
-REVIEW_CHECKS: tuple[tuple[str, str], ...] = (
-    (
-        'canonical_station_match',
-        'Confirm the planned canonical_station_id is the intended station for the source system/name evidence.',
-    ),
-    (
-        'external_identifier_present',
-        'Confirm the planned row has at least one source external identifier, edsm_station_id or market_id.',
-    ),
-    (
-        'source_provenance_present',
-        'Confirm source_run_key, source_file_key, and source_record_hash are present and match the reviewed load plan.',
-    ),
-    (
-        'identity_status_confirmed_only',
-        "Confirm identity_status is 'confirmed' and conflict_reason is null for this bounded row.",
-    ),
-    (
-        'no_station_type_or_canonical_write',
-        'Confirm the row does not plan station_type writes, canonical writes, imports, reconciliation, or apply.',
-    ),
+REVIEW_CHECK_KEYS: tuple[str, ...] = (
+    'canonical_station_id_present',
+    'system_id64_present',
+    'station_name_present',
+    'source_run_key_present',
+    'source_file_key_present',
+    'source_record_hash_present',
+    'external_id_present',
+    'identity_status_is_confirmed',
+    'conflict_reason_is_null',
+    'station_type_write_not_planned',
 )
 
 
@@ -216,6 +206,7 @@ def build_review_packet(
         'summary': {
             'planned_rows_available': len(planned_rows_raw),
             'planned_rows_included': len(planned_rows),
+            'planned_rows_count': len(planned_rows),
             'planned_rows_capped': len(planned_rows_raw) > len(planned_rows),
             'manual_review_items_count': len(manual_review_items),
             'manual_review_status_counts': {MANUAL_REVIEW_STATUS: len(manual_review_items)},
@@ -264,7 +255,7 @@ def _manual_review_item(
     source_artifact_sha256: str,
 ) -> dict[str, Any]:
     row = _json_clone(planned_row)
-    item = {
+    return {
         'review_item_id': hashlib.sha256(
             canonical_json([
                 'station_external_identity_review_packet_item',
@@ -275,21 +266,27 @@ def _manual_review_item(
             ]).encode('utf-8'),
         ).hexdigest(),
         'planned_row_index': index,
-        'plan_row_id': row.get('plan_row_id'),
-        'candidate_id': row.get('candidate_id'),
-        'canonical_station_id': row.get('canonical_station_id'),
-        'source_record_hash': row.get('source_record_hash'),
         'review_status': MANUAL_REVIEW_STATUS,
-        'review_checks': [
-            {
-                'check_id': check_id,
-                'prompt': prompt,
-                'review_status': MANUAL_REVIEW_STATUS,
-            }
-            for check_id, prompt in REVIEW_CHECKS
-        ],
+        'planned_row': row,
+        'checks': _planned_row_checks(row),
+        'reviewer_notes': None,
     }
-    return item
+
+
+def _planned_row_checks(row: Mapping[str, Any]) -> dict[str, bool]:
+    checks = {
+        'canonical_station_id_present': row.get('canonical_station_id') is not None,
+        'system_id64_present': row.get('system_id64') is not None,
+        'station_name_present': bool(row.get('station_name')),
+        'source_run_key_present': bool(row.get('source_run_key')),
+        'source_file_key_present': bool(row.get('source_file_key')),
+        'source_record_hash_present': bool(row.get('source_record_hash')),
+        'external_id_present': row.get('market_id') is not None or row.get('edsm_station_id') is not None,
+        'identity_status_is_confirmed': row.get('identity_status') == 'confirmed',
+        'conflict_reason_is_null': row.get('conflict_reason') is None,
+        'station_type_write_not_planned': row.get('station_type_writes_planned') == 0,
+    }
+    return {key: bool(checks[key]) for key in REVIEW_CHECK_KEYS}
 
 
 def _assert_load_plan_is_no_write(load_plan: Mapping[str, Any]) -> None:

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -671,6 +671,14 @@ no DSN, caps planned rows at `20`, and defaults every row review item to
 `Ready only after planned-row manual review`. See
 [`stage-18j-p12-p13-load-plan-review-packet.md`](./stage-18j-p12-p13-load-plan-review-packet.md).
 
+Stage 18J-P13A fixes the P12/P13 review packet contract after the first
+offline Hetzner packet proved safe but not human-reviewable enough. Each
+`manual_review_items` entry now embeds the full planned row, boolean review
+checks, and `reviewer_notes = null`, while the top-level `planned_rows` list
+remains for convenience and must match the embedded rows exactly. The wrapper
+prints and validates these contract fields before declaring the packet
+generated.
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -777,6 +785,10 @@ treated as a separate proposal.
   the bounded load-plan review and adds an offline packet generator for manual
   review of the `20` planned rows. It writes no identity rows and keeps
   station-type dry-run and canonical apply blocked.
+* **External identity review packet contract hardening**: Stage 18J-P13A makes
+  manual review items self-contained with embedded planned rows and boolean
+  checks, then requires a future offline packet rerun before planned rows can
+  be reviewed.
 * **External identity follow-up sequence**: use the execution board for Chunk A
   P12/P13 review pack, Chunk B P14 controlled identity load tooling, Chunk C
   P15 post-load identity coverage, Chunk D P16 read-only reconciliation

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -1291,6 +1291,41 @@ Non-goals:
 Support doc:
 `stage-18j-p12-p13-load-plan-review-packet.md`.
 
+### Stage 18J-P13A - Review Packet Contract Hardening
+
+Purpose: fix the P12/P13 offline review packet contract so manual review items
+are self-contained and human-reviewable.
+
+Scope:
+
+- Record that the first Hetzner offline review-packet run completed safely but
+  had insufficient `manual_review_items` structure for row review.
+- Keep `station_external_identity_review_packet/v1` as the packet schema.
+- Embed the exact planned row inside each `manual_review_items` entry.
+- Add a non-empty boolean `checks` object to each manual review item.
+- Add `reviewer_notes = null`.
+- Keep the top-level `planned_rows` list and require it to match embedded
+  manual review rows exactly.
+- Harden the operator wrapper summary so it validates and prints planned row
+  count, manual review item count, and first-item planned-row/check presence.
+- Add regression tests for embedded row/check fields, safety fields,
+  deterministic JSON, checksum failures, max-row caps, write/load refusal, and
+  no DSN acceptance.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No identity evidence load.
+- No writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p12-p13-load-plan-review-packet.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1379,9 +1414,10 @@ Do not add another large planner feature immediately. The healthiest next sequen
 41. Stage 18J-P11 bounded external identity load-plan artifact, no DB writes.
 42. Stage 18J-P-OPT identity evidence execution board.
 43. Stage 18J-P12/P13 load-plan review packet, no DB writes.
-44. Chunk B: Stage 18J-P14 controlled identity load tooling.
-45. Chunk C: Stage 18J-P15 post-load identity coverage.
-46. Chunk D: Stage 18J-P16 reconciliation integration with confirmed identity.
-47. Chunk E: Stage 18J-P17 retry strict station-type dry-run.
+44. Stage 18J-P13A review packet contract hardening, no DB writes.
+45. Chunk B: Stage 18J-P14 controlled identity load tooling.
+46. Chunk C: Stage 18J-P15 post-load identity coverage.
+47. Chunk D: Stage 18J-P16 reconciliation integration with confirmed identity.
+48. Chunk E: Stage 18J-P17 retry strict station-type dry-run.
 
 This keeps ED-Finder moving toward a genuinely intelligent colony planner while protecting the trust boundaries that make the tool useful. The warehouse should become observable, explainable, and storage-isolated before it becomes a canonical write source.

--- a/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
+++ b/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
@@ -35,6 +35,10 @@ Known state:
 - Stage 18J-P12/P13 records the bounded load-plan artifact review and adds an
   offline planned-row review packet generator.
 - Stage 18J-P12/P13 verdict: `Ready only after planned-row manual review`.
+- The first Hetzner offline review-packet run completed safely but exposed a
+  packet contract issue: `manual_review_items` were not self-contained enough
+  for manual row review. Stage 18J-P13A hardens the contract so each item
+  embeds `planned_row`, boolean `checks`, and `reviewer_notes = null`.
 - Stage 18K remains untouched.
 
 ## Why We Are Optimising
@@ -113,6 +117,8 @@ Exit criteria:
 
 - exact load-plan artifact path and checksum recorded;
 - each of the `20` planned rows can be inspected in a compact review packet;
+- every manual review item embeds the exact planned row being reviewed;
+- every manual review item embeds non-empty boolean review checks;
 - every review item defaults to `needs_manual_review`;
 - rejected/source-only and ambiguous rows remain non-loadable;
 - `identity_rows_written = 0`;

--- a/docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md
+++ b/docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md
@@ -112,7 +112,9 @@ The Python tool:
   `station_external_identity_review_packet/v1`;
 - includes planned rows capped by `--max-planned-rows`;
 - includes one manual review item per included planned row;
-- defaults each review item and each row check to `needs_manual_review`;
+- makes each manual review item self-contained with `planned_row`, `checks`,
+  and `reviewer_notes = null`;
+- defaults each review item to `needs_manual_review`;
 - keeps `canonical_writes_planned = 0`;
 - keeps `station_type_writes_planned = 0`;
 - keeps `identity_rows_written = 0`;
@@ -120,6 +122,71 @@ The Python tool:
 
 The generated packet is an offline manual review artifact. It is not a load
 artifact and it is not an approval record.
+
+## P13A Review Packet Contract Hardening
+
+The first Hetzner offline review-packet run completed safely:
+
+- review packet:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_review_packet_20260603T103130Z.json`;
+- review packet SHA-256:
+  `6b2415ef4f12a0f81808f90a9eb592d18269e181660e7cbd9fe597e63cc18705`;
+- source load-plan artifact:
+  `station_external_identity_load_plan_20260603T071913Z.json`;
+- source load-plan SHA-256:
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- `planned_rows_included = 20`;
+- `manual_review_items_count = 20`;
+- `manual_review_status_counts = {"needs_manual_review": 20}`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_written = 0`;
+- `approval_record_created = false`;
+- no database access;
+- no identity load;
+- no station-type dry-run;
+- no canonical apply.
+
+Manual inspection found that the safety fields were correct but
+`manual_review_items` were not self-contained enough for human review:
+
+- `manual_review_items` existed and had length `20`;
+- top-level `planned_rows` existed and had length `20`;
+- each `manual_review_items[n].planned_row` was missing or null in the
+  inspection contract;
+- each `manual_review_items[n].checks` was empty in the inspection contract.
+
+Stage 18J-P13A fixes the packet contract. Each item in
+`manual_review_items` must include:
+
+- `review_item_id`;
+- `review_status = "needs_manual_review"`;
+- `planned_row`;
+- `checks`;
+- `reviewer_notes = null`.
+
+The nested `planned_row` must include the planned identity row fields needed
+for review, including canonical station ID, source system/station, source,
+external IDs, source run/file/hash provenance, confidence, freshness class,
+identity status, and conflict reason. The top-level `planned_rows` list remains
+for convenience and must exactly match the rows embedded in
+`manual_review_items`.
+
+The nested `checks` object must include boolean fields for:
+
+- `canonical_station_id_present`;
+- `system_id64_present`;
+- `station_name_present`;
+- `source_run_key_present`;
+- `source_file_key_present`;
+- `source_record_hash_present`;
+- `external_id_present`;
+- `identity_status_is_confirmed`;
+- `conflict_reason_is_null`;
+- `station_type_write_not_planned`.
+
+The P13A fix does not approve a load. It only makes a future offline review
+packet rerun suitable for manual row inspection.
 
 ## Planned Row Review Requirements
 
@@ -165,7 +232,9 @@ The wrapper:
   `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
 - writes the review packet under the same artifact directory;
 - applies mode `600` to the output packet;
-- prints the packet path, output checksum, and compact summary fields.
+- prints the packet path, output checksum, compact summary fields, planned row
+  count, manual review item count, and whether the first review item has
+  non-empty `planned_row` and `checks` objects.
 
 This wrapper does not source DB environment variables, does not connect to a
 database, and does not run imports, reconciliation, summarizer,

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -780,6 +780,17 @@ reconciliation, summarizer, station-type dry-run, approval-record creation, or
 canonical apply. The verdict remains
 `Ready only after planned-row manual review`.
 
+Stage 18J-P13A hardens that review packet contract after the first offline
+Hetzner packet showed correct safety fields but non-self-contained
+`manual_review_items`. New packets must keep top-level `planned_rows` and must
+also embed the exact planned row plus non-empty boolean `checks` inside each
+manual review item. The wrapper summary now validates and prints the planned
+row count, manual review item count, and whether the first review item has
+`planned_row` and `checks`. After P13A merges, rerun only the offline guarded
+review-packet wrapper; do not load identity evidence or run reconciliation,
+summarizer, station-type dry-run, approval-record creation, or canonical
+apply.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/scripts/operator/stage18j_run_identity_review_packet.sh
+++ b/scripts/operator/stage18j_run_identity_review_packet.sh
@@ -81,21 +81,35 @@ with open(path, encoding='utf-8') as handle:
 summary = payload.get('summary') or {}
 source_artifact = payload.get('source_artifact') or {}
 source_scope = payload.get('source_scope') or {}
+planned_rows = payload.get('planned_rows') or []
+manual_review_items = payload.get('manual_review_items') or []
+embedded_planned_rows = [
+    item.get('planned_row') if isinstance(item, dict) else None
+    for item in manual_review_items
+]
+first_review_item = manual_review_items[0] if manual_review_items else {}
+first_planned_row = first_review_item.get('planned_row') if isinstance(first_review_item, dict) else None
+first_checks = first_review_item.get('checks') if isinstance(first_review_item, dict) else None
 
-checks = {
+validation_checks = {
     'schema_version': payload.get('schema_version') == 'station_external_identity_review_packet/v1',
     'dry_run': payload.get('dry_run') is True,
     'read_only': payload.get('read_only') is True,
     'report_only': payload.get('report_only') is True,
     'source_sha_matches': source_artifact.get('sha256') == expected_source_sha,
     'max_planned_rows_matches': str(payload.get('max_planned_rows')) == str(expected_max_rows),
+    'manual_review_items_count_matches': summary.get('manual_review_items_count') == len(manual_review_items),
+    'planned_rows_count_matches': summary.get('planned_rows_count') == len(planned_rows),
+    'review_items_match_planned_rows': embedded_planned_rows == planned_rows,
+    'first_review_item_has_planned_row': isinstance(first_planned_row, dict) and bool(first_planned_row),
+    'first_review_item_has_non_empty_checks': isinstance(first_checks, dict) and bool(first_checks),
     'canonical_writes_planned_zero': payload.get('canonical_writes_planned') == 0,
     'station_type_writes_planned_zero': payload.get('station_type_writes_planned') == 0,
     'identity_rows_written_zero': payload.get('identity_rows_written') == 0,
     'approval_record_created_false': payload.get('approval_record_created') is False,
 }
 
-for name, ok in checks.items():
+for name, ok in validation_checks.items():
     if not ok:
         raise SystemExit(f'STOP: review packet validation failed: {name}')
 
@@ -109,9 +123,12 @@ for key, value in (
     ('total_candidates_seen', source_scope.get('total_candidates_seen')),
     ('eligible_confirmed_candidates_seen', source_scope.get('eligible_confirmed_candidates_seen')),
     ('source_planned_rows_count', source_scope.get('source_planned_rows_count')),
+    ('planned_rows_count', summary.get('planned_rows_count')),
     ('planned_rows_included', summary.get('planned_rows_included')),
     ('manual_review_items_count', summary.get('manual_review_items_count')),
     ('manual_review_status_counts', json.dumps(summary.get('manual_review_status_counts') or {}, sort_keys=True)),
+    ('first_review_item_has_planned_row', isinstance(first_planned_row, dict) and bool(first_planned_row)),
+    ('first_review_item_has_non_empty_checks', isinstance(first_checks, dict) and bool(first_checks)),
     ('canonical_writes_planned', payload.get('canonical_writes_planned')),
     ('station_type_writes_planned', payload.get('station_type_writes_planned')),
     ('identity_rows_written', payload.get('identity_rows_written')),

--- a/tests/test_station_external_identity_review_packet.py
+++ b/tests/test_station_external_identity_review_packet.py
@@ -14,6 +14,37 @@ if str(IMPORTER_SRC) not in sys.path:
 import station_external_identity_review_packet as review_packet  # noqa: E402
 
 
+REQUIRED_PLANNED_ROW_FIELDS = {
+    'canonical_station_id',
+    'system_id64',
+    'station_name',
+    'source',
+    'market_id',
+    'edsm_station_id',
+    'source_run_key',
+    'source_file_key',
+    'source_record_hash',
+    'source_updated_at',
+    'confidence',
+    'freshness_class',
+    'identity_status',
+    'conflict_reason',
+}
+
+REQUIRED_CHECK_FIELDS = {
+    'canonical_station_id_present',
+    'system_id64_present',
+    'station_name_present',
+    'source_run_key_present',
+    'source_file_key_present',
+    'source_record_hash_present',
+    'external_id_present',
+    'identity_status_is_confirmed',
+    'conflict_reason_is_null',
+    'station_type_write_not_planned',
+}
+
+
 def planned_row(index: int) -> dict[str, object]:
     return {
         'plan_row_id': f'plan-row-{index}',
@@ -177,6 +208,7 @@ def test_planned_rows_are_capped(tmp_path):
     assert artifact['summary']['planned_rows_included'] == 2
     assert artifact['summary']['planned_rows_capped'] is True
     assert [row['plan_row_id'] for row in artifact['planned_rows']] == ['plan-row-1', 'plan-row-2']
+    assert len(artifact['manual_review_items']) == 2
 
 
 def test_review_items_default_to_needs_manual_review(tmp_path):
@@ -188,28 +220,74 @@ def test_review_items_default_to_needs_manual_review(tmp_path):
     assert artifact['summary']['manual_review_status_counts'] == {'needs_manual_review': 2}
     for item in artifact['manual_review_items']:
         assert item['review_status'] == 'needs_manual_review'
-        for check in item['review_checks']:
-            assert check['review_status'] == 'needs_manual_review'
+        assert item['reviewer_notes'] is None
 
 
-def test_review_checks_are_populated_correctly(tmp_path):
+def test_each_manual_review_item_embeds_planned_row_and_checks(tmp_path):
     path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
 
     artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
     review_item = artifact['manual_review_items'][0]
 
     assert review_item['planned_row_index'] == 1
-    assert review_item['plan_row_id'] == 'plan-row-1'
-    assert review_item['candidate_id'] == 'candidate-1'
-    assert review_item['canonical_station_id'] == 2001
-    assert review_item['source_record_hash'] == 'source-hash-1'
-    assert [check['check_id'] for check in review_item['review_checks']] == [
-        'canonical_station_match',
-        'external_identifier_present',
-        'source_provenance_present',
-        'identity_status_confirmed_only',
-        'no_station_type_or_canonical_write',
-    ]
+    assert review_item['planned_row']
+    assert review_item['planned_row'] == artifact['planned_rows'][0]
+    assert review_item['checks']
+    assert set(review_item['checks']) == REQUIRED_CHECK_FIELDS
+    assert all(isinstance(value, bool) for value in review_item['checks'].values())
+
+
+def test_planned_row_embedded_in_review_item_contains_reviewable_identity_fields(tmp_path):
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+    row = artifact['manual_review_items'][0]['planned_row']
+
+    assert REQUIRED_PLANNED_ROW_FIELDS <= set(row)
+    assert row['canonical_station_id'] == 2001
+    assert row['system_id64'] == 420001
+    assert row['station_name'] == 'Test Port 1'
+    assert row['source'] == 'edsm_nightly_stations'
+    assert row['edsm_station_id'] == 1001
+    assert row['source_run_key'] == 'run-key'
+    assert row['source_file_key'] == 'file-key'
+    assert row['source_record_hash'] == 'source-hash-1'
+    assert row['confidence'] == 'source_station_snapshot'
+    assert row['freshness_class'] == 'source_updated_at'
+    assert row['identity_status'] == 'confirmed'
+    assert row['conflict_reason'] is None
+
+
+def test_review_checks_are_populated_correctly(tmp_path):
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact([planned_row(1)]))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+    checks = artifact['manual_review_items'][0]['checks']
+
+    assert checks == {
+        'canonical_station_id_present': True,
+        'system_id64_present': True,
+        'station_name_present': True,
+        'source_run_key_present': True,
+        'source_file_key_present': True,
+        'source_record_hash_present': True,
+        'external_id_present': True,
+        'identity_status_is_confirmed': True,
+        'conflict_reason_is_null': True,
+        'station_type_write_not_planned': True,
+    }
+
+
+def test_top_level_planned_rows_match_embedded_manual_review_rows(tmp_path):
+    rows = [planned_row(1), planned_row(2)]
+    path, expected_sha = write_load_plan(tmp_path, load_plan_artifact(rows))
+
+    artifact = review_packet.build_review_packet_from_file(path, expected_load_plan_sha256=expected_sha)
+    embedded_rows = [item['planned_row'] for item in artifact['manual_review_items']]
+
+    assert len(artifact['planned_rows']) == len(artifact['manual_review_items'])
+    assert artifact['summary']['planned_rows_count'] == 2
+    assert embedded_rows == artifact['planned_rows']
 
 
 def test_safety_fields_remain_zero_or_false(tmp_path):


### PR DESCRIPTION
## What changed

* Fixes/hardens the review packet contract.
* Makes every manual review item self-contained with planned_row and checks.
* Updates wrapper summary checks.
* Adds regression tests for planned row/check embedding.
* Keeps identity writes blocked.
* Keeps station-type writes blocked.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No identity evidence loaded.
* No writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created.
* Stage 18K not started.

## Validation

```text
git diff --check
(no output; exit 0)

bash -n scripts/operator/require_hetzner_operator_env.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_compact_summary.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_identity_review_packet.sh
(no output; exit 0)

./scripts/run_canonical_safety_tests.sh
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py -q
........................................................................ [ 46%]
........................................................................ [ 93%]
..........                                                               [100%]
154 passed in 0.21s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py apps/importer/src/station_external_identity_review_packet.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py
(no output; exit 0)

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' apps/importer/src/station_external_identity_review_packet.py scripts/operator/stage18j_run_identity_review_packet.sh docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md docs/operations/enrichment-warehouse-runbook.md docs/colonisation-redesign/enrichment-roadmap.md docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
(no matches; grep exit 1, equivalent to requested scan with `|| true`)
```
