### PR TITLE
Stage 18J-P14 controlled external identity load tooling

### DIFF
--- a/apps/importer/src/station_external_identity_loader.py
+++ b/apps/importer/src/station_external_identity_loader.py
@@ -1,0 +1,606 @@
+#!/usr/bin/env python3
+"""Controlled external station identity loader and dry-run planner.
+
+The dry-run mode validates a local review packet and emits a compact execution
+plan without opening a database connection. The write-reviewed mode requires a
+separate approval allowlist artifact and writes only allowlisted rows to
+``station_external_identity``.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 'station_external_identity_load_execution_plan/v1'
+REVIEW_PACKET_SCHEMA_VERSION = 'station_external_identity_review_packet/v1'
+APPROVAL_ALLOWLIST_SCHEMA_VERSION = 'station_external_identity_load_approval_allowlist/v1'
+TOOL_NAME = 'station_external_identity_loader'
+TOOL_VERSION = 'v1'
+MAX_ROWS_CAP = 20
+REQUIRED_CHECK_KEYS = (
+    'canonical_station_id_present',
+    'system_id64_present',
+    'station_name_present',
+    'source_run_key_present',
+    'source_file_key_present',
+    'source_record_hash_present',
+    'external_id_present',
+    'identity_status_is_confirmed',
+    'conflict_reason_is_null',
+    'station_type_write_not_planned',
+)
+PLANNED_ROW_INSERT_COLUMNS = (
+    'canonical_station_id',
+    'system_id64',
+    'station_name',
+    'source',
+    'market_id',
+    'edsm_station_id',
+    'source_run_key',
+    'source_file_key',
+    'source_record_hash',
+    'source_updated_at',
+    'confidence',
+    'freshness_class',
+    'identity_status',
+    'conflict_reason',
+)
+FORBIDDEN_FLAG_ERROR = (
+    'write/apply/import/reconciliation/summarizer/station-type flags are not available; '
+    'use --dry-run or --write-reviewed only'
+)
+
+
+class IdentityLoaderError(ValueError):
+    """Raised when a review packet cannot be loaded safely."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Validate or load reviewed external station identity rows.',
+    )
+    parser.add_argument('--review-packet', required=True, help='Local station_external_identity_review_packet/v1 JSON file.')
+    parser.add_argument('--expected-review-packet-sha256', required=True, help='Expected SHA-256 of the review packet file.')
+    parser.add_argument('--dsn', required=True, help='Database DSN. Dry-run mode accepts this but does not connect.')
+    parser.add_argument('--max-rows', type=int, required=True, help=f'Maximum selected rows, maximum {MAX_ROWS_CAP}.')
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument('--dry-run', action='store_true', help='Validate and emit a load execution plan without DB writes.')
+    mode.add_argument('--write-reviewed', action='store_true', help='Write allowlisted reviewed rows to station_external_identity.')
+    parser.add_argument('--output', required=True, help='Path to write the JSON execution plan.')
+    parser.add_argument('--json', action='store_true', help='Emit JSON to stdout after writing output.')
+    parser.add_argument(
+        '--approved-review-items-file',
+        default=None,
+        help='Required for --write-reviewed. JSON allowlist of approved review_item_ids or plan_row_ids.',
+    )
+    parser.add_argument('--confirm-write-reviewed', action='store_true', help='Required confirmation for --write-reviewed.')
+    parser.add_argument(
+        '--confirm-station-external-identity-only',
+        action='store_true',
+        help='Required confirmation that only station_external_identity may be written.',
+    )
+    parser.add_argument(
+        '--confirm-no-canonical-writes',
+        action='store_true',
+        help='Required confirmation that canonical writes and apply remain blocked.',
+    )
+    parser.add_argument('--apply', action='store_true', help='Unsupported; canonical apply is blocked.')
+    parser.add_argument('--canonical-apply', action='store_true', help='Unsupported; canonical apply is blocked.')
+    parser.add_argument('--station-type-dry-run', action='store_true', help='Unsupported; station-type dry-run is blocked.')
+    parser.add_argument('--reconciliation', action='store_true', help='Unsupported; reconciliation is blocked.')
+    parser.add_argument('--import', dest='run_import', action='store_true', help='Unsupported; imports are blocked.')
+    parser.add_argument('--summarizer', action='store_true', help='Unsupported; summarizer runs are blocked.')
+    parser.add_argument('--write', action='store_true', help='Unsupported alias; use --write-reviewed.')
+    parser.add_argument('--commit', action='store_true', help='Unsupported; commits are not a loader mode.')
+    args = parser.parse_args(argv)
+
+    if (
+        args.apply
+        or args.canonical_apply
+        or args.station_type_dry_run
+        or args.reconciliation
+        or args.run_import
+        or args.summarizer
+        or args.write
+        or args.commit
+    ):
+        parser.error(FORBIDDEN_FLAG_ERROR)
+    if args.max_rows < 1:
+        parser.error('--max-rows must be >= 1')
+    if args.max_rows > MAX_ROWS_CAP:
+        parser.error(f'--max-rows must be <= {MAX_ROWS_CAP}')
+    if args.write_reviewed:
+        if not args.approved_review_items_file:
+            parser.error('--write-reviewed requires --approved-review-items-file')
+        missing_confirmations = [
+            name
+            for name, confirmed in (
+                ('--confirm-write-reviewed', args.confirm_write_reviewed),
+                ('--confirm-station-external-identity-only', args.confirm_station_external_identity_only),
+                ('--confirm-no-canonical-writes', args.confirm_no_canonical_writes),
+            )
+            if not confirmed
+        ]
+        if missing_confirmations:
+            parser.error('--write-reviewed requires ' + ', '.join(missing_confirmations))
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.dry_run:
+            artifact = build_execution_plan_from_files(
+                review_packet_path=args.review_packet,
+                expected_review_packet_sha256=args.expected_review_packet_sha256,
+                max_rows=args.max_rows,
+                dry_run=True,
+                write_reviewed=False,
+                approved_review_items_file=args.approved_review_items_file,
+            )
+        else:
+            with connect_write_db(args.dsn) as conn:
+                artifact = build_execution_plan_from_files(
+                    review_packet_path=args.review_packet,
+                    expected_review_packet_sha256=args.expected_review_packet_sha256,
+                    max_rows=args.max_rows,
+                    dry_run=False,
+                    write_reviewed=True,
+                    approved_review_items_file=args.approved_review_items_file,
+                    conn=conn,
+                )
+    except (OSError, ValueError) as exc:
+        print(f'station external identity loader failed: {exc}', file=sys.stderr)
+        return 2
+
+    output = json_dumps_artifact(artifact)
+    Path(args.output).write_text(output + '\n', encoding='utf-8')
+    if args.json:
+        print(output)
+    return 0
+
+
+def connect_write_db(dsn: str):
+    """Connect lazily so tests and dry-run imports do not require Postgres."""
+    import psycopg2  # noqa: PLC0415
+
+    conn = psycopg2.connect(dsn)
+    set_session = getattr(conn, 'set_session', None)
+    if callable(set_session):
+        set_session(readonly=False, autocommit=False)
+    return conn
+
+
+def build_execution_plan_from_files(
+    *,
+    review_packet_path: str | Path,
+    expected_review_packet_sha256: str,
+    max_rows: int,
+    dry_run: bool,
+    write_reviewed: bool,
+    approved_review_items_file: str | Path | None = None,
+    conn: Any | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    review_packet, packet_sha256, packet_size = _load_json_file_with_sha(
+        review_packet_path,
+        expected_sha256=expected_review_packet_sha256,
+        label='review packet',
+    )
+    approval_allowlist = None
+    approval_allowlist_sha256 = None
+    if approved_review_items_file:
+        approval_allowlist, approval_allowlist_sha256, _approval_size = _load_json_file(
+            approved_review_items_file,
+            label='approval allowlist',
+        )
+    return build_execution_plan(
+        review_packet,
+        review_packet_basename=Path(review_packet_path).name,
+        review_packet_sha256=packet_sha256,
+        review_packet_size_bytes=packet_size,
+        max_rows=max_rows,
+        dry_run=dry_run,
+        write_reviewed=write_reviewed,
+        approval_allowlist=approval_allowlist,
+        approval_allowlist_sha256=approval_allowlist_sha256,
+        conn=conn,
+        generated_at=generated_at,
+    )
+
+
+def build_execution_plan(
+    review_packet: Mapping[str, Any],
+    *,
+    review_packet_basename: str,
+    review_packet_sha256: str,
+    review_packet_size_bytes: int,
+    max_rows: int,
+    dry_run: bool,
+    write_reviewed: bool,
+    approval_allowlist: Mapping[str, Any] | None = None,
+    approval_allowlist_sha256: str | None = None,
+    conn: Any | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    if max_rows < 1:
+        raise IdentityLoaderError('max_rows must be >= 1')
+    if max_rows > MAX_ROWS_CAP:
+        raise IdentityLoaderError(f'max_rows must be <= {MAX_ROWS_CAP}')
+    if dry_run == write_reviewed:
+        raise IdentityLoaderError('exactly one of dry_run or write_reviewed must be selected')
+
+    approval = _validate_approval_allowlist(
+        approval_allowlist,
+        review_packet_sha256=review_packet_sha256,
+        require_approval=write_reviewed,
+    )
+    selected_items = _select_valid_review_items(
+        review_packet,
+        max_rows=max_rows,
+        approval=approval,
+        require_approval=write_reviewed,
+    )
+
+    insert_results: list[dict[str, Any]] = []
+    if write_reviewed:
+        if conn is None:
+            raise IdentityLoaderError('write_reviewed requires a database connection')
+        insert_results = insert_reviewed_identity_rows(conn, selected_items)
+
+    identity_rows_written = sum(1 for result in insert_results if result.get('inserted') is True)
+    duplicate_rows_skipped = sum(1 for result in insert_results if result.get('inserted') is False)
+    now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    selected_review_item_ids = [str(item['review_item_id']) for item in selected_items]
+    selected_plan_row_ids = [str(_mapping(item['planned_row']).get('plan_row_id')) for item in selected_items]
+
+    artifact: dict[str, Any] = {
+        'schema_version': SCHEMA_VERSION,
+        'generated_at': now,
+        'tool': {
+            'name': TOOL_NAME,
+            'version': TOOL_VERSION,
+        },
+        'dry_run': dry_run,
+        'write_reviewed': write_reviewed,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_selected': len(selected_items),
+        'identity_rows_written': identity_rows_written,
+        'max_rows': max_rows,
+        'review_packet_basename': review_packet_basename,
+        'review_packet_sha256': review_packet_sha256,
+        'review_packet_size_bytes': review_packet_size_bytes,
+        'selected_review_item_ids': selected_review_item_ids,
+        'selected_plan_row_ids': selected_plan_row_ids,
+        'validation_summary': {
+            'review_packet_schema_valid': True,
+            'review_packet_sha256_verified': True,
+            'approval_allowlist_required': write_reviewed,
+            'approval_allowlist_present': approval_allowlist is not None,
+            'approval_allowlist_sha256': approval_allowlist_sha256,
+            'manual_review_items_selected': len(selected_items),
+            'all_required_checks_passed': True,
+            'identity_status_confirmed': True,
+            'conflict_reason_null': True,
+            'source_provenance_present': True,
+            'external_id_present': True,
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': identity_rows_written,
+            'duplicate_rows_skipped': duplicate_rows_skipped,
+        },
+        'refusal_reasons': [],
+        'inserted_row_ids': [result['row_id'] for result in insert_results if result.get('inserted') is True],
+        'insert_results': insert_results,
+    }
+    if approval is not None:
+        artifact['approval_allowlist'] = {
+            'schema_version': approval['schema_version'],
+            'review_packet_sha256': approval['review_packet_sha256'],
+            'approved_review_item_ids_count': len(approval['approved_review_item_ids']),
+            'approved_plan_row_ids_count': len(approval['approved_plan_row_ids']),
+            'reviewer': approval['reviewer'],
+            'reviewed_at': approval['reviewed_at'],
+            'declaration': approval['declaration'],
+            'artifact_sha256': approval_allowlist_sha256,
+        }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+        'canonicalization': 'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False) excluding artifact_integrity',
+    }
+    return _json_clone(artifact)
+
+
+def insert_reviewed_identity_rows(conn: Any, selected_items: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    sql = _identity_insert_sql()
+    _assert_identity_insert_sql_is_safe(sql)
+    cur = conn.cursor()
+    results: list[dict[str, Any]] = []
+    try:
+        for item in selected_items:
+            row = _mapping(item.get('planned_row'))
+            cur.execute(sql, _insert_params(row))
+            returned = cur.fetchone()
+            inserted = returned is not None
+            row_id = returned[0] if inserted else None
+            results.append({
+                'review_item_id': item.get('review_item_id'),
+                'plan_row_id': row.get('plan_row_id'),
+                'inserted': inserted,
+                'row_id': row_id,
+            })
+        commit = getattr(conn, 'commit', None)
+        if callable(commit):
+            commit()
+    except Exception:
+        rollback = getattr(conn, 'rollback', None)
+        if callable(rollback):
+            rollback()
+        raise
+    finally:
+        close = getattr(cur, 'close', None)
+        if callable(close):
+            close()
+    return results
+
+
+def json_dumps_artifact(artifact: Mapping[str, Any]) -> str:
+    return canonical_json(artifact)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def artifact_sha256(value: Mapping[str, Any]) -> str:
+    payload = deepcopy(dict(value))
+    payload.pop('artifact_integrity', None)
+    return hashlib.sha256(canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def _load_json_file_with_sha(path_value: str | Path, *, expected_sha256: str, label: str) -> tuple[dict[str, Any], str, int]:
+    payload, actual_sha256, size_bytes = _read_file_with_sha(path_value, label=label)
+    if actual_sha256 != expected_sha256.lower():
+        raise IdentityLoaderError(f'{label} checksum mismatch. Expected {expected_sha256}, got {actual_sha256}')
+    return _parse_json_object(payload, label=label), actual_sha256, size_bytes
+
+
+def _load_json_file(path_value: str | Path, *, label: str) -> tuple[dict[str, Any], str, int]:
+    payload, actual_sha256, size_bytes = _read_file_with_sha(path_value, label=label)
+    return _parse_json_object(payload, label=label), actual_sha256, size_bytes
+
+
+def _read_file_with_sha(path_value: str | Path, *, label: str) -> tuple[bytes, str, int]:
+    path = Path(path_value)
+    if not path.is_file():
+        raise IdentityLoaderError(f'{label} is missing: {path}')
+    payload = path.read_bytes()
+    return payload, hashlib.sha256(payload).hexdigest(), len(payload)
+
+
+def _parse_json_object(payload: bytes, *, label: str) -> dict[str, Any]:
+    try:
+        data = json.loads(payload.decode('utf-8'))
+    except json.JSONDecodeError as exc:
+        raise IdentityLoaderError(f'{label} is not valid JSON: {exc}') from exc
+    if not isinstance(data, dict):
+        raise IdentityLoaderError(f'{label} must be a JSON object')
+    return data
+
+
+def _select_valid_review_items(
+    review_packet: Mapping[str, Any],
+    *,
+    max_rows: int,
+    approval: Mapping[str, Any] | None,
+    require_approval: bool,
+) -> list[dict[str, Any]]:
+    _validate_review_packet_safety(review_packet)
+    items = review_packet.get('manual_review_items')
+    if not isinstance(items, list):
+        raise IdentityLoaderError('review packet manual_review_items must be a list')
+    validated_items = [_validate_review_item(item_value) for item_value in items]
+    planned_rows = review_packet.get('planned_rows')
+    if planned_rows is not None:
+        embedded_rows = [
+            item['planned_row']
+            for item in validated_items
+        ]
+        if embedded_rows != planned_rows:
+            raise IdentityLoaderError('embedded manual review rows must match top-level planned_rows')
+
+    selected: list[dict[str, Any]] = []
+    approved_review_ids = set(approval.get('approved_review_item_ids', ())) if approval is not None else set()
+    approved_plan_row_ids = set(approval.get('approved_plan_row_ids', ())) if approval is not None else set()
+    for item in validated_items:
+        row = _mapping(item['planned_row'])
+        approved = item['review_item_id'] in approved_review_ids or row.get('plan_row_id') in approved_plan_row_ids
+        if require_approval and not approved:
+            continue
+        selected.append(item)
+
+    if not require_approval:
+        selected = selected[:max_rows]
+    if len(selected) > max_rows:
+        raise IdentityLoaderError('selected row count exceeds max_rows')
+    if require_approval and not selected:
+        raise IdentityLoaderError('approval allowlist selected zero review rows')
+    return selected
+
+
+def _validate_review_packet_safety(review_packet: Mapping[str, Any]) -> None:
+    if review_packet.get('schema_version') != REVIEW_PACKET_SCHEMA_VERSION:
+        raise IdentityLoaderError(f'review packet schema_version must be {REVIEW_PACKET_SCHEMA_VERSION}')
+    if review_packet.get('identity_rows_written') != 0:
+        raise IdentityLoaderError('review packet identity_rows_written must be 0')
+    if review_packet.get('canonical_writes_planned') != 0:
+        raise IdentityLoaderError('review packet canonical_writes_planned must be 0')
+    if review_packet.get('station_type_writes_planned') != 0:
+        raise IdentityLoaderError('review packet station_type_writes_planned must be 0')
+    if review_packet.get('approval_record_created') is True:
+        raise IdentityLoaderError('review packet approval_record_created must be false')
+    summary = _mapping(review_packet.get('summary'))
+    for key in ('canonical_writes_planned', 'station_type_writes_planned', 'identity_rows_written'):
+        value = summary.get(key)
+        if value is not None and value != 0:
+            raise IdentityLoaderError(f'review packet summary {key} must be 0')
+    if summary.get('approval_record_created') is True:
+        raise IdentityLoaderError('review packet summary approval_record_created must be false')
+
+
+def _validate_review_item(item_value: Any) -> dict[str, Any]:
+    if not isinstance(item_value, Mapping):
+        raise IdentityLoaderError('manual review item must be an object')
+    item = dict(item_value)
+    if not item.get('review_item_id'):
+        raise IdentityLoaderError('manual review item is missing review_item_id')
+    row = item.get('planned_row')
+    if not isinstance(row, Mapping) or not row:
+        raise IdentityLoaderError('manual review item is missing planned_row')
+    checks = item.get('checks')
+    if not isinstance(checks, Mapping) or not checks:
+        raise IdentityLoaderError('manual review item is missing checks')
+    failed_checks = [
+        key
+        for key in REQUIRED_CHECK_KEYS
+        if checks.get(key) is not True
+    ]
+    if failed_checks:
+        raise IdentityLoaderError('manual review item has failed required checks: ' + ', '.join(failed_checks))
+    if row.get('identity_status') != 'confirmed':
+        raise IdentityLoaderError('planned row identity_status must be confirmed')
+    if row.get('conflict_reason') is not None:
+        raise IdentityLoaderError('planned row conflict_reason must be null')
+    for field in ('source_run_key', 'source_file_key', 'source_record_hash'):
+        if not row.get(field):
+            raise IdentityLoaderError(f'planned row is missing source provenance field: {field}')
+    if row.get('market_id') is None and row.get('edsm_station_id') is None:
+        raise IdentityLoaderError('planned row must have market_id or edsm_station_id')
+    if row.get('station_type_writes_planned') != 0:
+        raise IdentityLoaderError('planned row station_type_writes_planned must be 0')
+    if row.get('canonical_writes_planned') != 0:
+        raise IdentityLoaderError('planned row canonical_writes_planned must be 0')
+    item['planned_row'] = _json_clone(row)
+    item['checks'] = _json_clone(checks)
+    return item
+
+
+def _validate_approval_allowlist(
+    approval_allowlist: Mapping[str, Any] | None,
+    *,
+    review_packet_sha256: str,
+    require_approval: bool,
+) -> dict[str, Any] | None:
+    if approval_allowlist is None:
+        if require_approval:
+            raise IdentityLoaderError('write-reviewed requires an approval allowlist')
+        return None
+    if approval_allowlist.get('schema_version') != APPROVAL_ALLOWLIST_SCHEMA_VERSION:
+        raise IdentityLoaderError(f'approval allowlist schema_version must be {APPROVAL_ALLOWLIST_SCHEMA_VERSION}')
+    if approval_allowlist.get('review_packet_sha256') != review_packet_sha256:
+        raise IdentityLoaderError('approval allowlist review_packet_sha256 does not match review packet')
+
+    approved_review_item_ids = _string_list(approval_allowlist.get('approved_review_item_ids'), 'approved_review_item_ids')
+    approved_plan_row_ids = _string_list(approval_allowlist.get('approved_plan_row_ids'), 'approved_plan_row_ids')
+    if not approved_review_item_ids and not approved_plan_row_ids:
+        raise IdentityLoaderError('approval allowlist must include approved review item ids or plan row ids')
+
+    reviewer = _required_string(approval_allowlist, 'reviewer')
+    reviewed_at = _required_string(approval_allowlist, 'reviewed_at')
+    declaration = _required_string(approval_allowlist, 'declaration')
+    return {
+        'schema_version': APPROVAL_ALLOWLIST_SCHEMA_VERSION,
+        'review_packet_sha256': review_packet_sha256,
+        'approved_review_item_ids': approved_review_item_ids,
+        'approved_plan_row_ids': approved_plan_row_ids,
+        'reviewer': reviewer,
+        'reviewed_at': reviewed_at,
+        'declaration': declaration,
+    }
+
+
+def _string_list(value: Any, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        raise IdentityLoaderError(f'approval allowlist {field_name} must be a list of non-empty strings')
+    return list(value)
+
+
+def _required_string(value: Mapping[str, Any], field_name: str) -> str:
+    field = value.get(field_name)
+    if not isinstance(field, str) or not field.strip():
+        raise IdentityLoaderError(f'approval allowlist {field_name} must be a non-empty string')
+    return field
+
+
+def _identity_insert_sql() -> str:
+    return """
+        INSERT INTO station_external_identity (
+            canonical_station_id,
+            system_id64,
+            station_name,
+            source,
+            market_id,
+            edsm_station_id,
+            source_run_key,
+            source_file_key,
+            source_record_hash,
+            source_updated_at,
+            confidence,
+            freshness_class,
+            identity_status,
+            conflict_reason
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT DO NOTHING
+        RETURNING id
+    """
+
+
+def _assert_identity_insert_sql_is_safe(sql: str) -> None:
+    text = _strip_sql_comments(sql).upper()
+    if re.search(r'\b(UPDATE|DELETE|MERGE|TRUNCATE|DROP|ALTER)\b', text):
+        raise IdentityLoaderError('identity loader SQL must not contain unsafe write or DDL keywords')
+    if not re.search(r'\bINSERT\s+INTO\s+STATION_EXTERNAL_IDENTITY\b', text):
+        raise IdentityLoaderError('identity loader SQL may only insert into station_external_identity')
+    forbidden_tables = ('SYSTEMS', 'STATIONS', 'BODIES', 'BODY_RINGS', 'BODY_SCAN_FACTS', 'STATION_BODY_LINKS')
+    for table in forbidden_tables:
+        if re.search(rf'\b(INSERT\s+INTO|UPDATE|DELETE\s+FROM|MERGE\s+INTO|TRUNCATE|DROP\s+TABLE|ALTER\s+TABLE)\s+{table}\b', text):
+            raise IdentityLoaderError(f'identity loader SQL must not write canonical table {table.lower()}')
+    if 'STATION_TYPE' in text:
+        raise IdentityLoaderError('identity loader SQL must not reference station_type')
+
+
+def _insert_params(row: Mapping[str, Any]) -> tuple[Any, ...]:
+    return tuple(row.get(column) for column in PLANNED_ROW_INSERT_COLUMNS)
+
+
+def _strip_sql_comments(sql: str) -> str:
+    without_line_comments = re.sub(r'--.*?$', '', sql, flags=re.MULTILINE)
+    return re.sub(r'/\*.*?\*/', '', without_line_comments, flags=re.DOTALL)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _json_clone(value: Any) -> Any:
+    return json.loads(canonical_json(value))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -679,6 +679,16 @@ remains for convenience and must match the embedded rows exactly. The wrapper
 prints and validates these contract fields before declaring the packet
 generated.
 
+Stage 18J-P14 adds controlled external identity load tooling in
+`apps/importer/src/station_external_identity_loader.py` and a dry-run-only
+Hetzner wrapper in `scripts/operator/stage18j_run_identity_load_dry_run.sh`.
+The loader validates verified review packets and emits
+`station_external_identity_load_execution_plan/v1`; write mode requires a
+separate `station_external_identity_load_approval_allowlist/v1` artifact plus
+explicit confirmation flags. This PR keeps production identity writes blocked
+and does not add a production write operator script. See
+[`stage-18j-p14-controlled-external-identity-load-tooling.md`](./stage-18j-p14-controlled-external-identity-load-tooling.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -789,6 +799,10 @@ treated as a separate proposal.
   manual review items self-contained with embedded planned rows and boolean
   checks, then requires a future offline packet rerun before planned rows can
   be reviewed.
+* **External identity controlled load tooling**: Stage 18J-P14 adds load
+  validation and dry-run execution plan tooling, plus approval allowlist support
+  for later write-reviewed runs. Production identity writes remain blocked in
+  this PR.
 * **External identity follow-up sequence**: use the execution board for Chunk A
   P12/P13 review pack, Chunk B P14 controlled identity load tooling, Chunk C
   P15 post-load identity coverage, Chunk D P16 read-only reconciliation

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -1326,6 +1326,50 @@ Non-goals:
 Support doc:
 `stage-18j-p12-p13-load-plan-review-packet.md`.
 
+### Stage 18J-P14 - Controlled External Identity Load Tooling
+
+Purpose: add controlled external identity load tooling and a dry-run execution
+plan path while keeping production writes blocked in repo work.
+
+Scope:
+
+- Add `apps/importer/src/station_external_identity_loader.py`.
+- Support `--dry-run` to validate a review packet and emit
+  `station_external_identity_load_execution_plan/v1` without opening a DB
+  connection or writing rows.
+- Support `--write-reviewed` only with a separate
+  `station_external_identity_load_approval_allowlist/v1` artifact and explicit
+  confirmation flags.
+- Require `--review-packet`, `--expected-review-packet-sha256`, `--dsn`,
+  `--max-rows`, `--output`, and exactly one mode.
+- Refuse `--max-rows > 20`.
+- Refuse packets with bad schema, bad checksum, non-zero write counters,
+  approval records, missing planned rows/checks, failed checks, non-confirmed
+  identity status, non-null conflict reason, missing provenance, or missing
+  external IDs.
+- Reject import, reconciliation, summarizer, station-type dry-run, canonical
+  apply, generic write, and commit flags.
+- Add `scripts/operator/stage18j_run_identity_load_dry_run.sh` as a
+  Hetzner-only dry-run wrapper guarded by
+  `scripts/operator/require_hetzner_operator_env.sh`.
+- Add synthetic tests for dry-run refusal modes, approval allowlist handling,
+  fake-DB write-reviewed behavior, duplicate skip behavior, and deterministic
+  JSON.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No production identity evidence load.
+- No production writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No production approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p14-controlled-external-identity-load-tooling.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner
@@ -1415,7 +1459,7 @@ Do not add another large planner feature immediately. The healthiest next sequen
 42. Stage 18J-P-OPT identity evidence execution board.
 43. Stage 18J-P12/P13 load-plan review packet, no DB writes.
 44. Stage 18J-P13A review packet contract hardening, no DB writes.
-45. Chunk B: Stage 18J-P14 controlled identity load tooling.
+45. Stage 18J-P14 controlled identity load tooling and dry-run plan.
 46. Chunk C: Stage 18J-P15 post-load identity coverage.
 47. Chunk D: Stage 18J-P16 reconciliation integration with confirmed identity.
 48. Chunk E: Stage 18J-P17 retry strict station-type dry-run.

--- a/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
+++ b/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
@@ -39,6 +39,9 @@ Known state:
   packet contract issue: `manual_review_items` were not self-contained enough
   for manual row review. Stage 18J-P13A hardens the contract so each item
   embeds `planned_row`, boolean `checks`, and `reviewer_notes = null`.
+- Stage 18J-P14 adds controlled external identity load tooling and a
+  dry-run-only Hetzner wrapper. It also defines a separate approval allowlist
+  artifact for future `--write-reviewed` runs.
 - Stage 18K remains untouched.
 
 ## Why We Are Optimising
@@ -141,8 +144,10 @@ Bundle:
 - add tests for refusal modes and no accidental canonical writes;
 - update docs/runbook.
 
-Repo work must not run production. The Hetzner production load remains a
-separate tiny operator action after review.
+P14 repo work must not run production. The added Hetzner wrapper is dry-run
+only. A production identity load remains blocked until a separate approval
+allowlist artifact exists and a later tiny operator write action is explicitly
+approved.
 
 ### Chunk C - P15 Post-load Identity Coverage
 
@@ -279,8 +284,10 @@ Recommended next actions:
    record.
 3. Run the planned-row review packet as a tiny Hetzner offline action after
    Chunk A merges.
-4. Proceed with Chunk B only after the planned rows are manually accepted.
-5. Keep station-type dry-run blocked until post-load coverage and read-only
+4. Run the P14 load dry-run wrapper after P14 merges.
+5. Create a separate approval allowlist only if the dry-run plan and planned
+   rows are manually accepted.
+6. Keep station-type dry-run blocked until post-load coverage and read-only
    reconciliation prove confirmed identity coverage.
 
 ## Final Recommendation

--- a/docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md
+++ b/docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md
@@ -188,6 +188,32 @@ The nested `checks` object must include boolean fields for:
 The P13A fix does not approve a load. It only makes a future offline review
 packet rerun suitable for manual row inspection.
 
+## P14 Controlled Loader Follow-up
+
+Stage 18J-P14 adds controlled external identity load tooling in
+`apps/importer/src/station_external_identity_loader.py` and a dry-run-only
+Hetzner wrapper in `scripts/operator/stage18j_run_identity_load_dry_run.sh`.
+
+The fixed review packet from the P13A rerun is reviewable:
+
+- review packet:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_review_packet_20260603T110848Z.json`;
+- review packet SHA-256:
+  `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`;
+- artifact integrity SHA-256:
+  `8cbcf4f2c0d4e3180c3fa6fcbf44f41e71269254168fee0b121f4c6b07bcab84`;
+- `manual_review_items = 20`;
+- `planned_rows = 20`;
+- `manual_review_status_counts = {"needs_manual_review": 20}`;
+- all inspected row checks were true;
+- `identity_rows_written = 0`;
+- no database access or load occurred.
+
+The rows are reviewable but not automatically approved. P14 therefore requires
+a separate approval allowlist artifact for `--write-reviewed`. The allowlist is
+only approval to load exact external identity evidence rows into
+`station_external_identity`; it is not canonical apply approval.
+
 ## Planned Row Review Requirements
 
 Each planned row must be manually reviewed before any future controlled load

--- a/docs/colonisation-redesign/stage-18j-p14-controlled-external-identity-load-tooling.md
+++ b/docs/colonisation-redesign/stage-18j-p14-controlled-external-identity-load-tooling.md
@@ -1,0 +1,265 @@
+# Stage 18J-P14 — Controlled External Identity Load Tooling
+
+## Purpose
+
+Stage 18J-P14 adds controlled external station identity load tooling and a
+dry-run operator path for reviewed identity rows.
+
+This is repo/tooling/tests/docs work only. It does not run production
+commands, touch the production database, load identity evidence in production,
+write to `station_external_identity` in production, run imports, run
+reconciliation, run the summarizer against production artifacts, run
+station-type dry-run, run canonical apply, create production approval records,
+or start Stage 18K.
+
+## Inputs
+
+Verified review packet context:
+
+- review packet:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_review_packet_20260603T110848Z.json`;
+- review packet SHA-256:
+  `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`;
+- review packet artifact integrity SHA-256:
+  `8cbcf4f2c0d4e3180c3fa6fcbf44f41e71269254168fee0b121f4c6b07bcab84`;
+- source load-plan artifact:
+  `station_external_identity_load_plan_20260603T071913Z.json`;
+- source load-plan SHA-256:
+  `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- schema: `station_external_identity_review_packet/v1`.
+
+## Review Packet Result
+
+The verified packet reports:
+
+- `manual_review_items = 20`;
+- `planned_rows = 20`;
+- `first_review_item_has_planned_row = true`;
+- `first_review_item_has_non_empty_checks = true`;
+- `manual_review_status_counts = {"needs_manual_review": 20}`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_written = 0`;
+- `approval_record_created = false`;
+- no database access;
+- no identity load;
+- no station-type dry-run;
+- no canonical apply.
+
+Observed row quality from inspection:
+
+- all `20` inspected rows had canonical station ID, system ID64, station name,
+  `source = edsm_nightly_stations`, EDSM station ID, source run/file/hash
+  provenance, `confidence = source_station_snapshot`,
+  `freshness_class = source_updated_at`, `identity_status = confirmed`,
+  `conflict_reason = null`, and all boolean checks true.
+
+These rows are reviewable, but not automatically approved. The packet still
+has `review_status = needs_manual_review`, so write tooling must require a
+separate approval allowlist before any row can be inserted.
+
+## Loader Modes
+
+P14 adds `apps/importer/src/station_external_identity_loader.py`.
+
+The loader supports two modes:
+
+- `--dry-run`: validates a review packet and emits
+  `station_external_identity_load_execution_plan/v1` without opening a DB
+  connection or writing rows.
+- `--write-reviewed`: writes only approved/allowlisted rows from the verified
+  packet to `station_external_identity`.
+
+Both modes require:
+
+- `--review-packet`;
+- `--expected-review-packet-sha256`;
+- `--dsn`;
+- `--max-rows`;
+- `--output`;
+- exactly one of `--dry-run` or `--write-reviewed`;
+- optional `--json` output.
+
+Dry-run accepts `--dsn` because the CLI contract is shared with write mode, but
+the dry-run implementation does not connect to the database.
+
+## Required Safety Checks
+
+The loader refuses to proceed when:
+
+- `--max-rows` is missing;
+- `--max-rows > 20`;
+- the review packet SHA-256 does not exactly match;
+- the review packet schema is not
+  `station_external_identity_review_packet/v1`;
+- `identity_rows_written` in the packet is not `0`;
+- `canonical_writes_planned` is not `0`;
+- `station_type_writes_planned` is not `0`;
+- `approval_record_created` is true;
+- any selected item is missing `planned_row`;
+- any selected item has missing or empty `checks`;
+- any selected item has a failed required check;
+- any selected item has `identity_status` other than `confirmed`;
+- any selected item has non-null `conflict_reason`;
+- any selected row lacks source run/file/hash provenance;
+- any selected row lacks both `market_id` and `edsm_station_id`;
+- selected row count exceeds `--max-rows`;
+- forbidden flags are present: `--write`, `--apply`, `--canonical-apply`,
+  `--station-type-dry-run`, `--reconciliation`, `--import`, `--summarizer`,
+  or `--commit`.
+
+The required boolean row checks are:
+
+- `canonical_station_id_present`;
+- `system_id64_present`;
+- `station_name_present`;
+- `source_run_key_present`;
+- `source_file_key_present`;
+- `source_record_hash_present`;
+- `external_id_present`;
+- `identity_status_is_confirmed`;
+- `conflict_reason_is_null`;
+- `station_type_write_not_planned`.
+
+## Approval / Allowlist Requirement
+
+P14 implements a separate approval allowlist artifact for write mode:
+
+- schema:
+  `station_external_identity_load_approval_allowlist/v1`;
+- `review_packet_sha256`;
+- `approved_review_item_ids`;
+- `approved_plan_row_ids`;
+- `reviewer`;
+- `reviewed_at`;
+- `declaration`.
+
+The allowlist is not a canonical apply approval. It only approves loading exact
+external identity evidence rows into `station_external_identity`.
+
+`--write-reviewed` requires:
+
+- `--approved-review-items-file`;
+- the allowlist `review_packet_sha256` to match the verified packet;
+- at least one approved review item ID or plan row ID;
+- `--confirm-write-reviewed`;
+- `--confirm-station-external-identity-only`;
+- `--confirm-no-canonical-writes`.
+
+The current verified review packet contains only
+`review_status = needs_manual_review`, so it is not sufficient by itself for
+write mode.
+
+## Dry-run Execution Plan
+
+Dry-run emits `station_external_identity_load_execution_plan/v1` with:
+
+- `dry_run = true`;
+- `write_reviewed = false`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_selected`;
+- `identity_rows_written = 0`;
+- `max_rows`;
+- review packet basename and SHA-256;
+- selected review item IDs;
+- selected plan row IDs;
+- validation summary;
+- empty refusal reasons when validation passes;
+- artifact integrity.
+
+Dry-run may select up to `--max-rows` valid review rows for the execution plan.
+It writes no database rows.
+
+## Write-reviewed Boundaries
+
+`--write-reviewed` is deliberately narrow:
+
+- it writes only allowlisted rows;
+- it inserts only into `station_external_identity`;
+- it uses `ON CONFLICT DO NOTHING` so duplicate confirmed external IDs are
+  skipped rather than updated;
+- it records inserted row IDs when available;
+- it reports duplicate rows skipped;
+- it writes no canonical station fields;
+- it never updates `stations`;
+- it never touches `station_type`;
+- it does not run station-type dry-run;
+- it does not run reconciliation;
+- it does not run canonical apply;
+- it does not create an approval record.
+
+This PR does not add a production write operator script.
+
+## Operator Workflow
+
+P14 adds:
+
+- `scripts/operator/stage18j_run_identity_load_dry_run.sh`
+
+The wrapper:
+
+- calls `scripts/operator/require_hetzner_operator_env.sh`;
+- defaults `ART_DIR` to
+  `/var/lib/ed-finder/operator-artifacts/stage-18j`;
+- defaults `REVIEW_PACKET` to the verified P13A packet path;
+- requires review packet SHA-256
+  `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`;
+- defaults `MAX_ROWS = 20`;
+- refuses `MAX_ROWS > 20`;
+- runs `--dry-run` only;
+- writes the execution plan under the operator artifact directory;
+- applies mode `600` to the output;
+- prints artifact path, checksum, and summary fields;
+- prints explicit no-write, no-station-type, no-apply confirmation.
+
+The wrapper does not perform production writes.
+
+## What This Does Not Enable
+
+P14 does not enable:
+
+- production commands from Codex;
+- production DB access from Codex;
+- production identity evidence loading;
+- production writes to `station_external_identity`;
+- imports;
+- reconciliation;
+- summarizer runs against production artifacts;
+- station-type dry-run;
+- canonical apply;
+- production approval-record creation;
+- Stage 18K.
+
+## Required Future Production Gates
+
+Before any future production write-reviewed run:
+
+- run the P14 load dry-run wrapper after this PR merges;
+- inspect the execution plan artifact and checksum;
+- create a separate approval allowlist artifact for exact reviewed rows;
+- verify the allowlist references the exact review packet SHA-256;
+- verify selected row IDs and plan row IDs match the manual review;
+- record pre-check `station_external_identity` row count;
+- run a tiny, explicit operator write action that loads only allowlisted rows;
+- record post-check row count and inserted/duplicate counts;
+- confirm no imports, reconciliation, summarizer, station-type dry-run,
+  canonical apply, or approval-record creation ran.
+
+## Recommended Next Stages
+
+Recommended sequence:
+
+- run P14 load dry-run as a tiny Hetzner offline validation action after merge;
+- manually review the load execution plan;
+- prepare a separate approval allowlist artifact only if rows are accepted;
+- add a future guarded write operator action only after the approval allowlist
+  is reviewed;
+- proceed to post-load coverage only after an approved controlled load has run.
+
+## Final Recommendation
+
+Merge P14 as controlled load tooling and dry-run guardrails only.
+
+Do not load identity evidence yet. The next appropriate Hetzner action after
+merge is a dry-run execution plan using the verified review packet and checksum.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -791,6 +791,19 @@ review-packet wrapper; do not load identity evidence or run reconciliation,
 summarizer, station-type dry-run, approval-record creation, or canonical
 apply.
 
+Stage 18J-P14 adds controlled external identity load tooling in
+`apps/importer/src/station_external_identity_loader.py` and a dry-run-only
+operator wrapper in `scripts/operator/stage18j_run_identity_load_dry_run.sh`.
+The wrapper validates the verified review packet
+`station_external_identity_review_packet_20260603T110848Z.json` with expected
+SHA-256 `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`,
+emits `station_external_identity_load_execution_plan/v1`, and prints explicit
+no-write/no-station-type/no-apply confirmation. It does not connect to the
+database in dry-run mode. Any future `--write-reviewed` run requires a separate
+`station_external_identity_load_approval_allowlist/v1` artifact tied to the
+exact review packet SHA-256 and must be a later, explicitly approved operator
+action. P14 does not add a production write operator script.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/scripts/operator/stage18j_run_identity_load_dry_run.sh
+++ b/scripts/operator/stage18j_run_identity_load_dry_run.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +H
+
+ART_DIR="${ART_DIR:-/var/lib/ed-finder/operator-artifacts/stage-18j}"
+REVIEW_PACKET="${REVIEW_PACKET:-$ART_DIR/station_external_identity_review_packet_20260603T110848Z.json}"
+EXPECTED_REVIEW_PACKET_SHA256="${EXPECTED_REVIEW_PACKET_SHA256:-8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6}"
+MAX_ROWS="${MAX_ROWS:-20}"
+LOAD_DRY_RUN_ARTIFACT="${LOAD_DRY_RUN_ARTIFACT:-$ART_DIR/station_external_identity_load_execution_plan_$(date -u +%Y%m%dT%H%M%SZ).json}"
+DRY_RUN_DSN="${DRY_RUN_DSN:-stage18j-p14-dry-run-no-db-connection}"
+
+stop() {
+  printf 'STOP: %s\n' "$*" >&2
+  exit 1
+}
+
+REQUIRE_STAGE18J_ARTIFACT_DIR=yes ART_DIR="$ART_DIR" \
+  scripts/operator/require_hetzner_operator_env.sh
+
+if [[ "${MAX_ROWS}" == "" || ! "${MAX_ROWS}" =~ ^[0-9]+$ ]]; then
+  stop "MAX_ROWS must be a positive integer."
+fi
+
+if (( MAX_ROWS < 1 || MAX_ROWS > 20 )); then
+  stop "MAX_ROWS must be between 1 and 20 for Stage 18J-P14 load dry-run."
+fi
+
+if [[ ! -s "$REVIEW_PACKET" ]]; then
+  stop "review packet is missing or empty: $REVIEW_PACKET"
+fi
+
+case "$REVIEW_PACKET" in
+  "$ART_DIR"/*) ;;
+  *) stop "REVIEW_PACKET must be read from ART_DIR: $ART_DIR" ;;
+esac
+
+case "$LOAD_DRY_RUN_ARTIFACT" in
+  "$ART_DIR"/*) ;;
+  *) stop "LOAD_DRY_RUN_ARTIFACT must be written under ART_DIR: $ART_DIR" ;;
+esac
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+  stop "sha256sum is required to verify the review packet."
+fi
+
+read -r actual_review_packet_sha _ < <(sha256sum "$REVIEW_PACKET")
+if [[ "$actual_review_packet_sha" != "$EXPECTED_REVIEW_PACKET_SHA256" ]]; then
+  stop "review packet checksum mismatch. Expected $EXPECTED_REVIEW_PACKET_SHA256, got $actual_review_packet_sha"
+fi
+
+echo "== Stage 18J-P14 external identity load dry-run =="
+echo "DRY-RUN ONLY: no database connection, no identity load, no station-type dry-run, no canonical apply."
+echo "ART_DIR: $ART_DIR"
+echo "REVIEW_PACKET: $REVIEW_PACKET"
+echo "REVIEW_PACKET_SHA256: $actual_review_packet_sha"
+echo "LOAD_DRY_RUN_ARTIFACT: $LOAD_DRY_RUN_ARTIFACT"
+echo "MAX_ROWS: $MAX_ROWS"
+
+python3 apps/importer/src/station_external_identity_loader.py \
+  --review-packet "$REVIEW_PACKET" \
+  --expected-review-packet-sha256 "$EXPECTED_REVIEW_PACKET_SHA256" \
+  --dsn "$DRY_RUN_DSN" \
+  --max-rows "$MAX_ROWS" \
+  --dry-run \
+  --output "$LOAD_DRY_RUN_ARTIFACT"
+
+chmod 600 "$LOAD_DRY_RUN_ARTIFACT"
+
+read -r load_dry_run_sha _ < <(sha256sum "$LOAD_DRY_RUN_ARTIFACT")
+
+echo "== Load dry-run file =="
+ls -lh "$LOAD_DRY_RUN_ARTIFACT"
+echo "load_dry_run_sha256: $load_dry_run_sha"
+
+echo "== Load dry-run summary =="
+python3 - "$LOAD_DRY_RUN_ARTIFACT" "$EXPECTED_REVIEW_PACKET_SHA256" "$MAX_ROWS" <<'PY'
+import json
+import sys
+
+path, expected_review_sha, expected_max_rows = sys.argv[1:4]
+with open(path, encoding='utf-8') as handle:
+    payload = json.load(handle)
+
+validation = payload.get('validation_summary') or {}
+
+checks = {
+    'schema_version': payload.get('schema_version') == 'station_external_identity_load_execution_plan/v1',
+    'dry_run': payload.get('dry_run') is True,
+    'write_reviewed_false': payload.get('write_reviewed') is False,
+    'review_packet_sha_matches': payload.get('review_packet_sha256') == expected_review_sha,
+    'max_rows_matches': str(payload.get('max_rows')) == str(expected_max_rows),
+    'identity_rows_selected_within_max': int(payload.get('identity_rows_selected') or 0) <= int(expected_max_rows),
+    'canonical_writes_planned_zero': payload.get('canonical_writes_planned') == 0,
+    'station_type_writes_planned_zero': payload.get('station_type_writes_planned') == 0,
+    'identity_rows_written_zero': payload.get('identity_rows_written') == 0,
+    'all_required_checks_passed': validation.get('all_required_checks_passed') is True,
+}
+
+for name, ok in checks.items():
+    if not ok:
+        raise SystemExit(f'STOP: load dry-run validation failed: {name}')
+
+for key, value in (
+    ('schema_version', payload.get('schema_version')),
+    ('dry_run', payload.get('dry_run')),
+    ('write_reviewed', payload.get('write_reviewed')),
+    ('review_packet_basename', payload.get('review_packet_basename')),
+    ('review_packet_sha256', payload.get('review_packet_sha256')),
+    ('identity_rows_selected', payload.get('identity_rows_selected')),
+    ('identity_rows_written', payload.get('identity_rows_written')),
+    ('max_rows', payload.get('max_rows')),
+    ('selected_review_item_ids_count', len(payload.get('selected_review_item_ids') or [])),
+    ('selected_plan_row_ids_count', len(payload.get('selected_plan_row_ids') or [])),
+    ('canonical_writes_planned', payload.get('canonical_writes_planned')),
+    ('station_type_writes_planned', payload.get('station_type_writes_planned')),
+    ('approval_allowlist_required', validation.get('approval_allowlist_required')),
+):
+    print(f'{key}: {value}')
+PY
+
+echo "== Secret/path sanity check =="
+sensitive_pattern='postgre''sql://|post''gres://|pass''word=|PG''PASSWORD|SEC''RET|TOK''EN'
+if grep -Eq "$sensitive_pattern" "$LOAD_DRY_RUN_ARTIFACT"; then
+  stop "load dry-run artifact may contain credentials. Review the operator artifact out of band; do not commit it."
+fi
+echo "OK: no obvious credential markers found"
+
+echo "OK: Stage 18J-P14 external identity load dry-run generated."
+echo "OK: dry-run only; no DB access, no identity load, no imports, no reconciliation, no summarizer, no station-type dry-run, no approval record, and no canonical apply."

--- a/tests/test_station_external_identity_loader.py
+++ b/tests/test_station_external_identity_loader.py
@@ -1,0 +1,410 @@
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_external_identity_loader as loader  # noqa: E402
+
+
+GENERATED_AT = '2026-01-02T00:00:00Z'
+
+
+def planned_row(index: int, **overrides):
+    row = {
+        'plan_row_id': f'plan-row-{index}',
+        'candidate_id': f'candidate-{index}',
+        'canonical_station_id': 2000 + index,
+        'system_id64': 420000 + index,
+        'station_name': f'Test Port {index}',
+        'source': 'edsm_nightly_stations',
+        'market_id': None,
+        'edsm_station_id': 1000 + index,
+        'source_run_key': 'run-key',
+        'source_file_key': 'file-key',
+        'source_record_hash': f'source-hash-{index}',
+        'source_updated_at': '2026-01-02T00:00:00Z',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'identity_status': 'confirmed',
+        'conflict_reason': None,
+        'match_basis': 'system_id64_normalized_station_name',
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_written': 0,
+    }
+    row.update(overrides)
+    return row
+
+
+def checks(**overrides):
+    result = {
+        'canonical_station_id_present': True,
+        'system_id64_present': True,
+        'station_name_present': True,
+        'source_run_key_present': True,
+        'source_file_key_present': True,
+        'source_record_hash_present': True,
+        'external_id_present': True,
+        'identity_status_is_confirmed': True,
+        'conflict_reason_is_null': True,
+        'station_type_write_not_planned': True,
+    }
+    result.update(overrides)
+    return result
+
+
+def review_packet(rows):
+    return {
+        'schema_version': 'station_external_identity_review_packet/v1',
+        'dry_run': True,
+        'read_only': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_planned': len(rows),
+        'identity_rows_written': 0,
+        'approval_record_created': False,
+        'max_planned_rows': 20,
+        'source_artifact': {
+            'artifact_type': 'station_external_identity_load_plan/v1',
+            'basename': 'load-plan.json',
+            'sha256': 'load-plan-sha',
+        },
+        'summary': {
+            'planned_rows_count': len(rows),
+            'manual_review_items_count': len(rows),
+            'manual_review_status_counts': {'needs_manual_review': len(rows)},
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': 0,
+            'approval_record_created': False,
+        },
+        'planned_rows': list(rows),
+        'manual_review_items': [
+            {
+                'review_item_id': f'review-item-{index}',
+                'planned_row_index': index,
+                'review_status': 'needs_manual_review',
+                'planned_row': row,
+                'checks': checks(),
+                'reviewer_notes': None,
+            }
+            for index, row in enumerate(rows, start=1)
+        ],
+    }
+
+
+def approval_allowlist(packet_sha, *, review_item_ids=None, plan_row_ids=None):
+    return {
+        'schema_version': 'station_external_identity_load_approval_allowlist/v1',
+        'review_packet_sha256': packet_sha,
+        'approved_review_item_ids': list(review_item_ids or []),
+        'approved_plan_row_ids': list(plan_row_ids or []),
+        'reviewer': 'Synthetic Reviewer',
+        'reviewed_at': '2026-01-02T00:00:00Z',
+        'declaration': 'Synthetic fixture approval for station_external_identity rows only.',
+    }
+
+
+def write_json(tmp_path: Path, name: str, payload: dict) -> tuple[Path, str]:
+    path = tmp_path / name
+    text = json.dumps(payload, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+    path.write_text(text + '\n', encoding='utf-8')
+    return path, hashlib.sha256((text + '\n').encode('utf-8')).hexdigest()
+
+
+def build_plan(packet, *, max_rows=20, approval=None, write_reviewed=False, conn=None, packet_sha='packet-sha'):
+    return loader.build_execution_plan(
+        packet,
+        review_packet_basename='packet.json',
+        review_packet_sha256=packet_sha,
+        review_packet_size_bytes=123,
+        max_rows=max_rows,
+        dry_run=not write_reviewed,
+        write_reviewed=write_reviewed,
+        approval_allowlist=approval,
+        approval_allowlist_sha256='approval-sha' if approval else None,
+        conn=conn,
+        generated_at=GENERATED_AT,
+    )
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.last_result = None
+
+    def execute(self, sql, params=None):
+        self.conn.statements.append((sql, tuple(params or ())))
+        self.last_result = self.conn.insert_identity(tuple(params or ()))
+
+    def fetchone(self):
+        return self.last_result
+
+    def close(self):
+        self.conn.cursor_closed = True
+
+
+class FakeConn:
+    def __init__(self, *, existing_external_ids=None):
+        self.statements = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.cursor_closed = False
+        self.next_id = 100
+        self.existing_external_ids = set(existing_external_ids or ())
+        self.station_type_updates = []
+        self.stations_updates = []
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def insert_identity(self, params):
+        source = params[3]
+        market_id = params[4]
+        edsm_station_id = params[5]
+        key = (source, market_id, edsm_station_id)
+        if key in self.existing_external_ids:
+            return None
+        self.existing_external_ids.add(key)
+        row_id = self.next_id
+        self.next_id += 1
+        return (row_id,)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+
+def test_dry_run_validates_good_review_packet():
+    artifact = build_plan(review_packet([planned_row(1), planned_row(2)]))
+
+    assert artifact['schema_version'] == 'station_external_identity_load_execution_plan/v1'
+    assert artifact['dry_run'] is True
+    assert artifact['write_reviewed'] is False
+    assert artifact['identity_rows_selected'] == 2
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['selected_review_item_ids'] == ['review-item-1', 'review-item-2']
+    assert artifact['selected_plan_row_ids'] == ['plan-row-1', 'plan-row-2']
+
+
+def test_dry_run_refuses_checksum_mismatch(tmp_path):
+    path, _actual_sha = write_json(tmp_path, 'packet.json', review_packet([planned_row(1)]))
+
+    with pytest.raises(loader.IdentityLoaderError, match='checksum mismatch'):
+        loader.build_execution_plan_from_files(
+            review_packet_path=path,
+            expected_review_packet_sha256='0' * 64,
+            max_rows=1,
+            dry_run=True,
+            write_reviewed=False,
+            generated_at=GENERATED_AT,
+        )
+
+
+def test_dry_run_refuses_missing_planned_row():
+    packet = review_packet([planned_row(1)])
+    packet['manual_review_items'][0]['planned_row'] = None
+
+    with pytest.raises(loader.IdentityLoaderError, match='missing planned_row'):
+        build_plan(packet)
+
+
+def test_dry_run_refuses_missing_checks():
+    packet = review_packet([planned_row(1)])
+    packet['manual_review_items'][0]['checks'] = {}
+
+    with pytest.raises(loader.IdentityLoaderError, match='missing checks'):
+        build_plan(packet)
+
+
+def test_dry_run_refuses_failed_checks():
+    packet = review_packet([planned_row(1)])
+    packet['manual_review_items'][0]['checks']['external_id_present'] = False
+
+    with pytest.raises(loader.IdentityLoaderError, match='failed required checks'):
+        build_plan(packet)
+
+
+def test_dry_run_refuses_non_confirmed_identity_status():
+    row = planned_row(1, identity_status='proposed')
+    packet = review_packet([row])
+
+    with pytest.raises(loader.IdentityLoaderError, match='identity_status must be confirmed'):
+        build_plan(packet)
+
+
+def test_dry_run_refuses_non_null_conflict_reason():
+    row = planned_row(1, conflict_reason='ambiguous_canonical_station_match')
+    packet = review_packet([row])
+
+    with pytest.raises(loader.IdentityLoaderError, match='conflict_reason must be null'):
+        build_plan(packet)
+
+
+def test_dry_run_refuses_missing_source_provenance():
+    row = planned_row(1, source_record_hash='')
+    packet = review_packet([row])
+
+    with pytest.raises(loader.IdentityLoaderError, match='source_record_hash'):
+        build_plan(packet)
+
+
+def test_dry_run_refuses_missing_external_id():
+    row = planned_row(1, market_id=None, edsm_station_id=None)
+    packet = review_packet([row])
+
+    with pytest.raises(loader.IdentityLoaderError, match='market_id or edsm_station_id'):
+        build_plan(packet)
+
+
+def test_parse_args_refuses_missing_max_rows():
+    with pytest.raises(SystemExit):
+        loader.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--dsn',
+            'dry-run-dsn',
+            '--dry-run',
+            '--output',
+            'out.json',
+        ])
+
+
+def test_parse_args_refuses_max_rows_over_20():
+    with pytest.raises(SystemExit):
+        loader.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--dsn',
+            'dry-run-dsn',
+            '--max-rows',
+            '21',
+            '--dry-run',
+            '--output',
+            'out.json',
+        ])
+
+
+@pytest.mark.parametrize(
+    'flag',
+    ['--write', '--apply', '--canonical-apply', '--station-type-dry-run', '--reconciliation', '--import', '--summarizer', '--commit'],
+)
+def test_forbidden_flags_are_rejected(flag):
+    with pytest.raises(SystemExit):
+        loader.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--dsn',
+            'dry-run-dsn',
+            '--max-rows',
+            '1',
+            '--dry-run',
+            '--output',
+            'out.json',
+            flag,
+        ])
+
+
+def test_dry_run_selects_only_up_to_max_rows():
+    rows = [planned_row(1), planned_row(2), planned_row(3)]
+    artifact = build_plan(review_packet(rows), max_rows=2)
+
+    assert artifact['identity_rows_selected'] == 2
+    assert artifact['selected_plan_row_ids'] == ['plan-row-1', 'plan-row-2']
+
+
+def test_dry_run_output_keeps_write_counts_zero():
+    artifact = build_plan(review_packet([planned_row(1)]))
+
+    assert artifact['canonical_writes_planned'] == 0
+    assert artifact['station_type_writes_planned'] == 0
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['validation_summary']['canonical_writes_planned'] == 0
+    assert artifact['validation_summary']['station_type_writes_planned'] == 0
+    assert artifact['validation_summary']['identity_rows_written'] == 0
+
+
+def test_write_reviewed_requires_approval_allowlist():
+    with pytest.raises(loader.IdentityLoaderError, match='approval allowlist'):
+        build_plan(review_packet([planned_row(1)]), write_reviewed=True, conn=FakeConn())
+
+
+def test_synthetic_local_write_inserts_only_selected_approved_rows():
+    packet_sha = 'packet-sha'
+    rows = [planned_row(1), planned_row(2)]
+    approval = approval_allowlist(packet_sha, review_item_ids=['review-item-2'])
+    conn = FakeConn()
+
+    artifact = build_plan(
+        review_packet(rows),
+        write_reviewed=True,
+        approval=approval,
+        conn=conn,
+        packet_sha=packet_sha,
+    )
+
+    assert artifact['dry_run'] is False
+    assert artifact['write_reviewed'] is True
+    assert artifact['identity_rows_selected'] == 1
+    assert artifact['identity_rows_written'] == 1
+    assert artifact['selected_review_item_ids'] == ['review-item-2']
+    assert artifact['selected_plan_row_ids'] == ['plan-row-2']
+    assert artifact['inserted_row_ids'] == [100]
+    assert conn.commits == 1
+
+
+def test_synthetic_local_write_never_updates_stations_or_station_type():
+    packet_sha = 'packet-sha'
+    approval = approval_allowlist(packet_sha, review_item_ids=['review-item-1'])
+    conn = FakeConn()
+
+    build_plan(review_packet([planned_row(1)]), write_reviewed=True, approval=approval, conn=conn, packet_sha=packet_sha)
+
+    assert conn.statements
+    for sql, _params in conn.statements:
+        normalized = ' '.join(sql.lower().split())
+        assert normalized.startswith('insert into station_external_identity')
+        assert 'update stations' not in normalized
+        assert ' station_type' not in normalized
+    assert conn.stations_updates == []
+    assert conn.station_type_updates == []
+
+
+def test_duplicate_insert_behavior_is_idempotent_skip():
+    packet_sha = 'packet-sha'
+    approval = approval_allowlist(packet_sha, review_item_ids=['review-item-1'])
+    existing_key = ('edsm_nightly_stations', None, 1001)
+    conn = FakeConn(existing_external_ids={existing_key})
+
+    artifact = build_plan(review_packet([planned_row(1)]), write_reviewed=True, approval=approval, conn=conn, packet_sha=packet_sha)
+
+    assert artifact['identity_rows_selected'] == 1
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['validation_summary']['duplicate_rows_skipped'] == 1
+    assert artifact['insert_results'][0]['inserted'] is False
+
+
+def test_deterministic_json_output():
+    packet = review_packet([planned_row(1)])
+    first = build_plan(packet)
+    second = build_plan(packet)
+
+    assert loader.json_dumps_artifact(first) == loader.json_dumps_artifact(second)
+    assert first['artifact_integrity']['canonical_json_sha256']


### PR DESCRIPTION
## What changed

* Adds controlled external identity load tooling.
* Adds dry-run load execution plan support.
* Adds approval/allowlist handling if implemented.
* Adds Hetzner dry-run operator script.
* Keeps production identity writes blocked in this PR.
* Keeps station-type writes blocked.
* Adds tests and docs.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No identity evidence loaded in production.
* No production writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No approval record created in production.
* Stage 18K not started.

## Validation

```text
git diff --check
(no output; exit 0)

git diff --cached --check
(no output; exit 0)

bash -n scripts/operator/require_hetzner_operator_env.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_compact_summary.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_identity_review_packet.sh
(no output; exit 0)

bash -n scripts/operator/stage18j_run_identity_load_dry_run.sh
(no output; exit 0)

./scripts/run_canonical_safety_tests.sh
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py tests/test_station_external_identity_loader.py -q
........................................................................ [ 40%]
........................................................................ [ 80%]
....................................                                     [100%]
180 passed in 0.24s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py apps/importer/src/station_external_identity_review_packet.py apps/importer/src/station_external_identity_loader.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py tests/test_station_external_identity_loader.py
(no output; exit 0)

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' apps/importer/src/station_external_identity_loader.py scripts/operator/stage18j_run_identity_load_dry_run.sh docs/colonisation-redesign/stage-18j-p14-controlled-external-identity-load-tooling.md docs/colonisation-redesign/stage-18j-p12-p13-load-plan-review-packet.md docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md docs/colonisation-redesign/enrichment-roadmap.md docs/operations/enrichment-warehouse-runbook.md docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
(no matches; grep exit 1, equivalent to requested scan with `|| true`)
```
