### PR TITLE
Stage 18J-P14C approval allowlist artifact

### DIFF
--- a/apps/importer/src/station_external_identity_approval_allowlist.py
+++ b/apps/importer/src/station_external_identity_approval_allowlist.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+"""Offline approval allowlist generator for external station identity rows.
+
+This tool reads a local ``station_external_identity_review_packet/v1`` JSON
+artifact and emits a deterministic allowlist for a future controlled
+``station_external_identity`` load. It does not accept a DSN and never connects
+to a database.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 'station_external_identity_load_approval_allowlist/v1'
+REVIEW_PACKET_SCHEMA_VERSION = 'station_external_identity_review_packet/v1'
+TOOL_NAME = 'station_external_identity_approval_allowlist'
+TOOL_VERSION = 'v1'
+MAX_ROWS_CAP = 20
+REVIEWER_DECISION = 'approve_selected_identity_rows'
+ALLOWED_REVIEW_STATUSES = ('needs_manual_review', 'reviewed_for_identity_load')
+FORBIDDEN_FLAG_ERROR = (
+    'write/apply/load/import/reconciliation/summarizer/station-type/canonical flags are not available; '
+    'this tool only emits an offline approval allowlist artifact'
+)
+REQUIRED_CHECK_KEYS = (
+    'canonical_station_id_present',
+    'system_id64_present',
+    'station_name_present',
+    'source_run_key_present',
+    'source_file_key_present',
+    'source_record_hash_present',
+    'external_id_present',
+    'identity_status_is_confirmed',
+    'conflict_reason_is_null',
+    'station_type_write_not_planned',
+)
+
+
+class IdentityApprovalAllowlistError(ValueError):
+    """Raised when an approval allowlist cannot be built safely."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Build an offline station_external_identity approval allowlist from a review packet.',
+    )
+    parser.add_argument('--review-packet', required=True, help='Local station_external_identity_review_packet/v1 JSON file.')
+    parser.add_argument('--expected-review-packet-sha256', required=True, help='Expected SHA-256 of the review packet file.')
+    parser.add_argument('--output', required=True, help='Path to write the JSON approval allowlist.')
+    parser.add_argument('--json', action='store_true', help='Emit JSON to stdout after writing output.')
+    parser.add_argument('--confirm-reviewed', action='store_true', help='Required confirmation that rows were reviewed for identity load.')
+    parser.add_argument(
+        '--reviewer-decision',
+        required=True,
+        help=f'Required decision string, must be {REVIEWER_DECISION}.',
+    )
+    parser.add_argument('--max-rows', type=int, required=True, help=f'Maximum approved rows, maximum {MAX_ROWS_CAP}.')
+    parser.add_argument(
+        '--reviewer',
+        default='stage-18j-p14c-offline-review',
+        help='Reviewer label recorded in the allowlist metadata.',
+    )
+    parser.add_argument('--write', action='store_true', help='Unsupported; this tool is offline allowlist-only.')
+    parser.add_argument('--apply', action='store_true', help='Unsupported; canonical apply is blocked.')
+    parser.add_argument('--canonical', action='store_true', help='Unsupported; canonical work is blocked.')
+    parser.add_argument('--canonical-apply', action='store_true', help='Unsupported; canonical apply is blocked.')
+    parser.add_argument('--station-type', action='store_true', help='Unsupported; station-type writes are blocked.')
+    parser.add_argument('--station-type-dry-run', action='store_true', help='Unsupported; station-type dry-run is blocked.')
+    parser.add_argument('--load', action='store_true', help='Unsupported; this tool does not load rows.')
+    parser.add_argument('--commit', action='store_true', help='Unsupported; this tool does not create commits.')
+    parser.add_argument('--reconciliation', action='store_true', help='Unsupported; reconciliation is blocked.')
+    parser.add_argument('--import', dest='run_import', action='store_true', help='Unsupported; imports are blocked.')
+    parser.add_argument('--summarizer', action='store_true', help='Unsupported; summarizer runs are blocked.')
+    args = parser.parse_args(argv)
+
+    if (
+        args.write
+        or args.apply
+        or args.canonical
+        or args.canonical_apply
+        or args.station_type
+        or args.station_type_dry_run
+        or args.load
+        or args.commit
+        or args.reconciliation
+        or args.run_import
+        or args.summarizer
+    ):
+        parser.error(FORBIDDEN_FLAG_ERROR)
+    if not args.confirm_reviewed:
+        parser.error('--confirm-reviewed is required')
+    if args.reviewer_decision != REVIEWER_DECISION:
+        parser.error(f'--reviewer-decision must be {REVIEWER_DECISION}')
+    if args.max_rows < 1:
+        parser.error('--max-rows must be >= 1')
+    if args.max_rows > MAX_ROWS_CAP:
+        parser.error(f'--max-rows must be <= {MAX_ROWS_CAP}')
+    if not args.reviewer.strip():
+        parser.error('--reviewer must be non-empty')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        artifact = build_allowlist_from_file(
+            args.review_packet,
+            expected_review_packet_sha256=args.expected_review_packet_sha256,
+            max_rows=args.max_rows,
+            reviewer=args.reviewer,
+            reviewer_decision=args.reviewer_decision,
+            confirm_reviewed=args.confirm_reviewed,
+        )
+    except (OSError, ValueError) as exc:
+        print(f'station external identity approval allowlist generation failed: {exc}', file=sys.stderr)
+        return 2
+
+    output = json_dumps_artifact(artifact)
+    Path(args.output).write_text(output + '\n', encoding='utf-8')
+    if args.json:
+        print(output)
+    return 0
+
+
+def build_allowlist_from_file(
+    review_packet_path: str | Path,
+    *,
+    expected_review_packet_sha256: str,
+    max_rows: int,
+    reviewer: str,
+    reviewer_decision: str = REVIEWER_DECISION,
+    confirm_reviewed: bool = True,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    if max_rows < 1:
+        raise IdentityApprovalAllowlistError('max_rows must be >= 1')
+    if max_rows > MAX_ROWS_CAP:
+        raise IdentityApprovalAllowlistError(f'max_rows must be <= {MAX_ROWS_CAP}')
+    if not confirm_reviewed:
+        raise IdentityApprovalAllowlistError('confirm_reviewed is required')
+    if reviewer_decision != REVIEWER_DECISION:
+        raise IdentityApprovalAllowlistError(f'reviewer_decision must be {REVIEWER_DECISION}')
+    if not reviewer.strip():
+        raise IdentityApprovalAllowlistError('reviewer must be non-empty')
+
+    review_packet, actual_sha256, size_bytes = _load_json_file_with_sha(
+        review_packet_path,
+        expected_sha256=expected_review_packet_sha256,
+    )
+    return build_allowlist(
+        review_packet,
+        source_review_packet_basename=Path(review_packet_path).name,
+        source_review_packet_sha256=actual_sha256,
+        source_review_packet_size_bytes=size_bytes,
+        max_rows=max_rows,
+        reviewer=reviewer,
+        reviewer_decision=reviewer_decision,
+        generated_at=generated_at,
+    )
+
+
+def build_allowlist(
+    review_packet: Mapping[str, Any],
+    *,
+    source_review_packet_basename: str,
+    source_review_packet_sha256: str,
+    source_review_packet_size_bytes: int,
+    max_rows: int,
+    reviewer: str,
+    reviewer_decision: str = REVIEWER_DECISION,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    if max_rows < 1:
+        raise IdentityApprovalAllowlistError('max_rows must be >= 1')
+    if max_rows > MAX_ROWS_CAP:
+        raise IdentityApprovalAllowlistError(f'max_rows must be <= {MAX_ROWS_CAP}')
+    if reviewer_decision != REVIEWER_DECISION:
+        raise IdentityApprovalAllowlistError(f'reviewer_decision must be {REVIEWER_DECISION}')
+    if not reviewer.strip():
+        raise IdentityApprovalAllowlistError('reviewer must be non-empty')
+
+    source_integrity = _mapping(review_packet.get('artifact_integrity'))
+    source_review_packet_integrity_sha256 = source_integrity.get('canonical_json_sha256')
+    if not isinstance(source_review_packet_integrity_sha256, str) or not source_review_packet_integrity_sha256:
+        raise IdentityApprovalAllowlistError('review packet artifact_integrity canonical_json_sha256 is required')
+    selected_items = _select_review_items(review_packet, max_rows=max_rows)
+    approved_review_item_ids = [str(item['review_item_id']) for item in selected_items]
+    approved_plan_row_ids = [str(_mapping(item['planned_row'])['plan_row_id']) for item in selected_items]
+    now = generated_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    declaration = (
+        'Approval is limited to loading the listed external identity evidence rows '
+        'into station_external_identity; it does not approve station-type writes or canonical apply.'
+    )
+
+    artifact: dict[str, Any] = {
+        'schema_version': SCHEMA_VERSION,
+        'generated_at': now,
+        'tool': {
+            'name': TOOL_NAME,
+            'version': TOOL_VERSION,
+        },
+        'offline': True,
+        'read_only': True,
+        'approval_record_created': False,
+        'source_review_packet_basename': source_review_packet_basename,
+        'source_review_packet_sha256': source_review_packet_sha256,
+        'source_review_packet_size_bytes': source_review_packet_size_bytes,
+        'source_review_packet_integrity_sha256': source_review_packet_integrity_sha256,
+        'review_packet_sha256': source_review_packet_sha256,
+        'reviewer_decision': reviewer_decision,
+        'reviewer': reviewer.strip(),
+        'reviewed_at': now,
+        'declaration': declaration,
+        'reviewer_attestation': {
+            'reviewed_packet_schema': REVIEW_PACKET_SCHEMA_VERSION,
+            'reviewed_packet_sha256': source_review_packet_sha256,
+            'reviewed_packet_integrity_sha256': source_review_packet_integrity_sha256,
+            'reviewed_rows_count': len(selected_items),
+            'decision_scope': 'external_identity_evidence_load_only',
+            'does_not_approve_station_type_writes': True,
+            'does_not_approve_canonical_apply': True,
+            'does_not_create_production_approval_record': True,
+        },
+        'max_rows': max_rows,
+        'approved_review_item_ids': approved_review_item_ids,
+        'approved_plan_row_ids': approved_plan_row_ids,
+        'approved_rows_count': len(selected_items),
+        'identity_rows_written': 0,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'safety_summary': {
+            'review_packet_schema_valid': True,
+            'review_packet_sha256_verified': True,
+            'manual_review_items_approved': len(selected_items),
+            'all_required_checks_passed': True,
+            'source_provenance_present': True,
+            'external_id_present': True,
+            'identity_status_confirmed': True,
+            'conflict_reason_null': True,
+            'station_type_writes_planned': 0,
+            'canonical_writes_planned': 0,
+            'identity_rows_written': 0,
+            'approval_record_created': False,
+            'db_connections_allowed': False,
+            'db_write_statements_included': False,
+            'identity_load_performed': False,
+            'station_type_dry_run_performed': False,
+            'canonical_apply_performed': False,
+        },
+    }
+    artifact['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_sha256(artifact),
+        'canonicalization': 'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False) excluding artifact_integrity',
+    }
+    return _json_clone(artifact)
+
+
+def json_dumps_artifact(artifact: Mapping[str, Any]) -> str:
+    return canonical_json(artifact)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def artifact_sha256(value: Mapping[str, Any]) -> str:
+    payload = deepcopy(dict(value))
+    payload.pop('artifact_integrity', None)
+    return hashlib.sha256(canonical_json(payload).encode('utf-8')).hexdigest()
+
+
+def _load_json_file_with_sha(
+    path_value: str | Path,
+    *,
+    expected_sha256: str,
+) -> tuple[dict[str, Any], str, int]:
+    path = Path(path_value)
+    if not path.is_file():
+        raise IdentityApprovalAllowlistError(f'review packet is missing: {path}')
+    payload = path.read_bytes()
+    actual_sha256 = hashlib.sha256(payload).hexdigest()
+    if actual_sha256 != expected_sha256.lower():
+        raise IdentityApprovalAllowlistError(
+            f'review packet checksum mismatch. Expected {expected_sha256}, got {actual_sha256}',
+        )
+    try:
+        data = json.loads(payload.decode('utf-8'))
+    except json.JSONDecodeError as exc:
+        raise IdentityApprovalAllowlistError(f'review packet is not valid JSON: {exc}') from exc
+    if not isinstance(data, Mapping):
+        raise IdentityApprovalAllowlistError('review packet must be a JSON object')
+    return dict(data), actual_sha256, len(payload)
+
+
+def _select_review_items(review_packet: Mapping[str, Any], *, max_rows: int) -> list[dict[str, Any]]:
+    _validate_review_packet_safety(review_packet)
+    items = review_packet.get('manual_review_items')
+    if not isinstance(items, list):
+        raise IdentityApprovalAllowlistError('review packet manual_review_items must be a list')
+    selected = [_validate_review_item(item_value) for item_value in items[:max_rows]]
+    if not selected:
+        raise IdentityApprovalAllowlistError('review packet selected zero review rows')
+
+    planned_rows = review_packet.get('planned_rows')
+    if planned_rows is not None:
+        if not isinstance(planned_rows, list):
+            raise IdentityApprovalAllowlistError('review packet planned_rows must be a list')
+        embedded_rows = [item['planned_row'] for item in selected]
+        if embedded_rows != planned_rows[:len(selected)]:
+            raise IdentityApprovalAllowlistError('embedded manual review rows must match top-level planned_rows')
+    return selected
+
+
+def _validate_review_packet_safety(review_packet: Mapping[str, Any]) -> None:
+    if review_packet.get('schema_version') != REVIEW_PACKET_SCHEMA_VERSION:
+        raise IdentityApprovalAllowlistError(f'review packet schema_version must be {REVIEW_PACKET_SCHEMA_VERSION}')
+    if review_packet.get('identity_rows_written') != 0:
+        raise IdentityApprovalAllowlistError('review packet identity_rows_written must be 0')
+    if review_packet.get('canonical_writes_planned') != 0:
+        raise IdentityApprovalAllowlistError('review packet canonical_writes_planned must be 0')
+    if review_packet.get('station_type_writes_planned') != 0:
+        raise IdentityApprovalAllowlistError('review packet station_type_writes_planned must be 0')
+    if review_packet.get('approval_record_created') is True:
+        raise IdentityApprovalAllowlistError('review packet approval_record_created must be false')
+    summary = _mapping(review_packet.get('summary'))
+    for key in ('canonical_writes_planned', 'station_type_writes_planned', 'identity_rows_written'):
+        value = summary.get(key)
+        if value is not None and value != 0:
+            raise IdentityApprovalAllowlistError(f'review packet summary {key} must be 0')
+    if summary.get('approval_record_created') is True:
+        raise IdentityApprovalAllowlistError('review packet summary approval_record_created must be false')
+
+
+def _validate_review_item(item_value: Any) -> dict[str, Any]:
+    if not isinstance(item_value, Mapping):
+        raise IdentityApprovalAllowlistError('manual review item must be an object')
+    item = dict(item_value)
+    review_item_id = item.get('review_item_id')
+    if not review_item_id:
+        raise IdentityApprovalAllowlistError('manual review item is missing review_item_id')
+    review_status = item.get('review_status')
+    if review_status not in ALLOWED_REVIEW_STATUSES:
+        allowed = ', '.join(ALLOWED_REVIEW_STATUSES)
+        raise IdentityApprovalAllowlistError(f'manual review item review_status must be one of: {allowed}')
+    row = item.get('planned_row')
+    if not isinstance(row, Mapping) or not row:
+        raise IdentityApprovalAllowlistError('manual review item is missing planned_row')
+    row = _json_clone(row)
+    if not row.get('plan_row_id'):
+        raise IdentityApprovalAllowlistError('planned row is missing plan_row_id')
+    checks = item.get('checks')
+    if not isinstance(checks, Mapping) or not checks:
+        raise IdentityApprovalAllowlistError('manual review item is missing checks')
+    failed_checks = [key for key in REQUIRED_CHECK_KEYS if checks.get(key) is not True]
+    if failed_checks:
+        raise IdentityApprovalAllowlistError('manual review item has failed required checks: ' + ', '.join(failed_checks))
+    if row.get('identity_status') != 'confirmed':
+        raise IdentityApprovalAllowlistError('planned row identity_status must be confirmed')
+    if row.get('conflict_reason') is not None:
+        raise IdentityApprovalAllowlistError('planned row conflict_reason must be null')
+    for field in ('source_run_key', 'source_file_key', 'source_record_hash'):
+        if not row.get(field):
+            raise IdentityApprovalAllowlistError(f'planned row is missing source provenance field: {field}')
+    if row.get('market_id') is None and row.get('edsm_station_id') is None:
+        raise IdentityApprovalAllowlistError('planned row must have market_id or edsm_station_id')
+    if row.get('station_type_writes_planned') != 0:
+        raise IdentityApprovalAllowlistError('planned row station_type_writes_planned must be 0')
+    if row.get('canonical_writes_planned') != 0:
+        raise IdentityApprovalAllowlistError('planned row canonical_writes_planned must be 0')
+    item['review_item_id'] = str(review_item_id)
+    item['planned_row'] = row
+    item['checks'] = _json_clone(checks)
+    return item
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _json_clone(value: Any) -> Any:
+    return json.loads(canonical_json(value))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/docs/colonisation-redesign/enrichment-roadmap.md
+++ b/docs/colonisation-redesign/enrichment-roadmap.md
@@ -699,6 +699,14 @@ review packet SHA-256
 The verdict is `Ready only after approval allowlist artifact`. See
 [`stage-18j-p14b-identity-load-dry-run-review.md`](./stage-18j-p14b-identity-load-dry-run-review.md).
 
+Stage 18J-P14C adds the offline approval allowlist artifact generator in
+`apps/importer/src/station_external_identity_approval_allowlist.py` and a
+Hetzner-only wrapper in
+`scripts/operator/stage18j_run_identity_approval_allowlist.sh`. The allowlist
+approves exact external identity evidence rows only; it is not station-type
+approval, canonical apply approval, or a production approval record. See
+[`stage-18j-p14c-approval-allowlist-artifact.md`](./stage-18j-p14c-approval-allowlist-artifact.md).
+
 Stage 19A defines the warehouse artifact taxonomy and chunked roadmap before
 the warehouse broadens beyond the station reconciliation path. It separates
 stations, bodies, rings, station/body links, markets, services, economies,
@@ -817,6 +825,10 @@ treated as a separate proposal.
   load dry-run result and sets the verdict to `Ready only after approval
   allowlist artifact`. The selected rows are structurally loadable but not yet
   approved for insertion.
+* **External identity approval allowlist artifact**: Stage 18J-P14C adds the
+  offline allowlist generator and Hetzner-only wrapper for exact selected
+  review item IDs and plan row IDs. It approves external identity evidence load
+  scope only and still loads no rows.
 * **External identity follow-up sequence**: use the execution board for Chunk A
   P12/P13 review pack, Chunk B P14/P14B controlled identity load tooling and
   dry-run review, P14C approval allowlist, P14D controlled write-reviewed load,

--- a/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
+++ b/docs/colonisation-redesign/stage-17p-current-state-forward-plan.md
@@ -1414,6 +1414,43 @@ Non-goals:
 Support doc:
 `stage-18j-p14b-identity-load-dry-run-review.md`.
 
+### Stage 18J-P14C - Approval Allowlist Artifact
+
+Purpose: add offline approval allowlist artifact tooling for the exact reviewed
+external identity rows before any controlled write-reviewed load.
+
+Scope:
+
+- Add `apps/importer/src/station_external_identity_approval_allowlist.py`.
+- Emit `station_external_identity_load_approval_allowlist/v1`.
+- Verify the review packet SHA-256 exactly.
+- Require explicit confirmation and
+  `reviewer_decision = approve_selected_identity_rows`.
+- Cap approved rows at `20`.
+- Approve exact review item IDs and plan row IDs only.
+- Include reviewer attestation for external identity evidence load scope only.
+- Record `approval_record_created = false`.
+- Record `identity_rows_written = 0`.
+- Record `canonical_writes_planned = 0`.
+- Record `station_type_writes_planned = 0`.
+- Add `scripts/operator/stage18j_run_identity_approval_allowlist.sh` as a
+  Hetzner-only offline wrapper.
+- Add synthetic tests and docs/runbook updates.
+
+Non-goals:
+
+- No production commands from Codex.
+- No production DB access from Codex.
+- No production identity evidence load.
+- No production writes to `station_external_identity`.
+- No imports, reconciliation, production summarizer run, station-type dry-run,
+  or canonical apply.
+- No production approval record.
+- No Stage 18K work.
+
+Support doc:
+`stage-18j-p14c-approval-allowlist-artifact.md`.
+
 ### Stage 19A.1 - Operator Path Guardrails
 
 Purpose: prevent Codex/local prompts from accidentally running Hetzner

--- a/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
+++ b/docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md
@@ -47,6 +47,10 @@ Known state:
   `canonical_writes_planned = 0`, `station_type_writes_planned = 0`, and
   `station_external_identity` row count remained `0`. Its verdict is
   `Ready only after approval allowlist artifact`.
+- Stage 18J-P14C adds offline approval allowlist artifact tooling for exact
+  selected review item IDs and plan row IDs. The allowlist approves only
+  external identity evidence loading and is not station-type approval, canonical
+  apply approval, or a production approval record.
 - Stage 18K remains untouched.
 
 ## Why We Are Optimising
@@ -158,6 +162,11 @@ P14B records that the P14 dry-run completed safely. It proves the selected
 `20` rows are structurally loadable, but it does not approve a write. The next
 gate is a separate `station_external_identity_load_approval_allowlist/v1`
 artifact for exact selected review item IDs or plan row IDs.
+
+P14C supplies that allowlist artifact generator and Hetzner-only wrapper. It
+does not load rows. The controlled write-reviewed load remains a later tiny
+operator action and must still verify the allowlist before writing anything to
+`station_external_identity`.
 
 ### Chunk C - P15 Post-load Identity Coverage
 
@@ -296,11 +305,13 @@ Recommended next actions:
    Chunk A merges.
 4. Use `stage-18j-p14b-identity-load-dry-run-review.md` as the Chunk B
    dry-run review record.
-5. Create a separate approval allowlist only if the dry-run plan and planned
+5. Use `stage-18j-p14c-approval-allowlist-artifact.md` as the approval
+   allowlist tooling and artifact contract record.
+6. Create the separate approval allowlist only if the dry-run plan and planned
    rows are manually accepted.
-6. Run a controlled write-reviewed identity load only after that allowlist
+7. Run a controlled write-reviewed identity load only after that allowlist
    exists and is explicitly approved.
-7. Keep station-type dry-run blocked until post-load coverage and read-only
+8. Keep station-type dry-run blocked until post-load coverage and read-only
    reconciliation prove confirmed identity coverage.
 
 ## Final Recommendation

--- a/docs/colonisation-redesign/stage-18j-p14-controlled-external-identity-load-tooling.md
+++ b/docs/colonisation-redesign/stage-18j-p14-controlled-external-identity-load-tooling.md
@@ -134,6 +134,17 @@ P14 implements a separate approval allowlist artifact for write mode:
 - `reviewed_at`;
 - `declaration`.
 
+Stage 18J-P14C adds offline allowlist artifact tooling in
+`apps/importer/src/station_external_identity_approval_allowlist.py` and a
+Hetzner-only wrapper in
+`scripts/operator/stage18j_run_identity_approval_allowlist.sh`. The generated
+artifact also records `offline = true`, `read_only = true`,
+`approval_record_created = false`, source review packet basename/checksum,
+source review packet integrity checksum, reviewer attestation, approved row
+count, `identity_rows_written = 0`, `canonical_writes_planned = 0`, and
+`station_type_writes_planned = 0`. See
+[`stage-18j-p14c-approval-allowlist-artifact.md`](./stage-18j-p14c-approval-allowlist-artifact.md).
+
 The allowlist is not a canonical apply approval. It only approves loading exact
 external identity evidence rows into `station_external_identity`.
 
@@ -252,7 +263,7 @@ Before any future production write-reviewed run:
 
 - use the P14B-reviewed load dry-run result;
 - inspect the execution plan artifact and checksum;
-- create a separate approval allowlist artifact for exact reviewed rows;
+- create the P14C separate approval allowlist artifact for exact reviewed rows;
 - verify the allowlist references the exact review packet SHA-256;
 - verify selected row IDs and plan row IDs match the manual review;
 - record pre-check `station_external_identity` row count;
@@ -267,7 +278,7 @@ Recommended sequence:
 
 - use the P14B load dry-run review as the dry-run gate record;
 - manually review the load execution plan;
-- prepare a separate approval allowlist artifact only if rows are accepted;
+- prepare the P14C approval allowlist artifact only if rows are accepted;
 - add a future guarded write operator action only after the approval allowlist
   is reviewed;
 - proceed to post-load coverage only after an approved controlled load has run.

--- a/docs/colonisation-redesign/stage-18j-p14b-identity-load-dry-run-review.md
+++ b/docs/colonisation-redesign/stage-18j-p14b-identity-load-dry-run-review.md
@@ -125,6 +125,15 @@ Before any controlled write-reviewed load:
 - run no imports, reconciliation, summarizer, station-type dry-run, canonical
   apply, or production approval-record creation as part of the allowlist step.
 
+Stage 18J-P14C adds this offline allowlist artifact tooling in
+`apps/importer/src/station_external_identity_approval_allowlist.py` and a
+Hetzner-only wrapper in
+`scripts/operator/stage18j_run_identity_approval_allowlist.sh`. The allowlist
+approves only external identity evidence loading for exact selected rows. It
+does not approve station-type writes, canonical apply, or production
+approval-record creation. See
+[`stage-18j-p14c-approval-allowlist-artifact.md`](./stage-18j-p14c-approval-allowlist-artifact.md).
+
 ## What Was Not Run
 
 Stage 18J-P14B did not run:

--- a/docs/colonisation-redesign/stage-18j-p14c-approval-allowlist-artifact.md
+++ b/docs/colonisation-redesign/stage-18j-p14c-approval-allowlist-artifact.md
@@ -1,0 +1,237 @@
+# Stage 18J-P14C — Approval Allowlist Artifact
+
+## Purpose
+
+Stage 18J-P14C adds offline tooling and operator guardrails for an explicit
+approval allowlist artifact for the exact reviewed external identity rows.
+
+This stage does not load identity evidence. It only prepares the artifact that
+a future controlled loader run must verify before `--write-reviewed` can insert
+rows into `station_external_identity`.
+
+This is repo/tooling/tests/docs work only. It does not run production commands,
+touch the production database, load identity evidence in production, write to
+`station_external_identity` in production, run imports, run reconciliation, run
+the summarizer against production artifacts, run station-type dry-run, run
+canonical apply, create production approval records, or start Stage 18K.
+
+## Inputs
+
+The allowlist generator is scoped to the fixed review packet:
+
+- review packet path:
+  `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_review_packet_20260603T110848Z.json`;
+- review packet SHA-256:
+  `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`;
+- review packet artifact integrity SHA-256:
+  `8cbcf4f2c0d4e3180c3fa6fcbf44f41e71269254168fee0b121f4c6b07bcab84`;
+- schema: `station_external_identity_review_packet/v1`;
+- manual review items: `20`;
+- planned rows: `20`.
+
+The P14B load dry-run selected the same bounded set:
+
+- schema: `station_external_identity_load_execution_plan/v1`;
+- `dry_run = true`;
+- `write_reviewed = false`;
+- `identity_rows_selected = 20`;
+- `identity_rows_written = 0`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `max_rows = 20`;
+- selected review item IDs: `20`;
+- selected plan row IDs: `20`;
+- `station_external_identity` row count after dry-run: `0`.
+
+## Why An Allowlist Is Required
+
+The P14B dry-run proves the selected rows are structurally loadable, but it
+does not approve a write. The review packet rows still need an explicit
+operator decision artifact before a future controlled write-reviewed load can
+insert anything.
+
+The allowlist is that decision artifact. It binds the decision to the exact
+review packet checksum and the exact selected review item IDs or plan row IDs.
+
+## Approval Scope
+
+The allowlist scope is deliberately narrow:
+
+- decision: `approve_selected_identity_rows`;
+- scope: external identity evidence load only;
+- target table for a future load: `station_external_identity`;
+- maximum rows: `20`;
+- source packet SHA-256 must match exactly.
+
+The allowlist is not a broad canonical approval.
+
+## What The Allowlist Approves
+
+The allowlist approves only the exact external identity evidence rows selected
+from the verified review packet. A future loader run must verify:
+
+- `schema_version = station_external_identity_load_approval_allowlist/v1`;
+- `review_packet_sha256` matches the review packet being loaded;
+- approved review item IDs or approved plan row IDs select rows from that
+  packet;
+- selected rows still pass all required checks;
+- selected rows still have `identity_status = confirmed`;
+- selected rows still have `conflict_reason = null`;
+- selected rows still include source run/file/hash provenance;
+- selected rows still include an external ID.
+
+## What The Allowlist Does Not Approve
+
+The allowlist does not approve:
+
+- station-type writes;
+- station-type dry-run;
+- canonical apply;
+- writes to `stations`;
+- imports;
+- reconciliation;
+- summarizer runs against production artifacts;
+- production approval-record creation;
+- Stage 18K.
+
+It is not a production approval record. It is only an input artifact for a
+future, separately approved controlled identity evidence load.
+
+## Artifact Contract
+
+P14C adds `apps/importer/src/station_external_identity_approval_allowlist.py`.
+
+The tool emits deterministic JSON with schema:
+
+`station_external_identity_load_approval_allowlist/v1`
+
+Required top-level fields include:
+
+- `schema_version`;
+- `generated_at`;
+- `offline = true`;
+- `read_only = true`;
+- `approval_record_created = false`;
+- `source_review_packet_basename`;
+- `source_review_packet_sha256`;
+- `source_review_packet_integrity_sha256`;
+- `review_packet_sha256`;
+- `reviewer_decision`;
+- `reviewer`;
+- `reviewed_at`;
+- `declaration`;
+- `reviewer_attestation`;
+- `max_rows`;
+- `approved_review_item_ids`;
+- `approved_plan_row_ids`;
+- `approved_rows_count`;
+- `identity_rows_written = 0`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `safety_summary`;
+- `artifact_integrity`.
+
+The reviewer attestation records:
+
+- reviewed packet schema;
+- reviewed packet SHA-256;
+- reviewed row count;
+- `decision_scope = external_identity_evidence_load_only`;
+- `does_not_approve_station_type_writes = true`;
+- `does_not_approve_canonical_apply = true`;
+- `does_not_create_production_approval_record = true`.
+
+The tool refuses:
+
+- checksum mismatch;
+- missing review packet;
+- missing `--confirm-reviewed`;
+- reviewer decision other than `approve_selected_identity_rows`;
+- `--max-rows > 20`;
+- `--dsn`;
+- write/apply/load/commit/reconciliation/import/station-type/canonical flags;
+- missing planned rows;
+- failed row checks;
+- missing source provenance;
+- missing external IDs;
+- non-confirmed identity status;
+- non-null conflict reason.
+
+## Operator Workflow
+
+P14C adds:
+
+`scripts/operator/stage18j_run_identity_approval_allowlist.sh`
+
+The wrapper:
+
+- calls `scripts/operator/require_hetzner_operator_env.sh`;
+- defaults `ART_DIR` to
+  `/var/lib/ed-finder/operator-artifacts/stage-18j`;
+- defaults the review packet path to the P13A packet;
+- requires review packet SHA-256
+  `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`;
+- requires review packet integrity SHA-256
+  `8cbcf4f2c0d4e3180c3fa6fcbf44f41e71269254168fee0b121f4c6b07bcab84`;
+- requires `CONFIRM_IDENTITY_ALLOWLIST=yes`;
+- defaults `MAX_ROWS = 20`;
+- refuses `MAX_ROWS > 20`;
+- writes the allowlist under the operator artifact directory;
+- applies mode `600` to the output;
+- prints artifact path, checksum, and summary fields;
+- prints explicit no-load, no-station-type, no-apply confirmation.
+
+The wrapper never sources DB env, never connects to a DB, and never runs
+imports, reconciliation, summarizer, station-type dry-run, or canonical apply.
+
+## Safety Boundaries
+
+P14C keeps these boundaries:
+
+- no production commands from Codex;
+- no production DB access from Codex;
+- no identity evidence loaded in production;
+- no production writes to `station_external_identity`;
+- no imports;
+- no reconciliation;
+- no summarizer against production artifacts;
+- no station-type dry-run;
+- no canonical apply;
+- no production approval record;
+- no Stage 18K.
+
+## Required Future Load Gate
+
+Before any future controlled write-reviewed load:
+
+- run the allowlist wrapper as a tiny Hetzner operator action;
+- inspect the allowlist artifact path and checksum;
+- verify the allowlist references the exact review packet SHA-256;
+- verify `approved_review_item_ids` and `approved_plan_row_ids` count `20`;
+- verify `approval_record_created = false`;
+- verify `identity_rows_written = 0`;
+- use the allowlist only as input to a separately approved controlled
+  write-reviewed loader action.
+
+The controlled load remains a future Hetzner action and must still be bounded
+to approved rows only.
+
+## Recommended Next Stages
+
+Recommended sequence:
+
+- Stage 18J-P14C — run the approval allowlist artifact wrapper after merge;
+- Stage 18J-P14D — controlled write-reviewed identity load of approved rows
+  only;
+- Stage 18J-P15 — post-load identity coverage artifact;
+- Stage 18J-P16 — read-only reconciliation integration with confirmed
+  identity;
+- Stage 18J-P17 — strict station-type dry-run retry.
+
+## Final Recommendation
+
+Merge P14C as approval-allowlist tooling and documentation only.
+
+After merge, a future Hetzner operator action may create the offline allowlist
+artifact. Do not load identity evidence until a later controlled write-reviewed
+stage explicitly uses that allowlist.

--- a/docs/operations/enrichment-warehouse-runbook.md
+++ b/docs/operations/enrichment-warehouse-runbook.md
@@ -817,6 +817,17 @@ write-reviewed identity load, create and review a separate
 review item IDs or plan row IDs. Do not treat that allowlist as canonical apply
 approval.
 
+Stage 18J-P14C adds the offline allowlist artifact generator in
+`apps/importer/src/station_external_identity_approval_allowlist.py` and a
+Hetzner-only wrapper in
+`scripts/operator/stage18j_run_identity_approval_allowlist.sh`. The wrapper
+requires `CONFIRM_IDENTITY_ALLOWLIST=yes`, verifies the review packet checksum,
+caps selected rows at `20`, and writes only
+`station_external_identity_load_approval_allowlist/v1` under the Stage 18J
+operator artifact directory. It does not source DB env, connect to DB, load
+rows, run imports, run reconciliation, run summarizer, run station-type
+dry-run, run canonical apply, or create a production approval record.
+
 Stage 19A documents the warehouse artifact taxonomy and chunked roadmap in
 `docs/colonisation-redesign/stage-19a-warehouse-artifact-taxonomy-and-chunked-roadmap.md`.
 Use domain-qualified artifact families for stations, bodies, rings,

--- a/scripts/operator/stage18j_run_identity_approval_allowlist.sh
+++ b/scripts/operator/stage18j_run_identity_approval_allowlist.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +H
+
+ART_DIR="${ART_DIR:-/var/lib/ed-finder/operator-artifacts/stage-18j}"
+REVIEW_PACKET="${REVIEW_PACKET:-$ART_DIR/station_external_identity_review_packet_20260603T110848Z.json}"
+EXPECTED_REVIEW_PACKET_SHA256="${EXPECTED_REVIEW_PACKET_SHA256:-8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6}"
+EXPECTED_REVIEW_PACKET_INTEGRITY_SHA256="${EXPECTED_REVIEW_PACKET_INTEGRITY_SHA256:-8cbcf4f2c0d4e3180c3fa6fcbf44f41e71269254168fee0b121f4c6b07bcab84}"
+MAX_ROWS="${MAX_ROWS:-20}"
+REVIEWER="${REVIEWER:-stage-18j-p14c-operator}"
+REVIEWER_DECISION="${REVIEWER_DECISION:-approve_selected_identity_rows}"
+ALLOWLIST_ARTIFACT="${ALLOWLIST_ARTIFACT:-$ART_DIR/station_external_identity_load_approval_allowlist_$(date -u +%Y%m%dT%H%M%SZ).json}"
+
+stop() {
+  printf 'STOP: %s\n' "$*" >&2
+  exit 1
+}
+
+REQUIRE_STAGE18J_ARTIFACT_DIR=yes ART_DIR="$ART_DIR" \
+  scripts/operator/require_hetzner_operator_env.sh
+
+if [[ "${CONFIRM_IDENTITY_ALLOWLIST:-}" != "yes" ]]; then
+  stop "CONFIRM_IDENTITY_ALLOWLIST=yes is required to create the offline allowlist artifact."
+fi
+
+if [[ "${MAX_ROWS}" == "" || ! "${MAX_ROWS}" =~ ^[0-9]+$ ]]; then
+  stop "MAX_ROWS must be a positive integer."
+fi
+
+if (( MAX_ROWS < 1 || MAX_ROWS > 20 )); then
+  stop "MAX_ROWS must be between 1 and 20 for Stage 18J-P14C approval allowlist."
+fi
+
+if [[ "$REVIEWER_DECISION" != "approve_selected_identity_rows" ]]; then
+  stop "REVIEWER_DECISION must be approve_selected_identity_rows."
+fi
+
+if [[ ! -s "$REVIEW_PACKET" ]]; then
+  stop "review packet is missing or empty: $REVIEW_PACKET"
+fi
+
+case "$REVIEW_PACKET" in
+  "$ART_DIR"/*) ;;
+  *) stop "REVIEW_PACKET must be read from ART_DIR: $ART_DIR" ;;
+esac
+
+case "$ALLOWLIST_ARTIFACT" in
+  "$ART_DIR"/*) ;;
+  *) stop "ALLOWLIST_ARTIFACT must be written under ART_DIR: $ART_DIR" ;;
+esac
+
+if ! command -v sha256sum >/dev/null 2>&1; then
+  stop "sha256sum is required to verify the review packet."
+fi
+
+read -r actual_review_packet_sha _ < <(sha256sum "$REVIEW_PACKET")
+if [[ "$actual_review_packet_sha" != "$EXPECTED_REVIEW_PACKET_SHA256" ]]; then
+  stop "review packet checksum mismatch. Expected $EXPECTED_REVIEW_PACKET_SHA256, got $actual_review_packet_sha"
+fi
+
+echo "== Stage 18J-P14C external identity approval allowlist =="
+echo "OFFLINE ARTIFACT ONLY: no database connection, no identity load, no station-type dry-run, no canonical apply."
+echo "ART_DIR: $ART_DIR"
+echo "REVIEW_PACKET: $REVIEW_PACKET"
+echo "REVIEW_PACKET_SHA256: $actual_review_packet_sha"
+echo "ALLOWLIST_ARTIFACT: $ALLOWLIST_ARTIFACT"
+echo "MAX_ROWS: $MAX_ROWS"
+echo "REVIEWER_DECISION: $REVIEWER_DECISION"
+
+python3 apps/importer/src/station_external_identity_approval_allowlist.py \
+  --review-packet "$REVIEW_PACKET" \
+  --expected-review-packet-sha256 "$EXPECTED_REVIEW_PACKET_SHA256" \
+  --output "$ALLOWLIST_ARTIFACT" \
+  --confirm-reviewed \
+  --reviewer-decision "$REVIEWER_DECISION" \
+  --max-rows "$MAX_ROWS" \
+  --reviewer "$REVIEWER"
+
+chmod 600 "$ALLOWLIST_ARTIFACT"
+
+read -r allowlist_sha _ < <(sha256sum "$ALLOWLIST_ARTIFACT")
+
+echo "== Approval allowlist file =="
+ls -lh "$ALLOWLIST_ARTIFACT"
+echo "allowlist_sha256: $allowlist_sha"
+
+echo "== Approval allowlist summary =="
+python3 - "$ALLOWLIST_ARTIFACT" "$EXPECTED_REVIEW_PACKET_SHA256" "$EXPECTED_REVIEW_PACKET_INTEGRITY_SHA256" "$MAX_ROWS" <<'PY'
+import json
+import sys
+
+path, expected_review_sha, expected_integrity_sha, expected_max_rows = sys.argv[1:5]
+with open(path, encoding='utf-8') as handle:
+    payload = json.load(handle)
+
+safety = payload.get('safety_summary') or {}
+
+checks = {
+    'schema_version': payload.get('schema_version') == 'station_external_identity_load_approval_allowlist/v1',
+    'offline': payload.get('offline') is True,
+    'read_only': payload.get('read_only') is True,
+    'review_packet_sha_matches': payload.get('source_review_packet_sha256') == expected_review_sha,
+    'review_packet_integrity_matches': payload.get('source_review_packet_integrity_sha256') == expected_integrity_sha,
+    'reviewer_decision': payload.get('reviewer_decision') == 'approve_selected_identity_rows',
+    'max_rows_matches': str(payload.get('max_rows')) == str(expected_max_rows),
+    'approved_rows_within_max': int(payload.get('approved_rows_count') or 0) <= int(expected_max_rows),
+    'approval_record_created_false': payload.get('approval_record_created') is False,
+    'identity_rows_written_zero': payload.get('identity_rows_written') == 0,
+    'canonical_writes_planned_zero': payload.get('canonical_writes_planned') == 0,
+    'station_type_writes_planned_zero': payload.get('station_type_writes_planned') == 0,
+    'all_required_checks_passed': safety.get('all_required_checks_passed') is True,
+    'db_write_statements_absent': safety.get('db_write_statements_included') is False,
+}
+
+for name, ok in checks.items():
+    if not ok:
+        raise SystemExit(f'STOP: approval allowlist validation failed: {name}')
+
+for key, value in (
+    ('schema_version', payload.get('schema_version')),
+    ('offline', payload.get('offline')),
+    ('read_only', payload.get('read_only')),
+    ('source_review_packet_basename', payload.get('source_review_packet_basename')),
+    ('source_review_packet_sha256', payload.get('source_review_packet_sha256')),
+    ('source_review_packet_integrity_sha256', payload.get('source_review_packet_integrity_sha256')),
+    ('reviewer_decision', payload.get('reviewer_decision')),
+    ('approved_rows_count', payload.get('approved_rows_count')),
+    ('approved_review_item_ids_count', len(payload.get('approved_review_item_ids') or [])),
+    ('approved_plan_row_ids_count', len(payload.get('approved_plan_row_ids') or [])),
+    ('approval_record_created', payload.get('approval_record_created')),
+    ('identity_rows_written', payload.get('identity_rows_written')),
+    ('canonical_writes_planned', payload.get('canonical_writes_planned')),
+    ('station_type_writes_planned', payload.get('station_type_writes_planned')),
+):
+    print(f'{key}: {value}')
+PY
+
+echo "== Secret/path sanity check =="
+sensitive_pattern='postgre''sql://|post''gres://|pass''word=|PG''PASSWORD|SEC''RET|TOK''EN'
+if grep -Eq "$sensitive_pattern" "$ALLOWLIST_ARTIFACT"; then
+  stop "approval allowlist artifact may contain credentials. Review the operator artifact out of band; do not commit it."
+fi
+echo "OK: no obvious credential markers found"
+
+echo "OK: Stage 18J-P14C external identity approval allowlist generated."
+echo "OK: allowlist artifact only; no DB access, no identity load, no imports, no reconciliation, no summarizer, no station-type dry-run, no production approval record, and no canonical apply."

--- a/tests/test_station_external_identity_approval_allowlist.py
+++ b/tests/test_station_external_identity_approval_allowlist.py
@@ -1,0 +1,412 @@
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import station_external_identity_approval_allowlist as allowlist  # noqa: E402
+import station_external_identity_loader as loader  # noqa: E402
+
+
+GENERATED_AT = '2026-01-02T00:00:00Z'
+
+
+def planned_row(index: int, **overrides):
+    row = {
+        'plan_row_id': f'plan-row-{index}',
+        'candidate_id': f'candidate-{index}',
+        'canonical_station_id': 2000 + index,
+        'system_id64': 420000 + index,
+        'station_name': f'Test Port {index}',
+        'source': 'edsm_nightly_stations',
+        'market_id': None,
+        'edsm_station_id': 1000 + index,
+        'source_run_key': 'run-key',
+        'source_file_key': 'file-key',
+        'source_record_hash': f'source-hash-{index}',
+        'source_updated_at': '2026-01-02T00:00:00Z',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'identity_status': 'confirmed',
+        'conflict_reason': None,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_written': 0,
+    }
+    row.update(overrides)
+    return row
+
+
+def checks(**overrides):
+    result = {
+        'canonical_station_id_present': True,
+        'system_id64_present': True,
+        'station_name_present': True,
+        'source_run_key_present': True,
+        'source_file_key_present': True,
+        'source_record_hash_present': True,
+        'external_id_present': True,
+        'identity_status_is_confirmed': True,
+        'conflict_reason_is_null': True,
+        'station_type_write_not_planned': True,
+    }
+    result.update(overrides)
+    return result
+
+
+def review_packet(rows):
+    packet = {
+        'schema_version': 'station_external_identity_review_packet/v1',
+        'dry_run': True,
+        'read_only': True,
+        'report_only': True,
+        'canonical_writes_planned': 0,
+        'station_type_writes_planned': 0,
+        'identity_rows_planned': len(rows),
+        'identity_rows_written': 0,
+        'approval_record_created': False,
+        'max_planned_rows': 20,
+        'summary': {
+            'planned_rows_count': len(rows),
+            'manual_review_items_count': len(rows),
+            'manual_review_status_counts': {'needs_manual_review': len(rows)},
+            'canonical_writes_planned': 0,
+            'station_type_writes_planned': 0,
+            'identity_rows_written': 0,
+            'approval_record_created': False,
+        },
+        'planned_rows': list(rows),
+        'manual_review_items': [
+            {
+                'review_item_id': f'review-item-{index}',
+                'planned_row_index': index,
+                'review_status': 'needs_manual_review',
+                'planned_row': row,
+                'checks': checks(),
+                'reviewer_notes': None,
+            }
+            for index, row in enumerate(rows, start=1)
+        ],
+    }
+    packet['artifact_integrity'] = {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': 'review-packet-integrity',
+    }
+    return packet
+
+
+def write_json(tmp_path: Path, name: str, payload: dict) -> tuple[Path, str]:
+    path = tmp_path / name
+    text = json.dumps(payload, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+    path.write_text(text + '\n', encoding='utf-8')
+    return path, hashlib.sha256((text + '\n').encode('utf-8')).hexdigest()
+
+
+def build_allowlist(packet, *, max_rows=20, reviewer_decision='approve_selected_identity_rows'):
+    return allowlist.build_allowlist(
+        packet,
+        source_review_packet_basename='review-packet.json',
+        source_review_packet_sha256='packet-sha',
+        source_review_packet_size_bytes=123,
+        max_rows=max_rows,
+        reviewer='Synthetic Reviewer',
+        reviewer_decision=reviewer_decision,
+        generated_at=GENERATED_AT,
+    )
+
+
+def test_allowlist_verifies_review_packet_sha(tmp_path):
+    path, packet_sha = write_json(tmp_path, 'packet.json', review_packet([planned_row(1)]))
+
+    artifact = allowlist.build_allowlist_from_file(
+        path,
+        expected_review_packet_sha256=packet_sha,
+        max_rows=1,
+        reviewer='Synthetic Reviewer',
+        generated_at=GENERATED_AT,
+    )
+
+    assert artifact['source_review_packet_sha256'] == packet_sha
+    assert artifact['review_packet_sha256'] == packet_sha
+    assert artifact['approved_review_item_ids'] == ['review-item-1']
+    assert artifact['approved_plan_row_ids'] == ['plan-row-1']
+
+
+def test_checksum_mismatch_fails(tmp_path):
+    path, _packet_sha = write_json(tmp_path, 'packet.json', review_packet([planned_row(1)]))
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='checksum mismatch'):
+        allowlist.build_allowlist_from_file(
+            path,
+            expected_review_packet_sha256='0' * 64,
+            max_rows=1,
+            reviewer='Synthetic Reviewer',
+            generated_at=GENERATED_AT,
+        )
+
+
+def test_missing_review_packet_fails(tmp_path):
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='review packet is missing'):
+        allowlist.build_allowlist_from_file(
+            tmp_path / 'missing.json',
+            expected_review_packet_sha256='0' * 64,
+            max_rows=1,
+            reviewer='Synthetic Reviewer',
+            generated_at=GENERATED_AT,
+        )
+
+
+def test_missing_review_packet_integrity_fails():
+    packet = review_packet([planned_row(1)])
+    packet.pop('artifact_integrity')
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='artifact_integrity'):
+        build_allowlist(packet)
+
+
+def test_missing_explicit_confirmation_fails():
+    with pytest.raises(SystemExit):
+        allowlist.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--output',
+            'out.json',
+            '--reviewer-decision',
+            'approve_selected_identity_rows',
+            '--max-rows',
+            '20',
+        ])
+
+
+def test_wrong_reviewer_decision_fails():
+    with pytest.raises(SystemExit):
+        allowlist.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--output',
+            'out.json',
+            '--confirm-reviewed',
+            '--reviewer-decision',
+            'approve_canonical_apply',
+            '--max-rows',
+            '20',
+        ])
+
+
+def test_max_rows_over_20_fails():
+    with pytest.raises(SystemExit):
+        allowlist.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--output',
+            'out.json',
+            '--confirm-reviewed',
+            '--reviewer-decision',
+            'approve_selected_identity_rows',
+            '--max-rows',
+            '21',
+        ])
+
+
+def test_dsn_is_rejected():
+    with pytest.raises(SystemExit):
+        allowlist.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--output',
+            'out.json',
+            '--confirm-reviewed',
+            '--reviewer-decision',
+            'approve_selected_identity_rows',
+            '--max-rows',
+            '20',
+            '--dsn',
+            'not-accepted',
+        ])
+
+
+@pytest.mark.parametrize(
+    'flag',
+    [
+        '--write',
+        '--apply',
+        '--load',
+        '--commit',
+        '--reconciliation',
+        '--import',
+        '--station-type',
+        '--station-type-dry-run',
+        '--canonical',
+        '--canonical-apply',
+        '--summarizer',
+    ],
+)
+def test_forbidden_flags_are_rejected(flag):
+    with pytest.raises(SystemExit):
+        allowlist.parse_args([
+            '--review-packet',
+            'packet.json',
+            '--expected-review-packet-sha256',
+            'a' * 64,
+            '--output',
+            'out.json',
+            '--confirm-reviewed',
+            '--reviewer-decision',
+            'approve_selected_identity_rows',
+            '--max-rows',
+            '20',
+            flag,
+        ])
+
+
+def test_rows_are_capped_by_max_rows():
+    packet = review_packet([planned_row(1), planned_row(2), planned_row(3)])
+
+    artifact = build_allowlist(packet, max_rows=2)
+
+    assert artifact['approved_rows_count'] == 2
+    assert artifact['approved_review_item_ids'] == ['review-item-1', 'review-item-2']
+    assert artifact['approved_plan_row_ids'] == ['plan-row-1', 'plan-row-2']
+
+
+def test_planned_row_missing_fails():
+    packet = review_packet([planned_row(1)])
+    packet['manual_review_items'][0]['planned_row'] = None
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='missing planned_row'):
+        build_allowlist(packet)
+
+
+def test_failed_item_checks_fail():
+    packet = review_packet([planned_row(1)])
+    packet['manual_review_items'][0]['checks']['external_id_present'] = False
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='failed required checks'):
+        build_allowlist(packet)
+
+
+def test_missing_source_provenance_fails():
+    row = planned_row(1, source_record_hash='')
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='source_record_hash'):
+        build_allowlist(review_packet([row]))
+
+
+def test_missing_external_id_fails():
+    row = planned_row(1, market_id=None, edsm_station_id=None)
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='market_id or edsm_station_id'):
+        build_allowlist(review_packet([row]))
+
+
+def test_identity_status_not_confirmed_fails():
+    row = planned_row(1, identity_status='proposed')
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='identity_status must be confirmed'):
+        build_allowlist(review_packet([row]))
+
+
+def test_conflict_reason_non_null_fails():
+    row = planned_row(1, conflict_reason='ambiguous_canonical_station_match')
+
+    with pytest.raises(allowlist.IdentityApprovalAllowlistError, match='conflict_reason must be null'):
+        build_allowlist(review_packet([row]))
+
+
+def test_allowlist_emits_required_safety_fields():
+    artifact = build_allowlist(review_packet([planned_row(1), planned_row(2)]), max_rows=2)
+
+    assert artifact['schema_version'] == 'station_external_identity_load_approval_allowlist/v1'
+    assert artifact['offline'] is True
+    assert artifact['read_only'] is True
+    assert artifact['approval_record_created'] is False
+    assert artifact['identity_rows_written'] == 0
+    assert artifact['canonical_writes_planned'] == 0
+    assert artifact['station_type_writes_planned'] == 0
+    assert artifact['approved_review_item_ids'] == ['review-item-1', 'review-item-2']
+    assert artifact['approved_plan_row_ids'] == ['plan-row-1', 'plan-row-2']
+    assert artifact['reviewer_attestation']['decision_scope'] == 'external_identity_evidence_load_only'
+    assert artifact['reviewer_attestation']['does_not_approve_station_type_writes'] is True
+    assert artifact['reviewer_attestation']['does_not_approve_canonical_apply'] is True
+    assert artifact['safety_summary']['db_write_statements_included'] is False
+
+
+def test_loader_accepts_allowlist_for_synthetic_write():
+    packet_sha = 'packet-sha'
+    packet = review_packet([planned_row(1)])
+    approval = build_allowlist(packet, max_rows=1)
+
+    artifact = loader.build_execution_plan(
+        packet,
+        review_packet_basename='packet.json',
+        review_packet_sha256=packet_sha,
+        review_packet_size_bytes=123,
+        max_rows=1,
+        dry_run=False,
+        write_reviewed=True,
+        approval_allowlist=approval,
+        approval_allowlist_sha256='approval-sha',
+        conn=_FakeConn(),
+        generated_at=GENERATED_AT,
+    )
+
+    assert artifact['identity_rows_selected'] == 1
+    assert artifact['identity_rows_written'] == 1
+
+
+def test_deterministic_json_output():
+    packet = review_packet([planned_row(1)])
+    first = build_allowlist(packet)
+    second = build_allowlist(packet)
+
+    assert allowlist.json_dumps_artifact(first) == allowlist.json_dumps_artifact(second)
+    assert first['artifact_integrity']['canonical_json_sha256']
+
+
+class _FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.last_result = None
+
+    def execute(self, _sql, _params=None):
+        self.last_result = self.conn.next_result()
+
+    def fetchone(self):
+        return self.last_result
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self):
+        self.next_id = 100
+
+    def cursor(self):
+        return _FakeCursor(self)
+
+    def next_result(self):
+        row_id = self.next_id
+        self.next_id += 1
+        return (row_id,)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass


### PR DESCRIPTION
## What changed

* Adds offline approval allowlist artifact tooling.
* Adds Hetzner-only allowlist operator wrapper.
* Requires review packet checksum verification.
* Requires explicit allowlist confirmation.
* Approves only external identity evidence load scope.
* Keeps identity loading separate.
* Keeps station-type writes blocked.
* Keeps canonical apply blocked.
* Adds tests and docs.

## Boundary confirmations

* No production commands run.
* No production DB touched.
* No identity evidence loaded in production.
* No production writes to `station_external_identity`.
* No imports run.
* No reconciliation run.
* No summarizer run against production artifacts.
* No station-type dry-run run.
* No canonical apply run.
* No production approval record created.
* Stage 18K not started.

## Validation

```text
git diff --check
passed with no output

bash -n scripts/operator/require_hetzner_operator_env.sh
passed with no output

bash -n scripts/operator/stage18j_run_compact_summary.sh
passed with no output

bash -n scripts/operator/stage18j_run_station_type_dry_run.sh
passed with no output

bash -n scripts/operator/stage18j_run_identity_review_packet.sh
passed with no output

bash -n scripts/operator/stage18j_run_identity_load_dry_run.sh
passed with no output

bash -n scripts/operator/stage18j_run_identity_approval_allowlist.sh
passed with no output

./scripts/run_canonical_safety_tests.sh
........................................................................ [ 72%]
...........................                                              [100%]
99 passed in 0.15s
Skipping disposable Postgres rehearsal tests; set EDFINDER_CANONICAL_TEST_DSN and EDFINDER_CONFIRM_CANONICAL_TEST_DB=yes to enable.

.venv/bin/pytest tests/test_station_type_canonical_pilot.py tests/test_enrichment_warehouse_boundary.py tests/test_enrichment_staging_db_loader.py tests/test_enrichment_report_contracts.py tests/test_edsm_station_normalization.py tests/test_station_external_identity_migration.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py tests/test_station_external_identity_loader.py tests/test_station_external_identity_approval_allowlist.py -q
........................................................................ [ 34%]
........................................................................ [ 68%]
.................................................................        [100%]
209 passed in 0.26s

.venv/bin/python -m py_compile apps/importer/src/station_type_canonical_pilot.py apps/importer/src/station_external_identity_candidates.py apps/importer/src/station_external_identity_load_plan.py apps/importer/src/station_external_identity_review_packet.py apps/importer/src/station_external_identity_loader.py apps/importer/src/station_external_identity_approval_allowlist.py tests/test_station_type_canonical_pilot.py tests/test_station_external_identity_candidates.py tests/test_station_external_identity_load_plan.py tests/test_station_external_identity_review_packet.py tests/test_station_external_identity_loader.py tests/test_station_external_identity_approval_allowlist.py
passed with no output

grep -RInE 'postgresql://|postgres://|password=|PGPASSWORD=|SECRET=|TOKEN=' apps/importer/src/station_external_identity_approval_allowlist.py scripts/operator/stage18j_run_identity_approval_allowlist.sh docs/colonisation-redesign/stage-18j-p14c-approval-allowlist-artifact.md docs/colonisation-redesign/stage-18j-p14b-identity-load-dry-run-review.md docs/colonisation-redesign/stage-18j-p14-controlled-external-identity-load-tooling.md docs/colonisation-redesign/stage-18j-p-identity-evidence-execution-board.md docs/colonisation-redesign/enrichment-roadmap.md docs/operations/enrichment-warehouse-runbook.md docs/colonisation-redesign/stage-17p-current-state-forward-plan.md 2>/dev/null || true
no matches
```