### PR TITLE
Stage 18J-P15 identity load production closeout

### DIFF
--- a/docs/colonisation-redesign/stage-18j-p15-identity-load-production-closeout.md
+++ b/docs/colonisation-redesign/stage-18j-p15-identity-load-production-closeout.md
@@ -1,0 +1,72 @@
+# Stage 18J-P15 — Controlled external identity load production closeout
+
+## Result
+
+Stage 18J-P15 completed the controlled `station_external_identity` write-reviewed load.
+
+The load inserted the 20 manually approved external identity evidence rows from the Stage 18J-P14C approval allowlist.
+
+## Source artifacts
+
+Review packet:
+
+- `station_external_identity_review_packet_20260603T110848Z.json`
+- SHA-256: `8cf118d552e6bc35d23ab302d9e1020092385b372729dbb9b2bae5cd5f0758b6`
+
+Approval allowlist:
+
+- `station_external_identity_load_approval_allowlist_20260603T174050Z.json`
+- SHA-256: `a07b60978028321325a83766395bff043aea1f37d1da04b3bf6f5c6ea9344cfe`
+
+Write-reviewed execution artifact:
+
+- `station_external_identity_load_write_reviewed_20260603T180332Z.json`
+- File SHA-256: `1230d7bb09ade718f9842d11f356913f0f52bb9fd38e7a653a0c638a3d4a32c8`
+- Artifact integrity SHA-256: `d2e717f2f77039e5b43051fd43459c3f351aa373c403df1e3c82d0574c1b9678`
+
+## Execution summary
+
+The write-reviewed load produced:
+
+| Check | Result |
+|---|---:|
+| `schema_version` | `station_external_identity_load_execution_plan/v1` |
+| `dry_run` | `False` |
+| `write_reviewed` | `True` |
+| `identity_rows_selected` | `20` |
+| `identity_rows_written` | `20` |
+| `duplicate_rows_skipped` | `0` |
+| `inserted_row_ids_count` | `20` |
+| `approval_record_created` | `False` |
+| `canonical_writes_planned` | `0` |
+| `station_type_writes_planned` | `0` |
+
+## Post-load database checks
+
+Post-load database validation returned:
+
+| Check | Result |
+|---|---:|
+| Total rows in `station_external_identity` | `20` |
+| `edsm_nightly_stations` / `confirmed` rows | `20` |
+| Rows with `conflict_reason IS NOT NULL` | `0` |
+| Rows where `identity_status <> 'confirmed'` | `0` |
+| Rows missing both `market_id` and `edsm_station_id` | `0` |
+
+## Safety boundaries confirmed
+
+This closeout confirms:
+
+- The operation wrote only to `station_external_identity`.
+- No canonical station rows were written.
+- No station-type writes were planned or performed.
+- No station-type dry-run was performed.
+- No imports, reconciliation, or summarizer runs were performed as part of this step.
+- No production approval record was created.
+- The write was bounded to the reviewed and allowlisted 20 rows.
+
+## Next stage
+
+The next stage may use the loaded external identity evidence as input for a separate, explicitly bounded station-type planning step.
+
+That next step must remain separate from this closeout and must require its own dry-run, review, and approval boundary before any station-type writes are considered.


### PR DESCRIPTION
## Summary

- Records the controlled Stage 18J-P15 external identity evidence load.
- Confirms 20 reviewed and allowlisted rows were inserted into `station_external_identity`.
- Records source artifact hashes, write-reviewed execution artifact hash, and post-load DB validation.
- Confirms canonical writes, station-type writes, station-type dry-run, imports, reconciliation, summarizer, and approval-record creation remained blocked.

## Validation

- `identity_rows_selected`: 20
- `identity_rows_written`: 20
- `duplicate_rows_skipped`: 0
- `inserted_row_ids_count`: 20
- total `station_external_identity` rows: 20
- confirmed `edsm_nightly_stations` rows: 20
- `rows_with_conflict_reason`: 0
- `rows_not_confirmed`: 0
- `rows_missing_external_id`: 0

## Boundary

Docs-only closeout PR. No production DB command is run by this PR.