### PR TITLE
Stage 18J-P18B impact scan closeout

### DIFF
--- a/docs/colonisation-redesign/stage-18j-p18b-dodec-enum-repo-impact-scan.md
+++ b/docs/colonisation-redesign/stage-18j-p18b-dodec-enum-repo-impact-scan.md
@@ -1,0 +1,91 @@
+# Stage 18J-P18B — Dodec enum repo impact scan closeout
+
+## Result
+
+Stage 18J-P18B generated a read-only repository impact scan for adding `Dodec` to the canonical `station_type` model.
+
+The scan did not access the database and did not edit the repository. It searched the repo for likely files that may need review when Dodec enum/model support is implemented.
+
+## Source artifact
+
+Impact scan artifact:
+
+- `dodec_enum_repo_impact_scan_20260604T095126Z.json`
+- File SHA-256: `6a4b7791222c79f0d20ca873ee69f5b9dd9a855ef6c7a8c297beb2dadcd3346b`
+- Artifact integrity SHA-256: `915571d12b912d9973c0e9696157b315aee4ace713d2146e5959f1142ade17fe`
+
+## Execution boundary
+
+The Stage 18J-P18B action was read-only and artifact-only.
+
+It did not perform any of the following:
+
+- DB access;
+- DB writes;
+- enum changes;
+- migrations;
+- station-type dry-run;
+- station-type writes;
+- canonical writes;
+- canonical apply;
+- repo edits.
+
+## Scan summary
+
+The artifact recorded:
+
+| Check | Result |
+|---|---:|
+| `schema_version` | `dodec_enum_repo_impact_scan/v1` |
+| `read_only` | `True` |
+| Git branch | `main` |
+| Likely impact file count | `113` |
+| `repo_edits_performed` | `False` |
+| `db_access_performed` | `False` |
+| `migrations_performed` | `False` |
+| `station_type_dry_run_performed` | `False` |
+| `canonical_apply_performed` | `False` |
+
+## Interpretation
+
+The scan is intentionally broad. The `113` likely-impact files are not all expected to change.
+
+The highest-value areas to inspect for the Dodec implementation branch are:
+
+1. SQL enum definition and migrations.
+2. Station-type mapping logic.
+3. Station-type dry-run/refusal tests.
+4. Generated or handwritten API/frontend station-type unions.
+5. Tests that currently assume the old enum set.
+
+## Policy carried forward
+
+Current human-reviewed station-type source policy:
+
+| Source value | Policy |
+|---|---|
+| `Coriolis Starport` | Safe candidate for `Coriolis`. |
+| `Dodec Starport` | Human-approved mapping to `Dodec`; requires enum/model support first. |
+| `Drake-Class Carrier` | Refuse/defer as transient/mobile carrier. |
+| `Space Construction Depot` | Refuse/defer as transient construction object. |
+| `NULL` | Refuse. |
+
+## Recommended change plan
+
+The next implementation branch should be small and focused:
+
+1. Add `Dodec` to the canonical station-type enum/model.
+2. Add mapping support for `Dodec Starport -> Dodec`.
+3. Keep fleet carriers and construction depots refused/deferred.
+4. Add tests for:
+   - `Dodec Starport -> Dodec`;
+   - `Drake-Class Carrier` refused/deferred;
+   - `Space Construction Depot` refused/deferred;
+   - `NULL` source station type refused.
+5. Do not include station-type writes or canonical apply in the schema/model branch.
+
+## Verdict
+
+Stage 18J-P18B confirms that Dodec support should proceed via a separate schema/model implementation branch.
+
+No enum changes, migrations, station-type dry-run, station-type writes, canonical writes, or canonical apply are approved by this stage.


### PR DESCRIPTION
Docs-only closeout for the read-only P18B Dodec enum repo impact scan.

Artifact: dodec_enum_repo_impact_scan_20260604T095126Z.json
File SHA-256: 6a4b7791222c79f0d20ca873ee69f5b9dd9a855ef6c7a8c297beb2dadcd3346b
Artifact integrity SHA-256: 915571d12b912d9973c0e9696157b315aee4ace713d2146e5959f1142ade17fe

Boundary: docs-only. No DB access, no enum changes, no migrations, no station-type dry-run, no canonical apply.