### PR TITLE
Stage 18J-P18C add Dodec station type enum support

### DIFF
--- a/sql/001_schema.sql
+++ b/sql/001_schema.sql
@@ -70,7 +70,7 @@ EXCEPTION WHEN duplicate_object THEN NULL; END $$;
 
 DO $$ BEGIN
     CREATE TYPE station_type AS ENUM (
-        'Coriolis', 'Orbis', 'Ocellus', 'Outpost',
+        'Coriolis', 'Orbis', 'Ocellus', 'Dodec', 'Outpost',
         'PlanetaryPort', 'PlanetaryOutpost', 'MegaShip',
         'AsteroidBase', 'FleetCarrier', 'Unknown'
     );

--- a/sql/028_add_dodec_station_type.sql
+++ b/sql/028_add_dodec_station_type.sql
@@ -1,0 +1,11 @@
+-- =============================================================================
+-- Stage 18J-P18C - add Dodec station type
+-- =============================================================================
+-- Additive/idempotent migration. Adds Dodec as a canonical station_type enum
+-- value so source evidence `Dodec Starport` can be mapped to canonical `Dodec`
+-- in later bounded station-type dry-runs.
+--
+-- This migration does not update station rows, does not run a dry-run, and does
+-- not approve station-type writes or downstream canonical operations.
+
+ALTER TYPE station_type ADD VALUE IF NOT EXISTS 'Dodec';

--- a/tests/test_station_type_enum_values.py
+++ b/tests/test_station_type_enum_values.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_station_type_enum_contains_dodec_in_base_schema() -> None:
+    schema = (REPO_ROOT / "sql" / "001_schema.sql").read_text(encoding="utf-8")
+
+    assert "'Dodec'" in schema
+    assert "'Coriolis'" in schema
+    assert "'Ocellus'" in schema
+    assert "'Orbis'" in schema
+
+
+def test_dodec_forward_migration_is_additive_only() -> None:
+    migration = (REPO_ROOT / "sql" / "028_add_dodec_station_type.sql").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ALTER TYPE station_type ADD VALUE IF NOT EXISTS 'Dodec';" in migration
+    assert "UPDATE stations" not in migration
+    assert "station_type_dry_run" not in migration
+    assert "canonical apply" not in migration.lower()


### PR DESCRIPTION
## Summary

- Adds `Dodec` to the canonical `station_type` enum in the base schema.
- Adds an additive forward migration: `ALTER TYPE station_type ADD VALUE IF NOT EXISTS 'Dodec';`.
- Adds focused tests proving the base schema contains `Dodec` and the migration is additive only.

## Validation

- Created temporary pytest venv under `/tmp/ed-finder-pytest-venv`.
- Ran focused test file after fixing the migration comment assertion.
- No production DB access.
- No production migrations run.
- No station-type dry-run.
- No station-type writes.
- No canonical apply.

## Boundary

Repo/test branch only. This PR adds schema/model support only; it does not update production rows or approve any station-type write path.