### PR TITLE
Stage 18J-P18M Dodec and bounded station-type write closeout

### DIFF
--- a/docs/colonisation-redesign/stage-18j-p18m-dodec-and-bounded-station-type-write-closeout.md
+++ b/docs/colonisation-redesign/stage-18j-p18m-dodec-and-bounded-station-type-write-closeout.md
@@ -1,0 +1,97 @@
+# Stage 18J-P18M — Dodec enum and bounded station-type write closeout
+
+## Result
+
+Stage 18J-P18 completed the Dodec enum support and bounded station-type write chain.
+
+Production now supports canonical `Dodec` station type. Four reviewed station rows were updated from `Unknown` to their approved station types:
+
+- `3` rows: `Coriolis Starport -> Coriolis`
+- `1` row: `Dodec Starport -> Dodec`
+
+No fleet carriers were written. No construction depots were written. No canonical apply was performed.
+
+## Artifact chain
+
+| Artifact | Schema | File SHA-256 | Artifact integrity SHA-256 |
+|---|---|---|---|
+| `dodec_enum_production_migration_apply_20260604T131548Z.json` | `dodec_enum_production_migration_apply/v1` | `991c6954d4e4f57f6521584e67ef92ebf9215f02d2ca94c93588c0f53c6ab8b5` | `4ed927c426fd13782d695443261d875dbfbd03448a4d3cbb27a8f15edbfbf7c3` |
+| `dodec_enum_post_migration_verification_20260604T131954Z.json` | `dodec_enum_post_migration_verification/v1` | `1f351b6c71ce6de0bd35eee3c2b9273d8d26ffd742a80dbbb178a3c4dc1b3ba3` | `8dd54b45c23ecb4ab1184c991620f01dbb2e914fe1530ef1a99f1a6807f2c0c1` |
+| `station_type_bounded_candidate_plan_20260604T132404Z.json` | `station_type_bounded_candidate_plan/v1` | `ebc5b74131e82d77c298bc5461242835cae38fe3fc6391c98b508c097cdb72cf` | `20c461c1734e4740b9c9cd28903c70d610dd6391303b1d28fb7bb718b7e44eff` |
+| `station_type_bounded_dry_run_review_packet_20260604T132702Z.json` | `station_type_bounded_dry_run_review_packet/v1` | `e474ae85bf74ffcfd9029d2e13c4df59999b33b11ebfd1cd4153e978277e6ad6` | `1ea19c25bc4a3c29d29d587342d266956024096f0b7e76398e5fbdc1096edf33` |
+| `station_type_bounded_dry_run_review_packet_20260604T132702Z.json` | `station_type_bounded_dry_run_review_packet/v1` | `e474ae85bf74ffcfd9029d2e13c4df59999b33b11ebfd1cd4153e978277e6ad6` | `1ea19c25bc4a3c29d29d587342d266956024096f0b7e76398e5fbdc1096edf33` |
+| `station_type_bounded_write_approval_allowlist_20260604T141844Z.json` | `station_type_bounded_write_approval_allowlist/v1` | `b63145e20f8bbec127f30c4fe1adf790ddccc0608c64c71dc98249af4795a11f` | `d6b7a1646ef4eee6b372b45d2539f7febca79ccfa5e188141a7f287b75e8c064` |
+| `station_type_bounded_write_reviewed_20260604T144112Z.json` | `station_type_bounded_write_reviewed/v1` | `923d6a692640fef18aa3ec2b23a2de70c10305b59ffe2fc2973c9ffd72f1972d` | `43ff74efc6a10a8a191b099af306c0cf1e756a6134483e21190d81820dbf7bfd` |
+| `station_type_bounded_post_write_verification_20260604T144536Z.json` | `station_type_bounded_post_write_verification/v1` | `55e1d9f742b58c342a8ce5f5fd5cd67a206abf2caf692e8bf2e90f86d5b57f1c` | `1184cb5f106539a8705c3040ef4c56f54e48b851d3e828c6ae6577b4893673c2` |
+
+## Controlled enum migration
+
+The Dodec enum migration executed exactly one additive enum change:
+
+`ALTER TYPE station_type ADD VALUE IF NOT EXISTS 'Dodec';`
+
+It did not update station rows and did not perform station-type writes or canonical apply.
+
+## Controlled station-type write
+
+The controlled write updated exactly four approved station rows.
+
+| Station ID | Station | New station type | Source |
+|---|---|---|---|
+| `4270354179` | Laughlin Prospect | `Coriolis` | `edsm_nightly_stations` |
+| `4223765507` | Port Flimley Binkkerton | `Coriolis` | `edsm_nightly_stations` |
+| `4332505347` | Piccard Town | `Dodec` | `edsm_nightly_stations` |
+| `4221009411` | Reeves Sanctuary | `Coriolis` | `edsm_nightly_stations` |
+
+## Post-write verification
+
+The read-only verification confirmed the written rows:
+
+| Station ID | Station | Source station type | Canonical station type | Pad | Economy |
+|---|---|---|---|---|---|
+| `4221009411` | Reeves Sanctuary | `Coriolis Starport` | `Coriolis` | `L` | `Industrial` |
+| `4223765507` | Port Flimley Binkkerton | `Coriolis Starport` | `Coriolis` | `L` | `Military` |
+| `4270354179` | Laughlin Prospect | `Coriolis Starport` | `Coriolis` | `L` | `Tourism` |
+| `4332505347` | Piccard Town | `Dodec Starport` | `Dodec` | `L` | `Tourism` |
+
+Station counts after verification:
+
+- total_station_rows: `284763`
+- station_rows_with_coriolis: `1382`
+- station_rows_with_dodec: `1`
+- station_rows_with_unknown: `160140`
+
+Remaining unknown source rows:
+
+| Source station type | Rows |
+|---|---:|
+| `Drake-Class Carrier` | `5` |
+| `None` | `1` |
+| `Space Construction Depot` | `1` |
+
+## Safety boundary
+
+The completed chain confirms:
+
+- Dodec enum added: yes.
+- Station rows updated: exactly `4`.
+- Identity rows written: `0`.
+- Fleet carrier rows written: `0`.
+- Construction depot rows written: `0`.
+- Canonical apply performed: `False`.
+
+## Policy carried forward
+
+| Source value | Policy |
+|---|---|
+| `Coriolis Starport` | May map to `Coriolis` when confirmed identity and review/approval exist. |
+| `Dodec Starport` | May map to `Dodec` now that enum support exists, when confirmed identity and review/approval exist. |
+| `Drake-Class Carrier` | Refuse/defer as transient/mobile carrier. |
+| `Space Construction Depot` | Refuse/defer as transient construction object. |
+| `NULL` | Refuse. |
+
+## Verdict
+
+Stage 18J-P18 is complete for this bounded batch.
+
+No additional station-type writes, canonical writes, or canonical apply are approved by this closeout.


### PR DESCRIPTION
## Summary

- Documents the completed Stage 18J-P18 chain.
- Confirms production now supports canonical `Dodec` station type.
- Confirms exactly 4 reviewed station rows were updated: 3 `Coriolis`, 1 `Dodec`.
- Confirms no fleet carriers were written, no construction depots were written, and no canonical apply was performed.
- Records the artifact chain from enum migration through post-write verification.

## Boundary

Docs-only closeout PR. No production DB command is run by this PR.