### PR TITLE
Stage 18J-P18N final state snapshot closeout

### DIFF
--- a/docs/colonisation-redesign/stage-18j-p18n-final-state-snapshot.md
+++ b/docs/colonisation-redesign/stage-18j-p18n-final-state-snapshot.md
@@ -1,0 +1,73 @@
+# Stage 18J-P18N — Final state snapshot closeout
+
+## Result
+
+Stage 18J-P18N generated the final read-only state snapshot after the Dodec enum support and bounded 4-row station-type write chain.
+
+The snapshot confirms the P18 chain is complete and stable.
+
+## Source artifact
+
+- Artifact: `stage18j_p18_final_state_snapshot_20260604T155926Z.json`
+- File SHA-256: `37fe0cc1a26f3f3cc2c3affaaf093681417cb88b3795da536dd511134de90a33`
+- Artifact integrity SHA-256: `78ad0a6ac27670d62f9ac0492d2712c102efae19b324d3ba2d6053ff90bf4ffd`
+- Schema: `stage18j_p18_final_state_snapshot/v1`
+
+## Final station counts
+
+| Metric | Value |
+|---|---:|
+| Total station rows | `284763` |
+| Coriolis rows | `1382` |
+| Dodec rows | `1` |
+| Unknown rows | `160140` |
+
+## Verified P18 written rows
+
+| Station ID | Station | Source station type | Canonical station type | Type source |
+|---|---|---|---|---|
+| `4221009411` | Reeves Sanctuary | `Coriolis Starport` | `Coriolis` | `edsm_nightly_stations` |
+| `4223765507` | Port Flimley Binkkerton | `Coriolis Starport` | `Coriolis` | `edsm_nightly_stations` |
+| `4270354179` | Laughlin Prospect | `Coriolis Starport` | `Coriolis` | `edsm_nightly_stations` |
+| `4332505347` | Piccard Town | `Dodec Starport` | `Dodec` | `edsm_nightly_stations` |
+
+## Remaining unknown source rows
+
+| Source station type | Rows |
+|---|---:|
+| `Drake-Class Carrier` | `5` |
+| `None` | `1` |
+| `Space Construction Depot` | `1` |
+
+## Identity status counts
+
+| Source | Identity status | Rows |
+|---|---|---:|
+| `edsm_nightly_stations` | `confirmed` | `20` |
+
+## Safety confirmation
+
+| Check | Result |
+|---|---:|
+| DB read-only confirmed | `True` |
+| DB writes performed | `False` |
+| Station rows updated | `0` |
+| Station-type writes performed | `False` |
+| Canonical apply performed | `False` |
+| Repo edits performed by snapshot | `False` |
+
+## Policy carried forward
+
+| Source value | Policy |
+|---|---|
+| `Coriolis Starport` | May map to `Coriolis` with confirmed identity and review/approval. |
+| `Dodec Starport` | May map to `Dodec` with confirmed identity and review/approval. |
+| `Drake-Class Carrier` | Refuse/defer as transient/mobile carrier. |
+| `Space Construction Depot` | Refuse/defer as transient construction object. |
+| `NULL` | Refuse. |
+
+## Verdict
+
+Stage 18J-P18 is complete for this bounded batch.
+
+No further station-type writes, canonical writes, or canonical apply are approved by this closeout.


### PR DESCRIPTION
## Summary

- Records the final read-only state snapshot after the Stage 18J-P18 Dodec enum and bounded station-type write chain.
- Confirms the four written rows remain verified.
- Confirms remaining transient/mobile and construction rows remain Unknown.
- Confirms no DB writes, no station-type writes, and no canonical apply were performed by the snapshot.

## Boundary

Docs-only closeout PR. No production DB command is run by this PR.