### PR TITLE
Add manual Hetzner operator GitHub Action

### DIFF
--- a/.github/workflows/hetzner-operator.yml
+++ b/.github/workflows/hetzner-operator.yml
@@ -1,0 +1,69 @@
+name: Hetzner Operator
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: "Allowlisted operator stage to run"
+        required: true
+        type: choice
+        options:
+          - context
+          - latest-artifacts
+
+jobs:
+  hetzner-operator:
+    name: Run safe Hetzner operator stage
+    runs-on: ubuntu-latest
+    environment: hetzner-operator
+
+    steps:
+      - name: Validate stage
+        shell: bash
+        run: |
+          case "${{ inputs.stage }}" in
+            context|latest-artifacts)
+              echo "Stage allowed: ${{ inputs.stage }}"
+              ;;
+            *)
+              echo "Unsupported stage: ${{ inputs.stage }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.HETZNER_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.HETZNER_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.HETZNER_OPERATOR_PORT }}
+        run: |
+          test -n "$SSH_KEY" || { echo "Missing HETZNER_OPERATOR_SSH_KEY" >&2; exit 1; }
+          test -n "$SSH_HOST" || { echo "Missing HETZNER_OPERATOR_HOST" >&2; exit 1; }
+          test -n "$SSH_PORT" || { echo "Missing HETZNER_OPERATOR_PORT" >&2; exit 1; }
+
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+
+          printf '%s
+' "$SSH_KEY" > ~/.ssh/hetzner_operator_key
+          chmod 600 ~/.ssh/hetzner_operator_key
+
+          ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts
+
+      - name: Run allowlisted Hetzner operator stage
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.HETZNER_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.HETZNER_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.HETZNER_OPERATOR_USER }}
+          STAGE: ${{ inputs.stage }}
+        run: |
+          test -n "$SSH_USER" || { echo "Missing HETZNER_OPERATOR_USER" >&2; exit 1; }
+
+          ssh -i ~/.ssh/hetzner_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              "$SSH_USER@$SSH_HOST" \
+              "cd /opt/ed-finder && git fetch origin main && git checkout main && git pull --ff-only origin main && bash scripts/operator/actions/dispatch.sh '$STAGE'"

--- a/docs/operations/github-actions-hetzner-operator.md
+++ b/docs/operations/github-actions-hetzner-operator.md
@@ -1,0 +1,47 @@
+# GitHub Actions Hetzner Operator
+
+## Purpose
+
+This manual workflow lets us run a tiny allowlisted set of safe operator checks on Hetzner without pasting large shell blocks into SSH.
+
+## Current stages
+
+The first version is read-only only.
+
+| Stage | What it does |
+|---|---|
+| `context` | Shows hostname, user, repo path, git branch, recent commits, and git status. |
+| `latest-artifacts` | Lists recent Stage 18J JSON artifacts and prints safe summaries. |
+
+## Hard boundary
+
+The first version does not perform:
+
+- DB access;
+- DB writes;
+- migrations;
+- station-type writes;
+- canonical apply;
+- arbitrary shell command execution.
+
+## Required GitHub secrets
+
+Add these repository secrets:
+
+- `HETZNER_OPERATOR_HOST`
+- `HETZNER_OPERATOR_PORT`
+- `HETZNER_OPERATOR_USER`
+- `HETZNER_OPERATOR_SSH_KEY`
+
+## How to run
+
+1. Go to the GitHub repository.
+2. Open the **Actions** tab.
+3. Select **Hetzner Operator**.
+4. Click **Run workflow**.
+5. Choose `context` or `latest-artifacts`.
+6. Click **Run workflow**.
+
+## Future stages
+
+Any future production DB write stage must be added by a separate PR and must not use arbitrary command input.

--- a/scripts/operator/actions/context.sh
+++ b/scripts/operator/actions/context.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /opt/ed-finder
+
+echo "== Hetzner operator context =="
+echo "Host: $(hostname)"
+echo "User: $(whoami)"
+echo "PWD: $(pwd)"
+echo "UTC: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+echo
+echo "== Git =="
+git branch --show-current
+git log --oneline -5
+git status --short
+
+echo
+echo "== Safety boundary =="
+echo "db_access_performed: false"
+echo "db_writes_performed: false"
+echo "migrations_performed: false"
+echo "station_type_writes_performed: false"
+echo "canonical_apply_performed: false"

--- a/scripts/operator/actions/dispatch.sh
+++ b/scripts/operator/actions/dispatch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stage="${1:-}"
+
+case "$stage" in
+  context)
+    exec bash scripts/operator/actions/context.sh
+    ;;
+  latest-artifacts)
+    exec bash scripts/operator/actions/latest-artifacts.sh
+    ;;
+  *)
+    echo "STOP: unsupported operator stage: $stage" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/operator/actions/latest-artifacts.sh
+++ b/scripts/operator/actions/latest-artifacts.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /opt/ed-finder
+
+ART_DIR="/var/lib/ed-finder/operator-artifacts/stage-18j"
+
+echo "== Latest operator artifacts =="
+if [ -d "$ART_DIR" ]; then
+  find "$ART_DIR" -maxdepth 1 -type f -name '*.json' -printf '%T@ %p\n' \
+    | sort -nr \
+    | head -n 20 \
+    | while read -r _ path; do
+        echo
+        echo "ARTIFACT=$path"
+        ls -lh "$path"
+        sha256sum "$path"
+
+        python3 - "$path" <<'PY_ART_SUMMARY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+except Exception as exc:
+    print(f"summary_error: {exc}")
+    raise SystemExit(0)
+
+print("schema_version:", payload.get("schema_version"))
+print("read_only:", payload.get("read_only"))
+print("dry_run:", payload.get("dry_run"))
+print("write_reviewed:", payload.get("write_reviewed"))
+print("offline:", payload.get("offline"))
+
+safety = payload.get("safety_summary") or {}
+for key in (
+    "db_read_only_confirmed",
+    "db_writes_performed",
+    "station_rows_updated",
+    "station_type_writes_performed",
+    "canonical_apply_performed",
+):
+    if key in safety:
+        print(f"{key}:", safety.get(key))
+
+integrity = payload.get("artifact_integrity") or {}
+if "canonical_json_sha256" in integrity:
+    print("artifact_integrity_sha256:", integrity.get("canonical_json_sha256"))
+PY_ART_SUMMARY
+      done
+else
+  echo "No artifact directory found: $ART_DIR"
+fi
+
+echo
+echo "== Safety boundary =="
+echo "db_access_performed: false"
+echo "db_writes_performed: false"
+echo "migrations_performed: false"
+echo "station_type_writes_performed: false"
+echo "canonical_apply_performed: false"


### PR DESCRIPTION
Adds a manual read-only Hetzner Operator workflow with allowlisted stages only: context and latest-artifacts. No arbitrary command input, no DB writes, no migrations, no station-type writes, and no canonical apply.