### PR TITLE
Stage 19J source_runs migration closeout

### DIFF
--- a/docs/colonisation-redesign/stage-19j-source-runs-migration-closeout.md
+++ b/docs/colonisation-redesign/stage-19j-source-runs-migration-closeout.md
@@ -1,0 +1,72 @@
+# Stage 19J — source_runs migration closeout
+
+## Result
+
+Stage 19J records the completed production schema migration for the Data Warehouse Utopia `source_runs` ledger.
+
+The `source_runs` table now exists in production and is empty, ready for future controlled import-run records.
+
+## Source artifacts
+
+| Stage | Artifact | Schema | File SHA-256 | Artifact integrity SHA-256 |
+|---|---|---|---|---|
+| 19H recovery | `source_runs_migration_apply_recovery_20260605T014520Z.json` | `source_runs_migration_apply_recovery/v1` | `1216b24aebade13f1a264b385fc0682e4cacecb1d0e05ecca1fa8e2a5d222e78` | `d49c44dbb92760861b1f8360b4ab7b344bd48dc226cb7fa3b034f89399bb7921` |
+| 19I verification | `source_runs_post_migration_verification_20260605T014724Z.json` | `source_runs_post_migration_verification/v1` | `683f9a5528618196bd16f0520fc9220e74c503c18818a73d30b6f39f475d764b` | `09be468999f7514b93990e5396a74086bd33f39a576e3f096e8221064ce9e5a8` |
+
+## Migration applied
+
+- Migration file: `sql/029_create_source_runs.sql`
+- Migration file SHA-256: `772bda03e8af1bd60c1b02ebe8aff6cfb4783896958df5cad8a1dccdbf446825`
+- Scope: create `source_runs` table and indexes only.
+
+## Verified production state
+
+| Check | Result |
+|---|---:|
+| `source_runs_exists` | `t` |
+| `source_runs_row_count` | `0` |
+| `source_runs_column_count` | `30` |
+| `source_runs_index_count` | `8` |
+| `source_runs_constraint_count` | `13` |
+| `running_index_exists` | `t` |
+
+## Safety boundary
+
+Stage 19H performed the schema migration. Stage 19I verified it read-only.
+
+No import or canonical mutation was performed.
+
+| Check | Stage 19H | Stage 19I |
+|---|---:|---:|
+| DB/schema write | `True` | `False` |
+| Imports performed | `False` | `False` |
+| source_run rows inserted | `0` | `0` |
+| Canonical apply | `False` | `False` |
+| Scheduler enabled | `False` | `False` |
+| Station rows updated | `0` | `0` |
+| System rows updated | `0` | `0` |
+| Body rows updated | `0` | `0` |
+
+## Interpretation
+
+The durable `source_runs` ledger now exists and can become the root provenance table for future automated imports.
+
+It is deliberately empty after migration because no imports have been run.
+
+## Next stage
+
+Stage 19K should implement the first repo-level source-run helper/wrapper contract.
+
+That work should be repo-only first and should use Codex:
+
+- create helper functions/classes for creating and completing source-run records;
+- create tests against disposable/local DB only;
+- no production imports;
+- no scheduler enablement;
+- no canonical apply.
+
+## Verdict
+
+Stage 19H/19I source_runs migration is complete and verified.
+
+No imports, scheduler/timer enablement, canonical writes, or canonical apply are approved by this closeout.


### PR DESCRIPTION
## Summary

- Records the completed source_runs production schema migration and post-migration verification.
- Confirms source_runs exists, is empty, has 30 columns, 8 indexes, 13 constraints, and the running-run safety index.
- Confirms no imports, scheduler/timer enablement, canonical writes, or canonical apply were performed.

## Boundary

Docs-only closeout PR. No production DB command is run by this PR.