### PR TITLE
Stage 19K add source-run ledger helper

### DIFF
--- a/apps/importer/src/source_run_ledger.py
+++ b/apps/importer/src/source_run_ledger.py
@@ -1,0 +1,706 @@
+"""Small repository helper for the Stage 19 source_runs ledger."""
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+
+SOURCE_RUNS_TABLE = 'source_runs'
+
+ALLOWED_STATUSES = frozenset((
+    'planned',
+    'running',
+    'succeeded',
+    'failed',
+    'rejected',
+    'superseded',
+    'cancelled',
+))
+INITIAL_STATUSES = frozenset(('planned', 'running'))
+OPEN_STATUSES = ('planned', 'running')
+SUPERSEDABLE_STATUSES = ('succeeded',)
+
+ALLOWED_SOURCE_NAMES = frozenset((
+    'edsm',
+    'spansh',
+    'inara',
+    'daftmav',
+    'mega_guide',
+    'operator_artifact',
+    'local_generated_artifact',
+    'mission_observation',
+    'frontier_journal',
+    'edcd',
+    'canonn',
+    'ravencolonial',
+))
+
+ALLOWED_SOURCE_CATEGORIES = frozenset((
+    'source_of_truth',
+    'source_of_evidence',
+    'source_of_inspiration',
+    'manual_operator_source',
+    'derived_source',
+))
+
+ALLOWED_DOMAINS = frozenset((
+    'systems',
+    'stars',
+    'bodies',
+    'rings',
+    'belt_clusters',
+    'stations',
+    'settlements',
+    'station_services',
+    'markets',
+    'shipyard_outfitting',
+    'factions_bgs',
+    'economies_security',
+    'construction_sites',
+    'fleet_carriers_transient',
+    'materials_resources',
+    'facility_templates',
+    'rules_reference',
+    'mission_intelligence',
+    'operator_artifacts',
+))
+
+ALLOWED_IMPORT_SCOPES = frozenset((
+    'raw_capture_only',
+    'staging_only',
+    'warehouse_fact_refresh',
+    'reconciliation_candidate',
+    'review_packet',
+    'approval_allowlist',
+    'bounded_write_reviewed',
+    'canonical_apply',
+))
+
+ROW_COUNT_FIELDS = ('rows_read', 'rows_staged', 'rows_rejected', 'rows_skipped')
+
+
+class SourceRunLedgerError(ValueError):
+    """Base error for source-run helper validation and state failures."""
+
+
+class SourceRunStateError(SourceRunLedgerError):
+    """Raised when a requested source-run transition is not valid."""
+
+
+class SourceRunLedger:
+    """Repository wrapper around a caller-owned DB-API connection."""
+
+    def __init__(self, conn: Any) -> None:
+        self.conn = conn
+
+    def create_source_run(self, **kwargs: Any) -> dict[str, Any]:
+        return create_source_run(self.conn, **kwargs)
+
+    def mark_source_run_running(self, source_run_key: str, **kwargs: Any) -> dict[str, Any]:
+        return mark_source_run_running(self.conn, source_run_key, **kwargs)
+
+    def complete_source_run_success(self, source_run_key: str, **kwargs: Any) -> dict[str, Any]:
+        return complete_source_run_success(self.conn, source_run_key, **kwargs)
+
+    def complete_source_run_failed(self, source_run_key: str, **kwargs: Any) -> dict[str, Any]:
+        return complete_source_run_failed(self.conn, source_run_key, **kwargs)
+
+    def complete_source_run_rejected(self, source_run_key: str, **kwargs: Any) -> dict[str, Any]:
+        return complete_source_run_rejected(self.conn, source_run_key, **kwargs)
+
+    def complete_source_run_cancelled(self, source_run_key: str, **kwargs: Any) -> dict[str, Any]:
+        return complete_source_run_cancelled(self.conn, source_run_key, **kwargs)
+
+    def supersede_source_run(self, source_run_key: str, **kwargs: Any) -> dict[str, Any]:
+        return supersede_source_run(self.conn, source_run_key, **kwargs)
+
+    def get_active_source_run(self, **kwargs: Any) -> dict[str, Any] | None:
+        return get_active_source_run(self.conn, **kwargs)
+
+    def assert_no_active_source_run(self, **kwargs: Any) -> None:
+        assert_no_active_source_run(self.conn, **kwargs)
+
+
+def create_source_run(
+    conn: Any,
+    *,
+    source_run_key: str,
+    source_name: str,
+    source_category: str,
+    domain: str,
+    import_scope: str,
+    git_commit_sha: str,
+    importer_name: str,
+    importer_version: str,
+    trigger_context: str,
+    status: str = 'planned',
+    source_uri: str | None = None,
+    source_input_sha256: str | None = None,
+    source_manifest_sha256: str | None = None,
+    started_at: datetime | None = None,
+    rows_read: int = 0,
+    rows_staged: int = 0,
+    rows_rejected: int = 0,
+    rows_skipped: int = 0,
+    safety_boundary: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    _validate_required_text(source_run_key, 'source_run_key')
+    _validate_source_contract(source_name, source_category, domain, import_scope)
+    _validate_allowed(status, ALLOWED_STATUSES, 'status')
+    if status not in INITIAL_STATUSES:
+        raise SourceRunLedgerError('new source runs must start as planned or running')
+    for field, value in {
+        'git_commit_sha': git_commit_sha,
+        'importer_name': importer_name,
+        'importer_version': importer_version,
+        'trigger_context': trigger_context,
+    }.items():
+        _validate_required_text(value, field)
+    counts = _normalise_row_counts(
+        rows_read=rows_read,
+        rows_staged=rows_staged,
+        rows_rejected=rows_rejected,
+        rows_skipped=rows_skipped,
+    )
+    started = started_at or _utc_now()
+
+    sql = f"""
+        INSERT INTO {SOURCE_RUNS_TABLE} (
+            source_run_key,
+            source_name,
+            source_category,
+            domain,
+            import_scope,
+            status,
+            source_uri,
+            source_input_sha256,
+            source_manifest_sha256,
+            started_at,
+            git_commit_sha,
+            importer_name,
+            importer_version,
+            trigger_context,
+            rows_read,
+            rows_staged,
+            rows_rejected,
+            rows_skipped,
+            safety_boundary,
+            metadata
+        )
+        VALUES (
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb
+        )
+        RETURNING id, source_run_key, status
+        """
+    return _execute_returning_one(
+        conn,
+        sql,
+        (
+            source_run_key,
+            source_name,
+            source_category,
+            domain,
+            import_scope,
+            status,
+            source_uri,
+            source_input_sha256,
+            source_manifest_sha256,
+            started,
+            git_commit_sha,
+            importer_name,
+            importer_version,
+            trigger_context,
+            counts['rows_read'],
+            counts['rows_staged'],
+            counts['rows_rejected'],
+            counts['rows_skipped'],
+            _jsonb(safety_boundary or {}),
+            _jsonb(metadata or {}),
+        ),
+    )
+
+
+def mark_source_run_running(
+    conn: Any,
+    source_run_key: str,
+    *,
+    started_at: datetime | None = None,
+) -> dict[str, Any]:
+    _validate_required_text(source_run_key, 'source_run_key')
+    sql = f"""
+        UPDATE {SOURCE_RUNS_TABLE}
+        SET
+            status = %s,
+            started_at = COALESCE(%s, started_at),
+            updated_at = NOW()
+        WHERE source_run_key = %s
+          AND status = 'planned'
+        RETURNING id, source_run_key, status
+        """
+    return _execute_transition(
+        conn,
+        sql,
+        ('running', started_at, source_run_key),
+        source_run_key=source_run_key,
+        transition='running',
+    )
+
+
+def complete_source_run_success(
+    conn: Any,
+    source_run_key: str,
+    *,
+    rows_read: int | None = None,
+    rows_staged: int | None = None,
+    rows_rejected: int | None = None,
+    rows_skipped: int | None = None,
+    artifact_path: str | None = None,
+    artifact_sha256: str | None = None,
+    artifact_integrity_sha256: str | None = None,
+    finished_at: datetime | None = None,
+    duration_ms: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _complete_source_run(
+        conn,
+        source_run_key,
+        status='succeeded',
+        rows_read=rows_read,
+        rows_staged=rows_staged,
+        rows_rejected=rows_rejected,
+        rows_skipped=rows_skipped,
+        artifact_path=artifact_path,
+        artifact_sha256=artifact_sha256,
+        artifact_integrity_sha256=artifact_integrity_sha256,
+        error_code=None,
+        error_summary=None,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        metadata=metadata,
+    )
+
+
+def complete_source_run_failed(
+    conn: Any,
+    source_run_key: str,
+    *,
+    error_code: str,
+    error_summary: str,
+    rows_read: int | None = None,
+    rows_staged: int | None = None,
+    rows_rejected: int | None = None,
+    rows_skipped: int | None = None,
+    artifact_path: str | None = None,
+    artifact_sha256: str | None = None,
+    artifact_integrity_sha256: str | None = None,
+    finished_at: datetime | None = None,
+    duration_ms: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    _validate_required_text(error_code, 'error_code')
+    _validate_required_text(error_summary, 'error_summary')
+    return _complete_source_run(
+        conn,
+        source_run_key,
+        status='failed',
+        rows_read=rows_read,
+        rows_staged=rows_staged,
+        rows_rejected=rows_rejected,
+        rows_skipped=rows_skipped,
+        artifact_path=artifact_path,
+        artifact_sha256=artifact_sha256,
+        artifact_integrity_sha256=artifact_integrity_sha256,
+        error_code=error_code,
+        error_summary=error_summary,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        metadata=metadata,
+    )
+
+
+def complete_source_run_rejected(
+    conn: Any,
+    source_run_key: str,
+    *,
+    error_code: str,
+    error_summary: str,
+    rows_read: int | None = None,
+    rows_staged: int | None = None,
+    rows_rejected: int | None = None,
+    rows_skipped: int | None = None,
+    artifact_path: str | None = None,
+    artifact_sha256: str | None = None,
+    artifact_integrity_sha256: str | None = None,
+    finished_at: datetime | None = None,
+    duration_ms: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    _validate_required_text(error_code, 'error_code')
+    _validate_required_text(error_summary, 'error_summary')
+    return _complete_source_run(
+        conn,
+        source_run_key,
+        status='rejected',
+        rows_read=rows_read,
+        rows_staged=rows_staged,
+        rows_rejected=rows_rejected,
+        rows_skipped=rows_skipped,
+        artifact_path=artifact_path,
+        artifact_sha256=artifact_sha256,
+        artifact_integrity_sha256=artifact_integrity_sha256,
+        error_code=error_code,
+        error_summary=error_summary,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        metadata=metadata,
+    )
+
+
+def complete_source_run_cancelled(
+    conn: Any,
+    source_run_key: str,
+    *,
+    error_code: str | None = None,
+    error_summary: str | None = None,
+    rows_read: int | None = None,
+    rows_staged: int | None = None,
+    rows_rejected: int | None = None,
+    rows_skipped: int | None = None,
+    artifact_path: str | None = None,
+    artifact_sha256: str | None = None,
+    artifact_integrity_sha256: str | None = None,
+    finished_at: datetime | None = None,
+    duration_ms: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _complete_source_run(
+        conn,
+        source_run_key,
+        status='cancelled',
+        rows_read=rows_read,
+        rows_staged=rows_staged,
+        rows_rejected=rows_rejected,
+        rows_skipped=rows_skipped,
+        artifact_path=artifact_path,
+        artifact_sha256=artifact_sha256,
+        artifact_integrity_sha256=artifact_integrity_sha256,
+        error_code=error_code,
+        error_summary=error_summary,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        metadata=metadata,
+    )
+
+
+def supersede_source_run(
+    conn: Any,
+    source_run_key: str,
+    *,
+    finished_at: datetime | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    _validate_required_text(source_run_key, 'source_run_key')
+    finished = finished_at or _utc_now()
+    sql = f"""
+        UPDATE {SOURCE_RUNS_TABLE}
+        SET
+            status = %s,
+            finished_at = COALESCE(finished_at, %s),
+            metadata = metadata || %s::jsonb,
+            updated_at = NOW()
+        WHERE source_run_key = %s
+          AND status = ANY(%s)
+        RETURNING id, source_run_key, status
+        """
+    return _execute_transition(
+        conn,
+        sql,
+        ('superseded', finished, _jsonb(metadata or {}), source_run_key, list(SUPERSEDABLE_STATUSES)),
+        source_run_key=source_run_key,
+        transition='superseded',
+    )
+
+
+def get_active_source_run(
+    conn: Any,
+    *,
+    source_name: str,
+    domain: str,
+    import_scope: str,
+) -> dict[str, Any] | None:
+    _validate_source_name_domain_scope(source_name, domain, import_scope)
+    sql = f"""
+        SELECT
+            id,
+            source_run_key,
+            source_name,
+            domain,
+            import_scope,
+            status,
+            started_at
+        FROM {SOURCE_RUNS_TABLE}
+        WHERE source_name = %s
+          AND domain = %s
+          AND import_scope = %s
+          AND status = 'running'
+        ORDER BY started_at DESC
+        LIMIT 1
+        """
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, (source_name, domain, import_scope))
+        return _row_to_dict(cur.fetchone())
+    finally:
+        _close_cursor(cur)
+
+
+def assert_no_active_source_run(
+    conn: Any,
+    *,
+    source_name: str,
+    domain: str,
+    import_scope: str,
+) -> None:
+    active_run = get_active_source_run(
+        conn,
+        source_name=source_name,
+        domain=domain,
+        import_scope=import_scope,
+    )
+    if active_run is not None:
+        raise SourceRunStateError(
+            'active source run already exists for '
+            f'{source_name}/{domain}/{import_scope}: {active_run.get("source_run_key")}'
+        )
+
+
+def _complete_source_run(
+    conn: Any,
+    source_run_key: str,
+    *,
+    status: str,
+    rows_read: int | None,
+    rows_staged: int | None,
+    rows_rejected: int | None,
+    rows_skipped: int | None,
+    artifact_path: str | None,
+    artifact_sha256: str | None,
+    artifact_integrity_sha256: str | None,
+    error_code: str | None,
+    error_summary: str | None,
+    finished_at: datetime | None,
+    duration_ms: int | None,
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    _validate_required_text(source_run_key, 'source_run_key')
+    _validate_allowed(status, ALLOWED_STATUSES, 'status')
+    if status not in {'succeeded', 'failed', 'rejected', 'cancelled'}:
+        raise SourceRunLedgerError(f'unsupported completion status: {status}')
+    counts = _normalise_optional_row_counts(
+        rows_read=rows_read,
+        rows_staged=rows_staged,
+        rows_rejected=rows_rejected,
+        rows_skipped=rows_skipped,
+    )
+    if duration_ms is not None and duration_ms < 0:
+        raise SourceRunLedgerError('duration_ms must be >= 0')
+    finished = finished_at or _utc_now()
+
+    sql = f"""
+        UPDATE {SOURCE_RUNS_TABLE}
+        SET
+            status = %s,
+            finished_at = %s,
+            duration_ms = COALESCE(%s, duration_ms),
+            rows_read = COALESCE(%s, rows_read),
+            rows_staged = COALESCE(%s, rows_staged),
+            rows_rejected = COALESCE(%s, rows_rejected),
+            rows_skipped = COALESCE(%s, rows_skipped),
+            artifact_path = COALESCE(%s, artifact_path),
+            artifact_sha256 = COALESCE(%s, artifact_sha256),
+            artifact_integrity_sha256 = COALESCE(%s, artifact_integrity_sha256),
+            error_code = COALESCE(%s, error_code),
+            error_summary = COALESCE(%s, error_summary),
+            metadata = metadata || %s::jsonb,
+            updated_at = NOW()
+        WHERE source_run_key = %s
+          AND status = ANY(%s)
+        RETURNING id, source_run_key, status
+        """
+    return _execute_transition(
+        conn,
+        sql,
+        (
+            status,
+            finished,
+            duration_ms,
+            counts['rows_read'],
+            counts['rows_staged'],
+            counts['rows_rejected'],
+            counts['rows_skipped'],
+            artifact_path,
+            artifact_sha256,
+            artifact_integrity_sha256,
+            error_code,
+            error_summary,
+            _jsonb(metadata or {}),
+            source_run_key,
+            list(OPEN_STATUSES),
+        ),
+        source_run_key=source_run_key,
+        transition=status,
+    )
+
+
+def _execute_transition(
+    conn: Any,
+    sql: str,
+    params: tuple[Any, ...],
+    *,
+    source_run_key: str,
+    transition: str,
+) -> dict[str, Any]:
+    row = _execute_returning_one_or_none(conn, sql, params)
+    if row is None:
+        raise SourceRunStateError(f'source run {source_run_key!r} cannot transition to {transition}')
+    return row
+
+
+def _execute_returning_one(conn: Any, sql: str, params: tuple[Any, ...]) -> dict[str, Any]:
+    row = _execute_returning_one_or_none(conn, sql, params)
+    if row is None:
+        raise SourceRunLedgerError('source-run write did not return a row')
+    return row
+
+
+def _execute_returning_one_or_none(conn: Any, sql: str, params: tuple[Any, ...]) -> dict[str, Any] | None:
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, params)
+        return _row_to_dict(cur.fetchone())
+    finally:
+        _close_cursor(cur)
+
+
+def _normalise_row_counts(
+    *,
+    rows_read: int,
+    rows_staged: int,
+    rows_rejected: int,
+    rows_skipped: int,
+) -> dict[str, int]:
+    counts = {
+        'rows_read': rows_read,
+        'rows_staged': rows_staged,
+        'rows_rejected': rows_rejected,
+        'rows_skipped': rows_skipped,
+    }
+    for field, value in counts.items():
+        _validate_non_negative_int(value, field)
+    return counts
+
+
+def _normalise_optional_row_counts(
+    *,
+    rows_read: int | None,
+    rows_staged: int | None,
+    rows_rejected: int | None,
+    rows_skipped: int | None,
+) -> dict[str, int | None]:
+    counts = {
+        'rows_read': rows_read,
+        'rows_staged': rows_staged,
+        'rows_rejected': rows_rejected,
+        'rows_skipped': rows_skipped,
+    }
+    for field, value in counts.items():
+        if value is not None:
+            _validate_non_negative_int(value, field)
+    return counts
+
+
+def _validate_source_contract(
+    source_name: str,
+    source_category: str,
+    domain: str,
+    import_scope: str,
+) -> None:
+    _validate_source_name_domain_scope(source_name, domain, import_scope)
+    _validate_allowed(source_category, ALLOWED_SOURCE_CATEGORIES, 'source_category')
+
+
+def _validate_source_name_domain_scope(source_name: str, domain: str, import_scope: str) -> None:
+    _validate_allowed(source_name, ALLOWED_SOURCE_NAMES, 'source_name')
+    _validate_allowed(domain, ALLOWED_DOMAINS, 'domain')
+    _validate_allowed(import_scope, ALLOWED_IMPORT_SCOPES, 'import_scope')
+
+
+def _validate_allowed(value: str, allowed_values: frozenset[str], field: str) -> None:
+    _validate_required_text(value, field)
+    if value not in allowed_values:
+        raise SourceRunLedgerError(f'invalid {field}: {value!r}')
+
+
+def _validate_required_text(value: str | None, field: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise SourceRunLedgerError(f'{field} is required')
+
+
+def _validate_non_negative_int(value: int, field: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SourceRunLedgerError(f'{field} must be an integer')
+    if value < 0:
+        raise SourceRunLedgerError(f'{field} must be >= 0')
+
+
+def _jsonb(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(',', ':'), ensure_ascii=True, allow_nan=False)
+
+
+def _row_to_dict(row: Any) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return dict(row)
+    if hasattr(row, 'keys'):
+        return {key: row[key] for key in row.keys()}
+    if isinstance(row, (tuple, list)):
+        keys = ('id', 'source_run_key', 'status')
+        return {key: row[index] for index, key in enumerate(keys[:len(row)])}
+    raise TypeError('source-run cursor rows must be mapping-like or tuple-like')
+
+
+def _close_cursor(cur: Any) -> None:
+    close = getattr(cur, 'close', None)
+    if close is not None:
+        close()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+__all__ = [
+    'ALLOWED_DOMAINS',
+    'ALLOWED_IMPORT_SCOPES',
+    'ALLOWED_SOURCE_CATEGORIES',
+    'ALLOWED_SOURCE_NAMES',
+    'ALLOWED_STATUSES',
+    'SOURCE_RUNS_TABLE',
+    'SourceRunLedger',
+    'SourceRunLedgerError',
+    'SourceRunStateError',
+    'assert_no_active_source_run',
+    'complete_source_run_cancelled',
+    'complete_source_run_failed',
+    'complete_source_run_rejected',
+    'complete_source_run_success',
+    'create_source_run',
+    'get_active_source_run',
+    'mark_source_run_running',
+    'supersede_source_run',
+]

--- a/tests/test_source_run_ledger.py
+++ b/tests/test_source_run_ledger.py
@@ -1,0 +1,419 @@
+import inspect
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import source_run_ledger as ledger  # noqa: E402
+
+
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.closed = False
+        self.last_result = None
+
+    def execute(self, sql, params=None):
+        params = tuple(params or ())
+        self.conn.statements.append((sql, params))
+        sql_normalised = ' '.join(sql.lower().split())
+
+        if sql_normalised.startswith('insert into source_runs'):
+            self.conn.next_id += 1
+            self.last_result = {
+                'id': self.conn.next_id,
+                'source_run_key': params[0],
+                'status': params[5],
+            }
+            return
+
+        if sql_normalised.startswith('update source_runs'):
+            if not self.conn.allow_transition:
+                self.last_result = None
+                return
+            self.conn.next_id += 1
+            self.last_result = {
+                'id': self.conn.next_id,
+                'source_run_key': self.conn.transition_key,
+                'status': params[0],
+            }
+            return
+
+        if sql_normalised.startswith('select') and 'from source_runs' in sql_normalised:
+            self.last_result = self.conn.active_run
+            return
+
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+    def fetchone(self):
+        return self.last_result
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(self, *, active_run=None, allow_transition=True):
+        self.statements = []
+        self.cursors = []
+        self.next_id = 100
+        self.active_run = active_run
+        self.allow_transition = allow_transition
+        self.transition_key = 'run-key'
+
+    def cursor(self):
+        cur = FakeCursor(self)
+        self.cursors.append(cur)
+        return cur
+
+
+def valid_create_kwargs(**overrides):
+    kwargs = {
+        'source_run_key': 'run-key',
+        'source_name': 'edsm',
+        'source_category': 'source_of_evidence',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'git_commit_sha': 'abcdef123456',
+        'importer_name': 'test-importer',
+        'importer_version': 'v1',
+        'trigger_context': 'test',
+        'started_at': NOW,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def all_sql(conn):
+    return '\n'.join(sql for sql, _params in conn.statements)
+
+
+def assert_helper_sql_only_touches_source_runs(conn):
+    assert conn.statements
+    for sql, _params in conn.statements:
+        referenced = {
+            match.group(1).replace('"', '').split('.')[-1].lower()
+            for match in re.finditer(
+                r'\b(?:from|into|update)\s+(?:only\s+)?("?[\w]+"?(?:\."?[\w]+"?)?)',
+                sql,
+                flags=re.IGNORECASE,
+            )
+        }
+        assert referenced == {'source_runs'}
+        assert re.search(
+            r'\b(insert\s+into|update|delete\s+from)\s+'
+            r'(systems|stations|bodies|body_rings|station_body_links)\b',
+            sql,
+            flags=re.IGNORECASE,
+        ) is None
+
+
+def test_create_source_run_populates_required_fields_and_default_counts():
+    conn = FakeConn()
+
+    row = ledger.create_source_run(conn, **valid_create_kwargs(status='running'))
+
+    assert row == {'id': 101, 'source_run_key': 'run-key', 'status': 'running'}
+    sql, params = conn.statements[0]
+    assert 'INSERT INTO source_runs' in sql
+    assert params[:6] == (
+        'run-key',
+        'edsm',
+        'source_of_evidence',
+        'stations',
+        'staging_only',
+        'running',
+    )
+    assert params[9] == NOW
+    assert params[10:14] == ('abcdef123456', 'test-importer', 'v1', 'test')
+    assert params[14:18] == (0, 0, 0, 0)
+    assert params[18] == '{}'
+    assert params[19] == '{}'
+    assert conn.cursors[-1].closed is True
+    assert_helper_sql_only_touches_source_runs(conn)
+
+
+@pytest.mark.parametrize('field,value', [
+    ('source_run_key', ''),
+    ('source_name', 'unknown_source'),
+    ('source_category', 'unknown_category'),
+    ('domain', 'unknown_domain'),
+    ('import_scope', 'unknown_scope'),
+    ('status', 'unknown_status'),
+    ('git_commit_sha', ''),
+    ('importer_name', ''),
+    ('importer_version', ''),
+    ('trigger_context', ''),
+])
+def test_create_source_run_rejects_invalid_values_before_db_write(field, value):
+    conn = FakeConn()
+    kwargs = valid_create_kwargs(**{field: value})
+
+    with pytest.raises(ledger.SourceRunLedgerError):
+        ledger.create_source_run(conn, **kwargs)
+
+    assert conn.statements == []
+
+
+@pytest.mark.parametrize('status', sorted(ledger.ALLOWED_STATUSES - {'planned', 'running'}))
+def test_create_source_run_rejects_terminal_initial_statuses(status):
+    conn = FakeConn()
+
+    with pytest.raises(ledger.SourceRunLedgerError, match='planned or running'):
+        ledger.create_source_run(conn, **valid_create_kwargs(status=status))
+
+    assert conn.statements == []
+
+
+def test_create_source_run_allows_stage19_schema_vocab_values():
+    assert 'canonical_apply' in ledger.ALLOWED_IMPORT_SCOPES
+    for value in ledger.ALLOWED_SOURCE_NAMES:
+        assert isinstance(value, str) and value
+    for value in ledger.ALLOWED_SOURCE_CATEGORIES:
+        assert isinstance(value, str) and value
+    for value in ledger.ALLOWED_DOMAINS:
+        assert isinstance(value, str) and value
+    for value in ledger.ALLOWED_STATUSES:
+        assert isinstance(value, str) and value
+
+
+@pytest.mark.parametrize('field', ['rows_read', 'rows_staged', 'rows_rejected', 'rows_skipped'])
+def test_negative_create_row_counts_are_rejected_before_db_write(field):
+    conn = FakeConn()
+
+    with pytest.raises(ledger.SourceRunLedgerError, match='>= 0'):
+        ledger.create_source_run(conn, **valid_create_kwargs(**{field: -1}))
+
+    assert conn.statements == []
+
+
+def test_mark_source_run_running_requires_planned_transition():
+    conn = FakeConn()
+
+    row = ledger.mark_source_run_running(conn, 'run-key', started_at=NOW)
+
+    assert row['status'] == 'running'
+    sql, params = conn.statements[0]
+    assert 'UPDATE source_runs' in sql
+    assert "AND status = 'planned'" in sql
+    assert params == ('running', NOW, 'run-key')
+    assert_helper_sql_only_touches_source_runs(conn)
+
+
+def test_invalid_transition_raises_state_error():
+    conn = FakeConn(allow_transition=False)
+
+    with pytest.raises(ledger.SourceRunStateError, match='cannot transition'):
+        ledger.complete_source_run_success(conn, 'run-key')
+
+    assert_helper_sql_only_touches_source_runs(conn)
+
+
+def test_success_completion_records_finished_counts_and_artifact_fields():
+    conn = FakeConn()
+
+    row = ledger.complete_source_run_success(
+        conn,
+        'run-key',
+        rows_read=10,
+        rows_staged=8,
+        rows_rejected=1,
+        rows_skipped=1,
+        artifact_path='artifacts/run.json',
+        artifact_sha256='a' * 64,
+        artifact_integrity_sha256='b' * 64,
+        finished_at=NOW,
+        duration_ms=1234,
+        metadata={'summary': 'ok'},
+    )
+
+    assert row['status'] == 'succeeded'
+    sql, params = conn.statements[0]
+    assert 'UPDATE source_runs' in sql
+    assert 'finished_at = %s' in sql
+    assert params[:13] == (
+        'succeeded',
+        NOW,
+        1234,
+        10,
+        8,
+        1,
+        1,
+        'artifacts/run.json',
+        'a' * 64,
+        'b' * 64,
+        None,
+        None,
+        '{"summary":"ok"}',
+    )
+    assert params[13] == 'run-key'
+    assert params[14] == ['planned', 'running']
+    assert_helper_sql_only_touches_source_runs(conn)
+
+
+@pytest.mark.parametrize('complete_func,status', [
+    (ledger.complete_source_run_failed, 'failed'),
+    (ledger.complete_source_run_rejected, 'rejected'),
+])
+def test_failed_and_rejected_completion_record_error_code_and_summary(complete_func, status):
+    conn = FakeConn()
+
+    row = complete_func(
+        conn,
+        'run-key',
+        error_code='source_schema_mismatch',
+        error_summary='source schema did not match expected fields',
+        rows_read=3,
+        rows_rejected=3,
+        finished_at=NOW,
+    )
+
+    assert row['status'] == status
+    _sql, params = conn.statements[0]
+    assert params[0] == status
+    assert params[3] == 3
+    assert params[5] == 3
+    assert params[10:12] == (
+        'source_schema_mismatch',
+        'source schema did not match expected fields',
+    )
+    assert_helper_sql_only_touches_source_runs(conn)
+
+
+def test_failed_and_rejected_completion_require_error_details():
+    for complete_func in (ledger.complete_source_run_failed, ledger.complete_source_run_rejected):
+        conn = FakeConn()
+        with pytest.raises(ledger.SourceRunLedgerError):
+            complete_func(conn, 'run-key', error_code='', error_summary='detail')
+        with pytest.raises(ledger.SourceRunLedgerError):
+            complete_func(conn, 'run-key', error_code='code', error_summary='')
+        assert conn.statements == []
+
+
+@pytest.mark.parametrize('field', ['rows_read', 'rows_staged', 'rows_rejected', 'rows_skipped'])
+def test_negative_completion_row_counts_are_rejected_before_db_write(field):
+    conn = FakeConn()
+
+    with pytest.raises(ledger.SourceRunLedgerError, match='>= 0'):
+        ledger.complete_source_run_success(conn, 'run-key', **{field: -1})
+
+    assert conn.statements == []
+
+
+def test_cancelled_and_superseded_transitions_are_explicit():
+    cancel_conn = FakeConn()
+    cancelled = ledger.complete_source_run_cancelled(
+        cancel_conn,
+        'run-key',
+        error_code='operator_cancelled',
+        error_summary='operator stopped the run',
+        finished_at=NOW,
+    )
+    assert cancelled['status'] == 'cancelled'
+
+    supersede_conn = FakeConn()
+    superseded = ledger.supersede_source_run(
+        supersede_conn,
+        'run-key',
+        finished_at=NOW,
+        metadata={'replaced_by': 'run-new'},
+    )
+    assert superseded['status'] == 'superseded'
+    assert supersede_conn.statements[0][1][-1] == ['succeeded']
+    assert_helper_sql_only_touches_source_runs(cancel_conn)
+    assert_helper_sql_only_touches_source_runs(supersede_conn)
+
+
+def test_active_run_helpers_read_and_block_duplicate_running_run():
+    active = {
+        'id': 10,
+        'source_run_key': 'active-run',
+        'source_name': 'edsm',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'status': 'running',
+    }
+    conn = FakeConn(active_run=active)
+
+    assert ledger.get_active_source_run(
+        conn,
+        source_name='edsm',
+        domain='stations',
+        import_scope='staging_only',
+    ) == active
+    with pytest.raises(ledger.SourceRunStateError, match='active source run already exists'):
+        ledger.assert_no_active_source_run(
+            conn,
+            source_name='edsm',
+            domain='stations',
+            import_scope='staging_only',
+        )
+
+    assert 'SELECT' in conn.statements[0][0]
+    assert_helper_sql_only_touches_source_runs(conn)
+
+
+def test_source_run_ledger_class_wraps_function_api():
+    conn = FakeConn()
+    repository = ledger.SourceRunLedger(conn)
+
+    row = repository.create_source_run(**valid_create_kwargs())
+
+    assert row['source_run_key'] == 'run-key'
+    assert 'INSERT INTO source_runs' in conn.statements[0][0]
+
+
+def test_helper_source_has_no_import_execution_scheduler_or_secret_side_effects():
+    source = inspect.getsource(ledger)
+    source_upper = source.upper()
+
+    forbidden_fragments = (
+        'PSYCOPG2.CONNECT',
+        'ASYNCPG.CONNECT',
+        'SUBPROCESS',
+        'OS.SYSTEM',
+        'SYSTEMCTL',
+        '.TIMER',
+        '.SERVICE',
+        'RUN_IMPORT',
+        'RUN_IMPORT.SH',
+        'CANONICAL APPLY',
+        'DATABASE' + '_URL',
+        'POSTGRESQL' + '://',
+        'PASSWORD' + '=',
+        'SECRET',
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in source_upper
+
+    assert 'source_runs' in source
+    assert 'enrichment_source_runs' not in source
+
+
+def test_helper_module_sql_only_writes_source_runs_not_canonical_tables():
+    source = inspect.getsource(ledger)
+    normalised = re.sub(r'\s+', ' ', source.upper())
+
+    forbidden_patterns = (
+        r'\bINSERT\s+INTO\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|STATION_BODY_LINKS)\b',
+        r'\bUPDATE\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|STATION_BODY_LINKS)\b',
+        r'\bDELETE\s+FROM\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|STATION_BODY_LINKS)\b',
+        r'\bALTER\s+TABLE\s+(SYSTEMS|STATIONS|BODIES|BODY_RINGS|STATION_BODY_LINKS)\b',
+    )
+    for pattern in forbidden_patterns:
+        assert re.search(pattern, normalised) is None
+
+    assert 'INSERT INTO {SOURCE_RUNS_TABLE}' in source
+    assert 'UPDATE {SOURCE_RUNS_TABLE}' in source
+    assert 'FROM {SOURCE_RUNS_TABLE}' in source


### PR DESCRIPTION
## Summary

- Adds `apps/importer/src/source_run_ledger.py`, a reusable DB-API helper/repository for recording `source_runs` lifecycle events.
- Supports creating planned/running runs, marking planned runs as running, completing runs as succeeded/failed/rejected/cancelled, superseding successful runs, and checking/asserting active running runs.
- Adds fake-connection and static inspection tests covering Stage 19 vocabulary validation, negative row count rejection, explicit state transitions, artifact/error recording, source-runs-only SQL, and absence of import/scheduler/secret side effects.

## Boundary

- Repo implementation + tests only.
- No production DB access.
- No rows inserted into production `source_runs`.
- No imports run.
- No scheduler/timer enablement.
- No canonical writes.
- No canonical apply.

## Validation

Local environment note: `python`, `py`, and `pytest` were not available on PATH, so I used the bundled Codex Python runtime with an existing workspace-local pytest dependency folder from the sibling checkout. This dependency folder was not in this clean Stage 19K checkout and was not committed.

- `C:\Users\brian\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests/test_source_run_ledger.py -q`
  - Result: `36 passed` with one `pytest-asyncio` deprecation warning about default fixture loop scope.
- `C:\Users\brian\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q`
  - Result: `44 passed` with the same `pytest-asyncio` deprecation warning.
- Attempted adjacent helper coverage: `C:\Users\brian\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests/test_source_run_ledger.py tests/test_source_runs_migration.py tests/test_enrichment_warehouse_repository.py -q`
  - Result: `49 passed, 5 failed` in `tests/test_enrichment_warehouse_repository.py` because existing fixture paths on Windows are parsed as URL schemes (`source file must be a local path, not a URL`). The failures occurred before this helper's code path and were not production DB related.

`git status --short --branch` in the clean Stage 19K checkout reports no uncommitted files after the local commit.