### PR TITLE
Stage 19Q add artifact canonical JSON helpers

### DIFF
--- a/apps/importer/src/artifact_utils.py
+++ b/apps/importer/src/artifact_utils.py
@@ -1,0 +1,139 @@
+"""Shared helpers for deterministic JSON artifacts and integrity hashes."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Mapping
+
+
+DEFAULT_INTEGRITY_KEY = 'artifact_integrity'
+HASH_ALGORITHM = 'sha256'
+CANONICALIZATION = (
+    'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False,default=str) '
+    f'excluding {DEFAULT_INTEGRITY_KEY}'
+)
+
+
+def canonical_json(value: Any) -> str:
+    """Return the stable compact JSON representation used for artifact hashes."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(',', ':'),
+        ensure_ascii=True,
+        allow_nan=False,
+        default=str,
+    )
+
+
+def sha256_bytes(data: bytes | bytearray | memoryview) -> str:
+    """Return the SHA-256 hex digest for byte-oriented data."""
+    return hashlib.sha256(bytes(data)).hexdigest()
+
+
+def sha256_text(text: str) -> str:
+    """Return the SHA-256 hex digest for UTF-8 encoded text."""
+    return sha256_bytes(text.encode('utf-8'))
+
+
+def sha256_file(path: str | Path, *, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 hex digest for a file without loading it all at once."""
+    hasher = hashlib.sha256()
+    with Path(path).open('rb') as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b''):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def artifact_integrity_sha256(
+    payload: Mapping[str, Any],
+    *,
+    integrity_key: str = DEFAULT_INTEGRITY_KEY,
+) -> str:
+    """Hash an artifact payload after excluding its self-referential integrity block."""
+    return sha256_text(canonical_json(_without_integrity(payload, integrity_key=integrity_key)))
+
+
+def attach_artifact_integrity(
+    payload: Mapping[str, Any],
+    *,
+    integrity_key: str = DEFAULT_INTEGRITY_KEY,
+) -> dict[str, Any]:
+    """Return a copy of the artifact payload with a refreshed integrity block."""
+    artifact = _without_integrity(payload, integrity_key=integrity_key)
+    artifact[integrity_key] = {
+        'hash_algorithm': HASH_ALGORITHM,
+        'canonical_json_sha256': artifact_integrity_sha256(artifact, integrity_key=integrity_key),
+        'canonicalization': _canonicalization_label(integrity_key),
+    }
+    return artifact
+
+
+def write_json_artifact(
+    path: str | Path,
+    payload: Mapping[str, Any],
+    *,
+    integrity_key: str = DEFAULT_INTEGRITY_KEY,
+    chmod_mode: int | None = 0o600,
+) -> dict[str, Any]:
+    """Write a canonical JSON artifact with integrity metadata and return file hashes."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    artifact = attach_artifact_integrity(payload, integrity_key=integrity_key)
+    text = canonical_json(artifact) + '\n'
+    data = text.encode('utf-8')
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, 'O_BINARY'):
+        flags |= os.O_BINARY
+    mode = 0o666 if chmod_mode is None else chmod_mode
+    fd = os.open(output_path, flags, mode)
+    try:
+        with os.fdopen(fd, 'wb') as handle:
+            handle.write(data)
+            fd = -1
+    finally:
+        if fd != -1:
+            os.close(fd)
+
+    if chmod_mode is not None:
+        output_path.chmod(chmod_mode)
+
+    return build_artifact_record(output_path, artifact, integrity_key=integrity_key)
+
+
+def build_artifact_record(
+    path: str | Path,
+    payload: Mapping[str, Any],
+    *,
+    integrity_key: str = DEFAULT_INTEGRITY_KEY,
+) -> dict[str, Any]:
+    """Return compact metadata for a written JSON artifact."""
+    output_path = Path(path)
+    return {
+        'path': str(output_path),
+        'file_sha256': sha256_file(output_path),
+        'artifact_integrity_sha256': artifact_integrity_sha256(payload, integrity_key=integrity_key),
+        'hash_algorithm': HASH_ALGORITHM,
+        'integrity_key': integrity_key,
+        'bytes_written': output_path.stat().st_size,
+    }
+
+
+def _without_integrity(payload: Mapping[str, Any], *, integrity_key: str) -> dict[str, Any]:
+    artifact = deepcopy(dict(payload))
+    artifact.pop(integrity_key, None)
+    return artifact
+
+
+def _canonicalization_label(integrity_key: str) -> str:
+    if integrity_key == DEFAULT_INTEGRITY_KEY:
+        return CANONICALIZATION
+    return (
+        'json.dumps(sort_keys=True,separators=(comma,colon),ensure_ascii=True,allow_nan=False,default=str) '
+        f'excluding {integrity_key}'
+    )

--- a/tests/test_artifact_utils.py
+++ b/tests/test_artifact_utils.py
@@ -1,0 +1,156 @@
+import hashlib
+import inspect
+import json
+import math
+import os
+import re
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import artifact_utils  # noqa: E402
+
+
+def test_canonical_json_is_stable_independent_of_key_order():
+    left = {
+        'station': {'name': 'Galileo', 'distanceToArrival': 503.2},
+        'services': ['Shipyard', 'Market'],
+        'none': None,
+    }
+    right = {
+        'none': None,
+        'services': ['Shipyard', 'Market'],
+        'station': {'distanceToArrival': 503.2, 'name': 'Galileo'},
+    }
+
+    assert artifact_utils.canonical_json(left) == artifact_utils.canonical_json(right)
+    assert artifact_utils.canonical_json(left) == (
+        '{"none":null,"services":["Shipyard","Market"],'
+        '"station":{"distanceToArrival":503.2,"name":"Galileo"}}'
+    )
+
+
+@pytest.mark.parametrize('value', [math.nan, math.inf, -math.inf])
+def test_canonical_json_rejects_nan_and_infinity(value):
+    with pytest.raises(ValueError):
+        artifact_utils.canonical_json({'value': value})
+
+
+def test_sha256_helpers_match_hashlib(tmp_path):
+    data = b'artifact bytes\n'
+    text = data.decode('utf-8')
+    path = tmp_path / 'artifact.bin'
+    path.write_bytes(data)
+    expected = hashlib.sha256(data).hexdigest()
+
+    assert artifact_utils.sha256_bytes(data) == expected
+    assert artifact_utils.sha256_bytes(memoryview(data)) == expected
+    assert artifact_utils.sha256_text(text) == expected
+    assert artifact_utils.sha256_file(path) == expected
+
+
+def test_artifact_integrity_excludes_integrity_block():
+    payload = {
+        'schema_version': 'example/v1',
+        'rows': [{'b': 2, 'a': 1}],
+    }
+    with_integrity = {
+        **payload,
+        'artifact_integrity': {
+            'hash_algorithm': 'sha256',
+            'canonical_json_sha256': 'not-the-real-hash',
+        },
+    }
+
+    assert artifact_utils.artifact_integrity_sha256(payload) == artifact_utils.artifact_integrity_sha256(with_integrity)
+
+
+def test_attach_artifact_integrity_is_deterministic_and_does_not_mutate_original():
+    payload = {
+        'schema_version': 'example/v1',
+        'nested': {'values': [3, 2, 1]},
+        'artifact_integrity': {'canonical_json_sha256': 'stale'},
+    }
+    original = deepcopy(payload)
+
+    first = artifact_utils.attach_artifact_integrity(payload)
+    second = artifact_utils.attach_artifact_integrity(payload)
+
+    assert payload == original
+    assert first == second
+    assert first['artifact_integrity'] == {
+        'hash_algorithm': 'sha256',
+        'canonical_json_sha256': artifact_utils.artifact_integrity_sha256(first),
+        'canonicalization': artifact_utils.CANONICALIZATION,
+    }
+
+    first['nested']['values'].append(4)
+    assert payload == original
+
+
+def test_write_json_artifact_writes_newline_parents_hashes_and_private_mode(tmp_path):
+    path = tmp_path / 'nested' / 'artifact.json'
+    payload = {
+        'schema_version': 'example/v1',
+        'station': {'name': 'Galileo', 'distanceToArrival': 503.2},
+    }
+
+    record = artifact_utils.write_json_artifact(path, payload)
+    raw = path.read_bytes()
+    loaded = json.loads(raw.decode('utf-8'))
+
+    assert path.exists()
+    assert raw.endswith(b'\n')
+    assert raw.decode('utf-8') == artifact_utils.canonical_json(loaded) + '\n'
+    assert loaded['artifact_integrity']['hash_algorithm'] == 'sha256'
+    assert loaded['artifact_integrity']['canonical_json_sha256'] == artifact_utils.artifact_integrity_sha256(loaded)
+    assert payload == {
+        'schema_version': 'example/v1',
+        'station': {'name': 'Galileo', 'distanceToArrival': 503.2},
+    }
+    assert record == {
+        'path': str(path),
+        'file_sha256': artifact_utils.sha256_bytes(raw),
+        'artifact_integrity_sha256': loaded['artifact_integrity']['canonical_json_sha256'],
+        'hash_algorithm': 'sha256',
+        'integrity_key': 'artifact_integrity',
+        'bytes_written': len(raw),
+    }
+    if os.name != 'nt':
+        assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_artifact_utils_has_no_prod_db_or_side_effect_fragments():
+    source = inspect.getsource(artifact_utils)
+    forbidden_fragments = [
+        'DATABASE_URL',
+        'postgresql://',
+        'postgres://',
+        'PASSWORD=',
+        'SECRET=',
+        'TOKEN=',
+        'systemctl',
+        '.timer',
+        '.service',
+        'scheduler',
+        'canonical apply',
+    ]
+
+    for fragment in forbidden_fragments:
+        assert fragment not in source
+
+    canonical_write_patterns = [
+        r'\binsert\s+into\s+(systems|stations|colonies|station_external_identity)\b',
+        r'\bupdate\s+(systems|stations|colonies|station_external_identity)\b',
+        r'\bdelete\s+from\s+(systems|stations|colonies|station_external_identity)\b',
+    ]
+    for pattern in canonical_write_patterns:
+        assert re.search(pattern, source, flags=re.IGNORECASE) is None


### PR DESCRIPTION
## Summary
- Add `apps/importer/src/artifact_utils.py` with shared canonical JSON serialization, SHA-256 helpers, artifact integrity hashing, integrity attachment, JSON artifact writing, and artifact metadata record helpers.
- Add focused tests covering deterministic canonical JSON, NaN/infinity rejection, text/bytes/file hashes, integrity exclusion and determinism, non-mutating attachment, newline/parent creation/hash/private-mode writes, and side-effect guardrails.

## Safety / Scope
- Repo implementation and tests only.
- No production DB strings or secrets in the helper module.
- No importer execution changes, scheduler changes, `systemctl`, timer, or service changes.
- No canonical apply behavior and no canonical table writes.

## Validation
- `python -m pytest tests/test_artifact_utils.py -q` - 9 passed.
- `python -m pytest tests/test_artifact_utils.py tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q` - 53 passed.

## Known unrelated test failures
- None observed in the required validation set. The run emitted the existing `pytest-asyncio` default fixture loop-scope deprecation warning.