### PR TITLE
Stage 19R prep import artifact source-run integration

### DIFF
--- a/apps/importer/src/source_run_artifacts.py
+++ b/apps/importer/src/source_run_artifacts.py
@@ -1,0 +1,218 @@
+"""Prep helpers for pairing source_runs ledger updates with JSON artifacts."""
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import artifact_utils
+import source_run_ledger
+
+
+FINAL_STATUSES = frozenset(('succeeded', 'failed', 'rejected', 'cancelled'))
+
+
+@dataclass(frozen=True)
+class SourceRunArtifactOutcome:
+    """Result returned by a future import operation before ledger completion."""
+
+    payload: Mapping[str, Any]
+    status: str = 'succeeded'
+    rows_read: int | None = None
+    rows_staged: int | None = None
+    rows_rejected: int | None = None
+    rows_skipped: int | None = None
+    error_code: str | None = None
+    error_summary: str | None = None
+    metadata: Mapping[str, Any] | None = None
+    finished_at: datetime | None = None
+    duration_ms: int | None = None
+
+
+def build_artifact_payload_shell(
+    *,
+    schema_version: str,
+    source_run_key: str,
+    source_name: str,
+    source_category: str,
+    domain: str,
+    import_scope: str,
+    git_commit_sha: str,
+    importer_name: str,
+    importer_version: str,
+    trigger_context: str,
+    generated_at: datetime | str | None = None,
+    source_uri: str | None = None,
+    source_input_sha256: str | None = None,
+    source_manifest_sha256: str | None = None,
+    safety_boundary: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    summary: Mapping[str, Any] | None = None,
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the standard outer shape for a source-run JSON artifact."""
+    return {
+        'schema_version': schema_version,
+        'generated_at': _format_generated_at(generated_at),
+        'source_run': {
+            'source_run_key': source_run_key,
+            'source_name': source_name,
+            'source_category': source_category,
+            'domain': domain,
+            'import_scope': import_scope,
+            'git_commit_sha': git_commit_sha,
+            'importer_name': importer_name,
+            'importer_version': importer_version,
+            'trigger_context': trigger_context,
+        },
+        'source': {
+            'uri': source_uri,
+            'input_sha256': source_input_sha256,
+            'manifest_sha256': source_manifest_sha256,
+        },
+        'safety_boundary': dict(safety_boundary or {}),
+        'metadata': dict(metadata or {}),
+        'summary': dict(summary or {}),
+        'payload': dict(payload or {}),
+    }
+
+
+def write_source_run_artifact(
+    path: str | Path,
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Write a JSON artifact and return metadata ready for source_runs completion."""
+    record = artifact_utils.write_json_artifact(path, payload)
+    return {
+        'path': record['path'],
+        'artifact_path': record['path'],
+        'file_sha256': record['file_sha256'],
+        'artifact_sha256': record['file_sha256'],
+        'artifact_integrity_sha256': record['artifact_integrity_sha256'],
+        'hash_algorithm': record['hash_algorithm'],
+        'integrity_key': record['integrity_key'],
+        'bytes_written': record['bytes_written'],
+    }
+
+
+def artifact_completion_metadata(
+    artifact_record: Mapping[str, Any],
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return completion metadata that preserves the artifact write record."""
+    completion_metadata = dict(metadata or {})
+    completion_metadata['artifact_record'] = {
+        'path': artifact_record['artifact_path'],
+        'file_sha256': artifact_record['file_sha256'],
+        'artifact_sha256': artifact_record['artifact_sha256'],
+        'artifact_integrity_sha256': artifact_record['artifact_integrity_sha256'],
+        'bytes_written': artifact_record['bytes_written'],
+        'hash_algorithm': artifact_record['hash_algorithm'],
+        'integrity_key': artifact_record['integrity_key'],
+    }
+    return completion_metadata
+
+
+def complete_source_run_with_artifact(
+    conn: Any,
+    source_run_key: str,
+    *,
+    status: str,
+    artifact_record: Mapping[str, Any],
+    rows_read: int | None = None,
+    rows_staged: int | None = None,
+    rows_rejected: int | None = None,
+    rows_skipped: int | None = None,
+    error_code: str | None = None,
+    error_summary: str | None = None,
+    finished_at: datetime | None = None,
+    duration_ms: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Complete a source run with artifact path, file hash, and integrity hash."""
+    kwargs = {
+        'rows_read': rows_read,
+        'rows_staged': rows_staged,
+        'rows_rejected': rows_rejected,
+        'rows_skipped': rows_skipped,
+        'artifact_path': artifact_record['artifact_path'],
+        'artifact_sha256': artifact_record['artifact_sha256'],
+        'artifact_integrity_sha256': artifact_record['artifact_integrity_sha256'],
+        'finished_at': finished_at,
+        'duration_ms': duration_ms,
+        'metadata': artifact_completion_metadata(artifact_record, metadata),
+    }
+
+    if status == 'succeeded':
+        return source_run_ledger.complete_source_run_success(conn, source_run_key, **kwargs)
+    if status == 'failed':
+        return source_run_ledger.complete_source_run_failed(
+            conn,
+            source_run_key,
+            error_code=error_code or '',
+            error_summary=error_summary or '',
+            **kwargs,
+        )
+    if status == 'rejected':
+        return source_run_ledger.complete_source_run_rejected(
+            conn,
+            source_run_key,
+            error_code=error_code or '',
+            error_summary=error_summary or '',
+            **kwargs,
+        )
+    if status == 'cancelled':
+        return source_run_ledger.complete_source_run_cancelled(
+            conn,
+            source_run_key,
+            error_code=error_code,
+            error_summary=error_summary,
+            **kwargs,
+        )
+    raise source_run_ledger.SourceRunLedgerError(f'unsupported artifact completion status: {status}')
+
+def run_source_run_artifact_flow(
+    conn: Any,
+    *,
+    source_run_kwargs: Mapping[str, Any],
+    artifact_path: str | Path,
+    operation: Callable[[Mapping[str, Any]], SourceRunArtifactOutcome],
+) -> dict[str, Any]:
+    """Example callback flow for future import jobs that produce an artifact."""
+    source_run = source_run_ledger.create_source_run(conn, **dict(source_run_kwargs))
+    outcome = operation(source_run)
+    if outcome.status not in FINAL_STATUSES:
+        raise source_run_ledger.SourceLedgerError(f'unsupported artifact completion status: {outcome.status}')
+
+    artifact_record = write_source_run_artifact(artifact_path, outcome.payload)
+    completion = complete_source_run_with_artifact(
+        conn,
+        source_run['source_run_key'],
+        status=outcome.status,
+        artifact_record=artifact_record,
+        rows_read=outcome.rows_read,
+        rows_staged=outcome.rows_staged,
+        rows_rejected=outcome.rows_rejected,
+        rows_skipped=outcome.rows_skipped,
+        error_code=outcome.error_code,
+        error_summary=outcome.error_summary,
+        finished_at=outcome.finished_at,
+        duration_ms=outcome.duration_ms,
+        metadata=outcome.metadata,
+    )
+    return {
+        'source_run': source_run,
+        'artifact_record': artifact_record,
+        'completion': completion,
+    }
+
+def _format_generated_at(value: datetime | str | None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc).replace(microsecond=0)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    return str(value)

--- a/apps/importer/src/source_run_artifacts.py
+++ b/apps/importer/src/source_run_artifacts.py
@@ -184,7 +184,7 @@ def run_source_run_artifact_flow(
     source_run = source_run_ledger.create_source_run(conn, **dict(source_run_kwargs))
     outcome = operation(source_run)
     if outcome.status not in FINAL_STATUSES:
-        raise source_run_ledger.SourceLedgerError(f'unsupported artifact completion status: {outcome.status}')
+        raise source_run_ledger.SourceRunLedgerError(f'unsupported artifact completion status: {outcome.status}')
 
     artifact_record = write_source_run_artifact(artifact_path, outcome.payload)
     completion = complete_source_run_with_artifact(

--- a/tests/test_source_run_artifacts.py
+++ b/tests/test_source_run_artifacts.py
@@ -209,7 +209,7 @@ def test_run_source_run_artifact_flow_creates_writes_and_completes_success(tmp_p
         update_params[12],
     )
     metadata = json.loads(update_params[12])
-    assert metadata['operation'] == 'fake_succesp'
+    assert metadata['operation'] == 'fake_success'
     assert metadata['artifact_record']['file_sha256'] == result['artifact_record']['file_sha256']
     assert update_params[13] == 'stage-19r-run'
     assert update_params[14] == ['planned', 'running']
@@ -268,7 +268,10 @@ def test_run_source_run_artifact_flow_rejects_unknown_completion_status(tmp_path
     def operation(_source_run):
         return artifacts.SourceRunArtifactOutcome(payload=payload_shell(), status='waiting')
 
-    with pytest.raises(Exception, match='unsupported artifact completion status'):
+    with pytest.raises(
+        artifacts.source_run_ledger.SourceRunLedgerError,
+        match='unsupported artifact completion status',
+    ):
         artifacts.run_source_run_artifact_flow(
             conn,
             source_run_kwargs=valid_source_run_kwargs(),

--- a/tests/test_source_run_artifacts.py
+++ b/tests/test_source_run_artifacts.py
@@ -1,0 +1,315 @@
+import inspect
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import artifact_utils  # noqa: E402
+import source_run_artifacts as artifacts  # noqa: E402
+
+
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.last_result = None
+        self.closed = False
+
+    def execute(self, sql, params=None):
+        params = tuple(params or ())
+        self.conn.statements.append((sql, params))
+        normalised = ' '.join(sql.lower().split())
+
+        if normalised.startswith('insert into source_runs'):
+            self.conn.next_id += 1
+            self.last_result = {
+                'id': self.conn.next_id,
+                'source_run_key': params[0],
+                'status': params[5],
+            }
+            return
+
+        if normalised.startswith('update source_runs'):
+            self.conn.next_id += 1
+            self.last_result = {
+                'id': self.conn.next_id,
+                'source_run_key': self.conn.transition_key,
+                'status': params[0],
+            }
+            return
+
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+    def fetchone(self):
+        return self.last_result
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(self):
+        self.statements = []
+        self.cursors = []
+        self.next_id = 100
+        self.transition_key = 'stage-19r-run'
+
+    def cursor(self):
+        cursor = FakeCursor(self)
+        self.cursors.append(cursor)
+        return cursor
+
+
+def valid_source_run_kwargs():
+    return {
+        'source_run_key': 'stage-19r-run',
+        'source_name': 'edsm',
+        'source_category': 'source_of_evidence',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'git_commit_sha': 'abc1234',
+        'importer_name': 'stage_19r_test_helper',
+        'importer_version': 'v1',
+        'trigger_context': 'manual_test',
+        'status': 'running',
+        'metadata': {'stage': '19r'},
+    }
+
+
+def assert_sql_only_touches_source_runs(conn):
+    canonical_tables = (
+        'stations',
+        'systems',
+        'bodies',
+        'body_rings',
+        'station_body_links',
+    )
+    for sql, _params in conn.statements:
+        compact = ' '.join(sql.lower().split())
+        assert 'source_runs' in compact
+        for table in canonical_tables:
+            assert re.search(rf'\b(insert\s+into|update|delete\s+from)\s+{table}\b', compact) is None
+
+
+def payload_shell():
+    return artifacts.build_artifact_payload_shell(
+        schema_version='stage_19r_artifact/v1',
+        source_run_key='stage-19r-run',
+        source_name='edsm',
+        source_category='source_of_evidence',
+        domain='stations',
+        import_scope='staging_only',
+        git_commit_sha='abc1234',
+        importer_name='stage_19r_test_helper',
+        importer_version='v1',
+        trigger_context='manual_test',
+        generated_at=NOW,
+        source_uri='file:///tmp/example.jsonl',
+        source_input_sha256='a' * 64,
+        safety_boundary={'canonical_writes_planned': 0},
+        metadata={'dry_run': True},
+        summary={'rows_seen': 2},
+        payload={'sample_rows': [{'station': 'Galileo'}]},
+    )
+
+
+def test_build_artifact_payload_shell_includes_source_run_metadata():
+    payload = payload_shell()
+
+    assert payload['generated_at'] == '2026-01-02T03:04:05Z'
+    assert payload['source_run'] == {
+        'source_run_key': 'stage-19r-run',
+        'source_name': 'edsm',
+        'source_category': 'source_of_evidence',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'git_commit_sha': 'abc1234',
+        'importer_name': 'stage_19r_test_helper',
+        'importer_version': 'v1',
+        'trigger_context': 'manual_test',
+    }
+    assert payload['source']['input_sha256'] == 'a' * 64
+    assert payload['safety_boundary']['canonical_writes_planned'] == 0
+    assert payload['summary']['rows_seen'] == 2
+
+
+def test_write_source_run_artifact_writes_canonical_json_and_record_hashes(tmp_path):
+    path = tmp_path / 'artifacts' / 'stage-19r.json'
+
+    record = artifacts.write_source_run_artifact(path, payload_shell())
+    raw = path.read_bytes()
+    loaded = json.loads(raw.decode('utf-8'))
+
+    assert raw.endswith(b'\n')
+    assert raw.decode('utf-8') == artifact_utils.canonical_json(loaded) + '\n'
+    assert loaded['artifact_integrity']['canonical_json_sha256'] == artifact_utils.artifact_integrity_sha256(loaded)
+    assert record['artifact_path'] == str(path)
+    assert record['path'] == str(path)
+    assert record['file_sha256'] == artifact_utils.sha256_bytes(raw)
+    assert record['artifact_sha256'] == record['file_sha256']
+    assert record['artifact_integrity_sha256'] == loaded['artifact_integrity']['canonical_json_sha256']
+    assert record['bytes_written'] == len(raw)
+
+def test_run_source_run_artifact_flow_creates_writes_and_completes_success(tmp_path):
+    conn = FakeConn()
+    artifact_path = tmp_path / 'runs' / 'stage-19r-success.json'
+    seen_source_runs = []
+
+    def operation(source_run):
+        seen_source_runs.append(dict(source_run))
+        payload = payload_shell()
+        return artifacts.SourceRunArtifactOutcome(
+            payload=payload,
+            rows_read=2,
+            rows_staged=2,
+            rows_rejected=0,
+            rows_skipped=0,
+            metadata={'operation': 'fake_success'},
+            finished_at=NOW,
+            duration_ms=42,
+        )
+
+    result = artifacts.run_source_run_artifact_flow(
+        conn,
+        source_run_kwargs=valid_source_run_kwargs(),
+        artifact_path=artifact_path,
+        operation=operation,
+    )
+
+    assert seen_source_runs == [{'id': 101, 'source_run_key': 'stage-19r-run', 'status': 'running'}]
+    assert result['completion']['status'] == 'succeeded'
+    assert artifact_path.exists()
+    assert len(conn.statements) == 2
+    update_sql, update_params = conn.statements[1]
+    assert 'UPDATE source_runs' in update_sql
+    assert update_params[:13] == (
+        'succeeded',
+        NOW,
+        42,
+        2,
+        2,
+        0,
+        0,
+        result['artifact_record']['artifact_path'],
+        result['artifact_record']['artifact_sha256'],
+        result['artifact_record']['artifact_integrity_sha256'],
+        None,
+        None,
+        update_params[12],
+    )
+    metadata = json.loads(update_params[12])
+    assert metadata['operation'] == 'fake_succesp'
+    assert metadata['artifact_record']['file_sha256'] == result['artifact_record']['file_sha256']
+    assert update_params[13] == 'stage-19r-run'
+    assert update_params[14] == ['planned', 'running']
+    assert_sql_only_touches_source_runs(conn)
+
+
+@pytest.mark.parametrize('status,complete_error_code', [
+    ('failed', 'source_read_failed'),
+    ('rejected', 'source_schema_mismatch'),
+])
+def test_complete_source_run_with_artifact_records_failure_and_rejection_errors(
+    tmp_path,
+    status,
+    complete_error_code,
+):
+    conn = FakeConn()
+    record = artifacts.write_source_run_artifact(tmp_path / f'{status}.json', payload_shell())
+
+    row = artifacts.complete_source_run_with_artifact(
+        conn,
+        'stage-19r-run',
+        status=status,
+        artifact_record=record,
+        rows_read=3,
+        rows_rejected=3,
+        error_code=complete_error_code,
+        error_summary='fake operation stopped before staging',
+        finished_at=NOW,
+        metadata={'operation': f'fake_{status}'},
+    )
+
+    assert row['status'] == status
+    sql, params = conn.statements[0]
+    assert 'UPDATE source_runs' in sql
+    assert params[0] == status
+    assert params[3] == 3
+    assert params[5] == 3
+    assert params[7:10] == (
+        record['artifact_path'],
+        record['artifact_sha256'],
+        record['artifact_integrity_sha256'],
+    )
+    assert params[10:12] == (
+        complete_error_code,
+        'fake operation stopped before staging',
+    )
+    metadata = json.loads(params[12])
+    assert metadata['operation'] == f'fake_{status}'
+    assert metadata['artifact_record']['artifact_integrity_sha256'] == record['artifact_integrity_sha256']
+    assert_sql_only_touches_source_runs(conn)
+
+
+def test_run_source_run_artifact_flow_rejects_unknown_completion_status(tmp_path):
+    conn = FakeConn()
+
+    def operation(_source_run):
+        return artifacts.SourceRunArtifactOutcome(payload=payload_shell(), status='waiting')
+
+    with pytest.raises(Exception, match='unsupported artifact completion status'):
+        artifacts.run_source_run_artifact_flow(
+            conn,
+            source_run_kwargs=valid_source_run_kwargs(),
+            artifact_path=tmp_path / 'unsupported.json',
+            operation=operation,
+        )
+
+    assert len(conn.statements) == 1
+    assert not (tmp_path / 'unsupported.json').exists()
+    assert_sql_only_touches_source_runs(conn)
+
+
+def test_source_run_artifacts_has_no_prod_db_import_scheduler_or_canonical_write_fragments():
+    source = inspect.getsource(artifacts)
+    source_upper = source.upper()
+    forbidden_fragments = (
+        'PSYCOPG2.CONNECT',
+        'ASYNCPG.CONNECT',
+        'SUBPROCESS',
+        'OS.SYSTEM',
+        'SYSTEMCTL',
+        '.TIMER',
+        '.SERVICE',
+        'SCHEDULER',
+        'RUN_IMPORT',
+        'RUN_IMPORT.SH',
+        'CANONICAL APPLY',
+        'DATABASE' + '_URL',
+        'POSTGRESQL' + '://',
+        'POSTGRES' + '://',
+        'PASSWORD' + '=',
+        'SECRET',
+        'TOKEN' + '=',
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in source_upper
+
+    canonical_write_patterns = (
+        r'\binsert\s+into\s+(stations|systems|bodies|body_rings|station_body_links)\b',
+        r'\bupdate\s+(stations|systems|bodies|body_rings|station_body_links)\b',
+        r'\bdelete\s+from\s+(stations|systems|bodies|body_rings|station_body_links)\b',
+    )
+    for pattern in canonical_write_patterns:
+        assert re.search(pattern, source, flags=re.IGNORECASE) is None


### PR DESCRIPTION
## Summary
- Added `apps/importer/src/source_run_artifacts.py` as a small prep layer for pairing `source_run_ledger` lifecycle updates with `artifact_utils` JSON artifact writes.
- Added `tests/test_source_run_artifacts.py` with fake-connection/temp-file coverage for the helper contracts.

## Helper / prep logic
- Builds a standard source-run artifact payload shell containing source-run metadata, source metadata, safety boundary, summary, and payload sections.
- Writes canonical JSON artifacts through `artifact_utils.write_json_artifact`, preserving the final newline, file SHA-256, and artifact integrity SHA-256.
- Maps artifact path/hash/integrity metadata into `source_run_ledger` completion calls.
- Provides a minimal callback-shaped example flow: create source run, invoke caller operation, write artifact, complete source run as succeeded/failed/rejected/cancelled.

## Validation
- `python -m pytest tests/test_source_run_artifacts.py -q` - 7 passed.
- `python -m pytest tests/test_source_run_artifacts.py tests/test_artifact_utils.py tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q` - 60 passed.

## Safety / scope confirmations
- No production DB access and no production DB connection strings or secrets introduced.
- No imports were run.
- No migrations were run.
- No scheduler, timer, service, or `systemctl` enablement.
- No canonical writes and no canonical apply.
- Fake SQL tests only touch `source_runs` and guard against writes to canonical tables such as `stations`, `systems`, `bodies`, `body_rings`, and `station_body_links`.

## Known unrelated issues / warnings
- No unrelated test failures observed in the required validation set.
- The test run emitted the existing `pytest-asyncio` default fixture loop-scope deprecation warning.