### PR TITLE
Stage 19T add EDSM station import MVP wrapper

### DIFF
--- a/apps/importer/src/edsm_station_import.py
+++ b/apps/importer/src/edsm_station_import.py
@@ -1,0 +1,559 @@
+"""Stage 19T local EDSM station import MVP wrapper.
+
+This helper accepts the existing local EDSM station snapshot shapes handled by
+``enrichment_snapshot_loader``: a JSON array of station objects, a JSONL stream
+of station objects, or a nested system object with a ``stations`` collection.
+Useful source fields include ``id``, ``marketId``, ``name``, ``systemName``,
+``systemId64``, ``type``, ``distanceToArrival``, ``services``, ``economy``,
+``secondEconomy``, and ``updatedAt``.
+
+It stages normalised source evidence into the EDSM staging table through a
+caller-owned connection, writes a source-run artifact, and completes the new
+``source_runs`` ledger row. It does not open database connections, call the
+network, or write canonical data.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import artifact_utils
+import source_run_artifacts
+from enrichment_snapshot_loader import (
+    iter_station_snapshot_load_entries,
+    source_file_format_metadata,
+)
+from enrichment_staging import (
+    first_present,
+    normalise_source_adapter,
+    read_text,
+)
+
+
+SCHEMA_VERSION = 'stage_19t_edsm_station_import_mvp/v1'
+IMPORTER_NAME = 'stage_19t_edsm_station_import_mvp'
+IMPORTER_VERSION = 'v1'
+SOURCE_ADAPTER = 'edsm_nightly_stations'
+STAGING_TABLE = 'staging_edsm_stations'
+SOURCE_RUN_TABLE = 'source_runs'
+NOISY_TRANSIENT_SOURCE_TYPES = frozenset((
+    'Drake-Class Carrier',
+    'Space Construction Depot',
+))
+MAX_ARTIFACT_DETAIL_ROWS = 50
+
+SAFETY_BOUNDARY = {
+    'repo_only': True,
+    'local_file_only': True,
+    'target_tables': [SOURCE_RUN_TABLE, STAGING_TABLE],
+    'canonical_writes_planned': 0,
+    'station_type_mapping_writes_planned': 0,
+    'production_db_connection_opened': False,
+    'scheduled_import_enabled': False,
+    'timer_enabled': False,
+    'service_enabled': False,
+    'canonical_apply_enabled': False,
+}
+
+
+class EdsmStationImportError(ValueError):
+    """Raised for Stage 19T wrapper validation or staging failures."""
+
+
+def run_edsm_station_import(
+    conn: Any,
+    *,
+    source_file: str | Path,
+    artifact_path: str | Path,
+    git_commit_sha: str,
+    trigger_context: str,
+    source_run_key: str | None = None,
+    generated_at: datetime | str | None = None,
+    finished_at: datetime | None = None,
+    station_stager: Callable[..., int] | None = None,
+    cancel_requested: bool = False,
+) -> dict[str, Any]:
+    """Run the local-file staging wrapper against a caller-owned connection."""
+    source_path = Path(source_file)
+    if not source_path.is_file():
+        raise EdsmStationImportError(f'local EDSM station source file does not exist: {source_path}')
+
+    source_input_sha256 = artifact_utils.sha256_file(source_path)
+    source_uri = _source_uri(source_path)
+    file_format = source_file_format_metadata(source_path)
+    source_run_key = source_run_key or build_source_run_key(source_input_sha256)
+    stager = station_stager or stage_edsm_station_rows
+
+    source_run_kwargs = build_source_run_kwargs(
+        source_run_key=source_run_key,
+        source_uri=source_uri,
+        source_input_sha256=source_input_sha256,
+        git_commit_sha=git_commit_sha,
+        trigger_context=trigger_context,
+        file_format=file_format,
+    )
+
+    def operation(source_run: Mapping[str, Any]) -> source_run_artifacts.SourceRunArtifactOutcome:
+        plan: dict[str, Any] | None = None
+        try:
+            plan = build_edsm_station_import_plan(
+                source_file=source_path,
+                source_run_key=str(source_run['source_run_key']),
+                source_uri=source_uri,
+                source_input_sha256=source_input_sha256,
+                file_format=file_format,
+            )
+
+            if cancel_requested:
+                status = 'cancelled'
+                error_code = 'edsm_station_import_cancelled'
+                error_summary = 'EDSM station import was cancelled before staging rows.'
+                rows_staged = 0
+            elif plan['rows_staged'] == 0:
+                status = 'rejected'
+                error_code = 'edsm_station_input_rejected'
+                error_summary = 'No valid EDSM station rows were available to stage.'
+                rows_staged = 0
+            else:
+                rows_staged = stager(conn, source_run_id=_source_run_id(source_run), rows=plan['staged_rows'])
+                if rows_staged != plan['rows_staged']:
+                    raise EdsmStationImportError(
+                        'staging row count mismatch: '
+                        f'planned {plan["rows_staged"]}, wrote {rows_staged}'
+                    )
+                status = 'succeeded'
+                error_code = None
+                error_summary = None
+
+            payload = build_edsm_station_import_artifact(
+                source_run_kwargs=source_run_kwargs,
+                source_uri=source_uri,
+                source_input_sha256=source_input_sha256,
+                file_format=file_format,
+                plan=plan,
+                status=status,
+                rows_staged=rows_staged,
+                error_code=error_code,
+                error_summary=error_summary,
+                generated_at=generated_at,
+            )
+            return source_run_artifacts.SourceRunArtifactOutcome(
+                payload=payload,
+                status=status,
+                rows_read=plan['rows_read'],
+                rows_staged=rows_staged,
+                rows_rejected=plan['rows_rejected'],
+                rows_skipped=plan['rows_skipped'],
+                error_code=error_code,
+                error_summary=error_summary,
+                metadata=_completion_metadata(plan, status=status),
+                finished_at=finished_at,
+            )
+        except Exception as exc:
+            failure_plan = plan or empty_import_plan(
+                source_uri=source_uri,
+                source_input_sha256=source_input_sha256,
+                file_format=file_format,
+            )
+            error_summary = _error_summary(exc)
+            payload = build_edsm_station_import_artifact(
+                source_run_kwargs=source_run_kwargs,
+                source_uri=source_uri,
+                source_input_sha256=source_input_sha256,
+                file_format=file_format,
+                plan=failure_plan,
+                status='failed',
+                rows_staged=0,
+                error_code='edsm_station_import_failed',
+                error_summary=error_summary,
+                generated_at=generated_at,
+            )
+            return source_run_artifacts.SourceRunArtifactOutcome(
+                payload=payload,
+                status='failed',
+                rows_read=failure_plan['rows_read'],
+                rows_staged=0,
+                rows_rejected=failure_plan['rows_rejected'],
+                rows_skipped=failure_plan['rows_skipped'],
+                error_code='edsm_station_import_failed',
+                error_summary=error_summary,
+                metadata=_completion_metadata(failure_plan, status='failed'),
+                finished_at=finished_at,
+            )
+
+    return source_run_artifacts.run_source_run_artifact_flow(
+        conn,
+        source_run_kwargs=source_run_kwargs,
+        artifact_path=artifact_path,
+        operation=operation,
+    )
+
+
+def build_source_run_key(source_input_sha256: str) -> str:
+    """Build a stable source-run key for one local file digest."""
+    return f'stage-19t-edsm-stations-{source_input_sha256[:16]}'
+
+
+def build_source_run_kwargs(
+    *,
+    source_run_key: str,
+    source_uri: str,
+    source_input_sha256: str,
+    git_commit_sha: str,
+    trigger_context: str,
+    file_format: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return validated ``source_runs`` create kwargs for this wrapper."""
+    return {
+        'source_run_key': source_run_key,
+        'source_name': 'edsm',
+        'source_category': 'source_of_evidence',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'git_commit_sha': git_commit_sha,
+        'importer_name': IMPORTER_NAME,
+        'importer_version': IMPORTER_VERSION,
+        'trigger_context': trigger_context,
+        'status': 'running',
+        'source_uri': source_uri,
+        'source_input_sha256': source_input_sha256,
+        'safety_boundary': SAFETY_BOUNDARY,
+        'metadata': {
+            'stage': '19t',
+            'source_adapter': SOURCE_ADAPTER,
+            'input_format': dict(file_format),
+        },
+    }
+
+
+def build_edsm_station_import_plan(
+    *,
+    source_file: str | Path,
+    source_run_key: str,
+    source_uri: str,
+    source_input_sha256: str,
+    file_format: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Parse and validate a local EDSM station file into staging-ready rows."""
+    source_path = Path(source_file)
+    normalised_source = normalise_source_adapter(SOURCE_ADAPTER)
+    source_file_summary = {
+        'source_file_key': artifact_utils.sha256_text(f'{normalised_source}:{source_input_sha256}'),
+        'source_path': source_uri,
+        'file_sha256': source_input_sha256,
+        'metadata': dict(file_format or source_file_format_metadata(source_path)),
+    }
+    source_run = {'source_run_key': source_run_key}
+
+    rows_read = 0
+    staged_rows: list[dict[str, Any]] = []
+    rejected_rows: list[dict[str, Any]] = []
+    skipped_rows: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+
+    for entry in iter_station_snapshot_load_entries(
+        source_file=source_path,
+        source=normalised_source,
+        source_run=source_run,
+        source_file_summary=source_file_summary,
+    ):
+        rows_read += 1
+        staged_rows.extend(_copy_rows(entry.get('staged_rows', ())))
+        warnings.extend(_copy_rows(entry.get('warnings', ())))
+        for skipped in _copy_rows(entry.get('skipped_rows', ())):
+            if skipped.get('reason') == 'invalid_station_snapshot_record':
+                rejected_rows.append(skipped)
+            else:
+                skipped_rows.append(skipped)
+
+    station_type_counts = _station_type_counts(staged_rows, rejected_rows, skipped_rows)
+    noisy_counts = {
+        station_type: count
+        for station_type, count in station_type_counts.items()
+        if station_type in NOISY_TRANSIENT_SOURCE_TYPES
+    }
+    warning_reason_counts = _reason_counts(warnings)
+    rejection_reason_counts = _reason_counts(rejected_rows)
+    skipped_reason_counts = _reason_counts(skipped_rows)
+
+    return {
+        'source_uri': source_uri,
+        'source_input_sha256': source_input_sha256,
+        'file_format': dict(source_file_summary['metadata']),
+        'rows_read': rows_read,
+        'rows_staged': len(staged_rows),
+        'rows_rejected': len(rejected_rows),
+        'rows_skipped': len(skipped_rows),
+        'staged_rows': staged_rows,
+        'rejected_rows': rejected_rows,
+        'skipped_rows': skipped_rows,
+        'warnings': warnings,
+        'source_station_type_counts': station_type_counts,
+        'noisy_transient_station_type_counts': noisy_counts,
+        'warning_reason_counts': warning_reason_counts,
+        'rejection_reason_counts': rejection_reason_counts,
+        'skipped_reason_counts': skipped_reason_counts,
+    }
+
+
+def empty_import_plan(
+    *,
+    source_uri: str,
+    source_input_sha256: str,
+    file_format: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return an artifact-safe zero-row plan for parse or staging failures."""
+    return {
+        'source_uri': source_uri,
+        'source_input_sha256': source_input_sha256,
+        'file_format': dict(file_format),
+        'rows_read': 0,
+        'rows_staged': 0,
+        'rows_rejected': 0,
+        'rows_skipped': 0,
+        'staged_rows': [],
+        'rejected_rows': [],
+        'skipped_rows': [],
+        'warnings': [],
+        'source_station_type_counts': {},
+        'noisy_transient_station_type_counts': {},
+        'warning_reason_counts': {},
+        'rejection_reason_counts': {},
+        'skipped_reason_counts': {},
+    }
+
+
+def build_edsm_station_import_artifact(
+    *,
+    source_run_kwargs: Mapping[str, Any],
+    source_uri: str,
+    source_input_sha256: str,
+    file_format: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    status: str,
+    rows_staged: int,
+    error_code: str | None,
+    error_summary: str | None,
+    generated_at: datetime | str | None,
+) -> dict[str, Any]:
+    """Build the Stage 19T artifact payload before integrity is attached."""
+    summary = {
+        'status': status,
+        'rows_read': plan['rows_read'],
+        'rows_staged': rows_staged,
+        'rows_rejected': plan['rows_rejected'],
+        'rows_skipped': plan['rows_skipped'],
+        'source_station_type_counts': dict(plan['source_station_type_counts']),
+        'noisy_transient_station_type_counts': dict(plan['noisy_transient_station_type_counts']),
+        'noisy_transient_station_types': sorted(plan['noisy_transient_station_type_counts']),
+        'warning_reason_counts': dict(plan['warning_reason_counts']),
+        'rejection_reason_counts': dict(plan['rejection_reason_counts']),
+        'skipped_reason_counts': dict(plan['skipped_reason_counts']),
+        'staging_target_table': STAGING_TABLE,
+        'source_run_target_table': SOURCE_RUN_TABLE,
+        'error_code': error_code,
+        'error_summary': error_summary,
+        'safety_summary': dict(SAFETY_BOUNDARY),
+    }
+    payload = {
+        'input_format': dict(file_format),
+        'staged_source_record_hashes': [
+            row.get('source_record_hash')
+            for row in plan['staged_rows'][:MAX_ARTIFACT_DETAIL_ROWS]
+        ],
+        'rejections': _detail_rows(plan['rejected_rows']),
+        'skipped_rows': _detail_rows(plan['skipped_rows']),
+        'warnings': _detail_rows(plan['warnings']),
+        'station_type_mapping_written': False,
+    }
+    return source_run_artifacts.build_artifact_payload_shell(
+        schema_version=SCHEMA_VERSION,
+        source_run_key=str(source_run_kwargs['source_run_key']),
+        source_name=str(source_run_kwargs['source_name']),
+        source_category=str(source_run_kwargs['source_category']),
+        domain=str(source_run_kwargs['domain']),
+        import_scope=str(source_run_kwargs['import_scope']),
+        git_commit_sha=str(source_run_kwargs['git_commit_sha']),
+        importer_name=str(source_run_kwargs['importer_name']),
+        importer_version=str(source_run_kwargs['importer_version']),
+        trigger_context=str(source_run_kwargs['trigger_context']),
+        generated_at=generated_at,
+        source_uri=source_uri,
+        source_input_sha256=source_input_sha256,
+        safety_boundary=SAFETY_BOUNDARY,
+        metadata={
+            'stage': '19t',
+            'source_adapter': SOURCE_ADAPTER,
+            'local_file_only': True,
+        },
+        summary=summary,
+        payload=payload,
+    )
+
+
+def stage_edsm_station_rows(conn: Any, *, source_run_id: int, rows: Sequence[Mapping[str, Any]]) -> int:
+    """Insert normalised station evidence into ``staging_edsm_stations`` only."""
+    cur = conn.cursor()
+    try:
+        written = 0
+        for row in rows:
+            cur.execute(
+                f"""
+                INSERT INTO {STAGING_TABLE} (
+                    source_run_id,
+                    source_file_id,
+                    raw_record_id,
+                    source_record_key,
+                    source_record_hash,
+                    system_id64,
+                    system_name,
+                    market_id,
+                    edsm_station_id,
+                    station_name,
+                    station_type,
+                    distance_to_arrival,
+                    body_name,
+                    services,
+                    economies,
+                    controlling_faction,
+                    allegiance,
+                    government,
+                    source_class,
+                    confidence,
+                    freshness_class,
+                    source_updated_at,
+                    raw_payload,
+                    provenance
+                )
+                VALUES (
+                    %s, NULL, NULL, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s::jsonb, %s::jsonb, %s, %s, %s, %s, %s, %s,
+                    %s, %s::jsonb, %s::jsonb
+                )
+                ON CONFLICT (source_run_id, source_record_hash) DO UPDATE SET
+                    source_record_key = EXCLUDED.source_record_key,
+                    system_id64 = EXCLUDED.system_id64,
+                    system_name = EXCLUDED.system_name,
+                    market_id = EXCLUDED.market_id,
+                    edsm_station_id = EXCLUDED.edsm_station_id,
+                    station_name = EXCLUDED.station_name,
+                    station_type = EXCLUDED.station_type,
+                    distance_to_arrival = EXCLUDED.distance_to_arrival,
+                    body_name = EXCLUDED.body_name,
+                    services = EXCLUDED.services,
+                    economies = EXCLUDED.economies,
+                    controlling_faction = EXCLUDED.controlling_faction,
+                    allegiance = EXCLUDED.allegiance,
+                    government = EXCLUDED.government,
+                    source_class = EXCLUDED.source_class,
+                    confidence = EXCLUDED.confidence,
+                    freshness_class = EXCLUDED.freshness_class,
+                    source_updated_at = EXCLUDED.source_updated_at,
+                    raw_payload = EXCLUDED.raw_payload,
+                    provenance = EXCLUDED.provenance
+                RETURNING id
+                """,
+                (
+                    source_run_id,
+                    row.get('source_record_key'),
+                    row.get('source_record_hash'),
+                    row.get('system_id64'),
+                    row.get('system_name'),
+                    row.get('market_id'),
+                    row.get('edsm_station_id'),
+                    row.get('station_name'),
+                    row.get('station_type'),
+                    row.get('distance_to_arrival'),
+                    row.get('body_name'),
+                    _jsonb(row.get('services', [])),
+                    _jsonb(row.get('economies', [])),
+                    row.get('controlling_faction'),
+                    row.get('allegiance'),
+                    row.get('government'),
+                    row.get('source_class'),
+                    row.get('confidence'),
+                    row.get('freshness_class'),
+                    row.get('source_updated_at'),
+                    _jsonb(row.get('raw_payload', {})),
+                    _jsonb(row.get('provenance', {})),
+                ),
+            )
+            cur.fetchone()
+            written += 1
+        return written
+    finally:
+        close = getattr(cur, 'close', None)
+        if callable(close):
+            close()
+
+
+def _source_run_id(source_run: Mapping[str, Any]) -> int:
+    source_run_id = source_run.get('id')
+    if isinstance(source_run_id, bool) or source_run_id is None:
+        raise EdsmStationImportError('source run creation did not return an integer id')
+    try:
+        return int(source_run_id)
+    except (TypeError, ValueError) as exc:
+        raise EdsmStationImportError('source run creation did not return an integer id') from exc
+
+
+def _source_uri(source_file: Path) -> str:
+    return source_file.resolve().as_uri()
+
+
+def _jsonb(value: Any) -> str:
+    return artifact_utils.canonical_json(value)
+
+
+def _copy_rows(rows: Any) -> list[dict[str, Any]]:
+    if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes, bytearray)):
+        return []
+    return [dict(row) for row in rows if isinstance(row, Mapping)]
+
+
+def _station_type_counts(*row_groups: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row_group in row_groups:
+        for row in row_group:
+            station_type = _station_type_label(row)
+            counts[station_type or 'Unknown'] += 1
+    return dict(sorted(counts.items()))
+
+
+def _station_type_label(row: Mapping[str, Any]) -> str | None:
+    station_type = read_text(row.get('station_type'))
+    if station_type:
+        return station_type
+    raw_payload = row.get('raw_payload')
+    if isinstance(raw_payload, Mapping):
+        return read_text(first_present(raw_payload, 'type', 'stationType', 'station_type'))
+    return None
+
+
+def _reason_counts(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for row in rows:
+        reason = read_text(row.get('reason')) or 'unknown'
+        counts[reason] += 1
+    return dict(sorted(counts.items()))
+
+
+def _detail_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [dict(row) for row in rows[:MAX_ARTIFACT_DETAIL_ROWS]]
+
+
+def _completion_metadata(plan: Mapping[str, Any], *, status: str) -> dict[str, Any]:
+    return {
+        'stage': '19t',
+        'status': status,
+        'source_station_type_counts': dict(plan['source_station_type_counts']),
+        'noisy_transient_station_type_counts': dict(plan['noisy_transient_station_type_counts']),
+        'safety_boundary': dict(SAFETY_BOUNDARY),
+    }
+
+
+def _error_summary(exc: Exception) -> str:
+    return f'{type(exc).__name__}: {exc}'[:500]

--- a/apps/importer/src/edsm_station_import.py
+++ b/apps/importer/src/edsm_station_import.py
@@ -7,8 +7,11 @@ Useful source fields include ``id``, ``marketId``, ``name``, ``systemName``,
 ``systemId64``, ``type``, ``distanceToArrival``, ``services``, ``economy``,
 ``secondEconomy``, and ``updatedAt``.
 
-It stages normalised source evidence into the EDSM staging table through a
-caller-owned connection, writes a source-run artifact, and completes the new
+It plans normalised source evidence and can stage rows only through an explicit
+caller-supplied stager. The repository staging table currently keys
+``staging_edsm_stations.source_run_id`` to ``enrichment_source_runs(id)``, so
+this wrapper does not ship a default stager that would misuse the new
+``source_runs`` ID. It writes a source-run artifact and completes the new
 ``source_runs`` ledger row. It does not open database connections, call the
 network, or write canonical data.
 """
@@ -85,7 +88,6 @@ def run_edsm_station_import(
     source_uri = _source_uri(source_path)
     file_format = source_file_format_metadata(source_path)
     source_run_key = source_run_key or build_source_run_key(source_input_sha256)
-    stager = station_stager or stage_edsm_station_rows
 
     source_run_kwargs = build_source_run_kwargs(
         source_run_key=source_run_key,
@@ -118,7 +120,12 @@ def run_edsm_station_import(
                 error_summary = 'No valid EDSM station rows were available to stage.'
                 rows_staged = 0
             else:
-                rows_staged = stager(conn, source_run_id=_source_run_id(source_run), rows=plan['staged_rows'])
+                rows_staged = run_explicit_station_stager(
+                    conn,
+                    source_run=source_run,
+                    rows=plan['staged_rows'],
+                    station_stager=station_stager,
+                )
                 if rows_staged != plan['rows_staged']:
                     raise EdsmStationImportError(
                         'staging row count mismatch: '
@@ -394,118 +401,25 @@ def build_edsm_station_import_artifact(
     )
 
 
-def stage_edsm_station_rows(conn: Any, *, source_run_id: int, rows: Sequence[Mapping[str, Any]]) -> int:
-    """Insert normalised station evidence into ``staging_edsm_stations`` only."""
-    cur = conn.cursor()
-    try:
-        written = 0
-        for row in rows:
-            cur.execute(
-                f"""
-                INSERT INTO {STAGING_TABLE} (
-                    source_run_id,
-                    source_file_id,
-                    raw_record_id,
-                    source_record_key,
-                    source_record_hash,
-                    system_id64,
-                    system_name,
-                    market_id,
-                    edsm_station_id,
-                    station_name,
-                    station_type,
-                    distance_to_arrival,
-                    body_name,
-                    services,
-                    economies,
-                    controlling_faction,
-                    allegiance,
-                    government,
-                    source_class,
-                    confidence,
-                    freshness_class,
-                    source_updated_at,
-                    raw_payload,
-                    provenance
-                )
-                VALUES (
-                    %s, NULL, NULL, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                    %s, %s::jsonb, %s::jsonb, %s, %s, %s, %s, %s, %s,
-                    %s, %s::jsonb, %s::jsonb
-                )
-                ON CONFLICT (source_run_id, source_record_hash) DO UPDATE SET
-                    source_record_key = EXCLUDED.source_record_key,
-                    system_id64 = EXCLUDED.system_id64,
-                    system_name = EXCLUDED.system_name,
-                    market_id = EXCLUDED.market_id,
-                    edsm_station_id = EXCLUDED.edsm_station_id,
-                    station_name = EXCLUDED.station_name,
-                    station_type = EXCLUDED.station_type,
-                    distance_to_arrival = EXCLUDED.distance_to_arrival,
-                    body_name = EXCLUDED.body_name,
-                    services = EXCLUDED.services,
-                    economies = EXCLUDED.economies,
-                    controlling_faction = EXCLUDED.controlling_faction,
-                    allegiance = EXCLUDED.allegiance,
-                    government = EXCLUDED.government,
-                    source_class = EXCLUDED.source_class,
-                    confidence = EXCLUDED.confidence,
-                    freshness_class = EXCLUDED.freshness_class,
-                    source_updated_at = EXCLUDED.source_updated_at,
-                    raw_payload = EXCLUDED.raw_payload,
-                    provenance = EXCLUDED.provenance
-                RETURNING id
-                """,
-                (
-                    source_run_id,
-                    row.get('source_record_key'),
-                    row.get('source_record_hash'),
-                    row.get('system_id64'),
-                    row.get('system_name'),
-                    row.get('market_id'),
-                    row.get('edsm_station_id'),
-                    row.get('station_name'),
-                    row.get('station_type'),
-                    row.get('distance_to_arrival'),
-                    row.get('body_name'),
-                    _jsonb(row.get('services', [])),
-                    _jsonb(row.get('economies', [])),
-                    row.get('controlling_faction'),
-                    row.get('allegiance'),
-                    row.get('government'),
-                    row.get('source_class'),
-                    row.get('confidence'),
-                    row.get('freshness_class'),
-                    row.get('source_updated_at'),
-                    _jsonb(row.get('raw_payload', {})),
-                    _jsonb(row.get('provenance', {})),
-                ),
-            )
-            cur.fetchone()
-            written += 1
-        return written
-    finally:
-        close = getattr(cur, 'close', None)
-        if callable(close):
-            close()
-
-
-def _source_run_id(source_run: Mapping[str, Any]) -> int:
-    source_run_id = source_run.get('id')
-    if isinstance(source_run_id, bool) or source_run_id is None:
-        raise EdsmStationImportError('source run creation did not return an integer id')
-    try:
-        return int(source_run_id)
-    except (TypeError, ValueError) as exc:
-        raise EdsmStationImportError('source run creation did not return an integer id') from exc
+def run_explicit_station_stager(
+    conn: Any,
+    *,
+    source_run: Mapping[str, Any],
+    rows: Sequence[Mapping[str, Any]],
+    station_stager: Callable[..., int] | None,
+) -> int:
+    """Run a caller-supplied stager, failing closed when none is provided."""
+    if station_stager is None:
+        raise EdsmStationImportError(
+            'staging execution requires an explicit compatible station_stager; '
+            'staging_edsm_stations.source_run_id currently expects enrichment_source_runs.id, '
+            'not source_runs.id from this wrapper'
+        )
+    return station_stager(conn, source_run=source_run, rows=rows)
 
 
 def _source_uri(source_file: Path) -> str:
     return source_file.resolve().as_uri()
-
-
-def _jsonb(value: Any) -> str:
-    return artifact_utils.canonical_json(value)
 
 
 def _copy_rows(rows: Any) -> list[dict[str, Any]]:

--- a/tests/test_edsm_station_import.py
+++ b/tests/test_edsm_station_import.py
@@ -1,0 +1,339 @@
+import inspect
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import artifact_utils  # noqa: E402
+import edsm_station_import as importer  # noqa: E402
+
+
+NOW = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.closed = False
+        self.last_result = None
+
+    def execute(self, sql, params=None):
+        params = tuple(params or ())
+        self.conn.statements.append((sql, params))
+        compact = ' '.join(sql.lower().split())
+
+        if compact.startswith('insert into source_runs'):
+            self.conn.next_source_run_id += 1
+            self.last_result = {
+                'id': self.conn.next_source_run_id,
+                'source_run_key': params[0],
+                'status': params[5],
+            }
+            self.conn.source_run_key = params[0]
+            return
+
+        if compact.startswith('insert into staging_edsm_stations'):
+            self.conn.next_staging_id += 1
+            self.conn.staging_params.append(params)
+            self.last_result = {'id': self.conn.next_staging_id}
+            return
+
+        if compact.startswith('update source_runs'):
+            self.last_result = {
+                'id': self.conn.next_source_run_id,
+                'source_run_key': self.conn.source_run_key,
+                'status': params[0],
+            }
+            return
+
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+    def fetchone(self):
+        return self.last_result
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(self):
+        self.statements = []
+        self.staging_params = []
+        self.next_source_run_id = 100
+        self.next_staging_id = 900
+        self.source_run_key = 'stage-19t-test'
+
+    def cursor(self):
+        return FakeCursor(self)
+
+
+def write_source(path, rows):
+    path.write_text(json.dumps(rows, sort_keys=True), encoding='utf-8')
+    return path
+
+
+def sample_rows():
+    return [
+        {
+            'systemName': 'Sol',
+            'systemId64': 10477373803,
+            'id': 322,
+            'marketId': 322,
+            'name': 'Galileo',
+            'type': 'Coriolis Starport',
+            'distanceToArrival': 503.2,
+            'bodyName': 'Moon',
+            'services': ['Dock', 'Market', 'Shipyard'],
+            'economy': 'High Tech',
+            'secondEconomy': 'Service',
+            'updatedAt': '2026-01-02T00:00:00Z',
+        },
+        {
+            'systemName': 'Carrier System',
+            'systemId64': 42,
+            'id': 7001,
+            'marketId': 7001,
+            'name': 'BVT-19T',
+            'type': 'Drake-Class Carrier',
+            'distanceToArrival': 12.5,
+            'updatedAt': '2026-01-02T00:00:00Z',
+        },
+        {
+            'systemName': 'Depot System',
+            'systemId64': 43,
+            'id': 7002,
+            'marketId': 7002,
+            'name': 'Rackham Depot Works',
+            'type': 'Space Construction Depot',
+            'distanceToArrival': 2200,
+            'updatedAt': '2026-01-02T00:00:00Z',
+        },
+    ]
+
+
+def load_artifact(path):
+    raw = path.read_bytes()
+    loaded = json.loads(raw.decode('utf-8'))
+    assert raw.endswith(b'\n')
+    assert raw.decode('utf-8') == artifact_utils.canonical_json(loaded) + '\n'
+    assert loaded['artifact_integrity']['canonical_json_sha256'] == artifact_utils.artifact_integrity_sha256(loaded)
+    return loaded
+
+
+def test_edsm_station_import_stages_valid_rows_and_completes_source_run(tmp_path):
+    conn = FakeConn()
+    source_file = write_source(tmp_path / 'edsm-stations.json', sample_rows())
+    artifact_path = tmp_path / 'artifacts' / 'stage-19t.json'
+
+    result = importer.run_edsm_station_import(
+        conn,
+        source_file=source_file,
+        artifact_path=artifact_path,
+        source_run_key='stage-19t-test',
+        git_commit_sha='abc1234',
+        trigger_context='unit_test',
+        generated_at=NOW,
+        finished_at=NOW,
+    )
+
+    source_input_sha256 = artifact_utils.sha256_file(source_file)
+    assert result['source_run'] == {'id': 101, 'source_run_key': 'stage-19t-test', 'status': 'running'}
+    assert result['completion']['status'] == 'succeeded'
+    assert len(conn.staging_params) == 3
+    assert {params[8] for params in conn.staging_params} == {
+        'Coriolis Starport',
+        'Drake-Class Carrier',
+        'Space Construction Depot',
+    }
+    assert {params[7] for params in conn.staging_params} == {'Galileo', 'BVT-19T', 'Rackham Depot Works'}
+    assert all(json.loads(params[21])['canonical_write_allowed'] is False for params in conn.staging_params)
+
+    create_sql, create_params = conn.statements[0]
+    assert 'INSERT INTO source_runs' in create_sql
+    assert create_params[:8] == (
+        'stage-19t-test',
+        'edsm',
+        'source_of_evidence',
+        'stations',
+        'staging_only',
+        'running',
+        source_file.resolve().as_uri(),
+        source_input_sha256,
+    )
+    assert json.loads(create_params[18])['canonical_writes_planned'] == 0
+
+    loaded = load_artifact(artifact_path)
+    assert loaded['schema_version'] == importer.SCHEMA_VERSION
+    assert loaded['source']['uri'] == source_file.resolve().as_uri()
+    assert loaded['source']['input_sha256'] == source_input_sha256
+    assert loaded['summary']['rows_read'] == 3
+    assert loaded['summary']['rows_staged'] == 3
+    assert loaded['summary']['rows_rejected'] == 0
+    assert loaded['summary']['rows_skipped'] == 0
+    assert loaded['summary']['source_station_type_counts'] == {
+        'Coriolis Starport': 1,
+        'Drake-Class Carrier': 1,
+        'Space Construction Depot': 1,
+    }
+    assert loaded['summary']['noisy_transient_station_type_counts'] == {
+        'Drake-Class Carrier': 1,
+        'Space Construction Depot': 1,
+    }
+    assert loaded['payload']['station_type_mapping_written'] is False
+    assert loaded['summary']['safety_summary']['target_tables'] == ['source_runs', 'staging_edsm_stations']
+    assert loaded['summary']['safety_summary']['canonical_writes_planned'] == 0
+    assert loaded['summary']['safety_summary']['canonical_apply_enabled'] is False
+
+    update_sql, update_params = conn.statements[-1]
+    assert 'UPDATE source_runs' in update_sql
+    assert update_params[0] == 'succeeded'
+    assert update_params[3:10] == (
+        3,
+        3,
+        0,
+        0,
+        result['artifact_record']['artifact_path'],
+        result['artifact_record']['artifact_sha256'],
+        result['artifact_record']['artifact_integrity_sha256'],
+    )
+    assert_sql_only_touches_allowed_tables(conn)
+
+
+def test_edsm_station_import_records_failed_completion_when_staging_raises(tmp_path):
+    conn = FakeConn()
+    source_file = write_source(tmp_path / 'edsm-stations.json', sample_rows()[:1])
+    artifact_path = tmp_path / 'artifacts' / 'stage-19t-failed.json'
+
+    def failing_stager(_conn, *, source_run_id, rows):
+        assert source_run_id == 101
+        assert len(rows) == 1
+        raise RuntimeError('staging insert failed')
+
+    result = importer.run_edsm_station_import(
+        conn,
+        source_file=source_file,
+        artifact_path=artifact_path,
+        source_run_key='stage-19t-failed',
+        git_commit_sha='abc1234',
+        trigger_context='unit_test',
+        generated_at=NOW,
+        finished_at=NOW,
+        station_stager=failing_stager,
+    )
+
+    assert result['completion']['status'] == 'failed'
+    assert conn.staging_params == []
+    update_params = conn.statements[-1][1]
+    assert update_params[0] == 'failed'
+    assert update_params[3:7] == (1, 0, 0, 0)
+    assert update_params[10] == 'edsm_station_import_failed'
+    assert 'RuntimeError: staging insert failed' in update_params[11]
+    loaded = load_artifact(artifact_path)
+    assert loaded['summary']['status'] == 'failed'
+    assert loaded['summary']['error_code'] == 'edsm_station_import_failed'
+    assert_sql_only_touches_allowed_tables(conn)
+
+
+def test_edsm_station_import_records_rejected_completion_for_invalid_input(tmp_path):
+    conn = FakeConn()
+    source_file = write_source(
+        tmp_path / 'edsm-invalid.json',
+        [{
+            'systemName': 'Broken Example',
+            'marketId': 999,
+            'type': 'Drake-Class Carrier',
+            'distanceToArrival': 12,
+        }],
+    )
+    artifact_path = tmp_path / 'artifacts' / 'stage-19t-rejected.json'
+
+    result = importer.run_edsm_station_import(
+        conn,
+        source_file=source_file,
+        artifact_path=artifact_path,
+        source_run_key='stage-19t-rejected',
+        git_commit_sha='abc1234',
+        trigger_context='unit_test',
+        generated_at=NOW,
+        finished_at=NOW,
+    )
+
+    assert result['completion']['status'] == 'rejected'
+    assert conn.staging_params == []
+    update_params = conn.statements[-1][1]
+    assert update_params[0] == 'rejected'
+    assert update_params[3:7] == (1, 0, 1, 0)
+    assert update_params[10] == 'edsm_station_input_rejected'
+    assert update_params[11] == 'No valid EDSM station rows were available to stage.'
+    loaded = load_artifact(artifact_path)
+    assert loaded['summary']['rows_rejected'] == 1
+    assert loaded['summary']['source_station_type_counts'] == {'Drake-Class Carrier': 1}
+    assert loaded['summary']['noisy_transient_station_type_counts'] == {'Drake-Class Carrier': 1}
+    assert loaded['payload']['rejections'][0]['reason'] == 'invalid_station_snapshot_record'
+    assert_sql_only_touches_allowed_tables(conn)
+
+
+def test_edsm_station_import_helper_has_no_prod_db_scheduler_or_canonical_write_fragments():
+    source = inspect.getsource(importer)
+    source_upper = source.upper()
+    forbidden_fragments = (
+        'PSYCOPG2.CONNECT',
+        'ASYNCPG.CONNECT',
+        'SUBPROCESS',
+        'OS.SYSTEM',
+        'SYSTEMCTL',
+        'RUN_IMPORT',
+        'RUN_IMPORT.SH',
+        'DATABASE' + '_URL',
+        'POSTGRESQL' + '://',
+        'POSTGRES' + '://',
+        'PASSWORD' + '=',
+        'SECRET',
+        'TOKEN' + '=',
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in source_upper
+    assert re.search(r'(?<![a-z0-9_])\.timer(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+    assert re.search(r'(?<![a-z0-9_])\.service(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+
+    canonical_write_patterns = (
+        r'\binsert\s+into\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bupdate\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bdelete\s+from\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+    )
+    for pattern in canonical_write_patterns:
+        assert re.search(pattern, source, flags=re.IGNORECASE) is None
+
+
+def assert_sql_only_touches_allowed_tables(conn):
+    assert conn.statements
+    allowed = {'source_runs', 'staging_edsm_stations'}
+    canonical_tables = (
+        'stations',
+        'systems',
+        'bodies',
+        'body_rings',
+        'station_body_links',
+        'station_external_identity',
+    )
+    for sql, _params in conn.statements:
+        compact = ' '.join(sql.lower().split())
+        referenced = {
+            match.group(1).replace('"', '').split('.')[-1].lower()
+            for match in re.finditer(
+                r'\b(?:from|into|update)\s+(?:only\s+)?("?[\w]+"?(?:\."?[\w]+"?)?)',
+                sql,
+                flags=re.IGNORECASE,
+            )
+        }
+        referenced.discard('set')
+        assert referenced <= allowed
+        for table in canonical_tables:
+            assert re.search(rf'\b(insert\s+into|update|delete\s+from)\s+{table}\b', compact) is None

--- a/tests/test_edsm_station_import.py
+++ b/tests/test_edsm_station_import.py
@@ -127,7 +127,38 @@ def load_artifact(path):
     return loaded
 
 
-def test_edsm_station_import_stages_valid_rows_and_completes_source_run(tmp_path):
+def compatible_fake_station_stager(conn, *, source_run, rows):
+    assert source_run['source_run_key'].startswith('stage-19t')
+    cur = conn.cursor()
+    try:
+        for row in rows:
+            cur.execute(
+                """
+                INSERT INTO staging_edsm_stations (
+                    source_run_id,
+                    source_record_hash,
+                    station_name,
+                    station_type,
+                    provenance
+                )
+                VALUES (%s, %s, %s, %s, %s::jsonb)
+                RETURNING id
+                """,
+                (
+                    'compatible-enrichment-source-run-id',
+                    row['source_record_hash'],
+                    row['station_name'],
+                    row['station_type'],
+                    artifact_utils.canonical_json(row['provenance']),
+                ),
+            )
+            cur.fetchone()
+        return len(rows)
+    finally:
+        cur.close()
+
+
+def test_edsm_station_import_stages_valid_rows_with_injected_stager_and_completes_source_run(tmp_path):
     conn = FakeConn()
     source_file = write_source(tmp_path / 'edsm-stations.json', sample_rows())
     artifact_path = tmp_path / 'artifacts' / 'stage-19t.json'
@@ -141,19 +172,20 @@ def test_edsm_station_import_stages_valid_rows_and_completes_source_run(tmp_path
         trigger_context='unit_test',
         generated_at=NOW,
         finished_at=NOW,
+        station_stager=compatible_fake_station_stager,
     )
 
     source_input_sha256 = artifact_utils.sha256_file(source_file)
     assert result['source_run'] == {'id': 101, 'source_run_key': 'stage-19t-test', 'status': 'running'}
     assert result['completion']['status'] == 'succeeded'
     assert len(conn.staging_params) == 3
-    assert {params[8] for params in conn.staging_params} == {
+    assert {params[3] for params in conn.staging_params} == {
         'Coriolis Starport',
         'Drake-Class Carrier',
         'Space Construction Depot',
     }
-    assert {params[7] for params in conn.staging_params} == {'Galileo', 'BVT-19T', 'Rackham Depot Works'}
-    assert all(json.loads(params[21])['canonical_write_allowed'] is False for params in conn.staging_params)
+    assert {params[2] for params in conn.staging_params} == {'Galileo', 'BVT-19T', 'Rackham Depot Works'}
+    assert all(json.loads(params[4])['canonical_write_allowed'] is False for params in conn.staging_params)
 
     create_sql, create_params = conn.statements[0]
     assert 'INSERT INTO source_runs' in create_sql
@@ -206,13 +238,47 @@ def test_edsm_station_import_stages_valid_rows_and_completes_source_run(tmp_path
     assert_sql_only_touches_allowed_tables(conn)
 
 
+def test_edsm_station_import_without_explicit_stager_fails_closed_before_staging_write(tmp_path):
+    conn = FakeConn()
+    source_file = write_source(tmp_path / 'edsm-stations.json', sample_rows())
+    artifact_path = tmp_path / 'artifacts' / 'stage-19t-no-default-stager.json'
+
+    result = importer.run_edsm_station_import(
+        conn,
+        source_file=source_file,
+        artifact_path=artifact_path,
+        source_run_key='stage-19t-no-default-stager',
+        git_commit_sha='abc1234',
+        trigger_context='unit_test',
+        generated_at=NOW,
+        finished_at=NOW,
+    )
+
+    assert result['completion']['status'] == 'failed'
+    assert conn.staging_params == []
+    assert not any('INSERT INTO staging_edsm_stations' in sql for sql, _params in conn.statements)
+    update_params = conn.statements[-1][1]
+    assert update_params[0] == 'failed'
+    assert update_params[3:7] == (3, 0, 0, 0)
+    assert update_params[10] == 'edsm_station_import_failed'
+    assert 'EdsmStationImportError' in update_params[11]
+    assert 'staging_edsm_stations.source_run_id currently expects enrichment_source_runs.id' in update_params[11]
+    assert 'not source_runs.id from this wrapper' in update_params[11]
+    loaded = load_artifact(artifact_path)
+    assert loaded['summary']['status'] == 'failed'
+    assert loaded['summary']['rows_read'] == 3
+    assert loaded['summary']['rows_staged'] == 0
+    assert loaded['summary']['error_summary'] == update_params[11]
+    assert_sql_only_touches_allowed_tables(conn)
+
+
 def test_edsm_station_import_records_failed_completion_when_staging_raises(tmp_path):
     conn = FakeConn()
     source_file = write_source(tmp_path / 'edsm-stations.json', sample_rows()[:1])
     artifact_path = tmp_path / 'artifacts' / 'stage-19t-failed.json'
 
-    def failing_stager(_conn, *, source_run_id, rows):
-        assert source_run_id == 101
+    def failing_stager(_conn, *, source_run, rows):
+        assert source_run['id'] == 101
         assert len(rows) == 1
         raise RuntimeError('staging insert failed')
 


### PR DESCRIPTION
## Files added/changed

- Added `apps/importer/src/edsm_station_import.py`
- Added `tests/test_edsm_station_import.py`

## What the MVP wrapper does

- Accepts a local EDSM station source file and computes its SHA-256.
- Creates a `source_runs` row with `source_name=edsm`, `source_category=source_of_evidence`, `domain=stations`, and `import_scope=staging_only`.
- Reuses the existing local EDSM snapshot parsing/normalisation helpers.
- Builds a staging-ready parse/plan for `staging_edsm_stations` evidence rows.
- Does not ship a default production stager because `staging_edsm_stations.source_run_id` currently expects `enrichment_source_runs.id`, not the new `source_runs.id`.
- Requires an explicit compatible `station_stager` injection before any staging write can occur.
- Writes a canonical JSON source-run artifact through `source_run_artifacts` / `artifact_utils`.
- Completes the source run as `succeeded`, `failed`, `rejected`, or `cancelled` depending on the wrapper outcome.
- Counts source station types and flags noisy/transient source labels including `Drake-Class Carrier` and `Space Construction Depot` without mapping them to canonical station types.

## Input format supported

Uses the existing local EDSM station snapshot shapes handled by `enrichment_snapshot_loader`:

- JSON array of station objects
- JSONL stream of station objects
- nested system object with a `stations` collection

Useful fields include `id`, `marketId`, `name`, `systemName`, `systemId64`, `type`, `distanceToArrival`, `services`, `economy`, `secondEconomy`, and `updatedAt`.

## Staging scope

This is repo-only parse/plan/artifact/source-run wrapper prep. The helper has no production DB connection path and accepts a caller-owned DB-API connection. Tests verify emitted SQL only touches:

- `source_runs`
- `staging_edsm_stations` only through an injected fake compatible stager

The default no-stager path fails closed before any staging write and records a failed source-run artifact explaining the `enrichment_source_runs.id` compatibility requirement.

No production staging execution was attempted.

## Validation

- `.venv/bin/python -m pytest tests/test_edsm_station_import.py -q` -> `5 passed`
- `.venv/bin/python -m pytest tests/test_edsm_station_import.py tests/test_source_run_artifacts.py tests/test_artifact_utils.py tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q` -> `65 passed`

## Safety confirmations

- No production DB access.
- No production import run.
- No scheduler/timer/service enablement.
- No canonical table writes.
- No canonical apply.
- No station-type mapping writes.

## Unrelated failures or warnings

None observed in the requested validation set.

## Final PR file list

The final changed files are only:

- `apps/importer/src/edsm_station_import.py`
- `tests/test_edsm_station_import.py`