### PR TITLE
Stage 19W add source-run legacy compatibility helper

### DIFF
--- a/apps/importer/src/source_run_compatibility.py
+++ b/apps/importer/src/source_run_compatibility.py
@@ -1,0 +1,332 @@
+"""Compatibility helpers for new source_runs and legacy enrichment staging FKs.
+
+Legacy enrichment staging tables, including ``staging_edsm_stations``, still
+reference ``enrichment_source_runs(id)``. New Stage 19 import wrappers use the
+durable ``source_runs`` ledger. These helpers create or resolve the legacy
+``enrichment_source_runs`` row that future explicit stagers must use as the
+legacy ``source_run_id`` value.
+
+This module does not connect to a database, write staging rows, run imports,
+or touch canonical tables.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import artifact_utils
+from enrichment_staging import SOURCE_CLASSES, classify_source_adapter
+
+
+BRIDGE_SCHEMA_VERSION = 'source_run_legacy_compatibility/v1'
+LEGACY_SOURCE_RUNS_TABLE = 'enrichment_source_runs'
+NEW_SOURCE_RUNS_TABLE = 'source_runs'
+LEGACY_SOURCE_RUN_KEY_PREFIX = 'source_runs:'
+TARGET_STAGING_FK = 'enrichment_source_runs(id)'
+DEFAULT_SOURCE_KIND = 'offline_snapshot'
+
+
+class SourceRunCompatibilityError(ValueError):
+    """Raised when source-run compatibility metadata is incomplete or invalid."""
+
+
+def build_enrichment_source_run_key(source_run: Mapping[str, Any] | str) -> str:
+    """Build the deterministic legacy enrichment source-run key for a source run."""
+    if isinstance(source_run, Mapping):
+        source_run_key = source_run.get('source_run_key')
+    else:
+        source_run_key = source_run
+    return f'{LEGACY_SOURCE_RUN_KEY_PREFIX}{_required_text(source_run_key, "source_run_key")}'
+
+
+def build_enrichment_source_run_metadata(
+    source_run: Mapping[str, Any],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build explicit dual-ledger provenance for a legacy source-run row."""
+    source_run_key = _required_text(source_run.get('source_run_key'), 'source_run_key')
+    source_runs_provenance = {
+        'id': source_run.get('id'),
+        'source_run_key': source_run_key,
+        'source_name': source_run.get('source_name'),
+        'source_category': source_run.get('source_category'),
+        'domain': source_run.get('domain'),
+        'import_scope': source_run.get('import_scope'),
+        'status': source_run.get('status'),
+        'source_uri': source_run.get('source_uri'),
+        'source_input_sha256': source_run.get('source_input_sha256'),
+        'source_manifest_sha256': source_run.get('source_manifest_sha256'),
+        'started_at': source_run.get('started_at'),
+        'finished_at': source_run.get('finished_at'),
+        'git_commit_sha': source_run.get('git_commit_sha'),
+        'importer_name': source_run.get('importer_name'),
+        'importer_version': source_run.get('importer_version'),
+        'trigger_context': source_run.get('trigger_context'),
+        'artifact_path': source_run.get('artifact_path'),
+        'artifact_sha256': source_run.get('artifact_sha256'),
+        'artifact_integrity_sha256': source_run.get('artifact_integrity_sha256'),
+        'safety_boundary': dict(source_run.get('safety_boundary') or {}),
+        'metadata': dict(source_run.get('metadata') or {}),
+    }
+    bridge_metadata = {
+        'schema_version': BRIDGE_SCHEMA_VERSION,
+        'compatibility_bridge': True,
+        'bridge_reason': (
+            'legacy staging source_run_id columns reference enrichment_source_runs(id), '
+            'not source_runs(id)'
+        ),
+        'new_source_run_table': NEW_SOURCE_RUNS_TABLE,
+        'legacy_source_run_table': LEGACY_SOURCE_RUNS_TABLE,
+        'target_staging_fk': TARGET_STAGING_FK,
+        'legacy_source_run_key': build_enrichment_source_run_key(source_run_key),
+        'source_runs_provenance': source_runs_provenance,
+        'staging_policy': {
+            'do_not_pass_source_runs_id_to_legacy_staging_source_run_id': True,
+            'legacy_source_run_id_required_for_legacy_staging': True,
+            'staging_rows_written_by_this_helper': False,
+            'canonical_writes_planned': 0,
+        },
+    }
+    bridge_metadata.update(dict(metadata or {}))
+    return bridge_metadata
+
+
+def build_enrichment_source_run_row(
+    source_run: Mapping[str, Any],
+    *,
+    source: str | None = None,
+    adapter_name: str | None = None,
+    adapter_version: str | None = None,
+    source_kind: str = DEFAULT_SOURCE_KIND,
+    source_class: str | None = None,
+    run_label: str | None = None,
+    dry_run: bool = True,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Map a new ``source_runs`` row/metadata into legacy enrichment shape."""
+    source_name = _required_text(source or source_run.get('source_name'), 'source')
+    resolved_adapter_name = _required_text(
+        adapter_name or source_run.get('importer_name'),
+        'adapter_name',
+    )
+    resolved_adapter_version = _required_text(
+        adapter_version or source_run.get('importer_version'),
+        'adapter_version',
+    )
+    resolved_source_class = source_class or classify_source_adapter(source_name)
+    if resolved_source_class not in SOURCE_CLASSES:
+        raise SourceRunCompatibilityError(f'invalid source_class: {resolved_source_class!r}')
+
+    source_run_key = _required_text(source_run.get('source_run_key'), 'source_run_key')
+    return {
+        'source_run_key': build_enrichment_source_run_key(source_run_key),
+        'source': source_name,
+        'adapter_name': resolved_adapter_name,
+        'adapter_version': resolved_adapter_version,
+        'source_kind': _required_text(source_kind, 'source_kind'),
+        'source_class': resolved_source_class,
+        'run_label': run_label if run_label is not None else source_run_key,
+        'dry_run': bool(dry_run),
+        'source_started_at': source_run.get('started_at'),
+        'source_completed_at': source_run.get('finished_at'),
+        'metadata': build_enrichment_source_run_metadata(source_run, metadata=metadata),
+    }
+
+
+def get_enrichment_source_run_by_key(conn: Any, source_run_key: str) -> dict[str, Any] | None:
+    """Fetch a legacy enrichment source-run row by its deterministic bridge key."""
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            SELECT
+                id,
+                source_run_key,
+                source,
+                adapter_name,
+                adapter_version,
+                source_kind,
+                source_class,
+                run_label,
+                dry_run,
+                source_started_at,
+                source_completed_at,
+                metadata
+            FROM {LEGACY_SOURCE_RUNS_TABLE}
+            WHERE source_run_key = %s
+            """,
+            (_required_text(source_run_key, 'source_run_key'),),
+        )
+        return _row_to_dict(cur.fetchone())
+    finally:
+        _close_cursor(cur)
+
+
+def create_enrichment_source_run_for_source_run(
+    conn: Any,
+    source_run: Mapping[str, Any],
+    **row_options: Any,
+) -> dict[str, Any]:
+    """Insert or update the legacy enrichment source-run compatibility row."""
+    row = build_enrichment_source_run_row(source_run, **row_options)
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            f"""
+            INSERT INTO {LEGACY_SOURCE_RUNS_TABLE} (
+                source_run_key,
+                source,
+                adapter_name,
+                adapter_version,
+                source_kind,
+                source_class,
+                run_label,
+                dry_run,
+                source_started_at,
+                source_completed_at,
+                metadata
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+            ON CONFLICT (source_run_key) DO UPDATE SET
+                source = EXCLUDED.source,
+                adapter_name = EXCLUDED.adapter_name,
+                adapter_version = EXCLUDED.adapter_version,
+                source_kind = EXCLUDED.source_kind,
+                source_class = EXCLUDED.source_class,
+                run_label = EXCLUDED.run_label,
+                dry_run = EXCLUDED.dry_run,
+                source_started_at = COALESCE(EXCLUDED.source_started_at, enrichment_source_runs.source_started_at),
+                source_completed_at = COALESCE(EXCLUDED.source_completed_at, enrichment_source_runs.source_completed_at),
+                metadata = enrichment_source_runs.metadata || EXCLUDED.metadata
+            RETURNING
+                id,
+                source_run_key,
+                source,
+                adapter_name,
+                adapter_version,
+                source_kind,
+                source_class,
+                run_label,
+                dry_run,
+                source_started_at,
+                source_completed_at,
+                metadata
+            """,
+            (
+                row['source_run_key'],
+                row['source'],
+                row['adapter_name'],
+                row['adapter_version'],
+                row['source_kind'],
+                row['source_class'],
+                row['run_label'],
+                row['dry_run'],
+                row['source_started_at'],
+                row['source_completed_at'],
+                _jsonb(row['metadata']),
+            ),
+        )
+        created = _row_to_dict(cur.fetchone())
+        if created is None:
+            raise SourceRunCompatibilityError('legacy enrichment source-run write did not return a row')
+        return created
+    finally:
+        _close_cursor(cur)
+
+
+def get_or_create_enrichment_source_run_for_source_run(
+    conn: Any,
+    source_run: Mapping[str, Any],
+    **row_options: Any,
+) -> dict[str, Any]:
+    """Resolve the legacy source-run row, inserting it if absent."""
+    bridge_key = build_enrichment_source_run_key(source_run)
+    existing = get_enrichment_source_run_by_key(conn, bridge_key)
+    if existing is not None:
+        return existing
+    return create_enrichment_source_run_for_source_run(conn, source_run, **row_options)
+
+
+def build_legacy_staging_context(
+    *,
+    source_run: Mapping[str, Any],
+    enrichment_source_run: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return the explicit legacy FK context future staging writers need."""
+    legacy_id = enrichment_source_run.get('id')
+    if isinstance(legacy_id, bool) or legacy_id is None:
+        raise SourceRunCompatibilityError('enrichment_source_run.id is required for legacy staging context')
+    try:
+        legacy_source_run_id = int(legacy_id)
+    except (TypeError, ValueError) as exc:
+        raise SourceRunCompatibilityError('enrichment_source_run.id must be an integer') from exc
+
+    return {
+        'source_run': dict(source_run),
+        'enrichment_source_run': dict(enrichment_source_run),
+        'legacy_source_run_id': legacy_source_run_id,
+        'target_staging_fk': TARGET_STAGING_FK,
+    }
+
+
+def get_or_create_legacy_staging_context(
+    conn: Any,
+    source_run: Mapping[str, Any],
+    **row_options: Any,
+) -> dict[str, Any]:
+    """Create/resolve the legacy row and return the FK context for stagers."""
+    enrichment_source_run = get_or_create_enrichment_source_run_for_source_run(
+        conn,
+        source_run,
+        **row_options,
+    )
+    return build_legacy_staging_context(
+        source_run=source_run,
+        enrichment_source_run=enrichment_source_run,
+    )
+
+
+def _jsonb(value: Mapping[str, Any]) -> str:
+    return artifact_utils.canonical_json(value)
+
+
+def _row_to_dict(row: Any) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return dict(row)
+    if hasattr(row, 'keys'):
+        return {key: row[key] for key in row.keys()}
+    raise TypeError('compatibility helper cursor rows must be mapping-like')
+
+
+def _close_cursor(cur: Any) -> None:
+    close = getattr(cur, 'close', None)
+    if callable(close):
+        close()
+
+
+def _required_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SourceRunCompatibilityError(f'{field} is required')
+    return value.strip()
+
+
+__all__ = [
+    'BRIDGE_SCHEMA_VERSION',
+    'DEFAULT_SOURCE_KIND',
+    'LEGACY_SOURCE_RUNS_TABLE',
+    'LEGACY_SOURCE_RUN_KEY_PREFIX',
+    'NEW_SOURCE_RUNS_TABLE',
+    'TARGET_STAGING_FK',
+    'SourceRunCompatibilityError',
+    'build_enrichment_source_run_key',
+    'build_enrichment_source_run_metadata',
+    'build_enrichment_source_run_row',
+    'build_legacy_staging_context',
+    'create_enrichment_source_run_for_source_run',
+    'get_enrichment_source_run_by_key',
+    'get_or_create_enrichment_source_run_for_source_run',
+    'get_or_create_legacy_staging_context',
+]

--- a/tests/test_source_run_compatibility.py
+++ b/tests/test_source_run_compatibility.py
@@ -1,0 +1,353 @@
+import inspect
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import source_run_compatibility as compat  # noqa: E402
+
+
+STARTED = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+FINISHED = datetime(2026, 1, 2, 3, 5, 0, tzinfo=timezone.utc)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.closed = False
+        self.last_result = None
+
+    def execute(self, sql, params=None):
+        params = tuple(params or ())
+        self.conn.statements.append((sql, params))
+        compact = ' '.join(sql.lower().split())
+
+        if compact.startswith('select') and 'from enrichment_source_runs' in compact:
+            self.last_result = self.conn.existing_rows.get(params[0])
+            return
+
+        if compact.startswith('insert into enrichment_source_runs'):
+            self.conn.next_id += 1
+            row = {
+                'id': self.conn.next_id,
+                'source_run_key': params[0],
+                'source': params[1],
+                'adapter_name': params[2],
+                'adapter_version': params[3],
+                'source_kind': params[4],
+                'source_class': params[5],
+                'run_label': params[6],
+                'dry_run': params[7],
+                'source_started_at': params[8],
+                'source_completed_at': params[9],
+                'metadata': json.loads(params[10]),
+            }
+            self.conn.existing_rows[params[0]] = row
+            self.last_result = row
+            return
+
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+    def fetchone(self):
+        return self.last_result
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(self, *, existing_rows=None):
+        self.statements = []
+        self.cursors = []
+        self.next_id = 700
+        self.existing_rows = dict(existing_rows or {})
+
+    def cursor(self):
+        cur = FakeCursor(self)
+        self.cursors.append(cur)
+        return cur
+
+
+def source_run_row(**overrides):
+    row = {
+        'id': 101,
+        'source_run_key': 'stage-19t-run',
+        'source_name': 'edsm',
+        'source_category': 'source_of_evidence',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'status': 'succeeded',
+        'source_uri': 'file:///tmp/edsm-stations.json',
+        'source_input_sha256': 'a' * 64,
+        'source_manifest_sha256': None,
+        'started_at': STARTED,
+        'finished_at': FINISHED,
+        'git_commit_sha': 'abc1234',
+        'importer_name': 'stage_19t_edsm_station_import_mvp',
+        'importer_version': 'v1',
+        'trigger_context': 'unit_test',
+        'artifact_path': 'artifacts/stage-19t.json',
+        'artifact_sha256': 'b' * 64,
+        'artifact_integrity_sha256': 'c' * 64,
+        'safety_boundary': {
+            'canonical_writes_planned': 0,
+            'canonical_apply_enabled': False,
+        },
+        'metadata': {
+            'stage': '19t',
+            'source_adapter': 'edsm_nightly_stations',
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def test_build_enrichment_source_run_key_is_deterministic_and_namespaced():
+    assert compat.build_enrichment_source_run_key('stage-19t-run') == 'source_runs:stage-19t-run'
+    assert compat.build_enrichment_source_run_key(source_run_row()) == 'source_runs:stage-19t-run'
+
+    with pytest.raises(compat.SourceRunCompatibilityError, match='source_run_key is required'):
+        compat.build_enrichment_source_run_key('')
+
+
+def test_build_enrichment_source_run_row_maps_source_runs_metadata_to_legacy_columns():
+    row = compat.build_enrichment_source_run_row(source_run_row())
+
+    assert row['source_run_key'] == 'source_runs:stage-19t-run'
+    assert row['source'] == 'edsm'
+    assert row['adapter_name'] == 'stage_19t_edsm_station_import_mvp'
+    assert row['adapter_version'] == 'v1'
+    assert row['source_kind'] == 'offline_snapshot'
+    assert row['source_class'] == 'semi-stable'
+    assert row['run_label'] == 'stage-19t-run'
+    assert row['dry_run'] is True
+    assert row['source_started_at'] == STARTED
+    assert row['source_completed_at'] == FINISHED
+
+    metadata = row['metadata']
+    assert metadata['schema_version'] == compat.BRIDGE_SCHEMA_VERSION
+    assert metadata['compatibility_bridge'] is True
+    assert metadata['new_source_run_table'] == 'source_runs'
+    assert metadata['legacy_source_run_table'] == 'enrichment_source_runs'
+    assert metadata['target_staging_fk'] == 'enrichment_source_runs(id)'
+    assert metadata['source_runs_provenance']['id'] == 101
+    assert metadata['source_runs_provenance']['source_run_key'] == 'stage-19t-run'
+    assert metadata['source_runs_provenance']['source_uri'] == 'file:///tmp/edsm-stations.json'
+    assert metadata['source_runs_provenance']['source_input_sha256'] == 'a' * 64
+    assert metadata['source_runs_provenance']['artifact_path'] == 'artifacts/stage-19t.json'
+    assert metadata['source_runs_provenance']['artifact_sha256'] == 'b' * 64
+    assert metadata['source_runs_provenance']['artifact_integrity_sha256'] == 'c' * 64
+    assert metadata['source_runs_provenance']['trigger_context'] == 'unit_test'
+    assert metadata['source_runs_provenance']['domain'] == 'stations'
+    assert metadata['source_runs_provenance']['import_scope'] == 'staging_only'
+    assert metadata['source_runs_provenance']['safety_boundary']['canonical_writes_planned'] == 0
+    assert metadata['staging_policy']['do_not_pass_source_runs_id_to_legacy_staging_source_run_id'] is True
+    assert metadata['staging_policy']['staging_rows_written_by_this_helper'] is False
+
+
+def test_build_enrichment_source_run_row_allows_explicit_staging_write_overrides():
+    row = compat.build_enrichment_source_run_row(
+        source_run_row(),
+        source='edsm_nightly_stations',
+        adapter_name='explicit_compatible_stager',
+        adapter_version='v2',
+        source_kind='offline_snapshot',
+        source_class='volatile',
+        run_label='operator-run-label',
+        dry_run=False,
+        metadata={'operator_note': 'real staging write approved elsewhere'},
+    )
+
+    assert row['source'] == 'edsm_nightly_stations'
+    assert row['adapter_name'] == 'explicit_compatible_stager'
+    assert row['adapter_version'] == 'v2'
+    assert row['source_class'] == 'volatile'
+    assert row['run_label'] == 'operator-run-label'
+    assert row['dry_run'] is False
+    assert row['metadata']['operator_note'] == 'real staging write approved elsewhere'
+
+
+def test_create_enrichment_source_run_for_source_run_upserts_legacy_row():
+    conn = FakeConn()
+
+    row = compat.create_enrichment_source_run_for_source_run(conn, source_run_row())
+
+    assert row['id'] == 701
+    assert row['source_run_key'] == 'source_runs:stage-19t-run'
+    assert row['source'] == 'edsm'
+    assert row['adapter_name'] == 'stage_19t_edsm_station_import_mvp'
+    assert row['metadata']['compatibility_bridge'] is True
+    sql, params = conn.statements[0]
+    assert 'INSERT INTO enrichment_source_runs' in sql
+    assert 'ON CONFLICT (source_run_key)' in sql
+    assert 'RETURNING' in sql
+    assert params[:8] == (
+        'source_runs:stage-19t-run',
+        'edsm',
+        'stage_19t_edsm_station_import_mvp',
+        'v1',
+        'offline_snapshot',
+        'semi-stable',
+        'stage-19t-run',
+        True,
+    )
+    assert params[8] == STARTED
+    assert params[9] == FINISHED
+    metadata = json.loads(params[10])
+    assert metadata['target_staging_fk'] == 'enrichment_source_runs(id)'
+    assert_only_compat_sql(conn)
+
+
+def test_get_or_create_returns_existing_row_without_insert_for_idempotency():
+    existing = {
+        'id': 777,
+        'source_run_key': 'source_runs:stage-19t-run',
+        'source': 'edsm',
+        'adapter_name': 'stage_19t_edsm_station_import_mvp',
+        'adapter_version': 'v1',
+        'source_kind': 'offline_snapshot',
+        'source_class': 'semi-stable',
+        'run_label': 'stage-19t-run',
+        'dry_run': True,
+        'source_started_at': STARTED,
+        'source_completed_at': FINISHED,
+        'metadata': {'compatibility_bridge': True},
+    }
+    conn = FakeConn(existing_rows={'source_runs:stage-19t-run': existing})
+
+    row = compat.get_or_create_enrichment_source_run_for_source_run(conn, source_run_row())
+
+    assert row == existing
+    assert len(conn.statements) == 1
+    assert 'SELECT' in conn.statements[0][0]
+    assert 'FROM enrichment_source_runs' in conn.statements[0][0]
+    assert_only_compat_sql(conn)
+
+
+def test_get_or_create_inserts_when_bridge_row_is_absent():
+    conn = FakeConn()
+
+    row = compat.get_or_create_enrichment_source_run_for_source_run(conn, source_run_row())
+
+    assert row['id'] == 701
+    assert [statement[0].lstrip().split()[0].upper() for statement in conn.statements] == ['SELECT', 'INSERT']
+    assert_only_compat_sql(conn)
+
+
+def test_build_legacy_staging_context_exposes_legacy_fk_id():
+    source_run = source_run_row()
+    enrichment_source_run = {
+        'id': 888,
+        'source_run_key': 'source_runs:stage-19t-run',
+        'source': 'edsm',
+    }
+
+    context = compat.build_legacy_staging_context(
+        source_run=source_run,
+        enrichment_source_run=enrichment_source_run,
+    )
+
+    assert context['source_run'] == source_run
+    assert context['enrichment_source_run'] == enrichment_source_run
+    assert context['legacy_source_run_id'] == 888
+    assert context['target_staging_fk'] == 'enrichment_source_runs(id)'
+
+
+def test_get_or_create_legacy_staging_context_creates_row_and_returns_fk_context():
+    conn = FakeConn()
+
+    context = compat.get_or_create_legacy_staging_context(conn, source_run_row())
+
+    assert context['legacy_source_run_id'] == 701
+    assert context['target_staging_fk'] == 'enrichment_source_runs(id)'
+    assert context['enrichment_source_run']['source_run_key'] == 'source_runs:stage-19t-run'
+    assert_only_compat_sql(conn)
+
+
+def test_helper_rejects_invalid_source_class_before_db_write():
+    conn = FakeConn()
+
+    with pytest.raises(compat.SourceRunCompatibilityError, match='invalid source_class'):
+        compat.create_enrichment_source_run_for_source_run(
+            conn,
+            source_run_row(),
+            source_class='canonical',
+        )
+
+    assert conn.statements == []
+
+
+def test_source_run_compatibility_helper_has_no_prod_db_scheduler_import_or_canonical_fragments():
+    source = inspect.getsource(compat)
+    source_upper = source.upper()
+    forbidden_fragments = (
+        'PSYCOPG2.CONNECT',
+        'ASYNCPG.CONNECT',
+        'SUBPROCESS',
+        'OS.SYSTEM',
+        'SYSTEMCTL',
+        'RUN_IMPORT',
+        'RUN_IMPORT.SH',
+        'DATABASE' + '_URL',
+        'POSTGRESQL' + '://',
+        'POSTGRES' + '://',
+        'PASSWORD' + '=',
+        'SECRET',
+        'TOKEN' + '=',
+        'CANONICAL APPLY',
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in source_upper
+    assert re.search(r'(?<![a-z0-9_])\.timer(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+    assert re.search(r'(?<![a-z0-9_])\.service(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+
+    forbidden_write_patterns = (
+        r'\binsert\s+into\s+staging_[a-z0-9_]+\b',
+        r'\bupdate\s+staging_[a-z0-9_]+\b',
+        r'\bdelete\s+from\s+staging_[a-z0-9_]+\b',
+        r'\binsert\s+into\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bupdate\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bdelete\s+from\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+    )
+    for pattern in forbidden_write_patterns:
+        assert re.search(pattern, source, flags=re.IGNORECASE) is None
+
+
+def assert_only_compat_sql(conn):
+    assert conn.statements
+    allowed = {'enrichment_source_runs'}
+    forbidden_write_tables = (
+        'stations',
+        'systems',
+        'bodies',
+        'body_rings',
+        'station_body_links',
+        'station_external_identity',
+    )
+    for sql, _params in conn.statements:
+        compact = ' '.join(sql.lower().split())
+        referenced = {
+            match.group(1).replace('"', '').split('.')[-1].lower()
+            for match in re.finditer(
+                r'\b(?:from|into|update)\s+(?:only\s+)?("?[\w]+"?(?:\."?[\w]+"?)?)',
+                sql,
+                flags=re.IGNORECASE,
+            )
+        }
+        referenced.discard('set')
+        assert referenced <= allowed
+        assert re.search(
+            r'\b(insert\s+into|update|delete\s+from)\s+staging_[a-z0-9_]+\b',
+            compact,
+        ) is None
+        for table in forbidden_write_tables:
+            assert re.search(rf'\b(insert\s+into|update|delete\s+from)\s+{table}\b', compact) is None


### PR DESCRIPTION
## Files added/changed

- Added `apps/importer/src/source_run_compatibility.py`
- Added `tests/test_source_run_compatibility.py`

## Helper functions added

- `build_enrichment_source_run_key(...)`
- `build_enrichment_source_run_metadata(...)`
- `build_enrichment_source_run_row(...)`
- `get_enrichment_source_run_by_key(...)`
- `create_enrichment_source_run_for_source_run(...)`
- `get_or_create_enrichment_source_run_for_source_run(...)`
- `build_legacy_staging_context(...)`
- `get_or_create_legacy_staging_context(...)`

## Bridge key generation

The deterministic legacy key is namespaced from the new source-run key:

`source_runs:<source_run_key>`

This avoids blindly reusing the new key in `enrichment_source_runs.source_run_key` and makes the dual-ledger bridge explicit.

## Legacy enrichment_source_runs mapping

The helper maps a new `source_runs` row/metadata into a legacy `enrichment_source_runs` row:

- `source_run_key`: deterministic bridge key, e.g. `source_runs:stage-19t-run`
- `source`: defaults to original `source_name`
- `adapter_name`: defaults to original `importer_name`, with override support
- `adapter_version`: defaults to original `importer_version`, with override support
- `source_kind`: defaults to `offline_snapshot`
- `source_class`: defaults via existing source classification helpers, with validation against legacy allowed values
- `run_label`: defaults to original `source_run_key`
- `dry_run`: defaults to `true`, with explicit override for approved real staging writers
- `source_started_at`: original `started_at`
- `source_completed_at`: original `finished_at`
- `metadata`: includes bridge schema/version marker, explicit dual-ledger reason, target FK `enrichment_source_runs(id)`, source URI/hash, artifact path/hash/integrity, trigger context, domain/import scope, safety boundary, and original source-run metadata

The staging context helper returns `legacy_source_run_id`, explicitly the `enrichment_source_runs.id` value future legacy staging writers should pass into `staging_* source_run_id` columns.

## SQL scope

The helper only reads/writes:

- `enrichment_source_runs`

It does not write to `source_runs`, `staging_*`, or canonical tables. Tests assert no SQL writes to:

- `staging_*`
- `stations`
- `systems`
- `bodies`
- `body_rings`
- `station_body_links`
- `station_external_identity`

## Validation

- `.venv/bin/python -m pytest tests/test_source_run_compatibility.py -q` -> `10 passed`
- `.venv/bin/python -m pytest tests/test_source_run_compatibility.py tests/test_edsm_station_import.py tests/test_source_run_artifacts.py tests/test_artifact_utils.py tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q` -> `75 passed`

## Safety confirmations

- No production DB access.
- No production imports.
- No scheduler/timer/service enablement.
- No production migrations.
- No staging writes by this helper.
- No canonical writes.
- No canonical apply.

## Unrelated failures or warnings

None observed in the requested validation set.