### PR TITLE
Stage 19AP add operator visibility skeleton

### DIFF
--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -10,6 +10,7 @@ in routers/ and helpers/.
 Endpoint surface (see individual router docstrings for detail):
 
   routers/meta.py       health, status, local/status, metrics
+  routers/operator.py   read-only source-run/operator visibility
   routers/watchlist.py  watchlist CRUD + changelog
   routers/notes.py      per-system user notes
   routers/events.py     EDDN SSE live feed + recent
@@ -59,6 +60,7 @@ from routers.systems   import router as systems_router
 from routers.watchlist import router as watchlist_router
 from routers.optimiser import router as optimiser_router
 from routers.observations import router as observations_router
+from routers.operator import router as operator_router
 from share_router      import router as share_router
 
 # ---------------------------------------------------------------------------
@@ -284,6 +286,7 @@ app.include_router(simulation_router)
 app.include_router(optimiser_router)
 app.include_router(observations_router)
 app.include_router(colony_planner_router)
+app.include_router(operator_router)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/operator_visibility.py
+++ b/apps/api/src/operator_visibility.py
@@ -1,0 +1,1063 @@
+"""Read-only Stage 19 operator visibility repository helpers.
+
+The helpers in this module accept a caller-owned asyncpg-style connection.
+They build compact, sanitized view models for source-run, artifact, legacy
+bridge, staging, diagnostic, and safety-gate visibility.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, is_dataclass
+from pathlib import PurePosixPath
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
+
+
+MAX_OPERATOR_VISIBILITY_LIMIT = 100
+DEFAULT_RECENT_SOURCE_RUN_LIMIT = 25
+DEFAULT_DIAGNOSTIC_ROW_LIMIT = 100
+LEGACY_SOURCE_RUN_KEY_PREFIX = 'source_runs:'
+TARGET_STAGING_FK = 'enrichment_source_runs(id)'
+BRIDGE_SCHEMA_VERSION = 'source_run_legacy_compatibility/v1'
+STAGING_TABLE = 'staging_edsm_stations'
+DIAGNOSTIC_ONLY = 'diagnostic-only'
+STAGE19ANR_MARKER_KEY = 'stage19anr_diagnostic_mark'
+PILOT_SOURCE_NAME = 'edsm'
+PILOT_DOMAIN = 'stations'
+PILOT_IMPORT_SCOPE = 'staging_only'
+
+
+@dataclass(frozen=True)
+class OperatorSourceRunSummary:
+    source_run_key: str
+    source_name: str | None
+    source_category: str | None
+    domain: str | None
+    import_scope: str | None
+    status: str | None
+    started_at: Any
+    finished_at: Any
+    duration_ms: int | None
+    rows_read: int
+    rows_staged: int
+    rows_rejected: int
+    rows_skipped: int
+    artifact_present: bool
+    artifact_hash_present: bool
+    bridge_present: bool
+    staging_rows_known: bool
+    trigger_context: str | None
+    git_commit_sha: str | None
+    error_code: str | None
+    error_summary: str | None
+
+
+@dataclass(frozen=True)
+class OperatorArtifactSummary:
+    source_run_key: str
+    artifact_path_redacted: str | None
+    artifact_sha256: str | None
+    artifact_integrity_sha256: str | None
+    artifact_record_present: bool
+    file_exists: bool | None
+    file_sha256_matches: bool | None
+    integrity_hash_matches: bool | None
+    schema_version: str | None
+    rows_read: int
+    rows_staged: int
+    status: str | None
+    validation_note: str
+
+
+@dataclass(frozen=True)
+class OperatorBridgeSummary:
+    bridge_key: str
+    legacy_source_run_id: int | None
+    source_run_key: str
+    bridge_present: bool
+    dry_run: bool | None
+    adapter_name: str | None
+    adapter_version: str | None
+    target_staging_fk: str
+    metadata_has_compatibility_bridge: bool
+    staging_policy_blocks_source_runs_id: bool
+
+
+@dataclass(frozen=True)
+class OperatorDiagnosticRowSummary:
+    row_id: int
+    legacy_source_run_id: int | None
+    station_name: str | None
+    station_type: str | None
+    system_name: str | None
+    source_class: str | None
+    confidence: str | None
+    marker_keys: list[str]
+    canonical_write_allowed: bool | None
+
+
+@dataclass(frozen=True)
+class OperatorStagingImpactSummary:
+    source_run_key: str | None
+    bridge_key: str | None
+    legacy_source_run_id: int
+    staging_table: str
+    rows_total: int
+    rows_diagnostic_only: int
+    rows_canonical_write_blocked: int
+    rows_with_stage_markers: int
+    rows_using_legacy_bridge_id: int
+    rows_using_source_runs_id: int
+    sample_rows: list[OperatorDiagnosticRowSummary]
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class OperatorSourceRunDetail:
+    summary: OperatorSourceRunSummary
+    importer_name: str | None
+    importer_version: str | None
+    source_uri_redacted: str | None
+    source_input_sha256: str | None
+    source_manifest_sha256: str | None
+    safety_boundary: dict[str, Any]
+    metadata_summary: dict[str, Any]
+    artifact_summary: OperatorArtifactSummary
+    bridge_summary: OperatorBridgeSummary
+    staging_impact_summary: OperatorStagingImpactSummary | None
+    validation_warnings: list[str]
+    operator_notes: list[str]
+
+
+@dataclass(frozen=True)
+class OperatorSafetyGateSummary:
+    no_running_source_runs: bool
+    latest_artifacts_present: bool
+    bridge_fk_path_verified: bool
+    diagnostic_rows_isolated: bool
+    no_failed_unrecovered_source_runs: bool
+    scheduler_assumed_disabled: bool
+    canonical_apply_assumed_disabled: bool
+    safe_to_proceed: bool
+    blockers: list[str]
+    latest_source_run_key: str | None
+    notes: list[str]
+
+
+async def list_recent_source_runs(
+    conn: Any,
+    limit: int = DEFAULT_RECENT_SOURCE_RUN_LIMIT,
+    status: str | None = None,
+    source_name: str | None = None,
+    domain: str | None = None,
+) -> list[OperatorSourceRunSummary]:
+    bounded_limit = _bounded_limit(limit, default=DEFAULT_RECENT_SOURCE_RUN_LIMIT)
+    where_clauses: list[str] = []
+    params: list[Any] = []
+
+    if status:
+        params.append(status)
+        where_clauses.append(f'sr.status = ${len(params)}')
+    if source_name:
+        params.append(source_name)
+        where_clauses.append(f'sr.source_name = ${len(params)}')
+    if domain:
+        params.append(domain)
+        where_clauses.append(f'sr.domain = ${len(params)}')
+
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ''
+    params.append(bounded_limit)
+    sql = f"""
+        /* operator_visibility:list_recent_source_runs */
+        SELECT
+          sr.source_run_key,
+          sr.source_name,
+          sr.source_category,
+          sr.domain,
+          sr.import_scope,
+          sr.status,
+          sr.started_at,
+          sr.finished_at,
+          sr.duration_ms,
+          sr.rows_read,
+          sr.rows_staged,
+          sr.rows_rejected,
+          sr.rows_skipped,
+          (sr.artifact_path IS NOT NULL) AS artifact_present,
+          (
+            sr.artifact_sha256 IS NOT NULL
+            AND sr.artifact_integrity_sha256 IS NOT NULL
+          ) AS artifact_hash_present,
+          EXISTS (
+            SELECT 1
+            FROM enrichment_source_runs esr
+            WHERE esr.source_run_key = '{LEGACY_SOURCE_RUN_KEY_PREFIX}' || sr.source_run_key
+          ) AS bridge_present,
+          sr.trigger_context,
+          sr.git_commit_sha,
+          sr.error_code,
+          sr.error_summary
+        FROM source_runs sr
+        {where_sql}
+        ORDER BY sr.started_at DESC, sr.id DESC
+        LIMIT ${len(params)}
+    """
+    rows = await conn.fetch(sql, *params)
+    return [_source_run_summary_from_row(row) for row in rows]
+
+
+async def get_source_run_detail(
+    conn: Any,
+    source_run_key: str,
+) -> OperatorSourceRunDetail | None:
+    source_run_row = await conn.fetchrow(
+        f"""
+        /* operator_visibility:get_source_run_detail */
+        SELECT
+          sr.id,
+          sr.source_run_key,
+          sr.source_name,
+          sr.source_category,
+          sr.domain,
+          sr.import_scope,
+          sr.status,
+          sr.source_uri,
+          sr.source_input_sha256,
+          sr.source_manifest_sha256,
+          sr.started_at,
+          sr.finished_at,
+          sr.duration_ms,
+          sr.git_commit_sha,
+          sr.importer_name,
+          sr.importer_version,
+          sr.trigger_context,
+          sr.artifact_path,
+          sr.artifact_sha256,
+          sr.artifact_integrity_sha256,
+          sr.rows_read,
+          sr.rows_staged,
+          sr.rows_rejected,
+          sr.rows_skipped,
+          sr.error_code,
+          sr.error_summary,
+          sr.safety_boundary,
+          sr.metadata,
+          (sr.artifact_path IS NOT NULL) AS artifact_present,
+          (
+            sr.artifact_sha256 IS NOT NULL
+            AND sr.artifact_integrity_sha256 IS NOT NULL
+          ) AS artifact_hash_present,
+          EXISTS (
+            SELECT 1
+            FROM enrichment_source_runs esr
+            WHERE esr.source_run_key = '{LEGACY_SOURCE_RUN_KEY_PREFIX}' || sr.source_run_key
+          ) AS bridge_present
+        FROM source_runs sr
+        WHERE sr.source_run_key = $1
+        """,
+        source_run_key,
+    )
+    row = _row_to_dict(source_run_row)
+    if row is None:
+        return None
+
+    summary = _source_run_summary_from_row(row)
+    artifact = await get_source_run_artifacts(conn, source_run_key)
+    bridge = await get_legacy_bridge_for_source_run(conn, source_run_key)
+    staging_impact = None
+    if bridge.bridge_present and bridge.legacy_source_run_id is not None:
+        staging_impact = await get_staging_impact_for_bridge(
+            conn,
+            bridge.legacy_source_run_id,
+            limit=DEFAULT_DIAGNOSTIC_ROW_LIMIT,
+        )
+
+    warnings = _detail_warnings(artifact, bridge, staging_impact)
+    metadata = _mapping(row.get('metadata'))
+    return OperatorSourceRunDetail(
+        summary=summary,
+        importer_name=_safe_text(row.get('importer_name')),
+        importer_version=_safe_text(row.get('importer_version')),
+        source_uri_redacted=_redact_uri(row.get('source_uri')),
+        source_input_sha256=_safe_text(row.get('source_input_sha256')),
+        source_manifest_sha256=_safe_text(row.get('source_manifest_sha256')),
+        safety_boundary=_sanitized_mapping(row.get('safety_boundary')),
+        metadata_summary=_metadata_summary(metadata),
+        artifact_summary=artifact,
+        bridge_summary=bridge,
+        staging_impact_summary=staging_impact,
+        validation_warnings=warnings,
+        operator_notes=_operator_notes(metadata),
+    )
+
+
+async def get_source_run_artifacts(
+    conn: Any,
+    source_run_key: str,
+) -> OperatorArtifactSummary:
+    source_run_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_source_run_artifacts */
+        SELECT
+          source_run_key,
+          status,
+          artifact_path,
+          artifact_sha256,
+          artifact_integrity_sha256,
+          rows_read,
+          rows_staged,
+          metadata
+        FROM source_runs
+        WHERE source_run_key = $1
+        """,
+        source_run_key,
+    )
+    row = _row_to_dict(source_run_row)
+    if row is None:
+        return OperatorArtifactSummary(
+            source_run_key=source_run_key,
+            artifact_path_redacted=None,
+            artifact_sha256=None,
+            artifact_integrity_sha256=None,
+            artifact_record_present=False,
+            file_exists=None,
+            file_sha256_matches=None,
+            integrity_hash_matches=None,
+            schema_version=None,
+            rows_read=0,
+            rows_staged=0,
+            status=None,
+            validation_note='source run not found; no artifact metadata available',
+        )
+
+    metadata = _mapping(row.get('metadata'))
+    artifact_record = _mapping(metadata.get('artifact_record'))
+    artifact_path = row.get('artifact_path') or artifact_record.get('path')
+    return OperatorArtifactSummary(
+        source_run_key=str(row.get('source_run_key') or source_run_key),
+        artifact_path_redacted=_redact_path(artifact_path),
+        artifact_sha256=_safe_text(row.get('artifact_sha256')),
+        artifact_integrity_sha256=_safe_text(row.get('artifact_integrity_sha256')),
+        artifact_record_present=bool(artifact_record),
+        file_exists=None,
+        file_sha256_matches=None,
+        integrity_hash_matches=None,
+        schema_version=_schema_version(metadata),
+        rows_read=_int_or_zero(row.get('rows_read')),
+        rows_staged=_int_or_zero(row.get('rows_staged')),
+        status=_safe_text(row.get('status')),
+        validation_note=(
+            'ledger metadata only; artifact file validation requires a later allowlisted path check'
+        ),
+    )
+
+
+async def get_legacy_bridge_for_source_run(
+    conn: Any,
+    source_run_key: str,
+) -> OperatorBridgeSummary:
+    bridge_key = _bridge_key(source_run_key)
+    row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_legacy_bridge_for_source_run */
+        SELECT
+          id,
+          source_run_key,
+          dry_run,
+          adapter_name,
+          adapter_version,
+          metadata
+        FROM enrichment_source_runs
+        WHERE source_run_key = $1
+        """,
+        bridge_key,
+    )
+    if row is None:
+        return OperatorBridgeSummary(
+            bridge_key=bridge_key,
+            legacy_source_run_id=None,
+            source_run_key=source_run_key,
+            bridge_present=False,
+            dry_run=None,
+            adapter_name=None,
+            adapter_version=None,
+            target_staging_fk=TARGET_STAGING_FK,
+            metadata_has_compatibility_bridge=False,
+            staging_policy_blocks_source_runs_id=False,
+        )
+    return _bridge_summary_from_row(row, source_run_key=source_run_key)
+
+
+async def get_staging_impact_for_bridge(
+    conn: Any,
+    legacy_source_run_id: int,
+    limit: int = DEFAULT_DIAGNOSTIC_ROW_LIMIT,
+) -> OperatorStagingImpactSummary:
+    bounded_limit = _bounded_limit(limit, default=DEFAULT_DIAGNOSTIC_ROW_LIMIT)
+    legacy_id = _required_positive_int(legacy_source_run_id, 'legacy_source_run_id')
+    bridge_row = await _get_bridge_by_legacy_id(conn, legacy_id)
+    bridge_key = _safe_text(bridge_row.get('source_run_key')) if bridge_row else None
+    source_run_key = _source_run_key_from_bridge_key(bridge_key)
+    source_runs_id = await _get_source_runs_id(conn, source_run_key) if source_run_key else None
+
+    counts_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_staging_impact_for_bridge:counts */
+        SELECT
+          (
+            SELECT COUNT(*)::int
+            FROM staging_edsm_stations
+            WHERE source_run_id = $1
+          ) AS rows_total,
+          (
+            SELECT COUNT(*)::int
+            FROM staging_edsm_stations
+            WHERE source_run_id = $1
+              AND source_class = 'diagnostic-only'
+              AND confidence = 'diagnostic-only'
+          ) AS rows_diagnostic_only,
+          (
+            SELECT COUNT(*)::int
+            FROM staging_edsm_stations
+            WHERE source_run_id = $1
+              AND provenance->>'canonical_write_allowed' = 'false'
+          ) AS rows_canonical_write_blocked,
+          (
+            SELECT COUNT(*)::int
+            FROM staging_edsm_stations
+            WHERE source_run_id = $1
+              AND provenance ? $3
+          ) AS rows_with_stage_markers,
+          (
+            SELECT COUNT(*)::int
+            FROM staging_edsm_stations
+            WHERE source_run_id = $2
+          ) AS rows_using_source_runs_id
+        """,
+        legacy_id,
+        source_runs_id,
+        STAGE19ANR_MARKER_KEY,
+    )
+    counts = _row_to_dict(counts_row) or {}
+    sample_rows = await conn.fetch(
+        """
+        /* operator_visibility:get_staging_impact_for_bridge:sample */
+        SELECT
+          id,
+          source_run_id,
+          station_name,
+          station_type,
+          system_name,
+          source_class,
+          confidence,
+          provenance
+        FROM staging_edsm_stations
+        WHERE source_run_id = $1
+        ORDER BY id
+        LIMIT $2
+        """,
+        legacy_id,
+        bounded_limit,
+    )
+    rows_total = _int_or_zero(counts.get('rows_total'))
+    warnings: list[str] = []
+    if bridge_row is None:
+        warnings.append('legacy bridge row was not found for the supplied enrichment_source_runs.id')
+    if source_run_key and source_runs_id is None:
+        warnings.append('new source_runs.id could not be resolved from the bridge key')
+    return OperatorStagingImpactSummary(
+        source_run_key=source_run_key,
+        bridge_key=bridge_key,
+        legacy_source_run_id=legacy_id,
+        staging_table=STAGING_TABLE,
+        rows_total=rows_total,
+        rows_diagnostic_only=_int_or_zero(counts.get('rows_diagnostic_only')),
+        rows_canonical_write_blocked=_int_or_zero(
+            counts.get('rows_canonical_write_blocked')
+        ),
+        rows_with_stage_markers=_int_or_zero(counts.get('rows_with_stage_markers')),
+        rows_using_legacy_bridge_id=rows_total,
+        rows_using_source_runs_id=_int_or_zero(counts.get('rows_using_source_runs_id')),
+        sample_rows=[_diagnostic_row_from_row(row) for row in sample_rows],
+        warnings=warnings,
+    )
+
+
+async def list_diagnostic_staging_rows(
+    conn: Any,
+    source_run_key: str | None = None,
+    limit: int = DEFAULT_DIAGNOSTIC_ROW_LIMIT,
+) -> list[OperatorDiagnosticRowSummary]:
+    bounded_limit = _bounded_limit(limit, default=DEFAULT_DIAGNOSTIC_ROW_LIMIT)
+    if source_run_key:
+        bridge = await get_legacy_bridge_for_source_run(conn, source_run_key)
+        if not bridge.bridge_present or bridge.legacy_source_run_id is None:
+            return []
+        rows = await conn.fetch(
+            """
+            /* operator_visibility:list_diagnostic_staging_rows:by_source_run */
+            SELECT
+              id,
+              source_run_id,
+              station_name,
+              station_type,
+              system_name,
+              source_class,
+              confidence,
+              provenance
+            FROM staging_edsm_stations
+            WHERE source_run_id = $1
+              AND (
+                source_class = 'diagnostic-only'
+                OR confidence = 'diagnostic-only'
+                OR provenance ? $2
+              )
+            ORDER BY id DESC
+            LIMIT $3
+            """,
+            bridge.legacy_source_run_id,
+            STAGE19ANR_MARKER_KEY,
+            bounded_limit,
+        )
+    else:
+        rows = await conn.fetch(
+            """
+            /* operator_visibility:list_diagnostic_staging_rows */
+            SELECT
+              id,
+              source_run_id,
+              station_name,
+              station_type,
+              system_name,
+              source_class,
+              confidence,
+              provenance
+            FROM staging_edsm_stations
+            WHERE
+              source_class = 'diagnostic-only'
+              OR confidence = 'diagnostic-only'
+              OR provenance ? $1
+            ORDER BY id DESC
+            LIMIT $2
+            """,
+            STAGE19ANR_MARKER_KEY,
+            bounded_limit,
+        )
+    return [_diagnostic_row_from_row(row) for row in rows]
+
+
+async def get_operator_safety_gates(conn: Any) -> OperatorSafetyGateSummary:
+    active_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_operator_safety_gates:active */
+        SELECT COUNT(*)::int AS active_source_runs
+        FROM source_runs
+        WHERE source_name = $1
+          AND domain = $2
+          AND import_scope = $3
+          AND status IN ('planned', 'running')
+        """,
+        PILOT_SOURCE_NAME,
+        PILOT_DOMAIN,
+        PILOT_IMPORT_SCOPE,
+    )
+    failed_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_operator_safety_gates:failed */
+        SELECT COUNT(*)::int AS failed_unrecovered_source_runs
+        FROM source_runs
+        WHERE source_name = $1
+          AND domain = $2
+          AND import_scope = $3
+          AND status IN ('failed', 'rejected')
+        """,
+        PILOT_SOURCE_NAME,
+        PILOT_DOMAIN,
+        PILOT_IMPORT_SCOPE,
+    )
+    latest_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_operator_safety_gates:latest */
+        SELECT
+          source_run_key,
+          artifact_path,
+          artifact_sha256,
+          artifact_integrity_sha256
+        FROM source_runs
+        WHERE source_name = $1
+          AND domain = $2
+          AND import_scope = $3
+          AND status = 'succeeded'
+        ORDER BY started_at DESC, id DESC
+        LIMIT 1
+        """,
+        PILOT_SOURCE_NAME,
+        PILOT_DOMAIN,
+        PILOT_IMPORT_SCOPE,
+    )
+
+    active = _row_to_dict(active_row) or {}
+    failed = _row_to_dict(failed_row) or {}
+    latest = _row_to_dict(latest_row)
+
+    active_count = _int_or_zero(active.get('active_source_runs'))
+    failed_count = _int_or_zero(failed.get('failed_unrecovered_source_runs'))
+    latest_source_run_key = _safe_text(latest.get('source_run_key')) if latest else None
+    latest_artifacts_present = bool(
+        latest
+        and latest.get('artifact_path')
+        and latest.get('artifact_sha256')
+        and latest.get('artifact_integrity_sha256')
+    )
+
+    bridge_fk_path_verified = False
+    diagnostic_rows_isolated = False
+    if latest_source_run_key:
+        bridge = await get_legacy_bridge_for_source_run(conn, latest_source_run_key)
+        if bridge.bridge_present and bridge.legacy_source_run_id is not None:
+            impact = await get_staging_impact_for_bridge(conn, bridge.legacy_source_run_id, limit=25)
+            bridge_fk_path_verified = (
+                bridge.target_staging_fk == TARGET_STAGING_FK
+                and bridge.metadata_has_compatibility_bridge
+                and bridge.staging_policy_blocks_source_runs_id
+                and impact.rows_using_source_runs_id == 0
+            )
+            diagnostic_rows_isolated = (
+                impact.rows_total == 0
+                or (
+                    impact.rows_total == impact.rows_diagnostic_only
+                    and impact.rows_total == impact.rows_canonical_write_blocked
+                )
+            )
+
+    no_running_source_runs = active_count == 0
+    no_failed_unrecovered_source_runs = failed_count == 0
+    scheduler_assumed_disabled = True
+    canonical_apply_assumed_disabled = True
+    blockers: list[str] = []
+    if not no_running_source_runs:
+        blockers.append(
+            f'{active_count} planned/running source run(s) exist for '
+            f'{PILOT_SOURCE_NAME}/{PILOT_DOMAIN}/{PILOT_IMPORT_SCOPE}'
+        )
+    if not latest_artifacts_present:
+        blockers.append('latest succeeded pilot source run artifact metadata is missing or incomplete')
+    if not bridge_fk_path_verified:
+        blockers.append('legacy bridge FK path is missing or not verified')
+    if not diagnostic_rows_isolated:
+        blockers.append('diagnostic staging rows are not fully isolated/canonical-write-blocked')
+    if not no_failed_unrecovered_source_runs:
+        blockers.append(
+            f'{failed_count} failed/rejected source run(s) exist without a recovery marker in this skeleton'
+        )
+
+    notes = [
+        'Scheduler state is assumed disabled from Stage 19 repository state; no service manager check is performed.',
+        'Canonical apply is assumed disabled from Stage 19 repository state; no canonical executor check is performed.',
+    ]
+    return OperatorSafetyGateSummary(
+        no_running_source_runs=no_running_source_runs,
+        latest_artifacts_present=latest_artifacts_present,
+        bridge_fk_path_verified=bridge_fk_path_verified,
+        diagnostic_rows_isolated=diagnostic_rows_isolated,
+        no_failed_unrecovered_source_runs=no_failed_unrecovered_source_runs,
+        scheduler_assumed_disabled=scheduler_assumed_disabled,
+        canonical_apply_assumed_disabled=canonical_apply_assumed_disabled,
+        safe_to_proceed=not blockers,
+        blockers=blockers,
+        latest_source_run_key=latest_source_run_key,
+        notes=notes,
+    )
+
+
+async def get_staging_impact_for_source_run(
+    conn: Any,
+    source_run_key: str,
+    limit: int = DEFAULT_DIAGNOSTIC_ROW_LIMIT,
+) -> OperatorStagingImpactSummary | None:
+    bridge = await get_legacy_bridge_for_source_run(conn, source_run_key)
+    if not bridge.bridge_present or bridge.legacy_source_run_id is None:
+        return None
+    return await get_staging_impact_for_bridge(conn, bridge.legacy_source_run_id, limit=limit)
+
+
+def to_operator_visibility_dict(value: Any) -> Any:
+    if is_dataclass(value):
+        return {
+            key: to_operator_visibility_dict(item)
+            for key, item in asdict(value).items()
+        }
+    if isinstance(value, list):
+        return [to_operator_visibility_dict(item) for item in value]
+    if isinstance(value, tuple):
+        return [to_operator_visibility_dict(item) for item in value]
+    if isinstance(value, dict):
+        return {key: to_operator_visibility_dict(item) for key, item in value.items()}
+    return value
+
+
+async def _get_bridge_by_legacy_id(conn: Any, legacy_source_run_id: int) -> dict[str, Any] | None:
+    bridge_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_bridge_by_legacy_id */
+        SELECT
+          id,
+          source_run_key,
+          dry_run,
+          adapter_name,
+          adapter_version,
+          metadata
+        FROM enrichment_source_runs
+        WHERE id = $1
+        """,
+        legacy_source_run_id,
+    )
+    return _row_to_dict(bridge_row)
+
+
+async def _get_source_runs_id(conn: Any, source_run_key: str | None) -> int | None:
+    if not source_run_key:
+        return None
+    source_run_row = await conn.fetchrow(
+        """
+        /* operator_visibility:get_source_runs_id */
+        SELECT id
+        FROM source_runs
+        WHERE source_run_key = $1
+        """,
+        source_run_key,
+    )
+    row = _row_to_dict(source_run_row)
+    if row is None:
+        return None
+    value = row.get('id')
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _source_run_summary_from_row(row_value: Any) -> OperatorSourceRunSummary:
+    row = _row_to_dict(row_value) or {}
+    bridge_present = _bool(row.get('bridge_present'))
+    return OperatorSourceRunSummary(
+        source_run_key=str(row.get('source_run_key') or ''),
+        source_name=_safe_text(row.get('source_name')),
+        source_category=_safe_text(row.get('source_category')),
+        domain=_safe_text(row.get('domain')),
+        import_scope=_safe_text(row.get('import_scope')),
+        status=_safe_text(row.get('status')),
+        started_at=row.get('started_at'),
+        finished_at=row.get('finished_at'),
+        duration_ms=_int_or_none(row.get('duration_ms')),
+        rows_read=_int_or_zero(row.get('rows_read')),
+        rows_staged=_int_or_zero(row.get('rows_staged')),
+        rows_rejected=_int_or_zero(row.get('rows_rejected')),
+        rows_skipped=_int_or_zero(row.get('rows_skipped')),
+        artifact_present=_bool(row.get('artifact_present')),
+        artifact_hash_present=_bool(row.get('artifact_hash_present')),
+        bridge_present=bridge_present,
+        staging_rows_known=bridge_present,
+        trigger_context=_safe_text(row.get('trigger_context')),
+        git_commit_sha=_safe_text(row.get('git_commit_sha')),
+        error_code=_safe_text(row.get('error_code')),
+        error_summary=_safe_text(row.get('error_summary')),
+    )
+
+
+def _bridge_summary_from_row(row_value: Any, *, source_run_key: str) -> OperatorBridgeSummary:
+    row = _row_to_dict(row_value) or {}
+    metadata = _mapping(row.get('metadata'))
+    staging_policy = _mapping(metadata.get('staging_policy'))
+    return OperatorBridgeSummary(
+        bridge_key=str(row.get('source_run_key') or _bridge_key(source_run_key)),
+        legacy_source_run_id=_int_or_none(row.get('id')),
+        source_run_key=source_run_key,
+        bridge_present=True,
+        dry_run=_bool_or_none(row.get('dry_run')),
+        adapter_name=_safe_text(row.get('adapter_name')),
+        adapter_version=_safe_text(row.get('adapter_version')),
+        target_staging_fk=_safe_text(metadata.get('target_staging_fk')) or TARGET_STAGING_FK,
+        metadata_has_compatibility_bridge=(
+            metadata.get('compatibility_bridge') is True
+            or metadata.get('schema_version') == BRIDGE_SCHEMA_VERSION
+        ),
+        staging_policy_blocks_source_runs_id=(
+            staging_policy.get('do_not_pass_source_runs_id_to_legacy_staging_source_run_id') is True
+        ),
+    )
+
+
+def _diagnostic_row_from_row(row_value: Any) -> OperatorDiagnosticRowSummary:
+    row = _row_to_dict(row_value) or {}
+    provenance = _mapping(row.get('provenance'))
+    marker_keys = sorted(
+        key for key in provenance.keys()
+        if key == STAGE19ANR_MARKER_KEY or key.startswith('stage19')
+    )
+    canonical_allowed = provenance.get('canonical_write_allowed')
+    return OperatorDiagnosticRowSummary(
+        row_id=_int_or_zero(row.get('id')),
+        legacy_source_run_id=_int_or_none(row.get('source_run_id')),
+        station_name=_safe_text(row.get('station_name')),
+        station_type=_safe_text(row.get('station_type')),
+        system_name=_safe_text(row.get('system_name')),
+        source_class=_safe_text(row.get('source_class')),
+        confidence=_safe_text(row.get('confidence')),
+        marker_keys=marker_keys,
+        canonical_write_allowed=canonical_allowed if isinstance(canonical_allowed, bool) else None,
+    )
+
+
+def _detail_warnings(
+    artifact: OperatorArtifactSummary,
+    bridge: OperatorBridgeSummary,
+    impact: OperatorStagingImpactSummary | None,
+) -> list[str]:
+    warnings: list[str] = []
+    if artifact.artifact_path_redacted is None:
+        warnings.append('source run has no artifact path in the ledger')
+    if artifact.artifact_sha256 is None or artifact.artifact_integrity_sha256 is None:
+        warnings.append('source run artifact hashes are incomplete')
+    if not bridge.bridge_present:
+        warnings.append('legacy enrichment_source_runs bridge is missing')
+    elif not bridge.staging_policy_blocks_source_runs_id:
+        warnings.append('bridge metadata does not record the source_runs.id staging block policy')
+    if impact is not None and impact.rows_using_source_runs_id:
+        warnings.append('staging rows exist under the new source_runs.id; legacy bridge FK path is suspect')
+    return warnings
+
+
+def _metadata_summary(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for key in (
+        'stage',
+        'operator_stage',
+        'source_adapter',
+        'bounded_rehearsal',
+        'staging_rows_written_by_explicit_stager',
+        'operation',
+    ):
+        if key in metadata:
+            summary[key] = _safe_json_scalar(metadata.get(key))
+    if isinstance(metadata.get('input_format'), Mapping):
+        summary['input_format_keys'] = sorted(str(key) for key in metadata['input_format'].keys())
+    artifact_record = _mapping(metadata.get('artifact_record'))
+    if artifact_record:
+        summary['artifact_record_present'] = True
+        summary['artifact_record_keys'] = sorted(
+            key for key in artifact_record.keys()
+            if key not in {'path', 'artifact_path'}
+        )
+        if artifact_record.get('bytes_written') is not None:
+            summary['artifact_bytes_written'] = _int_or_none(artifact_record.get('bytes_written'))
+    return summary
+
+
+def _operator_notes(metadata: Mapping[str, Any]) -> list[str]:
+    raw_notes = metadata.get('operator_notes')
+    if isinstance(raw_notes, str):
+        note = _safe_text(raw_notes)
+        return [note] if note else []
+    if isinstance(raw_notes, Sequence) and not isinstance(raw_notes, (str, bytes, bytearray)):
+        return [note for note in (_safe_text(item) for item in raw_notes) if note]
+    return []
+
+
+def _schema_version(metadata: Mapping[str, Any]) -> str | None:
+    for key in ('schema_version', 'artifact_schema_version'):
+        value = _safe_text(metadata.get(key))
+        if value:
+            return value
+    return None
+
+
+def _sanitized_mapping(value: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, item in _mapping(value).items():
+        key_text = str(key)
+        if _looks_sensitive_key(key_text):
+            result[key_text] = '[redacted]'
+        else:
+            result[key_text] = _safe_json_scalar(item)
+    return result
+
+
+def _safe_json_scalar(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): ('[redacted]' if _looks_sensitive_key(str(key)) else _safe_json_scalar(item))
+            for key, item in value.items()
+            if str(key) not in {'path', 'artifact_path', 'source_path'}
+        }
+    if isinstance(value, list):
+        return [_safe_json_scalar(item) for item in value[:10]]
+    if isinstance(value, tuple):
+        return [_safe_json_scalar(item) for item in value[:10]]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return _safe_text(value) if isinstance(value, str) else value
+    return _safe_text(value)
+
+
+def _row_to_dict(row: Any) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return dict(row)
+    try:
+        return dict(row)
+    except (TypeError, ValueError):
+        return {key: row[key] for key in row.keys()}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _bounded_limit(value: int | None, *, default: int) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(1, min(parsed, MAX_OPERATOR_VISIBILITY_LIMIT))
+
+
+def _required_positive_int(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f'{field} must be a positive integer')
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f'{field} must be a positive integer') from exc
+    if parsed < 1:
+        raise ValueError(f'{field} must be a positive integer')
+    return parsed
+
+
+def _bridge_key(source_run_key: str) -> str:
+    return f'{LEGACY_SOURCE_RUN_KEY_PREFIX}{source_run_key}'
+
+
+def _source_run_key_from_bridge_key(bridge_key: str | None) -> str | None:
+    if not bridge_key or not bridge_key.startswith(LEGACY_SOURCE_RUN_KEY_PREFIX):
+        return None
+    return bridge_key[len(LEGACY_SOURCE_RUN_KEY_PREFIX):]
+
+
+def _redact_uri(value: Any) -> str | None:
+    text = _safe_text(value)
+    if not text:
+        return None
+    parsed = urlsplit(text)
+    if parsed.scheme:
+        filename = PurePosixPath(parsed.path).name
+        if parsed.scheme == 'file':
+            return f'file://.../{filename}' if filename else 'file://...'
+        if parsed.username or parsed.password:
+            return f'{parsed.scheme}://[redacted]/{filename}' if filename else f'{parsed.scheme}://[redacted]'
+        return text
+    return _redact_path(text)
+
+
+def _redact_path(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    text = _SECRET_ASSIGNMENT_RE.sub(r'\1=[redacted]', text)
+    normalised = text.replace('\\', '/')
+    parsed = urlsplit(normalised)
+    if parsed.scheme:
+        return _redact_uri(normalised)
+    path = PurePosixPath(normalised)
+    parts = path.parts
+    private_markers = {'home', 'Users', 'tmp', 'var'}
+    if normalised.startswith('/') or normalised.startswith('~') or any(part in private_markers for part in parts):
+        return f'.../{path.name}' if path.name else '...'
+    if len(parts) > 3:
+        return str(PurePosixPath(*parts[-2:]))
+    return normalised
+
+
+def _safe_text(value: Any, max_length: int = 400) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    text = _SECRET_ASSIGNMENT_RE.sub(r'\1=[redacted]', text)
+    text = _PATH_IN_TEXT_RE.sub(lambda match: _redact_path(match.group(0)) or '[redacted]', text)
+    if len(text) > max_length:
+        return f'{text[:max_length - 3]}...'
+    return text
+
+
+def _looks_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return any(marker in lowered for marker in ('password', 'secret', 'token', 'api_key', 'apikey', 'dsn'))
+
+
+def _int_or_zero(value: Any) -> int:
+    parsed = _int_or_none(value)
+    return parsed if parsed is not None else 0
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool(value: Any) -> bool:
+    return value is True or value == 'true' or value == 't' or value == 1
+
+
+def _bool_or_none(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if value in ('true', 't', '1', 1):
+        return True
+    if value in ('false', 'f', '0', 0):
+        return False
+    return None
+
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r'(?i)\b(password|secret|token|api_key|apikey|dsn)\s*=\s*[^,\s;]+'
+)
+_PATH_IN_TEXT_RE = re.compile(r'(?<![\w:/.-])(?:/home|/var|/tmp)/[^\s,;]+')
+
+
+__all__ = [
+    'MAX_OPERATOR_VISIBILITY_LIMIT',
+    'OperatorArtifactSummary',
+    'OperatorBridgeSummary',
+    'OperatorDiagnosticRowSummary',
+    'OperatorSafetyGateSummary',
+    'OperatorSourceRunDetail',
+    'OperatorSourceRunSummary',
+    'OperatorStagingImpactSummary',
+    'get_legacy_bridge_for_source_run',
+    'get_operator_safety_gates',
+    'get_source_run_artifacts',
+    'get_source_run_detail',
+    'get_staging_impact_for_bridge',
+    'get_staging_impact_for_source_run',
+    'list_diagnostic_staging_rows',
+    'list_recent_source_runs',
+    'to_operator_visibility_dict',
+]

--- a/apps/api/src/routers/operator.py
+++ b/apps/api/src/routers/operator.py
@@ -1,0 +1,117 @@
+"""Read-only operator visibility endpoints for Stage 19 source-run state."""
+from __future__ import annotations
+
+from typing import Optional
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from deps import get_pool, require_admin
+from operator_visibility import (
+    get_legacy_bridge_for_source_run,
+    get_operator_safety_gates,
+    get_source_run_artifacts,
+    get_source_run_detail,
+    get_staging_impact_for_source_run,
+    list_diagnostic_staging_rows,
+    list_recent_source_runs,
+    to_operator_visibility_dict,
+)
+
+
+router = APIRouter(tags=['operator'])
+
+
+@router.get('/api/operator/source-runs', dependencies=[Depends(require_admin)])
+async def operator_source_runs(
+    limit: int = Query(25, ge=1),
+    status: Optional[str] = None,
+    source_name: Optional[str] = None,
+    domain: Optional[str] = None,
+    pool: asyncpg.Pool = Depends(get_pool),
+):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            rows = await list_recent_source_runs(
+                conn,
+                limit=limit,
+                status=status,
+                source_name=source_name,
+                domain=domain,
+            )
+    return to_operator_visibility_dict(rows)
+
+
+@router.get('/api/operator/source-runs/{source_run_key}', dependencies=[Depends(require_admin)])
+async def operator_source_run_detail(
+    source_run_key: str,
+    pool: asyncpg.Pool = Depends(get_pool),
+):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            detail = await get_source_run_detail(conn, source_run_key)
+    if detail is None:
+        raise HTTPException(404, 'Source run not found')
+    return to_operator_visibility_dict(detail)
+
+
+@router.get('/api/operator/source-runs/{source_run_key}/artifacts', dependencies=[Depends(require_admin)])
+async def operator_source_run_artifacts(
+    source_run_key: str,
+    pool: asyncpg.Pool = Depends(get_pool),
+):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            summary = await get_source_run_artifacts(conn, source_run_key)
+    return to_operator_visibility_dict(summary)
+
+
+@router.get('/api/operator/source-runs/{source_run_key}/bridge', dependencies=[Depends(require_admin)])
+async def operator_source_run_bridge(
+    source_run_key: str,
+    pool: asyncpg.Pool = Depends(get_pool),
+):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            summary = await get_legacy_bridge_for_source_run(conn, source_run_key)
+    return to_operator_visibility_dict(summary)
+
+
+@router.get('/api/operator/source-runs/{source_run_key}/staging-impact', dependencies=[Depends(require_admin)])
+async def operator_source_run_staging_impact(
+    source_run_key: str,
+    limit: int = Query(100, ge=1),
+    pool: asyncpg.Pool = Depends(get_pool),
+):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            impact = await get_staging_impact_for_source_run(conn, source_run_key, limit=limit)
+    return {
+        'source_run_key': source_run_key,
+        'bridge_present': impact is not None,
+        'staging_impact': to_operator_visibility_dict(impact) if impact is not None else None,
+    }
+
+
+@router.get('/api/operator/diagnostic-staging-rows', dependencies=[Depends(require_admin)])
+async def operator_diagnostic_staging_rows(
+    source_run_key: Optional[str] = None,
+    limit: int = Query(100, ge=1),
+    pool: asyncpg.Pool = Depends(get_pool),
+):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            rows = await list_diagnostic_staging_rows(
+                conn,
+                source_run_key=source_run_key,
+                limit=limit,
+            )
+    return to_operator_visibility_dict(rows)
+
+
+@router.get('/api/operator/safety-gates', dependencies=[Depends(require_admin)])
+async def operator_safety_gates(pool: asyncpg.Pool = Depends(get_pool)):
+    async with pool.acquire() as conn:
+        async with conn.transaction(readonly=True):
+            summary = await get_operator_safety_gates(conn)
+    return to_operator_visibility_dict(summary)

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -1145,6 +1145,125 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/operator/source-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Source Runs */
+        get: operations["operator_source_runs_api_operator_source_runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/operator/source-runs/{source_run_key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Source Run Detail */
+        get: operations["operator_source_run_detail_api_operator_source_runs__source_run_key__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/operator/source-runs/{source_run_key}/artifacts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Source Run Artifacts */
+        get: operations["operator_source_run_artifacts_api_operator_source_runs__source_run_key__artifacts_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/operator/source-runs/{source_run_key}/bridge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Source Run Bridge */
+        get: operations["operator_source_run_bridge_api_operator_source_runs__source_run_key__bridge_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/operator/source-runs/{source_run_key}/staging-impact": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Source Run Staging Impact */
+        get: operations["operator_source_run_staging_impact_api_operator_source_runs__source_run_key__staging_impact_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/operator/diagnostic-staging-rows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Diagnostic Staging Rows */
+        get: operations["operator_diagnostic_staging_rows_api_operator_diagnostic_staging_rows_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/operator/safety-gates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Operator Safety Gates */
+        get: operations["operator_safety_gates_api_operator_safety_gates_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -5874,6 +5993,218 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_source_runs_api_operator_source_runs_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+                status?: string | null;
+                source_name?: string | null;
+                domain?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_source_run_detail_api_operator_source_runs__source_run_key__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                source_run_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_source_run_artifacts_api_operator_source_runs__source_run_key__artifacts_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                source_run_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_source_run_bridge_api_operator_source_runs__source_run_key__bridge_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                source_run_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_source_run_staging_impact_api_operator_source_runs__source_run_key__staging_impact_get: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                source_run_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_diagnostic_staging_rows_api_operator_diagnostic_staging_rows_get: {
+        parameters: {
+            query?: {
+                source_run_key?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    operator_safety_gates_api_operator_safety_gates_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };

--- a/tests/test_stage19ap_operator_visibility.py
+++ b/tests/test_stage19ap_operator_visibility.py
@@ -1,0 +1,503 @@
+import inspect
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+API_SRC = ROOT / 'apps' / 'api' / 'src'
+API_ROUTERS = API_SRC / 'routers'
+if str(API_SRC) not in sys.path:
+    sys.path.insert(0, str(API_SRC))
+if str(API_ROUTERS) not in sys.path:
+    sys.path.insert(0, str(API_ROUTERS))
+
+import operator_visibility as visibility  # noqa: E402
+
+_ROUTER_SPEC = importlib.util.spec_from_file_location(
+    'stage19ap_operator_router',
+    API_ROUTERS / 'operator.py',
+)
+operator_router = importlib.util.module_from_spec(_ROUTER_SPEC)
+assert _ROUTER_SPEC.loader is not None
+_ROUTER_SPEC.loader.exec_module(operator_router)
+
+
+def source_run(**overrides):
+    row = {
+        'id': 101,
+        'source_run_key': 'stage19anr-run',
+        'source_name': 'edsm',
+        'source_category': 'source_of_evidence',
+        'domain': 'stations',
+        'import_scope': 'staging_only',
+        'status': 'succeeded',
+        'source_uri': 'file:///tmp/edsm-stations.json',
+        'source_input_sha256': 'a' * 64,
+        'source_manifest_sha256': None,
+        'started_at': '2026-06-06T10:00:00Z',
+        'finished_at': '2026-06-06T10:01:00Z',
+        'duration_ms': 60000,
+        'git_commit_sha': 'abc1234',
+        'importer_name': 'stage_19t_edsm_station_import_mvp',
+        'importer_version': 'v1',
+        'trigger_context': 'unit_test',
+        'artifact_path': '/var/lib/ed-finder/operator-artifacts/stage19anr-import.json',
+        'artifact_sha256': 'b' * 64,
+        'artifact_integrity_sha256': 'c' * 64,
+        'rows_read': 5,
+        'rows_staged': 5,
+        'rows_rejected': 0,
+        'rows_skipped': 0,
+        'error_code': None,
+        'error_summary': None,
+        'safety_boundary': {
+            'canonical_writes_planned': 0,
+            'canonical_apply_enabled': False,
+        },
+        'metadata': {
+            'stage': '19t',
+            'artifact_record': {
+                'path': '/var/lib/ed-finder/operator-artifacts/stage19anr-import.json',
+                'file_sha256': 'b' * 64,
+                'artifact_integrity_sha256': 'c' * 64,
+                'bytes_written': 1234,
+            },
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def legacy_bridge(**overrides):
+    row = {
+        'id': 701,
+        'source_run_key': 'source_runs:stage19anr-run',
+        'dry_run': False,
+        'adapter_name': 'stage19anr_warehouse_derived_compatible_stager',
+        'adapter_version': 'v1',
+        'metadata': {
+            'schema_version': visibility.BRIDGE_SCHEMA_VERSION,
+            'compatibility_bridge': True,
+            'target_staging_fk': visibility.TARGET_STAGING_FK,
+            'source_runs_provenance': {
+                'id': 101,
+                'source_run_key': 'stage19anr-run',
+            },
+            'staging_policy': {
+                'do_not_pass_source_runs_id_to_legacy_staging_source_run_id': True,
+                'legacy_source_run_id_required_for_legacy_staging': True,
+            },
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def staging_row(index=1, **overrides):
+    row = {
+        'id': 900 + index,
+        'source_run_id': 701,
+        'station_name': f'Stage 19 Port {index}',
+        'station_type': 'Coriolis Starport',
+        'system_name': f'Stage 19 System {index}',
+        'source_class': 'diagnostic-only',
+        'confidence': 'diagnostic-only',
+        'provenance': {
+            'canonical_write_allowed': False,
+            'stage19anr_diagnostic_mark': {'source_run_key': 'stage19anr-run'},
+        },
+        'raw_payload': {'full': 'payload must not be returned'},
+    }
+    row.update(overrides)
+    return row
+
+
+class FakeAsyncConn:
+    def __init__(self, *, source_runs=None, legacy_rows=None, staging_rows=None):
+        self.source_runs = list(source_runs or [])
+        self.legacy_rows = list(legacy_rows or [])
+        self.staging_rows = list(staging_rows or [])
+        self.statements = []
+
+    async def fetch(self, sql, *params):
+        self.statements.append((sql, params))
+        compact = ' '.join(sql.lower().split())
+
+        if 'operator_visibility:list_recent_source_runs' in compact:
+            limit = int(params[-1])
+            rows = list(self.source_runs)
+            rows.sort(key=lambda row: (row['started_at'], row['id']), reverse=True)
+            return [self._source_run_summary_row(row) for row in rows[:limit]]
+
+        if 'operator_visibility:get_staging_impact_for_bridge:sample' in compact:
+            legacy_id, limit = params
+            rows = [row for row in self.staging_rows if row['source_run_id'] == legacy_id]
+            rows.sort(key=lambda row: row['id'])
+            return [self._staging_projection(row) for row in rows[:int(limit)]]
+
+        if 'operator_visibility:list_diagnostic_staging_rows:by_source_run' in compact:
+            legacy_id, marker_key, limit = params
+            rows = [
+                row for row in self.staging_rows
+                if row['source_run_id'] == legacy_id and self._is_diagnostic(row, marker_key)
+            ]
+            rows.sort(key=lambda row: row['id'], reverse=True)
+            return [self._staging_projection(row) for row in rows[:int(limit)]]
+
+        if 'operator_visibility:list_diagnostic_staging_rows' in compact:
+            marker_key, limit = params
+            rows = [row for row in self.staging_rows if self._is_diagnostic(row, marker_key)]
+            rows.sort(key=lambda row: row['id'], reverse=True)
+            return [self._staging_projection(row) for row in rows[:int(limit)]]
+
+        raise AssertionError(f'unexpected fetch SQL: {sql}')
+
+    async def fetchrow(self, sql, *params):
+        self.statements.append((sql, params))
+        compact = ' '.join(sql.lower().split())
+
+        if 'operator_visibility:get_source_run_detail' in compact:
+            row = self._source_run_by_key(params[0])
+            return self._source_run_detail_row(row) if row else None
+
+        if 'operator_visibility:get_source_run_artifacts' in compact:
+            row = self._source_run_by_key(params[0])
+            if row is None:
+                return None
+            return {
+                key: row.get(key)
+                for key in (
+                    'source_run_key',
+                    'status',
+                    'artifact_path',
+                    'artifact_sha256',
+                    'artifact_integrity_sha256',
+                    'rows_read',
+                    'rows_staged',
+                    'metadata',
+                )
+            }
+
+        if 'operator_visibility:get_legacy_bridge_for_source_run' in compact:
+            return self._legacy_by_key(params[0])
+
+        if 'operator_visibility:get_bridge_by_legacy_id' in compact:
+            return self._legacy_by_id(params[0])
+
+        if 'operator_visibility:get_source_runs_id' in compact:
+            row = self._source_run_by_key(params[0])
+            return {'id': row['id']} if row else None
+
+        if 'operator_visibility:get_staging_impact_for_bridge:counts' in compact:
+            legacy_id, source_runs_id, marker_key = params
+            rows = [row for row in self.staging_rows if row['source_run_id'] == legacy_id]
+            source_runs_rows = [
+                row for row in self.staging_rows
+                if source_runs_id is not None and row['source_run_id'] == source_runs_id
+            ]
+            return {
+                'rows_total': len(rows),
+                'rows_diagnostic_only': sum(
+                    1 for row in rows
+                    if row['source_class'] == 'diagnostic-only'
+                    and row['confidence'] == 'diagnostic-only'
+                ),
+                'rows_canonical_write_blocked': sum(
+                    1 for row in rows
+                    if row['provenance'].get('canonical_write_allowed') is False
+                ),
+                'rows_with_stage_markers': sum(1 for row in rows if marker_key in row['provenance']),
+                'rows_using_source_runs_id': len(source_runs_rows),
+            }
+
+        if 'operator_visibility:get_operator_safety_gates:active' in compact:
+            return {'active_source_runs': sum(
+                1 for row in self.source_runs
+                if row['source_name'] == params[0]
+                and row['domain'] == params[1]
+                and row['import_scope'] == params[2]
+                and row['status'] in {'planned', 'running'}
+            )}
+
+        if 'operator_visibility:get_operator_safety_gates:failed' in compact:
+            return {'failed_unrecovered_source_runs': sum(
+                1 for row in self.source_runs
+                if row['source_name'] == params[0]
+                and row['domain'] == params[1]
+                and row['import_scope'] == params[2]
+                and row['status'] in {'failed', 'rejected'}
+            )}
+
+        if 'operator_visibility:get_operator_safety_gates:latest' in compact:
+            rows = [
+                row for row in self.source_runs
+                if row['source_name'] == params[0]
+                and row['domain'] == params[1]
+                and row['import_scope'] == params[2]
+                and row['status'] == 'succeeded'
+            ]
+            rows.sort(key=lambda row: (row['started_at'], row['id']), reverse=True)
+            if not rows:
+                return None
+            latest = rows[0]
+            return {
+                'source_run_key': latest['source_run_key'],
+                'artifact_path': latest['artifact_path'],
+                'artifact_sha256': latest['artifact_sha256'],
+                'artifact_integrity_sha256': latest['artifact_integrity_sha256'],
+            }
+
+        raise AssertionError(f'unexpected fetchrow SQL: {sql}')
+
+    def _source_run_by_key(self, source_run_key):
+        return next((row for row in self.source_runs if row['source_run_key'] == source_run_key), None)
+
+    def _legacy_by_key(self, bridge_key):
+        return next((row for row in self.legacy_rows if row['source_run_key'] == bridge_key), None)
+
+    def _legacy_by_id(self, legacy_id):
+        return next((row for row in self.legacy_rows if row['id'] == legacy_id), None)
+
+    def _bridge_present(self, source_run_key):
+        return self._legacy_by_key(f'source_runs:{source_run_key}') is not None
+
+    def _source_run_summary_row(self, row):
+        return {
+            key: row.get(key)
+            for key in (
+                'source_run_key',
+                'source_name',
+                'source_category',
+                'domain',
+                'import_scope',
+                'status',
+                'started_at',
+                'finished_at',
+                'duration_ms',
+                'rows_read',
+                'rows_staged',
+                'rows_rejected',
+                'rows_skipped',
+                'trigger_context',
+                'git_commit_sha',
+                'error_code',
+                'error_summary',
+            )
+        } | {
+            'artifact_present': row.get('artifact_path') is not None,
+            'artifact_hash_present': (
+                row.get('artifact_sha256') is not None
+                and row.get('artifact_integrity_sha256') is not None
+            ),
+            'bridge_present': self._bridge_present(row['source_run_key']),
+        }
+
+    def _source_run_detail_row(self, row):
+        return dict(row) | self._source_run_summary_row(row)
+
+    @staticmethod
+    def _staging_projection(row):
+        return {
+            key: row.get(key)
+            for key in (
+                'id',
+                'source_run_id',
+                'station_name',
+                'station_type',
+                'system_name',
+                'source_class',
+                'confidence',
+                'provenance',
+            )
+        }
+
+    @staticmethod
+    def _is_diagnostic(row, marker_key):
+        return (
+            row['source_class'] == 'diagnostic-only'
+            or row['confidence'] == 'diagnostic-only'
+            or marker_key in row['provenance']
+        )
+
+
+@pytest.mark.asyncio
+async def test_recent_source_runs_list_returns_bounded_summaries():
+    conn = FakeAsyncConn(
+        source_runs=[
+            source_run(source_run_key='older-run', id=100, started_at='2026-06-05T10:00:00Z'),
+            source_run(),
+        ],
+        legacy_rows=[legacy_bridge()],
+    )
+
+    rows = await visibility.list_recent_source_runs(conn, limit=25)
+
+    assert [row.source_run_key for row in rows] == ['stage19anr-run', 'older-run']
+    assert rows[0].artifact_present is True
+    assert rows[0].artifact_hash_present is True
+    assert rows[0].bridge_present is True
+    assert rows[0].staging_rows_known is True
+
+
+@pytest.mark.asyncio
+async def test_limit_hard_cap_is_enforced():
+    conn = FakeAsyncConn(source_runs=[source_run(id=index, source_run_key=f'run-{index}') for index in range(150)])
+
+    await visibility.list_recent_source_runs(conn, limit=1000)
+
+    sql, params = conn.statements[-1]
+    assert 'operator_visibility:list_recent_source_runs' in sql
+    assert params[-1] == visibility.MAX_OPERATOR_VISIBILITY_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_source_run_detail_handles_missing_bridge_and_artifact_gracefully():
+    conn = FakeAsyncConn(source_runs=[
+        source_run(
+            source_run_key='no-bridge',
+            artifact_path=None,
+            artifact_sha256=None,
+            artifact_integrity_sha256=None,
+            metadata={},
+        ),
+    ])
+
+    detail = await visibility.get_source_run_detail(conn, 'no-bridge')
+
+    assert detail is not None
+    assert detail.artifact_summary.artifact_path_redacted is None
+    assert detail.artifact_summary.artifact_record_present is False
+    assert detail.bridge_summary.bridge_present is False
+    assert detail.staging_impact_summary is None
+    assert 'legacy enrichment_source_runs bridge is missing' in detail.validation_warnings
+
+
+@pytest.mark.asyncio
+async def test_bridge_lookup_uses_deterministic_source_runs_key():
+    conn = FakeAsyncConn(legacy_rows=[legacy_bridge()])
+
+    bridge = await visibility.get_legacy_bridge_for_source_run(conn, 'stage19anr-run')
+
+    assert bridge.bridge_present is True
+    assert bridge.bridge_key == 'source_runs:stage19anr-run'
+    assert conn.statements[-1][1] == ('source_runs:stage19anr-run',)
+
+
+@pytest.mark.asyncio
+async def test_staging_impact_uses_legacy_bridge_id_not_source_runs_id():
+    conn = FakeAsyncConn(
+        source_runs=[source_run(id=101)],
+        legacy_rows=[legacy_bridge(id=701)],
+        staging_rows=[staging_row(1), staging_row(2)],
+    )
+
+    impact = await visibility.get_staging_impact_for_bridge(conn, 701, limit=10)
+
+    assert impact.legacy_source_run_id == 701
+    assert impact.rows_total == 2
+    assert impact.rows_using_legacy_bridge_id == 2
+    assert impact.rows_using_source_runs_id == 0
+    count_sql, count_params = next(
+        statement for statement in conn.statements
+        if 'get_staging_impact_for_bridge:counts' in statement[0]
+    )
+    sample_sql, sample_params = next(
+        statement for statement in conn.statements
+        if 'get_staging_impact_for_bridge:sample' in statement[0]
+    )
+    assert count_sql
+    assert count_params[:2] == (701, 101)
+    assert sample_sql
+    assert sample_params[0] == 701
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_rows_are_listed_with_bounded_limit_and_no_raw_payload():
+    conn = FakeAsyncConn(staging_rows=[staging_row(index) for index in range(1, 5)])
+
+    rows = await visibility.list_diagnostic_staging_rows(conn, limit=500)
+
+    assert len(rows) == 4
+    assert conn.statements[-1][1][-1] == visibility.MAX_OPERATOR_VISIBILITY_LIMIT
+    encoded = visibility.to_operator_visibility_dict(rows)
+    assert all('raw_payload' not in row for row in encoded)
+    assert encoded[0]['canonical_write_allowed'] is False
+
+
+@pytest.mark.asyncio
+async def test_safety_gate_summary_produces_blockers_for_running_and_failed_runs():
+    conn = FakeAsyncConn(
+        source_runs=[
+            source_run(),
+            source_run(id=102, source_run_key='running-run', status='running'),
+            source_run(id=103, source_run_key='failed-run', status='failed'),
+        ],
+        legacy_rows=[legacy_bridge()],
+        staging_rows=[staging_row(1), staging_row(2)],
+    )
+
+    summary = await visibility.get_operator_safety_gates(conn)
+
+    assert summary.no_running_source_runs is False
+    assert summary.no_failed_unrecovered_source_runs is False
+    assert summary.latest_artifacts_present is True
+    assert summary.bridge_fk_path_verified is True
+    assert summary.diagnostic_rows_isolated is True
+    assert summary.safe_to_proceed is False
+    assert any('planned/running source run' in blocker for blocker in summary.blockers)
+    assert any('failed/rejected source run' in blocker for blocker in summary.blockers)
+
+
+@pytest.mark.asyncio
+async def test_file_paths_are_redacted_or_normalized_when_returned():
+    conn = FakeAsyncConn(source_runs=[
+        source_run(
+            source_uri='file:///home/brian/private/edsm-stations.json',
+            artifact_path='/var/lib/ed-finder/operator-artifacts/stage19anr-import.json',
+        ),
+    ])
+
+    artifact = await visibility.get_source_run_artifacts(conn, 'stage19anr-run')
+    detail = await visibility.get_source_run_detail(conn, 'stage19anr-run')
+
+    assert artifact.artifact_path_redacted == '.../stage19anr-import.json'
+    assert detail.source_uri_redacted == 'file://.../edsm-stations.json'
+    encoded = visibility.to_operator_visibility_dict(detail)
+    assert '/var/lib' not in repr(encoded)
+    assert '/home/brian' not in repr(encoded)
+
+
+def test_static_guardrails_for_operator_visibility_module_and_router():
+    source = inspect.getsource(visibility) + inspect.getsource(operator_router)
+    source_upper = source.upper()
+
+    assert re.search(r'\bINSERT\s+INTO\b|\bUPDATE\s+\w+\b|\bDELETE\s+FROM\b', source, flags=re.IGNORECASE) is None
+    canonical_write_patterns = (
+        r'\binsert\s+into\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bupdate\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bdelete\s+from\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+    )
+    for pattern in canonical_write_patterns:
+        assert re.search(pattern, source, flags=re.IGNORECASE) is None
+
+    forbidden_fragments = (
+        'SYSTEMCTL',
+        'RUN_IMPORT',
+        'RUN_IMPORT.SH',
+        'DATABASE' + '_URL',
+        'POSTGRESQL' + '://',
+        'POSTGRES' + '://',
+        'PASSWORD' + '=',
+        'SECRET' + '=',
+        'TOKEN' + '=',
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in source_upper
+    assert re.search(r'(?<![a-z0-9_])\.timer(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+    assert re.search(r'(?<![a-z0-9_])\.service(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+    assert 'raw_payload' not in source
+    assert 'canonical_apply(' not in source


### PR DESCRIPTION
## Files added/changed

- `apps/api/src/operator_visibility.py` — read-only Stage 19AP repository/view-model helpers for source runs, artifact metadata, legacy bridge state, staging impact, diagnostic rows, and safety gates.
- `apps/api/src/routers/operator.py` — minimal admin-gated read-only `/api/operator/*` endpoints using readonly DB transactions.
- `apps/api/src/main.py` — wires the operator router into the FastAPI app.
- `tests/test_stage19ap_operator_visibility.py` — fake-DB unit tests and static guardrails.

## API endpoints

Implemented minimal read-only endpoints because the existing backend conventions were clear:

- `GET /api/operator/source-runs`
- `GET /api/operator/source-runs/{source_run_key}`
- `GET /api/operator/source-runs/{source_run_key}/artifacts`
- `GET /api/operator/source-runs/{source_run_key}/bridge`
- `GET /api/operator/source-runs/{source_run_key}/staging-impact`
- `GET /api/operator/diagnostic-staging-rows`
- `GET /api/operator/safety-gates`

All routes use the existing `require_admin` dependency and `transaction(readonly=True)` pattern.

## Read-only repository/view-model summary

Added dataclass view models for:

- `OperatorSourceRunSummary`
- `OperatorSourceRunDetail`
- `OperatorArtifactSummary`
- `OperatorBridgeSummary`
- `OperatorStagingImpactSummary`
- `OperatorDiagnosticRowSummary`
- `OperatorSafetyGateSummary`

Added repository functions for:

- `list_recent_source_runs(conn, limit=25, status=None, source_name=None, domain=None)`
- `get_source_run_detail(conn, source_run_key)`
- `get_source_run_artifacts(conn, source_run_key)`
- `get_legacy_bridge_for_source_run(conn, source_run_key)`
- `get_staging_impact_for_bridge(conn, legacy_source_run_id, limit=100)`
- `list_diagnostic_staging_rows(conn, source_run_key=None, limit=100)`
- `get_operator_safety_gates(conn)`

## Safety behavior

- Read-only SQL only; no DB writes are introduced.
- List/sample limits are hard-capped at 100.
- Source-run detail uses exact `source_run_key` lookup.
- Bridge lookup uses deterministic `source_runs:<source_run_key>` keys.
- Staging impact is keyed by `enrichment_source_runs.id`, with a separate exact check for accidental `source_runs.id` use.
- Diagnostic row summaries omit full `raw_payload`.
- Artifact handling is metadata-only; no filesystem artifact validation or arbitrary file reads are added.
- Local artifact paths/source URIs are redacted or normalized.
- Scheduler and canonical apply state are represented as assumed-disabled repository-state notes only; no service-manager checks are performed.

## Tests run

- `.venv/bin/python -m pytest tests/test_stage19ap_operator_visibility.py -q` — 9 passed.
- `.venv/bin/python -m pytest tests/test_stage19ap_operator_visibility.py tests/test_stage19anr_operator_script.py tests/test_source_run_compatibility.py tests/test_artifact_utils.py -q` — 43 passed.
- `.venv/bin/python -m py_compile apps/api/src/operator_visibility.py apps/api/src/routers/operator.py apps/api/src/main.py` — passed.
- `git diff --check` — passed.
- `git diff --cached --check` — passed.

## Confirmations

- No production DB access.
- No imports run.
- No scheduler/timer enablement.
- No canonical writes.
- No canonical apply.

## Known warnings

- Artifact file/hash validation is intentionally deferred until a later allowlisted artifact-path validation stage.
- Scheduler/canonical apply status is assumed from repository-known Stage 19 state; live service state requires a later explicitly approved operator check.