### PR TITLE
Stage 19AQ add operator cockpit UI

### DIFF
--- a/apps/api/src/routers/operator.py
+++ b/apps/api/src/routers/operator.py
@@ -42,9 +42,9 @@ async def operator_source_runs(
     return to_operator_visibility_dict(rows)
 
 
-@router.get('/api/operator/source-runs/{source_run_key}', dependencies=[Depends(require_admin)])
+@router.get('/api/operator/source-run-detail', dependencies=[Depends(require_admin)])
 async def operator_source_run_detail(
-    source_run_key: str,
+    source_run_key: str = Query(..., min_length=1),
     pool: asyncpg.Pool = Depends(get_pool),
 ):
     async with pool.acquire() as conn:
@@ -55,9 +55,9 @@ async def operator_source_run_detail(
     return to_operator_visibility_dict(detail)
 
 
-@router.get('/api/operator/source-runs/{source_run_key}/artifacts', dependencies=[Depends(require_admin)])
+@router.get('/api/operator/source-run-artifacts', dependencies=[Depends(require_admin)])
 async def operator_source_run_artifacts(
-    source_run_key: str,
+    source_run_key: str = Query(..., min_length=1),
     pool: asyncpg.Pool = Depends(get_pool),
 ):
     async with pool.acquire() as conn:
@@ -66,9 +66,9 @@ async def operator_source_run_artifacts(
     return to_operator_visibility_dict(summary)
 
 
-@router.get('/api/operator/source-runs/{source_run_key}/bridge', dependencies=[Depends(require_admin)])
+@router.get('/api/operator/source-run-bridge', dependencies=[Depends(require_admin)])
 async def operator_source_run_bridge(
-    source_run_key: str,
+    source_run_key: str = Query(..., min_length=1),
     pool: asyncpg.Pool = Depends(get_pool),
 ):
     async with pool.acquire() as conn:
@@ -77,9 +77,9 @@ async def operator_source_run_bridge(
     return to_operator_visibility_dict(summary)
 
 
-@router.get('/api/operator/source-runs/{source_run_key}/staging-impact', dependencies=[Depends(require_admin)])
+@router.get('/api/operator/source-run-staging-impact', dependencies=[Depends(require_admin)])
 async def operator_source_run_staging_impact(
-    source_run_key: str,
+    source_run_key: str = Query(..., min_length=1),
     limit: int = Query(100, ge=1),
     pool: asyncpg.Pool = Depends(get_pool),
 ):

--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -594,6 +594,32 @@ Recommended next stages:
 | Stage 19AR | Bounded 25-row staging pilot using operator visibility. |
 | Stage 19AS | Post-pilot verification and closeout. |
 
+## Stage 19AQ minimal operator cockpit UI closeout
+
+Stage 19AQ adds the first minimal read-only operator cockpit UI for Stage 19 source-run visibility.
+
+Committed scope:
+
+- `#operator` frontend route;
+- safety gates panel using Stage 19AP `GET /api/operator/safety-gates`;
+- recent source-runs table using `GET /api/operator/source-runs`;
+- selected source-run detail panel using `GET /api/operator/source-runs/{source_run_key}`;
+- diagnostic staging rows panel using `GET /api/operator/diagnostic-staging-rows`;
+- focused frontend tests and read-only API helper guardrails.
+
+Safety boundary:
+
+- no production DB access;
+- no imports;
+- no migrations;
+- no scheduler/timer enablement;
+- no staging writes;
+- no canonical writes;
+- no canonical apply;
+- no write actions or buttons added to the operator cockpit.
+
+Next recommended stage: Stage 19AR bounded 25-row staging pilot using the cockpit, only if safety gates remain green.
+
 ## Stage 19AL bounded EDSM staging smoke final closeout
 
 Stage 19AL closed the first bounded EDSM station staging-smoke chain.

--- a/docs/colonisation-redesign/stage-19aq-operator-cockpit-ui-closeout.md
+++ b/docs/colonisation-redesign/stage-19aq-operator-cockpit-ui-closeout.md
@@ -1,0 +1,35 @@
+# Stage 19AQ - Operator cockpit UI closeout
+
+## Summary
+
+Stage 19AQ adds a minimal read-only operator/admin cockpit UI for Data Warehouse Utopia.
+
+The cockpit is available at the frontend `#operator` route and consumes the Stage 19AP read-only operator visibility endpoints:
+
+- `GET /api/operator/safety-gates`;
+- `GET /api/operator/source-runs`;
+- `GET /api/operator/source-runs/{source_run_key}`;
+- `GET /api/operator/diagnostic-staging-rows`.
+
+## Panels
+
+- Safety Gates panel with safe/not-safe state, blockers, latest source run key, notes, and explicit scheduler/canonical-apply warnings.
+- Recent Source Runs table with source, domain, status, timestamps, row counts, artifact/hash state, bridge state, trigger context, and short git SHA.
+- Selected Source Run detail panel with redacted source/artifact paths, artifact summary, bridge summary, staging impact summary, validation warnings, and operator notes.
+- Diagnostic Rows panel showing diagnostic-only staging rows without raw payloads.
+
+## Safety boundary
+
+- Read-only UI only.
+- No production DB access.
+- No imports.
+- No migrations.
+- No scheduler/timer enablement.
+- No staging writes.
+- No canonical writes.
+- No canonical apply.
+- No import, scheduler, canonical write, or canonical apply buttons/actions added.
+
+## Next stage
+
+The next recommended stage is Stage 19AR: a bounded 25-row staging pilot using the cockpit, only if safety gates remain green.

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -21,6 +21,7 @@ import { useFcPlanner } from '@/features/fc-planner/useFcPlanner';
 import { FcPlannerTab } from '@/features/fc-planner/FcPlannerTab';
 import { useAdmin } from '@/features/admin/useAdmin';
 import { AdminTab } from '@/features/admin/AdminTab';
+import { OperatorCockpitTab } from '@/features/operator/OperatorCockpitTab';
 import { MapTab } from '@/features/map/MapTab';
 import { SystemDetailModal } from '@/features/system-detail/SystemDetailModal';
 import { ColonyPlannerWorkspace } from '@/features/colony-planner/ColonyPlannerWorkspace';
@@ -259,6 +260,10 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
 
       {route === 'admin' && (
         <AdminTab admin={admin} />
+      )}
+
+      {route === 'operator' && (
+        <OperatorCockpitTab />
       )}
 
       {route === 'map' && (

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -263,7 +263,7 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
       )}
 
       {route === 'operator' && (
-        <OperatorCockpitTab />
+        <OperatorCockpitTab admin={admin} />
       )}
 
       {route === 'map' && (

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -41,6 +41,7 @@ export function NavBar({
     { route: 'colony' as const, label: '🏗️ Colony Tracker', testid: 'nav-colony', badge: colonyCount },
     { route: 'map' as const, label: '🗺️ Map', testid: 'nav-map' },
     { route: 'admin' as const, label: '⚙️ Admin', testid: 'nav-admin' },
+    { route: 'operator' as const, label: 'Operator', testid: 'nav-operator' },
   ]), [watchlistCount, pinnedCount, compareCount, fcCount, colonyCount]);
 
   useEffect(() => {

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
@@ -337,12 +337,10 @@ describe('OperatorCockpitTab', () => {
     expect(screen.queryByText('Scoped Station / Scoped System / Scoped Type')).toBeNull();
   });
 
-  it('keeps selected source-run diagnostics when an earlier full refresh resolves later', async () => {
+  it('disables source-run selection during refresh and re-enables after refresh completes', async () => {
     const refreshGates = deferred<OperatorSafetyGateSummary>();
     const refreshRuns = deferred<OperatorSourceRunSummary[]>();
     const refreshDiagnostics = deferred<OperatorDiagnosticRowSummary[]>();
-    const selectedDetail = deferred<OperatorSourceRunDetail>();
-    const selectedDiagnostics = deferred<OperatorDiagnosticRowSummary[]>();
     let unscopedDiagnosticCalls = 0;
     apiMock.operatorSafetyGates
       .mockResolvedValueOnce(safety())
@@ -350,9 +348,18 @@ describe('OperatorCockpitTab', () => {
     apiMock.operatorSourceRuns
       .mockResolvedValueOnce([sourceRun()])
       .mockReturnValueOnce(refreshRuns.promise);
-    apiMock.operatorSourceRunDetail.mockReturnValue(selectedDetail.promise);
+    apiMock.operatorSourceRunDetail.mockResolvedValue(detail());
     apiMock.operatorDiagnosticRows.mockImplementation((_token, options = {}) => {
-      if (options.sourceRunKey === 'run-001') return selectedDiagnostics.promise;
+      if (options.sourceRunKey === 'run-001') {
+        return Promise.resolve([
+          diagnosticRow({
+            row_id: 601,
+            station_name: 'Scoped Station',
+            system_name: 'Scoped System',
+            station_type: 'Scoped Type',
+          }),
+        ]);
+      }
       unscopedDiagnosticCalls += 1;
       if (unscopedDiagnosticCalls === 1) {
         return Promise.resolve([
@@ -368,25 +375,13 @@ describe('OperatorCockpitTab', () => {
     });
     render(<OperatorCockpitTab admin={admin()} />);
 
-    fireEvent.click(await screen.findByRole('button', { name: 'run-001' }));
+    const sourceRunButton = await screen.findByRole('button', { name: 'run-001' });
     fireEvent.click(screen.getByTestId('operator-refresh'));
-    fireEvent.click(screen.getByRole('button', { name: 'run-001' }));
 
-    selectedDetail.resolve(detail({
-      operator_notes: ['Scoped detail remains selected.'],
-    }));
-    selectedDiagnostics.resolve([
-      diagnosticRow({
-        row_id: 601,
-        station_name: 'Scoped Station',
-        system_name: 'Scoped System',
-        station_type: 'Scoped Type',
-      }),
-    ]);
-
-    expect(await screen.findByText(/Diagnostic staging rows scoped to run-001\./)).toBeTruthy();
-    expect(screen.getByText('Scoped Station / Scoped System / Scoped Type')).toBeTruthy();
-    expect(screen.getByText('Scoped detail remains selected.')).toBeTruthy();
+    expect((screen.getByTestId('operator-refresh') as HTMLButtonElement).disabled).toBe(true);
+    expect((sourceRunButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(sourceRunButton);
+    expect(apiMock.operatorSourceRunDetail).not.toHaveBeenCalled();
 
     refreshGates.resolve(safety({ latest_source_run_key: 'refresh-run' }));
     refreshRuns.resolve([sourceRun()]);
@@ -400,10 +395,10 @@ describe('OperatorCockpitTab', () => {
     ]);
 
     await waitFor(() => {
-      expect(screen.getByText(/Diagnostic staging rows scoped to run-001\./)).toBeTruthy();
-      expect(screen.getByText('Scoped Station / Scoped System / Scoped Type')).toBeTruthy();
-      expect(screen.queryByText(/Latest diagnostic staging rows\./)).toBeNull();
-      expect(screen.queryByText('Unscoped Refresh Station / Unscoped Refresh System / Unscoped Refresh Type')).toBeNull();
+      expect((screen.getByTestId('operator-refresh') as HTMLButtonElement).disabled).toBe(false);
+      expect((sourceRunButton as HTMLButtonElement).disabled).toBe(false);
+      expect(screen.getByText(/Latest diagnostic staging rows\./)).toBeTruthy();
+      expect(screen.getByText('Unscoped Refresh Station / Unscoped Refresh System / Unscoped Refresh Type')).toBeTruthy();
     });
   });
 

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
@@ -337,6 +337,76 @@ describe('OperatorCockpitTab', () => {
     expect(screen.queryByText('Scoped Station / Scoped System / Scoped Type')).toBeNull();
   });
 
+  it('keeps selected source-run diagnostics when an earlier full refresh resolves later', async () => {
+    const refreshGates = deferred<OperatorSafetyGateSummary>();
+    const refreshRuns = deferred<OperatorSourceRunSummary[]>();
+    const refreshDiagnostics = deferred<OperatorDiagnosticRowSummary[]>();
+    const selectedDetail = deferred<OperatorSourceRunDetail>();
+    const selectedDiagnostics = deferred<OperatorDiagnosticRowSummary[]>();
+    let unscopedDiagnosticCalls = 0;
+    apiMock.operatorSafetyGates
+      .mockResolvedValueOnce(safety())
+      .mockReturnValueOnce(refreshGates.promise);
+    apiMock.operatorSourceRuns
+      .mockResolvedValueOnce([sourceRun()])
+      .mockReturnValueOnce(refreshRuns.promise);
+    apiMock.operatorSourceRunDetail.mockReturnValue(selectedDetail.promise);
+    apiMock.operatorDiagnosticRows.mockImplementation((_token, options = {}) => {
+      if (options.sourceRunKey === 'run-001') return selectedDiagnostics.promise;
+      unscopedDiagnosticCalls += 1;
+      if (unscopedDiagnosticCalls === 1) {
+        return Promise.resolve([
+          diagnosticRow({
+            row_id: 501,
+            station_name: 'Initial Station',
+            system_name: 'Initial System',
+            station_type: 'Initial Type',
+          }),
+        ]);
+      }
+      return refreshDiagnostics.promise;
+    });
+    render(<OperatorCockpitTab admin={admin()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'run-001' }));
+    fireEvent.click(screen.getByTestId('operator-refresh'));
+    fireEvent.click(screen.getByRole('button', { name: 'run-001' }));
+
+    selectedDetail.resolve(detail({
+      operator_notes: ['Scoped detail remains selected.'],
+    }));
+    selectedDiagnostics.resolve([
+      diagnosticRow({
+        row_id: 601,
+        station_name: 'Scoped Station',
+        system_name: 'Scoped System',
+        station_type: 'Scoped Type',
+      }),
+    ]);
+
+    expect(await screen.findByText(/Diagnostic staging rows scoped to run-001\./)).toBeTruthy();
+    expect(screen.getByText('Scoped Station / Scoped System / Scoped Type')).toBeTruthy();
+    expect(screen.getByText('Scoped detail remains selected.')).toBeTruthy();
+
+    refreshGates.resolve(safety({ latest_source_run_key: 'refresh-run' }));
+    refreshRuns.resolve([sourceRun()]);
+    refreshDiagnostics.resolve([
+      diagnosticRow({
+        row_id: 701,
+        station_name: 'Unscoped Refresh Station',
+        system_name: 'Unscoped Refresh System',
+        station_type: 'Unscoped Refresh Type',
+      }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Diagnostic staging rows scoped to run-001\./)).toBeTruthy();
+      expect(screen.getByText('Scoped Station / Scoped System / Scoped Type')).toBeTruthy();
+      expect(screen.queryByText(/Latest diagnostic staging rows\./)).toBeNull();
+      expect(screen.queryByText('Unscoped Refresh Station / Unscoped Refresh System / Unscoped Refresh Type')).toBeNull();
+    });
+  });
+
   it('renders diagnostic rows without raw payload text', async () => {
     const { container } = arrange();
 

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
@@ -7,7 +7,7 @@ import type {
   OperatorSourceRunDetail,
   OperatorSourceRunSummary,
 } from '@/types/api';
-import { OperatorCockpitTab } from './OperatorCockpitTab';
+import { OperatorCockpitTab, type OperatorCockpitTabProps } from './OperatorCockpitTab';
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -19,6 +19,28 @@ vi.mock('@/lib/api', () => ({
 }));
 
 const apiMock = vi.mocked(api);
+
+type TestAdmin = OperatorCockpitTabProps['admin'];
+
+function admin(overrides: Partial<TestAdmin> = {}): TestAdmin {
+  return {
+    token: 'test-token',
+    setToken: vi.fn(),
+    forgetToken: vi.fn(),
+    hasToken: true,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 function safety(overrides: Partial<OperatorSafetyGateSummary> = {}): OperatorSafetyGateSummary {
   return {
@@ -142,18 +164,19 @@ function arrange({
   runs = [sourceRun()],
   diagnostics = [diagnosticRow()],
   selectedDetail = detail(),
+  adminState = admin(),
 }: {
   gates?: OperatorSafetyGateSummary;
   runs?: OperatorSourceRunSummary[];
   diagnostics?: OperatorDiagnosticRowSummary[];
   selectedDetail?: OperatorSourceRunDetail;
+  adminState?: TestAdmin;
 } = {}) {
-  sessionStorage.setItem('ed_admin_token', 'test-token');
   apiMock.operatorSafetyGates.mockResolvedValue(gates);
   apiMock.operatorSourceRuns.mockResolvedValue(runs);
   apiMock.operatorSourceRunDetail.mockResolvedValue(selectedDetail);
   apiMock.operatorDiagnosticRows.mockResolvedValue(diagnostics);
-  return render(<OperatorCockpitTab />);
+  return render(<OperatorCockpitTab admin={adminState} />);
 }
 
 beforeEach(() => {
@@ -213,6 +236,107 @@ describe('OperatorCockpitTab', () => {
     expect(screen.getByText('Pilot remains blocked until gates stay green.')).toBeTruthy();
   });
 
+  it('ignores stale detail and diagnostic responses from an earlier selected source run', async () => {
+    const detailA = deferred<OperatorSourceRunDetail>();
+    const diagnosticsA = deferred<OperatorDiagnosticRowSummary[]>();
+    const detailB = deferred<OperatorSourceRunDetail>();
+    const diagnosticsB = deferred<OperatorDiagnosticRowSummary[]>();
+    arrange({
+      runs: [
+        sourceRun({ source_run_key: 'run-A' }),
+        sourceRun({ source_run_key: 'run-B', git_commit_sha: 'bbbbbbbb90abcdef' }),
+      ],
+      diagnostics: [diagnosticRow({ row_id: 1, station_name: 'Latest station' })],
+    });
+    apiMock.operatorSourceRunDetail.mockImplementation((_token, sourceRunKey) => (
+      sourceRunKey === 'run-A' ? detailA.promise : detailB.promise
+    ));
+    apiMock.operatorDiagnosticRows.mockImplementation((_token, options = {}) => {
+      if (options.sourceRunKey === 'run-A') return diagnosticsA.promise;
+      if (options.sourceRunKey === 'run-B') return diagnosticsB.promise;
+      return Promise.resolve([diagnosticRow({ row_id: 1, station_name: 'Latest station' })]);
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'run-A' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'run-B' }));
+
+    detailB.resolve(detail({
+      source_uri_redacted: '[redacted]/run-B.json',
+      operator_notes: ['B detail remains selected.'],
+    }));
+    diagnosticsB.resolve([
+      diagnosticRow({
+        row_id: 200,
+        station_name: 'B Station',
+        system_name: 'B System',
+        station_type: 'B Type',
+      }),
+    ]);
+
+    expect(await screen.findByText('[redacted]/run-B.json')).toBeTruthy();
+    expect(screen.getByText('B detail remains selected.')).toBeTruthy();
+    expect(screen.getByText('B Station / B System / B Type')).toBeTruthy();
+
+    detailA.resolve(detail({
+      source_uri_redacted: '[redacted]/run-A.json',
+      operator_notes: ['A detail must not overwrite B.'],
+    }));
+    diagnosticsA.resolve([
+      diagnosticRow({
+        row_id: 100,
+        station_name: 'A Station',
+        system_name: 'A System',
+        station_type: 'A Type',
+      }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByText('[redacted]/run-B.json')).toBeTruthy();
+      expect(screen.queryByText('[redacted]/run-A.json')).toBeNull();
+      expect(screen.queryByText('A Station / A System / A Type')).toBeNull();
+    });
+  });
+
+  it('clears selected source-run state on full refresh before showing unscoped diagnostics', async () => {
+    apiMock.operatorSafetyGates.mockResolvedValue(safety());
+    apiMock.operatorSourceRuns.mockResolvedValue([sourceRun()]);
+    apiMock.operatorSourceRunDetail.mockResolvedValue(detail());
+    apiMock.operatorDiagnosticRows.mockImplementation((_token, options = {}) => {
+      if (options.sourceRunKey) {
+        return Promise.resolve([
+          diagnosticRow({
+            row_id: 301,
+            station_name: 'Scoped Station',
+            system_name: 'Scoped System',
+            station_type: 'Scoped Type',
+          }),
+        ]);
+      }
+      return Promise.resolve([
+        diagnosticRow({
+          row_id: 401,
+          station_name: 'Latest Refresh Station',
+          system_name: 'Latest Refresh System',
+          station_type: 'Latest Refresh Type',
+        }),
+      ]);
+    });
+    render(<OperatorCockpitTab admin={admin()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'run-001' }));
+
+    expect(await screen.findByText(/Diagnostic staging rows scoped to run-001\./)).toBeTruthy();
+    expect(screen.getByText('Scoped Station / Scoped System / Scoped Type')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('operator-refresh'));
+
+    expect(await screen.findByText(/Latest diagnostic staging rows\./)).toBeTruthy();
+    expect(screen.getByText('Latest Refresh Station / Latest Refresh System / Latest Refresh Type')).toBeTruthy();
+    expect(screen.getByText('Select a source run to load detail.')).toBeTruthy();
+    expect(screen.queryByText(/Diagnostic staging rows scoped to run-001\./)).toBeNull();
+    expect(screen.queryByText('Scoped Station / Scoped System / Scoped Type')).toBeNull();
+  });
+
   it('renders diagnostic rows without raw payload text', async () => {
     const { container } = arrange();
 
@@ -243,5 +367,39 @@ describe('OperatorCockpitTab', () => {
     expect(buttonText).not.toMatch(/scheduler/i);
     expect(buttonText).not.toMatch(/canonical write/i);
     expect(buttonText).not.toMatch(/canonical apply/i);
+  });
+
+  it('uses the shared admin token handlers when saving and forgetting a token', async () => {
+    const setToken = vi.fn();
+    const forgetToken = vi.fn();
+    render(
+      <OperatorCockpitTab
+        admin={admin({
+          token: '',
+          hasToken: false,
+          setToken,
+          forgetToken,
+        })}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('operator-token-input'), {
+      target: { value: 'new-admin-token' },
+    });
+    fireEvent.click(screen.getByTestId('operator-token-save'));
+
+    expect(setToken).toHaveBeenCalledWith('new-admin-token');
+    expect(sessionStorage.getItem('ed_admin_token')).toBeNull();
+
+    cleanup();
+    apiMock.operatorSafetyGates.mockResolvedValue(safety());
+    apiMock.operatorSourceRuns.mockResolvedValue([]);
+    apiMock.operatorDiagnosticRows.mockResolvedValue([]);
+    render(<OperatorCockpitTab admin={admin({ forgetToken })} />);
+
+    expect(await screen.findByText('No source runs found.')).toBeTruthy();
+    fireEvent.click(screen.getByTestId('operator-token-forget'));
+
+    expect(forgetToken).toHaveBeenCalled();
   });
 });

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx
@@ -1,0 +1,247 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '@/lib/api';
+import type {
+  OperatorDiagnosticRowSummary,
+  OperatorSafetyGateSummary,
+  OperatorSourceRunDetail,
+  OperatorSourceRunSummary,
+} from '@/types/api';
+import { OperatorCockpitTab } from './OperatorCockpitTab';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    operatorSafetyGates: vi.fn(),
+    operatorSourceRuns: vi.fn(),
+    operatorSourceRunDetail: vi.fn(),
+    operatorDiagnosticRows: vi.fn(),
+  },
+}));
+
+const apiMock = vi.mocked(api);
+
+function safety(overrides: Partial<OperatorSafetyGateSummary> = {}): OperatorSafetyGateSummary {
+  return {
+    no_running_source_runs: true,
+    latest_artifacts_present: true,
+    bridge_fk_path_verified: true,
+    diagnostic_rows_isolated: true,
+    no_failed_unrecovered_source_runs: true,
+    scheduler_assumed_disabled: true,
+    canonical_apply_assumed_disabled: true,
+    safe_to_proceed: true,
+    blockers: [],
+    latest_source_run_key: 'run-001',
+    notes: ['Read-only visibility only.'],
+    ...overrides,
+  };
+}
+
+function sourceRun(overrides: Partial<OperatorSourceRunSummary> = {}): OperatorSourceRunSummary {
+  return {
+    source_run_key: 'run-001',
+    source_name: 'edsm',
+    source_category: 'nightly',
+    domain: 'stations',
+    import_scope: 'staging_only',
+    status: 'completed',
+    started_at: '2026-06-06T08:00:00Z',
+    finished_at: '2026-06-06T08:01:00Z',
+    duration_ms: 60_000,
+    rows_read: 25,
+    rows_staged: 25,
+    rows_rejected: 0,
+    rows_skipped: 0,
+    artifact_present: true,
+    artifact_hash_present: true,
+    bridge_present: true,
+    staging_rows_known: true,
+    trigger_context: 'manual_rehearsal',
+    git_commit_sha: '1234567890abcdef',
+    error_code: null,
+    error_summary: null,
+    ...overrides,
+  };
+}
+
+function diagnosticRow(overrides: Partial<OperatorDiagnosticRowSummary> = {}): OperatorDiagnosticRowSummary {
+  return {
+    row_id: 42,
+    legacy_source_run_id: 7,
+    station_name: 'Jameson Memorial',
+    station_type: 'Coriolis Starport',
+    system_name: 'Shinrarta Dezhra',
+    source_class: 'diagnostic-only',
+    confidence: 'high',
+    marker_keys: ['stage19anr_diagnostic_mark'],
+    canonical_write_allowed: false,
+    ...overrides,
+  };
+}
+
+function detail(overrides: Partial<OperatorSourceRunDetail> = {}): OperatorSourceRunDetail {
+  const summary = sourceRun();
+  return {
+    summary,
+    importer_name: 'operator-rehearsal',
+    importer_version: '19ap',
+    source_uri_redacted: '[redacted]/nightly/edsm-stations.json',
+    source_input_sha256: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    source_manifest_sha256: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    safety_boundary: { read_only: true },
+    metadata_summary: { keys: ['operator_notes'] },
+    artifact_summary: {
+      source_run_key: summary.source_run_key,
+      artifact_path_redacted: '[redacted]/artifacts/edsm-stations.json',
+      artifact_sha256: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+      artifact_integrity_sha256: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+      artifact_record_present: true,
+      file_exists: true,
+      file_sha256_matches: true,
+      integrity_hash_matches: true,
+      schema_version: 'source_run_artifact/v1',
+      rows_read: 25,
+      rows_staged: 25,
+      status: 'present',
+      validation_note: 'Artifact hash verified.',
+    },
+    bridge_summary: {
+      bridge_key: 'source_runs:run-001',
+      legacy_source_run_id: 7,
+      source_run_key: summary.source_run_key,
+      bridge_present: true,
+      dry_run: true,
+      adapter_name: 'source-run-compat',
+      adapter_version: 'v1',
+      target_staging_fk: 'enrichment_source_runs(id)',
+      metadata_has_compatibility_bridge: true,
+      staging_policy_blocks_source_runs_id: true,
+    },
+    staging_impact_summary: {
+      source_run_key: summary.source_run_key,
+      bridge_key: 'source_runs:run-001',
+      legacy_source_run_id: 7,
+      staging_table: 'staging_edsm_stations',
+      rows_total: 25,
+      rows_diagnostic_only: 25,
+      rows_canonical_write_blocked: 25,
+      rows_with_stage_markers: 25,
+      rows_using_legacy_bridge_id: 25,
+      rows_using_source_runs_id: 0,
+      sample_rows: [diagnosticRow()],
+      warnings: [],
+    },
+    validation_warnings: [],
+    operator_notes: ['Pilot remains blocked until gates stay green.'],
+    ...overrides,
+  };
+}
+
+function arrange({
+  gates = safety(),
+  runs = [sourceRun()],
+  diagnostics = [diagnosticRow()],
+  selectedDetail = detail(),
+}: {
+  gates?: OperatorSafetyGateSummary;
+  runs?: OperatorSourceRunSummary[];
+  diagnostics?: OperatorDiagnosticRowSummary[];
+  selectedDetail?: OperatorSourceRunDetail;
+} = {}) {
+  sessionStorage.setItem('ed_admin_token', 'test-token');
+  apiMock.operatorSafetyGates.mockResolvedValue(gates);
+  apiMock.operatorSourceRuns.mockResolvedValue(runs);
+  apiMock.operatorSourceRunDetail.mockResolvedValue(selectedDetail);
+  apiMock.operatorDiagnosticRows.mockResolvedValue(diagnostics);
+  return render(<OperatorCockpitTab />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('OperatorCockpitTab', () => {
+  it('renders green safety gate state', async () => {
+    arrange();
+
+    expect(await screen.findByText('Safe to proceed')).toBeTruthy();
+    expect(screen.getByText(/Scheduler\/timers remain assumed disabled/i)).toBeTruthy();
+    expect(screen.getByText(/The 25-row pilot should not proceed if safety gates are red/i)).toBeTruthy();
+  });
+
+  it('renders red safety gate blockers', async () => {
+    arrange({
+      gates: safety({
+        safe_to_proceed: false,
+        latest_artifacts_present: false,
+        blockers: ['latest artifacts missing', 'diagnostic rows are not isolated'],
+      }),
+    });
+
+    expect(await screen.findByText('Not safe to proceed')).toBeTruthy();
+    expect(screen.getByText('latest artifacts missing')).toBeTruthy();
+    expect(screen.getByText('diagnostic rows are not isolated')).toBeTruthy();
+  });
+
+  it('renders recent source run rows', async () => {
+    arrange();
+
+    expect(await screen.findByRole('button', { name: 'run-001' })).toBeTruthy();
+    expect(screen.getByText('edsm / nightly / stations / staging_only')).toBeTruthy();
+    expect(screen.getByText(/25 read \/ 25 staged \/ 0 rejected \/ 0 skipped/i)).toBeTruthy();
+    expect(screen.getByText('manual_rehearsal')).toBeTruthy();
+    expect(screen.getByText('12345678')).toBeTruthy();
+  });
+
+  it('selects a source run and renders detail panels', async () => {
+    arrange();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'run-001' }));
+
+    await waitFor(() => {
+      expect(apiMock.operatorSourceRunDetail).toHaveBeenCalledWith('test-token', 'run-001');
+    });
+    expect(await screen.findByText('Artifact summary')).toBeTruthy();
+    expect(screen.getByText('Bridge summary')).toBeTruthy();
+    expect(screen.getByText('Staging impact summary')).toBeTruthy();
+    expect(screen.getByText('[redacted]/artifacts/edsm-stations.json')).toBeTruthy();
+    expect(screen.getByText('Pilot remains blocked until gates stay green.')).toBeTruthy();
+  });
+
+  it('renders diagnostic rows without raw payload text', async () => {
+    const { container } = arrange();
+
+    expect(await screen.findByText('Jameson Memorial / Shinrarta Dezhra / Coriolis Starport')).toBeTruthy();
+    expect(screen.getByText('stage19anr_diagnostic_mark')).toBeTruthy();
+    expect(container.textContent).not.toMatch(/raw_payload|payload_json|secret_source_payload/i);
+  });
+
+  it('keeps redacted paths and URIs redacted in detail', async () => {
+    const { container } = arrange();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'run-001' }));
+
+    expect(await screen.findByText('[redacted]/nightly/edsm-stations.json')).toBeTruthy();
+    expect(screen.getByText('[redacted]/artifacts/edsm-stations.json')).toBeTruthy();
+    expect(container.textContent).not.toMatch(/C:\\prod\\warehouse|s3:\/\/ed-prod-private/i);
+  });
+
+  it('does not expose import, scheduler, canonical write, or canonical apply action buttons', async () => {
+    arrange();
+
+    await screen.findByText('Safe to proceed');
+    const buttonText = screen.getAllByRole('button')
+      .map((button) => button.textContent ?? '')
+      .join(' ');
+
+    expect(buttonText).not.toMatch(/import/i);
+    expect(buttonText).not.toMatch(/scheduler/i);
+    expect(buttonText).not.toMatch(/canonical write/i);
+    expect(buttonText).not.toMatch(/canonical apply/i);
+  });
+});

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
@@ -331,7 +331,8 @@ function SourceRunsTable({
                     <button
                       type="button"
                       onClick={() => onSelect(run.source_run_key)}
-                      className="text-left text-orange-lt underline decoration-orange/40 underline-offset-2 hover:text-orange"
+                      disabled={loading}
+                      className="text-left text-orange-lt underline decoration-orange/40 underline-offset-2 hover:text-orange disabled:text-silver-dk disabled:no-underline disabled:cursor-not-allowed"
                     >
                       {run.source_run_key}
                     </button>

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
@@ -87,6 +87,7 @@ export function OperatorCockpitTab({ admin }: OperatorCockpitTabProps) {
 
   const selectSourceRun = useCallback(async (sourceRunKey: string) => {
     if (!admin.token) return;
+    cockpitRequestSeq.current += 1;
     const requestSeq = detailRequestSeq.current + 1;
     detailRequestSeq.current = requestSeq;
     setSelectedKey(sourceRunKey);

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
@@ -1,0 +1,622 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+import type {
+  OperatorArtifactSummary,
+  OperatorBridgeSummary,
+  OperatorDiagnosticRowSummary,
+  OperatorSafetyGateSummary,
+  OperatorSourceRunDetail,
+  OperatorSourceRunSummary,
+  OperatorStagingImpactSummary,
+} from '@/types/api';
+
+const TOKEN_KEY = 'ed_admin_token';
+const RECENT_LIMIT = 25;
+
+type LoadState = 'idle' | 'loading' | 'ok' | 'err';
+
+export function OperatorCockpitTab() {
+  const [token, setToken] = useState(() => sessionStorage.getItem(TOKEN_KEY) ?? '');
+  const [tokenDraft, setTokenDraft] = useState(token);
+  const [loadState, setLoadState] = useState<LoadState>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [safetyGates, setSafetyGates] = useState<OperatorSafetyGateSummary | null>(null);
+  const [sourceRuns, setSourceRuns] = useState<OperatorSourceRunSummary[]>([]);
+  const [diagnosticRows, setDiagnosticRows] = useState<OperatorDiagnosticRowSummary[]>([]);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [detail, setDetail] = useState<OperatorSourceRunDetail | null>(null);
+  const [detailState, setDetailState] = useState<LoadState>('idle');
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const persistToken = (nextToken: string) => {
+    setToken(nextToken);
+    setTokenDraft(nextToken);
+    if (nextToken) sessionStorage.setItem(TOKEN_KEY, nextToken);
+    else sessionStorage.removeItem(TOKEN_KEY);
+  };
+
+  const loadCockpit = useCallback(async () => {
+    if (!token) {
+      setLoadState('idle');
+      setSafetyGates(null);
+      setSourceRuns([]);
+      setDiagnosticRows([]);
+      setSelectedKey(null);
+      setDetail(null);
+      setDetailState('idle');
+      setError(null);
+      return;
+    }
+
+    setLoadState('loading');
+    setError(null);
+    try {
+      const [gates, runs, diagnostics] = await Promise.all([
+        api.operatorSafetyGates(token),
+        api.operatorSourceRuns(token, RECENT_LIMIT),
+        api.operatorDiagnosticRows(token, { limit: RECENT_LIMIT }),
+      ]);
+      setSafetyGates(gates);
+      setSourceRuns(runs);
+      setDiagnosticRows(diagnostics);
+      setLoadState('ok');
+    } catch (caught: unknown) {
+      setSafetyGates(null);
+      setSourceRuns([]);
+      setDiagnosticRows([]);
+      setLoadState('err');
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void loadCockpit();
+  }, [loadCockpit]);
+
+  const selectSourceRun = useCallback(async (sourceRunKey: string) => {
+    if (!token) return;
+    setSelectedKey(sourceRunKey);
+    setDetailState('loading');
+    setDetailError(null);
+    try {
+      const [nextDetail, nextDiagnostics] = await Promise.all([
+        api.operatorSourceRunDetail(token, sourceRunKey),
+        api.operatorDiagnosticRows(token, { sourceRunKey, limit: RECENT_LIMIT }),
+      ]);
+      setDetail(nextDetail);
+      setDiagnosticRows(nextDiagnostics);
+      setDetailState('ok');
+    } catch (caught: unknown) {
+      setDetail(null);
+      setDetailState('err');
+      setDetailError(caught instanceof Error ? caught.message : String(caught));
+    }
+  }, [token]);
+
+  return (
+    <section data-testid="operator-cockpit" className="space-y-5">
+      <header className="panel flex flex-wrap items-center gap-3 px-5 py-3">
+        <div>
+          <h2 className="font-display text-orange tracking-[0.14em] text-lg">Operator cockpit</h2>
+          <p className="font-mono text-xs text-silver-dk">
+            read-only warehouse instruments before throttle
+          </p>
+        </div>
+        <span className="flex-1" />
+        <button
+          type="button"
+          onClick={() => void loadCockpit()}
+          disabled={!token || loadState === 'loading'}
+          data-testid="operator-refresh"
+          className="btn-metal text-[11px] py-1.5 px-3 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Refresh cockpit
+        </button>
+      </header>
+
+      <section className="panel p-5 space-y-3">
+        <h3 className="font-display text-orange text-xs uppercase tracking-[0.18em]">
+          Admin access
+        </h3>
+        <p className="text-[11px] text-silver-dk leading-snug">
+          This page is read-only. It uses Stage 19AP operator visibility endpoints and does not run imports,
+          enable scheduler/timers, write canonical tables, or run canonical apply.
+        </p>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="password"
+            value={tokenDraft}
+            onChange={(event) => setTokenDraft(event.target.value)}
+            placeholder="X-Admin-Token"
+            data-testid="operator-token-input"
+            className="flex-1 min-w-[220px]"
+            autoComplete="off"
+          />
+          <button
+            type="button"
+            onClick={() => persistToken(tokenDraft.trim())}
+            data-testid="operator-token-save"
+            className="btn-primary text-[11px] py-1.5 px-3"
+          >
+            Save token
+          </button>
+          {token && (
+            <button
+              type="button"
+              onClick={() => persistToken('')}
+              data-testid="operator-token-forget"
+              className="btn-metal text-[11px] py-1.5 px-3"
+            >
+              Forget token
+            </button>
+          )}
+          <span className={token ? 'font-mono text-[10px] text-green' : 'font-mono text-[10px] text-silver-dk'}>
+            {token ? 'Token set' : 'No token'}
+          </span>
+        </div>
+      </section>
+
+      {loadState === 'loading' && (
+        <div className="text-text-dim font-mono text-sm py-8 text-center">
+          Loading cockpit...
+        </div>
+      )}
+
+      {loadState === 'err' && (
+        <div className="rounded border border-red/50 bg-red/10 p-4 font-mono text-sm text-red">
+          <div className="font-bold mb-1">Failed to load operator cockpit.</div>
+          {error && <div className="text-xs">{error}</div>}
+        </div>
+      )}
+
+      {!token && (
+        <div className="panel p-5 text-[11px] text-silver-dk font-mono">
+          Set an admin token to load the read-only operator cockpit.
+        </div>
+      )}
+
+      {token && (
+        <>
+          <SafetyGatesPanel safetyGates={safetyGates} loading={loadState === 'loading'} />
+          <SourceRunsTable
+            sourceRuns={sourceRuns}
+            selectedKey={selectedKey}
+            loading={loadState === 'loading'}
+            onSelect={(sourceRunKey) => void selectSourceRun(sourceRunKey)}
+          />
+          <SourceRunDetailPanel
+            selectedKey={selectedKey}
+            detail={detail}
+            detailState={detailState}
+            detailError={detailError}
+          />
+          <DiagnosticRowsPanel rows={diagnosticRows} selectedKey={selectedKey} />
+        </>
+      )}
+    </section>
+  );
+}
+
+function SafetyGatesPanel({
+  safetyGates,
+  loading,
+}: {
+  safetyGates: OperatorSafetyGateSummary | null;
+  loading: boolean;
+}) {
+  const safe = safetyGates?.safe_to_proceed === true;
+  const statusClass = !safetyGates
+    ? 'border-border bg-bg3/40 text-silver-dk'
+    : safe
+      ? 'border-green/50 bg-green/10 text-green'
+      : 'border-red/50 bg-red/10 text-red';
+  const statusLabel = !safetyGates
+    ? 'Safety gates pending'
+    : safe
+      ? 'Safe to proceed'
+      : 'Not safe to proceed';
+
+  return (
+    <section className="panel p-5 space-y-4" data-testid="operator-safety-gates">
+      <div className="flex flex-wrap items-center gap-3">
+        <h3 className="font-display text-orange text-xs uppercase tracking-[0.18em]">
+          1. Safety gates
+        </h3>
+        <span
+          className={[
+            'rounded-chunk-sm border px-2 py-1 font-mono text-[11px]',
+            statusClass,
+          ].join(' ')}
+        >
+          {statusLabel}
+        </span>
+        {loading && <span className="font-mono text-[10px] text-orange-lt">refreshing...</span>}
+      </div>
+
+      <p className="text-[11px] leading-snug text-silver-dk">
+        Scheduler/timers remain assumed disabled. Canonical apply remains assumed disabled.
+        Diagnostic rows are not canonical candidates. The 25-row pilot should not proceed if safety gates are red.
+      </p>
+
+      {safetyGates ? (
+        <>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3 font-mono text-xs">
+            <Flag label="No running runs" value={safetyGates.no_running_source_runs} />
+            <Flag label="Artifacts present" value={safetyGates.latest_artifacts_present} />
+            <Flag label="Bridge FK verified" value={safetyGates.bridge_fk_path_verified} />
+            <Flag label="Diagnostics isolated" value={safetyGates.diagnostic_rows_isolated} />
+            <Flag label="No unrecovered failures" value={safetyGates.no_failed_unrecovered_source_runs} />
+            <Flag label="Scheduler disabled" value={safetyGates.scheduler_assumed_disabled} />
+            <Flag label="Canonical apply disabled" value={safetyGates.canonical_apply_assumed_disabled} />
+            <Stat label="Latest source run" value={safetyGates.latest_source_run_key ?? '-'} />
+          </div>
+          <WarningList title="Blockers" items={safetyGates.blockers} empty="No blockers reported." danger />
+          <WarningList title="Notes" items={safetyGates.notes} empty="No operator notes reported." />
+        </>
+      ) : (
+        <p className="text-[11px] text-silver-dk font-mono">
+          Safety gate status has not loaded yet.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function SourceRunsTable({
+  sourceRuns,
+  selectedKey,
+  loading,
+  onSelect,
+}: {
+  sourceRuns: OperatorSourceRunSummary[];
+  selectedKey: string | null;
+  loading: boolean;
+  onSelect: (sourceRunKey: string) => void;
+}) {
+  return (
+    <section className="panel p-5 space-y-3" data-testid="operator-source-runs">
+      <div className="flex flex-wrap items-center gap-3">
+        <h3 className="font-display text-orange text-xs uppercase tracking-[0.18em]">
+          2. Recent source runs
+        </h3>
+        {loading && <span className="font-mono text-[10px] text-orange-lt">refreshing...</span>}
+      </div>
+      {sourceRuns.length === 0 ? (
+        <p className="text-[11px] text-silver-dk font-mono">No source runs found.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[1120px] text-left font-mono text-[11px]">
+            <thead className="text-silver-dk uppercase tracking-[0.12em]">
+              <tr>
+                <th className="py-2 pr-3">Source run key</th>
+                <th className="py-2 pr-3">Source / category / domain / scope</th>
+                <th className="py-2 pr-3">Status</th>
+                <th className="py-2 pr-3">Started / finished</th>
+                <th className="py-2 pr-3">Rows</th>
+                <th className="py-2 pr-3">Artifact / hash</th>
+                <th className="py-2 pr-3">Bridge</th>
+                <th className="py-2 pr-3">Trigger</th>
+                <th className="py-2 pr-3">Git</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sourceRuns.map((run) => (
+                <tr
+                  key={run.source_run_key}
+                  className={[
+                    'border-t border-border/60 align-top',
+                    selectedKey === run.source_run_key ? 'bg-orange/10' : '',
+                  ].join(' ')}
+                >
+                  <td className="py-2 pr-3">
+                    <button
+                      type="button"
+                      onClick={() => onSelect(run.source_run_key)}
+                      className="text-left text-orange-lt underline decoration-orange/40 underline-offset-2 hover:text-orange"
+                    >
+                      {run.source_run_key}
+                    </button>
+                  </td>
+                  <td className="py-2 pr-3 text-silver">
+                    {joinDefined([run.source_name, run.source_category, run.domain, run.import_scope])}
+                  </td>
+                  <td className="py-2 pr-3 text-silver">{run.status ?? '-'}</td>
+                  <td className="py-2 pr-3 text-silver-dk">
+                    {formatDate(run.started_at)} / {formatDate(run.finished_at)}
+                  </td>
+                  <td className="py-2 pr-3 text-silver">
+                    {run.rows_read.toLocaleString()} read / {run.rows_staged.toLocaleString()} staged /
+                    {' '}{run.rows_rejected.toLocaleString()} rejected / {run.rows_skipped.toLocaleString()} skipped
+                  </td>
+                  <td className="py-2 pr-3 text-silver-dk">
+                    {formatBool(run.artifact_present)} / {formatBool(run.artifact_hash_present)}
+                  </td>
+                  <td className="py-2 pr-3 text-silver-dk">{formatBool(run.bridge_present)}</td>
+                  <td className="py-2 pr-3 text-silver-dk">{run.trigger_context ?? '-'}</td>
+                  <td className="py-2 pr-3 text-silver-dk">{shortSha(run.git_commit_sha)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SourceRunDetailPanel({
+  selectedKey,
+  detail,
+  detailState,
+  detailError,
+}: {
+  selectedKey: string | null;
+  detail: OperatorSourceRunDetail | null;
+  detailState: LoadState;
+  detailError: string | null;
+}) {
+  return (
+    <section className="panel p-5 space-y-3" data-testid="operator-source-run-detail">
+      <h3 className="font-display text-orange text-xs uppercase tracking-[0.18em]">
+        3. Selected source run detail
+      </h3>
+      {!selectedKey && (
+        <p className="text-[11px] text-silver-dk font-mono">
+          Select a source run to load detail.
+        </p>
+      )}
+      {selectedKey && detailState === 'loading' && (
+        <p className="text-[11px] text-silver-dk font-mono">
+          Loading detail for {selectedKey}...
+        </p>
+      )}
+      {selectedKey && detailState === 'err' && (
+        <div className="panel-thin border-red/50 p-2 font-mono text-xs text-red" style={{ background: 'rgba(248,113,113,0.10)' }}>
+          <div>Detail unavailable.</div>
+          {detailError && <div>{detailError}</div>}
+        </div>
+      )}
+      {detail && detailState === 'ok' && (
+        <div className="space-y-3">
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-3 font-mono text-xs">
+            <Stat label="Source URI" value={detail.source_uri_redacted ?? '-'} />
+            <Stat label="Importer" value={joinDefined([detail.importer_name, detail.importer_version])} />
+            <Stat label="Input hash" value={shortHash(detail.source_input_sha256)} />
+            <Stat label="Manifest hash" value={shortHash(detail.source_manifest_sha256)} />
+          </div>
+          <div className="grid lg:grid-cols-3 gap-3">
+            <ArtifactSummaryPanel artifact={detail.artifact_summary} />
+            <BridgeSummaryPanel bridge={detail.bridge_summary} />
+            <StagingImpactPanel impact={detail.staging_impact_summary} />
+          </div>
+          <WarningList title="Validation warnings" items={detail.validation_warnings} empty="No validation warnings reported." danger />
+          <WarningList title="Operator notes" items={detail.operator_notes} empty="No operator notes reported." />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ArtifactSummaryPanel({ artifact }: { artifact: OperatorArtifactSummary }) {
+  return (
+    <div className="panel-thin p-3 space-y-2">
+      <div className="font-display text-orange text-[11px] uppercase tracking-[0.16em]">
+        Artifact summary
+      </div>
+      <MetricList rows={[
+        ['Path', artifact.artifact_path_redacted ?? '-'],
+        ['Record', formatBool(artifact.artifact_record_present)],
+        ['File exists', formatNullableBool(artifact.file_exists)],
+        ['File hash', shortHash(artifact.artifact_sha256)],
+        ['Integrity hash', shortHash(artifact.artifact_integrity_sha256)],
+        ['Schema', artifact.schema_version ?? '-'],
+        ['Rows', `${artifact.rows_read.toLocaleString()} read / ${artifact.rows_staged.toLocaleString()} staged`],
+        ['Status', artifact.status ?? '-'],
+        ['Validation', artifact.validation_note],
+      ]} />
+    </div>
+  );
+}
+
+function BridgeSummaryPanel({ bridge }: { bridge: OperatorBridgeSummary }) {
+  return (
+    <div className="panel-thin p-3 space-y-2">
+      <div className="font-display text-orange text-[11px] uppercase tracking-[0.16em]">
+        Bridge summary
+      </div>
+      <MetricList rows={[
+        ['Present', formatBool(bridge.bridge_present)],
+        ['Bridge key', bridge.bridge_key],
+        ['Legacy id', bridge.legacy_source_run_id == null ? '-' : String(bridge.legacy_source_run_id)],
+        ['Adapter', joinDefined([bridge.adapter_name, bridge.adapter_version])],
+        ['Target FK', bridge.target_staging_fk],
+        ['Dry run', formatNullableBool(bridge.dry_run)],
+        ['Metadata bridge', formatBool(bridge.metadata_has_compatibility_bridge)],
+        ['Source_runs FK blocked', formatBool(bridge.staging_policy_blocks_source_runs_id)],
+      ]} />
+    </div>
+  );
+}
+
+function StagingImpactPanel({ impact }: { impact: OperatorStagingImpactSummary | null }) {
+  if (!impact) {
+    return (
+      <div className="panel-thin p-3 space-y-2">
+        <div className="font-display text-orange text-[11px] uppercase tracking-[0.16em]">
+          Staging impact summary
+        </div>
+        <p className="text-[11px] text-silver-dk font-mono">No bridge-backed staging impact available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel-thin p-3 space-y-2">
+      <div className="font-display text-orange text-[11px] uppercase tracking-[0.16em]">
+        Staging impact summary
+      </div>
+      <MetricList rows={[
+        ['Table', impact.staging_table],
+        ['Legacy id', String(impact.legacy_source_run_id)],
+        ['Rows total', impact.rows_total.toLocaleString()],
+        ['Diagnostic only', impact.rows_diagnostic_only.toLocaleString()],
+        ['Canonical blocked', impact.rows_canonical_write_blocked.toLocaleString()],
+        ['Stage markers', impact.rows_with_stage_markers.toLocaleString()],
+        ['Legacy FK rows', impact.rows_using_legacy_bridge_id.toLocaleString()],
+        ['Source_runs FK rows', impact.rows_using_source_runs_id.toLocaleString()],
+      ]} />
+      <WarningList title="Staging warnings" items={impact.warnings} empty="No staging warnings reported." danger />
+    </div>
+  );
+}
+
+function DiagnosticRowsPanel({
+  rows,
+  selectedKey,
+}: {
+  rows: OperatorDiagnosticRowSummary[];
+  selectedKey: string | null;
+}) {
+  return (
+    <section className="panel p-5 space-y-3" data-testid="operator-diagnostic-rows">
+      <div>
+        <h3 className="font-display text-orange text-xs uppercase tracking-[0.18em]">
+          4. Diagnostic rows
+        </h3>
+        <p className="text-[11px] text-silver-dk">
+          {selectedKey
+            ? `Diagnostic staging rows scoped to ${selectedKey}.`
+            : 'Latest diagnostic staging rows.'}
+          {' '}These rows are not canonical candidates.
+        </p>
+      </div>
+      {rows.length === 0 ? (
+        <p className="text-[11px] text-silver-dk font-mono">No diagnostic rows found.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[900px] text-left font-mono text-[11px]">
+            <thead className="text-silver-dk uppercase tracking-[0.12em]">
+              <tr>
+                <th className="py-2 pr-3">Row id</th>
+                <th className="py-2 pr-3">Legacy source run id</th>
+                <th className="py-2 pr-3">Station / system / type</th>
+                <th className="py-2 pr-3">Source class / confidence</th>
+                <th className="py-2 pr-3">Marker keys</th>
+                <th className="py-2 pr-3">canonical_write_allowed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.row_id} className="border-t border-border/60 align-top">
+                  <td className="py-2 pr-3 text-silver">{row.row_id}</td>
+                  <td className="py-2 pr-3 text-silver-dk">{row.legacy_source_run_id ?? '-'}</td>
+                  <td className="py-2 pr-3 text-silver">
+                    {joinDefined([row.station_name, row.system_name, row.station_type])}
+                  </td>
+                  <td className="py-2 pr-3 text-silver-dk">
+                    {joinDefined([row.source_class, row.confidence])}
+                  </td>
+                  <td className="py-2 pr-3 text-silver-dk">{row.marker_keys.join(', ') || '-'}</td>
+                  <td className="py-2 pr-3 text-silver-dk">{formatNullableBool(row.canonical_write_allowed)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MetricList({ rows }: { rows: Array<[string, string]> }) {
+  return (
+    <dl className="space-y-1 font-mono text-[11px]">
+      {rows.map(([label, value]) => (
+        <div key={label} className="grid grid-cols-[130px_1fr] gap-2">
+          <dt className="text-silver-dk">{label}</dt>
+          <dd className="text-silver break-words">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function WarningList({
+  title,
+  items,
+  empty,
+  danger = false,
+}: {
+  title: string;
+  items: string[];
+  empty: string;
+  danger?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="font-display text-orange text-[11px] uppercase tracking-[0.16em]">
+        {title}
+      </div>
+      {items.length === 0 ? (
+        <p className="text-[11px] text-silver-dk font-mono">{empty}</p>
+      ) : (
+        <ul className={danger ? 'space-y-1 text-[11px] text-red font-mono' : 'space-y-1 text-[11px] text-silver-dk font-mono'}>
+          {items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-chunk-sm p-2.5 border border-border bg-bg3/40">
+      <div className="text-silver-dk uppercase tracking-[0.16em] text-[10px]">{label}</div>
+      <div className="tabular-nums font-bold mt-0.5 text-silver break-words">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function Flag({ label, value }: { label: string; value: boolean }) {
+  return (
+    <div className="rounded-chunk-sm p-2.5 border border-border bg-bg3/40 flex items-center justify-between gap-2">
+      <span className="text-silver-dk uppercase tracking-[0.16em] text-[10px]">{label}</span>
+      <span className={value ? 'text-green' : 'text-red'}>{value ? 'yes' : 'no'}</span>
+    </div>
+  );
+}
+
+function joinDefined(values: Array<string | null | undefined>): string {
+  const parts = values.filter((value): value is string => Boolean(value));
+  return parts.length === 0 ? '-' : parts.join(' / ');
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function formatBool(value: boolean): string {
+  return value ? 'yes' : 'no';
+}
+
+function formatNullableBool(value: boolean | null): string {
+  if (value === null) return '-';
+  return formatBool(value);
+}
+
+function shortSha(value: string | null): string {
+  if (!value) return '-';
+  return value.slice(0, 8);
+}
+
+function shortHash(value: string | null): string {
+  if (!value) return '-';
+  return value.length > 16 ? value.slice(0, 16) : value;
+}

--- a/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
+++ b/frontend-v2/src/features/operator/OperatorCockpitTab.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { api } from '@/lib/api';
+import type { UseAdmin } from '@/features/admin/useAdmin';
 import type {
   OperatorArtifactSummary,
   OperatorBridgeSummary,
@@ -10,14 +11,16 @@ import type {
   OperatorStagingImpactSummary,
 } from '@/types/api';
 
-const TOKEN_KEY = 'ed_admin_token';
 const RECENT_LIMIT = 25;
 
 type LoadState = 'idle' | 'loading' | 'ok' | 'err';
 
-export function OperatorCockpitTab() {
-  const [token, setToken] = useState(() => sessionStorage.getItem(TOKEN_KEY) ?? '');
-  const [tokenDraft, setTokenDraft] = useState(token);
+export interface OperatorCockpitTabProps {
+  admin: Pick<UseAdmin, 'token' | 'setToken' | 'forgetToken' | 'hasToken'>;
+}
+
+export function OperatorCockpitTab({ admin }: OperatorCockpitTabProps) {
+  const [tokenDraft, setTokenDraft] = useState(admin.token);
   const [loadState, setLoadState] = useState<LoadState>('idle');
   const [error, setError] = useState<string | null>(null);
   const [safetyGates, setSafetyGates] = useState<OperatorSafetyGateSummary | null>(null);
@@ -27,16 +30,23 @@ export function OperatorCockpitTab() {
   const [detail, setDetail] = useState<OperatorSourceRunDetail | null>(null);
   const [detailState, setDetailState] = useState<LoadState>('idle');
   const [detailError, setDetailError] = useState<string | null>(null);
+  const cockpitRequestSeq = useRef(0);
+  const detailRequestSeq = useRef(0);
 
-  const persistToken = (nextToken: string) => {
-    setToken(nextToken);
-    setTokenDraft(nextToken);
-    if (nextToken) sessionStorage.setItem(TOKEN_KEY, nextToken);
-    else sessionStorage.removeItem(TOKEN_KEY);
-  };
+  useEffect(() => {
+    setTokenDraft(admin.token);
+  }, [admin.token]);
 
   const loadCockpit = useCallback(async () => {
-    if (!token) {
+    const requestSeq = cockpitRequestSeq.current + 1;
+    cockpitRequestSeq.current = requestSeq;
+    detailRequestSeq.current += 1;
+    setSelectedKey(null);
+    setDetail(null);
+    setDetailState('idle');
+    setDetailError(null);
+
+    if (!admin.token) {
       setLoadState('idle');
       setSafetyGates(null);
       setSourceRuns([]);
@@ -52,46 +62,54 @@ export function OperatorCockpitTab() {
     setError(null);
     try {
       const [gates, runs, diagnostics] = await Promise.all([
-        api.operatorSafetyGates(token),
-        api.operatorSourceRuns(token, RECENT_LIMIT),
-        api.operatorDiagnosticRows(token, { limit: RECENT_LIMIT }),
+        api.operatorSafetyGates(admin.token),
+        api.operatorSourceRuns(admin.token, RECENT_LIMIT),
+        api.operatorDiagnosticRows(admin.token, { limit: RECENT_LIMIT }),
       ]);
+      if (requestSeq !== cockpitRequestSeq.current) return;
       setSafetyGates(gates);
       setSourceRuns(runs);
       setDiagnosticRows(diagnostics);
       setLoadState('ok');
     } catch (caught: unknown) {
+      if (requestSeq !== cockpitRequestSeq.current) return;
       setSafetyGates(null);
       setSourceRuns([]);
       setDiagnosticRows([]);
       setLoadState('err');
       setError(caught instanceof Error ? caught.message : String(caught));
     }
-  }, [token]);
+  }, [admin.token]);
 
   useEffect(() => {
     void loadCockpit();
   }, [loadCockpit]);
 
   const selectSourceRun = useCallback(async (sourceRunKey: string) => {
-    if (!token) return;
+    if (!admin.token) return;
+    const requestSeq = detailRequestSeq.current + 1;
+    detailRequestSeq.current = requestSeq;
     setSelectedKey(sourceRunKey);
+    setDetail(null);
+    setDiagnosticRows([]);
     setDetailState('loading');
     setDetailError(null);
     try {
       const [nextDetail, nextDiagnostics] = await Promise.all([
-        api.operatorSourceRunDetail(token, sourceRunKey),
-        api.operatorDiagnosticRows(token, { sourceRunKey, limit: RECENT_LIMIT }),
+        api.operatorSourceRunDetail(admin.token, sourceRunKey),
+        api.operatorDiagnosticRows(admin.token, { sourceRunKey, limit: RECENT_LIMIT }),
       ]);
+      if (requestSeq !== detailRequestSeq.current) return;
       setDetail(nextDetail);
       setDiagnosticRows(nextDiagnostics);
       setDetailState('ok');
     } catch (caught: unknown) {
+      if (requestSeq !== detailRequestSeq.current) return;
       setDetail(null);
       setDetailState('err');
       setDetailError(caught instanceof Error ? caught.message : String(caught));
     }
-  }, [token]);
+  }, [admin.token]);
 
   return (
     <section data-testid="operator-cockpit" className="space-y-5">
@@ -106,7 +124,7 @@ export function OperatorCockpitTab() {
         <button
           type="button"
           onClick={() => void loadCockpit()}
-          disabled={!token || loadState === 'loading'}
+          disabled={!admin.hasToken || loadState === 'loading'}
           data-testid="operator-refresh"
           className="btn-metal text-[11px] py-1.5 px-3 disabled:opacity-40 disabled:cursor-not-allowed"
         >
@@ -134,24 +152,24 @@ export function OperatorCockpitTab() {
           />
           <button
             type="button"
-            onClick={() => persistToken(tokenDraft.trim())}
+            onClick={() => admin.setToken(tokenDraft.trim())}
             data-testid="operator-token-save"
             className="btn-primary text-[11px] py-1.5 px-3"
           >
             Save token
           </button>
-          {token && (
+          {admin.hasToken && (
             <button
               type="button"
-              onClick={() => persistToken('')}
+              onClick={() => admin.forgetToken()}
               data-testid="operator-token-forget"
               className="btn-metal text-[11px] py-1.5 px-3"
             >
               Forget token
             </button>
           )}
-          <span className={token ? 'font-mono text-[10px] text-green' : 'font-mono text-[10px] text-silver-dk'}>
-            {token ? 'Token set' : 'No token'}
+          <span className={admin.hasToken ? 'font-mono text-[10px] text-green' : 'font-mono text-[10px] text-silver-dk'}>
+            {admin.hasToken ? 'Token set' : 'No token'}
           </span>
         </div>
       </section>
@@ -169,13 +187,13 @@ export function OperatorCockpitTab() {
         </div>
       )}
 
-      {!token && (
+      {!admin.hasToken && (
         <div className="panel p-5 text-[11px] text-silver-dk font-mono">
           Set an admin token to load the read-only operator cockpit.
         </div>
       )}
 
-      {token && (
+      {admin.hasToken && (
         <>
           <SafetyGatesPanel safetyGates={safetyGates} loading={loadState === 'loading'} />
           <SourceRunsTable

--- a/frontend-v2/src/hooks/useHashRoute.test.ts
+++ b/frontend-v2/src/hooks/useHashRoute.test.ts
@@ -17,6 +17,7 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     ['#fc', 'fc'],
     ['#colony', 'colony'],
     ['#admin', 'admin'],
+    ['#operator', 'operator'],
     ['#colony-planner', 'colony-planner'],
     ['#colony-planner-prototype', 'colony-planner-prototype'],
   ] as const)('parses %s as %s', (hash, route) => {

--- a/frontend-v2/src/hooks/useHashRoute.ts
+++ b/frontend-v2/src/hooks/useHashRoute.ts
@@ -11,6 +11,7 @@ import { useEffect, useState } from 'react';
  *   #optimizer                    → route='search-tuning', selectedSystemId=null (legacy alias)
  *   #system/12345678              → route='finder',    selectedSystemId=12345678   (deep-link from external)
  *   #colony-planner/system/123    → route='colony-planner', plannerSystemId=123
+ *   #operator                     → route='operator', selectedSystemId=null
  *   #colony-planner               → route='colony-planner', plannerSystemId=null
  *   #colony-planner-prototype     → route='colony-planner-prototype', static visual prototype
  *   <empty> or unknown            → route='finder',    selectedSystemId=null
@@ -26,8 +27,8 @@ import { useEffect, useState } from 'react';
  * The route set is still simple enough that this hand-rolled parser beats
  * pulling in react-router. Re-evaluate that trade-off if nested routes grow.
  */
-export type Route = 'finder' | 'watchlist' | 'pinned' | 'compare' | 'map' | 'search-tuning' | 'fc' | 'colony' | 'admin' | 'colony-planner' | 'colony-planner-prototype';
-const VALID_ROUTES: Route[] = ['finder', 'watchlist', 'pinned', 'compare', 'map', 'search-tuning', 'fc', 'colony', 'admin', 'colony-planner', 'colony-planner-prototype'];
+export type Route = 'finder' | 'watchlist' | 'pinned' | 'compare' | 'map' | 'search-tuning' | 'fc' | 'colony' | 'admin' | 'operator' | 'colony-planner' | 'colony-planner-prototype';
+const VALID_ROUTES: Route[] = ['finder', 'watchlist', 'pinned', 'compare', 'map', 'search-tuning', 'fc', 'colony', 'admin', 'operator', 'colony-planner', 'colony-planner-prototype'];
 
 export interface ParsedHash {
   route:            Route;

--- a/frontend-v2/src/lib/api.operator.test.ts
+++ b/frontend-v2/src/lib/api.operator.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from './api';
+
+describe('operator API helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('call Stage 19 operator endpoints with GET/read-only requests only', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => ({
+      ok: true,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({}),
+    } as Response));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await api.operatorSafetyGates('token-123');
+    await api.operatorSourceRuns('token-123', 25);
+    await api.operatorSourceRunDetail('token-123', 'source/run 1');
+    await api.operatorDiagnosticRows('token-123', { sourceRunKey: 'source/run 1', limit: 25 });
+
+    const calls = fetchMock.mock.calls as Array<[RequestInfo | URL, RequestInit | undefined]>;
+    expect(calls).toHaveLength(4);
+    expect(calls.map(([url]) => String(url))).toEqual([
+      '/api/operator/safety-gates',
+      '/api/operator/source-runs?limit=25',
+      '/api/operator/source-runs/source%2Frun%201',
+      '/api/operator/diagnostic-staging-rows?limit=25&source_run_key=source%2Frun+1',
+    ]);
+
+    for (const [, init] of calls) {
+      expect(['GET', undefined]).toContain(init?.method);
+      expect(String(init?.method ?? 'GET')).not.toMatch(/POST|PATCH|DELETE|PUT/i);
+      expect(init?.headers).toMatchObject({ 'X-Admin-Token': 'token-123' });
+    }
+  });
+});

--- a/frontend-v2/src/lib/api.operator.test.ts
+++ b/frontend-v2/src/lib/api.operator.test.ts
@@ -17,14 +17,20 @@ describe('operator API helpers', () => {
     await api.operatorSafetyGates('token-123');
     await api.operatorSourceRuns('token-123', 25);
     await api.operatorSourceRunDetail('token-123', 'source/run 1');
+    await api.operatorSourceRunArtifacts('token-123', 'source/run 1');
+    await api.operatorSourceRunBridge('token-123', 'source/run 1');
+    await api.operatorSourceRunStagingImpact('token-123', 'source/run 1', 25);
     await api.operatorDiagnosticRows('token-123', { sourceRunKey: 'source/run 1', limit: 25 });
 
     const calls = fetchMock.mock.calls as Array<[RequestInfo | URL, RequestInit | undefined]>;
-    expect(calls).toHaveLength(4);
+    expect(calls).toHaveLength(7);
     expect(calls.map(([url]) => String(url))).toEqual([
       '/api/operator/safety-gates',
       '/api/operator/source-runs?limit=25',
-      '/api/operator/source-runs/source%2Frun%201',
+      '/api/operator/source-run-detail?source_run_key=source%2Frun+1',
+      '/api/operator/source-run-artifacts?source_run_key=source%2Frun+1',
+      '/api/operator/source-run-bridge?source_run_key=source%2Frun+1',
+      '/api/operator/source-run-staging-impact?source_run_key=source%2Frun+1&limit=25',
       '/api/operator/diagnostic-staging-rows?limit=25&source_run_key=source%2Frun+1',
     ]);
 

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -28,6 +28,10 @@ import type {
   ObservedFactUpdateRequest,
   OptimiserCandidatesRequest,
   OptimiserCandidatesResponse,
+  OperatorDiagnosticRowSummary,
+  OperatorSafetyGateSummary,
+  OperatorSourceRunDetail,
+  OperatorSourceRunSummary,
   PredictionObservationCompareRequest,
   PredictionObservationCompareResponse,
   RecommendedBuildsResponse,
@@ -356,6 +360,32 @@ export const api = {
   },
   adminDataStatus(token: string): Promise<AdminDataStatus> {
     return jsonFetch('/admin/data-status', {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorSafetyGates(token: string): Promise<OperatorSafetyGateSummary> {
+    return jsonFetch('/api/operator/safety-gates', {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorSourceRuns(token: string, limit = 25): Promise<OperatorSourceRunSummary[]> {
+    const params = new URLSearchParams({ limit: String(limit) });
+    return jsonFetch(`/api/operator/source-runs?${params.toString()}`, {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorSourceRunDetail(token: string, sourceRunKey: string): Promise<OperatorSourceRunDetail> {
+    return jsonFetch(`/api/operator/source-runs/${encodeURIComponent(sourceRunKey)}`, {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorDiagnosticRows(
+    token: string,
+    options: { sourceRunKey?: string | null; limit?: number } = {},
+  ): Promise<OperatorDiagnosticRowSummary[]> {
+    const params = new URLSearchParams({ limit: String(options.limit ?? 25) });
+    if (options.sourceRunKey) params.set('source_run_key', options.sourceRunKey);
+    return jsonFetch(`/api/operator/diagnostic-staging-rows?${params.toString()}`, {
       headers: { 'X-Admin-Token': token },
     });
   },

--- a/frontend-v2/src/lib/api.ts
+++ b/frontend-v2/src/lib/api.ts
@@ -28,10 +28,13 @@ import type {
   ObservedFactUpdateRequest,
   OptimiserCandidatesRequest,
   OptimiserCandidatesResponse,
+  OperatorArtifactSummary,
+  OperatorBridgeSummary,
   OperatorDiagnosticRowSummary,
   OperatorSafetyGateSummary,
   OperatorSourceRunDetail,
   OperatorSourceRunSummary,
+  OperatorStagingImpactSummary,
   PredictionObservationCompareRequest,
   PredictionObservationCompareResponse,
   RecommendedBuildsResponse,
@@ -375,7 +378,34 @@ export const api = {
     });
   },
   operatorSourceRunDetail(token: string, sourceRunKey: string): Promise<OperatorSourceRunDetail> {
-    return jsonFetch(`/api/operator/source-runs/${encodeURIComponent(sourceRunKey)}`, {
+    const params = new URLSearchParams({ source_run_key: sourceRunKey });
+    return jsonFetch(`/api/operator/source-run-detail?${params.toString()}`, {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorSourceRunArtifacts(token: string, sourceRunKey: string): Promise<OperatorArtifactSummary> {
+    const params = new URLSearchParams({ source_run_key: sourceRunKey });
+    return jsonFetch(`/api/operator/source-run-artifacts?${params.toString()}`, {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorSourceRunBridge(token: string, sourceRunKey: string): Promise<OperatorBridgeSummary> {
+    const params = new URLSearchParams({ source_run_key: sourceRunKey });
+    return jsonFetch(`/api/operator/source-run-bridge?${params.toString()}`, {
+      headers: { 'X-Admin-Token': token },
+    });
+  },
+  operatorSourceRunStagingImpact(
+    token: string,
+    sourceRunKey: string,
+    limit = 100,
+  ): Promise<{
+    source_run_key: string;
+    bridge_present: boolean;
+    staging_impact: OperatorStagingImpactSummary | null;
+  }> {
+    const params = new URLSearchParams({ source_run_key: sourceRunKey, limit: String(limit) });
+    return jsonFetch(`/api/operator/source-run-staging-impact?${params.toString()}`, {
       headers: { 'X-Admin-Token': token },
     });
   },

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -1162,7 +1162,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/operator/source-runs/{source_run_key}": {
+    "/api/operator/source-run-detail": {
         parameters: {
             query?: never;
             header?: never;
@@ -1170,7 +1170,7 @@ export interface paths {
             cookie?: never;
         };
         /** Operator Source Run Detail */
-        get: operations["operator_source_run_detail_api_operator_source_runs__source_run_key__get"];
+        get: operations["operator_source_run_detail_api_operator_source_run_detail_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1179,7 +1179,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/operator/source-runs/{source_run_key}/artifacts": {
+    "/api/operator/source-run-artifacts": {
         parameters: {
             query?: never;
             header?: never;
@@ -1187,7 +1187,7 @@ export interface paths {
             cookie?: never;
         };
         /** Operator Source Run Artifacts */
-        get: operations["operator_source_run_artifacts_api_operator_source_runs__source_run_key__artifacts_get"];
+        get: operations["operator_source_run_artifacts_api_operator_source_run_artifacts_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1196,7 +1196,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/operator/source-runs/{source_run_key}/bridge": {
+    "/api/operator/source-run-bridge": {
         parameters: {
             query?: never;
             header?: never;
@@ -1204,7 +1204,7 @@ export interface paths {
             cookie?: never;
         };
         /** Operator Source Run Bridge */
-        get: operations["operator_source_run_bridge_api_operator_source_runs__source_run_key__bridge_get"];
+        get: operations["operator_source_run_bridge_api_operator_source_run_bridge_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1213,7 +1213,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/operator/source-runs/{source_run_key}/staging-impact": {
+    "/api/operator/source-run-staging-impact": {
         parameters: {
             query?: never;
             header?: never;
@@ -1221,7 +1221,7 @@ export interface paths {
             cookie?: never;
         };
         /** Operator Source Run Staging Impact */
-        get: operations["operator_source_run_staging_impact_api_operator_source_runs__source_run_key__staging_impact_get"];
+        get: operations["operator_source_run_staging_impact_api_operator_source_run_staging_impact_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -2011,9 +2011,13 @@ export interface components {
             /** Notes */
             notes?: string | null;
             /** Prerequisites */
-            prerequisites?: Record<string, never>[];
+            prerequisites?: {
+                [key: string]: unknown;
+            }[];
             /** Economy Effects */
-            economy_effects?: Record<string, never>;
+            economy_effects?: {
+                [key: string]: unknown;
+            };
             /**
              * Yellow Cp Generated
              * @default 0
@@ -2035,7 +2039,9 @@ export interface components {
              */
             green_cp_cost: number;
             /** Stat Effects */
-            stat_effects?: Record<string, never>;
+            stat_effects?: {
+                [key: string]: unknown;
+            };
         };
         /** GalaxySearchRequest */
         GalaxySearchRequest: {
@@ -2080,7 +2086,6 @@ export interface components {
              * Source
              * @default spansh
              * @constant
-             * @enum {string}
              */
             source: "spansh";
         };
@@ -2091,7 +2096,6 @@ export interface components {
             /**
              * Source
              * @constant
-             * @enum {string}
              */
             source: "spansh";
             /**
@@ -2179,9 +2183,13 @@ export interface components {
             /** Confidence */
             confidence: string;
             /** Observed Value */
-            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            observed_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            expected_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Notes */
             notes?: string | null;
         };
@@ -2224,9 +2232,13 @@ export interface components {
             subject_id?: string | null;
             status: components["schemas"]["ObservedStatus"];
             /** Observed Value */
-            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            observed_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            expected_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** @default medium */
             confidence: components["schemas"]["ObservedConfidence"];
             /** Notes */
@@ -2248,7 +2260,9 @@ export interface components {
             /** Tags */
             tags?: string[];
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
             /** System Id64 */
             system_id64: number;
         };
@@ -2280,9 +2294,13 @@ export interface components {
             subject_id?: string | null;
             status: components["schemas"]["ObservedStatus"];
             /** Observed Value */
-            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            observed_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            expected_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** @default medium */
             confidence: components["schemas"]["ObservedConfidence"];
             /** Notes */
@@ -2304,7 +2322,9 @@ export interface components {
             /** Tags */
             tags?: string[];
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
         };
         /** ObservedFactListResponse */
         ObservedFactListResponse: {
@@ -2339,9 +2359,13 @@ export interface components {
             /** Status */
             status: string;
             /** Observed Value */
-            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            observed_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            expected_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Confidence */
             confidence: string;
             /** Notes */
@@ -2363,7 +2387,9 @@ export interface components {
             /** Tags */
             tags?: string[];
             /** Metadata */
-            metadata?: Record<string, never>;
+            metadata?: {
+                [key: string]: unknown;
+            };
         };
         /**
          * ObservedFactType
@@ -2379,9 +2405,13 @@ export interface components {
             subject_id?: string | null;
             status?: components["schemas"]["ObservedStatus"] | null;
             /** Observed Value */
-            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            observed_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            expected_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             confidence?: components["schemas"]["ObservedConfidence"] | null;
             /** Notes */
             notes?: string | null;
@@ -2402,7 +2432,9 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
             /** Metadata */
-            metadata?: Record<string, never> | null;
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * ObservedStatus
@@ -2652,7 +2684,9 @@ export interface components {
             /** Target Archetype */
             target_archetype?: string | null;
             /** Prediction */
-            prediction: Record<string, never>;
+            prediction: {
+                [key: string]: unknown;
+            };
             /** Observed Facts */
             observed_facts?: components["schemas"]["ObservedFactInput"][] | null;
             /**
@@ -2688,9 +2722,13 @@ export interface components {
             /** Subject Id */
             subject_id: string | null;
             /** Predicted Value */
-            predicted_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            predicted_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Observed Value */
-            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
+            observed_value?: string | number | boolean | {
+                [key: string]: unknown;
+            } | unknown[] | null;
             /** Status */
             status: string;
             /** Severity */
@@ -2863,9 +2901,13 @@ export interface components {
             /** Archetype Regional Fit */
             archetype_regional_fit?: number | null;
             /** Regional Rationale */
-            regional_rationale?: Record<string, never>;
+            regional_rationale?: {
+                [key: string]: unknown;
+            };
             /** Decision Explanation */
-            decision_explanation?: Record<string, never>;
+            decision_explanation?: {
+                [key: string]: unknown;
+            };
             /** Rank Breakdown */
             rank_breakdown?: {
                 [key: string]: number;
@@ -2926,7 +2968,9 @@ export interface components {
              */
             mechanics_version: string;
             /** Nearest Colonised System */
-            nearest_colonised_system?: Record<string, never> | null;
+            nearest_colonised_system?: {
+                [key: string]: unknown;
+            } | null;
             /** Counts */
             counts?: {
                 [key: string]: number;
@@ -2945,13 +2989,17 @@ export interface components {
                 [key: string]: number;
             };
             /** Rationale */
-            rationale?: Record<string, never>;
+            rationale?: {
+                [key: string]: unknown;
+            };
             /** Data Quality */
             data_quality?: {
                 [key: string]: string;
             };
             /** Confidence Signals */
-            confidence_signals?: Record<string, never>[];
+            confidence_signals?: {
+                [key: string]: unknown;
+            }[];
             /** Computed At */
             computed_at?: unknown | null;
         };
@@ -3145,13 +3193,21 @@ export interface components {
             confidence: number;
             cp: components["schemas"]["SimulationCPResult"];
             /** Cp Timeline */
-            cp_timeline?: Record<string, never>[];
+            cp_timeline?: {
+                [key: string]: unknown;
+            }[];
             /** Cp Repair Suggestions */
-            cp_repair_suggestions?: Record<string, never>[];
+            cp_repair_suggestions?: {
+                [key: string]: unknown;
+            }[];
             /** Observation Summary */
-            observation_summary?: Record<string, never>;
+            observation_summary?: {
+                [key: string]: unknown;
+            };
             /** Prediction Observation Diffs */
-            prediction_observation_diffs?: Record<string, never>[];
+            prediction_observation_diffs?: {
+                [key: string]: unknown;
+            }[];
             /** Economy Composition */
             economy_composition?: {
                 [key: string]: number;
@@ -3159,30 +3215,48 @@ export interface components {
             /** Economy Order */
             economy_order?: string[];
             /** Economy Stack */
-            economy_stack?: Record<string, never>;
+            economy_stack?: {
+                [key: string]: unknown;
+            };
             /** Port Economy States */
-            port_economy_states?: Record<string, never>[];
+            port_economy_states?: {
+                [key: string]: unknown;
+            }[];
             /** Influence Ledger */
-            influence_ledger?: Record<string, never>[];
+            influence_ledger?: {
+                [key: string]: unknown;
+            }[];
             /** Inherited Economies */
             inherited_economies?: components["schemas"]["SimulationInheritedEconomy"][];
             /** Topology */
-            topology?: Record<string, never>;
+            topology?: {
+                [key: string]: unknown;
+            };
             /** Services */
-            services?: Record<string, never>;
+            services?: {
+                [key: string]: unknown;
+            };
             /** Port Service States */
-            port_service_states?: Record<string, never>[];
+            port_service_states?: {
+                [key: string]: unknown;
+            }[];
             /** Service Unlock Ledger */
-            service_unlock_ledger?: Record<string, never>[];
+            service_unlock_ledger?: {
+                [key: string]: unknown;
+            }[];
             /** Data Quality */
             data_quality?: {
                 [key: string]: string;
             };
             /** Confidence Signals */
-            confidence_signals?: Record<string, never>[];
+            confidence_signals?: {
+                [key: string]: unknown;
+            }[];
             /** Mechanics Trace */
             mechanics_trace?: {
-                [key: string]: Record<string, never>[];
+                [key: string]: {
+                    [key: string]: unknown;
+                }[];
             };
             /** Top Two Alignment */
             top_two_alignment: string;
@@ -3930,6 +4004,10 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+            /** Input */
+            input?: unknown;
+            /** Context */
+            ctx?: Record<string, never>;
         };
         /**
          * ValidationReviewRequest
@@ -3947,7 +4025,9 @@ export interface components {
             /** Target Archetype */
             target_archetype?: string | null;
             /** Prediction */
-            prediction: Record<string, never>;
+            prediction: {
+                [key: string]: unknown;
+            };
             /** Observed Facts */
             observed_facts?: components["schemas"]["ObservedFactInput"][] | null;
             /**
@@ -6031,13 +6111,13 @@ export interface operations {
             };
         };
     };
-    operator_source_run_detail_api_operator_source_runs__source_run_key__get: {
+    operator_source_run_detail_api_operator_source_run_detail_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path: {
+            query: {
                 source_run_key: string;
             };
+            header?: never;
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -6062,13 +6142,13 @@ export interface operations {
             };
         };
     };
-    operator_source_run_artifacts_api_operator_source_runs__source_run_key__artifacts_get: {
+    operator_source_run_artifacts_api_operator_source_run_artifacts_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path: {
+            query: {
                 source_run_key: string;
             };
+            header?: never;
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -6093,13 +6173,13 @@ export interface operations {
             };
         };
     };
-    operator_source_run_bridge_api_operator_source_runs__source_run_key__bridge_get: {
+    operator_source_run_bridge_api_operator_source_run_bridge_get: {
         parameters: {
-            query?: never;
-            header?: never;
-            path: {
+            query: {
                 source_run_key: string;
             };
+            header?: never;
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;
@@ -6124,15 +6204,14 @@ export interface operations {
             };
         };
     };
-    operator_source_run_staging_impact_api_operator_source_runs__source_run_key__staging_impact_get: {
+    operator_source_run_staging_impact_api_operator_source_run_staging_impact_get: {
         parameters: {
-            query?: {
+            query: {
+                source_run_key: string;
                 limit?: number;
             };
             header?: never;
-            path: {
-                source_run_key: string;
-            };
+            path?: never;
             cookie?: never;
         };
         requestBody?: never;

--- a/frontend-v2/src/types/api.gen.ts
+++ b/frontend-v2/src/types/api.gen.ts
@@ -2011,13 +2011,9 @@ export interface components {
             /** Notes */
             notes?: string | null;
             /** Prerequisites */
-            prerequisites?: {
-                [key: string]: unknown;
-            }[];
+            prerequisites?: Record<string, never>[];
             /** Economy Effects */
-            economy_effects?: {
-                [key: string]: unknown;
-            };
+            economy_effects?: Record<string, never>;
             /**
              * Yellow Cp Generated
              * @default 0
@@ -2039,9 +2035,7 @@ export interface components {
              */
             green_cp_cost: number;
             /** Stat Effects */
-            stat_effects?: {
-                [key: string]: unknown;
-            };
+            stat_effects?: Record<string, never>;
         };
         /** GalaxySearchRequest */
         GalaxySearchRequest: {
@@ -2086,6 +2080,7 @@ export interface components {
              * Source
              * @default spansh
              * @constant
+             * @enum {string}
              */
             source: "spansh";
         };
@@ -2096,6 +2091,7 @@ export interface components {
             /**
              * Source
              * @constant
+             * @enum {string}
              */
             source: "spansh";
             /**
@@ -2183,13 +2179,9 @@ export interface components {
             /** Confidence */
             confidence: string;
             /** Observed Value */
-            observed_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Notes */
             notes?: string | null;
         };
@@ -2232,13 +2224,9 @@ export interface components {
             subject_id?: string | null;
             status: components["schemas"]["ObservedStatus"];
             /** Observed Value */
-            observed_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** @default medium */
             confidence: components["schemas"]["ObservedConfidence"];
             /** Notes */
@@ -2260,9 +2248,7 @@ export interface components {
             /** Tags */
             tags?: string[];
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
             /** System Id64 */
             system_id64: number;
         };
@@ -2294,13 +2280,9 @@ export interface components {
             subject_id?: string | null;
             status: components["schemas"]["ObservedStatus"];
             /** Observed Value */
-            observed_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** @default medium */
             confidence: components["schemas"]["ObservedConfidence"];
             /** Notes */
@@ -2322,9 +2304,7 @@ export interface components {
             /** Tags */
             tags?: string[];
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
         };
         /** ObservedFactListResponse */
         ObservedFactListResponse: {
@@ -2359,13 +2339,9 @@ export interface components {
             /** Status */
             status: string;
             /** Observed Value */
-            observed_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Confidence */
             confidence: string;
             /** Notes */
@@ -2387,9 +2363,7 @@ export interface components {
             /** Tags */
             tags?: string[];
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            };
+            metadata?: Record<string, never>;
         };
         /**
          * ObservedFactType
@@ -2405,13 +2379,9 @@ export interface components {
             subject_id?: string | null;
             status?: components["schemas"]["ObservedStatus"] | null;
             /** Observed Value */
-            observed_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Expected Value */
-            expected_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            expected_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             confidence?: components["schemas"]["ObservedConfidence"] | null;
             /** Notes */
             notes?: string | null;
@@ -2432,9 +2402,7 @@ export interface components {
             /** Tags */
             tags?: string[] | null;
             /** Metadata */
-            metadata?: {
-                [key: string]: unknown;
-            } | null;
+            metadata?: Record<string, never> | null;
         };
         /**
          * ObservedStatus
@@ -2684,9 +2652,7 @@ export interface components {
             /** Target Archetype */
             target_archetype?: string | null;
             /** Prediction */
-            prediction: {
-                [key: string]: unknown;
-            };
+            prediction: Record<string, never>;
             /** Observed Facts */
             observed_facts?: components["schemas"]["ObservedFactInput"][] | null;
             /**
@@ -2722,13 +2688,9 @@ export interface components {
             /** Subject Id */
             subject_id: string | null;
             /** Predicted Value */
-            predicted_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            predicted_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Observed Value */
-            observed_value?: string | number | boolean | {
-                [key: string]: unknown;
-            } | unknown[] | null;
+            observed_value?: string | number | boolean | Record<string, never> | unknown[] | null;
             /** Status */
             status: string;
             /** Severity */
@@ -2901,13 +2863,9 @@ export interface components {
             /** Archetype Regional Fit */
             archetype_regional_fit?: number | null;
             /** Regional Rationale */
-            regional_rationale?: {
-                [key: string]: unknown;
-            };
+            regional_rationale?: Record<string, never>;
             /** Decision Explanation */
-            decision_explanation?: {
-                [key: string]: unknown;
-            };
+            decision_explanation?: Record<string, never>;
             /** Rank Breakdown */
             rank_breakdown?: {
                 [key: string]: number;
@@ -2968,9 +2926,7 @@ export interface components {
              */
             mechanics_version: string;
             /** Nearest Colonised System */
-            nearest_colonised_system?: {
-                [key: string]: unknown;
-            } | null;
+            nearest_colonised_system?: Record<string, never> | null;
             /** Counts */
             counts?: {
                 [key: string]: number;
@@ -2989,17 +2945,13 @@ export interface components {
                 [key: string]: number;
             };
             /** Rationale */
-            rationale?: {
-                [key: string]: unknown;
-            };
+            rationale?: Record<string, never>;
             /** Data Quality */
             data_quality?: {
                 [key: string]: string;
             };
             /** Confidence Signals */
-            confidence_signals?: {
-                [key: string]: unknown;
-            }[];
+            confidence_signals?: Record<string, never>[];
             /** Computed At */
             computed_at?: unknown | null;
         };
@@ -3193,21 +3145,13 @@ export interface components {
             confidence: number;
             cp: components["schemas"]["SimulationCPResult"];
             /** Cp Timeline */
-            cp_timeline?: {
-                [key: string]: unknown;
-            }[];
+            cp_timeline?: Record<string, never>[];
             /** Cp Repair Suggestions */
-            cp_repair_suggestions?: {
-                [key: string]: unknown;
-            }[];
+            cp_repair_suggestions?: Record<string, never>[];
             /** Observation Summary */
-            observation_summary?: {
-                [key: string]: unknown;
-            };
+            observation_summary?: Record<string, never>;
             /** Prediction Observation Diffs */
-            prediction_observation_diffs?: {
-                [key: string]: unknown;
-            }[];
+            prediction_observation_diffs?: Record<string, never>[];
             /** Economy Composition */
             economy_composition?: {
                 [key: string]: number;
@@ -3215,48 +3159,30 @@ export interface components {
             /** Economy Order */
             economy_order?: string[];
             /** Economy Stack */
-            economy_stack?: {
-                [key: string]: unknown;
-            };
+            economy_stack?: Record<string, never>;
             /** Port Economy States */
-            port_economy_states?: {
-                [key: string]: unknown;
-            }[];
+            port_economy_states?: Record<string, never>[];
             /** Influence Ledger */
-            influence_ledger?: {
-                [key: string]: unknown;
-            }[];
+            influence_ledger?: Record<string, never>[];
             /** Inherited Economies */
             inherited_economies?: components["schemas"]["SimulationInheritedEconomy"][];
             /** Topology */
-            topology?: {
-                [key: string]: unknown;
-            };
+            topology?: Record<string, never>;
             /** Services */
-            services?: {
-                [key: string]: unknown;
-            };
+            services?: Record<string, never>;
             /** Port Service States */
-            port_service_states?: {
-                [key: string]: unknown;
-            }[];
+            port_service_states?: Record<string, never>[];
             /** Service Unlock Ledger */
-            service_unlock_ledger?: {
-                [key: string]: unknown;
-            }[];
+            service_unlock_ledger?: Record<string, never>[];
             /** Data Quality */
             data_quality?: {
                 [key: string]: string;
             };
             /** Confidence Signals */
-            confidence_signals?: {
-                [key: string]: unknown;
-            }[];
+            confidence_signals?: Record<string, never>[];
             /** Mechanics Trace */
             mechanics_trace?: {
-                [key: string]: {
-                    [key: string]: unknown;
-                }[];
+                [key: string]: Record<string, never>[];
             };
             /** Top Two Alignment */
             top_two_alignment: string;
@@ -4004,10 +3930,6 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
-            /** Input */
-            input?: unknown;
-            /** Context */
-            ctx?: Record<string, never>;
         };
         /**
          * ValidationReviewRequest
@@ -4025,9 +3947,7 @@ export interface components {
             /** Target Archetype */
             target_archetype?: string | null;
             /** Prediction */
-            prediction: {
-                [key: string]: unknown;
-            };
+            prediction: Record<string, never>;
             /** Observed Facts */
             observed_facts?: components["schemas"]["ObservedFactInput"][] | null;
             /**

--- a/frontend-v2/src/types/api.ts
+++ b/frontend-v2/src/types/api.ts
@@ -260,6 +260,116 @@ export interface AdminDataStatus {
   };
 }
 
+export interface OperatorSourceRunSummary {
+  source_run_key: string;
+  source_name: string | null;
+  source_category: string | null;
+  domain: string | null;
+  import_scope: string | null;
+  status: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+  duration_ms: number | null;
+  rows_read: number;
+  rows_staged: number;
+  rows_rejected: number;
+  rows_skipped: number;
+  artifact_present: boolean;
+  artifact_hash_present: boolean;
+  bridge_present: boolean;
+  staging_rows_known: boolean;
+  trigger_context: string | null;
+  git_commit_sha: string | null;
+  error_code: string | null;
+  error_summary: string | null;
+}
+
+export interface OperatorArtifactSummary {
+  source_run_key: string;
+  artifact_path_redacted: string | null;
+  artifact_sha256: string | null;
+  artifact_integrity_sha256: string | null;
+  artifact_record_present: boolean;
+  file_exists: boolean | null;
+  file_sha256_matches: boolean | null;
+  integrity_hash_matches: boolean | null;
+  schema_version: string | null;
+  rows_read: number;
+  rows_staged: number;
+  status: string | null;
+  validation_note: string;
+}
+
+export interface OperatorBridgeSummary {
+  bridge_key: string;
+  legacy_source_run_id: number | null;
+  source_run_key: string;
+  bridge_present: boolean;
+  dry_run: boolean | null;
+  adapter_name: string | null;
+  adapter_version: string | null;
+  target_staging_fk: string;
+  metadata_has_compatibility_bridge: boolean;
+  staging_policy_blocks_source_runs_id: boolean;
+}
+
+export interface OperatorDiagnosticRowSummary {
+  row_id: number;
+  legacy_source_run_id: number | null;
+  station_name: string | null;
+  station_type: string | null;
+  system_name: string | null;
+  source_class: string | null;
+  confidence: string | null;
+  marker_keys: string[];
+  canonical_write_allowed: boolean | null;
+}
+
+export interface OperatorStagingImpactSummary {
+  source_run_key: string | null;
+  bridge_key: string | null;
+  legacy_source_run_id: number;
+  staging_table: string;
+  rows_total: number;
+  rows_diagnostic_only: number;
+  rows_canonical_write_blocked: number;
+  rows_with_stage_markers: number;
+  rows_using_legacy_bridge_id: number;
+  rows_using_source_runs_id: number;
+  sample_rows: OperatorDiagnosticRowSummary[];
+  warnings: string[];
+}
+
+export interface OperatorSourceRunDetail {
+  summary: OperatorSourceRunSummary;
+  importer_name: string | null;
+  importer_version: string | null;
+  source_uri_redacted: string | null;
+  source_input_sha256: string | null;
+  source_manifest_sha256: string | null;
+  safety_boundary: Record<string, unknown>;
+  metadata_summary: Record<string, unknown>;
+  artifact_summary: OperatorArtifactSummary;
+  bridge_summary: OperatorBridgeSummary;
+  staging_impact_summary: OperatorStagingImpactSummary | null;
+  validation_warnings: string[];
+  operator_notes: string[];
+}
+
+export interface OperatorSafetyGateSummary {
+  no_running_source_runs: boolean;
+  latest_artifacts_present: boolean;
+  bridge_fk_path_verified: boolean;
+  diagnostic_rows_isolated: boolean;
+  no_failed_unrecovered_source_runs: boolean;
+  scheduler_assumed_disabled: boolean;
+  canonical_apply_assumed_disabled: boolean;
+  safe_to_proceed: boolean;
+  blockers: string[];
+  latest_source_run_key: string | null;
+  notes: string[];
+}
+
 
 // ─── Stage 18H Warehouse-to-Planner Evidence Bridge (read-only) ───────────
 //

--- a/tests/test_stage19ap_operator_visibility.py
+++ b/tests/test_stage19ap_operator_visibility.py
@@ -1,5 +1,6 @@
 import inspect
 import importlib.util
+import os
 import re
 import sys
 from pathlib import Path
@@ -14,6 +15,7 @@ if str(API_SRC) not in sys.path:
     sys.path.insert(0, str(API_SRC))
 if str(API_ROUTERS) not in sys.path:
     sys.path.insert(0, str(API_ROUTERS))
+os.environ.setdefault('CORS_ORIGINS', 'http://localhost')
 
 import operator_visibility as visibility  # noqa: E402
 
@@ -24,6 +26,33 @@ _ROUTER_SPEC = importlib.util.spec_from_file_location(
 operator_router = importlib.util.module_from_spec(_ROUTER_SPEC)
 assert _ROUTER_SPEC.loader is not None
 _ROUTER_SPEC.loader.exec_module(operator_router)
+
+
+class FakeAsyncTransaction:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class FakePoolAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        return FakePoolAcquire(self.conn)
 
 
 def source_run(**overrides):
@@ -122,6 +151,9 @@ class FakeAsyncConn:
         self.legacy_rows = list(legacy_rows or [])
         self.staging_rows = list(staging_rows or [])
         self.statements = []
+
+    def transaction(self, readonly=False):
+        return FakeAsyncTransaction()
 
     async def fetch(self, sql, *params):
         self.statements.append((sql, params))
@@ -469,6 +501,45 @@ async def test_file_paths_are_redacted_or_normalized_when_returned():
     encoded = visibility.to_operator_visibility_dict(detail)
     assert '/var/lib' not in repr(encoded)
     assert '/home/brian' not in repr(encoded)
+
+
+@pytest.mark.asyncio
+async def test_operator_query_endpoints_preserve_slash_and_space_source_run_keys():
+    source_run_key = 'source/run 1'
+    conn = FakeAsyncConn(
+        source_runs=[source_run(source_run_key=source_run_key)],
+        legacy_rows=[legacy_bridge(source_run_key=f'source_runs:{source_run_key}')],
+        staging_rows=[
+            staging_row(
+                source_run_id=701,
+                provenance={
+                    'canonical_write_allowed': False,
+                    'stage19anr_diagnostic_mark': {'source_run_key': source_run_key},
+                },
+            ),
+        ],
+    )
+    pool = FakePool(conn)
+
+    detail = await operator_router.operator_source_run_detail(source_run_key=source_run_key, pool=pool)
+    artifacts = await operator_router.operator_source_run_artifacts(source_run_key=source_run_key, pool=pool)
+    bridge = await operator_router.operator_source_run_bridge(source_run_key=source_run_key, pool=pool)
+    staging = await operator_router.operator_source_run_staging_impact(
+        source_run_key=source_run_key,
+        limit=5,
+        pool=pool,
+    )
+
+    assert detail['summary']['source_run_key'] == source_run_key
+    assert artifacts['source_run_key'] == source_run_key
+    assert bridge['source_run_key'] == source_run_key
+    assert staging['source_run_key'] == source_run_key
+    assert staging['staging_impact']['source_run_key'] == source_run_key
+    route_paths = {route.path for route in operator_router.router.routes}
+    assert '/api/operator/source-runs/{source_run_key}' not in route_paths
+    assert '/api/operator/source-runs/{source_run_key}/artifacts' not in route_paths
+    assert '/api/operator/source-runs/{source_run_key}/bridge' not in route_paths
+    assert '/api/operator/source-runs/{source_run_key}/staging-impact' not in route_paths
 
 
 def test_static_guardrails_for_operator_visibility_module_and_router():


### PR DESCRIPTION
## Summary

Stage 19AQ adds the minimal read-only operator/admin cockpit UI for the Stage 19AP operator visibility endpoints.

## Files added/changed

- Added `frontend-v2/src/features/operator/OperatorCockpitTab.tsx`.
- Added `frontend-v2/src/features/operator/OperatorCockpitTab.test.tsx`.
- Added `frontend-v2/src/lib/api.operator.test.ts`.
- Updated `frontend-v2/src/lib/api.ts` with GET-only operator API helpers.
- Updated `frontend-v2/src/types/api.ts` with operator wire types because generated OpenAPI currently exposes these endpoint responses as `unknown`.
- Updated `frontend-v2/src/hooks/useHashRoute.ts` and test coverage for the new route.
- Updated `frontend-v2/src/components/NavBar.tsx` and `frontend-v2/src/App.tsx` to expose/render the cockpit.
- Updated `docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md`.
- Added `docs/colonisation-redesign/stage-19aq-operator-cockpit-ui-closeout.md`.

## Route/path added

- Frontend hash route: `#operator`.

## Panels implemented

- Safety Gates panel from `GET /api/operator/safety-gates`.
- Recent Source Runs table from `GET /api/operator/source-runs?limit=25`.
- Selected Source Run detail panel from `GET /api/operator/source-runs/{source_run_key}`.
- Diagnostic Rows panel from `GET /api/operator/diagnostic-staging-rows`, scoped to the selected source run after selection.

## Tests run and results

- `yarn.cmd test OperatorCockpitTab api.operator useHashRoute` - passed, 37 tests.
- `yarn.cmd test` - passed.
- `yarn.cmd typecheck` - passed.
- `yarn.cmd build` - passed.
- `git diff --check` - passed.

## Safety confirmations

- No production DB access.
- No imports run.
- No migrations run.
- No scheduler/timer enablement.
- No staging writes.
- No canonical writes or canonical apply.
- No write endpoints added.
- No import, scheduler, canonical write, or canonical apply buttons/actions added.

## Known warnings

- Full Vitest still emits existing unrelated jsdom/Recharts/canvas and React `act(...)` warnings in older map/planner/radar tests.
- Build still emits existing `/v2/bg/coalsack-*` runtime asset resolution warnings and a chunk-size warning.