### PR TITLE
Stage 19AR add bounded 25-row staging pilot script

### DIFF
--- a/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
+++ b/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
@@ -1,0 +1,1047 @@
+#!/usr/bin/env python3
+"""Stage 19AR bounded 25-row EDSM station staging pilot.
+
+This operator script samples exactly 25 existing real-shaped
+``staging_edsm_stations`` rows for commit mode, converts them into a local
+EDSM-like JSON fixture, and optionally commits them through the Stage 19T
+local-file importer with an explicit legacy-compatible stager.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+if str(IMPORTER_SRC) not in sys.path:
+    sys.path.insert(0, str(IMPORTER_SRC))
+
+import artifact_utils  # noqa: E402
+import edsm_station_import  # noqa: E402
+import source_run_compatibility  # noqa: E402
+
+
+SCHEMA_VERSION = 'stage19ar_edsm_25_row_staging_pilot/v1'
+STAGER_NAME = 'stage19ar_edsm_25_row_compatible_stager'
+STAGER_VERSION = 'v1'
+SOURCE_RUN_KEY_PREFIX = 'stage19ar-edsm-25-row-staging-pilot-'
+SOURCE_RUN_PREFIXES = ('stage19ar-', 'stage-19ar-')
+PROVENANCE_MARKER_KEY = 'stage19ar_bounded_25_row_pilot'
+DEFAULT_TRIGGER_CONTEXT = PROVENANCE_MARKER_KEY
+DEFAULT_ARTIFACT_DIR = Path('/var/lib/ed-finder/operator-artifacts/stage-19ar')
+DEFAULT_LIMIT = 25
+HARD_MAX_LIMIT = 25
+DIAGNOSTIC_ONLY = 'diagnostic-only'
+REQUIRED_TABLES = ('source_runs', 'enrichment_source_runs', 'staging_edsm_stations')
+STAGING_TARGET_TABLE = 'staging_edsm_stations'
+LEDGER_TARGET_TABLES = ('source_runs', 'enrichment_source_runs')
+CANONICAL_TABLES = (
+    'stations',
+    'systems',
+    'bodies',
+    'body_rings',
+    'station_body_links',
+    'station_external_identity',
+)
+SAMPLE_EXCLUDED_SOURCE_RUN_PATTERNS = ('source_runs:stage19%', 'source_runs:stage-19%')
+SAMPLE_EXCLUDED_STATION_NAME_PATTERNS = ('Stage 19%',)
+
+
+class Stage19ArPilotError(ValueError):
+    """Raised when the bounded pilot fails a safety or validation check."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Run the Stage 19AR bounded 25-row EDSM station staging pilot.',
+    )
+    parser.add_argument('--limit', type=int, default=DEFAULT_LIMIT, help='Exact number of staging rows to pilot.')
+    parser.add_argument(
+        '--artifact-dir',
+        default=str(DEFAULT_ARTIFACT_DIR),
+        help='Directory for sample, import, and operator artifacts.',
+    )
+    parser.add_argument('--git-head', default='auto', help='Git SHA for source_runs, or "auto".')
+    parser.add_argument('--trigger-context', default=DEFAULT_TRIGGER_CONTEXT, help='source_runs trigger context.')
+    parser.add_argument('--commit', action='store_true', help='Opt in to bounded DB staging writes.')
+    parser.add_argument('--db-host', default='127.0.0.1', help='Local Postgres host.')
+    parser.add_argument('--db-port', default='5432', help='Local Postgres port.')
+    parser.add_argument('--db-name', default='edfinder', help='Local Postgres database name.')
+    parser.add_argument('--db-user', default='edfinder', help='Local Postgres user.')
+    args = parser.parse_args(argv)
+    if args.limit < 1:
+        parser.error('--limit must be >= 1')
+    if args.limit > HARD_MAX_LIMIT:
+        parser.error(f'--limit must be <= {HARD_MAX_LIMIT} for Stage 19AR')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    conn = None
+    try:
+        git_head = resolve_git_head(args.git_head)
+        dsn = build_operator_dsn(args)
+        conn = connect_operator_db(dsn)
+        set_connection_mode(conn, commit=args.commit)
+        result = run_pilot(
+            conn,
+            limit=args.limit,
+            artifact_dir=Path(args.artifact_dir),
+            git_head=git_head,
+            trigger_context=args.trigger_context,
+            commit=args.commit,
+        )
+    except (OSError, Stage19ArPilotError, edsm_station_import.EdsmStationImportError) as exc:
+        if conn is not None:
+            rollback(conn)
+        print(f'stage19ar pilot failed: {exc}', file=sys.stderr)
+        return 2
+    finally:
+        if conn is not None:
+            close_connection(conn)
+
+    print(json.dumps(_summary_for_stdout(result), sort_keys=True, indent=2))
+    return 0
+
+
+def run_pilot(
+    conn: Any,
+    *,
+    limit: int,
+    artifact_dir: Path,
+    git_head: str,
+    trigger_context: str,
+    commit: bool,
+    generated_at: datetime | None = None,
+) -> dict[str, Any]:
+    if limit < 1:
+        raise Stage19ArPilotError('limit must be >= 1')
+    if limit > HARD_MAX_LIMIT:
+        raise Stage19ArPilotError(f'limit must be <= {HARD_MAX_LIMIT}')
+    if commit and limit != DEFAULT_LIMIT:
+        raise Stage19ArPilotError(f'commit mode requires exactly {DEFAULT_LIMIT} rows')
+    generated = generated_at or _utc_now()
+    run_label = _run_label(generated)
+
+    try:
+        artifact_dir_check = verify_artifact_directory_writable(artifact_dir)
+        preflight = preflight_pilot(conn, artifact_dir_check=artifact_dir_check)
+        sampled_rows = sample_existing_staging_rows(conn, limit=limit)
+        fixture_rows = [staging_row_to_edsm_fixture_record(row) for row in sampled_rows]
+        sample_path = artifact_dir / f'stage19ar_edsm_sample_{run_label}.json'
+        sample_record = write_sample_fixture(sample_path, fixture_rows)
+        source_run_key = build_source_run_key(sample_record['file_sha256'])
+
+        if not commit:
+            rollback(conn)
+            operator_artifact = write_operator_artifact(
+                artifact_dir=artifact_dir,
+                run_label=run_label,
+                generated_at=generated,
+                commit_requested=False,
+                source_run_key=source_run_key,
+                bridge_key=source_run_compatibility.build_enrichment_source_run_key(source_run_key),
+                sample_record=sample_record,
+                import_artifact_record=None,
+                preflight=preflight,
+                rows_inserted=0,
+                rows_marked=0,
+                validation_checks={
+                    'dry_run_read_only': True,
+                    'db_writes_attempted': False,
+                    'sampled_exact_limit': len(sampled_rows) == limit,
+                    'selected_sample_count': len(sampled_rows),
+                    'ready_for_commit': len(sampled_rows) == DEFAULT_LIMIT and limit == DEFAULT_LIMIT,
+                    'canonical_table_writes_performed_by_script': False,
+                    'no_scheduler_or_service_invoked': True,
+                },
+            )
+            return {
+                'commit_requested': False,
+                'source_run_key': source_run_key,
+                'bridge_key': source_run_compatibility.build_enrichment_source_run_key(source_run_key),
+                'sample_record': sample_record,
+                'operator_artifact_record': operator_artifact,
+                'validation_checks': operator_artifact['payload']['validation_checks'],
+            }
+
+        stager = CompatibleStage19ArStationStager(generated_at=generated)
+        import_artifact_path = artifact_dir / f'stage19ar_edsm_import_{run_label}.json'
+        import_result = edsm_station_import.run_edsm_station_import(
+            conn,
+            source_file=sample_path,
+            artifact_path=import_artifact_path,
+            source_run_key=source_run_key,
+            git_commit_sha=git_head,
+            trigger_context=trigger_context,
+            generated_at=generated,
+            station_stager=stager,
+        )
+        if import_result['completion']['status'] != 'succeeded':
+            raise Stage19ArPilotError(
+                f'EDSM station import did not succeed: {import_result["completion"]["status"]}'
+            )
+
+        marked_rows = mark_inserted_rows_diagnostic(
+            conn,
+            row_ids=stager.inserted_row_ids,
+            legacy_source_run_id=stager.legacy_source_run_id,
+            source_run_key=source_run_key,
+            generated_at=generated,
+        )
+        validation = validate_pilot(
+            conn,
+            limit=limit,
+            source_run_key=source_run_key,
+            bridge_key=stager.bridge_key,
+            source_run_id=int(import_result['source_run']['id']),
+            legacy_source_run_id=int(stager.legacy_source_run_id),
+            inserted_row_ids=stager.inserted_row_ids,
+            import_artifact_record=import_result['artifact_record'],
+        )
+        assert_validation_passes(validation)
+        operator_artifact = write_operator_artifact(
+            artifact_dir=artifact_dir,
+            run_label=run_label,
+            generated_at=generated,
+            commit_requested=True,
+            source_run_key=source_run_key,
+            bridge_key=stager.bridge_key,
+            sample_record=sample_record,
+            import_artifact_record=import_result['artifact_record'],
+            preflight=preflight,
+            rows_inserted=len(stager.inserted_row_ids),
+            rows_marked=len(marked_rows),
+            validation_checks=validation,
+        )
+        commit_connection(conn)
+        return {
+            'commit_requested': True,
+            'source_run_key': source_run_key,
+            'bridge_key': stager.bridge_key,
+            'sample_record': sample_record,
+            'import_result': import_result,
+            'operator_artifact_record': operator_artifact,
+            'validation_checks': validation,
+            'inserted_row_ids': list(stager.inserted_row_ids),
+        }
+    except Exception:
+        rollback(conn)
+        raise
+
+
+def preflight_pilot(conn: Any, *, artifact_dir_check: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    helper_checks = verify_required_helpers_available()
+    schema = verify_target_tables_exist(conn)
+    staging_fk = verify_staging_source_run_fk_targets_legacy_bridge(conn)
+    leftovers = count_existing_stage19ar_rows(conn)
+    if any(leftovers.values()):
+        if leftovers.get('running_source_runs'):
+            raise Stage19ArPilotError(f'running Stage 19AR source run found: {leftovers}')
+        raise Stage19ArPilotError(f'existing Stage 19AR rows found: {leftovers}')
+    return {
+        'helper_imports': helper_checks,
+        'target_tables': schema,
+        'staging_source_run_fk': staging_fk,
+        'existing_stage19ar_rows': leftovers,
+        'artifact_directory': dict(artifact_dir_check or {}),
+    }
+
+
+def verify_required_helpers_available() -> dict[str, bool]:
+    checks = {
+        'edsm_station_import.run_edsm_station_import': hasattr(
+            edsm_station_import,
+            'run_edsm_station_import',
+        ),
+        'source_run_compatibility.get_or_create_legacy_staging_context': hasattr(
+            source_run_compatibility,
+            'get_or_create_legacy_staging_context',
+        ),
+        'artifact_utils.write_json_artifact': hasattr(artifact_utils, 'write_json_artifact'),
+    }
+    if not all(checks.values()):
+        raise Stage19ArPilotError(f'required helper imports unavailable: {checks}')
+    return checks
+
+
+def verify_target_tables_exist(conn: Any) -> dict[str, Any]:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema IN (current_schema(), 'public')
+              AND table_name = ANY(%s)
+            """,
+            (list(REQUIRED_TABLES),),
+        )
+        rows = _fetchall_dicts(cur)
+    finally:
+        close_cursor(cur)
+
+    present = sorted({str(row['table_name']) for row in rows})
+    missing = sorted(set(REQUIRED_TABLES) - set(present))
+    result = {'required_tables': list(REQUIRED_TABLES), 'present_tables': present, 'missing_tables': missing}
+    if missing:
+        raise Stage19ArPilotError(f'required target tables missing: {missing}')
+    return result
+
+
+def verify_staging_source_run_fk_targets_legacy_bridge(conn: Any) -> dict[str, Any]:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              tc.constraint_name,
+              ccu.table_name AS foreign_table_name,
+              ccu.column_name AS foreign_column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+            JOIN information_schema.constraint_column_usage ccu
+              ON ccu.constraint_name = tc.constraint_name
+             AND ccu.table_schema = tc.table_schema
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_schema IN (current_schema(), 'public')
+              AND tc.table_name = 'staging_edsm_stations'
+              AND kcu.column_name = 'source_run_id'
+            """,
+        )
+        rows = _fetchall_dicts(cur)
+    finally:
+        close_cursor(cur)
+
+    targets = sorted({
+        f'{row.get("foreign_table_name")}({row.get("foreign_column_name")})'
+        for row in rows
+    })
+    uses_legacy_bridge = 'enrichment_source_runs(id)' in targets
+    uses_new_source_runs = 'source_runs(id)' in targets
+    result = {
+        'targets': targets,
+        'uses_legacy_bridge_id': uses_legacy_bridge,
+        'uses_source_runs_id': uses_new_source_runs,
+    }
+    if not uses_legacy_bridge or uses_new_source_runs:
+        raise Stage19ArPilotError(
+            'staging_edsm_stations.source_run_id must target enrichment_source_runs(id), '
+            f'not source_runs(id): {targets}'
+        )
+    return result
+
+
+def count_existing_stage19ar_rows(conn: Any) -> dict[str, int]:
+    source_patterns = [f'{prefix}%' for prefix in SOURCE_RUN_PREFIXES]
+    bridge_patterns = [
+        f'{source_run_compatibility.LEGACY_SOURCE_RUN_KEY_PREFIX}{pattern}'
+        for pattern in source_patterns
+    ]
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              (
+                SELECT COUNT(*)::int
+                FROM source_runs
+                WHERE source_run_key LIKE ANY(%s)
+              ) AS source_runs,
+              (
+                SELECT COUNT(*)::int
+                FROM source_runs
+                WHERE source_run_key LIKE ANY(%s)
+                  AND status = 'running'
+              ) AS running_source_runs,
+              (
+                SELECT COUNT(*)::int
+                FROM enrichment_source_runs
+                WHERE source_run_key LIKE ANY(%s)
+              ) AS legacy_source_runs,
+              (
+                SELECT COUNT(*)::int
+                FROM staging_edsm_stations s
+                JOIN enrichment_source_runs e ON e.id = s.source_run_id
+                WHERE e.source_run_key LIKE ANY(%s)
+                  AND s.provenance ? %s
+              ) AS marked_staging_rows
+            """,
+            (source_patterns, source_patterns, bridge_patterns, bridge_patterns, PROVENANCE_MARKER_KEY),
+        )
+        row = _fetchone_dict(cur) or {}
+    finally:
+        close_cursor(cur)
+    return {
+        'source_runs': int(row.get('source_runs') or 0),
+        'running_source_runs': int(row.get('running_source_runs') or 0),
+        'legacy_source_runs': int(row.get('legacy_source_runs') or 0),
+        'marked_staging_rows': int(row.get('marked_staging_rows') or 0),
+    }
+
+
+def verify_artifact_directory_writable(artifact_dir: Path) -> dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    probe_path = artifact_dir / '.stage19ar-write-probe'
+    try:
+        probe_path.write_text('stage19ar\n', encoding='utf-8')
+        probe_path.unlink()
+    except OSError as exc:
+        raise Stage19ArPilotError(f'artifact directory is not writable: {artifact_dir}') from exc
+    return {
+        'path': str(artifact_dir),
+        'exists': artifact_dir.is_dir(),
+        'writable': True,
+    }
+
+
+def sample_existing_staging_rows(conn: Any, *, limit: int) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              s.id,
+              s.system_id64,
+              s.system_name,
+              s.market_id,
+              s.edsm_station_id,
+              s.station_name,
+              s.station_type,
+              s.distance_to_arrival,
+              s.body_name,
+              s.services,
+              s.economies,
+              s.controlling_faction,
+              s.allegiance,
+              s.government,
+              s.source_updated_at,
+              s.raw_payload,
+              s.provenance
+            FROM staging_edsm_stations s
+            JOIN enrichment_source_runs r ON r.id = s.source_run_id
+            WHERE s.station_name IS NOT NULL
+              AND btrim(s.station_name) <> ''
+              AND s.station_type IS NOT NULL
+              AND btrim(s.station_type) <> ''
+              AND s.system_name IS NOT NULL
+              AND btrim(s.system_name) <> ''
+              AND s.source_class <> %s
+              AND s.confidence <> %s
+              AND r.source_run_key NOT LIKE ALL(%s)
+              AND s.station_name NOT ILIKE ALL(%s)
+            ORDER BY s.station_name, s.id
+            LIMIT %s
+            """,
+            (
+                DIAGNOSTIC_ONLY,
+                DIAGNOSTIC_ONLY,
+                list(SAMPLE_EXCLUDED_SOURCE_RUN_PATTERNS),
+                list(SAMPLE_EXCLUDED_STATION_NAME_PATTERNS),
+                limit,
+            ),
+        )
+        rows = _fetchall_dicts(cur)
+    finally:
+        close_cursor(cur)
+    if len(rows) != limit:
+        raise Stage19ArPilotError(f'expected exactly {limit} sampled rows, found {len(rows)}')
+    return rows
+
+
+def staging_row_to_edsm_fixture_record(row: Mapping[str, Any]) -> dict[str, Any]:
+    station_name = _required_text(row.get('station_name'), 'station_name')
+    station_type = _required_text(row.get('station_type'), 'station_type')
+    system_name = _required_text(row.get('system_name'), 'system_name')
+    record: dict[str, Any] = {
+        'name': station_name,
+        'type': station_type,
+        'systemName': system_name,
+    }
+    _copy_if_present(record, 'systemId64', row.get('system_id64'))
+    _copy_if_present(record, 'marketId', row.get('market_id'))
+    _copy_if_present(record, 'id', row.get('edsm_station_id') or row.get('market_id'))
+    _copy_if_present(record, 'distanceToArrival', row.get('distance_to_arrival'))
+    _copy_if_present(record, 'bodyName', row.get('body_name'))
+    services = _json_list(row.get('services'))
+    if services:
+        record['services'] = services
+    economies = _json_list(row.get('economies'))
+    if economies:
+        record.update(_economy_fields(economies))
+    _copy_if_present(record, 'controllingFaction', _controlling_faction(row.get('controlling_faction')))
+    _copy_if_present(record, 'allegiance', row.get('allegiance'))
+    _copy_if_present(record, 'government', row.get('government'))
+    _copy_if_present(record, 'updatedAt', _json_scalar(row.get('source_updated_at')))
+    return record
+
+
+class CompatibleStage19ArStationStager:
+    """Explicit stager that writes legacy bridge IDs into staging FK columns."""
+
+    def __init__(self, *, generated_at: datetime) -> None:
+        self.generated_at = generated_at
+        self.inserted_row_ids: list[int] = []
+        self.legacy_source_run_id: int | None = None
+        self.bridge_key: str | None = None
+
+    def __call__(self, conn: Any, *, source_run: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> int:
+        context = source_run_compatibility.get_or_create_legacy_staging_context(
+            conn,
+            source_run,
+            source='edsm',
+            adapter_name=STAGER_NAME,
+            adapter_version=STAGER_VERSION,
+            source_kind='offline_snapshot',
+            dry_run=False,
+            metadata={
+                'operator_stage': '19ar',
+                'bounded_25_row_pilot': True,
+                'staging_rows_written_by_explicit_stager': True,
+                'canonical_table_writes_planned': 0,
+            },
+        )
+        legacy_source_run_id = int(context['legacy_source_run_id'])
+        self.legacy_source_run_id = legacy_source_run_id
+        self.bridge_key = str(context['enrichment_source_run']['source_run_key'])
+
+        cur = conn.cursor()
+        try:
+            for row in rows:
+                cur.execute(
+                    """
+                    INSERT INTO staging_edsm_stations (
+                        source_run_id,
+                        source_file_id,
+                        raw_record_id,
+                        source_record_key,
+                        source_record_hash,
+                        system_id64,
+                        system_name,
+                        market_id,
+                        edsm_station_id,
+                        station_name,
+                        station_type,
+                        distance_to_arrival,
+                        body_name,
+                        services,
+                        economies,
+                        controlling_faction,
+                        allegiance,
+                        government,
+                        source_class,
+                        confidence,
+                        freshness_class,
+                        source_updated_at,
+                        raw_payload,
+                        provenance
+                    )
+                    VALUES (
+                        %s, NULL, NULL, %s, %s,
+                        %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s::jsonb, %s::jsonb,
+                        %s, %s, %s, %s, %s,
+                        %s, %s, %s::jsonb, %s::jsonb
+                    )
+                    RETURNING id
+                    """,
+                    (
+                        legacy_source_run_id,
+                        row.get('source_record_key'),
+                        _required_text(row.get('source_record_hash'), 'source_record_hash'),
+                        row.get('system_id64'),
+                        row.get('system_name'),
+                        row.get('market_id'),
+                        row.get('edsm_station_id'),
+                        row.get('station_name'),
+                        row.get('station_type'),
+                        row.get('distance_to_arrival'),
+                        row.get('body_name'),
+                        artifact_utils.canonical_json(_json_list(row.get('services'))),
+                        artifact_utils.canonical_json(_json_list(row.get('economies'))),
+                        row.get('controlling_faction'),
+                        row.get('allegiance'),
+                        row.get('government'),
+                        _required_text(row.get('source_class'), 'source_class'),
+                        _required_text(row.get('confidence'), 'confidence'),
+                        row.get('freshness_class'),
+                        row.get('source_updated_at'),
+                        artifact_utils.canonical_json(row.get('raw_payload') or {}),
+                        artifact_utils.canonical_json(row.get('provenance') or {}),
+                    ),
+                )
+                inserted = _fetchone_dict(cur)
+                if inserted is None:
+                    raise Stage19ArPilotError('staging insert did not return an id')
+                self.inserted_row_ids.append(int(inserted['id']))
+        finally:
+            close_cursor(cur)
+        return len(rows)
+
+
+def mark_inserted_rows_diagnostic(
+    conn: Any,
+    *,
+    row_ids: Sequence[int],
+    legacy_source_run_id: int | None,
+    source_run_key: str,
+    generated_at: datetime,
+) -> list[dict[str, Any]]:
+    if not row_ids:
+        raise Stage19ArPilotError('no inserted staging row ids available for diagnostic mark')
+    if legacy_source_run_id is None:
+        raise Stage19ArPilotError('legacy source-run id is required for diagnostic mark')
+    marker = {
+        PROVENANCE_MARKER_KEY: {
+            'source_run_key': source_run_key,
+            'marked_at': _format_timestamp(generated_at),
+            'reason': 'Stage 19AR bounded 25-row EDSM staging pilot',
+        },
+        'canonical_write_allowed': False,
+    }
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            UPDATE staging_edsm_stations
+            SET
+              source_class = %s,
+              confidence = %s,
+              provenance = provenance || %s::jsonb
+            WHERE id = ANY(%s)
+              AND source_run_id = %s
+            RETURNING id, source_class, confidence, provenance
+            """,
+            (
+                DIAGNOSTIC_ONLY,
+                DIAGNOSTIC_ONLY,
+                artifact_utils.canonical_json(marker),
+                list(row_ids),
+                int(legacy_source_run_id),
+            ),
+        )
+        rows = _fetchall_dicts(cur)
+    finally:
+        close_cursor(cur)
+    if len(rows) != len(row_ids):
+        raise Stage19ArPilotError(
+            f'diagnostic mark count mismatch: expected {len(row_ids)}, marked {len(rows)}'
+        )
+    return rows
+
+
+def validate_pilot(
+    conn: Any,
+    *,
+    limit: int,
+    source_run_key: str,
+    bridge_key: str | None,
+    source_run_id: int,
+    legacy_source_run_id: int,
+    inserted_row_ids: Sequence[int],
+    import_artifact_record: Mapping[str, Any],
+) -> dict[str, bool]:
+    source_run = fetch_source_run(conn, source_run_key)
+    bridge = fetch_legacy_bridge(conn, bridge_key)
+    staging = fetch_staging_validation_counts(
+        conn,
+        row_ids=inserted_row_ids,
+        source_run_id=source_run_id,
+        legacy_source_run_id=legacy_source_run_id,
+    )
+    artifact_path = Path(str(import_artifact_record['artifact_path']))
+    artifact_sha256 = artifact_utils.sha256_file(artifact_path) if artifact_path.is_file() else None
+    checks = {
+        'one_source_run_inserted': source_run is not None and source_run.get('source_run_key') == source_run_key,
+        'source_run_succeeded': source_run is not None and source_run.get('status') == 'succeeded',
+        'one_legacy_bridge_inserted': bridge is not None and bridge.get('source_run_key') == bridge_key,
+        'exactly_25_staging_rows_inserted': staging['rows_inserted'] == DEFAULT_LIMIT and limit == DEFAULT_LIMIT,
+        'exactly_25_staging_rows_marked_diagnostic': (
+            staging['rows_marked_diagnostic'] == DEFAULT_LIMIT and limit == DEFAULT_LIMIT
+        ),
+        'staging_rows_use_legacy_bridge_id': staging['rows_using_legacy_bridge_id'] == limit,
+        'staging_rows_do_not_use_source_runs_id': staging['rows_using_source_runs_id'] == 0,
+        'staging_rows_have_stage19ar_marker': staging['rows_with_stage19ar_marker'] == limit,
+        'staging_rows_preserve_canonical_write_block': staging['rows_with_canonical_write_blocked'] == limit,
+        'source_run_artifact_hash_matches': (
+            source_run is not None
+            and source_run.get('artifact_sha256') == import_artifact_record['artifact_sha256']
+            and source_run.get('artifact_sha256') == artifact_sha256
+        ),
+        'source_run_artifact_integrity_matches': (
+            source_run is not None
+            and source_run.get('artifact_integrity_sha256')
+            == import_artifact_record['artifact_integrity_sha256']
+        ),
+        'no_scheduler_or_service_invoked': True,
+        'canonical_table_writes_performed_by_script': False,
+    }
+    return checks
+
+
+def fetch_source_run(conn: Any, source_run_key: str) -> dict[str, Any] | None:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              id,
+              source_run_key,
+              status,
+              artifact_path,
+              artifact_sha256,
+              artifact_integrity_sha256
+            FROM source_runs
+            WHERE source_run_key = %s
+            """,
+            (source_run_key,),
+        )
+        return _fetchone_dict(cur)
+    finally:
+        close_cursor(cur)
+
+
+def fetch_legacy_bridge(conn: Any, bridge_key: str | None) -> dict[str, Any] | None:
+    if bridge_key is None:
+        return None
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT id, source_run_key, dry_run, metadata
+            FROM enrichment_source_runs
+            WHERE source_run_key = %s
+            """,
+            (bridge_key,),
+        )
+        return _fetchone_dict(cur)
+    finally:
+        close_cursor(cur)
+
+
+def fetch_staging_validation_counts(
+    conn: Any,
+    *,
+    row_ids: Sequence[int],
+    source_run_id: int,
+    legacy_source_run_id: int,
+) -> dict[str, int]:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              COUNT(*)::int AS rows_inserted,
+              COUNT(*) FILTER (WHERE source_class = %s AND confidence = %s)::int
+                AS rows_marked_diagnostic,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_legacy_bridge_id,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_source_runs_id,
+              COUNT(*) FILTER (WHERE provenance ? %s)::int AS rows_with_stage19ar_marker,
+              COUNT(*) FILTER (WHERE provenance->>%s = 'false')::int
+                AS rows_with_canonical_write_blocked
+            FROM staging_edsm_stations
+            WHERE id = ANY(%s)
+            """,
+            (
+                DIAGNOSTIC_ONLY,
+                DIAGNOSTIC_ONLY,
+                int(legacy_source_run_id),
+                int(source_run_id),
+                PROVENANCE_MARKER_KEY,
+                'canonical_write_allowed',
+                list(row_ids),
+            ),
+        )
+        row = _fetchone_dict(cur) or {}
+    finally:
+        close_cursor(cur)
+    return {
+        'rows_inserted': int(row.get('rows_inserted') or 0),
+        'rows_marked_diagnostic': int(row.get('rows_marked_diagnostic') or 0),
+        'rows_using_legacy_bridge_id': int(row.get('rows_using_legacy_bridge_id') or 0),
+        'rows_using_source_runs_id': int(row.get('rows_using_source_runs_id') or 0),
+        'rows_with_stage19ar_marker': int(row.get('rows_with_stage19ar_marker') or 0),
+        'rows_with_canonical_write_blocked': int(row.get('rows_with_canonical_write_blocked') or 0),
+    }
+
+
+def assert_validation_passes(checks: Mapping[str, bool]) -> None:
+    failed = sorted(key for key, passed in checks.items() if not passed)
+    allowed_false = {'canonical_table_writes_performed_by_script'}
+    failed = [key for key in failed if key not in allowed_false]
+    if checks.get('canonical_table_writes_performed_by_script') is not False:
+        failed.append('canonical_table_writes_performed_by_script')
+    if failed:
+        raise Stage19ArPilotError(f'validation failed: {failed}')
+
+
+def write_operator_artifact(
+    *,
+    artifact_dir: Path,
+    run_label: str,
+    generated_at: datetime,
+    commit_requested: bool,
+    source_run_key: str,
+    bridge_key: str,
+    sample_record: Mapping[str, Any],
+    import_artifact_record: Mapping[str, Any] | None,
+    preflight: Mapping[str, Any],
+    rows_inserted: int,
+    rows_marked: int,
+    validation_checks: Mapping[str, bool],
+) -> dict[str, Any]:
+    payload = {
+        'schema_version': SCHEMA_VERSION,
+        'generated_at': _format_timestamp(generated_at),
+        'source_sample': {
+            'path': sample_record['path'],
+            'file_sha256': sample_record['file_sha256'],
+            'rows': sample_record['rows'],
+        },
+        'import_artifact': dict(import_artifact_record or {}),
+        'source_run_key': source_run_key,
+        'bridge_key': bridge_key,
+        'rows_inserted': rows_inserted,
+        'rows_marked_diagnostic': rows_marked,
+        'preflight': dict(preflight),
+        'validation_checks': dict(validation_checks),
+        'safety_summary': safety_summary(commit_requested=commit_requested),
+    }
+    path = artifact_dir / f'stage19ar_operator_pilot_{run_label}.json'
+    raw_record = artifact_utils.write_json_artifact(path, payload)
+    record = {
+        **raw_record,
+        'artifact_path': raw_record['path'],
+        'artifact_sha256': raw_record['file_sha256'],
+    }
+    return {'record': record, 'payload': payload}
+
+
+def safety_summary(*, commit_requested: bool) -> dict[str, Any]:
+    return {
+        'commit_requested': bool(commit_requested),
+        'default_mode': 'read_only_no_db_writes',
+        'source_sample_rows_bounded_by_limit': True,
+        'local_fixture_only': True,
+        'network_import_performed': False,
+        'production_import_run': False,
+        'scheduler_invoked': False,
+        'service_manager_invoked': False,
+        'migrations_performed': False,
+        'target_tables': [*LEDGER_TARGET_TABLES, STAGING_TARGET_TABLE],
+        'canonical_tables_touched': [],
+        'canonical_table_writes_planned': 0,
+        'canonical_write_executor_invoked': False,
+    }
+
+
+def write_sample_fixture(path: Path, rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(list(rows), sort_keys=True, indent=2, default=str) + '\n'
+    path.write_text(text, encoding='utf-8')
+    path.chmod(0o600)
+    return {
+        'path': str(path),
+        'file_sha256': artifact_utils.sha256_file(path),
+        'rows': len(rows),
+        'hash_algorithm': artifact_utils.HASH_ALGORITHM,
+    }
+
+
+def build_source_run_key(sample_sha256: str) -> str:
+    return f'{SOURCE_RUN_KEY_PREFIX}{sample_sha256[:16]}'
+
+
+def build_operator_dsn(args: argparse.Namespace, env: Mapping[str, str] | None = None) -> str:
+    source_env = env if env is not None else os.environ
+    password = source_env.get('POSTGRES_PASSWORD')
+    if not password:
+        raise Stage19ArPilotError('POSTGRES_PASSWORD is required for operator DB connection')
+    parts = {
+        'host': args.db_host,
+        'port': args.db_port,
+        'dbname': args.db_name,
+        'user': args.db_user,
+        'password': password,
+        'sslmode': 'disable',
+    }
+    return ' '.join(f'{key}={value}' for key, value in parts.items())
+
+
+def connect_operator_db(dsn: str) -> Any:
+    import psycopg2  # noqa: PLC0415
+    import psycopg2.extras  # noqa: PLC0415
+
+    return psycopg2.connect(dsn, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def set_connection_mode(conn: Any, *, commit: bool) -> None:
+    set_session = getattr(conn, 'set_session', None)
+    if callable(set_session):
+        set_session(readonly=not commit, autocommit=False)
+
+
+def resolve_git_head(value: str) -> str:
+    if value != 'auto':
+        return _required_text(value, 'git_head')
+    completed = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _required_text(completed.stdout.strip(), 'git_head')
+
+
+def _summary_for_stdout(result: Mapping[str, Any]) -> dict[str, Any]:
+    operator_record = result['operator_artifact_record']['record']
+    return {
+        'commit_requested': result['commit_requested'],
+        'source_run_key': result['source_run_key'],
+        'bridge_key': result['bridge_key'],
+        'sample_path': result['sample_record']['path'],
+        'operator_artifact_path': operator_record['artifact_path'],
+        'operator_artifact_sha256': operator_record['artifact_sha256'],
+        'validation_checks': dict(result.get('validation_checks') or {}),
+    }
+
+
+def _fetchone_dict(cur: Any) -> dict[str, Any] | None:
+    return _row_to_dict(cur.fetchone(), cur)
+
+
+def _fetchall_dicts(cur: Any) -> list[dict[str, Any]]:
+    return [_row_to_dict(row, cur) for row in cur.fetchall()]
+
+
+def _row_to_dict(row: Any, cursor: Any | None = None) -> dict[str, Any] | None:
+    if row is None:
+        return None
+    if isinstance(row, Mapping):
+        return dict(row)
+    if hasattr(row, 'keys'):
+        return {key: row[key] for key in row.keys()}
+    if isinstance(row, Sequence) and not isinstance(row, (str, bytes, bytearray)):
+        description = getattr(cursor, 'description', None)
+        if not description:
+            raise TypeError('cursor.description is required for positional rows')
+        columns = [str(column[0]) for column in description]
+        return dict(zip(columns, row))
+    raise TypeError('cursor rows must be mapping-like or positional')
+
+
+def _required_text(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise Stage19ArPilotError(f'{field} is required')
+    return value.strip()
+
+
+def _copy_if_present(record: dict[str, Any], key: str, value: Any) -> None:
+    if value is not None:
+        record[key] = _json_scalar(value)
+
+
+def _json_scalar(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return _format_timestamp(value)
+    return value
+
+
+def _json_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            return [value]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_scalar(item) for item in value]
+    return [value]
+
+
+def _economy_fields(economies: Sequence[Any]) -> dict[str, Any]:
+    names = [_economy_name(item) for item in economies]
+    names = [name for name in names if name]
+    fields: dict[str, Any] = {}
+    if names:
+        fields['economy'] = names[0]
+    if len(names) > 1:
+        fields['secondEconomy'] = names[1]
+    return fields
+
+
+def _economy_name(item: Any) -> str | None:
+    if isinstance(item, Mapping):
+        for key in ('name', 'economy', 'type'):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+    if isinstance(item, str) and item.strip():
+        return item.strip()
+    return None
+
+
+def _controlling_faction(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {'name': value}
+
+
+def _format_timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _run_label(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+
+
+def commit_connection(conn: Any) -> None:
+    commit = getattr(conn, 'commit', None)
+    if callable(commit):
+        commit()
+
+
+def rollback(conn: Any) -> None:
+    rollback_func = getattr(conn, 'rollback', None)
+    if callable(rollback_func):
+        rollback_func()
+
+
+def close_cursor(cur: Any) -> None:
+    close = getattr(cur, 'close', None)
+    if callable(close):
+        close()
+
+
+def close_connection(conn: Any) -> None:
+    close = getattr(conn, 'close', None)
+    if callable(close):
+        close()
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_stage19ar_operator_script.py
+++ b/tests/test_stage19ar_operator_script.py
@@ -1,0 +1,662 @@
+import ast
+import inspect
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OPERATOR_SCRIPTS = ROOT / 'scripts' / 'operator'
+if str(OPERATOR_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(OPERATOR_SCRIPTS))
+
+import stage19ar_edsm_25_row_staging_pilot as rehearsal  # noqa: E402
+
+
+NOW = datetime(2026, 6, 6, 10, 30, 0, tzinfo=timezone.utc)
+
+
+class FakeCursor:
+    def __init__(self, conn):
+        self.conn = conn
+        self.closed = False
+        self.fetchone_result = None
+        self.fetchall_result = []
+        self.description = None
+
+    def execute(self, sql, params=None):
+        params = tuple(params or ())
+        self.conn.statements.append((sql, params))
+        compact = ' '.join(sql.lower().split())
+
+        if 'from information_schema.tables' in compact:
+            self.fetchall_result = [
+                {'table_name': table_name}
+                for table_name in sorted(self.conn.present_tables)
+            ]
+            self.fetchone_result = None
+            return
+
+        if 'from information_schema.table_constraints' in compact:
+            self.fetchall_result = [dict(row) for row in self.conn.fk_rows]
+            self.fetchone_result = None
+            return
+
+        if 'as source_runs' in compact and 'marked_staging_rows' in compact:
+            self.fetchone_result = dict(self.conn.existing_stage19ar_counts)
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('select s.id') and 'from staging_edsm_stations s' in compact:
+            limit = int(params[-1])
+            self.fetchall_result = [dict(row) for row in self.conn.sample_rows[:limit]]
+            self.fetchone_result = None
+            return
+
+        if compact.startswith('insert into source_runs'):
+            self.conn.next_source_run_id += 1
+            row = {
+                'id': self.conn.next_source_run_id,
+                'source_run_key': params[0],
+                'status': params[5],
+                'artifact_path': None,
+                'artifact_sha256': None,
+                'artifact_integrity_sha256': None,
+            }
+            self.conn.source_runs[params[0]] = row
+            self.fetchone_result = {
+                'id': row['id'],
+                'source_run_key': row['source_run_key'],
+                'status': row['status'],
+            }
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('update source_runs'):
+            source_run_key = params[13]
+            row = self.conn.source_runs[source_run_key]
+            row.update({
+                'status': params[0],
+                'artifact_path': params[7],
+                'artifact_sha256': params[8],
+                'artifact_integrity_sha256': params[9],
+            })
+            self.fetchone_result = {
+                'id': row['id'],
+                'source_run_key': row['source_run_key'],
+                'status': row['status'],
+            }
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('select') and 'from enrichment_source_runs' in compact and 'where source_run_key = %s' in compact:
+            row = self.conn.legacy_rows.get(params[0])
+            self.fetchone_result = dict(row) if row is not None else None
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('insert into enrichment_source_runs'):
+            self.conn.next_legacy_id += 1
+            row = {
+                'id': self.conn.next_legacy_id,
+                'source_run_key': params[0],
+                'source': params[1],
+                'adapter_name': params[2],
+                'adapter_version': params[3],
+                'source_kind': params[4],
+                'source_class': params[5],
+                'run_label': params[6],
+                'dry_run': params[7],
+                'source_started_at': params[8],
+                'source_completed_at': params[9],
+                'metadata': json.loads(params[10]),
+            }
+            self.conn.legacy_rows[params[0]] = row
+            self.fetchone_result = dict(row)
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('insert into staging_edsm_stations'):
+            self.conn.next_staging_id += 1
+            row = {
+                'id': self.conn.next_staging_id,
+                'source_run_id': params[0],
+                'source_record_key': params[1],
+                'source_record_hash': params[2],
+                'system_id64': params[3],
+                'system_name': params[4],
+                'market_id': params[5],
+                'edsm_station_id': params[6],
+                'station_name': params[7],
+                'station_type': params[8],
+                'distance_to_arrival': params[9],
+                'body_name': params[10],
+                'services': json.loads(params[11]),
+                'economies': json.loads(params[12]),
+                'controlling_faction': params[13],
+                'allegiance': params[14],
+                'government': params[15],
+                'source_class': params[16],
+                'confidence': params[17],
+                'freshness_class': params[18],
+                'source_updated_at': params[19],
+                'raw_payload': json.loads(params[20]),
+                'provenance': json.loads(params[21]),
+            }
+            self.conn.staging_rows[row['id']] = row
+            self.fetchone_result = {'id': row['id']}
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('update staging_edsm_stations'):
+            marker = json.loads(params[2])
+            row_ids = set(params[3])
+            legacy_source_run_id = params[4]
+            rows = []
+            for row_id in row_ids:
+                row = self.conn.staging_rows[row_id]
+                if row['source_run_id'] != legacy_source_run_id:
+                    continue
+                row['source_class'] = params[0]
+                row['confidence'] = params[1]
+                row['provenance'].update(marker)
+                rows.append({
+                    'id': row['id'],
+                    'source_class': row['source_class'],
+                    'confidence': row['confidence'],
+                    'provenance': dict(row['provenance']),
+                })
+            self.fetchall_result = rows
+            self.fetchone_result = None
+            return
+
+        if compact.startswith('select id, source_run_key, status') and 'from source_runs' in compact:
+            row = self.conn.source_runs.get(params[0])
+            self.fetchone_result = dict(row) if row is not None else None
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('select count(*)::int as rows_inserted'):
+            row_ids = set(params[6])
+            rows = [row for row_id, row in self.conn.staging_rows.items() if row_id in row_ids]
+            legacy_source_run_id = params[2]
+            source_run_id = params[3]
+            marker_key = params[4]
+            canonical_key = params[5]
+            self.fetchone_result = {
+                'rows_inserted': len(rows),
+                'rows_marked_diagnostic': sum(
+                    1
+                    for row in rows
+                    if row['source_class'] == params[0] and row['confidence'] == params[1]
+                ),
+                'rows_using_legacy_bridge_id': sum(1 for row in rows if row['source_run_id'] == legacy_source_run_id),
+                'rows_using_source_runs_id': sum(1 for row in rows if row['source_run_id'] == source_run_id),
+                'rows_with_stage19ar_marker': sum(1 for row in rows if marker_key in row['provenance']),
+                'rows_with_canonical_write_blocked': sum(
+                    1
+                    for row in rows
+                    if row['provenance'].get(canonical_key) is False
+                ),
+            }
+            self.fetchall_result = []
+            return
+
+        raise AssertionError(f'unexpected SQL: {sql}')
+
+    def fetchone(self):
+        return self.fetchone_result
+
+    def fetchall(self):
+        return list(self.fetchall_result)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeConn:
+    def __init__(
+        self,
+        *,
+        sample_rows=None,
+        existing_stage19ar_counts=None,
+        present_tables=None,
+        fk_rows=None,
+    ):
+        self.sample_rows = list(sample_rows or [])
+        self.existing_stage19ar_counts = existing_stage19ar_counts or {
+            'source_runs': 0,
+            'running_source_runs': 0,
+            'legacy_source_runs': 0,
+            'marked_staging_rows': 0,
+        }
+        self.fk_rows = list(fk_rows or [{
+            'constraint_name': 'staging_edsm_stations_source_run_id_fkey',
+            'foreign_table_name': 'enrichment_source_runs',
+            'foreign_column_name': 'id',
+        }])
+        self.present_tables = set(present_tables or rehearsal.REQUIRED_TABLES)
+        self.statements = []
+        self.source_runs = {}
+        self.legacy_rows = {}
+        self.staging_rows = {}
+        self.next_source_run_id = 100
+        self.next_legacy_id = 700
+        self.next_staging_id = 900
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def cursor(self):
+        return FakeCursor(self)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def sample_staging_row(index=1, **overrides):
+    row = {
+        'id': 1000 + index,
+        'system_id64': 10477373803 + index,
+        'system_name': f'Sample System {index}',
+        'market_id': 700000 + index,
+        'edsm_station_id': 800000 + index,
+        'station_name': f'Sample Port {index}',
+        'station_type': 'Coriolis Starport',
+        'distance_to_arrival': 503.2,
+        'body_name': f'Sample Body {index}',
+        'services': ['Dock', 'Market'],
+        'economies': [{'name': 'High Tech'}, {'name': 'Service'}],
+        'controlling_faction': f'Faction {index}',
+        'allegiance': 'Independent',
+        'government': 'Corporate',
+        'source_updated_at': '2026-06-06T08:00:00Z',
+        'raw_payload': {'source': 'warehouse', 'row': index},
+        'provenance': {'canonical_write_allowed': False},
+    }
+    row.update(overrides)
+    return row
+
+
+def sample_staging_rows(count):
+    return [sample_staging_row(index) for index in range(1, count + 1)]
+
+
+def normalised_import_row(index=1, **overrides):
+    row = {
+        'source_record_key': f'source-record-key-{index}',
+        'source_record_hash': f'hash-{index}',
+        'system_id64': 10477373803 + index,
+        'system_name': f'Sample System {index}',
+        'market_id': 700000 + index,
+        'edsm_station_id': 800000 + index,
+        'station_name': f'Sample Port {index}',
+        'station_type': 'Coriolis Starport',
+        'distance_to_arrival': 503.2,
+        'body_name': f'Sample Body {index}',
+        'services': ['Dock', 'Market'],
+        'economies': ['High Tech', 'Service'],
+        'controlling_faction': f'Faction {index}',
+        'allegiance': 'Independent',
+        'government': 'Corporate',
+        'source_class': 'semi-stable',
+        'confidence': 'source_station_snapshot',
+        'freshness_class': 'source_updated_at',
+        'source_updated_at': '2026-06-06T08:00:00Z',
+        'raw_payload': {'source': 'fixture', 'row': index},
+        'provenance': {'canonical_write_allowed': False},
+    }
+    row.update(overrides)
+    return row
+
+
+def test_cli_defaults_to_25_row_read_only_and_does_not_commit_without_flag(tmp_path):
+    args = rehearsal.parse_args([
+        '--artifact-dir',
+        str(tmp_path),
+        '--git-head',
+        'abc1234',
+    ])
+    assert args.commit is False
+    assert args.limit == 25
+    assert args.trigger_context == 'stage19ar_bounded_25_row_pilot'
+
+    conn = FakeConn(sample_rows=sample_staging_rows(25))
+    result = rehearsal.run_pilot(
+        conn,
+        limit=25,
+        artifact_dir=tmp_path,
+        git_head='abc1234',
+        trigger_context='unit_test',
+        commit=False,
+        generated_at=NOW,
+    )
+
+    assert result['commit_requested'] is False
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+    assert conn.source_runs == {}
+    assert conn.legacy_rows == {}
+    assert conn.staging_rows == {}
+    assert not any('insert into source_runs' in sql.lower() for sql, _params in conn.statements)
+    assert result['validation_checks']['db_writes_attempted'] is False
+    assert result['validation_checks']['selected_sample_count'] == 25
+    assert result['validation_checks']['ready_for_commit'] is True
+
+
+def test_limit_hard_max_is_25(tmp_path):
+    with pytest.raises(SystemExit):
+        rehearsal.parse_args(['--limit', '26', '--artifact-dir', str(tmp_path)])
+
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='limit must be <= 25'):
+        rehearsal.run_pilot(
+            FakeConn(sample_rows=sample_staging_rows(25)),
+            limit=26,
+            artifact_dir=tmp_path,
+            git_head='abc1234',
+            trigger_context='unit_test',
+            commit=False,
+            generated_at=NOW,
+        )
+
+
+def test_commit_mode_refuses_limit_other_than_25(tmp_path):
+    conn = FakeConn(sample_rows=sample_staging_rows(2))
+
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='commit mode requires exactly 25 rows'):
+        rehearsal.run_pilot(
+            conn,
+            limit=2,
+            artifact_dir=tmp_path,
+            git_head='abc1234',
+            trigger_context='unit_test',
+            commit=True,
+            generated_at=NOW,
+        )
+
+    assert conn.commits == 0
+    assert conn.source_runs == {}
+
+
+def test_preflight_detects_existing_stage19ar_rows_and_stops():
+    conn = FakeConn(existing_stage19ar_counts={
+        'source_runs': 1,
+        'running_source_runs': 0,
+        'legacy_source_runs': 0,
+        'marked_staging_rows': 0,
+    })
+
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='existing Stage 19AR rows found'):
+        rehearsal.preflight_pilot(conn)
+
+
+def test_preflight_detects_running_stage19ar_source_run_first():
+    conn = FakeConn(existing_stage19ar_counts={
+        'source_runs': 1,
+        'running_source_runs': 1,
+        'legacy_source_runs': 0,
+        'marked_staging_rows': 0,
+    })
+
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='running Stage 19AR source run found'):
+        rehearsal.preflight_pilot(conn)
+
+
+def test_existing_stage19anr_rows_do_not_block_stage19ar_preflight():
+    conn = FakeConn()
+
+    preflight = rehearsal.preflight_pilot(conn)
+
+    assert preflight['existing_stage19ar_rows'] == {
+        'source_runs': 0,
+        'running_source_runs': 0,
+        'legacy_source_runs': 0,
+        'marked_staging_rows': 0,
+    }
+    params_text = json.dumps([params for _sql, params in conn.statements], default=str)
+    assert 'stage19ar' in params_text
+    assert 'stage19anr' not in params_text
+
+
+def test_preflight_requires_staging_fk_to_legacy_bridge():
+    conn = FakeConn(fk_rows=[{
+        'constraint_name': 'bad_fk',
+        'foreign_table_name': 'source_runs',
+        'foreign_column_name': 'id',
+    }])
+
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='must target enrichment_source_runs'):
+        rehearsal.preflight_pilot(conn)
+
+
+def test_sample_conversion_from_staging_row_to_edsm_like_json():
+    converted = rehearsal.staging_row_to_edsm_fixture_record(sample_staging_row())
+
+    assert converted == {
+        'allegiance': 'Independent',
+        'bodyName': 'Sample Body 1',
+        'controllingFaction': {'name': 'Faction 1'},
+        'distanceToArrival': 503.2,
+        'economy': 'High Tech',
+        'government': 'Corporate',
+        'id': 800001,
+        'marketId': 700001,
+        'name': 'Sample Port 1',
+        'secondEconomy': 'Service',
+        'services': ['Dock', 'Market'],
+        'systemId64': 10477373804,
+        'systemName': 'Sample System 1',
+        'type': 'Coriolis Starport',
+        'updatedAt': '2026-06-06T08:00:00Z',
+    }
+
+
+def test_explicit_compatible_stager_uses_legacy_bridge_id_for_staging():
+    conn = FakeConn()
+    stager = rehearsal.CompatibleStage19ArStationStager(generated_at=NOW)
+    source_run = {'id': 101, 'source_run_key': 'stage19ar-test', 'status': 'running'}
+
+    rows_written = stager(conn, source_run=source_run, rows=[normalised_import_row()])
+
+    assert rows_written == 1
+    assert stager.legacy_source_run_id == 701
+    assert stager.bridge_key == 'source_runs:stage19ar-test'
+    staged = conn.staging_rows[901]
+    assert staged['source_run_id'] == 701
+    assert staged['source_run_id'] != source_run['id']
+    assert conn.legacy_rows['source_runs:stage19ar-test']['dry_run'] is False
+
+
+def test_inserted_rows_are_marked_diagnostic_only_and_preserve_no_canonical_write():
+    conn = FakeConn()
+    stager = rehearsal.CompatibleStage19ArStationStager(generated_at=NOW)
+    stager(conn, source_run={'id': 101, 'source_run_key': 'stage19ar-test', 'status': 'running'}, rows=[
+        normalised_import_row(),
+    ])
+
+    marked = rehearsal.mark_inserted_rows_diagnostic(
+        conn,
+        row_ids=stager.inserted_row_ids,
+        legacy_source_run_id=stager.legacy_source_run_id,
+        source_run_key='stage19ar-test',
+        generated_at=NOW,
+    )
+
+    assert len(marked) == 1
+    staged = conn.staging_rows[901]
+    assert staged['source_class'] == 'diagnostic-only'
+    assert staged['confidence'] == 'diagnostic-only'
+    assert staged['provenance']['canonical_write_allowed'] is False
+    assert staged['provenance']['stage19ar_bounded_25_row_pilot']['source_run_key'] == 'stage19ar-test'
+
+
+def test_validation_passes_for_exactly_n_marked_rows(tmp_path):
+    conn = FakeConn()
+    import_record = rehearsal.artifact_utils.write_json_artifact(
+        tmp_path / 'import.json',
+        {'schema_version': 'unit/v1', 'summary': {'rows': 25}},
+    )
+    import_artifact_record = {
+        'artifact_path': import_record['path'],
+        'artifact_sha256': import_record['file_sha256'],
+        'artifact_integrity_sha256': import_record['artifact_integrity_sha256'],
+    }
+    conn.source_runs['stage19ar-test'] = {
+        'id': 101,
+        'source_run_key': 'stage19ar-test',
+        'status': 'succeeded',
+        **import_artifact_record,
+    }
+    conn.legacy_rows['source_runs:stage19ar-test'] = {
+        'id': 701,
+        'source_run_key': 'source_runs:stage19ar-test',
+        'dry_run': False,
+        'metadata': {},
+    }
+    for index in range(1, 26):
+        conn.staging_rows[900 + index] = {
+            **normalised_import_row(index),
+            'id': 900 + index,
+            'source_run_id': 701,
+            'source_class': 'diagnostic-only',
+            'confidence': 'diagnostic-only',
+            'provenance': {
+                'canonical_write_allowed': False,
+                'stage19ar_bounded_25_row_pilot': {'source_run_key': 'stage19ar-test'},
+            },
+        }
+
+    checks = rehearsal.validate_pilot(
+        conn,
+        limit=25,
+        source_run_key='stage19ar-test',
+        bridge_key='source_runs:stage19ar-test',
+        source_run_id=101,
+        legacy_source_run_id=701,
+        inserted_row_ids=list(range(901, 926)),
+        import_artifact_record=import_artifact_record,
+    )
+
+    assert checks['one_source_run_inserted'] is True
+    assert checks['one_legacy_bridge_inserted'] is True
+    assert checks['exactly_25_staging_rows_inserted'] is True
+    assert checks['exactly_25_staging_rows_marked_diagnostic'] is True
+    assert checks['staging_rows_use_legacy_bridge_id'] is True
+    assert checks['staging_rows_do_not_use_source_runs_id'] is True
+    assert checks['staging_rows_have_stage19ar_marker'] is True
+    assert checks['staging_rows_preserve_canonical_write_block'] is True
+    assert checks['source_run_artifact_hash_matches'] is True
+    assert checks['source_run_artifact_integrity_matches'] is True
+    rehearsal.assert_validation_passes(checks)
+
+
+def test_committed_pilot_runs_import_marks_rows_validates_and_writes_artifact(tmp_path):
+    conn = FakeConn(sample_rows=sample_staging_rows(25))
+
+    result = rehearsal.run_pilot(
+        conn,
+        limit=25,
+        artifact_dir=tmp_path,
+        git_head='abc1234',
+        trigger_context='unit_test',
+        commit=True,
+        generated_at=NOW,
+    )
+
+    assert result['commit_requested'] is True
+    assert conn.commits == 1
+    assert conn.rollbacks == 0
+    assert len(conn.source_runs) == 1
+    assert len(conn.legacy_rows) == 1
+    assert len(conn.staging_rows) == 25
+    assert all(row['source_run_id'] == 701 for row in conn.staging_rows.values())
+    assert all(row['source_class'] == 'diagnostic-only' for row in conn.staging_rows.values())
+    assert all(row['confidence'] == 'diagnostic-only' for row in conn.staging_rows.values())
+    assert all(row['provenance']['canonical_write_allowed'] is False for row in conn.staging_rows.values())
+    assert all('stage19ar_bounded_25_row_pilot' in row['provenance'] for row in conn.staging_rows.values())
+    assert Path(result['sample_record']['path']).is_file()
+    assert Path(result['import_result']['artifact_record']['artifact_path']).is_file()
+    assert Path(result['operator_artifact_record']['record']['artifact_path']).is_file()
+    assert result['source_run_key'].startswith('stage19ar-edsm-25-row-staging-pilot-')
+    assert not result['source_run_key'].startswith('stage19anr-')
+    assert result['bridge_key'].startswith('source_runs:stage19ar-edsm-25-row-staging-pilot-')
+    assert result['validation_checks']['exactly_25_staging_rows_inserted'] is True
+    assert result['validation_checks']['exactly_25_staging_rows_marked_diagnostic'] is True
+    assert result['validation_checks']['canonical_table_writes_performed_by_script'] is False
+    assert result['validation_checks']['no_scheduler_or_service_invoked'] is True
+
+
+def test_static_guardrails_no_scheduler_canonical_apply_canonical_writes_or_secrets():
+    source = inspect.getsource(rehearsal)
+    source_upper = source.upper()
+
+    forbidden_fragments = (
+        'SYSTEMCTL',
+        'RUN_IMPORT',
+        'RUN_IMPORT.SH',
+        'DATABASE' + '_URL',
+        'POSTGRESQL' + '://',
+        'POSTGRES' + '://',
+        'PASSWORD' + '=',
+        'SECRET' + '=',
+        'TOKEN' + '=',
+    )
+    for fragment in forbidden_fragments:
+        assert fragment not in source_upper
+    assert re.search(r'(?<![a-z0-9_])\.timer(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+    assert re.search(r'(?<![a-z0-9_])\.service(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
+    assert 'canonical_apply' not in source.lower()
+
+    canonical_write_patterns = (
+        r'\binsert\s+into\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bupdate\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+        r'\bdelete\s+from\s+(stations|systems|bodies|body_rings|station_body_links|station_external_identity)\b',
+    )
+    for pattern in canonical_write_patterns:
+        assert re.search(pattern, source, flags=re.IGNORECASE) is None
+
+
+def test_static_import_call_does_not_override_finished_at():
+    tree = ast.parse(inspect.getsource(rehearsal))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == 'run_edsm_station_import'
+    ]
+
+    assert calls
+    assert all(
+        keyword.arg != 'finished_at'
+        for call in calls
+        for keyword in call.keywords
+    )
+
+
+def test_static_import_call_uses_explicit_stage19ar_stager():
+    tree = ast.parse(inspect.getsource(rehearsal))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == 'run_edsm_station_import'
+    ]
+
+    assert calls
+    assert all(
+        any(keyword.arg == 'station_stager' for keyword in call.keywords)
+        for call in calls
+    )
+    assert 'CompatibleStage19ArStationStager' in inspect.getsource(rehearsal)


### PR DESCRIPTION
## Files added/changed

- Added `scripts/operator/stage19ar_edsm_25_row_staging_pilot.py`.
- Added `tests/test_stage19ar_operator_script.py`.

## How this differs from Stage 19AN-R

- Uses a Stage 19AR-specific source-run key prefix: `stage19ar-edsm-25-row-staging-pilot-`.
- Uses a Stage 19AR-specific bridge key through `source_runs:<source_run_key>`.
- Uses the Stage 19AR provenance marker and trigger context: `stage19ar_bounded_25_row_pilot`.
- Writes Stage 19AR-specific sample, import, and operator artifact names.
- Detects only Stage 19AR leftovers; it does not treat existing Stage 19AN-R proof rows as blockers.
- Enforces a hard max limit of 25 and requires exactly 25 rows for commit mode.
- Adds preflight verification that `staging_edsm_stations.source_run_id` targets legacy `enrichment_source_runs(id)`, not `source_runs(id)`.

## Dry-run behavior

- Dry-run is the default.
- Dry-run performs no DB writes and rolls back the connection.
- Dry-run deterministically samples the requested bounded rows and writes operator artifacts.
- Dry-run reports `commit_requested: false`, `db_writes_attempted: false`, selected sample count, and commit readiness.

## Commit behavior

- Commit requires explicit `--commit`.
- Commit mode refuses any limit other than exactly 25.
- Commit creates one Stage 19AR `source_runs` row, one Stage 19AR legacy `enrichment_source_runs` bridge row, exactly 25 `staging_edsm_stations` rows, diagnostic-only marking for those rows, and operator artifacts.
- Commit validation includes the required source-run, bridge, staging count, marker, canonical-write-block, artifact hash/integrity, scheduler/service, and canonical write checks.

## Allowed write scope

- One Stage 19AR `source_runs` row.
- One Stage 19AR `enrichment_source_runs` compatibility bridge row.
- Exactly 25 Stage 19AR `staging_edsm_stations` rows.
- Diagnostic-only marking for those 25 staging rows.
- Operator artifact files.

## Forbidden write scope

- No canonical table writes.
- No scheduler/timer writes or enablement.
- No service/systemd writes or enablement.
- No existing Stage 19AN-R row deletion or mutation.
- No unbounded EDSM import.

## Tests run and results

- `python -m pytest tests/test_stage19ar_operator_script.py -q` passed: 15 passed, 1 existing pytest config warning for unknown `asyncio_mode`.
- `python -m pytest tests/test_stage19ar_operator_script.py tests/test_stage19anr_operator_script.py tests/test_edsm_station_import.py tests/test_source_run_compatibility.py tests/test_source_run_artifacts.py tests/test_artifact_utils.py tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q` passed: 105 passed, 1 existing pytest config warning for unknown `asyncio_mode`.
- `python -m py_compile scripts/operator/stage19ar_edsm_25_row_staging_pilot.py` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed.

## Safety confirmations

- No production DB access by Codex.
- No imports run by Codex.
- No migrations run.
- No scheduler/timer enablement.
- No canonical writes.
- No canonical apply.