### PR TITLE
Stage 19AR closeout validation gap fix

### DIFF
--- a/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
+++ b/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
@@ -155,6 +155,7 @@ def run_pilot(
                 preflight=preflight,
                 rows_inserted=0,
                 rows_marked=0,
+                inserted_row_ids=[],
                 validation_checks={
                     'dry_run_read_only': True,
                     'db_writes_attempted': False,
@@ -172,6 +173,8 @@ def run_pilot(
                 'sample_record': sample_record,
                 'operator_artifact_record': operator_artifact,
                 'validation_checks': operator_artifact['payload']['validation_checks'],
+                'inserted_row_ids': [],
+                'inserted_row_count': 0,
             }
 
         stager = CompatibleStage19ArStationStager(generated_at=generated)
@@ -221,6 +224,7 @@ def run_pilot(
             preflight=preflight,
             rows_inserted=len(stager.inserted_row_ids),
             rows_marked=len(marked_rows),
+            inserted_row_ids=stager.inserted_row_ids,
             validation_checks=validation,
         )
         commit_connection(conn)
@@ -233,6 +237,7 @@ def run_pilot(
             'operator_artifact_record': operator_artifact,
             'validation_checks': validation,
             'inserted_row_ids': list(stager.inserted_row_ids),
+            'inserted_row_count': len(stager.inserted_row_ids),
         }
     except Exception:
         rollback(conn)
@@ -653,6 +658,7 @@ def validate_pilot(
     import_artifact_record: Mapping[str, Any],
 ) -> dict[str, bool]:
     source_run = fetch_source_run(conn, source_run_key)
+    source_run_counts = source_run_row_counts(source_run)
     bridge = fetch_legacy_bridge(conn, bridge_key)
     staging = fetch_staging_validation_counts(
         conn,
@@ -665,6 +671,13 @@ def validate_pilot(
     checks = {
         'one_source_run_inserted': source_run is not None and source_run.get('source_run_key') == source_run_key,
         'source_run_succeeded': source_run is not None and source_run.get('status') == 'succeeded',
+        'source_run_rows_read_matches_limit': source_run_counts['rows_read'] == limit,
+        'source_run_rows_staged_matches_inserted_rows': (
+            source_run_counts['rows_staged'] == limit
+            and source_run_counts['rows_staged'] == len(inserted_row_ids)
+        ),
+        'source_run_rows_rejected_is_zero': source_run_counts['rows_rejected'] == 0,
+        'source_run_rows_skipped_is_zero': source_run_counts['rows_skipped'] == 0,
         'one_legacy_bridge_inserted': bridge is not None and bridge.get('source_run_key') == bridge_key,
         'exactly_25_staging_rows_inserted': staging['rows_inserted'] == DEFAULT_LIMIT and limit == DEFAULT_LIMIT,
         'exactly_25_staging_rows_marked_diagnostic': (
@@ -699,6 +712,10 @@ def fetch_source_run(conn: Any, source_run_key: str) -> dict[str, Any] | None:
               id,
               source_run_key,
               status,
+              rows_read,
+              rows_staged,
+              rows_rejected,
+              rows_skipped,
               artifact_path,
               artifact_sha256,
               artifact_integrity_sha256
@@ -710,6 +727,22 @@ def fetch_source_run(conn: Any, source_run_key: str) -> dict[str, Any] | None:
         return _fetchone_dict(cur)
     finally:
         close_cursor(cur)
+
+
+def source_run_row_counts(source_run: Mapping[str, Any] | None) -> dict[str, int | None]:
+    if source_run is None:
+        return {
+            'rows_read': None,
+            'rows_staged': None,
+            'rows_rejected': None,
+            'rows_skipped': None,
+        }
+    return {
+        'rows_read': _optional_int(source_run.get('rows_read')),
+        'rows_staged': _optional_int(source_run.get('rows_staged')),
+        'rows_rejected': _optional_int(source_run.get('rows_rejected')),
+        'rows_skipped': _optional_int(source_run.get('rows_skipped')),
+    }
 
 
 def fetch_legacy_bridge(conn: Any, bridge_key: str | None) -> dict[str, Any] | None:
@@ -799,8 +832,10 @@ def write_operator_artifact(
     preflight: Mapping[str, Any],
     rows_inserted: int,
     rows_marked: int,
+    inserted_row_ids: Sequence[int],
     validation_checks: Mapping[str, bool],
 ) -> dict[str, Any]:
+    inserted_ids = [int(row_id) for row_id in inserted_row_ids]
     payload = {
         'schema_version': SCHEMA_VERSION,
         'generated_at': _format_timestamp(generated_at),
@@ -814,6 +849,8 @@ def write_operator_artifact(
         'bridge_key': bridge_key,
         'rows_inserted': rows_inserted,
         'rows_marked_diagnostic': rows_marked,
+        'inserted_row_count': len(inserted_ids),
+        'inserted_row_ids': inserted_ids,
         'preflight': dict(preflight),
         'validation_checks': dict(validation_checks),
         'safety_summary': safety_summary(commit_requested=commit_requested),
@@ -907,6 +944,7 @@ def resolve_git_head(value: str) -> str:
 
 def _summary_for_stdout(result: Mapping[str, Any]) -> dict[str, Any]:
     operator_record = result['operator_artifact_record']['record']
+    operator_payload = result['operator_artifact_record']['payload']
     return {
         'commit_requested': result['commit_requested'],
         'source_run_key': result['source_run_key'],
@@ -914,6 +952,8 @@ def _summary_for_stdout(result: Mapping[str, Any]) -> dict[str, Any]:
         'sample_path': result['sample_record']['path'],
         'operator_artifact_path': operator_record['artifact_path'],
         'operator_artifact_sha256': operator_record['artifact_sha256'],
+        'inserted_row_count': int(operator_payload.get('inserted_row_count') or 0),
+        'inserted_row_ids': list(operator_payload.get('inserted_row_ids') or []),
         'validation_checks': dict(result.get('validation_checks') or {}),
     }
 
@@ -951,6 +991,12 @@ def _required_text(value: Any, field: str) -> str:
 def _copy_if_present(record: dict[str, Any], key: str, value: Any) -> None:
     if value is not None:
         record[key] = _json_scalar(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
 
 
 def _json_scalar(value: Any) -> Any:

--- a/tests/test_stage19ar_operator_script.py
+++ b/tests/test_stage19ar_operator_script.py
@@ -63,6 +63,10 @@ class FakeCursor:
                 'id': self.conn.next_source_run_id,
                 'source_run_key': params[0],
                 'status': params[5],
+                'rows_read': 0,
+                'rows_staged': 0,
+                'rows_rejected': 0,
+                'rows_skipped': 0,
                 'artifact_path': None,
                 'artifact_sha256': None,
                 'artifact_integrity_sha256': None,
@@ -81,6 +85,10 @@ class FakeCursor:
             row = self.conn.source_runs[source_run_key]
             row.update({
                 'status': params[0],
+                'rows_read': params[3],
+                'rows_staged': params[4],
+                'rows_rejected': params[5],
+                'rows_skipped': params[6],
                 'artifact_path': params[7],
                 'artifact_sha256': params[8],
                 'artifact_integrity_sha256': params[9],
@@ -352,6 +360,17 @@ def test_cli_defaults_to_25_row_read_only_and_does_not_commit_without_flag(tmp_p
     assert result['validation_checks']['db_writes_attempted'] is False
     assert result['validation_checks']['selected_sample_count'] == 25
     assert result['validation_checks']['ready_for_commit'] is True
+    assert result['inserted_row_count'] == 0
+    assert result['inserted_row_ids'] == []
+    payload = result['operator_artifact_record']['payload']
+    assert payload['inserted_row_count'] == 0
+    assert payload['inserted_row_ids'] == []
+    written_payload = json.loads(Path(result['operator_artifact_record']['record']['artifact_path']).read_text())
+    assert written_payload['inserted_row_count'] == 0
+    assert written_payload['inserted_row_ids'] == []
+    summary = rehearsal._summary_for_stdout(result)
+    assert summary['inserted_row_count'] == 0
+    assert summary['inserted_row_ids'] == []
 
 
 def test_limit_hard_max_is_25(tmp_path):
@@ -515,6 +534,10 @@ def test_validation_passes_for_exactly_n_marked_rows(tmp_path):
         'id': 101,
         'source_run_key': 'stage19ar-test',
         'status': 'succeeded',
+        'rows_read': 25,
+        'rows_staged': 25,
+        'rows_rejected': 0,
+        'rows_skipped': 0,
         **import_artifact_record,
     }
     conn.legacy_rows['source_runs:stage19ar-test'] = {
@@ -548,6 +571,10 @@ def test_validation_passes_for_exactly_n_marked_rows(tmp_path):
     )
 
     assert checks['one_source_run_inserted'] is True
+    assert checks['source_run_rows_read_matches_limit'] is True
+    assert checks['source_run_rows_staged_matches_inserted_rows'] is True
+    assert checks['source_run_rows_rejected_is_zero'] is True
+    assert checks['source_run_rows_skipped_is_zero'] is True
     assert checks['one_legacy_bridge_inserted'] is True
     assert checks['exactly_25_staging_rows_inserted'] is True
     assert checks['exactly_25_staging_rows_marked_diagnostic'] is True
@@ -587,13 +614,28 @@ def test_committed_pilot_runs_import_marks_rows_validates_and_writes_artifact(tm
     assert Path(result['sample_record']['path']).is_file()
     assert Path(result['import_result']['artifact_record']['artifact_path']).is_file()
     assert Path(result['operator_artifact_record']['record']['artifact_path']).is_file()
+    assert result['inserted_row_count'] == 25
+    assert result['inserted_row_ids'] == list(range(901, 926))
     assert result['source_run_key'].startswith('stage19ar-edsm-25-row-staging-pilot-')
     assert not result['source_run_key'].startswith('stage19anr-')
     assert result['bridge_key'].startswith('source_runs:stage19ar-edsm-25-row-staging-pilot-')
+    assert result['validation_checks']['source_run_rows_read_matches_limit'] is True
+    assert result['validation_checks']['source_run_rows_staged_matches_inserted_rows'] is True
+    assert result['validation_checks']['source_run_rows_rejected_is_zero'] is True
+    assert result['validation_checks']['source_run_rows_skipped_is_zero'] is True
     assert result['validation_checks']['exactly_25_staging_rows_inserted'] is True
     assert result['validation_checks']['exactly_25_staging_rows_marked_diagnostic'] is True
     assert result['validation_checks']['canonical_table_writes_performed_by_script'] is False
     assert result['validation_checks']['no_scheduler_or_service_invoked'] is True
+    payload = result['operator_artifact_record']['payload']
+    assert payload['inserted_row_count'] == 25
+    assert payload['inserted_row_ids'] == list(range(901, 926))
+    written_payload = json.loads(Path(result['operator_artifact_record']['record']['artifact_path']).read_text())
+    assert written_payload['inserted_row_count'] == 25
+    assert written_payload['inserted_row_ids'] == list(range(901, 926))
+    summary = rehearsal._summary_for_stdout(result)
+    assert summary['inserted_row_count'] == 25
+    assert summary['inserted_row_ids'] == list(range(901, 926))
 
 
 def test_static_guardrails_no_scheduler_canonical_apply_canonical_writes_or_secrets():


### PR DESCRIPTION
## Summary

Applies the Stage 19AR closeout validation gap fix on a fresh branch from latest `main`, after the original PR had already merged.

- validates the completed `source_runs` row counters for the bounded 25-row pilot
- records `inserted_row_ids` and `inserted_row_count` in the operator artifact payload
- includes the same inserted-row fields in the stdout summary
- keeps dry-run output explicit with empty inserted-row fields
- updates the Stage 19AR tests for the committed and dry-run schemas

## Safety confirmations

- no production DB access
- no imports run
- no migrations
- no scheduler or timer enablement
- no canonical writes
- no canonical apply

## Validation

- `.venv/bin/python -m pytest tests/test_stage19ar_operator_script.py -q`
- `.venv/bin/python -m pytest tests/test_stage19ar_operator_script.py tests/test_stage19anr_operator_script.py tests/test_edsm_station_import.py tests/test_source_run_compatibility.py tests/test_source_run_artifacts.py tests/test_artifact_utils.py tests/test_source_run_ledger.py tests/test_source_runs_migration.py -q`
- `.venv/bin/python -m py_compile scripts/operator/stage19ar_edsm_25_row_staging_pilot.py`
- `git diff --check`