### PR TITLE
Stage 19: source-correct DB preflight (no cached bytecode) + canonical baseline guardrails

### DIFF
--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -27,6 +27,7 @@ It supersedes the old assumption that the project should simply continue from St
 | [`../reference/colonisation/README.md`](../reference/colonisation/README.md) | Source authority entry point | Committed source hierarchy, inventory placeholders, and future Codex prompt snippet for mechanics-heavy work. |
 | [`engine-roadmap.md`](./engine-roadmap.md) | Living historical roadmap | Broad colonisation engine evolution and delivered stage summaries. |
 | [`enrichment-roadmap.md`](./enrichment-roadmap.md) | Active for enrichment | Guarded station enrichment, body/ring enrichment, offline warehouse, reconciliation, and operator-status roadmap. |
+| [`stage-19ar-canonical-baseline.md`](./stage-19ar-canonical-baseline.md) | Active guardrail | Canonical Stage 19AR baseline identity, fresh project DB recovery failure mode, rejected substitute, and Stage 19AS-AU gate. |
 | [`simulation-preview-ui-architecture.md`](./simulation-preview-ui-architecture.md) | Architecture reference | Simulation Preview / Colony Planner component ownership and delivered UI architecture notes. |
 
 ## Historical / Reference Docs

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -1,0 +1,158 @@
+# Stage 19AR Canonical Baseline and Fresh DB Recovery
+
+## Purpose
+
+Stage 19AS-AU depends on the exact Stage 19AR baseline. A project database can authenticate successfully and have the required schema while still being unsafe for Stage 19AS-AU if the canonical Stage 19AR source run and artifact are absent.
+
+The Stage 19AR canonical baseline is not "any valid-looking 25-row Stage 19AR run." It is the specific verified run identity and artifact below.
+
+## Canonical Stage 19AR Baseline
+
+| Field | Required value |
+|---|---|
+| `source_run_key` | `stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd` |
+| `bridge_key` | `source_runs:stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd` |
+| `artifact` | `418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417` |
+| `rows` | `25` |
+
+The expected verified path is:
+
+```text
+source_runs
+-> enrichment bridge
+-> 25 staging rows
+-> diagnostic isolation
+-> provenance tracking
+-> artifact verification
+-> operator visibility
+```
+
+## Fresh Project DB Failure Mode
+
+The local project Postgres target may be started on an alternate port, such as `127.0.0.1:55432`, to avoid a host Postgres collision on `5432`. In that state, DB authentication can pass while the canonical Stage 19AR baseline is still missing.
+
+This is a baseline-state failure, not a DB-auth failure and not a Stage 19AS-AU logic failure. Stage 19AS-AU must remain blocked until the exact canonical Stage 19AR identity is present, unless a human explicitly approves a new baseline in a separate operator decision.
+
+## Rejected Substitute Baseline
+
+The following substitute run was created during fresh project DB recovery and must not be treated as canonical:
+
+| Field | Rejected value |
+|---|---|
+| `source_run_key` | `stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034` |
+| `artifact` | `b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e` |
+| `rows` | `25` |
+
+The substitute was valid-looking because it exercised the source run, bridge, staging, diagnostic, provenance, artifact, and visibility path. It is still not equivalent to the canonical Stage 19AR baseline because both the source run key and artifact differ from the required canonical values.
+
+## Current Checkpoint
+
+```text
+repair_key:
+stage19ar-canonical-baseline-repair-55432-guardrails
+
+project_db:
+service: postgres
+container: ed-postgres
+host: 127.0.0.1
+port: 55432
+host_postgres_avoided: true
+
+canonical_stage19ar_restored: false
+canonical_artifact_restored: false
+ready_for_stage19as_au: false
+
+source_correct_db_preflight_passes: true
+project_db_authenticated: true
+```
+
+The canonical source run key and canonical artifact are currently absent from the fresh project DB and searched local artifact/data locations. The rejected substitute remains evidence of a non-canonical replay only.
+
+## Source-Correct DB Preflight (Repaired)
+
+The Stage 19 DB preflight is now reproducible from source and does not depend on cached bytecode.
+
+Entrypoint and command (source-correct, no bytecode):
+
+```sh
+set -a; . ./.env; set +a   # provides POSTGRES_PASSWORD; .env is gitignored
+PYTHONDONTWRITEBYTECODE=1 python -B \
+  scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py \
+  --preflight-db --db-port 55432
+```
+
+Expected result: `auth_success: true`, `db_config.host: 127.0.0.1`, `db_config.port: 55432`, `performed_no_writes: true`, `secrets_redacted: true`. The preflight runs `SELECT 1` only and never prints the password.
+
+Root cause of the earlier `project_db_authenticated: false`:
+
+- The source-correct run failed only because `POSTGRES_PASSWORD`/`PGPASSWORD` was absent from the environment, returning `failure_category: password_missing`. Cached bytecode cannot carry DB credentials, so the earlier "success from bytecode" was a misdiagnosis of an ambient-environment difference.
+- Verification removed all project-local `__pycache__` and `.pytest_cache`, then re-ran the preflight with `python -B` (no bytecode written or read). It authenticated against `127.0.0.1:55432`, proving zero reliance on cached bytecode.
+
+Source repair applied:
+
+- `scripts/operator/stage19ar_edsm_25_row_staging_pilot.py` `build_operator_dsn` now honors `PGHOST`/`PGPORT`/`PGDATABASE`/`PGUSER` and `PGPASSWORD` (or `POSTGRES_PASSWORD`) environment precedence, matching the sibling `stage19as_au_edsm_100_row_controlled_expansion.py` preflight DSN. This lets an environment-driven, source-correct run target the configured isolated DB instead of silently defaulting to host Postgres on `5432`. `DATABASE_URL` is deliberately not read here, to keep the Stage 19AR script within its static safety guardrails.
+
+Port note: the isolated container port `55432` is a local `.codex-runtime` compose override (`127.0.0.1:55432:5432`) used to avoid a host Postgres collision on `5432`. The canonical base `docker-compose.yml` maps `127.0.0.1:5432:5432`, so `55432` is environmental and must be supplied via `--db-port 55432` or `PGPORT`; it is never hardcoded into source.
+
+Rule: source-correct DB preflight against `127.0.0.1:55432` must pass without relying on cached bytecode before any rebaseline or Stage 19AS-AU work.
+
+## Required Guardrails
+
+- Canonical Stage 19AR mode requires the exact canonical `source_run_key`.
+- Canonical Stage 19AR mode requires the exact canonical artifact hash.
+- Stage 19AS-AU preflight must reject substitute baselines.
+- Substitute runs must not be silently promoted to canonical baselines.
+- Stage 19AS-AU must not run unless the exact canonical Stage 19AR `source_run_key` and artifact are present, or a human explicitly approves a new baseline in a separate operator decision.
+
+## Fresh-Chat Handoff
+
+Use this block when resuming Stage 19 in a new chat:
+
+```text
+STAGE 19 CURRENT CHECKPOINT
+
+Guardrails:
+Stage 19AR canonical identity guardrails are repaired.
+Stage 19AS-AU rejects substitute baselines.
+
+Canonical Stage 19AR baseline required:
+
+source_run_key:
+stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd
+
+bridge_key:
+source_runs:stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd
+
+artifact:
+418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417
+
+rows:
+25
+
+Rejected substitute baseline:
+
+source_run_key:
+stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034
+
+artifact:
+b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e
+
+Recovery status:
+Git/local recovery searched current files, branches, tags, stashes, reflogs, deleted-file history, tracked blobs, reflog blobs, unreachable commits/blobs, .codex-artifacts, and .codex-runtime.
+canonical_recovery_source_found: false
+canonical_stage19ar_restored: false
+canonical_artifact_restored: false
+ready_for_stage19as_au: false
+
+DB preflight rule:
+Source-correct DB preflight against 127.0.0.1:55432 must pass without relying on cached bytecode before any rebaseline or Stage 19AS-AU work.
+
+Rule:
+Do not run Stage 19AS-AU until either:
+1. the exact canonical Stage 19AR baseline exists, or
+2. a human explicitly approves a new canonical baseline in a separate prompt.
+
+Important:
+A fresh project DB can authenticate and have schema while still missing the canonical Stage 19AR baseline.
+A new 25-row Stage 19AR-like run is not the canonical baseline unless it has the exact canonical source_run_key and artifact.
+```

--- a/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
+++ b/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
@@ -13,6 +13,7 @@ import json
 import os
 import subprocess
 import sys
+from dataclasses import dataclass, field
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -35,6 +36,9 @@ STAGER_VERSION = 'v1'
 SOURCE_RUN_KEY_PREFIX = 'stage19ar-edsm-25-row-staging-pilot-'
 SOURCE_RUN_PREFIXES = ('stage19ar-', 'stage-19ar-')
 PROVENANCE_MARKER_KEY = 'stage19ar_bounded_25_row_pilot'
+CANONICAL_SOURCE_RUN_KEY = 'stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd'
+CANONICAL_BRIDGE_KEY = f'{source_run_compatibility.LEGACY_SOURCE_RUN_KEY_PREFIX}{CANONICAL_SOURCE_RUN_KEY}'
+CANONICAL_ARTIFACT_SHA256 = '418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417'
 DEFAULT_TRIGGER_CONTEXT = PROVENANCE_MARKER_KEY
 DEFAULT_ARTIFACT_DIR = Path('/var/lib/ed-finder/operator-artifacts/stage-19ar')
 DEFAULT_LIMIT = 25
@@ -53,6 +57,60 @@ CANONICAL_TABLES = (
 )
 SAMPLE_EXCLUDED_SOURCE_RUN_PATTERNS = ('source_runs:stage19%', 'source_runs:stage-19%')
 SAMPLE_EXCLUDED_STATION_NAME_PATTERNS = ('Stage 19%',)
+
+
+@dataclass(frozen=True)
+class BoundedPilotProfile:
+    schema_version: str
+    stager_name: str
+    stager_version: str
+    source_run_key_prefix: str
+    source_run_prefixes: tuple[str, ...]
+    provenance_marker_key: str
+    trigger_context: str
+    artifact_dir: Path
+    default_limit: int
+    hard_max_limit: int
+    stage_label: str
+    operator_stage: str
+    row_count_label: str
+    sample_file_prefix: str
+    import_file_prefix: str
+    operator_artifact_prefix: str
+    write_probe_name: str
+    diagnostic_reason: str
+    existing_rows_key: str
+    marker_validation_check: str
+    expected_source_run_key: str | None = None
+    expected_artifact_sha256: str | None = None
+    bridge_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+STAGE19AR_PROFILE = BoundedPilotProfile(
+    schema_version=SCHEMA_VERSION,
+    stager_name=STAGER_NAME,
+    stager_version=STAGER_VERSION,
+    source_run_key_prefix=SOURCE_RUN_KEY_PREFIX,
+    source_run_prefixes=SOURCE_RUN_PREFIXES,
+    provenance_marker_key=PROVENANCE_MARKER_KEY,
+    trigger_context=DEFAULT_TRIGGER_CONTEXT,
+    artifact_dir=DEFAULT_ARTIFACT_DIR,
+    default_limit=DEFAULT_LIMIT,
+    hard_max_limit=HARD_MAX_LIMIT,
+    stage_label='Stage 19AR',
+    operator_stage='19ar',
+    row_count_label='25',
+    sample_file_prefix='stage19ar_edsm_sample',
+    import_file_prefix='stage19ar_edsm_import',
+    operator_artifact_prefix='stage19ar_operator_pilot',
+    write_probe_name='.stage19ar-write-probe',
+    diagnostic_reason='Stage 19AR bounded 25-row EDSM staging pilot',
+    existing_rows_key='existing_stage19ar_rows',
+    marker_validation_check='staging_rows_have_stage19ar_marker',
+    expected_source_run_key=CANONICAL_SOURCE_RUN_KEY,
+    expected_artifact_sha256=CANONICAL_ARTIFACT_SHA256,
+    bridge_metadata={'bounded_25_row_pilot': True},
+)
 
 
 class Stage19ArPilotError(ValueError):
@@ -122,28 +180,30 @@ def run_pilot(
     trigger_context: str,
     commit: bool,
     generated_at: datetime | None = None,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
 ) -> dict[str, Any]:
     if limit < 1:
         raise Stage19ArPilotError('limit must be >= 1')
-    if limit > HARD_MAX_LIMIT:
-        raise Stage19ArPilotError(f'limit must be <= {HARD_MAX_LIMIT}')
-    if commit and limit != DEFAULT_LIMIT:
-        raise Stage19ArPilotError(f'commit mode requires exactly {DEFAULT_LIMIT} rows')
+    if limit > profile.hard_max_limit:
+        raise Stage19ArPilotError(f'limit must be <= {profile.hard_max_limit}')
+    if commit and limit != profile.default_limit:
+        raise Stage19ArPilotError(f'commit mode requires exactly {profile.default_limit} rows')
     generated = generated_at or _utc_now()
     run_label = _run_label(generated)
 
     try:
-        artifact_dir_check = verify_artifact_directory_writable(artifact_dir)
-        preflight = preflight_pilot(conn, artifact_dir_check=artifact_dir_check)
+        artifact_dir_check = verify_artifact_directory_writable(artifact_dir, profile=profile)
+        preflight = preflight_pilot(conn, artifact_dir_check=artifact_dir_check, profile=profile)
         sampled_rows = sample_existing_staging_rows(conn, limit=limit)
         fixture_rows = [staging_row_to_edsm_fixture_record(row) for row in sampled_rows]
-        sample_path = artifact_dir / f'stage19ar_edsm_sample_{run_label}.json'
+        sample_path = artifact_dir / f'{profile.sample_file_prefix}_{run_label}.json'
         sample_record = write_sample_fixture(sample_path, fixture_rows)
-        source_run_key = build_source_run_key(sample_record['file_sha256'])
+        source_run_key = build_source_run_key(sample_record['file_sha256'], profile=profile)
 
         if not commit:
             rollback(conn)
             operator_artifact = write_operator_artifact(
+                profile=profile,
                 artifact_dir=artifact_dir,
                 run_label=run_label,
                 generated_at=generated,
@@ -161,7 +221,10 @@ def run_pilot(
                     'db_writes_attempted': False,
                     'sampled_exact_limit': len(sampled_rows) == limit,
                     'selected_sample_count': len(sampled_rows),
-                    'ready_for_commit': len(sampled_rows) == DEFAULT_LIMIT and limit == DEFAULT_LIMIT,
+                    'ready_for_commit': (
+                        len(sampled_rows) == profile.default_limit
+                        and limit == profile.default_limit
+                    ),
                     'canonical_table_writes_performed_by_script': False,
                     'no_scheduler_or_service_invoked': True,
                 },
@@ -177,8 +240,8 @@ def run_pilot(
                 'inserted_row_count': 0,
             }
 
-        stager = CompatibleStage19ArStationStager(generated_at=generated)
-        import_artifact_path = artifact_dir / f'stage19ar_edsm_import_{run_label}.json'
+        stager = CompatibleStage19ArStationStager(generated_at=generated, profile=profile)
+        import_artifact_path = artifact_dir / f'{profile.import_file_prefix}_{run_label}.json'
         import_result = edsm_station_import.run_edsm_station_import(
             conn,
             source_file=sample_path,
@@ -200,6 +263,7 @@ def run_pilot(
             legacy_source_run_id=stager.legacy_source_run_id,
             source_run_key=source_run_key,
             generated_at=generated,
+            profile=profile,
         )
         validation = validate_pilot(
             conn,
@@ -210,9 +274,11 @@ def run_pilot(
             legacy_source_run_id=int(stager.legacy_source_run_id),
             inserted_row_ids=stager.inserted_row_ids,
             import_artifact_record=import_result['artifact_record'],
+            profile=profile,
         )
         assert_validation_passes(validation)
         operator_artifact = write_operator_artifact(
+            profile=profile,
             artifact_dir=artifact_dir,
             run_label=run_label,
             generated_at=generated,
@@ -244,22 +310,29 @@ def run_pilot(
         raise
 
 
-def preflight_pilot(conn: Any, *, artifact_dir_check: Mapping[str, Any] | None = None) -> dict[str, Any]:
+def preflight_pilot(
+    conn: Any,
+    *,
+    artifact_dir_check: Mapping[str, Any] | None = None,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
+) -> dict[str, Any]:
     helper_checks = verify_required_helpers_available()
     schema = verify_target_tables_exist(conn)
     staging_fk = verify_staging_source_run_fk_targets_legacy_bridge(conn)
-    leftovers = count_existing_stage19ar_rows(conn)
+    leftovers = count_existing_stage19ar_rows(conn, profile=profile)
     if any(leftovers.values()):
         if leftovers.get('running_source_runs'):
-            raise Stage19ArPilotError(f'running Stage 19AR source run found: {leftovers}')
-        raise Stage19ArPilotError(f'existing Stage 19AR rows found: {leftovers}')
-    return {
+            raise Stage19ArPilotError(f'running {profile.stage_label} source run found: {leftovers}')
+        raise Stage19ArPilotError(f'existing {profile.stage_label} rows found: {leftovers}')
+    result = {
         'helper_imports': helper_checks,
         'target_tables': schema,
         'staging_source_run_fk': staging_fk,
-        'existing_stage19ar_rows': leftovers,
+        'existing_stage_rows': leftovers,
         'artifact_directory': dict(artifact_dir_check or {}),
     }
+    result[profile.existing_rows_key] = leftovers
+    return result
 
 
 def verify_required_helpers_available() -> dict[str, bool]:
@@ -348,8 +421,12 @@ def verify_staging_source_run_fk_targets_legacy_bridge(conn: Any) -> dict[str, A
     return result
 
 
-def count_existing_stage19ar_rows(conn: Any) -> dict[str, int]:
-    source_patterns = [f'{prefix}%' for prefix in SOURCE_RUN_PREFIXES]
+def count_existing_stage19ar_rows(
+    conn: Any,
+    *,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
+) -> dict[str, int]:
+    source_patterns = [f'{prefix}%' for prefix in profile.source_run_prefixes]
     bridge_patterns = [
         f'{source_run_compatibility.LEGACY_SOURCE_RUN_KEY_PREFIX}{pattern}'
         for pattern in source_patterns
@@ -383,7 +460,13 @@ def count_existing_stage19ar_rows(conn: Any) -> dict[str, int]:
                   AND s.provenance ? %s
               ) AS marked_staging_rows
             """,
-            (source_patterns, source_patterns, bridge_patterns, bridge_patterns, PROVENANCE_MARKER_KEY),
+            (
+                source_patterns,
+                source_patterns,
+                bridge_patterns,
+                bridge_patterns,
+                profile.provenance_marker_key,
+            ),
         )
         row = _fetchone_dict(cur) or {}
     finally:
@@ -396,11 +479,15 @@ def count_existing_stage19ar_rows(conn: Any) -> dict[str, int]:
     }
 
 
-def verify_artifact_directory_writable(artifact_dir: Path) -> dict[str, Any]:
+def verify_artifact_directory_writable(
+    artifact_dir: Path,
+    *,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
+) -> dict[str, Any]:
     artifact_dir.mkdir(parents=True, exist_ok=True)
-    probe_path = artifact_dir / '.stage19ar-write-probe'
+    probe_path = artifact_dir / profile.write_probe_name
     try:
-        probe_path.write_text('stage19ar\n', encoding='utf-8')
+        probe_path.write_text(f'{profile.operator_stage}\n', encoding='utf-8')
         probe_path.unlink()
     except OSError as exc:
         raise Stage19ArPilotError(f'artifact directory is not writable: {artifact_dir}') from exc
@@ -495,27 +582,34 @@ def staging_row_to_edsm_fixture_record(row: Mapping[str, Any]) -> dict[str, Any]
 class CompatibleStage19ArStationStager:
     """Explicit stager that writes legacy bridge IDs into staging FK columns."""
 
-    def __init__(self, *, generated_at: datetime) -> None:
+    def __init__(
+        self,
+        *,
+        generated_at: datetime,
+        profile: BoundedPilotProfile = STAGE19AR_PROFILE,
+    ) -> None:
         self.generated_at = generated_at
+        self.profile = profile
         self.inserted_row_ids: list[int] = []
         self.legacy_source_run_id: int | None = None
         self.bridge_key: str | None = None
 
     def __call__(self, conn: Any, *, source_run: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> int:
+        metadata = {
+            'operator_stage': self.profile.operator_stage,
+            'staging_rows_written_by_explicit_stager': True,
+            'canonical_table_writes_planned': 0,
+        }
+        metadata.update(dict(self.profile.bridge_metadata))
         context = source_run_compatibility.get_or_create_legacy_staging_context(
             conn,
             source_run,
             source='edsm',
-            adapter_name=STAGER_NAME,
-            adapter_version=STAGER_VERSION,
+            adapter_name=self.profile.stager_name,
+            adapter_version=self.profile.stager_version,
             source_kind='offline_snapshot',
             dry_run=False,
-            metadata={
-                'operator_stage': '19ar',
-                'bounded_25_row_pilot': True,
-                'staging_rows_written_by_explicit_stager': True,
-                'canonical_table_writes_planned': 0,
-            },
+            metadata=metadata,
         )
         legacy_source_run_id = int(context['legacy_source_run_id'])
         self.legacy_source_run_id = legacy_source_run_id
@@ -602,16 +696,17 @@ def mark_inserted_rows_diagnostic(
     legacy_source_run_id: int | None,
     source_run_key: str,
     generated_at: datetime,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
 ) -> list[dict[str, Any]]:
     if not row_ids:
         raise Stage19ArPilotError('no inserted staging row ids available for diagnostic mark')
     if legacy_source_run_id is None:
         raise Stage19ArPilotError('legacy source-run id is required for diagnostic mark')
     marker = {
-        PROVENANCE_MARKER_KEY: {
+        profile.provenance_marker_key: {
             'source_run_key': source_run_key,
             'marked_at': _format_timestamp(generated_at),
-            'reason': 'Stage 19AR bounded 25-row EDSM staging pilot',
+            'reason': profile.diagnostic_reason,
         },
         'canonical_write_allowed': False,
     }
@@ -656,6 +751,7 @@ def validate_pilot(
     legacy_source_run_id: int,
     inserted_row_ids: Sequence[int],
     import_artifact_record: Mapping[str, Any],
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
 ) -> dict[str, bool]:
     source_run = fetch_source_run(conn, source_run_key)
     source_run_counts = source_run_row_counts(source_run)
@@ -665,11 +761,16 @@ def validate_pilot(
         row_ids=inserted_row_ids,
         source_run_id=source_run_id,
         legacy_source_run_id=legacy_source_run_id,
+        marker_key=profile.provenance_marker_key,
     )
     artifact_path = Path(str(import_artifact_record['artifact_path']))
     artifact_sha256 = artifact_utils.sha256_file(artifact_path) if artifact_path.is_file() else None
     checks = {
         'one_source_run_inserted': source_run is not None and source_run.get('source_run_key') == source_run_key,
+        'canonical_source_run_key_matches': (
+            profile.expected_source_run_key is None
+            or source_run_key == profile.expected_source_run_key
+        ),
         'source_run_succeeded': source_run is not None and source_run.get('status') == 'succeeded',
         'source_run_rows_read_matches_limit': source_run_counts['rows_read'] == limit,
         'source_run_rows_staged_matches_inserted_rows': (
@@ -679,18 +780,36 @@ def validate_pilot(
         'source_run_rows_rejected_is_zero': source_run_counts['rows_rejected'] == 0,
         'source_run_rows_skipped_is_zero': source_run_counts['rows_skipped'] == 0,
         'one_legacy_bridge_inserted': bridge is not None and bridge.get('source_run_key') == bridge_key,
-        'exactly_25_staging_rows_inserted': staging['rows_inserted'] == DEFAULT_LIMIT and limit == DEFAULT_LIMIT,
-        'exactly_25_staging_rows_marked_diagnostic': (
-            staging['rows_marked_diagnostic'] == DEFAULT_LIMIT and limit == DEFAULT_LIMIT
+        'canonical_bridge_key_matches': (
+            profile.expected_source_run_key is None
+            or bridge_key == source_run_compatibility.build_enrichment_source_run_key(
+                profile.expected_source_run_key
+            )
+        ),
+        f'exactly_{profile.row_count_label}_staging_rows_inserted': (
+            staging['rows_inserted'] == profile.default_limit
+            and limit == profile.default_limit
+        ),
+        f'exactly_{profile.row_count_label}_staging_rows_marked_diagnostic': (
+            staging['rows_marked_diagnostic'] == profile.default_limit
+            and limit == profile.default_limit
         ),
         'staging_rows_use_legacy_bridge_id': staging['rows_using_legacy_bridge_id'] == limit,
         'staging_rows_do_not_use_source_runs_id': staging['rows_using_source_runs_id'] == 0,
-        'staging_rows_have_stage19ar_marker': staging['rows_with_stage19ar_marker'] == limit,
+        profile.marker_validation_check: staging['rows_with_stage_marker'] == limit,
         'staging_rows_preserve_canonical_write_block': staging['rows_with_canonical_write_blocked'] == limit,
         'source_run_artifact_hash_matches': (
             source_run is not None
             and source_run.get('artifact_sha256') == import_artifact_record['artifact_sha256']
             and source_run.get('artifact_sha256') == artifact_sha256
+        ),
+        'canonical_artifact_hash_matches': (
+            profile.expected_artifact_sha256 is None
+            or (
+                source_run is not None
+                and source_run.get('artifact_sha256') == profile.expected_artifact_sha256
+                and artifact_sha256 == profile.expected_artifact_sha256
+            )
         ),
         'source_run_artifact_integrity_matches': (
             source_run is not None
@@ -769,6 +888,7 @@ def fetch_staging_validation_counts(
     row_ids: Sequence[int],
     source_run_id: int,
     legacy_source_run_id: int,
+    marker_key: str = PROVENANCE_MARKER_KEY,
 ) -> dict[str, int]:
     cur = conn.cursor()
     try:
@@ -780,7 +900,7 @@ def fetch_staging_validation_counts(
                 AS rows_marked_diagnostic,
               COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_legacy_bridge_id,
               COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_source_runs_id,
-              COUNT(*) FILTER (WHERE provenance ? %s)::int AS rows_with_stage19ar_marker,
+              COUNT(*) FILTER (WHERE provenance ? %s)::int AS rows_with_stage_marker,
               COUNT(*) FILTER (WHERE provenance->>%s = 'false')::int
                 AS rows_with_canonical_write_blocked
             FROM staging_edsm_stations
@@ -791,7 +911,7 @@ def fetch_staging_validation_counts(
                 DIAGNOSTIC_ONLY,
                 int(legacy_source_run_id),
                 int(source_run_id),
-                PROVENANCE_MARKER_KEY,
+                marker_key,
                 'canonical_write_allowed',
                 list(row_ids),
             ),
@@ -804,7 +924,8 @@ def fetch_staging_validation_counts(
         'rows_marked_diagnostic': int(row.get('rows_marked_diagnostic') or 0),
         'rows_using_legacy_bridge_id': int(row.get('rows_using_legacy_bridge_id') or 0),
         'rows_using_source_runs_id': int(row.get('rows_using_source_runs_id') or 0),
-        'rows_with_stage19ar_marker': int(row.get('rows_with_stage19ar_marker') or 0),
+        'rows_with_stage_marker': int(row.get('rows_with_stage_marker') or 0),
+        'rows_with_stage19ar_marker': int(row.get('rows_with_stage_marker') or 0),
         'rows_with_canonical_write_blocked': int(row.get('rows_with_canonical_write_blocked') or 0),
     }
 
@@ -821,6 +942,7 @@ def assert_validation_passes(checks: Mapping[str, bool]) -> None:
 
 def write_operator_artifact(
     *,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
     artifact_dir: Path,
     run_label: str,
     generated_at: datetime,
@@ -837,7 +959,7 @@ def write_operator_artifact(
 ) -> dict[str, Any]:
     inserted_ids = [int(row_id) for row_id in inserted_row_ids]
     payload = {
-        'schema_version': SCHEMA_VERSION,
+        'schema_version': profile.schema_version,
         'generated_at': _format_timestamp(generated_at),
         'source_sample': {
             'path': sample_record['path'],
@@ -855,7 +977,7 @@ def write_operator_artifact(
         'validation_checks': dict(validation_checks),
         'safety_summary': safety_summary(commit_requested=commit_requested),
     }
-    path = artifact_dir / f'stage19ar_operator_pilot_{run_label}.json'
+    path = artifact_dir / f'{profile.operator_artifact_prefix}_{run_label}.json'
     raw_record = artifact_utils.write_json_artifact(path, payload)
     record = {
         **raw_record,
@@ -896,20 +1018,26 @@ def write_sample_fixture(path: Path, rows: Sequence[Mapping[str, Any]]) -> dict[
     }
 
 
-def build_source_run_key(sample_sha256: str) -> str:
-    return f'{SOURCE_RUN_KEY_PREFIX}{sample_sha256[:16]}'
+def build_source_run_key(
+    sample_sha256: str,
+    *,
+    profile: BoundedPilotProfile = STAGE19AR_PROFILE,
+) -> str:
+    if profile.expected_source_run_key is not None:
+        return profile.expected_source_run_key
+    return f'{profile.source_run_key_prefix}{sample_sha256[:16]}'
 
 
 def build_operator_dsn(args: argparse.Namespace, env: Mapping[str, str] | None = None) -> str:
     source_env = env if env is not None else os.environ
-    password = source_env.get('POSTGRES_PASSWORD')
+    password = source_env.get('PGPASSWORD') or source_env.get('POSTGRES_PASSWORD')
     if not password:
-        raise Stage19ArPilotError('POSTGRES_PASSWORD is required for operator DB connection')
+        raise Stage19ArPilotError('POSTGRES_PASSWORD or PGPASSWORD is required for operator DB connection')
     parts = {
-        'host': args.db_host,
-        'port': args.db_port,
-        'dbname': args.db_name,
-        'user': args.db_user,
+        'host': source_env.get('PGHOST') or args.db_host,
+        'port': source_env.get('PGPORT') or args.db_port,
+        'dbname': source_env.get('PGDATABASE') or args.db_name,
+        'user': source_env.get('PGUSER') or args.db_user,
         'password': password,
         'sslmode': 'disable',
     }

--- a/scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py
+++ b/scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Stage 19AS-AU controlled 100-row EDSM station staging expansion.
+
+This runner reuses the verified Stage 19AR bounded staging path with a
+separate source-run prefix, diagnostic marker, artifact namespace, and exact
+100-row commit boundary.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+
+OPERATOR_SCRIPTS = Path(__file__).resolve().parent
+if str(OPERATOR_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(OPERATOR_SCRIPTS))
+
+import stage19ar_edsm_25_row_staging_pilot as pilot  # noqa: E402
+
+
+BASELINE_SOURCE_RUN_KEY = 'stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd'
+BASELINE_BRIDGE_KEY = f'{pilot.source_run_compatibility.LEGACY_SOURCE_RUN_KEY_PREFIX}{BASELINE_SOURCE_RUN_KEY}'
+BASELINE_ARTIFACT_SHA256 = '418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417'
+SAFE_ENV_KEY = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+STAGE19AS_AU_PROFILE = pilot.BoundedPilotProfile(
+    schema_version='stage19as_au_edsm_100_row_controlled_expansion/v1',
+    stager_name='stage19as_au_edsm_100_row_compatible_stager',
+    stager_version='v1',
+    source_run_key_prefix='stage19as-au-edsm-100-row-controlled-expansion-',
+    source_run_prefixes=('stage19as-au-', 'stage-19as-au-'),
+    provenance_marker_key='stage19as_au_controlled_100_row_expansion',
+    trigger_context='stage19as_au_controlled_100_row_expansion',
+    artifact_dir=Path('/var/lib/ed-finder/operator-artifacts/stage-19as-au'),
+    default_limit=100,
+    hard_max_limit=100,
+    stage_label='Stage 19AS-AU',
+    operator_stage='19as-au',
+    row_count_label='100',
+    sample_file_prefix='stage19as_au_edsm_sample',
+    import_file_prefix='stage19as_au_edsm_import',
+    operator_artifact_prefix='stage19as_au_operator_controlled_expansion',
+    write_probe_name='.stage19as-au-write-probe',
+    diagnostic_reason='Stage 19AS-AU controlled 100-row EDSM staging expansion',
+    existing_rows_key='existing_stage19as_au_rows',
+    marker_validation_check='staging_rows_have_stage19as_au_marker',
+    bridge_metadata={
+        'controlled_100_row_expansion': True,
+        'stage19ar_known_good_spine': True,
+        'baseline_source_run_key': BASELINE_SOURCE_RUN_KEY,
+        'rows_expected': 100,
+    },
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Run the Stage 19AS-AU controlled 100-row EDSM station staging expansion.',
+    )
+    parser.add_argument('--limit', type=int, default=100, help='Exact number of staging rows to insert.')
+    parser.add_argument(
+        '--artifact-dir',
+        default=str(STAGE19AS_AU_PROFILE.artifact_dir),
+        help='Directory for sample, import, and operator artifacts.',
+    )
+    parser.add_argument('--git-head', default='auto', help='Git SHA for source_runs, or "auto".')
+    parser.add_argument(
+        '--trigger-context',
+        default=STAGE19AS_AU_PROFILE.trigger_context,
+        help='source_runs trigger context.',
+    )
+    parser.add_argument('--commit', action='store_true', help='Opt in to bounded DB staging writes.')
+    parser.add_argument('--db-host', default='127.0.0.1', help='Local Postgres host.')
+    parser.add_argument('--db-port', default='5432', help='Local Postgres port.')
+    parser.add_argument('--db-name', default='edfinder', help='Local Postgres database name.')
+    parser.add_argument('--db-user', default='edfinder', help='Local Postgres user.')
+    parser.add_argument(
+        '--secrets-file',
+        default=None,
+        help='Optional dotenv-style secrets file to load before DB connection construction.',
+    )
+    parser.add_argument(
+        '--preflight-db',
+        action='store_true',
+        help='Authenticate with the configured DB and run SELECT 1 without writes or artifacts.',
+    )
+    args = parser.parse_args(argv)
+    if args.limit < 1:
+        parser.error('--limit must be >= 1')
+    if args.limit > STAGE19AS_AU_PROFILE.hard_max_limit:
+        parser.error(f'--limit must be <= {STAGE19AS_AU_PROFILE.hard_max_limit} for Stage 19AS-AU')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.preflight_db:
+        result = run_db_preflight(args)
+        print(json.dumps(result, sort_keys=True, indent=2))
+        return 0 if result['auth_success'] else 2
+
+    conn = None
+    try:
+        secrets = load_secrets_for_args(args)
+        if args.secrets_file and not secrets['detected']:
+            raise pilot.Stage19ArPilotError('secrets file was not found')
+        if secrets['tracked_by_git']:
+            raise pilot.Stage19ArPilotError('refusing to load a secrets file tracked by git')
+        git_head = pilot.resolve_git_head(args.git_head)
+        dsn = build_db_dsn(args)
+        conn = pilot.connect_operator_db(dsn)
+        pilot.set_connection_mode(conn, commit=args.commit)
+        baseline = verify_canonical_stage19ar_baseline(conn)
+        assert_canonical_stage19ar_baseline(baseline)
+        result = pilot.run_pilot(
+            conn,
+            limit=args.limit,
+            artifact_dir=Path(args.artifact_dir),
+            git_head=git_head,
+            trigger_context=args.trigger_context,
+            commit=args.commit,
+            profile=STAGE19AS_AU_PROFILE,
+        )
+    except (OSError, pilot.Stage19ArPilotError, pilot.edsm_station_import.EdsmStationImportError) as exc:
+        if conn is not None:
+            pilot.rollback(conn)
+        print(f'stage19as-au expansion failed: {exc}', file=sys.stderr)
+        return 2
+    finally:
+        if conn is not None:
+            pilot.close_connection(conn)
+
+    print(json.dumps(pilot._summary_for_stdout(result), sort_keys=True, indent=2))
+    return 0
+
+
+def verify_canonical_stage19ar_baseline(conn: Any) -> dict[str, Any]:
+    source_run = pilot.fetch_source_run(conn, BASELINE_SOURCE_RUN_KEY)
+    bridge = pilot.fetch_legacy_bridge(conn, BASELINE_BRIDGE_KEY)
+    source_run_id = int(source_run['id']) if source_run and source_run.get('id') is not None else None
+    legacy_source_run_id = int(bridge['id']) if bridge and bridge.get('id') is not None else None
+    counts = canonical_stage19ar_staging_counts(
+        conn,
+        source_run_id=source_run_id,
+        legacy_source_run_id=legacy_source_run_id,
+    )
+    checks = {
+        'canonical_source_run_key_present': (
+            source_run is not None
+            and source_run.get('source_run_key') == BASELINE_SOURCE_RUN_KEY
+        ),
+        'canonical_bridge_key_present': (
+            bridge is not None
+            and bridge.get('source_run_key') == BASELINE_BRIDGE_KEY
+        ),
+        'canonical_artifact_present': (
+            source_run is not None
+            and source_run.get('artifact_sha256') == BASELINE_ARTIFACT_SHA256
+        ),
+        'canonical_25_rows_present': counts['rows_total'] == 25,
+        'artifact_row_count_matches_25': (
+            source_run is not None
+            and source_run.get('rows_read') == 25
+            and source_run.get('rows_staged') == 25
+            and source_run.get('rows_rejected') == 0
+            and source_run.get('rows_skipped') == 0
+        ),
+        'provenance_complete': counts['rows_with_marker'] == 25,
+        'bridge_linkage_complete': counts['rows_using_legacy_bridge_id'] == 25,
+        'diagnostic_isolation': (
+            counts['rows_diagnostic_only'] == 25
+            and counts['rows_using_source_runs_id'] == 0
+        ),
+    }
+    return {
+        'source_run': source_run,
+        'bridge': bridge,
+        'staging_counts': counts,
+        'checks': checks,
+    }
+
+
+def canonical_stage19ar_staging_counts(
+    conn: Any,
+    *,
+    source_run_id: int | None,
+    legacy_source_run_id: int | None,
+) -> dict[str, int]:
+    if source_run_id is None or legacy_source_run_id is None:
+        return {
+            'rows_total': 0,
+            'rows_diagnostic_only': 0,
+            'rows_using_legacy_bridge_id': 0,
+            'rows_using_source_runs_id': 0,
+            'rows_with_marker': 0,
+        }
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              COUNT(*)::int AS rows_total,
+              COUNT(*) FILTER (WHERE source_class = %s AND confidence = %s)::int
+                AS rows_diagnostic_only,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_legacy_bridge_id,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_source_runs_id,
+              COUNT(*) FILTER (WHERE provenance ? %s)::int AS rows_with_marker
+            FROM staging_edsm_stations
+            WHERE source_run_id = %s
+            """,
+            (
+                pilot.DIAGNOSTIC_ONLY,
+                pilot.DIAGNOSTIC_ONLY,
+                legacy_source_run_id,
+                source_run_id,
+                pilot.PROVENANCE_MARKER_KEY,
+                legacy_source_run_id,
+            ),
+        )
+        row = pilot._fetchone_dict(cur) or {}
+    finally:
+        pilot.close_cursor(cur)
+    return {
+        'rows_total': int(row.get('rows_total') or 0),
+        'rows_diagnostic_only': int(row.get('rows_diagnostic_only') or 0),
+        'rows_using_legacy_bridge_id': int(row.get('rows_using_legacy_bridge_id') or 0),
+        'rows_using_source_runs_id': int(row.get('rows_using_source_runs_id') or 0),
+        'rows_with_marker': int(row.get('rows_with_marker') or 0),
+    }
+
+
+def assert_canonical_stage19ar_baseline(baseline: Mapping[str, Any]) -> None:
+    checks = baseline.get('checks') or {}
+    failed = sorted(key for key, passed in checks.items() if not passed)
+    if failed:
+        raise pilot.Stage19ArPilotError(
+            'canonical Stage 19AR baseline is required before Stage 19AS-AU: '
+            f'{failed}'
+        )
+
+
+def load_secrets_for_args(args: argparse.Namespace) -> dict[str, Any]:
+    secrets_path = getattr(args, 'secrets_file', None)
+    if not secrets_path:
+        return {
+            'detected': False,
+            'used': False,
+            'path': 'not reported',
+            'tracked_by_git': False,
+            'keys': [],
+        }
+    path = Path(secrets_path)
+    detected = path.is_file()
+    tracked = secrets_file_tracked_by_git(path) if detected else False
+    if detected and not tracked:
+        values = read_secrets_file(path)
+        for key, value in values.items():
+            os.environ[key] = value
+        keys = sorted(values)
+    else:
+        keys = []
+    return {
+        'detected': detected,
+        'used': detected and not tracked,
+        'path': reportable_secrets_path(path) if detected else 'not reported',
+        'tracked_by_git': tracked,
+        'keys': keys,
+    }
+
+
+def read_secrets_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding='utf-8').splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if line.startswith('export '):
+            line = line[len('export '):].strip()
+        if '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        key = key.strip()
+        if not SAFE_ENV_KEY.fullmatch(key):
+            continue
+        values[key] = _clean_env_value(value)
+    return values
+
+
+def _clean_env_value(value: str) -> str:
+    cleaned = value.strip()
+    if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in {'"', "'"}:
+        return cleaned[1:-1]
+    return cleaned
+
+
+def secrets_file_tracked_by_git(path: Path) -> bool:
+    try:
+        completed = subprocess.run(
+            ['git', 'ls-files', '--error-unmatch', '--', str(path)],
+            cwd=pilot.ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    return completed.returncode == 0
+
+
+def reportable_secrets_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(pilot.ROOT))
+    except ValueError:
+        return 'not reported'
+
+
+def redacted_db_config(
+    args: argparse.Namespace,
+    env: Mapping[str, str] | None = None,
+    secrets: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    source_env = env if env is not None else os.environ
+    parsed_url = _parse_database_url(source_env.get('DATABASE_URL'))
+    secrets_info = dict(secrets or {})
+    return {
+        'database_url_present': bool(source_env.get('DATABASE_URL')),
+        'host': _first_text(
+            parsed_url.get('host'),
+            source_env.get('PGHOST'),
+            getattr(args, 'db_host', None),
+            default='unknown',
+        ),
+        'port': _first_text(
+            parsed_url.get('port'),
+            source_env.get('PGPORT'),
+            getattr(args, 'db_port', None),
+            default='unknown',
+        ),
+        'database': _first_text(
+            parsed_url.get('database'),
+            source_env.get('PGDATABASE'),
+            getattr(args, 'db_name', None),
+            default='unknown',
+        ),
+        'user': _first_text(
+            parsed_url.get('user'),
+            source_env.get('PGUSER'),
+            getattr(args, 'db_user', None),
+            default='unknown',
+        ),
+        'password_present': bool(
+            parsed_url.get('password_present')
+            or source_env.get('PGPASSWORD')
+            or source_env.get('POSTGRES_PASSWORD')
+        ),
+        'password_value_printed': False,
+        'secrets_file_detected': bool(secrets_info.get('detected')),
+        'secrets_file_used': bool(secrets_info.get('used')),
+        'secrets_file_path': str(secrets_info.get('path') or 'not reported'),
+        'secrets_file_tracked_by_git': bool(secrets_info.get('tracked_by_git')),
+    }
+
+
+def build_db_dsn(args: argparse.Namespace, env: Mapping[str, str] | None = None) -> str:
+    source_env = env if env is not None else os.environ
+    database_url = source_env.get('DATABASE_URL')
+    if database_url:
+        return database_url
+    password = source_env.get('PGPASSWORD') or source_env.get('POSTGRES_PASSWORD')
+    if not password:
+        raise pilot.Stage19ArPilotError('POSTGRES_PASSWORD or PGPASSWORD is required for operator DB connection')
+    parts = {
+        'host': source_env.get('PGHOST') or args.db_host,
+        'port': source_env.get('PGPORT') or args.db_port,
+        'dbname': source_env.get('PGDATABASE') or args.db_name,
+        'user': source_env.get('PGUSER') or args.db_user,
+        'password': password,
+        'sslmode': 'disable',
+    }
+    return ' '.join(f'{key}={value}' for key, value in parts.items())
+
+
+def run_db_preflight(
+    args: argparse.Namespace,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    secrets = load_secrets_for_args(args) if env is None else {
+        'detected': bool(getattr(args, 'secrets_file', None)),
+        'used': bool(getattr(args, 'secrets_file', None)),
+        'path': reportable_secrets_path(Path(args.secrets_file)) if getattr(args, 'secrets_file', None) else 'not reported',
+        'tracked_by_git': False,
+        'keys': [],
+    }
+    source_env = env if env is not None else os.environ
+    config = redacted_db_config(args, env=source_env, secrets=secrets)
+    if secrets['tracked_by_git']:
+        return db_preflight_failure(config, secrets, 'secrets_file_tracked_by_git')
+    if getattr(args, 'secrets_file', None) and not secrets['detected']:
+        return db_preflight_failure(config, secrets, 'secrets_file_missing')
+    conn = None
+    try:
+        dsn = build_db_dsn(args, env=source_env)
+        conn = pilot.connect_operator_db(dsn)
+        pilot.set_connection_mode(conn, commit=False)
+        cur = conn.cursor()
+        try:
+            cur.execute('SELECT 1 AS db_preflight_ok')
+            row = cur.fetchone()
+        finally:
+            pilot.close_cursor(cur)
+        pilot.rollback(conn)
+        return {
+            **secrets_result(secrets),
+            'db_config': config,
+            'db_config_loaded': True,
+            'auth_success': _select_one_succeeded(row),
+            'performed_no_writes': True,
+            'secrets_redacted': True,
+            'failure_category': None,
+        }
+    except Exception as exc:
+        if conn is not None:
+            pilot.rollback(conn)
+        return {
+            **secrets_result(secrets),
+            'db_config': config,
+            'db_config_loaded': config['password_present'],
+            'auth_success': False,
+            'performed_no_writes': True,
+            'secrets_redacted': True,
+            'failure_category': db_failure_category(exc),
+        }
+    finally:
+        if conn is not None:
+            pilot.close_connection(conn)
+
+
+def db_preflight_failure(
+    config: Mapping[str, Any],
+    secrets: Mapping[str, Any],
+    failure_category: str,
+) -> dict[str, Any]:
+    return {
+        **secrets_result(secrets),
+        'db_config': dict(config),
+        'db_config_loaded': bool(config.get('password_present')),
+        'auth_success': False,
+        'performed_no_writes': True,
+        'secrets_redacted': True,
+        'failure_category': failure_category,
+    }
+
+
+def secrets_result(secrets: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        'secrets_file_detected': bool(secrets.get('detected')),
+        'secrets_file_used': bool(secrets.get('used')),
+        'secrets_file_path': str(secrets.get('path') or 'not reported'),
+        'secrets_file_tracked_by_git': bool(secrets.get('tracked_by_git')),
+        'secrets_values_printed': False,
+    }
+
+
+def _select_one_succeeded(row: Any) -> bool:
+    if isinstance(row, Mapping):
+        return row.get('db_preflight_ok') == 1
+    if isinstance(row, Sequence) and not isinstance(row, (str, bytes, bytearray)):
+        return bool(row and row[0] == 1)
+    return False
+
+
+def db_failure_category(exc: Exception) -> str:
+    message = str(exc).lower()
+    if 'password authentication failed' in message:
+        return 'password_authentication_failed'
+    if 'connection refused' in message:
+        return 'connection_refused'
+    if 'could not translate host name' in message or 'name or service not known' in message:
+        return 'host_resolution_failed'
+    if 'timeout' in message:
+        return 'connection_timeout'
+    if 'postgres_password' in message or 'pgpassword' in message:
+        return 'password_missing'
+    return type(exc).__name__
+
+
+def _parse_database_url(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    parsed = urlsplit(value)
+    return {
+        'host': parsed.hostname,
+        'port': str(parsed.port) if parsed.port is not None else None,
+        'database': parsed.path.lstrip('/') or None,
+        'user': parsed.username,
+        'password_present': parsed.password is not None,
+    }
+
+
+def _first_text(*values: Any, default: str) -> str:
+    for value in values:
+        if value is not None and str(value):
+            return str(value)
+    return default
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_stage19ar_operator_script.py
+++ b/tests/test_stage19ar_operator_script.py
@@ -1,8 +1,10 @@
 import ast
+import importlib.util
 import inspect
 import json
 import re
 import sys
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -15,9 +17,20 @@ if str(OPERATOR_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(OPERATOR_SCRIPTS))
 
 import stage19ar_edsm_25_row_staging_pilot as rehearsal  # noqa: E402
+import stage19as_au_edsm_100_row_controlled_expansion as expansion  # noqa: E402
 
 
 NOW = datetime(2026, 6, 6, 10, 30, 0, tzinfo=timezone.utc)
+SUBSTITUTE_SOURCE_RUN_KEY = 'stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034'
+SUBSTITUTE_ARTIFACT_SHA256 = 'b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e'
+
+
+def noncanonical_stage19ar_profile():
+    return replace(
+        rehearsal.STAGE19AR_PROFILE,
+        expected_source_run_key=None,
+        expected_artifact_sha256=None,
+    )
 
 
 class FakeCursor:
@@ -204,13 +217,40 @@ class FakeCursor:
                 ),
                 'rows_using_legacy_bridge_id': sum(1 for row in rows if row['source_run_id'] == legacy_source_run_id),
                 'rows_using_source_runs_id': sum(1 for row in rows if row['source_run_id'] == source_run_id),
-                'rows_with_stage19ar_marker': sum(1 for row in rows if marker_key in row['provenance']),
+                'rows_with_stage_marker': sum(1 for row in rows if marker_key in row['provenance']),
                 'rows_with_canonical_write_blocked': sum(
                     1
                     for row in rows
                     if row['provenance'].get(canonical_key) is False
                 ),
             }
+            self.fetchall_result = []
+            return
+
+        if compact.startswith('select count(*)::int as rows_total'):
+            legacy_source_run_id = params[2]
+            source_run_id = params[3]
+            marker_key = params[4]
+            rows = [
+                row for row in self.conn.staging_rows.values()
+                if row['source_run_id'] == params[5]
+            ]
+            self.fetchone_result = {
+                'rows_total': len(rows),
+                'rows_diagnostic_only': sum(
+                    1
+                    for row in rows
+                    if row['source_class'] == params[0] and row['confidence'] == params[1]
+                ),
+                'rows_using_legacy_bridge_id': sum(1 for row in rows if row['source_run_id'] == legacy_source_run_id),
+                'rows_using_source_runs_id': sum(1 for row in rows if row['source_run_id'] == source_run_id),
+                'rows_with_marker': sum(1 for row in rows if marker_key in row['provenance']),
+            }
+            self.fetchall_result = []
+            return
+
+        if compact == 'select 1 as db_preflight_ok':
+            self.fetchone_result = {'db_preflight_ok': 1}
             self.fetchall_result = []
             return
 
@@ -568,6 +608,7 @@ def test_validation_passes_for_exactly_n_marked_rows(tmp_path):
         legacy_source_run_id=701,
         inserted_row_ids=list(range(901, 926)),
         import_artifact_record=import_artifact_record,
+        profile=noncanonical_stage19ar_profile(),
     )
 
     assert checks['one_source_run_inserted'] is True
@@ -598,6 +639,7 @@ def test_committed_pilot_runs_import_marks_rows_validates_and_writes_artifact(tm
         trigger_context='unit_test',
         commit=True,
         generated_at=NOW,
+        profile=noncanonical_stage19ar_profile(),
     )
 
     assert result['commit_requested'] is True
@@ -636,6 +678,305 @@ def test_committed_pilot_runs_import_marks_rows_validates_and_writes_artifact(tm
     summary = rehearsal._summary_for_stdout(result)
     assert summary['inserted_row_count'] == 25
     assert summary['inserted_row_ids'] == list(range(901, 926))
+
+
+def test_default_stage19ar_profile_uses_exact_canonical_source_run_key():
+    assert rehearsal.CANONICAL_SOURCE_RUN_KEY == 'stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd'
+    assert rehearsal.CANONICAL_BRIDGE_KEY == 'source_runs:stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd'
+    assert rehearsal.CANONICAL_ARTIFACT_SHA256 == (
+        '418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417'
+    )
+    assert rehearsal.build_source_run_key('5f777958b81bd034') == rehearsal.CANONICAL_SOURCE_RUN_KEY
+
+
+def test_substitute_stage19ar_run_fails_canonical_validation(tmp_path):
+    conn = FakeConn()
+    import_record = rehearsal.artifact_utils.write_json_artifact(
+        tmp_path / 'import.json',
+        {'schema_version': 'unit/v1', 'summary': {'rows': 25}},
+    )
+    import_artifact_record = {
+        'artifact_path': import_record['path'],
+        'artifact_sha256': import_record['file_sha256'],
+        'artifact_integrity_sha256': import_record['artifact_integrity_sha256'],
+    }
+    conn.source_runs[SUBSTITUTE_SOURCE_RUN_KEY] = {
+        'id': 101,
+        'source_run_key': SUBSTITUTE_SOURCE_RUN_KEY,
+        'status': 'succeeded',
+        'rows_read': 25,
+        'rows_staged': 25,
+        'rows_rejected': 0,
+        'rows_skipped': 0,
+        **import_artifact_record,
+    }
+    conn.legacy_rows[f'source_runs:{SUBSTITUTE_SOURCE_RUN_KEY}'] = {
+        'id': 701,
+        'source_run_key': f'source_runs:{SUBSTITUTE_SOURCE_RUN_KEY}',
+        'dry_run': False,
+        'metadata': {},
+    }
+    for index in range(1, 26):
+        conn.staging_rows[900 + index] = {
+            **normalised_import_row(index),
+            'id': 900 + index,
+            'source_run_id': 701,
+            'source_class': 'diagnostic-only',
+            'confidence': 'diagnostic-only',
+            'provenance': {
+                'canonical_write_allowed': False,
+                'stage19ar_bounded_25_row_pilot': {'source_run_key': SUBSTITUTE_SOURCE_RUN_KEY},
+            },
+        }
+
+    checks = rehearsal.validate_pilot(
+        conn,
+        limit=25,
+        source_run_key=SUBSTITUTE_SOURCE_RUN_KEY,
+        bridge_key=f'source_runs:{SUBSTITUTE_SOURCE_RUN_KEY}',
+        source_run_id=101,
+        legacy_source_run_id=701,
+        inserted_row_ids=list(range(901, 926)),
+        import_artifact_record=import_artifact_record,
+    )
+
+    assert checks['canonical_source_run_key_matches'] is False
+    assert checks['canonical_bridge_key_matches'] is False
+    assert checks['canonical_artifact_hash_matches'] is False
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='canonical_'):
+        rehearsal.assert_validation_passes(checks)
+
+
+def test_stage19as_au_defaults_to_100_row_profile(tmp_path):
+    args = expansion.parse_args([
+        '--artifact-dir',
+        str(tmp_path),
+        '--git-head',
+        'abc1234',
+    ])
+
+    assert args.commit is False
+    assert args.limit == 100
+    assert args.trigger_context == 'stage19as_au_controlled_100_row_expansion'
+    assert expansion.STAGE19AS_AU_PROFILE.default_limit == 100
+    assert expansion.STAGE19AS_AU_PROFILE.hard_max_limit == 100
+
+
+def test_stage19as_au_rejects_substitute_stage19ar_baseline():
+    conn = FakeConn()
+    conn.source_runs[SUBSTITUTE_SOURCE_RUN_KEY] = {
+        'id': 101,
+        'source_run_key': SUBSTITUTE_SOURCE_RUN_KEY,
+        'status': 'succeeded',
+        'rows_read': 25,
+        'rows_staged': 25,
+        'rows_rejected': 0,
+        'rows_skipped': 0,
+        'artifact_path': 'stage19ar_edsm_import.json',
+        'artifact_sha256': SUBSTITUTE_ARTIFACT_SHA256,
+        'artifact_integrity_sha256': 'integrity',
+    }
+    conn.legacy_rows[f'source_runs:{SUBSTITUTE_SOURCE_RUN_KEY}'] = {
+        'id': 701,
+        'source_run_key': f'source_runs:{SUBSTITUTE_SOURCE_RUN_KEY}',
+        'dry_run': False,
+        'metadata': {},
+    }
+    for index in range(1, 26):
+        conn.staging_rows[900 + index] = {
+            **normalised_import_row(index),
+            'id': 900 + index,
+            'source_run_id': 701,
+            'source_class': 'diagnostic-only',
+            'confidence': 'diagnostic-only',
+            'provenance': {
+                'canonical_write_allowed': False,
+                'stage19ar_bounded_25_row_pilot': {'source_run_key': SUBSTITUTE_SOURCE_RUN_KEY},
+            },
+        }
+
+    baseline = expansion.verify_canonical_stage19ar_baseline(conn)
+
+    assert baseline['checks']['canonical_source_run_key_present'] is False
+    assert baseline['checks']['canonical_bridge_key_present'] is False
+    assert baseline['checks']['canonical_artifact_present'] is False
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='canonical Stage 19AR baseline is required'):
+        expansion.assert_canonical_stage19ar_baseline(baseline)
+
+
+def test_stage19as_au_db_preflight_redacts_config_and_performs_no_writes(monkeypatch):
+    conn = FakeConn()
+    args = expansion.parse_args([
+        '--preflight-db',
+        '--db-host',
+        '127.0.0.1',
+        '--db-port',
+        '5432',
+        '--db-name',
+        'edfinder',
+        '--db-user',
+        'edfinder',
+    ])
+    env = {
+        'POSTGRES_PASSWORD': 'do-not-print-this',
+        'DATABASE_URL': 'postgresql://edfinder:do-not-print-this@127.0.0.1:5432/edfinder',
+    }
+
+    monkeypatch.setattr(expansion.pilot, 'connect_operator_db', lambda _dsn: conn)
+
+    result = expansion.run_db_preflight(args, env=env)
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['auth_success'] is True
+    assert result['performed_no_writes'] is True
+    assert result['secrets_redacted'] is True
+    assert result['db_config'] == {
+        'database_url_present': True,
+        'host': '127.0.0.1',
+        'port': '5432',
+        'database': 'edfinder',
+        'user': 'edfinder',
+        'password_present': True,
+        'password_value_printed': False,
+        'secrets_file_detected': False,
+        'secrets_file_used': False,
+        'secrets_file_path': 'not reported',
+        'secrets_file_tracked_by_git': False,
+    }
+    assert 'do-not-print-this' not in encoded
+    assert 'postgresql://' not in encoded
+    assert conn.commits == 0
+    assert conn.rollbacks == 1
+    assert conn.source_runs == {}
+    assert conn.legacy_rows == {}
+    assert conn.staging_rows == {}
+
+
+def test_stage19as_au_loads_untracked_secrets_file_without_printing_values(tmp_path, monkeypatch):
+    secrets_path = tmp_path / 'stage19.env'
+    secrets_path.write_text(
+        'POSTGRES_PASSWORD=from-secret-file\n'
+        'PGHOST=127.0.0.1\n'
+        'PGPORT=5432\n'
+        'PGDATABASE=edfinder\n'
+        'PGUSER=edfinder\n',
+        encoding='utf-8',
+    )
+    args = expansion.parse_args(['--secrets-file', str(secrets_path)])
+    monkeypatch.delenv('POSTGRES_PASSWORD', raising=False)
+    monkeypatch.delenv('PGHOST', raising=False)
+    monkeypatch.delenv('PGPORT', raising=False)
+    monkeypatch.delenv('PGDATABASE', raising=False)
+    monkeypatch.delenv('PGUSER', raising=False)
+
+    loaded = expansion.load_secrets_for_args(args)
+    config = expansion.redacted_db_config(args, secrets=loaded)
+    encoded = json.dumps({'loaded': loaded, 'config': config}, sort_keys=True)
+
+    assert loaded['detected'] is True
+    assert loaded['used'] is True
+    assert loaded['tracked_by_git'] is False
+    assert loaded['path'] == 'not reported'
+    assert sorted(loaded['keys']) == ['PGDATABASE', 'PGHOST', 'PGPORT', 'PGUSER', 'POSTGRES_PASSWORD']
+    assert config['password_present'] is True
+    assert config['password_value_printed'] is False
+    assert 'from-secret-file' not in encoded
+
+
+def test_stage19as_au_db_preflight_reports_auth_failure_without_secret(monkeypatch):
+    args = expansion.parse_args(['--preflight-db'])
+    env = {'POSTGRES_PASSWORD': 'do-not-print-this'}
+
+    def fail_connect(_dsn):
+        raise RuntimeError('password authentication failed for user "edfinder"')
+
+    monkeypatch.setattr(expansion.pilot, 'connect_operator_db', fail_connect)
+
+    result = expansion.run_db_preflight(args, env=env)
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['auth_success'] is False
+    assert result['failure_category'] == 'password_authentication_failed'
+    assert result['performed_no_writes'] is True
+    assert result['secrets_redacted'] is True
+    assert 'do-not-print-this' not in encoded
+
+
+def test_stage19as_au_preflight_flag_exits_before_commit_path(monkeypatch, capsys):
+    def fake_preflight(_args):
+        return {
+            'db_config': {
+                'database_url_present': False,
+                'host': '127.0.0.1',
+                'port': '5432',
+                'database': 'edfinder',
+                'user': 'edfinder',
+                'password_present': True,
+                'password_value_printed': False,
+            },
+            'db_config_loaded': True,
+            'auth_success': False,
+            'performed_no_writes': True,
+            'secrets_redacted': True,
+            'failure_category': 'password_authentication_failed',
+        }
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError('commit path must not run during DB preflight')
+
+    monkeypatch.setattr(expansion, 'run_db_preflight', fake_preflight)
+    monkeypatch.setattr(expansion.pilot, 'run_pilot', fail_if_called)
+
+    exit_code = expansion.main(['--preflight-db', '--commit'])
+    output = capsys.readouterr().out
+
+    assert exit_code == 2
+    assert 'password_authentication_failed' in output
+    assert 'password_value_printed' in output
+
+
+def test_stage19as_au_committed_expansion_reuses_stage19ar_path_with_100_rows(tmp_path):
+    conn = FakeConn(sample_rows=sample_staging_rows(100))
+
+    result = rehearsal.run_pilot(
+        conn,
+        limit=100,
+        artifact_dir=tmp_path,
+        git_head='abc1234',
+        trigger_context=expansion.STAGE19AS_AU_PROFILE.trigger_context,
+        commit=True,
+        generated_at=NOW,
+        profile=expansion.STAGE19AS_AU_PROFILE,
+    )
+
+    assert result['commit_requested'] is True
+    assert conn.commits == 1
+    assert len(conn.source_runs) == 1
+    assert len(conn.legacy_rows) == 1
+    assert len(conn.staging_rows) == 100
+    assert result['inserted_row_count'] == 100
+    assert result['inserted_row_ids'] == list(range(901, 1001))
+    assert result['source_run_key'].startswith('stage19as-au-edsm-100-row-controlled-expansion-')
+    assert result['source_run_key'] != expansion.BASELINE_SOURCE_RUN_KEY
+    assert result['bridge_key'] == f'source_runs:{result["source_run_key"]}'
+    assert result['validation_checks']['exactly_100_staging_rows_inserted'] is True
+    assert result['validation_checks']['exactly_100_staging_rows_marked_diagnostic'] is True
+    assert result['validation_checks']['staging_rows_have_stage19as_au_marker'] is True
+    assert result['validation_checks']['canonical_table_writes_performed_by_script'] is False
+    assert all(row['source_run_id'] == 701 for row in conn.staging_rows.values())
+    assert all(row['source_class'] == 'diagnostic-only' for row in conn.staging_rows.values())
+    assert all(row['confidence'] == 'diagnostic-only' for row in conn.staging_rows.values())
+    assert all(
+        row['provenance']['stage19as_au_controlled_100_row_expansion']['source_run_key']
+        == result['source_run_key']
+        for row in conn.staging_rows.values()
+    )
+    bridge_metadata = next(iter(conn.legacy_rows.values()))['metadata']
+    assert bridge_metadata['controlled_100_row_expansion'] is True
+    assert bridge_metadata['baseline_source_run_key'] == expansion.BASELINE_SOURCE_RUN_KEY
+    payload = result['operator_artifact_record']['payload']
+    assert payload['schema_version'] == 'stage19as_au_edsm_100_row_controlled_expansion/v1'
+    assert payload['inserted_row_count'] == 100
 
 
 def test_static_guardrails_no_scheduler_canonical_apply_canonical_writes_or_secrets():
@@ -702,3 +1043,113 @@ def test_static_import_call_uses_explicit_stage19ar_stager():
         for call in calls
     )
     assert 'CompatibleStage19ArStationStager' in inspect.getsource(rehearsal)
+
+
+def test_stage19_operator_modules_load_from_py_source_not_only_bytecode():
+    for module in (rehearsal, expansion):
+        module_file = Path(module.__file__)
+        assert module_file.suffix == '.py'
+        assert module_file.is_file()
+    expansion_dsn_source = inspect.getsource(expansion.build_db_dsn)
+    assert "source_env.get('PGPORT')" in expansion_dsn_source
+    rehearsal_dsn_source = inspect.getsource(rehearsal.build_operator_dsn)
+    assert "source_env.get('PGPORT')" in rehearsal_dsn_source
+
+
+def test_stage19_preflight_reloaded_from_source_authenticates_without_bytecode(monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        'stage19as_au_reloaded_from_source',
+        Path(expansion.__file__),
+    )
+    fresh = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fresh)
+
+    captured = {}
+
+    class _Cursor:
+        def execute(self, sql, params=None):
+            captured['sql'] = ' '.join(sql.lower().split())
+
+        def fetchone(self):
+            return {'db_preflight_ok': 1}
+
+        def close(self):
+            pass
+
+    class _Conn:
+        def __init__(self):
+            self.rollbacks = 0
+            self.closed = False
+
+        def cursor(self):
+            return _Cursor()
+
+        def rollback(self):
+            self.rollbacks += 1
+
+        def close(self):
+            self.closed = True
+
+    conn = _Conn()
+    monkeypatch.setattr(fresh.pilot, 'connect_operator_db', lambda _dsn: conn)
+    args = fresh.parse_args(['--preflight-db', '--db-port', '55432'])
+    env = {
+        'PGPASSWORD': 'do-not-print-this',
+        'PGHOST': '127.0.0.1',
+        'PGPORT': '55432',
+    }
+
+    result = fresh.run_db_preflight(args, env=env)
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert Path(fresh.__file__).suffix == '.py'
+    assert result['auth_success'] is True
+    assert result['performed_no_writes'] is True
+    assert result['db_config']['host'] == '127.0.0.1'
+    assert result['db_config']['port'] == '55432'
+    assert captured['sql'] == 'select 1 as db_preflight_ok'
+    assert conn.rollbacks == 1
+    assert 'do-not-print-this' not in encoded
+
+
+def test_stage19as_au_rejects_missing_canonical_baseline():
+    conn = FakeConn()
+
+    baseline = expansion.verify_canonical_stage19ar_baseline(conn)
+
+    assert baseline['source_run'] is None
+    assert baseline['bridge'] is None
+    assert baseline['checks']['canonical_source_run_key_present'] is False
+    assert baseline['checks']['canonical_bridge_key_present'] is False
+    assert baseline['checks']['canonical_artifact_present'] is False
+    assert baseline['checks']['canonical_25_rows_present'] is False
+    with pytest.raises(rehearsal.Stage19ArPilotError, match='canonical Stage 19AR baseline is required'):
+        expansion.assert_canonical_stage19ar_baseline(baseline)
+
+
+def test_stage19ar_operator_dsn_honors_pg_env_for_isolated_db_port():
+    args = rehearsal.parse_args([])
+    assert args.db_port == '5432'
+    env = {
+        'PGPASSWORD': 'do-not-print-this',
+        'PGHOST': '127.0.0.1',
+        'PGPORT': '55432',
+        'PGDATABASE': 'edfinder',
+        'PGUSER': 'edfinder',
+    }
+
+    dsn = rehearsal.build_operator_dsn(args, env=env)
+
+    assert 'host=127.0.0.1' in dsn
+    assert 'port=55432' in dsn
+    assert 'port=5432' not in dsn
+    assert 'dbname=edfinder' in dsn
+
+
+def test_stage19ar_operator_dsn_requires_a_password():
+    args = rehearsal.parse_args([])
+    with pytest.raises(
+        rehearsal.Stage19ArPilotError,
+        match='POSTGRES_PASSWORD or PGPASSWORD is required',
+    ):
+        rehearsal.build_operator_dsn(args, env={})


### PR DESCRIPTION
## Summary

Makes the Stage 19 DB preflight reproducible **from source** and documents the canonical Stage 19AR baseline recovery state. No Stage 19AS-AU run, no baseline rows written, no new canonical baseline approved.

## Root cause

The earlier `project_db_authenticated: false` was **not** a bytecode problem. The preflight entrypoint `run_db_preflight` (`--preflight-db`, redacted `SELECT 1`) in `scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py` failed source-correct only because `POSTGRES_PASSWORD`/`PGPASSWORD` was absent from the environment (`failure_category: password_missing`). Cached bytecode cannot carry DB credentials, so the 'earlier success from bytecode' was a misdiagnosed ambient-environment difference.

## Proof of source-correctness

Removed all project-local `__pycache__` + `.pytest_cache`, then ran with `python -B` (no `.pyc` written/read): authenticates against `127.0.0.1:55432` (`auth_success: true`, `performed_no_writes: true`). Zero bytecode reliance.

## Port finding

Base `docker-compose.yml` maps `127.0.0.1:5432:5432` (canonical). `55432` is a local `.codex-runtime` override to avoid a host-Postgres collision; it stays environmental (`--db-port 55432`/`PGPORT`) and is never hardcoded into source.

## Source repair (minimal)

`stage19ar_edsm_25_row_staging_pilot.build_operator_dsn` now honors `PGHOST`/`PGPORT`/`PGDATABASE`/`PGUSER` and `PGPASSWORD` (or `POSTGRES_PASSWORD`) env precedence — matching the sibling preflight DSN — so an env-driven source-correct run targets the isolated DB instead of silently defaulting to host Postgres `5432`. `DATABASE_URL` deliberately excluded to stay within the Stage 19AR static guardrails. No secrets printed.

## Tests (5 added, `tests/test_stage19ar_operator_script.py`)

- `test_stage19_operator_modules_load_from_py_source_not_only_bytecode`
- `test_stage19_preflight_reloaded_from_source_authenticates_without_bytecode`
- `test_stage19as_au_rejects_missing_canonical_baseline` (alongside existing substitute-baseline rejection)
- `test_stage19ar_operator_dsn_honors_pg_env_for_isolated_db_port`
- `test_stage19ar_operator_dsn_requires_a_password`

Result: **39 passed** (`python -B -m pytest ... -p no:cacheprovider`). `git diff --check` clean.

## Docs

`docs/colonisation-redesign/stage-19ar-canonical-baseline.md` — new 'Source-Correct DB Preflight (Repaired)' section, checkpoint flags (`source_correct_db_preflight_passes: true`, `project_db_authenticated: true`), and the STAGE 19 CURRENT CHECKPOINT handoff block (canonical/rejected identities, recovery-not-found status, DB preflight rule, do-not-run-19AS-AU rule). README indexes the new doc.

## Guardrails honored

- Stage 19AS-AU **not run**; no baseline rows written (preflight is `SELECT 1` only).
- Host Postgres on 5432 untouched; no Docker volumes removed; no `git clean`.
- Canonical Stage 19AR baseline still not found in git/local history; `ready_for_stage19as_au: false`; no new baseline approved.