### PR TITLE
Test environment: preflight, fake inventory, and real Stage 19 DB readiness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@
 # Real builds happen via docker compose / yarn / pytest directly; this
 # Makefile just collects the most-used recipes so you don't have to
 # remember the env-var incantations.
-.PHONY: help lint typecheck test seed-check api-smoke clean
+.PHONY: help lint typecheck test seed-check api-smoke test-env-check test-unit test-operator test-db test-integration test-ci-local clean
+
+PYTHON ?= python
 
 help:  ## Show this help
 	@awk 'BEGIN{FS=":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -22,6 +24,26 @@ test:  ## Run backend unit + integration tests
 	LOG_LEVEL=$${LOG_LEVEL:-WARNING} \
 	EXPOSE_ERROR_DETAIL=true \
 	python -m pytest tests/integration/ -q
+
+test-env-check:  ## Run the local test-environment preflight without writes
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/test_env_preflight.py
+
+test-unit:  ## Run tests that do not require external services
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m "unit or not (integration or db or operator or e2e or slow)"
+
+test-operator:  ## Run Stage 19 operator safety tests
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py -m operator
+
+test-db:  ## Run DB-marked tests, including explicit skips for absent real services
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m db -rs
+
+test-integration:  ## Run integration-marked tests
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m integration -rs
+
+test-ci-local: test-env-check  ## Run focused local CI checks for the test environment stack
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_test_env_preflight.py tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py tests/test_stage19_real_postgres_readiness.py -rs
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m py_compile scripts/dev/test_env_preflight.py scripts/operator/stage19ar_edsm_25_row_staging_pilot.py scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py
+	git diff --check
 
 api-smoke:  ## Curl the Phase-2 happy paths against a running API
 	@API=$${API:-http://localhost:8000}; \

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -177,6 +177,36 @@ Still prohibited:
 - running Stage 19AS-AU from stale local main
 ```
 
+## Test Environment Roadmap Gate
+
+Stage 19AS-AU is paused while the test-environment roadmap is restored and validated. The pause is a test-environment gate, not a new baseline decision.
+
+Current test-environment restoration state:
+
+```text
+stage19_resume_gate:
+paused_until_next_agreed_test_environment_gate
+
+real_stage19_db_readiness_tests:
+pending_real_service_result
+
+real_db_tests_skip_status:
+explicit_skip_allowed_only_when_credentials_or_service_are_absent
+
+fakeconn_fakecursor_status:
+unit-level fakes paired with real local Postgres readiness coverage
+
+stage19as_au_expansion_attempted:
+false
+```
+
+The restored real-service readiness path is `tests/test_stage19_real_postgres_readiness.py`. It must pass against local Postgres before FakeConn/FakeCursor coverage is treated as paired readiness coverage. Until that real-service result is recorded, FakeConn/FakeCursor remain unit-level confidence only.
+
+Stale states that remain non-authoritative:
+
+- `fix/stage19-approved-rebaseline` at `45e2d58`: superseded partial attempt with `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance.
+- `run/stage19as-au-100-row-expansion` at `f72812a`: local docs-only stopped checkpoint with `password_missing`, no writes, not pushed, and not a successful Stage 19AS-AU run.
+
 ## Fresh-Chat Handoff
 
 Use the `STAGE 19 CURRENT CHECKPOINT` block above when resuming Stage 19 in a new chat.

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -185,13 +185,14 @@ Current test-environment restoration state:
 
 ```text
 stage19_resume_gate:
-paused_until_next_agreed_test_environment_gate
+fake-only readiness blocker cleared
+Stage 19 remains paused until the next agreed test-env gate or operator decision
 
 real_stage19_db_readiness_tests:
-pending_real_service_result
+passed
 
 real_db_tests_skip_status:
-explicit_skip_allowed_only_when_credentials_or_service_are_absent
+not_skipped
 
 fakeconn_fakecursor_status:
 unit-level fakes paired with real local Postgres readiness coverage
@@ -200,7 +201,7 @@ stage19as_au_expansion_attempted:
 false
 ```
 
-The restored real-service readiness path is `tests/test_stage19_real_postgres_readiness.py`. It must pass against local Postgres before FakeConn/FakeCursor coverage is treated as paired readiness coverage. Until that real-service result is recorded, FakeConn/FakeCursor remain unit-level confidence only.
+The restored real-service readiness path is `tests/test_stage19_real_postgres_readiness.py`. It passed against local Postgres on the recreated test-environment branch, so FakeConn/FakeCursor coverage is now paired with real-service readiness coverage. Stage 19 remains paused until the next agreed test-environment gate or operator decision.
 
 Stale states that remain non-authoritative:
 

--- a/docs/development/test-double-inventory.md
+++ b/docs/development/test-double-inventory.md
@@ -1,0 +1,47 @@
+# Test Double Inventory
+
+## Scope
+
+This inventory separates unit-level test doubles from real-service proof. A fake can prove local branching and SQL shape, but it cannot prove credentials, live schema, transaction mode, or service availability.
+
+## Current Critical Doubles
+
+| Test double | Location | Classification | Purpose | Required real-service pair |
+|---|---|---|---|---|
+| `FakeConn` / `FakeCursor` | `tests/test_stage19ar_operator_script.py` | unit fake | Exercise Stage 19AR and Stage 19AS-AU operator SQL paths without DB writes | `tests/test_stage19_real_postgres_readiness.py` |
+| `FakeAsyncConn` / `FakePool` | `tests/test_stage19ap_operator_visibility.py` | unit fake | Exercise operator visibility query composition and router path handling | `tests/test_stage19_real_postgres_readiness.py` plus local preflight |
+| command runner doubles | `tests/test_test_env_preflight.py` | unit stub | Classify Docker/Postgres/preflight command outcomes without touching services | `scripts/dev/test_env_preflight.py` |
+
+## FakeConn and FakeCursor Status
+
+```text
+fakeconn_fakecursor_status:
+unit-level fakes paired with real local Postgres readiness coverage
+```
+
+`FakeConn` and `FakeCursor` are still useful for commit/rollback, validation, and artifact-guard tests. They are not accepted as Stage 19 readiness proof by themselves.
+
+The real-service pair is `tests/test_stage19_real_postgres_readiness.py`. It uses live Postgres through `psycopg2`, runs in read-only transaction mode, checks `SELECT 1`, and verifies the approved Stage 19AR baseline identity when local credentials and service are available. It skips explicitly for absent credentials or absent service and does not fall back to fakes.
+
+## Confidence Rules
+
+- Unit fakes may validate deterministic control flow and SQL intent.
+- Integration tests must carry `integration`, `db`, `operator`, and service requirement markers when they touch local services.
+- Missing credentials or unavailable services must be visible as explicit skips, not fake-backed passes.
+- Broad runtime dependency stubs are not allowed for real-service tests.
+- No test double may be treated as proof that Stage 19AS-AU is safe to run.
+
+## Current Gate
+
+```text
+real_stage19_db_readiness_tests:
+pending_real_service_result
+
+real_db_tests_skip_status:
+explicit_skip_allowed_only_when_credentials_or_service_are_absent
+
+critical_fakes_replaced_or_paired_with_real_service_tests:
+true
+```
+
+The fake-only readiness blocker is cleared when the real Stage 19 DB readiness test passes against local Postgres. Stage 19 remains paused until the next agreed test-environment gate.

--- a/docs/development/test-double-inventory.md
+++ b/docs/development/test-double-inventory.md
@@ -35,13 +35,20 @@ The real-service pair is `tests/test_stage19_real_postgres_readiness.py`. It use
 
 ```text
 real_stage19_db_readiness_tests:
-pending_real_service_result
+passed
 
 real_db_tests_skip_status:
-explicit_skip_allowed_only_when_credentials_or_service_are_absent
+not_skipped
+
+fakeconn_fakecursor_status:
+unit-level fakes paired with real local Postgres readiness coverage
 
 critical_fakes_replaced_or_paired_with_real_service_tests:
 true
+
+stage19_resume_gate:
+fake-only readiness blocker cleared
+Stage 19 remains paused until the next agreed test-env gate or operator decision
 ```
 
-The fake-only readiness blocker is cleared when the real Stage 19 DB readiness test passes against local Postgres. Stage 19 remains paused until the next agreed test-environment gate.
+The fake-only readiness blocker is cleared by the real Stage 19 DB readiness test passing against local Postgres. Stage 19 remains paused until the next agreed test-environment gate or operator decision.

--- a/docs/development/test-environment.md
+++ b/docs/development/test-environment.md
@@ -1,0 +1,71 @@
+# Test Environment
+
+## Purpose
+
+The local test environment is a safety boundary for operator and data-workflow work. It must distinguish unit tests that intentionally use fakes from integration tests that prove the same path against local services.
+
+## Canonical Local Preflight
+
+Run the preflight from the repository root:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 python -B scripts/dev/test_env_preflight.py
+```
+
+The preflight is fail-closed and reports structured JSON. It checks:
+
+- pytest availability
+- importability of Stage 19 operator modules and operator visibility modules
+- Docker CLI availability
+- Docker Compose availability
+- `ed-postgres` container presence
+- local Postgres readiness on the configured host and port
+- credential presence without printing values
+- read-only `SELECT 1` when credentials are available
+
+The default project Postgres target is `127.0.0.1:55432`. That keeps this validation away from a host Postgres listener on `5432` unless the operator explicitly supplies a different target through `PGHOST`, `PGPORT`, or `DATABASE_URL`.
+
+Expected safety properties:
+
+```text
+writes_performed: false
+secrets_printed: false
+db_read_only_select_1_passed: true when credentials and service are available
+failure_category: set on the first failed check
+```
+
+## Pytest Markers
+
+The project registers these local markers:
+
+- `unit`
+- `integration`
+- `db`
+- `operator`
+- `slow`
+- `e2e`
+- `frontend`
+- `requires_docker`
+- `requires_postgres`
+- `requires_redis`
+
+Real-service tests must use the applicable service markers and skip explicitly when the service or credentials are absent. They must not silently pass by falling back to unit fakes.
+
+## Make Targets
+
+The Makefile includes:
+
+- `test-env-check`
+- `test-unit`
+- `test-operator`
+- `test-db`
+- `test-integration`
+- `test-ci-local`
+
+`test-ci-local` runs the focused test-environment stack and source compilation checks without running Stage 19AS-AU.
+
+## Stage 19 Status
+
+Stage 19 remains paused for test-environment hardening. The fake-only readiness blocker is cleared only when the real Stage 19 local Postgres readiness test passes against the approved Stage 19AR baseline. Until then, FakeConn/FakeCursor coverage is unit confidence only.
+
+Stage 19AS-AU must not run from this test-environment branch. Do not use `--commit`, do not rebaseline, and do not promote staged rows from this work.

--- a/docs/development/test-environment.md
+++ b/docs/development/test-environment.md
@@ -66,6 +66,23 @@ The Makefile includes:
 
 ## Stage 19 Status
 
-Stage 19 remains paused for test-environment hardening. The fake-only readiness blocker is cleared only when the real Stage 19 local Postgres readiness test passes against the approved Stage 19AR baseline. Until then, FakeConn/FakeCursor coverage is unit confidence only.
+Stage 19 remains paused for test-environment hardening. The fake-only readiness blocker is cleared: the real Stage 19 local Postgres readiness test passed against the approved Stage 19AR baseline on the recreated test-environment branch.
+
+Current real-service validation result:
+
+```text
+real_stage19_db_readiness_tests:
+passed
+
+real_db_tests_skip_status:
+not_skipped
+
+fakeconn_fakecursor_status:
+unit-level fakes paired with real local Postgres readiness coverage
+
+stage19_resume_gate:
+fake-only readiness blocker cleared
+Stage 19 remains paused until the next agreed test-env gate or operator decision
+```
 
 Stage 19AS-AU must not run from this test-environment branch. Do not use `--commit`, do not rebaseline, and do not promote staged rows from this work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,15 @@ requires-python = ">=3.12"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 asyncio_mode = "auto"
+markers = [
+    "unit: unit-level tests that do not require external services",
+    "integration: integration tests that exercise cross-module or service boundaries",
+    "db: tests that require a database contract or a live database",
+    "operator: tests for operator scripts, operator APIs, and operator safety surfaces",
+    "slow: tests that are expected to take longer than the default unit path",
+    "e2e: browser or full-stack end-to-end tests",
+    "frontend: frontend tests",
+    "requires_docker: tests or preflights that require Docker",
+    "requires_postgres: tests or preflights that require local Postgres",
+    "requires_redis: tests or preflights that require Redis",
+]

--- a/scripts/dev/test_env_preflight.py
+++ b/scripts/dev/test_env_preflight.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Local test environment preflight with no writes and no secret output."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_HOST = '127.0.0.1'
+DEFAULT_DB_PORT = '55432'
+DEFAULT_DB_NAME = 'edfinder'
+DEFAULT_DB_USER = 'edfinder'
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    name: str
+    ok: bool
+    failure_category: str | None = None
+    detail: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'ok': self.ok,
+            'failure_category': self.failure_category,
+            'detail': dict(self.detail or {}),
+        }
+
+
+CommandRunner = Callable[[Sequence[str], int], subprocess.CompletedProcess[str]]
+DbProbe = Callable[[Mapping[str, str], Mapping[str, Any]], CheckResult]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    result = run_preflight(env=os.environ, timeout=args.timeout_seconds)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result['ok'] else 2
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Check the local test environment without writes.')
+    parser.add_argument('--timeout-seconds', type=int, default=5)
+    return parser.parse_args(argv)
+
+
+def run_preflight(
+    *,
+    env: Mapping[str, str],
+    runner: CommandRunner | None = None,
+    db_probe: DbProbe | None = None,
+    timeout: int = 5,
+) -> dict[str, Any]:
+    command_runner = runner or run_command
+    database = resolve_db_config(env)
+    checks = [
+        check_pytest_available(),
+        check_project_imports(),
+        check_docker_cli(command_runner, timeout),
+        check_docker_compose(command_runner, timeout),
+        check_postgres_container(command_runner, timeout),
+        check_pg_isready(command_runner, database, timeout),
+        check_db_credentials(env),
+    ]
+    if database['password_present']:
+        checks.append((db_probe or run_read_only_select_one)(env, database))
+    else:
+        checks.append(CheckResult(
+            'db_read_only_select_1',
+            False,
+            'credentials_missing',
+            {'attempted': False},
+        ))
+
+    failure_category = next((check.failure_category for check in checks if not check.ok), None)
+    return {
+        'ok': all(check.ok for check in checks),
+        'failure_category': failure_category,
+        'writes_performed': False,
+        'secrets_printed': False,
+        'db_read_only_select_1_passed': any(
+            check.name == 'db_read_only_select_1' and check.ok for check in checks
+        ),
+        'credentials': {
+            'postgres_password_present': bool(env.get('POSTGRES_PASSWORD')),
+            'pgpassword_present': bool(env.get('PGPASSWORD')),
+            'database_url_present': bool(env.get('DATABASE_URL')),
+            'password_value_printed': False,
+        },
+        'database': database,
+        'checks': {check.name: check.to_dict() for check in checks},
+    }
+
+
+def run_command(args: Sequence[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def check_pytest_available() -> CheckResult:
+    return CheckResult(
+        'pytest_available',
+        importlib.util.find_spec('pytest') is not None,
+        None if importlib.util.find_spec('pytest') is not None else 'pytest_missing',
+    )
+
+
+def check_project_imports() -> CheckResult:
+    try:
+        import_file('stage19ar_preflight_import', ROOT / 'scripts/operator/stage19ar_edsm_25_row_staging_pilot.py')
+        import_file('stage19as_au_preflight_import', ROOT / 'scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py')
+        with sys_path(ROOT / 'apps/api/src', ROOT / 'apps/api/src/routers'):
+            importlib.import_module('operator_visibility')
+            import_file('operator_router_preflight_import', ROOT / 'apps/api/src/routers/operator.py')
+    except Exception as exc:
+        return CheckResult('project_imports', False, classify_exception(exc))
+    return CheckResult('project_imports', True)
+
+
+def import_file(module_name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f'cannot load {path.relative_to(ROOT)}')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class sys_path:
+    def __init__(self, *paths: Path):
+        self.paths = [str(path) for path in paths]
+
+    def __enter__(self) -> None:
+        for path in reversed(self.paths):
+            if path not in sys.path:
+                sys.path.insert(0, path)
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        for path in self.paths:
+            try:
+                sys.path.remove(path)
+            except ValueError:
+                pass
+
+
+def check_docker_cli(runner: CommandRunner, timeout: int) -> CheckResult:
+    if shutil.which('docker') is None:
+        return CheckResult('docker_cli', False, 'docker_cli_missing')
+    completed = runner(('docker', 'version', '--format', '{{.Server.Version}}'), timeout)
+    return command_result('docker_cli', completed, failure='docker_unavailable')
+
+
+def check_docker_compose(runner: CommandRunner, timeout: int) -> CheckResult:
+    if shutil.which('docker') is None:
+        return CheckResult('docker_compose', False, 'docker_cli_missing')
+    completed = runner(('docker', 'compose', 'version'), timeout)
+    return command_result('docker_compose', completed, failure='docker_compose_unavailable')
+
+
+def check_postgres_container(runner: CommandRunner, timeout: int) -> CheckResult:
+    if shutil.which('docker') is None:
+        return CheckResult('postgres_container', False, 'docker_cli_missing')
+    completed = runner(('docker', 'ps', '--filter', 'name=ed-postgres', '--format', '{{.Names}}'), timeout)
+    if completed.returncode != 0:
+        return command_result('postgres_container', completed, failure='docker_unavailable')
+    names = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
+    return CheckResult(
+        'postgres_container',
+        'ed-postgres' in names,
+        None if 'ed-postgres' in names else 'postgres_container_not_running',
+        {'container_name_present': 'ed-postgres' in names},
+    )
+
+
+def check_pg_isready(runner: CommandRunner, database: Mapping[str, Any], timeout: int) -> CheckResult:
+    if shutil.which('pg_isready') is None:
+        return CheckResult('pg_isready', False, 'pg_isready_missing')
+    completed = runner(('pg_isready', '-h', str(database['host']), '-p', str(database['port'])), timeout)
+    return command_result('pg_isready', completed, failure='postgres_unavailable')
+
+
+def command_result(name: str, completed: subprocess.CompletedProcess[str], *, failure: str) -> CheckResult:
+    return CheckResult(
+        name,
+        completed.returncode == 0,
+        None if completed.returncode == 0 else failure,
+        {
+            'returncode': completed.returncode,
+            'stdout': completed.stdout.strip()[:300],
+            'stderr': completed.stderr.strip()[:300],
+        },
+    )
+
+
+def check_db_credentials(env: Mapping[str, str]) -> CheckResult:
+    present = bool(env.get('POSTGRES_PASSWORD') or env.get('PGPASSWORD') or env.get('DATABASE_URL'))
+    return CheckResult(
+        'db_credentials',
+        present,
+        None if present else 'credentials_missing',
+        {'present_without_printing': present},
+    )
+
+
+def resolve_db_config(env: Mapping[str, str]) -> dict[str, Any]:
+    parsed = parse_database_url(env.get('DATABASE_URL'))
+    return {
+        'host': first_text(env.get('PGHOST'), parsed.get('host'), DEFAULT_DB_HOST),
+        'port': first_text(env.get('PGPORT'), parsed.get('port'), DEFAULT_DB_PORT),
+        'database': first_text(env.get('PGDATABASE'), parsed.get('database'), DEFAULT_DB_NAME),
+        'user': first_text(env.get('PGUSER'), parsed.get('user'), DEFAULT_DB_USER),
+        'database_url_present': bool(env.get('DATABASE_URL')),
+        'password_present': bool(
+            env.get('PGPASSWORD')
+            or env.get('POSTGRES_PASSWORD')
+            or parsed.get('password_present')
+        ),
+        'password_value_printed': False,
+        'default_isolated_port': DEFAULT_DB_PORT,
+        'host_postgres_5432_targeted': first_text(env.get('PGPORT'), parsed.get('port'), DEFAULT_DB_PORT) == '5432',
+    }
+
+
+def run_read_only_select_one(env: Mapping[str, str], database: Mapping[str, Any]) -> CheckResult:
+    try:
+        import psycopg2  # noqa: PLC0415
+        import psycopg2.extras  # noqa: PLC0415
+    except Exception as exc:
+        return CheckResult('db_read_only_select_1', False, classify_exception(exc), {'attempted': False})
+
+    conn = None
+    try:
+        conn = psycopg2.connect(build_db_dsn(env, database), cursor_factory=psycopg2.extras.RealDictCursor)
+        conn.set_session(readonly=True, autocommit=False)
+        with conn.cursor() as cur:
+            cur.execute('SHOW transaction_read_only')
+            read_only = cur.fetchone()['transaction_read_only'] == 'on'
+            cur.execute('SELECT 1 AS db_preflight_ok')
+            selected = cur.fetchone()['db_preflight_ok'] == 1
+        conn.rollback()
+        return CheckResult(
+            'db_read_only_select_1',
+            read_only and selected,
+            None if read_only and selected else 'read_only_select_failed',
+            {'attempted': True, 'transaction_read_only': read_only},
+        )
+    except Exception as exc:
+        if conn is not None:
+            conn.rollback()
+        return CheckResult('db_read_only_select_1', False, classify_exception(exc), {'attempted': True})
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def build_db_dsn(env: Mapping[str, str], database: Mapping[str, Any]) -> str:
+    if env.get('DATABASE_URL'):
+        return str(env['DATABASE_URL'])
+    password = env.get('PGPASSWORD') or env.get('POSTGRES_PASSWORD')
+    if not password:
+        raise RuntimeError('credentials_missing')
+    return ' '.join((
+        f'host={database["host"]}',
+        f'port={database["port"]}',
+        f'dbname={database["database"]}',
+        f'user={database["user"]}',
+        f'password={password}',
+        'sslmode=disable',
+    ))
+
+
+def parse_database_url(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    parsed = urlsplit(value)
+    return {
+        'host': parsed.hostname,
+        'port': str(parsed.port) if parsed.port is not None else None,
+        'database': parsed.path.lstrip('/') or None,
+        'user': parsed.username,
+        'password_present': parsed.password is not None,
+    }
+
+
+def first_text(*values: Any) -> str:
+    for value in values:
+        if value is not None and str(value):
+            return str(value)
+    return 'unknown'
+
+
+def classify_exception(exc: Exception) -> str:
+    text = str(exc).lower()
+    if 'password authentication failed' in text:
+        return 'password_authentication_failed'
+    if 'connection refused' in text:
+        return 'connection_refused'
+    if 'could not translate host name' in text or 'name or service not known' in text:
+        return 'host_resolution_failed'
+    if 'timeout' in text:
+        return 'connection_timeout'
+    if 'credentials_missing' in text:
+        return 'credentials_missing'
+    return type(exc).__name__
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_stage19_real_postgres_readiness.py
+++ b/tests/test_stage19_real_postgres_readiness.py
@@ -1,0 +1,191 @@
+import os
+from collections.abc import Iterator, Mapping
+from urllib.parse import urlsplit
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.db,
+    pytest.mark.operator,
+    pytest.mark.requires_postgres,
+]
+
+APPROVED_SOURCE_RUN_KEY = 'stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034'
+APPROVED_BRIDGE_KEY = f'source_runs:{APPROVED_SOURCE_RUN_KEY}'
+APPROVED_ARTIFACT_SHA256 = 'b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e'
+PROVENANCE_MARKER_KEY = 'stage19ar_bounded_25_row_pilot'
+
+
+def db_config(env: Mapping[str, str]) -> dict[str, object]:
+    parsed = parse_database_url(env.get('DATABASE_URL'))
+    return {
+        'database_url': env.get('DATABASE_URL'),
+        'host': first_text(env.get('PGHOST'), parsed.get('host'), '127.0.0.1'),
+        'port': first_text(env.get('PGPORT'), parsed.get('port'), '55432'),
+        'database': first_text(env.get('PGDATABASE'), parsed.get('database'), 'edfinder'),
+        'user': first_text(env.get('PGUSER'), parsed.get('user'), 'edfinder'),
+        'password_present': bool(
+            env.get('PGPASSWORD')
+            or env.get('POSTGRES_PASSWORD')
+            or parsed.get('password_present')
+        ),
+    }
+
+
+@pytest.fixture(scope='module')
+def real_stage19_conn() -> Iterator[object]:
+    config = db_config(os.environ)
+    if not config['password_present']:
+        pytest.skip('real Stage 19 DB readiness skipped explicitly: credentials_missing')
+
+    try:
+        import psycopg2  # noqa: PLC0415
+        import psycopg2.extras  # noqa: PLC0415
+    except Exception:
+        pytest.skip('real Stage 19 DB readiness skipped explicitly: psycopg2_missing')
+
+    conn = None
+    try:
+        conn = psycopg2.connect(build_dsn(config), cursor_factory=psycopg2.extras.RealDictCursor)
+        conn.set_session(readonly=True, autocommit=False)
+    except Exception as exc:
+        if conn is not None:
+            conn.close()
+        pytest.skip(f'real Stage 19 DB readiness skipped explicitly: {connection_skip_reason(exc)}')
+
+    try:
+        yield conn
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+def test_real_stage19_db_readiness_uses_no_fake_fallbacks():
+    source = __import__('pathlib').Path(__file__).read_text(encoding='utf-8')
+
+    assert 'Fake' + 'Conn' not in source
+    assert 'Fake' + 'Cursor' not in source
+    assert '-' + '-commit' not in source
+    assert 'psycopg2.connect' in source
+
+
+def test_real_stage19_db_readiness_select_1_is_read_only(real_stage19_conn):
+    with real_stage19_conn.cursor() as cur:
+        cur.execute('SHOW transaction_read_only')
+        assert cur.fetchone()['transaction_read_only'] == 'on'
+        cur.execute('SELECT 1 AS db_readiness_ok')
+        assert cur.fetchone()['db_readiness_ok'] == 1
+    real_stage19_conn.rollback()
+
+
+def test_approved_stage19ar_baseline_is_present_in_real_local_postgres(real_stage19_conn):
+    with real_stage19_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, source_run_key, status, artifact_sha256, rows_read, rows_staged, rows_rejected, rows_skipped
+            FROM source_runs
+            WHERE source_run_key = %s
+            """,
+            (APPROVED_SOURCE_RUN_KEY,),
+        )
+        source_run = cur.fetchone()
+        assert source_run is not None
+        assert source_run['artifact_sha256'] == APPROVED_ARTIFACT_SHA256
+        assert source_run['rows_read'] == 25
+        assert source_run['rows_staged'] == 25
+        assert source_run['rows_rejected'] == 0
+        assert source_run['rows_skipped'] == 0
+
+        cur.execute(
+            """
+            SELECT id, source_run_key
+            FROM enrichment_source_runs
+            WHERE source_run_key = %s
+            """,
+            (APPROVED_BRIDGE_KEY,),
+        )
+        bridge = cur.fetchone()
+        assert bridge is not None
+
+        cur.execute(
+            """
+            SELECT
+              COUNT(*)::int AS rows_total,
+              COUNT(*) FILTER (WHERE source_class = %s AND confidence = %s)::int AS rows_diagnostic_only,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_legacy_bridge_id,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_source_runs_id,
+              COUNT(*) FILTER (WHERE provenance ? %s)::int AS rows_with_marker,
+              COUNT(*) FILTER (WHERE provenance->>%s = 'false')::int AS rows_with_canonical_write_blocked
+            FROM staging_edsm_stations
+            WHERE source_run_id = %s
+            """,
+            (
+                'diagnostic-only',
+                'diagnostic-only',
+                bridge['id'],
+                source_run['id'],
+                PROVENANCE_MARKER_KEY,
+                'canonical_write_allowed',
+                bridge['id'],
+            ),
+        )
+        counts = cur.fetchone()
+
+    real_stage19_conn.rollback()
+    assert counts == {
+        'rows_total': 25,
+        'rows_diagnostic_only': 25,
+        'rows_using_legacy_bridge_id': 25,
+        'rows_using_source_runs_id': 0,
+        'rows_with_marker': 25,
+        'rows_with_canonical_write_blocked': 25,
+    }
+
+
+def build_dsn(config: Mapping[str, object]) -> str:
+    if config.get('database_url'):
+        return str(config['database_url'])
+    password = os.environ.get('PGPASSWORD') or os.environ.get('POSTGRES_PASSWORD')
+    return ' '.join((
+        f'host={config["host"]}',
+        f'port={config["port"]}',
+        f'dbname={config["database"]}',
+        f'user={config["user"]}',
+        f'password={password}',
+        'sslmode=disable',
+    ))
+
+
+def parse_database_url(value: str | None) -> dict[str, object]:
+    if not value:
+        return {}
+    parsed = urlsplit(value)
+    return {
+        'host': parsed.hostname,
+        'port': str(parsed.port) if parsed.port is not None else None,
+        'database': parsed.path.lstrip('/') or None,
+        'user': parsed.username,
+        'password_present': parsed.password is not None,
+    }
+
+
+def first_text(*values: object) -> str:
+    for value in values:
+        if value is not None and str(value):
+            return str(value)
+    return 'unknown'
+
+
+def connection_skip_reason(exc: Exception) -> str:
+    text = str(exc).lower()
+    if 'password authentication failed' in text:
+        return 'password_authentication_failed'
+    if 'connection refused' in text:
+        return 'postgres_unavailable'
+    if 'timeout' in text:
+        return 'postgres_unavailable'
+    if 'could not translate host name' in text or 'name or service not known' in text:
+        return 'postgres_unavailable'
+    return 'postgres_unavailable'

--- a/tests/test_stage19ap_operator_visibility.py
+++ b/tests/test_stage19ap_operator_visibility.py
@@ -19,6 +19,9 @@ os.environ.setdefault('CORS_ORIGINS', 'http://localhost')
 
 import operator_visibility as visibility  # noqa: E402
 
+
+pytestmark = pytest.mark.operator
+
 _ROUTER_SPEC = importlib.util.spec_from_file_location(
     'stage19ap_operator_router',
     API_ROUTERS / 'operator.py',
@@ -572,3 +575,14 @@ def test_static_guardrails_for_operator_visibility_module_and_router():
     assert re.search(r'(?<![a-z0-9_])\.service(?![a-z0-9_])', source, flags=re.IGNORECASE) is None
     assert 'raw_payload' not in source
     assert 'canonical_apply(' not in source
+
+
+def test_fake_operator_visibility_boundary_is_paired_with_real_stage19_readiness_test():
+    readiness_test = ROOT / 'tests' / 'test_stage19_real_postgres_readiness.py'
+    source = readiness_test.read_text(encoding='utf-8')
+
+    assert readiness_test.is_file()
+    assert 'Fake' + 'Conn' not in source
+    assert 'Fake' + 'Cursor' not in source
+    assert 'psycopg2.connect' in source
+    assert 'real Stage 19 DB readiness skipped explicitly' in source

--- a/tests/test_stage19ar_operator_script.py
+++ b/tests/test_stage19ar_operator_script.py
@@ -27,6 +27,8 @@ APPROVED_REPLACEMENT_ARTIFACT_SHA256 = 'b617d0239b7458b5b881895b564d091c771394b5
 RETIRED_SOURCE_RUN_KEY = 'stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd'
 RETIRED_ARTIFACT_SHA256 = '418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417'
 
+pytestmark = pytest.mark.operator
+
 
 def noncanonical_stage19ar_profile():
     return replace(

--- a/tests/test_test_env_preflight.py
+++ b/tests/test_test_env_preflight.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PREFLIGHT_PATH = ROOT / 'scripts' / 'dev' / 'test_env_preflight.py'
+
+spec = importlib.util.spec_from_file_location('test_env_preflight', PREFLIGHT_PATH)
+preflight = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = preflight
+spec.loader.exec_module(preflight)
+
+
+pytestmark = pytest.mark.unit
+
+
+def successful_runner(args, timeout):
+    del timeout
+    stdout = ''
+    if tuple(args[:2]) == ('docker', 'ps'):
+        stdout = 'ed-postgres\n'
+    if tuple(args[:1]) == ('pg_isready',):
+        stdout = '127.0.0.1:55432 - accepting connections\n'
+    return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr='')
+
+
+def test_preflight_fails_closed_without_credentials_and_never_prints_secret():
+    result = preflight.run_preflight(env={}, runner=successful_runner)
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['ok'] is False
+    assert result['failure_category'] == 'credentials_missing'
+    assert result['writes_performed'] is False
+    assert result['secrets_printed'] is False
+    assert result['checks']['db_read_only_select_1']['detail']['attempted'] is False
+    assert 'POSTGRES_PASSWORD=' not in encoded
+    assert 'PGPASSWORD=' not in encoded
+    assert 'postgresql://' not in encoded
+
+
+def test_preflight_runs_read_only_select_when_credentials_are_present_without_printing_secret():
+    def db_probe(env, database):
+        assert env['POSTGRES_PASSWORD'] == 'do-not-print-this'
+        assert database['password_value_printed'] is False
+        return preflight.CheckResult(
+            'db_read_only_select_1',
+            True,
+            None,
+            {'attempted': True, 'transaction_read_only': True},
+        )
+
+    result = preflight.run_preflight(
+        env={'POSTGRES_PASSWORD': 'do-not-print-this'},
+        runner=successful_runner,
+        db_probe=db_probe,
+    )
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['ok'] is True
+    assert result['db_read_only_select_1_passed'] is True
+    assert result['writes_performed'] is False
+    assert result['checks']['db_credentials']['detail']['present_without_printing'] is True
+    assert 'do-not-print-this' not in encoded
+
+
+def test_preflight_uses_isolated_project_postgres_port_by_default():
+    config = preflight.resolve_db_config({})
+
+    assert config['host'] == '127.0.0.1'
+    assert config['port'] == '55432'
+    assert config['host_postgres_5432_targeted'] is False
+
+
+def test_command_failures_are_classified_without_secret_material():
+    def failing_pg_isready(args, timeout):
+        del timeout
+        if args[0] == 'pg_isready':
+            return subprocess.CompletedProcess(args, 2, stdout='', stderr='no response')
+        return successful_runner(args, timeout=5)
+
+    result = preflight.run_preflight(
+        env={'PGPASSWORD': 'hidden-password'},
+        runner=failing_pg_isready,
+        db_probe=lambda _env, _database: preflight.CheckResult('db_read_only_select_1', True),
+    )
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['checks']['pg_isready']['failure_category'] == 'postgres_unavailable'
+    assert 'hidden-password' not in encoded


### PR DESCRIPTION
This PR starts the full test-environment roadmap while Stage 19AS-AU remains paused.

It includes:
- canonical test environment preflight
- pytest markers and Make targets
- no-secret and no-write hardening
- test double inventory
- fake-tolerant unit vs real-service integration boundary
- real Stage 19 local Postgres readiness test path
- Stage 19 pause/resume gate docs

Validation:
- real Stage 19 DB readiness tests: passed, not skipped
- preflight tests: passed
- Stage 19 operator/visibility tests: passed
- py_compile: passed
- git diff --check: passed
- writes_performed:false
- no secrets printed
- Stage 19AS-AU expansion attempted:false