### PR TITLE
chore(test-env): add state authority branch gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Real builds happen via docker compose / yarn / pytest directly; this
 # Makefile just collects the most-used recipes so you don't have to
 # remember the env-var incantations.
-.PHONY: help lint typecheck test seed-check api-smoke test-env-check test-unit test-operator test-db test-integration test-ci-local clean
+.PHONY: help lint typecheck test seed-check api-smoke state-check state-check-docs test-env-check test-unit test-operator test-db test-integration test-ci-local clean
 
 PYTHON ?= python
 
@@ -27,6 +27,12 @@ test:  ## Run backend unit + integration tests
 
 test-env-check:  ## Run the local test-environment preflight without writes
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/test_env_preflight.py
+
+state-check:  ## Resolve Stage 19/test-env state authority before operational work
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/resolve_project_state.py --strict
+
+state-check-docs:  ## Resolve Stage 19/test-env state authority for docs-only work
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/resolve_project_state.py --strict --allow-docs-only
 
 test-unit:  ## Run tests that do not require external services
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m "unit or not (integration or db or operator or e2e or slow)"

--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "stage19_state_authority/v1",
+  "current_authority": {
+    "origin_main": "49b0940cb014a319443525c3554d59387c2b6d90",
+    "stage19_status": "paused",
+    "stage19as_au_status": "not_run",
+    "test_env_pr": 198,
+    "test_env_branch": "fix/test-env-roadmap-recreate",
+    "test_env_head": "581a84c1159b58dff86e3359a28d00f9b4f5a82b"
+  },
+  "approved_stage19ar_baseline": {
+    "source_run_key": "stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034",
+    "bridge_key": "source_runs:stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034",
+    "artifact": "b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e",
+    "rows": 25
+  },
+  "retired_stage19ar_baseline": {
+    "source_run_key": "stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd",
+    "artifact": "418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417",
+    "status": "retired_unrecoverable"
+  },
+  "superseded_states": [
+    {
+      "id": "superseded_partial_rebaseline_45e2d58",
+      "commits": [
+        "45e2d58"
+      ],
+      "branch": "fix/stage19-approved-rebaseline",
+      "status": "superseded",
+      "reason": "password_missing; replacement_baseline_verified:false; ready_for_stage19as_au:false; missing origin/main provenance"
+    },
+    {
+      "id": "superseded_stage19as_au_docs_only_checkpoint_f72812a",
+      "commits": [
+        "f72812a"
+      ],
+      "branch": "run/stage19as-au-100-row-expansion",
+      "status": "superseded_docs_only_stopped_checkpoint",
+      "reason": "password_missing; no writes; no successful 100-row expansion; docs-only stopped checkpoint"
+    },
+    {
+      "id": "unrecoverable_historical_test_env_stack_0042471_d66a568_09eee44",
+      "commits": [
+        "0042471",
+        "d66a568",
+        "09eee44"
+      ],
+      "status": "unrecoverable_historical_context",
+      "reason": "reported in earlier local context but not recoverable from current refs/remotes/reflogs/checkouts",
+      "replacement": {
+        "branch": "fix/test-env-roadmap-recreate",
+        "commit": "581a84c1159b58dff86e3359a28d00f9b4f5a82b"
+      }
+    },
+    {
+      "id": "non_authoritative_state_authority_attempt_850917_on_work",
+      "commit": "8509171250b1449832a7fe3227d87acc02fb015e",
+      "commits": [
+        "8509171250b1449832a7fe3227d87acc02fb015e"
+      ],
+      "branch": "work",
+      "status": "non_authoritative_wrong_branch_attempt",
+      "reason": "State-authority hardening was reportedly implemented on branch work, but the commit is unavailable in the current repo and was never authority. Do not require it, do not recover it, and do not treat it as a patch source.",
+      "evidence_only": true
+    },
+    {
+      "id": "uploaded_or_pasted_prompt_bundles",
+      "status": "evidence_only",
+      "reason": "Uploaded or pasted prompt bundles may be duplicated, truncated, stale, or mixed with old prompts and results. They must never override this state authority file, latest merged docs checkpoint, or live git state.",
+      "evidence_only": true
+    }
+  ],
+  "non_authoritative_branches": [
+    {
+      "branch": "work",
+      "reason": "work is not authoritative for Stage 19/test-env operational work unless a task is explicitly scratch or docs-only"
+    }
+  ],
+  "prompt_rules": {
+    "completed_reserved_for_all_required_checks_true": true,
+    "partial_requires_stopped_or_partial_label": true,
+    "source_of_truth_unavailable_is_hard_stop": true,
+    "expected_branch_unavailable_is_hard_stop": true,
+    "branch_mismatch_is_hard_stop": true,
+    "db_credentials_missing_is_hard_stop_for_db_work": true,
+    "do_not_commit_final_success_when_required_verification_false": true,
+    "docs_checkpoint_required_after_material_state_change": true,
+    "pasted_chat_logs_are_evidence_not_authority": true
+  }
+}

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -211,3 +211,24 @@ Stale states that remain non-authoritative:
 ## Fresh-Chat Handoff
 
 Use the `STAGE 19 CURRENT CHECKPOINT` block above when resuming Stage 19 in a new chat.
+
+## State Authority and Superseded Context
+
+The current source of truth is `docs/colonisation-redesign/stage-19-state-authority.json`, this latest merged docs checkpoint, and live git state. Pasted or uploaded prompt bundles are evidence only. They must not override the state authority file, current branch/head, or latest merged checkpoint.
+
+Prompts must run state resolution before operational work:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If source-of-truth branch/commit, expected branch/head, or branch provenance is unavailable, stop. Branch mismatch is a hard stop. `completed` is forbidden when branch provenance is false.
+
+Superseded or non-authoritative states:
+
+- `45e2d58` on `fix/stage19-approved-rebaseline`: superseded partial rebaseline with `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance.
+- `f72812a` on `run/stage19as-au-100-row-expansion`: docs-only stopped checkpoint with `password_missing`, no writes, and no successful 100-row expansion.
+- `0042471`, `d66a568`, and `09eee44`: unrecoverable historical test-env stack replaced by `fix/test-env-roadmap-recreate` at `581a84c1159b58dff86e3359a28d00f9b4f5a82b`.
+- `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative wrong-branch state-authority attempt, unavailable in the current repo, and not a patch source.
+
+Branch `work` is non-authoritative for Stage 19/test-env operations unless explicitly declared scratch or docs-only. Stage 19 remains paused while test-environment hardening proceeds.

--- a/docs/development/agent-prompt-contract.md
+++ b/docs/development/agent-prompt-contract.md
@@ -1,0 +1,55 @@
+# Agent Prompt Contract
+
+## Scope
+
+This contract applies to operational prompts that can change repository state, run data-workflow commands, touch local services, or report Stage 19/test-environment status.
+
+## State Resolution Gate
+
+Every operational prompt must run state resolution first from the repository root:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this command fails, stop before operational work. Do not edit, commit, push, run DB writes, or report `completed`.
+
+The machine-readable authority is `docs/colonisation-redesign/stage-19-state-authority.json`, plus the latest merged docs checkpoint and live git state. Pasted or uploaded chat logs are evidence only. They can help explain a request, but they never override the state authority file, latest merged docs, or live git state.
+
+## Hard Stops
+
+Stop immediately when any required source of truth is unavailable:
+
+- source-of-truth branch or commit unavailable
+- expected branch unavailable
+- expected head unavailable
+- current branch mismatches the prompt's expected branch
+- current branch is `work` for Stage 19/test-env operational work, unless the prompt explicitly declares scratch or docs-only scope
+- current state matches a superseded branch or commit in the authority file
+- DB credentials are missing for DB work
+
+For DB work, missing credentials are a hard stop before writes. `password_missing` is diagnostic, not success.
+
+## Output Semantics
+
+Use `completed` only when every required acceptance check is true.
+
+If branch provenance, source authority, DB verification, or required tests fail, the output must be named one of:
+
+- `stopped`
+- `blocked`
+- `partial_checkpoint`
+
+A commit after failed DB verification is allowed only when the task is explicitly docs-only or a partial-checkpoint task and the output does not claim operational success.
+
+## Branch Authority
+
+The current Stage 19/test-environment authority is:
+
+- branch: `fix/test-env-roadmap-recreate`
+- head: `581a84c1159b58dff86e3359a28d00f9b4f5a82b`
+- PR: `198`
+- origin/main checkpoint: `49b0940cb014a319443525c3554d59387c2b6d90`
+
+Branch `work` is non-authoritative for Stage 19/test-env work unless a prompt explicitly declares scratch or docs-only scope. Wrong-branch outputs must not say `completed`, and wrong-branch operational work must not commit.
+

--- a/docs/development/agent-prompt-templates.md
+++ b/docs/development/agent-prompt-templates.md
@@ -1,0 +1,193 @@
+# Agent Prompt Templates
+
+Each template starts with the same state resolution gate. If the gate fails, stop before operational work.
+
+## Codex Repo Implementation
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- implement the requested repository change on the resolved branch or a clean child branch
+- preserve Stage 19/test-env authority
+- run focused tests and `git diff --check`
+- use `completed` only when every required check passes
+
+## Codex DB Verification
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- verify credentials are present without printing values
+- use read-only probes before any write-capable command
+- stop on `password_missing`, service unavailable, wrong branch, or stale state
+- report skipped real DB tests explicitly
+
+## Codex Docs-Only Checkpoint
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- declare docs-only scope before editing
+- do not run Stage 19AS-AU, rebaseline, promotion, or canonical apply commands
+- label incomplete or failed verification as `partial_checkpoint` or `blocked`
+
+## Codex PR/CI Merge Gate
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- inspect PR branch, base branch, and latest checks
+- reject wrong-branch or stale-source merge decisions
+- do not merge if required CI, state authority, or provenance checks are false
+
+## Windsurf Local IDE Multi-File Edit
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- navigate and edit only the resolved checkout
+- keep changes scoped to the requested files or modules
+- do not trust pasted chat over state authority or git state
+
+## Windsurf Repo Navigation/Refactor
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- map call sites before moving code
+- preserve existing behavior unless the prompt explicitly requests behavior change
+- stop if branch or head provenance becomes ambiguous
+
+## Grok Adversarial Review
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- challenge assumptions against the authority file, latest merged docs, and live git state
+- identify stale prompt context, missing checks, and unsupported success claims
+- do not approve `completed` when required checks are false
+
+## Grok Stale-State Detection Review
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- compare prompt claims with `stage-19-state-authority.json`
+- reject `45e2d58`, `f72812a`, `0042471`, `d66a568`, `09eee44`, and `850917` on `work` as current authority
+- treat uploaded or pasted prompt bundles as evidence only
+
+## Human Operator Approval Decision
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- decide whether the resolved state permits the next command
+- approve credentialed or write-capable operations only after branch, head, and DB gates pass
+- keep Stage 19AS-AU paused until explicitly approved
+
+## Human Operator Credentialed Shell Setup
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- load credentials locally without echoing values
+- target the isolated project DB unless another target is explicitly approved
+- run read-only verification before any write-capable command
+
+## Human Operator Fresh-Chat Handoff
+
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Task:
+
+- paste the authority file summary, latest merged docs checkpoint, and live branch/head
+- mark prompt bundles as evidence only
+- state whether Stage 19 is paused and whether Stage 19AS-AU has run
+

--- a/docs/development/test-double-inventory.md
+++ b/docs/development/test-double-inventory.md
@@ -52,3 +52,24 @@ Stage 19 remains paused until the next agreed test-env gate or operator decision
 ```
 
 The fake-only readiness blocker is cleared by the real Stage 19 DB readiness test passing against local Postgres. Stage 19 remains paused until the next agreed test-environment gate or operator decision.
+
+## State Authority and Superseded Context
+
+Current truth for Stage 19/test-environment readiness lives in `docs/colonisation-redesign/stage-19-state-authority.json`, latest merged docs, and live git state. Pasted or uploaded logs are evidence only and cannot override the authority file.
+
+Run the state resolver before operational work:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+The resolver rejects superseded or non-authoritative context before any fake-backed test result can be treated as readiness proof.
+
+Superseded or non-authoritative context:
+
+- `45e2d58`: superseded partial rebaseline with missing password, failed replacement baseline verification, and missing `origin/main` provenance.
+- `f72812a`: docs-only stopped Stage 19AS-AU checkpoint with missing password, no writes, and no successful 100-row expansion.
+- `0042471`, `d66a568`, and `09eee44`: unrecoverable historical test-env context replaced by `fix/test-env-roadmap-recreate`.
+- `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative and unavailable in the current repo.
+
+Stage 19 remains paused while test-environment hardening proceeds.

--- a/docs/development/test-environment.md
+++ b/docs/development/test-environment.md
@@ -86,3 +86,24 @@ Stage 19 remains paused until the next agreed test-env gate or operator decision
 ```
 
 Stage 19AS-AU must not run from this test-environment branch. Do not use `--commit`, do not rebaseline, and do not promote staged rows from this work.
+
+## State Authority and Superseded Context
+
+Current Stage 19/test-environment truth lives in `docs/colonisation-redesign/stage-19-state-authority.json`, the latest merged docs checkpoint, and live git state. Pasted or uploaded logs are evidence only; they may be stale, duplicated, truncated, or mixed with old prompt results.
+
+Prompts must run the resolver before operational work:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+The resolver is fail-closed for source-of-truth unavailability, expected branch/head unavailability, branch mismatch, and superseded state. `completed` is forbidden when branch provenance is false.
+
+Superseded or non-authoritative context:
+
+- `45e2d58` on `fix/stage19-approved-rebaseline`: superseded partial rebaseline with `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance.
+- `f72812a` on `run/stage19as-au-100-row-expansion`: docs-only stopped checkpoint with `password_missing`, no writes, and no successful 100-row expansion.
+- `0042471`, `d66a568`, and `09eee44`: unrecoverable historical test-env stack, replaced by `fix/test-env-roadmap-recreate` at `581a84c1159b58dff86e3359a28d00f9b4f5a82b`.
+- `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative wrong-branch state-authority attempt, unavailable in the current repo, and not a patch source.
+
+Branch `work` is non-authoritative for Stage 19/test-env operations unless explicitly declared scratch or docs-only. Stage 19 remains paused while test-environment hardening proceeds.

--- a/scripts/dev/resolve_project_state.py
+++ b/scripts/dev/resolve_project_state.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Resolve Stage 19/test-environment authority before operational work."""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_AUTHORITY_FILE = ROOT / 'docs/colonisation-redesign/stage-19-state-authority.json'
+
+FAILURE_CATEGORIES = {
+    'none',
+    'not_git_repo',
+    'origin_main_unavailable',
+    'authority_file_missing',
+    'authority_file_invalid',
+    'authority_commit_missing',
+    'wrong_branch',
+    'current_branch_superseded',
+    'current_head_superseded',
+    'ambiguous_local_state',
+    'stale_stage19_context',
+    'unknown',
+}
+
+GitRunner = Callable[[Sequence[str]], subprocess.CompletedProcess[str]]
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    authority_path: Path = DEFAULT_AUTHORITY_FILE,
+    git_runner: GitRunner | None = None,
+) -> int:
+    args = parse_args(argv)
+    result = resolve_project_state(
+        authority_path=authority_path,
+        git_runner=git_runner,
+        allow_docs_only=args.allow_docs_only,
+    )
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print_human(result)
+
+    strict_ok = result['safe_for_operational_work']
+    if args.allow_docs_only:
+        strict_ok = result['safe_for_docs_only_work']
+    return 0 if not args.strict or strict_ok else 2
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Resolve Stage 19/test-environment authority before operational work.',
+    )
+    parser.add_argument('--json', action='store_true', help='Print machine-readable JSON.')
+    parser.add_argument('--strict', action='store_true', help='Exit nonzero when state is not safe.')
+    parser.add_argument(
+        '--allow-docs-only',
+        action='store_true',
+        help='Permit docs-only/scratch work while keeping operational work unsafe.',
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_project_state(
+    *,
+    authority_path: Path = DEFAULT_AUTHORITY_FILE,
+    git_runner: GitRunner | None = None,
+    allow_docs_only: bool = False,
+) -> dict[str, Any]:
+    runner = git_runner or default_git_runner
+    authority, authority_error = load_authority(authority_path)
+    if authority_error is not None:
+        return build_failure(
+            authority_path=authority_path,
+            failure_category=authority_error,
+            next_action='Restore a valid Stage 19 state authority file before continuing.',
+            allow_docs_only=allow_docs_only,
+        )
+
+    assert authority is not None
+    current_authority = authority.get('current_authority', {})
+    stage19_status = str(current_authority.get('stage19_status', 'unknown'))
+    stage19as_au_status = str(current_authority.get('stage19as_au_status', 'unknown'))
+
+    inside = run_git(runner, ('rev-parse', '--is-inside-work-tree'))
+    if inside.returncode != 0 or inside.stdout.strip() != 'true':
+        return build_failure(
+            authority_path=authority_path,
+            authority=authority,
+            stage19_status=stage19_status,
+            stage19as_au_status=stage19as_au_status,
+            failure_category='not_git_repo',
+            next_action='Run state resolution from a valid ed-finder git checkout.',
+            allow_docs_only=allow_docs_only,
+        )
+
+    current_branch = git_output(runner, ('branch', '--show-current'))
+    current_head = git_output(runner, ('rev-parse', 'HEAD'))
+    if not current_branch or not current_head:
+        return build_failure(
+            authority_path=authority_path,
+            authority=authority,
+            stage19_status=stage19_status,
+            stage19as_au_status=stage19as_au_status,
+            current_branch=current_branch,
+            current_head=current_head,
+            failure_category='ambiguous_local_state',
+            next_action='Check out a named branch with a resolvable HEAD before continuing.',
+            allow_docs_only=allow_docs_only,
+        )
+
+    expected_origin_main = str(current_authority.get('origin_main', ''))
+    origin_main = git_output(runner, ('rev-parse', 'origin/main'))
+    origin_main_contains_authority = False
+    if origin_main:
+        origin_main_contains_authority = (
+            run_git(runner, ('merge-base', '--is-ancestor', expected_origin_main, 'origin/main')).returncode == 0
+        )
+
+    expected_head = str(current_authority.get('test_env_head', ''))
+    authority_commit_available = False
+    head_contains_authority = False
+    if expected_head:
+        authority_commit_available = run_git(runner, ('rev-parse', '--verify', expected_head)).returncode == 0
+        head_contains_authority = (
+            run_git(runner, ('merge-base', '--is-ancestor', expected_head, 'HEAD')).returncode == 0
+        )
+
+    matched_state, matched_by = find_matching_superseded_state(authority, current_branch, current_head)
+    failure_category = 'none'
+    next_action = 'State authority checks passed for operational work.'
+
+    if not origin_main:
+        failure_category = 'origin_main_unavailable'
+        next_action = 'Fetch origin/main and rerun state resolution before operational work.'
+    elif not origin_main_contains_authority:
+        failure_category = 'stale_stage19_context'
+        next_action = 'Update origin/main to include the authoritative checkpoint before continuing.'
+    elif not authority_commit_available:
+        failure_category = 'authority_commit_missing'
+        next_action = 'Fetch the authoritative test-environment commit before continuing.'
+    elif matched_state and current_branch == 'work':
+        failure_category = 'wrong_branch'
+        next_action = 'Switch off work; use fix/test-env-roadmap-recreate or a clean child branch.'
+    elif current_branch == 'work':
+        failure_category = 'wrong_branch'
+        next_action = 'Branch work is non-authoritative for Stage 19/test-env operational work.'
+    elif matched_state and matched_by == 'branch':
+        failure_category = 'current_branch_superseded'
+        next_action = 'Switch to fix/test-env-roadmap-recreate or a clean child branch.'
+    elif matched_state and matched_by == 'head':
+        failure_category = 'current_head_superseded'
+        next_action = 'Do not use this superseded commit as authority; switch to the current test-env branch.'
+    elif not head_contains_authority:
+        failure_category = 'stale_stage19_context'
+        next_action = 'Current HEAD is not based on the authoritative test-environment commit.'
+
+    safe_for_operational_work = failure_category == 'none'
+    safe_for_docs_only_work = safe_for_operational_work or (
+        allow_docs_only
+        and failure_category == 'wrong_branch'
+        and source_of_truth_available(origin_main, origin_main_contains_authority, authority_commit_available)
+    )
+
+    return {
+        'state_authority_file': relative_path(authority_path),
+        'current_branch': current_branch,
+        'current_head': current_head,
+        'origin_main': origin_main,
+        'origin_main_contains_authority': origin_main_contains_authority,
+        'stage19_status': stage19_status,
+        'stage19as_au_status': stage19as_au_status,
+        'current_state_is_superseded': matched_state is not None,
+        'matched_superseded_state': public_state(matched_state),
+        'safe_for_operational_work': safe_for_operational_work,
+        'safe_for_docs_only_work': safe_for_docs_only_work,
+        'failure_category': failure_category,
+        'next_action': next_action,
+        'authority_test_env_branch': current_authority.get('test_env_branch'),
+        'authority_test_env_head': expected_head,
+        'head_contains_authority': head_contains_authority,
+        'authority_commit_available': authority_commit_available,
+        'superseded_states': [public_state(state) for state in authority.get('superseded_states', [])],
+        'prompt_rules': authority.get('prompt_rules', {}),
+    }
+
+
+def load_authority(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    if not path.exists():
+        return None, 'authority_file_missing'
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return None, 'authority_file_invalid'
+    if not isinstance(data, dict):
+        return None, 'authority_file_invalid'
+    required = ('current_authority', 'superseded_states', 'prompt_rules')
+    if any(key not in data for key in required):
+        return None, 'authority_file_invalid'
+    return data, None
+
+
+def build_failure(
+    *,
+    authority_path: Path,
+    failure_category: str,
+    next_action: str,
+    allow_docs_only: bool,
+    authority: Mapping[str, Any] | None = None,
+    stage19_status: str = 'unknown',
+    stage19as_au_status: str = 'unknown',
+    current_branch: str | None = None,
+    current_head: str | None = None,
+) -> dict[str, Any]:
+    assert failure_category in FAILURE_CATEGORIES
+    return {
+        'state_authority_file': relative_path(authority_path),
+        'current_branch': current_branch,
+        'current_head': current_head,
+        'origin_main': None,
+        'origin_main_contains_authority': False,
+        'stage19_status': stage19_status,
+        'stage19as_au_status': stage19as_au_status,
+        'current_state_is_superseded': False,
+        'matched_superseded_state': None,
+        'safe_for_operational_work': False,
+        'safe_for_docs_only_work': False,
+        'failure_category': failure_category,
+        'next_action': next_action,
+        'authority_test_env_branch': (authority or {}).get('current_authority', {}).get('test_env_branch'),
+        'authority_test_env_head': (authority or {}).get('current_authority', {}).get('test_env_head'),
+        'head_contains_authority': False,
+        'authority_commit_available': False,
+        'superseded_states': [public_state(state) for state in (authority or {}).get('superseded_states', [])],
+        'prompt_rules': (authority or {}).get('prompt_rules', {}),
+        'allow_docs_only': allow_docs_only,
+    }
+
+
+def default_git_runner(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ('git', *args),
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def run_git(runner: GitRunner, args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner(tuple(args))
+    except Exception as exc:
+        return subprocess.CompletedProcess(tuple(args), 1, stdout='', stderr=type(exc).__name__)
+
+
+def git_output(runner: GitRunner, args: Sequence[str]) -> str | None:
+    completed = run_git(runner, args)
+    if completed.returncode != 0:
+        return None
+    text = completed.stdout.strip()
+    return text or None
+
+
+def find_matching_superseded_state(
+    authority: Mapping[str, Any],
+    current_branch: str,
+    current_head: str,
+) -> tuple[Mapping[str, Any] | None, str | None]:
+    for state in authority.get('superseded_states', []):
+        if state.get('branch') and state.get('branch') == current_branch:
+            return state, 'branch'
+    for state in authority.get('superseded_states', []):
+        if any(commit_matches(current_head, commit) for commit in state_commits(state)):
+            return state, 'head'
+    return None, None
+
+
+def state_commits(state: Mapping[str, Any]) -> list[str]:
+    commits: list[str] = []
+    if state.get('commit'):
+        commits.append(str(state['commit']))
+    commits.extend(str(commit) for commit in state.get('commits', []))
+    return commits
+
+
+def commit_matches(current_head: str, known_commit: str) -> bool:
+    current = current_head.lower()
+    known = known_commit.lower()
+    return current.startswith(known) or known.startswith(current)
+
+
+def source_of_truth_available(
+    origin_main: str | None,
+    origin_main_contains_authority: bool,
+    authority_commit_available: bool,
+) -> bool:
+    return bool(origin_main and origin_main_contains_authority and authority_commit_available)
+
+
+def public_state(state: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not state:
+        return None
+    keys = ('id', 'branch', 'commit', 'commits', 'status', 'reason', 'replacement', 'evidence_only')
+    return {key: state[key] for key in keys if key in state}
+
+
+def relative_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def print_human(result: Mapping[str, Any]) -> None:
+    for key in (
+        'state_authority_file',
+        'current_branch',
+        'current_head',
+        'origin_main',
+        'origin_main_contains_authority',
+        'stage19_status',
+        'stage19as_au_status',
+        'current_state_is_superseded',
+        'safe_for_operational_work',
+        'safe_for_docs_only_work',
+        'failure_category',
+        'next_action',
+    ):
+        print(f'{key}: {format_value(result.get(key))}')
+
+
+def format_value(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True)
+    if value is None:
+        return 'null'
+    return str(value)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_project_state_resolver.py
+++ b/tests/test_project_state_resolver.py
@@ -1,0 +1,208 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RESOLVER_PATH = ROOT / 'scripts' / 'dev' / 'resolve_project_state.py'
+AUTHORITY_PATH = ROOT / 'docs' / 'colonisation-redesign' / 'stage-19-state-authority.json'
+
+EXPECTED_HEAD = '581a84c1159b58dff86e3359a28d00f9b4f5a82b'
+EXPECTED_ORIGIN_MAIN = '49b0940cb014a319443525c3554d59387c2b6d90'
+SECRET_SENTINEL = 'do-not-print-this-secret'
+
+spec = importlib.util.spec_from_file_location('resolve_project_state', RESOLVER_PATH)
+resolver = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = resolver
+spec.loader.exec_module(resolver)
+
+
+pytestmark = pytest.mark.unit
+
+
+def completed(args, returncode=0, stdout='', stderr=''):
+    return subprocess.CompletedProcess(tuple(args), returncode, stdout=stdout, stderr=stderr)
+
+
+def git_runner(
+    *,
+    branch='fix/test-env-roadmap-recreate',
+    head=EXPECTED_HEAD,
+    origin_main=EXPECTED_ORIGIN_MAIN,
+    origin_available=True,
+    origin_contains=True,
+    authority_available=True,
+    head_contains=True,
+    inside_git=True,
+):
+    def run(args):
+        args = tuple(args)
+        if args == ('rev-parse', '--is-inside-work-tree'):
+            return completed(args, 0 if inside_git else 128, 'true\n' if inside_git else '')
+        if args == ('branch', '--show-current'):
+            return completed(args, 0, f'{branch}\n')
+        if args == ('rev-parse', 'HEAD'):
+            return completed(args, 0, f'{head}\n')
+        if args == ('rev-parse', 'origin/main'):
+            if not origin_available:
+                return completed(args, 128, '', SECRET_SENTINEL)
+            return completed(args, 0, f'{origin_main}\n')
+        if args == ('rev-parse', '--verify', EXPECTED_HEAD):
+            return completed(args, 0 if authority_available else 128, f'{EXPECTED_HEAD}\n')
+        if args[:2] == ('merge-base', '--is-ancestor'):
+            ancestor = args[2]
+            target = args[3]
+            if ancestor == EXPECTED_ORIGIN_MAIN and target == 'origin/main':
+                return completed(args, 0 if origin_contains else 1)
+            if ancestor == EXPECTED_HEAD and target == 'HEAD':
+                return completed(args, 0 if head_contains else 1)
+        return completed(args, 1, '', SECRET_SENTINEL)
+
+    return run
+
+
+def resolve(**kwargs):
+    return resolver.resolve_project_state(
+        authority_path=AUTHORITY_PATH,
+        git_runner=git_runner(**kwargs),
+        allow_docs_only=kwargs.get('allow_docs_only', False),
+    )
+
+
+def test_authority_file_parses():
+    authority, error = resolver.load_authority(AUTHORITY_PATH)
+
+    assert error is None
+    assert authority['current_authority']['stage19_status'] == 'paused'
+    assert authority['current_authority']['stage19as_au_status'] == 'not_run'
+    assert authority['approved_stage19ar_baseline']['rows'] == 25
+
+
+def test_json_output_works(capsys):
+    exit_code = resolver.main(
+        ['--json'],
+        authority_path=AUTHORITY_PATH,
+        git_runner=git_runner(),
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload['failure_category'] == 'none'
+    assert payload['safe_for_operational_work'] is True
+
+
+def test_resolver_rejects_work_branch_for_operational_work():
+    result = resolve(branch='work')
+
+    assert result['failure_category'] == 'wrong_branch'
+    assert result['safe_for_operational_work'] is False
+    assert result['current_branch'] == 'work'
+
+
+def test_resolver_identifies_850917_on_work_as_non_authoritative():
+    result = resolve(
+        branch='work',
+        head='8509171250b1449832a7fe3227d87acc02fb015e',
+        head_contains=False,
+    )
+
+    assert result['failure_category'] == 'wrong_branch'
+    assert result['current_state_is_superseded'] is True
+    assert result['matched_superseded_state']['id'] == 'non_authoritative_state_authority_attempt_850917_on_work'
+    assert result['matched_superseded_state']['evidence_only'] is True
+
+
+def test_resolver_rejects_45e2d58():
+    result = resolve(
+        branch='fix/stage19-approved-rebaseline',
+        head='45e2d58abc000000000000000000000000000000',
+        head_contains=False,
+    )
+
+    assert result['failure_category'] == 'current_branch_superseded'
+    assert result['matched_superseded_state']['id'] == 'superseded_partial_rebaseline_45e2d58'
+    assert result['safe_for_operational_work'] is False
+
+
+def test_resolver_rejects_f72812a():
+    result = resolve(
+        branch='run/stage19as-au-100-row-expansion',
+        head='f72812abc0000000000000000000000000000000',
+        head_contains=False,
+    )
+
+    assert result['failure_category'] == 'current_branch_superseded'
+    assert result['matched_superseded_state']['id'] == 'superseded_stage19as_au_docs_only_checkpoint_f72812a'
+    assert result['safe_for_operational_work'] is False
+
+
+def test_resolver_lists_unrecoverable_historical_test_env_context():
+    result = resolve()
+    state = next(
+        item for item in result['superseded_states']
+        if item['id'] == 'unrecoverable_historical_test_env_stack_0042471_d66a568_09eee44'
+    )
+
+    assert state['status'] == 'unrecoverable_historical_context'
+    assert state['commits'] == ['0042471', 'd66a568', '09eee44']
+    assert state['replacement']['commit'] == EXPECTED_HEAD
+
+
+def test_resolver_marks_uploaded_prompt_bundles_evidence_only():
+    result = resolve()
+    state = next(
+        item for item in result['superseded_states']
+        if item['id'] == 'uploaded_or_pasted_prompt_bundles'
+    )
+
+    assert state['status'] == 'evidence_only'
+    assert state['evidence_only'] is True
+    assert result['prompt_rules']['pasted_chat_logs_are_evidence_not_authority'] is True
+
+
+def test_missing_authority_file_fails_closed(tmp_path):
+    result = resolver.resolve_project_state(
+        authority_path=tmp_path / 'missing.json',
+        git_runner=git_runner(),
+    )
+
+    assert result['failure_category'] == 'authority_file_missing'
+    assert result['safe_for_operational_work'] is False
+
+
+def test_origin_main_unavailable_reports_cleanly_without_secret():
+    result = resolve(origin_available=False)
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['failure_category'] == 'origin_main_unavailable'
+    assert result['origin_main'] is None
+    assert SECRET_SENTINEL not in encoded
+
+
+def test_docs_only_mode_does_not_permit_operational_work():
+    result = resolver.resolve_project_state(
+        authority_path=AUTHORITY_PATH,
+        git_runner=git_runner(branch='work'),
+        allow_docs_only=True,
+    )
+
+    assert result['failure_category'] == 'wrong_branch'
+    assert result['safe_for_operational_work'] is False
+    assert result['safe_for_docs_only_work'] is True
+
+
+def test_no_secrets_printed_in_cli_output(capsys):
+    exit_code = resolver.main(
+        ['--json'],
+        authority_path=AUTHORITY_PATH,
+        git_runner=git_runner(origin_available=False),
+    )
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert SECRET_SENTINEL not in output


### PR DESCRIPTION
## Summary

Recreates the Stage 19/test-environment state-authority guardrails directly on the correct PR #198 lineage without depending on the unavailable `8509171250b1449832a7fe3227d87acc02fb015e` patch source.

Adds:

- machine-readable `stage-19-state-authority.json`
- `scripts/dev/resolve_project_state.py` with strict branch/source/superseded-state gates
- prompt contract and runner-specific prompt templates
- current docs updates for superseded context and evidence-only prompt bundles
- resolver unit tests and Make targets

PR #198 remains the source branch context for the recreated test-environment work; this child branch is opened separately so the guardrails can be reviewed before merging.

## State Authority Warnings

- Branch `work` is non-authoritative for Stage 19/test-env operational work unless explicitly declared scratch/docs-only.
- Uploaded or pasted prompt bundles are evidence only and do not override live git state, the state-authority file, or latest merged docs.
- `45e2d58` is superseded partial rebaseline context and is not current authority.
- `f72812a` is a docs-only stopped checkpoint, not a successful Stage 19AS-AU run.
- `0042471`, `d66a568`, and `09eee44` are unrecoverable historical test-env context replaced by `fix/test-env-roadmap-recreate`.
- `8509171250b1449832a7fe3227d87acc02fb015e` on `work` is non-authoritative, unavailable as a patch source, and not current authority.
- Stage 19 remains paused.
- Stage 19AS-AU was not attempted.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_project_state_resolver.py -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_test_env_preflight.py -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19_real_postgres_readiness.py -p no:cacheprovider -rs` - 1 passed, 2 skipped explicitly for `credentials_missing`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m py_compile scripts/dev/resolve_project_state.py scripts/dev/test_env_preflight.py`
- `git diff --check`

Stage 19AS-AU remains paused and was not run.