### PR TITLE
Refresh state authority after PR199 merge

### DIFF
--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -1,12 +1,17 @@
 {
   "schema_version": "stage19_state_authority/v1",
   "current_authority": {
-    "origin_main": "49b0940cb014a319443525c3554d59387c2b6d90",
+    "origin_main": "887c690bdf0e47345782cf0e81d28c013d8f83db",
     "stage19_status": "paused",
     "stage19as_au_status": "not_run",
-    "test_env_pr": 198,
-    "test_env_branch": "fix/test-env-roadmap-recreate",
-    "test_env_head": "581a84c1159b58dff86e3359a28d00f9b4f5a82b"
+    "test_env_prs": [
+      198,
+      199
+    ],
+    "test_env_pr198_status": "merged",
+    "test_env_pr198_merge_commit": "7ed8b050a02b2d43a87452302c594ad791051ab1",
+    "test_env_pr199_status": "merged",
+    "test_env_pr199_merge_commit": "887c690bdf0e47345782cf0e81d28c013d8f83db"
   },
   "approved_stage19ar_baseline": {
     "source_run_key": "stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034",
@@ -26,7 +31,7 @@
         "45e2d58"
       ],
       "branch": "fix/stage19-approved-rebaseline",
-      "status": "superseded",
+      "status": "superseded_invalid_as_current_authority",
       "reason": "password_missing; replacement_baseline_verified:false; ready_for_stage19as_au:false; missing origin/main provenance"
     },
     {
@@ -35,7 +40,7 @@
         "f72812a"
       ],
       "branch": "run/stage19as-au-100-row-expansion",
-      "status": "superseded_docs_only_stopped_checkpoint",
+      "status": "superseded_not_successful_expansion",
       "reason": "password_missing; no writes; no successful 100-row expansion; docs-only stopped checkpoint"
     },
     {
@@ -49,7 +54,9 @@
       "reason": "reported in earlier local context but not recoverable from current refs/remotes/reflogs/checkouts",
       "replacement": {
         "branch": "fix/test-env-roadmap-recreate",
-        "commit": "581a84c1159b58dff86e3359a28d00f9b4f5a82b"
+        "commit": "581a84c1159b58dff86e3359a28d00f9b4f5a82b",
+        "merged_via_pr": 198,
+        "merge_commit": "7ed8b050a02b2d43a87452302c594ad791051ab1"
       }
     },
     {
@@ -59,7 +66,7 @@
         "8509171250b1449832a7fe3227d87acc02fb015e"
       ],
       "branch": "work",
-      "status": "non_authoritative_wrong_branch_attempt",
+      "status": "non_authoritative_wrong_branch_attempt_unavailable",
       "reason": "State-authority hardening was reportedly implemented on branch work, but the commit is unavailable in the current repo and was never authority. Do not require it, do not recover it, and do not treat it as a patch source.",
       "evidence_only": true
     },
@@ -68,6 +75,24 @@
       "status": "evidence_only",
       "reason": "Uploaded or pasted prompt bundles may be duplicated, truncated, stale, or mixed with old prompts and results. They must never override this state authority file, latest merged docs checkpoint, or live git state.",
       "evidence_only": true
+    }
+  ],
+  "historical_states": [
+    {
+      "id": "test_env_roadmap_recreate_pr198",
+      "branch": "fix/test-env-roadmap-recreate",
+      "head": "581a84c1159b58dff86e3359a28d00f9b4f5a82b",
+      "status": "merged_via_pr198",
+      "merge_commit": "7ed8b050a02b2d43a87452302c594ad791051ab1",
+      "reason": "Historical PR #198 branch. Current authority is merged origin/main at 887c690bdf0e47345782cf0e81d28c013d8f83db."
+    },
+    {
+      "id": "state_authority_branch_gate_pr199",
+      "branch": "fix/test-env-state-authority-branch-gate",
+      "head": "2216a7c2369c71a8c00d24fe92f2cf0dbdee04d0",
+      "status": "merged_via_pr199",
+      "merge_commit": "887c690bdf0e47345782cf0e81d28c013d8f83db",
+      "reason": "Historical PR #199 branch. Current authority is merged origin/main at 887c690bdf0e47345782cf0e81d28c013d8f83db."
     }
   ],
   "non_authoritative_branches": [

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -232,3 +232,35 @@ Superseded or non-authoritative states:
 - `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative wrong-branch state-authority attempt, unavailable in the current repo, and not a patch source.
 
 Branch `work` is non-authoritative for Stage 19/test-env operations unless explicitly declared scratch or docs-only. Stage 19 remains paused while test-environment hardening proceeds.
+
+## Post-PR #199 Authority Refresh
+
+PR #198 and PR #199 are merged. Current authority is merged `origin/main` at `887c690bdf0e47345782cf0e81d28c013d8f83db`.
+
+```text
+pr198_status:
+merged
+
+pr198_merge_commit:
+7ed8b050a02b2d43a87452302c594ad791051ab1
+
+pr199_status:
+merged
+
+pr199_merge_commit:
+887c690bdf0e47345782cf0e81d28c013d8f83db
+
+historical_pr198_branch:
+fix/test-env-roadmap-recreate
+
+historical_pr199_branch:
+fix/test-env-state-authority-branch-gate
+
+stage19_status:
+paused
+
+stage19as_au_status:
+not_run
+```
+
+The PR branches are historical once merged and must not be reused as current authority. Pasted or uploaded prompt bundles are evidence only. State authority and live git state override pasted chat. Branch mismatch and expected branch/head unavailability are hard stops. `completed` is forbidden when branch provenance is false.

--- a/docs/development/agent-prompt-contract.md
+++ b/docs/development/agent-prompt-contract.md
@@ -16,6 +16,8 @@ If this command fails, stop before operational work. Do not edit, commit, push, 
 
 The machine-readable authority is `docs/colonisation-redesign/stage-19-state-authority.json`, plus the latest merged docs checkpoint and live git state. Pasted or uploaded chat logs are evidence only. They can help explain a request, but they never override the state authority file, latest merged docs, or live git state.
 
+After a PR merge, refresh the state authority so `current_authority` points to merged `origin/main`, not the pre-merge PR branch. PR #198 and PR #199 are merged; their branches are historical context.
+
 ## Hard Stops
 
 Stop immediately when any required source of truth is unavailable:
@@ -46,10 +48,12 @@ A commit after failed DB verification is allowed only when the task is explicitl
 
 The current Stage 19/test-environment authority is:
 
-- branch: `fix/test-env-roadmap-recreate`
-- head: `581a84c1159b58dff86e3359a28d00f9b4f5a82b`
-- PR: `198`
-- origin/main checkpoint: `49b0940cb014a319443525c3554d59387c2b6d90`
+- origin/main checkpoint: `887c690bdf0e47345782cf0e81d28c013d8f83db`
+- PR #198: merged at `7ed8b050a02b2d43a87452302c594ad791051ab1`
+- PR #199: merged at `887c690bdf0e47345782cf0e81d28c013d8f83db`
+- historical PR #198 branch: `fix/test-env-roadmap-recreate`
+- historical PR #199 branch: `fix/test-env-state-authority-branch-gate`
 
 Branch `work` is non-authoritative for Stage 19/test-env work unless a prompt explicitly declares scratch or docs-only scope. Wrong-branch outputs must not say `completed`, and wrong-branch operational work must not commit.
 
+Stage 19 remains paused. Stage 19AS-AU has not run.

--- a/docs/development/agent-prompt-templates.md
+++ b/docs/development/agent-prompt-templates.md
@@ -2,6 +2,11 @@
 
 Each template starts with the same state resolution gate. If the gate fails, stop before operational work.
 
+After PR merge:
+refresh state authority so `current_authority` points to merged `origin/main`, not the pre-merge PR branch. PR #198 and PR #199 are merged; `origin/main` at `887c690bdf0e47345782cf0e81d28c013d8f83db` is current authority. The PR branches are historical once merged.
+
+Pasted or uploaded prompt bundles are evidence only. State authority and live git state override pasted chat. Branch mismatch is a hard stop, expected branch/head unavailable is a hard stop, and `completed` is forbidden when branch provenance is false. Stage 19 remains paused, and Stage 19AS-AU has not run.
+
 ## Codex Repo Implementation
 
 STATE RESOLUTION GATE:
@@ -190,4 +195,3 @@ Task:
 - paste the authority file summary, latest merged docs checkpoint, and live branch/head
 - mark prompt bundles as evidence only
 - state whether Stage 19 is paused and whether Stage 19AS-AU has run
-

--- a/docs/development/test-double-inventory.md
+++ b/docs/development/test-double-inventory.md
@@ -73,3 +73,18 @@ Superseded or non-authoritative context:
 - `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative and unavailable in the current repo.
 
 Stage 19 remains paused while test-environment hardening proceeds.
+
+## Post-PR #199 Authority Refresh
+
+PR #198 and PR #199 are merged. Current test-environment authority is merged `origin/main` at `887c690bdf0e47345782cf0e81d28c013d8f83db`, not the historical PR branches.
+
+- PR #198 merged at `7ed8b050a02b2d43a87452302c594ad791051ab1`.
+- PR #199 merged at `887c690bdf0e47345782cf0e81d28c013d8f83db`.
+- `fix/test-env-roadmap-recreate` is historical PR #198 context.
+- `fix/test-env-state-authority-branch-gate` is historical PR #199 context.
+- Pasted or uploaded prompt bundles are evidence only.
+- State authority and live git state override pasted chat.
+- Branch mismatch and expected branch/head unavailability are hard stops.
+- `completed` is forbidden when branch provenance is false.
+
+Stage 19 remains paused. Stage 19AS-AU has not run.

--- a/docs/development/test-environment.md
+++ b/docs/development/test-environment.md
@@ -107,3 +107,18 @@ Superseded or non-authoritative context:
 - `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative wrong-branch state-authority attempt, unavailable in the current repo, and not a patch source.
 
 Branch `work` is non-authoritative for Stage 19/test-env operations unless explicitly declared scratch or docs-only. Stage 19 remains paused while test-environment hardening proceeds.
+
+## Post-PR #199 Authority Refresh
+
+PR #198 and PR #199 are merged. The current authority is `origin/main` at `887c690bdf0e47345782cf0e81d28c013d8f83db`.
+
+```text
+pr198_status: merged
+pr198_merge_commit: 7ed8b050a02b2d43a87452302c594ad791051ab1
+pr199_status: merged
+pr199_merge_commit: 887c690bdf0e47345782cf0e81d28c013d8f83db
+stage19_status: paused
+stage19as_au_status: not_run
+```
+
+The PR branches `fix/test-env-roadmap-recreate` and `fix/test-env-state-authority-branch-gate` are historical once merged. They are no longer the current authority. State authority and live git state override pasted chat, and pasted or uploaded prompt bundles remain evidence only. Branch mismatch and expected branch/head unavailability are hard stops. `completed` is forbidden when branch provenance is false.

--- a/scripts/dev/resolve_project_state.py
+++ b/scripts/dev/resolve_project_state.py
@@ -125,7 +125,7 @@ def resolve_project_state(
             run_git(runner, ('merge-base', '--is-ancestor', expected_origin_main, 'origin/main')).returncode == 0
         )
 
-    expected_head = str(current_authority.get('test_env_head', ''))
+    expected_head = authority_commit(current_authority)
     authority_commit_available = False
     head_contains_authority = False
     if expected_head:
@@ -186,9 +186,14 @@ def resolve_project_state(
         'next_action': next_action,
         'authority_test_env_branch': current_authority.get('test_env_branch'),
         'authority_test_env_head': expected_head,
+        'authority_origin_main': expected_origin_main,
+        'authority_test_env_prs': current_authority.get('test_env_prs', []),
+        'authority_pr198_merge_commit': current_authority.get('test_env_pr198_merge_commit'),
+        'authority_pr199_merge_commit': current_authority.get('test_env_pr199_merge_commit'),
         'head_contains_authority': head_contains_authority,
         'authority_commit_available': authority_commit_available,
         'superseded_states': [public_state(state) for state in authority.get('superseded_states', [])],
+        'historical_states': [public_historical_state(state) for state in authority.get('historical_states', [])],
         'prompt_rules': authority.get('prompt_rules', {}),
     }
 
@@ -236,10 +241,17 @@ def build_failure(
         'failure_category': failure_category,
         'next_action': next_action,
         'authority_test_env_branch': (authority or {}).get('current_authority', {}).get('test_env_branch'),
-        'authority_test_env_head': (authority or {}).get('current_authority', {}).get('test_env_head'),
+        'authority_test_env_head': authority_commit((authority or {}).get('current_authority', {})),
+        'authority_origin_main': (authority or {}).get('current_authority', {}).get('origin_main'),
+        'authority_test_env_prs': (authority or {}).get('current_authority', {}).get('test_env_prs', []),
+        'authority_pr198_merge_commit': (authority or {}).get('current_authority', {}).get('test_env_pr198_merge_commit'),
+        'authority_pr199_merge_commit': (authority or {}).get('current_authority', {}).get('test_env_pr199_merge_commit'),
         'head_contains_authority': False,
         'authority_commit_available': False,
         'superseded_states': [public_state(state) for state in (authority or {}).get('superseded_states', [])],
+        'historical_states': [
+            public_historical_state(state) for state in (authority or {}).get('historical_states', [])
+        ],
         'prompt_rules': (authority or {}).get('prompt_rules', {}),
         'allow_docs_only': allow_docs_only,
     }
@@ -269,6 +281,14 @@ def git_output(runner: GitRunner, args: Sequence[str]) -> str | None:
         return None
     text = completed.stdout.strip()
     return text or None
+
+
+def authority_commit(current_authority: Mapping[str, Any]) -> str:
+    for key in ('test_env_pr199_merge_commit', 'test_env_head', 'origin_main'):
+        value = current_authority.get(key)
+        if value:
+            return str(value)
+    return ''
 
 
 def find_matching_superseded_state(
@@ -311,6 +331,13 @@ def public_state(state: Mapping[str, Any] | None) -> dict[str, Any] | None:
     if not state:
         return None
     keys = ('id', 'branch', 'commit', 'commits', 'status', 'reason', 'replacement', 'evidence_only')
+    return {key: state[key] for key in keys if key in state}
+
+
+def public_historical_state(state: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not state:
+        return None
+    keys = ('id', 'branch', 'head', 'status', 'merge_commit', 'reason')
     return {key: state[key] for key in keys if key in state}
 
 

--- a/tests/test_project_state_resolver.py
+++ b/tests/test_project_state_resolver.py
@@ -11,8 +11,9 @@ ROOT = Path(__file__).resolve().parents[1]
 RESOLVER_PATH = ROOT / 'scripts' / 'dev' / 'resolve_project_state.py'
 AUTHORITY_PATH = ROOT / 'docs' / 'colonisation-redesign' / 'stage-19-state-authority.json'
 
-EXPECTED_HEAD = '581a84c1159b58dff86e3359a28d00f9b4f5a82b'
-EXPECTED_ORIGIN_MAIN = '49b0940cb014a319443525c3554d59387c2b6d90'
+AUTHORITY_COMMIT = '887c690bdf0e47345782cf0e81d28c013d8f83db'
+PR198_HEAD = '581a84c1159b58dff86e3359a28d00f9b4f5a82b'
+PR198_MERGE_COMMIT = '7ed8b050a02b2d43a87452302c594ad791051ab1'
 SECRET_SENTINEL = 'do-not-print-this-secret'
 
 spec = importlib.util.spec_from_file_location('resolve_project_state', RESOLVER_PATH)
@@ -31,9 +32,9 @@ def completed(args, returncode=0, stdout='', stderr=''):
 
 def git_runner(
     *,
-    branch='fix/test-env-roadmap-recreate',
-    head=EXPECTED_HEAD,
-    origin_main=EXPECTED_ORIGIN_MAIN,
+    branch='docs/state-authority-post-pr199-refresh',
+    head=AUTHORITY_COMMIT,
+    origin_main=AUTHORITY_COMMIT,
     origin_available=True,
     origin_contains=True,
     authority_available=True,
@@ -52,14 +53,14 @@ def git_runner(
             if not origin_available:
                 return completed(args, 128, '', SECRET_SENTINEL)
             return completed(args, 0, f'{origin_main}\n')
-        if args == ('rev-parse', '--verify', EXPECTED_HEAD):
-            return completed(args, 0 if authority_available else 128, f'{EXPECTED_HEAD}\n')
+        if args == ('rev-parse', '--verify', AUTHORITY_COMMIT):
+            return completed(args, 0 if authority_available else 128, f'{AUTHORITY_COMMIT}\n')
         if args[:2] == ('merge-base', '--is-ancestor'):
             ancestor = args[2]
             target = args[3]
-            if ancestor == EXPECTED_ORIGIN_MAIN and target == 'origin/main':
+            if ancestor == AUTHORITY_COMMIT and target == 'origin/main':
                 return completed(args, 0 if origin_contains else 1)
-            if ancestor == EXPECTED_HEAD and target == 'HEAD':
+            if ancestor == AUTHORITY_COMMIT and target == 'HEAD':
                 return completed(args, 0 if head_contains else 1)
         return completed(args, 1, '', SECRET_SENTINEL)
 
@@ -80,7 +81,22 @@ def test_authority_file_parses():
     assert error is None
     assert authority['current_authority']['stage19_status'] == 'paused'
     assert authority['current_authority']['stage19as_au_status'] == 'not_run'
+    assert authority['current_authority']['origin_main'] == AUTHORITY_COMMIT
+    assert authority['current_authority']['test_env_pr198_merge_commit'] == PR198_MERGE_COMMIT
+    assert authority['current_authority']['test_env_pr199_merge_commit'] == AUTHORITY_COMMIT
     assert authority['approved_stage19ar_baseline']['rows'] == 25
+
+
+def test_origin_main_887c690_is_accepted_as_current_authority():
+    result = resolve()
+
+    assert result['origin_main'] == AUTHORITY_COMMIT
+    assert result['authority_origin_main'] == AUTHORITY_COMMIT
+    assert result['authority_test_env_head'] == AUTHORITY_COMMIT
+    assert result['authority_test_env_prs'] == [198, 199]
+    assert result['failure_category'] == 'none'
+    assert result['safe_for_operational_work'] is True
+    assert result['current_state_is_superseded'] is False
 
 
 def test_json_output_works(capsys):
@@ -94,6 +110,39 @@ def test_json_output_works(capsys):
     assert exit_code == 0
     assert payload['failure_category'] == 'none'
     assert payload['safe_for_operational_work'] is True
+
+
+def test_pr198_branch_state_is_historical_after_merge():
+    result = resolve()
+    state = next(
+        item for item in result['historical_states']
+        if item['id'] == 'test_env_roadmap_recreate_pr198'
+    )
+
+    assert state['branch'] == 'fix/test-env-roadmap-recreate'
+    assert state['status'] == 'merged_via_pr198'
+    assert state['merge_commit'] == PR198_MERGE_COMMIT
+
+
+def test_pr199_branch_state_is_historical_after_merge():
+    result = resolve()
+    state = next(
+        item for item in result['historical_states']
+        if item['id'] == 'state_authority_branch_gate_pr199'
+    )
+
+    assert state['branch'] == 'fix/test-env-state-authority-branch-gate'
+    assert state['status'] == 'merged_via_pr199'
+    assert state['merge_commit'] == AUTHORITY_COMMIT
+
+
+def test_resolver_does_not_require_pr198_branch_after_merge():
+    result = resolve(branch='main', head=AUTHORITY_COMMIT)
+
+    assert result['current_branch'] == 'main'
+    assert result['authority_test_env_branch'] is None
+    assert result['failure_category'] == 'none'
+    assert result['safe_for_operational_work'] is True
 
 
 def test_resolver_rejects_work_branch_for_operational_work():
@@ -150,7 +199,7 @@ def test_resolver_lists_unrecoverable_historical_test_env_context():
 
     assert state['status'] == 'unrecoverable_historical_context'
     assert state['commits'] == ['0042471', 'd66a568', '09eee44']
-    assert state['replacement']['commit'] == EXPECTED_HEAD
+    assert state['replacement']['commit'] == PR198_HEAD
 
 
 def test_resolver_marks_uploaded_prompt_bundles_evidence_only():


### PR DESCRIPTION
## Summary

Refreshes the Stage 19/test-environment state authority after the test-environment roadmap and state-authority guardrails merged.

- PR #198 merged at `7ed8b050a02b2d43a87452302c594ad791051ab1`
- PR #199 merged at `887c690bdf0e47345782cf0e81d28c013d8f83db`
- `origin/main` at `887c690bdf0e47345782cf0e81d28c013d8f83db` is current authority
- Stage 19 remains paused
- Stage 19AS-AU was not run
- uploaded/pasted prompt bundles are evidence only
- stale states remain rejected, including `45e2d58`, `f72812a`, `0042471`/`d66a568`/`09eee44`, and the unavailable `850917` work-branch attempt

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_project_state_resolver.py -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_test_env_preflight.py -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19_real_postgres_readiness.py -p no:cacheprovider -rs` - 1 passed, 2 skipped explicitly for `credentials_missing`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m py_compile scripts/dev/resolve_project_state.py scripts/dev/test_env_preflight.py`
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --json`

Stage 19AS-AU remains paused and was not run.