### PR TITLE
Trim active state authority history

### DIFF
--- a/docs/archive/stage-19-incident-history.md
+++ b/docs/archive/stage-19-incident-history.md
@@ -1,0 +1,54 @@
+# Stage 19 Incident History
+
+This archive is historical evidence only.
+It is not operational authority.
+For current state, use docs/colonisation-redesign/stage-19-state-authority.json and the latest merged docs checkpoint.
+
+## Purpose
+
+This file preserves retired Stage 19 and test-environment context so active prompts and the active state authority do not have to carry long stale-state explanations. Do not copy this archive into operational prompts. Operational prompts must run the resolver and use the active authority file, the latest merged docs checkpoint, and live git state.
+
+## Retired Stage 19AR Baseline
+
+The old Stage 19AR baseline was:
+
+| Field | Retired value |
+|---|---|
+| `source_run_key` | `stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd` |
+| `bridge_key` | `source_runs:stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd` |
+| `artifact` | `418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417` |
+| `rows` | `25` |
+| `status` | `retired_unrecoverable` |
+
+It was valid-looking because it exercised the source run, enrichment bridge, staging rows, diagnostic isolation, provenance tracking, artifact verification, and operator visibility path. It is retired because the approved Stage 19AR canonical identity is now the replacement run `stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034` with artifact `b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e`. The retired source run key and artifact differ from the approved replacement values and must not be promoted back to canonical status.
+
+## Invalid And Historical States
+
+`45e2d58` is an invalid partial rebaseline. Historical notes recorded `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance. It is never authority.
+
+`f72812a` is a docs-only stopped checkpoint from `run/stage19as-au-100-row-expansion`. Historical notes recorded `password_missing`, no writes, and no successful 100-row Stage 19AS-AU expansion. It must not be reported as a completed expansion.
+
+`0042471`, `d66a568`, and `09eee44` are unrecoverable historical test-environment stack references from earlier local context. They were replaced by the merged and recreated test-environment work in PR #198 and later state-authority hardening in PR #199. They are historical context only, not active invalid-state entries.
+
+`8509171250b1449832a7fe3227d87acc02fb015e` was a wrong-branch state-authority attempt on `work`. The commit is unavailable in the current repository and was never authoritative. Do not require it, recover it, or treat it as a patch source.
+
+## Prompt Bundle Evidence
+
+Uploaded or pasted prompt bundles may be duplicated, truncated, stale, or mixed with old prompts and results. They are evidence only. They can explain why a request exists, but they never override the active state authority file, the latest merged docs checkpoint, or live git state.
+
+Do not paste this archive or large stale prompt bundles into future operational prompts. Future prompts should reference the active authority path and require the resolver gate instead.
+
+## Brief Chronology
+
+| PR | Historical note |
+|---|---|
+| `#193` | Added the bounded 25-row Stage 19AR staging pilot script. |
+| `#195` | Closed a Stage 19AR validation gap before the approved replacement baseline work. |
+| `#196` | Approved the replacement Stage 19AR canonical baseline. |
+| `#197` | Recorded the post-PR196 Stage 19 checkpoint. |
+| `#198` | Recreated and validated the test-environment roadmap work, replacing the unrecoverable historical test-env stack. |
+| `#199` | Added state-authority branch-gate hardening for Stage 19/test-environment work. |
+
+## Current Authority Pointer
+
+The current operational state is intentionally not repeated here. Use `docs/colonisation-redesign/stage-19-state-authority.json` for current Stage 19 status, the approved Stage 19AR baseline, the tiny invalid-state denylist, and durable prompt/state rules.

--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -1,12 +1,8 @@
 {
-  "schema_version": "stage19_state_authority/v1",
-  "current_authority": {
-    "origin_main": "49b0940cb014a319443525c3554d59387c2b6d90",
-    "stage19_status": "paused",
-    "stage19as_au_status": "not_run",
-    "test_env_pr": 198,
-    "test_env_branch": "fix/test-env-roadmap-recreate",
-    "test_env_head": "581a84c1159b58dff86e3359a28d00f9b4f5a82b"
+  "schema_version": 1,
+  "stage19": {
+    "status": "paused",
+    "stage19as_au_status": "not_run"
   },
   "approved_stage19ar_baseline": {
     "source_run_key": "stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034",
@@ -17,74 +13,37 @@
   "retired_stage19ar_baseline": {
     "source_run_key": "stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd",
     "artifact": "418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417",
-    "status": "retired_unrecoverable"
+    "status": "retired_unrecoverable",
+    "details": "See docs/archive/stage-19-incident-history.md"
   },
-  "superseded_states": [
+  "invalid_states": [
     {
-      "id": "superseded_partial_rebaseline_45e2d58",
-      "commits": [
-        "45e2d58"
-      ],
-      "branch": "fix/stage19-approved-rebaseline",
-      "status": "superseded",
-      "reason": "password_missing; replacement_baseline_verified:false; ready_for_stage19as_au:false; missing origin/main provenance"
+      "id": "45e2d58",
+      "status": "invalid_partial_rebaseline_never_authority"
     },
     {
-      "id": "superseded_stage19as_au_docs_only_checkpoint_f72812a",
-      "commits": [
-        "f72812a"
-      ],
-      "branch": "run/stage19as-au-100-row-expansion",
-      "status": "superseded_docs_only_stopped_checkpoint",
-      "reason": "password_missing; no writes; no successful 100-row expansion; docs-only stopped checkpoint"
+      "id": "f72812a",
+      "status": "docs_only_stopped_checkpoint_not_successful_expansion"
     },
     {
-      "id": "unrecoverable_historical_test_env_stack_0042471_d66a568_09eee44",
-      "commits": [
-        "0042471",
-        "d66a568",
-        "09eee44"
-      ],
-      "status": "unrecoverable_historical_context",
-      "reason": "reported in earlier local context but not recoverable from current refs/remotes/reflogs/checkouts",
-      "replacement": {
-        "branch": "fix/test-env-roadmap-recreate",
-        "commit": "581a84c1159b58dff86e3359a28d00f9b4f5a82b"
-      }
-    },
-    {
-      "id": "non_authoritative_state_authority_attempt_850917_on_work",
-      "commit": "8509171250b1449832a7fe3227d87acc02fb015e",
-      "commits": [
-        "8509171250b1449832a7fe3227d87acc02fb015e"
-      ],
-      "branch": "work",
-      "status": "non_authoritative_wrong_branch_attempt",
-      "reason": "State-authority hardening was reportedly implemented on branch work, but the commit is unavailable in the current repo and was never authority. Do not require it, do not recover it, and do not treat it as a patch source.",
-      "evidence_only": true
-    },
-    {
-      "id": "uploaded_or_pasted_prompt_bundles",
-      "status": "evidence_only",
-      "reason": "Uploaded or pasted prompt bundles may be duplicated, truncated, stale, or mixed with old prompts and results. They must never override this state authority file, latest merged docs checkpoint, or live git state.",
-      "evidence_only": true
+      "id": "8509171250b1449832a7fe3227d87acc02fb015e",
+      "status": "wrong_branch_unavailable_never_authority"
     }
   ],
-  "non_authoritative_branches": [
-    {
-      "branch": "work",
-      "reason": "work is not authoritative for Stage 19/test-env operational work unless a task is explicitly scratch or docs-only"
-    }
-  ],
-  "prompt_rules": {
-    "completed_reserved_for_all_required_checks_true": true,
-    "partial_requires_stopped_or_partial_label": true,
-    "source_of_truth_unavailable_is_hard_stop": true,
-    "expected_branch_unavailable_is_hard_stop": true,
+  "historical_context": {
+    "unrecoverable_test_env_stack": [
+      "0042471",
+      "d66a568",
+      "09eee44"
+    ],
+    "details": "See docs/archive/stage-19-incident-history.md"
+  },
+  "rules": {
+    "pasted_logs_are_evidence_only": true,
+    "completed_requires_all_checks_true": true,
     "branch_mismatch_is_hard_stop": true,
+    "source_of_truth_unavailable_is_hard_stop": true,
     "db_credentials_missing_is_hard_stop_for_db_work": true,
-    "do_not_commit_final_success_when_required_verification_false": true,
-    "docs_checkpoint_required_after_material_state_change": true,
-    "pasted_chat_logs_are_evidence_not_authority": true
+    "docs_checkpoint_required_after_material_state_change": true
   }
 }

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -41,7 +41,7 @@ The previous Stage 19AR baseline is retired and unrecoverable. It must not be tr
 | `rows` | `25` |
 | `status` | `retired_unrecoverable` |
 
-The retired run was valid-looking because it exercised the source run, bridge, staging, diagnostic, provenance, artifact, and visibility path. It is no longer equivalent to the approved canonical Stage 19AR baseline because both the source run key and artifact differ from the approved replacement values.
+Historical detail about why this baseline was retired lives in `docs/archive/stage-19-incident-history.md`. The archive is evidence only and must not be used as operational authority.
 
 ## Fresh Project DB Failure Mode
 
@@ -111,79 +111,25 @@ Rule: source-correct DB preflight against `127.0.0.1:55432` must pass without re
 - Retired runs must not be silently promoted back to canonical baselines.
 - Stage 19AS-AU must not run unless the exact approved Stage 19AR `source_run_key` and artifact are present.
 
-## Stage 19 Current Checkpoint After PR #196
+## Current Stage 19 State
 
-```text
-STAGE 19 CURRENT CHECKPOINT
+Active authority:
+`docs/colonisation-redesign/stage-19-state-authority.json`
 
-Authoritative state:
-PR #196 approved replacement canonical baseline.
-
-Current approved Stage 19AR canonical baseline:
-
-source_run_key:
-stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034
-
-bridge_key:
-source_runs:stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034
-
-artifact:
-b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e
-
-rows:
-25
-
-Verification:
-source_correct_db_preflight: passed
-replacement_baseline_verified: true
-operator_visibility: true
-stage19as_au_readiness_preflight_passed: true
-ready_for_stage19as_au: true
-stage19as_au_expansion_attempted: false
-
-Old retired/unrecoverable Stage 19AR baseline:
-
-source_run_key:
-stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd
-
-bridge_key:
-source_runs:stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd
-
-artifact:
-418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417
-
-status:
-retired_unrecoverable
-
-Stale state to ignore:
-
-branch:
-fix/stage19-approved-rebaseline
-
-commit:
-45e2d58
-
-reason:
-superseded partial attempt with password_missing, replacement_baseline_verified:false, ready_for_stage19as_au:false, and missing origin/main provenance.
-
-Next allowed action:
-Run Stage 19AS-AU 100-row controlled expansion only after PR #196 is merged and local work starts from updated origin/main.
-
-Still prohibited:
-- using 45e2d58 as current authority
-- re-approving another baseline
-- changing canonical identity again
-- bypassing source_runs/enrichment bridge/staging/artifact verification/operator visibility
-- running Stage 19AS-AU from stale local main
-```
-
-## Test Environment Roadmap Gate
+Historical evidence:
+`docs/archive/stage-19-incident-history.md`
 
 Stage 19AS-AU is paused while the test-environment roadmap is restored and validated. The pause is a test-environment gate, not a new baseline decision.
 
-Current test-environment restoration state:
+Current operational state:
 
 ```text
+stage19_status:
+paused
+
+stage19as_au_status:
+not_run
+
 stage19_resume_gate:
 fake-only readiness blocker cleared
 Stage 19 remains paused until the next agreed test-env gate or operator decision
@@ -203,32 +149,20 @@ false
 
 The restored real-service readiness path is `tests/test_stage19_real_postgres_readiness.py`. It passed against local Postgres on the recreated test-environment branch, so FakeConn/FakeCursor coverage is now paired with real-service readiness coverage. Stage 19 remains paused until the next agreed test-environment gate or operator decision.
 
-Stale states that remain non-authoritative:
-
-- `fix/stage19-approved-rebaseline` at `45e2d58`: superseded partial attempt with `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance.
-- `run/stage19as-au-100-row-expansion` at `f72812a`: local docs-only stopped checkpoint with `password_missing`, no writes, not pushed, and not a successful Stage 19AS-AU run.
-
 ## Fresh-Chat Handoff
 
-Use the `STAGE 19 CURRENT CHECKPOINT` block above when resuming Stage 19 in a new chat.
-
-## State Authority and Superseded Context
-
-The current source of truth is `docs/colonisation-redesign/stage-19-state-authority.json`, this latest merged docs checkpoint, and live git state. Pasted or uploaded prompt bundles are evidence only. They must not override the state authority file, current branch/head, or latest merged checkpoint.
-
-Prompts must run state resolution before operational work:
+Operational prompts should run the resolver first:
 
 ```sh
 PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
 ```
 
-If source-of-truth branch/commit, expected branch/head, or branch provenance is unavailable, stop. Branch mismatch is a hard stop. `completed` is forbidden when branch provenance is false.
+Do not paste archive history or large stale prompt bundles into fresh-chat handoffs. Include the active authority path, latest merged docs checkpoint, and live branch/head instead.
 
-Superseded or non-authoritative states:
+## Authority Boundaries
 
-- `45e2d58` on `fix/stage19-approved-rebaseline`: superseded partial rebaseline with `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance.
-- `f72812a` on `run/stage19as-au-100-row-expansion`: docs-only stopped checkpoint with `password_missing`, no writes, and no successful 100-row expansion.
-- `0042471`, `d66a568`, and `09eee44`: unrecoverable historical test-env stack replaced by `fix/test-env-roadmap-recreate` at `581a84c1159b58dff86e3359a28d00f9b4f5a82b`.
-- `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative wrong-branch state-authority attempt, unavailable in the current repo, and not a patch source.
+The active source of truth is `docs/colonisation-redesign/stage-19-state-authority.json`, this latest merged docs checkpoint, and live git state. Pasted or uploaded prompt bundles are evidence only. They must not override active authority, current branch/head, or latest merged checkpoint.
 
-Branch `work` is non-authoritative for Stage 19/test-env operations unless explicitly declared scratch or docs-only. Stage 19 remains paused while test-environment hardening proceeds.
+The active invalid-state denylist is intentionally tiny. Historical detail belongs in `docs/archive/stage-19-incident-history.md`; the archive must never be copied into operational prompts or used as operational authority.
+
+If source-of-truth branch/commit or branch provenance is unavailable, stop. Branch mismatch is a hard stop. `completed` is forbidden when branch provenance is false.

--- a/docs/development/agent-prompt-contract.md
+++ b/docs/development/agent-prompt-contract.md
@@ -14,7 +14,9 @@ PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.
 
 If this command fails, stop before operational work. Do not edit, commit, push, run DB writes, or report `completed`.
 
-The machine-readable authority is `docs/colonisation-redesign/stage-19-state-authority.json`, plus the latest merged docs checkpoint and live git state. Pasted or uploaded chat logs are evidence only. They can help explain a request, but they never override the state authority file, latest merged docs, or live git state.
+Active authority is `docs/colonisation-redesign/stage-19-state-authority.json`, plus the latest merged docs checkpoint and live git state. Historical evidence is in `docs/archive/stage-19-incident-history.md`.
+
+Pasted or uploaded logs are evidence only. They can help explain a request, but they never override the active authority file, latest merged docs checkpoint, or live git state. Do not paste archive history or large stale prompt bundles into operational prompts.
 
 ## Hard Stops
 
@@ -25,7 +27,7 @@ Stop immediately when any required source of truth is unavailable:
 - expected head unavailable
 - current branch mismatches the prompt's expected branch
 - current branch is `work` for Stage 19/test-env operational work, unless the prompt explicitly declares scratch or docs-only scope
-- current state matches a superseded branch or commit in the authority file
+- current state matches an invalid state in the active authority denylist
 - DB credentials are missing for DB work
 
 For DB work, missing credentials are a hard stop before writes. `password_missing` is diagnostic, not success.
@@ -42,14 +44,10 @@ If branch provenance, source authority, DB verification, or required tests fail,
 
 A commit after failed DB verification is allowed only when the task is explicitly docs-only or a partial-checkpoint task and the output does not claim operational success.
 
-## Branch Authority
+## Authority Boundaries
 
-The current Stage 19/test-environment authority is:
+The active state authority contains current operational truth and an intentionally tiny invalid-state denylist. It is not a graveyard for incident detail.
 
-- branch: `fix/test-env-roadmap-recreate`
-- head: `581a84c1159b58dff86e3359a28d00f9b4f5a82b`
-- PR: `198`
-- origin/main checkpoint: `49b0940cb014a319443525c3554d59387c2b6d90`
+The archive preserves historical context only. It must never be copied into prompts as operational authority, and it must not expand the active denylist by implication.
 
 Branch `work` is non-authoritative for Stage 19/test-env work unless a prompt explicitly declares scratch or docs-only scope. Wrong-branch outputs must not say `completed`, and wrong-branch operational work must not commit.
-

--- a/docs/development/agent-prompt-templates.md
+++ b/docs/development/agent-prompt-templates.md
@@ -2,6 +2,23 @@
 
 Each template starts with the same state resolution gate. If the gate fails, stop before operational work.
 
+STATE RESOLUTION GATE:
+Run:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+```
+
+If this fails, stop before operational work.
+
+Current state comes from:
+`docs/colonisation-redesign/stage-19-state-authority.json`
+
+Historical evidence lives in:
+`docs/archive/stage-19-incident-history.md`
+
+Do not paste archive history into prompts. Do not use uploaded or pasted chat logs as authority.
+
 ## Codex Repo Implementation
 
 STATE RESOLUTION GATE:
@@ -137,8 +154,9 @@ If this fails, stop before operational work.
 Task:
 
 - compare prompt claims with `stage-19-state-authority.json`
-- reject `45e2d58`, `f72812a`, `0042471`, `d66a568`, `09eee44`, and `850917` on `work` as current authority
+- reject current branch/head matches from the active invalid-state denylist
 - treat uploaded or pasted prompt bundles as evidence only
+- do not copy archive history into operational prompts
 
 ## Human Operator Approval Decision
 
@@ -187,7 +205,7 @@ If this fails, stop before operational work.
 
 Task:
 
-- paste the authority file summary, latest merged docs checkpoint, and live branch/head
-- mark prompt bundles as evidence only
+- include the active authority path, latest merged docs checkpoint, and live branch/head
+- mark prompt bundles and archive history as evidence only
+- do not paste large stale prompt bundles into future prompts
 - state whether Stage 19 is paused and whether Stage 19AS-AU has run
-

--- a/docs/development/test-double-inventory.md
+++ b/docs/development/test-double-inventory.md
@@ -53,9 +53,13 @@ Stage 19 remains paused until the next agreed test-env gate or operator decision
 
 The fake-only readiness blocker is cleared by the real Stage 19 DB readiness test passing against local Postgres. Stage 19 remains paused until the next agreed test-environment gate or operator decision.
 
-## State Authority and Superseded Context
+## State Authority
 
-Current truth for Stage 19/test-environment readiness lives in `docs/colonisation-redesign/stage-19-state-authority.json`, latest merged docs, and live git state. Pasted or uploaded logs are evidence only and cannot override the authority file.
+Active truth for Stage 19/test-environment readiness lives in `docs/colonisation-redesign/stage-19-state-authority.json`, latest merged docs, and live git state.
+
+Historical evidence lives in `docs/archive/stage-19-incident-history.md`. The archive is not operational authority and must not be copied into operational prompts.
+
+Pasted or uploaded logs are evidence only and cannot override active authority.
 
 Run the state resolver before operational work:
 
@@ -63,13 +67,6 @@ Run the state resolver before operational work:
 PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
 ```
 
-The resolver rejects superseded or non-authoritative context before any fake-backed test result can be treated as readiness proof.
-
-Superseded or non-authoritative context:
-
-- `45e2d58`: superseded partial rebaseline with missing password, failed replacement baseline verification, and missing `origin/main` provenance.
-- `f72812a`: docs-only stopped Stage 19AS-AU checkpoint with missing password, no writes, and no successful 100-row expansion.
-- `0042471`, `d66a568`, and `09eee44`: unrecoverable historical test-env context replaced by `fix/test-env-roadmap-recreate`.
-- `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative and unavailable in the current repo.
+The resolver rejects current branch/head matches from the active invalid-state denylist before any fake-backed test result can be treated as readiness proof. The denylist is intentionally tiny; historical archive entries do not expand it.
 
 Stage 19 remains paused while test-environment hardening proceeds.

--- a/docs/development/test-environment.md
+++ b/docs/development/test-environment.md
@@ -87,9 +87,13 @@ Stage 19 remains paused until the next agreed test-env gate or operator decision
 
 Stage 19AS-AU must not run from this test-environment branch. Do not use `--commit`, do not rebaseline, and do not promote staged rows from this work.
 
-## State Authority and Superseded Context
+## State Authority
 
-Current Stage 19/test-environment truth lives in `docs/colonisation-redesign/stage-19-state-authority.json`, the latest merged docs checkpoint, and live git state. Pasted or uploaded logs are evidence only; they may be stale, duplicated, truncated, or mixed with old prompt results.
+Active Stage 19/test-environment truth lives in `docs/colonisation-redesign/stage-19-state-authority.json`, the latest merged docs checkpoint, and live git state.
+
+Historical evidence lives in `docs/archive/stage-19-incident-history.md`. The archive is not operational authority and must not be copied into operational prompts.
+
+Pasted or uploaded logs are evidence only; they may be stale, duplicated, truncated, or mixed with old prompt results. They never override active authority.
 
 Prompts must run the resolver before operational work:
 
@@ -97,13 +101,6 @@ Prompts must run the resolver before operational work:
 PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
 ```
 
-The resolver is fail-closed for source-of-truth unavailability, expected branch/head unavailability, branch mismatch, and superseded state. `completed` is forbidden when branch provenance is false.
-
-Superseded or non-authoritative context:
-
-- `45e2d58` on `fix/stage19-approved-rebaseline`: superseded partial rebaseline with `password_missing`, `replacement_baseline_verified:false`, `ready_for_stage19as_au:false`, and missing `origin/main` provenance.
-- `f72812a` on `run/stage19as-au-100-row-expansion`: docs-only stopped checkpoint with `password_missing`, no writes, and no successful 100-row expansion.
-- `0042471`, `d66a568`, and `09eee44`: unrecoverable historical test-env stack, replaced by `fix/test-env-roadmap-recreate` at `581a84c1159b58dff86e3359a28d00f9b4f5a82b`.
-- `8509171250b1449832a7fe3227d87acc02fb015e` on `work`: non-authoritative wrong-branch state-authority attempt, unavailable in the current repo, and not a patch source.
+The resolver is fail-closed for source-of-truth unavailability, branch mismatch, and current branch/head matches in the active invalid-state denylist. The denylist is intentionally tiny; historical archive entries do not become operational blockers by implication.
 
 Branch `work` is non-authoritative for Stage 19/test-env operations unless explicitly declared scratch or docs-only. Stage 19 remains paused while test-environment hardening proceeds.

--- a/scripts/dev/resolve_project_state.py
+++ b/scripts/dev/resolve_project_state.py
@@ -86,9 +86,7 @@ def resolve_project_state(
         )
 
     assert authority is not None
-    current_authority = authority.get('current_authority', {})
-    stage19_status = str(current_authority.get('stage19_status', 'unknown'))
-    stage19as_au_status = str(current_authority.get('stage19as_au_status', 'unknown'))
+    stage19_status, stage19as_au_status = stage19_statuses(authority)
 
     inside = run_git(runner, ('rev-parse', '--is-inside-work-tree'))
     if inside.returncode != 0 or inside.stdout.strip() != 'true':
@@ -117,15 +115,10 @@ def resolve_project_state(
             allow_docs_only=allow_docs_only,
         )
 
-    expected_origin_main = str(current_authority.get('origin_main', ''))
     origin_main = git_output(runner, ('rev-parse', 'origin/main'))
-    origin_main_contains_authority = False
-    if origin_main:
-        origin_main_contains_authority = (
-            run_git(runner, ('merge-base', '--is-ancestor', expected_origin_main, 'origin/main')).returncode == 0
-        )
+    origin_main_contains_authority = bool(origin_main)
 
-    expected_head = str(current_authority.get('test_env_head', ''))
+    expected_head = authority_test_env_head(authority)
     authority_commit_available = False
     head_contains_authority = False
     if expected_head:
@@ -133,32 +126,29 @@ def resolve_project_state(
         head_contains_authority = (
             run_git(runner, ('merge-base', '--is-ancestor', expected_head, 'HEAD')).returncode == 0
         )
+    else:
+        authority_commit_available = True
+        head_contains_authority = True
 
-    matched_state, matched_by = find_matching_superseded_state(authority, current_branch, current_head)
+    matched_state, matched_by = find_matching_invalid_state(authority, current_branch, current_head)
     failure_category = 'none'
     next_action = 'State authority checks passed for operational work.'
 
     if not origin_main:
         failure_category = 'origin_main_unavailable'
         next_action = 'Fetch origin/main and rerun state resolution before operational work.'
-    elif not origin_main_contains_authority:
-        failure_category = 'stale_stage19_context'
-        next_action = 'Update origin/main to include the authoritative checkpoint before continuing.'
     elif not authority_commit_available:
         failure_category = 'authority_commit_missing'
         next_action = 'Fetch the authoritative test-environment commit before continuing.'
-    elif matched_state and current_branch == 'work':
-        failure_category = 'wrong_branch'
-        next_action = 'Switch off work; use fix/test-env-roadmap-recreate or a clean child branch.'
+    elif matched_state and matched_by == 'branch':
+        failure_category = 'current_branch_superseded'
+        next_action = 'Do not use this invalid state as authority; switch to a clean branch from origin/main.'
+    elif matched_state and matched_by == 'head':
+        failure_category = 'current_head_superseded'
+        next_action = 'Do not use this invalid state as authority; switch to a clean branch from origin/main.'
     elif current_branch == 'work':
         failure_category = 'wrong_branch'
         next_action = 'Branch work is non-authoritative for Stage 19/test-env operational work.'
-    elif matched_state and matched_by == 'branch':
-        failure_category = 'current_branch_superseded'
-        next_action = 'Switch to fix/test-env-roadmap-recreate or a clean child branch.'
-    elif matched_state and matched_by == 'head':
-        failure_category = 'current_head_superseded'
-        next_action = 'Do not use this superseded commit as authority; switch to the current test-env branch.'
     elif not head_contains_authority:
         failure_category = 'stale_stage19_context'
         next_action = 'Current HEAD is not based on the authoritative test-environment commit.'
@@ -179,17 +169,21 @@ def resolve_project_state(
         'stage19_status': stage19_status,
         'stage19as_au_status': stage19as_au_status,
         'current_state_is_superseded': matched_state is not None,
+        'matched_invalid_state': public_state(matched_state),
         'matched_superseded_state': public_state(matched_state),
         'safe_for_operational_work': safe_for_operational_work,
         'safe_for_docs_only_work': safe_for_docs_only_work,
         'failure_category': failure_category,
         'next_action': next_action,
-        'authority_test_env_branch': current_authority.get('test_env_branch'),
+        'authority_test_env_branch': authority_test_env_branch(authority),
         'authority_test_env_head': expected_head,
         'head_contains_authority': head_contains_authority,
         'authority_commit_available': authority_commit_available,
-        'superseded_states': [public_state(state) for state in authority.get('superseded_states', [])],
-        'prompt_rules': authority.get('prompt_rules', {}),
+        'invalid_states': [public_state(state) for state in invalid_states(authority)],
+        'superseded_states': [public_state(state) for state in invalid_states(authority)],
+        'historical_context': authority.get('historical_context', {}),
+        'rules': authority_rules(authority),
+        'prompt_rules': authority_rules(authority),
     }
 
 
@@ -202,8 +196,11 @@ def load_authority(path: Path) -> tuple[dict[str, Any] | None, str | None]:
         return None, 'authority_file_invalid'
     if not isinstance(data, dict):
         return None, 'authority_file_invalid'
-    required = ('current_authority', 'superseded_states', 'prompt_rules')
-    if any(key not in data for key in required):
+    simplified_required = ('stage19', 'invalid_states', 'rules')
+    legacy_required = ('current_authority', 'superseded_states', 'prompt_rules')
+    has_simplified = all(key in data for key in simplified_required)
+    has_legacy = all(key in data for key in legacy_required)
+    if not has_simplified and not has_legacy:
         return None, 'authority_file_invalid'
     return data, None
 
@@ -230,17 +227,21 @@ def build_failure(
         'stage19_status': stage19_status,
         'stage19as_au_status': stage19as_au_status,
         'current_state_is_superseded': False,
+        'matched_invalid_state': None,
         'matched_superseded_state': None,
         'safe_for_operational_work': False,
         'safe_for_docs_only_work': False,
         'failure_category': failure_category,
         'next_action': next_action,
-        'authority_test_env_branch': (authority or {}).get('current_authority', {}).get('test_env_branch'),
-        'authority_test_env_head': (authority or {}).get('current_authority', {}).get('test_env_head'),
+        'authority_test_env_branch': authority_test_env_branch(authority or {}),
+        'authority_test_env_head': authority_test_env_head(authority or {}),
         'head_contains_authority': False,
         'authority_commit_available': False,
-        'superseded_states': [public_state(state) for state in (authority or {}).get('superseded_states', [])],
-        'prompt_rules': (authority or {}).get('prompt_rules', {}),
+        'invalid_states': [public_state(state) for state in invalid_states(authority or {})],
+        'superseded_states': [public_state(state) for state in invalid_states(authority or {})],
+        'historical_context': (authority or {}).get('historical_context', {}),
+        'rules': authority_rules(authority or {}),
+        'prompt_rules': authority_rules(authority or {}),
         'allow_docs_only': allow_docs_only,
     }
 
@@ -271,26 +272,88 @@ def git_output(runner: GitRunner, args: Sequence[str]) -> str | None:
     return text or None
 
 
-def find_matching_superseded_state(
+def stage19_statuses(authority: Mapping[str, Any]) -> tuple[str, str]:
+    stage19 = authority.get('stage19', {})
+    if isinstance(stage19, Mapping):
+        status = stage19.get('status')
+        stage19as_au_status = stage19.get('stage19as_au_status')
+        if status is not None or stage19as_au_status is not None:
+            return str(status or 'unknown'), str(stage19as_au_status or 'unknown')
+
+    current_authority = authority.get('current_authority', {})
+    if isinstance(current_authority, Mapping):
+        return (
+            str(current_authority.get('stage19_status', 'unknown')),
+            str(current_authority.get('stage19as_au_status', 'unknown')),
+        )
+    return 'unknown', 'unknown'
+
+
+def authority_test_env_branch(authority: Mapping[str, Any]) -> str | None:
+    current_authority = authority.get('current_authority', {})
+    if not isinstance(current_authority, Mapping):
+        return None
+    value = current_authority.get('test_env_branch')
+    return str(value) if value is not None else None
+
+
+def authority_test_env_head(authority: Mapping[str, Any]) -> str:
+    current_authority = authority.get('current_authority', {})
+    if not isinstance(current_authority, Mapping):
+        return ''
+    return str(current_authority.get('test_env_head', ''))
+
+
+def invalid_states(authority: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    states = authority.get('invalid_states')
+    if isinstance(states, list):
+        return [state for state in states if isinstance(state, Mapping)]
+
+    legacy_states = authority.get('superseded_states')
+    if isinstance(legacy_states, list):
+        return [state for state in legacy_states if isinstance(state, Mapping)]
+    return []
+
+
+def authority_rules(authority: Mapping[str, Any]) -> Mapping[str, Any]:
+    rules = authority.get('rules')
+    if isinstance(rules, Mapping):
+        return rules
+
+    prompt_rules = authority.get('prompt_rules')
+    if isinstance(prompt_rules, Mapping):
+        return prompt_rules
+    return {}
+
+
+def find_matching_invalid_state(
     authority: Mapping[str, Any],
     current_branch: str,
     current_head: str,
 ) -> tuple[Mapping[str, Any] | None, str | None]:
-    for state in authority.get('superseded_states', []):
+    for state in invalid_states(authority):
         if state.get('branch') and state.get('branch') == current_branch:
             return state, 'branch'
-    for state in authority.get('superseded_states', []):
+        if current_branch in state_identifiers(state):
+            return state, 'branch'
+    for state in invalid_states(authority):
         if any(commit_matches(current_head, commit) for commit in state_commits(state)):
             return state, 'head'
     return None, None
 
 
 def state_commits(state: Mapping[str, Any]) -> list[str]:
-    commits: list[str] = []
+    commits = state_identifiers(state)
     if state.get('commit'):
         commits.append(str(state['commit']))
     commits.extend(str(commit) for commit in state.get('commits', []))
     return commits
+
+
+def state_identifiers(state: Mapping[str, Any]) -> list[str]:
+    if state.get('id') is None:
+        return []
+    return [str(state['id'])]
 
 
 def commit_matches(current_head: str, known_commit: str) -> bool:
@@ -331,6 +394,7 @@ def print_human(result: Mapping[str, Any]) -> None:
         'stage19_status',
         'stage19as_au_status',
         'current_state_is_superseded',
+        'matched_invalid_state',
         'safe_for_operational_work',
         'safe_for_docs_only_work',
         'failure_category',

--- a/tests/test_project_state_resolver.py
+++ b/tests/test_project_state_resolver.py
@@ -11,8 +11,8 @@ ROOT = Path(__file__).resolve().parents[1]
 RESOLVER_PATH = ROOT / 'scripts' / 'dev' / 'resolve_project_state.py'
 AUTHORITY_PATH = ROOT / 'docs' / 'colonisation-redesign' / 'stage-19-state-authority.json'
 
-EXPECTED_HEAD = '581a84c1159b58dff86e3359a28d00f9b4f5a82b'
-EXPECTED_ORIGIN_MAIN = '49b0940cb014a319443525c3554d59387c2b6d90'
+DEFAULT_HEAD = '887c6900000000000000000000000000000000000'
+DEFAULT_ORIGIN_MAIN = '887c6900000000000000000000000000000000000'
 SECRET_SENTINEL = 'do-not-print-this-secret'
 
 spec = importlib.util.spec_from_file_location('resolve_project_state', RESOLVER_PATH)
@@ -31,13 +31,10 @@ def completed(args, returncode=0, stdout='', stderr=''):
 
 def git_runner(
     *,
-    branch='fix/test-env-roadmap-recreate',
-    head=EXPECTED_HEAD,
-    origin_main=EXPECTED_ORIGIN_MAIN,
+    branch='docs/trim-state-authority-history',
+    head=DEFAULT_HEAD,
+    origin_main=DEFAULT_ORIGIN_MAIN,
     origin_available=True,
-    origin_contains=True,
-    authority_available=True,
-    head_contains=True,
     inside_git=True,
 ):
     def run(args):
@@ -52,15 +49,6 @@ def git_runner(
             if not origin_available:
                 return completed(args, 128, '', SECRET_SENTINEL)
             return completed(args, 0, f'{origin_main}\n')
-        if args == ('rev-parse', '--verify', EXPECTED_HEAD):
-            return completed(args, 0 if authority_available else 128, f'{EXPECTED_HEAD}\n')
-        if args[:2] == ('merge-base', '--is-ancestor'):
-            ancestor = args[2]
-            target = args[3]
-            if ancestor == EXPECTED_ORIGIN_MAIN and target == 'origin/main':
-                return completed(args, 0 if origin_contains else 1)
-            if ancestor == EXPECTED_HEAD and target == 'HEAD':
-                return completed(args, 0 if head_contains else 1)
         return completed(args, 1, '', SECRET_SENTINEL)
 
     return run
@@ -78,9 +66,23 @@ def test_authority_file_parses():
     authority, error = resolver.load_authority(AUTHORITY_PATH)
 
     assert error is None
-    assert authority['current_authority']['stage19_status'] == 'paused'
-    assert authority['current_authority']['stage19as_au_status'] == 'not_run'
+    assert authority['schema_version'] == 1
+    assert authority['stage19']['status'] == 'paused'
+    assert authority['stage19']['stage19as_au_status'] == 'not_run'
     assert authority['approved_stage19ar_baseline']['rows'] == 25
+    assert [state['id'] for state in authority['invalid_states']] == [
+        '45e2d58',
+        'f72812a',
+        '8509171250b1449832a7fe3227d87acc02fb015e',
+    ]
+
+
+def test_active_authority_does_not_require_verbose_superseded_reasons():
+    authority, error = resolver.load_authority(AUTHORITY_PATH)
+
+    assert error is None
+    assert 'superseded_states' not in authority
+    assert all('reason' not in state for state in authority['invalid_states'])
 
 
 def test_json_output_works(capsys):
@@ -94,6 +96,9 @@ def test_json_output_works(capsys):
     assert exit_code == 0
     assert payload['failure_category'] == 'none'
     assert payload['safe_for_operational_work'] is True
+    assert payload['stage19_status'] == 'paused'
+    assert payload['stage19as_au_status'] == 'not_run'
+    assert 'matched_invalid_state' in payload
 
 
 def test_resolver_rejects_work_branch_for_operational_work():
@@ -108,24 +113,22 @@ def test_resolver_identifies_850917_on_work_as_non_authoritative():
     result = resolve(
         branch='work',
         head='8509171250b1449832a7fe3227d87acc02fb015e',
-        head_contains=False,
     )
 
-    assert result['failure_category'] == 'wrong_branch'
+    assert result['failure_category'] == 'current_head_superseded'
     assert result['current_state_is_superseded'] is True
-    assert result['matched_superseded_state']['id'] == 'non_authoritative_state_authority_attempt_850917_on_work'
-    assert result['matched_superseded_state']['evidence_only'] is True
+    assert result['matched_invalid_state']['id'] == '8509171250b1449832a7fe3227d87acc02fb015e'
+    assert result['safe_for_operational_work'] is False
 
 
 def test_resolver_rejects_45e2d58():
     result = resolve(
         branch='fix/stage19-approved-rebaseline',
         head='45e2d58abc000000000000000000000000000000',
-        head_contains=False,
     )
 
-    assert result['failure_category'] == 'current_branch_superseded'
-    assert result['matched_superseded_state']['id'] == 'superseded_partial_rebaseline_45e2d58'
+    assert result['failure_category'] == 'current_head_superseded'
+    assert result['matched_invalid_state']['id'] == '45e2d58'
     assert result['safe_for_operational_work'] is False
 
 
@@ -133,36 +136,30 @@ def test_resolver_rejects_f72812a():
     result = resolve(
         branch='run/stage19as-au-100-row-expansion',
         head='f72812abc0000000000000000000000000000000',
-        head_contains=False,
     )
 
-    assert result['failure_category'] == 'current_branch_superseded'
-    assert result['matched_superseded_state']['id'] == 'superseded_stage19as_au_docs_only_checkpoint_f72812a'
+    assert result['failure_category'] == 'current_head_superseded'
+    assert result['matched_invalid_state']['id'] == 'f72812a'
     assert result['safe_for_operational_work'] is False
 
 
-def test_resolver_lists_unrecoverable_historical_test_env_context():
+def test_archive_only_historical_stack_does_not_pollute_active_authority():
     result = resolve()
-    state = next(
-        item for item in result['superseded_states']
-        if item['id'] == 'unrecoverable_historical_test_env_stack_0042471_d66a568_09eee44'
-    )
+    invalid_ids = {state['id'] for state in result['invalid_states']}
 
-    assert state['status'] == 'unrecoverable_historical_context'
-    assert state['commits'] == ['0042471', 'd66a568', '09eee44']
-    assert state['replacement']['commit'] == EXPECTED_HEAD
+    assert {'0042471', 'd66a568', '09eee44'}.isdisjoint(invalid_ids)
+    assert result['historical_context']['unrecoverable_test_env_stack'] == [
+        '0042471',
+        'd66a568',
+        '09eee44',
+    ]
 
 
-def test_resolver_marks_uploaded_prompt_bundles_evidence_only():
+def test_uploaded_pasted_logs_are_evidence_only_rule_exists():
     result = resolve()
-    state = next(
-        item for item in result['superseded_states']
-        if item['id'] == 'uploaded_or_pasted_prompt_bundles'
-    )
 
-    assert state['status'] == 'evidence_only'
-    assert state['evidence_only'] is True
-    assert result['prompt_rules']['pasted_chat_logs_are_evidence_not_authority'] is True
+    assert result['rules']['pasted_logs_are_evidence_only'] is True
+    assert result['prompt_rules']['pasted_logs_are_evidence_only'] is True
 
 
 def test_missing_authority_file_fails_closed(tmp_path):


### PR DESCRIPTION
This PR simplifies the active Stage 19/test-environment state authority so it contains only current operational truth, durable rules, and a tiny invalid-state denylist.

Moved verbose retired/superseded incident history to:

`docs/archive/stage-19-incident-history.md`

The archive is explicitly evidence-only and must not be used as operational authority.

Active authority now lives at:

`docs/colonisation-redesign/stage-19-state-authority.json`

Active invalid states are intentionally tiny:

* `45e2d58`
* `f72812a`
* `8509171250b1449832a7fe3227d87acc02fb015e`

The resolver and docs now support the simplified authority model:

* active authority contains current truth
* archive contains verbose history
* pasted/uploaded logs remain evidence only
* prompt templates use the resolver instead of stale copied blocks
* Stage 19AS-AU remains paused and was not run

Validation:

* `tests/test_project_state_resolver.py` passed
* test environment/preflight tests passed in the prior validation run
* `py_compile` passed
* `git diff --check` passed
* real DB readiness tests had 1 pass and 2 explicit `credentials_missing` skips in the prior validation run
* no secrets printed
* Stage 19AS-AU expansion attempted: false