### PR TITLE
Add safe DB isolation test guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Real builds happen via docker compose / yarn / pytest directly; this
 # Makefile just collects the most-used recipes so you don't have to
 # remember the env-var incantations.
-.PHONY: help lint typecheck test seed-check api-smoke state-check state-check-docs test-env-check test-unit test-operator test-db test-integration test-ci-local clean
+.PHONY: help lint typecheck test seed-check api-smoke state-check state-check-docs test-env-check test-unit test-operator test-db test-db-isolation test-integration test-ci-local clean
 
 PYTHON ?= python
 
@@ -17,7 +17,7 @@ seed-check:  ## Apply every sql/*.sql with ON_ERROR_STOP=1 + invariants
 # ── Backend ──────────────────────────────────────────────────────────────────
 test:  ## Run backend unit + integration tests
 	python -m unittest discover -s tests -p test_smoke.py
-	DATABASE_URL=$${DATABASE_URL:-postgresql://edfinder:edfinder@localhost:5432/edfinder} \
+	DATABASE_URL=$${DATABASE_URL:-postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder} \
 	REDIS_URL=$${REDIS_URL:-redis://localhost:6379/15} \
 	CORS_ORIGINS=$${CORS_ORIGINS:-http://test} \
 	ADMIN_TOKEN=$${ADMIN_TOKEN:-test-admin-token} \
@@ -43,12 +43,16 @@ test-operator:  ## Run Stage 19 operator safety tests
 test-db:  ## Run DB-marked tests, including explicit skips for absent real services
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m db -rs
 
+test-db-isolation:  ## Run DB isolation guardrails and real Postgres readiness checks
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_db_isolation_guardrails.py tests/test_stage19_real_postgres_readiness.py -p no:cacheprovider -rs
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m py_compile tests/helpers/db_isolation.py
+
 test-integration:  ## Run integration-marked tests
 	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m integration -rs
 
-test-ci-local: test-env-check  ## Run focused local CI checks for the test environment stack
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_test_env_preflight.py tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py tests/test_stage19_real_postgres_readiness.py -rs
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m py_compile scripts/dev/test_env_preflight.py scripts/operator/stage19ar_edsm_25_row_staging_pilot.py scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py
+test-ci-local: test-env-check test-db-isolation  ## Run focused local CI checks for the test environment stack
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_test_env_preflight.py tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py -rs
+	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m py_compile scripts/dev/test_env_preflight.py scripts/operator/stage19ar_edsm_25_row_staging_pilot.py scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py tests/helpers/db_isolation.py
 	git diff --check
 
 api-smoke:  ## Curl the Phase-2 happy paths against a running API

--- a/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
+++ b/docs/colonisation-redesign/stage-19ar-canonical-baseline.md
@@ -103,6 +103,25 @@ Source repair already applied:
 
 Rule: source-correct DB preflight against `127.0.0.1:55432` must pass without relying on cached bytecode before any Stage 19AR rebaseline verification or Stage 19AS-AU work.
 
+## DB isolation guardrails
+
+The shared test helper `tests/helpers/db_isolation.py` is now the local DB
+safety gate for optional Postgres smoke tests and real Stage 19 readiness
+checks.
+
+Required properties:
+
+- local/disposable database targets only;
+- production-like DSNs fail closed;
+- passwords are redacted in summaries;
+- `localhost:5432` is not selected silently for local work;
+- destructive reset requires `EDFINDER_TEST_DB_ALLOW_DESTRUCTIVE_RESET=yes`
+  outside CI;
+- optional staging/canonical smoke tests keep their explicit `*_CONFIRM_*`
+  environment gates;
+- Stage 19AS-AU remains paused and no expansion has been attempted from this
+  branch.
+
 ## Required Guardrails
 
 - Canonical Stage 19AR mode requires the exact approved replacement `source_run_key`.

--- a/docs/development/test-double-inventory.md
+++ b/docs/development/test-double-inventory.md
@@ -11,6 +11,7 @@ This inventory separates unit-level test doubles from real-service proof. A fake
 | `FakeConn` / `FakeCursor` | `tests/test_stage19ar_operator_script.py` | unit fake | Exercise Stage 19AR and Stage 19AS-AU operator SQL paths without DB writes | `tests/test_stage19_real_postgres_readiness.py` |
 | `FakeAsyncConn` / `FakePool` | `tests/test_stage19ap_operator_visibility.py` | unit fake | Exercise operator visibility query composition and router path handling | `tests/test_stage19_real_postgres_readiness.py` plus local preflight |
 | command runner doubles | `tests/test_test_env_preflight.py` | unit stub | Classify Docker/Postgres/preflight command outcomes without touching services | `scripts/dev/test_env_preflight.py` |
+| DB connection doubles | `tests/test_db_isolation_guardrails.py` | unit fake | Prove rollback and close behavior without opening a real database socket | Optional Postgres smoke tests using `tests/helpers/db_isolation.py` |
 
 ## FakeConn and FakeCursor Status
 
@@ -22,6 +23,12 @@ unit-level fakes paired with real local Postgres readiness coverage
 `FakeConn` and `FakeCursor` are still useful for commit/rollback, validation, and artifact-guard tests. They are not accepted as Stage 19 readiness proof by themselves.
 
 The real-service pair is `tests/test_stage19_real_postgres_readiness.py`. It uses live Postgres through `psycopg2`, runs in read-only transaction mode, checks `SELECT 1`, and verifies the approved Stage 19AR baseline identity when local credentials and service are available. It skips explicitly for absent credentials or absent service and does not fall back to fakes.
+
+All optional Postgres smoke tests now route their DSN checks through
+`tests/helpers/db_isolation.py`. The helper rejects production-like hosts or
+database names, redacts passwords from summaries, requires explicit
+confirmation for staging/canonical smoke writes, and keeps `localhost:5432`
+out of the local default path.
 
 ## Confidence Rules
 

--- a/docs/development/test-environment.md
+++ b/docs/development/test-environment.md
@@ -25,6 +25,35 @@ The preflight is fail-closed and reports structured JSON. It checks:
 
 The default project Postgres target is `127.0.0.1:55432`. That keeps this validation away from a host Postgres listener on `5432` unless the operator explicitly supplies a different target through `PGHOST`, `PGPORT`, or `DATABASE_URL`.
 
+## DB Isolation Guardrails
+
+Shared test DB target validation lives in `tests/helpers/db_isolation.py`.
+It is fail-closed and test-only. It validates local/disposable database
+targets, redacts DSNs for reporting, provides rollback-transaction support,
+generates safe schema names, and blocks destructive reset unless the caller is
+inside CI or explicitly sets:
+
+```text
+EDFINDER_TEST_DB_ALLOW_DESTRUCTIVE_RESET=yes
+```
+
+The helper refuses production-looking targets and does not silently default to
+host Postgres on `5432`. Local `localhost:5432` is allowed only when the target
+is known disposable and the operator explicitly sets:
+
+```text
+EDFINDER_ALLOW_HOST_5432_TEST_DB=yes
+```
+
+CI may use `localhost:5432` because the workflow service container is
+disposable for that run. Local work should prefer `127.0.0.1:55432`.
+
+Run the guardrails directly:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 python -B -m pytest tests/test_db_isolation_guardrails.py -p no:cacheprovider
+```
+
 Expected safety properties:
 
 ```text
@@ -59,6 +88,7 @@ The Makefile includes:
 - `test-unit`
 - `test-operator`
 - `test-db`
+- `test-db-isolation`
 - `test-integration`
 - `test-ci-local`
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers."""

--- a/tests/helpers/db_isolation.py
+++ b/tests/helpers/db_isolation.py
@@ -1,0 +1,284 @@
+"""Fail-closed helpers for local/disposable database tests.
+
+The helpers in this module are test-only. They intentionally reject
+production-looking targets, avoid secret output, and keep host Postgres on
+5432 out of the default path unless CI or an explicit local opt-in says the
+target is disposable.
+"""
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urlsplit, urlunsplit
+
+
+DEFAULT_TEST_DB_HOST = '127.0.0.1'
+DEFAULT_TEST_DB_PORT = '55432'
+DEFAULT_TEST_DB_NAME = 'edfinder'
+DEFAULT_TEST_DB_USER = 'edfinder'
+DEFAULT_TEST_DB_PASSWORD = 'edfinder'
+
+ALLOWED_TEST_HOSTS = {'localhost', '127.0.0.1', '::1', 'postgres'}
+PRODUCTION_MARKERS = (
+    'prod',
+    'production',
+    'live',
+    'hetzner',
+    'ed-finder.app',
+    'edfinder.app',
+)
+HOST_5432_OPT_IN_ENV = 'EDFINDER_ALLOW_HOST_5432_TEST_DB'
+DESTRUCTIVE_RESET_OPT_IN_ENV = 'EDFINDER_TEST_DB_ALLOW_DESTRUCTIVE_RESET'
+
+_SAFE_SCHEMA_RE = re.compile(r'^[a-z][a-z0-9_]{0,62}$')
+
+
+class DbIsolationError(RuntimeError):
+    """Raised when a test database target is unsafe or ambiguous."""
+
+
+@dataclass(frozen=True)
+class DbTarget:
+    dsn: str
+    redacted_dsn: str
+    host: str
+    port: str
+    database: str
+    user: str | None
+    password_present: bool
+    host_postgres_5432_targeted: bool
+    host_5432_allowed: bool
+    source: str
+
+    def safe_summary(self) -> dict[str, object]:
+        return {
+            'dsn': self.redacted_dsn,
+            'host': self.host,
+            'port': self.port,
+            'database': self.database,
+            'user': self.user,
+            'password_present': self.password_present,
+            'host_postgres_5432_targeted': self.host_postgres_5432_targeted,
+            'host_5432_allowed': self.host_5432_allowed,
+            'source': self.source,
+        }
+
+
+def default_database_url() -> str:
+    return (
+        f'postgresql://{DEFAULT_TEST_DB_USER}:{DEFAULT_TEST_DB_PASSWORD}'
+        f'@{DEFAULT_TEST_DB_HOST}:{DEFAULT_TEST_DB_PORT}/{DEFAULT_TEST_DB_NAME}'
+    )
+
+
+def default_target(env: Mapping[str, str] | None = None) -> DbTarget:
+    return validate_test_db_target(default_database_url(), env=env or {}, source='default_test_db')
+
+
+def target_from_env(
+    env: Mapping[str, str] | None = None,
+    *,
+    dsn_env: str = 'DATABASE_URL',
+    source: str | None = None,
+) -> DbTarget:
+    source_env = env or os.environ
+    if source_env.get(dsn_env):
+        return validate_test_db_target(source_env[dsn_env], env=source_env, source=source or dsn_env)
+    return target_from_pg_env(source_env, source=source or 'pg_env')
+
+
+def target_from_pg_env(env: Mapping[str, str] | None = None, *, source: str = 'pg_env') -> DbTarget:
+    source_env = env or os.environ
+    host = _first_text(source_env.get('PGHOST'), DEFAULT_TEST_DB_HOST)
+    port = _first_text(source_env.get('PGPORT'), DEFAULT_TEST_DB_PORT)
+    database = _first_text(source_env.get('PGDATABASE'), DEFAULT_TEST_DB_NAME)
+    user = _first_text(source_env.get('PGUSER'), DEFAULT_TEST_DB_USER)
+    password = _first_text(
+        source_env.get('PGPASSWORD'),
+        source_env.get('POSTGRES_PASSWORD'),
+        DEFAULT_TEST_DB_PASSWORD,
+    )
+    dsn = f'postgresql://{quote(user)}:{quote(password)}@{host}:{port}/{database}'
+    return validate_test_db_target(dsn, env=source_env, source=source)
+
+
+def confirmed_target_or_skip(
+    *,
+    dsn_env: str,
+    confirm_env: str,
+    purpose: str,
+    env: Mapping[str, str] | None = None,
+) -> DbTarget:
+    import pytest
+
+    source_env = env or os.environ
+    dsn = source_env.get(dsn_env)
+    confirmed = source_env.get(confirm_env) == 'yes'
+    if not dsn or not confirmed:
+        pytest.skip(f'{purpose} requires {dsn_env} and {confirm_env}=yes')
+    try:
+        return validate_test_db_target(dsn, env=source_env, source=dsn_env)
+    except DbIsolationError as exc:
+        pytest.fail(str(exc))
+
+
+def validate_test_db_target(
+    dsn: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    source: str = 'dsn',
+) -> DbTarget:
+    source_env = env or os.environ
+    parsed = parse_dsn(dsn)
+    host = _first_text(parsed.get('host'), '')
+    port = _first_text(parsed.get('port'), DEFAULT_TEST_DB_PORT)
+    database = _first_text(parsed.get('database'), '')
+    user = parsed.get('user')
+    password_present = bool(parsed.get('password_present'))
+
+    if not host:
+        raise DbIsolationError('test DB target has no host')
+    if host not in ALLOWED_TEST_HOSTS:
+        raise DbIsolationError(f'unsafe test DB host {host!r}; expected local/disposable host')
+    if not database:
+        raise DbIsolationError('test DB target has no database name')
+    if _contains_production_marker(' '.join((dsn, host, database, str(user or '')))):
+        raise DbIsolationError('unsafe test DB target contains production-like marker')
+    if not password_present:
+        raise DbIsolationError('test DB target must include credentials without printing them')
+
+    host_5432 = host in {'localhost', '127.0.0.1', '::1'} and str(port) == '5432'
+    host_5432_allowed = host_5432_is_allowed(source_env)
+    if host_5432 and not host_5432_allowed:
+        raise DbIsolationError(
+            'localhost:5432 is not a default-safe test DB target; use the isolated '
+            f'{DEFAULT_TEST_DB_PORT} port or set {HOST_5432_OPT_IN_ENV}=yes for a disposable DB'
+        )
+
+    return DbTarget(
+        dsn=dsn,
+        redacted_dsn=redact_dsn(dsn),
+        host=host,
+        port=str(port),
+        database=database,
+        user=str(user) if user is not None else None,
+        password_present=password_present,
+        host_postgres_5432_targeted=host_5432,
+        host_5432_allowed=host_5432_allowed,
+        source=source,
+    )
+
+
+def parse_dsn(dsn: str) -> dict[str, object]:
+    if '://' in dsn:
+        parsed = urlsplit(dsn)
+        return {
+            'host': parsed.hostname,
+            'port': str(parsed.port) if parsed.port is not None else None,
+            'database': parsed.path.lstrip('/') or None,
+            'user': parsed.username,
+            'password_present': bool(parsed.password),
+        }
+    parts = dict(part.split('=', 1) for part in dsn.split() if '=' in part)
+    return {
+        'host': parts.get('host'),
+        'port': parts.get('port'),
+        'database': parts.get('dbname') or parts.get('database'),
+        'user': parts.get('user'),
+        'password_present': bool(parts.get('password')),
+    }
+
+
+def redact_dsn(dsn: str) -> str:
+    if '://' in dsn:
+        parsed = urlsplit(dsn)
+        netloc = parsed.netloc
+        if parsed.password is not None:
+            user = quote(parsed.username or '', safe='')
+            host = parsed.hostname or ''
+            if ':' in host and not host.startswith('['):
+                host = f'[{host}]'
+            port = f':{parsed.port}' if parsed.port is not None else ''
+            netloc = f'{user}:***@{host}{port}'
+        return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+    redacted_parts: list[str] = []
+    for part in dsn.split():
+        if part.lower().startswith('password='):
+            redacted_parts.append('password=***')
+        else:
+            redacted_parts.append(part)
+    return ' '.join(redacted_parts)
+
+
+def require_destructive_reset_opt_in(env: Mapping[str, str] | None = None) -> None:
+    source_env = env or os.environ
+    if source_env.get(DESTRUCTIVE_RESET_OPT_IN_ENV) == 'yes':
+        return
+    if source_env.get('CI') == 'true':
+        return
+    raise DbIsolationError(f'destructive reset requires {DESTRUCTIVE_RESET_OPT_IN_ENV}=yes')
+
+
+def safe_schema_name(prefix: str, token: str | None = None) -> str:
+    normalized = re.sub(r'[^a-z0-9_]+', '_', prefix.lower()).strip('_')
+    if not normalized or not normalized[0].isalpha():
+        normalized = f't_{normalized}'
+    suffix = token or uuid.uuid4().hex[:12]
+    schema = f'{normalized}_{suffix}'
+    schema = schema[:63].rstrip('_')
+    if not _SAFE_SCHEMA_RE.match(schema):
+        raise DbIsolationError(f'unsafe generated schema name {schema!r}')
+    return schema
+
+
+def validate_schema_name(schema: str) -> str:
+    if not _SAFE_SCHEMA_RE.match(schema):
+        raise DbIsolationError(f'unsafe schema name {schema!r}')
+    return schema
+
+
+@contextmanager
+def rollback_transaction(
+    connect: Callable[[str], Any],
+    target: DbTarget | str,
+    *,
+    readonly: bool = False,
+) -> Iterator[Any]:
+    dsn = target.dsn if isinstance(target, DbTarget) else target
+    conn = connect(dsn)
+    try:
+        if hasattr(conn, 'set_session'):
+            conn.set_session(readonly=readonly, autocommit=False)
+        elif hasattr(conn, 'autocommit'):
+            conn.autocommit = False
+        yield conn
+    finally:
+        rollback = getattr(conn, 'rollback', None)
+        if callable(rollback):
+            rollback()
+        close = getattr(conn, 'close', None)
+        if callable(close):
+            close()
+
+
+def host_5432_is_allowed(env: Mapping[str, str] | None = None) -> bool:
+    source_env = env or os.environ
+    return source_env.get(HOST_5432_OPT_IN_ENV) == 'yes' or source_env.get('CI') == 'true'
+
+
+def _contains_production_marker(value: str) -> bool:
+    lowered = value.lower()
+    return any(marker in lowered for marker in PRODUCTION_MARKERS)
+
+
+def _first_text(*values: object) -> str:
+    for value in values:
+        if value is not None and str(value):
+            return str(value)
+    return ''

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ Provides:
 These fixtures expect a running PostgreSQL with the project schema
 already loaded, plus a Redis instance, both pointed at by env vars:
 
-    DATABASE_URL  = postgresql://edfinder:edfinder@localhost:5432/edfinder
+    DATABASE_URL  = postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder
     REDIS_URL     = redis://localhost:6379/15        # /15 = test DB
     CORS_ORIGINS  = http://test
     ADMIN_TOKEN   = test-admin-token
@@ -30,8 +30,18 @@ _ROOT = _HERE.parent.parent     # tests/integration/conftest.py → repo root
 sys.path.insert(0, str(_ROOT / 'apps' / 'api' / 'src'))
 sys.path.insert(0, str(_ROOT / 'apps' / 'importer' / 'src'))
 
+from tests.helpers import db_isolation
+
 # --- env defaults that must be set BEFORE importing the api ----------
-os.environ.setdefault('DATABASE_URL', 'postgresql://edfinder:edfinder@localhost:5432/edfinder')
+if 'DATABASE_URL' in os.environ:
+    _db_target = db_isolation.validate_test_db_target(
+        os.environ['DATABASE_URL'],
+        env=os.environ,
+        source='DATABASE_URL',
+    )
+else:
+    _db_target = db_isolation.default_target(os.environ)
+    os.environ['DATABASE_URL'] = _db_target.dsn
 os.environ.setdefault('REDIS_URL', 'redis://localhost:6379/15')
 os.environ.setdefault('CORS_ORIGINS', 'http://test')
 os.environ.setdefault('ADMIN_TOKEN', 'test-admin-token')
@@ -94,6 +104,7 @@ async def clean_db():
     it (and slow the suite). Uses a separate connection to keep the
     truncate transaction tiny.
     """
+    db_isolation.require_destructive_reset_opt_in(os.environ)
     pool = await asyncpg.create_pool(
         dsn=os.environ['DATABASE_URL'], min_size=1, max_size=2,
         statement_cache_size=0,

--- a/tests/test_db_isolation_guardrails.py
+++ b/tests/test_db_isolation_guardrails.py
@@ -1,0 +1,121 @@
+import pytest
+
+from tests.helpers import db_isolation
+
+
+def test_default_target_uses_isolated_port_not_host_5432():
+    target = db_isolation.default_target({})
+
+    assert target.host == '127.0.0.1'
+    assert target.port == '55432'
+    assert target.host_postgres_5432_targeted is False
+    assert 'edfinder' in target.redacted_dsn
+    assert '***' in target.redacted_dsn
+
+
+@pytest.mark.parametrize(
+    'dsn,match',
+    [
+        ('postgresql://edfinder:secret@db.example.com:55432/edfinder', 'unsafe test DB host'),
+        ('postgresql://edfinder:secret@127.0.0.1:55432/edfinder_prod', 'production-like marker'),
+        ('postgresql://edfinder:secret@prod-db:55432/edfinder', 'unsafe test DB host'),
+        ('postgresql://edfinder@127.0.0.1:55432/edfinder', 'must include credentials'),
+        ('postgresql://edfinder:@127.0.0.1:55432/edfinder', 'must include credentials'),
+        ('postgresql://edfinder:secret@127.0.0.1:5432/edfinder', 'localhost:5432'),
+    ],
+)
+def test_unsafe_targets_fail_closed(dsn, match):
+    with pytest.raises(db_isolation.DbIsolationError, match=match):
+        db_isolation.validate_test_db_target(dsn, env={})
+
+
+def test_explicit_opt_in_allows_localhost_5432_for_disposable_db():
+    target = db_isolation.validate_test_db_target(
+        'postgresql://edfinder:secret@127.0.0.1:5432/edfinder',
+        env={db_isolation.HOST_5432_OPT_IN_ENV: 'yes'},
+    )
+
+    assert target.host_postgres_5432_targeted is True
+    assert target.host_5432_allowed is True
+
+
+def test_ci_allows_localhost_5432_service_container():
+    target = db_isolation.validate_test_db_target(
+        'postgresql://edfinder:secret@localhost:5432/edfinder',
+        env={'CI': 'true'},
+    )
+
+    assert target.host_postgres_5432_targeted is True
+    assert target.host_5432_allowed is True
+
+
+def test_secrets_are_redacted_from_url_and_keyword_dsns():
+    assert db_isolation.redact_dsn(
+        'postgresql://edfinder:super-secret@127.0.0.1:55432/edfinder'
+    ) == 'postgresql://edfinder:***@127.0.0.1:55432/edfinder'
+    assert db_isolation.redact_dsn(
+        'host=127.0.0.1 port=55432 dbname=edfinder user=edfinder password=super-secret'
+    ) == 'host=127.0.0.1 port=55432 dbname=edfinder user=edfinder password=***'
+
+
+def test_safe_summary_never_prints_secret():
+    target = db_isolation.validate_test_db_target(
+        'postgresql://edfinder:do-not-print@127.0.0.1:55432/edfinder',
+        env={},
+    )
+
+    summary = target.safe_summary()
+    assert 'do-not-print' not in repr(summary)
+    assert summary['dsn'] == 'postgresql://edfinder:***@127.0.0.1:55432/edfinder'
+
+
+def test_destructive_reset_requires_explicit_opt_in():
+    with pytest.raises(db_isolation.DbIsolationError, match='destructive reset requires'):
+        db_isolation.require_destructive_reset_opt_in({})
+
+    db_isolation.require_destructive_reset_opt_in({
+        db_isolation.DESTRUCTIVE_RESET_OPT_IN_ENV: 'yes',
+    })
+
+
+def test_safe_schema_names_are_generated_and_validated():
+    schema = db_isolation.safe_schema_name('Stage 19 AR', token='abc123')
+
+    assert schema == 'stage_19_ar_abc123'
+    assert db_isolation.validate_schema_name(schema) == schema
+    with pytest.raises(db_isolation.DbIsolationError):
+        db_isolation.validate_schema_name('unsafe-name;drop')
+
+
+def test_rollback_transaction_rolls_back_and_closes():
+    class FakeConn:
+        def __init__(self):
+            self.session = None
+            self.rollbacks = 0
+            self.closed = False
+
+        def set_session(self, **kwargs):
+            self.session = kwargs
+
+        def rollback(self):
+            self.rollbacks += 1
+
+        def close(self):
+            self.closed = True
+
+    fake = FakeConn()
+
+    def connect(dsn):
+        assert dsn == 'postgresql://edfinder:secret@127.0.0.1:55432/edfinder'
+        return fake
+
+    with db_isolation.rollback_transaction(
+        connect,
+        'postgresql://edfinder:secret@127.0.0.1:55432/edfinder',
+        readonly=True,
+    ) as conn:
+        assert conn is fake
+        assert fake.session == {'readonly': True, 'autocommit': False}
+
+    assert fake.rollbacks == 1
+    assert fake.closed is True

--- a/tests/test_enrichment_body_ring_staging_loader_postgres_smoke.py
+++ b/tests/test_enrichment_body_ring_staging_loader_postgres_smoke.py
@@ -8,16 +8,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers import db_isolation
 
-DSN = os.environ.get('EDFINDER_STAGING_TEST_DSN')
-CONFIRMED = os.environ.get('EDFINDER_CONFIRM_STAGING_TEST_DB') == 'yes'
-
-if not DSN or not CONFIRMED:
-    pytest.skip(
-        'optional body/ring Postgres smoke tests require EDFINDER_STAGING_TEST_DSN and '
-        'EDFINDER_CONFIRM_STAGING_TEST_DB=yes',
-        allow_module_level=True,
-    )
+TARGET = db_isolation.confirmed_target_or_skip(
+    dsn_env='EDFINDER_STAGING_TEST_DSN',
+    confirm_env='EDFINDER_CONFIRM_STAGING_TEST_DB',
+    purpose='optional body/ring Postgres smoke tests',
+)
+DSN = TARGET.dsn
 
 
 os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')

--- a/tests/test_enrichment_staging_db_loader_postgres_smoke.py
+++ b/tests/test_enrichment_staging_db_loader_postgres_smoke.py
@@ -7,16 +7,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers import db_isolation
 
-DSN = os.environ.get('EDFINDER_STAGING_TEST_DSN')
-CONFIRMED = os.environ.get('EDFINDER_CONFIRM_STAGING_TEST_DB') == 'yes'
-
-if not DSN or not CONFIRMED:
-    pytest.skip(
-        'optional Postgres smoke tests require EDFINDER_STAGING_TEST_DSN and '
-        'EDFINDER_CONFIRM_STAGING_TEST_DB=yes',
-        allow_module_level=True,
-    )
+TARGET = db_isolation.confirmed_target_or_skip(
+    dsn_env='EDFINDER_STAGING_TEST_DSN',
+    confirm_env='EDFINDER_CONFIRM_STAGING_TEST_DB',
+    purpose='optional Postgres staging loader smoke tests',
+)
+DSN = TARGET.dsn
 
 
 os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')

--- a/tests/test_enrichment_staging_reconciliation_postgres_smoke.py
+++ b/tests/test_enrichment_staging_reconciliation_postgres_smoke.py
@@ -9,16 +9,14 @@ from pathlib import Path
 
 import pytest
 
+from tests.helpers import db_isolation
 
-DSN = os.environ.get('EDFINDER_STAGING_TEST_DSN')
-CONFIRMED = os.environ.get('EDFINDER_CONFIRM_STAGING_TEST_DB') == 'yes'
-
-if not DSN or not CONFIRMED:
-    pytest.skip(
-        'optional reconciliation Postgres smoke tests require EDFINDER_STAGING_TEST_DSN and '
-        'EDFINDER_CONFIRM_STAGING_TEST_DB=yes',
-        allow_module_level=True,
-    )
+TARGET = db_isolation.confirmed_target_or_skip(
+    dsn_env='EDFINDER_STAGING_TEST_DSN',
+    confirm_env='EDFINDER_CONFIRM_STAGING_TEST_DB',
+    purpose='optional reconciliation Postgres smoke tests',
+)
+DSN = TARGET.dsn
 
 
 os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')

--- a/tests/test_stage19_real_postgres_readiness.py
+++ b/tests/test_stage19_real_postgres_readiness.py
@@ -1,8 +1,9 @@
 import os
 from collections.abc import Iterator, Mapping
-from urllib.parse import urlsplit
 
 import pytest
+
+from tests.helpers import db_isolation
 
 
 pytestmark = [
@@ -19,26 +20,25 @@ PROVENANCE_MARKER_KEY = 'stage19ar_bounded_25_row_pilot'
 
 
 def db_config(env: Mapping[str, str]) -> dict[str, object]:
-    parsed = parse_database_url(env.get('DATABASE_URL'))
+    target = db_isolation.target_from_env(env)
     return {
-        'database_url': env.get('DATABASE_URL'),
-        'host': first_text(env.get('PGHOST'), parsed.get('host'), '127.0.0.1'),
-        'port': first_text(env.get('PGPORT'), parsed.get('port'), '55432'),
-        'database': first_text(env.get('PGDATABASE'), parsed.get('database'), 'edfinder'),
-        'user': first_text(env.get('PGUSER'), parsed.get('user'), 'edfinder'),
-        'password_present': bool(
-            env.get('PGPASSWORD')
-            or env.get('POSTGRES_PASSWORD')
-            or parsed.get('password_present')
-        ),
+        'database_url': target.dsn,
+        'redacted_database_url': target.redacted_dsn,
+        'host': target.host,
+        'port': target.port,
+        'database': target.database,
+        'user': target.user,
+        'password_present': target.password_present,
+        'host_postgres_5432_targeted': target.host_postgres_5432_targeted,
     }
 
 
 @pytest.fixture(scope='module')
 def real_stage19_conn() -> Iterator[object]:
-    config = db_config(os.environ)
-    if not config['password_present']:
-        pytest.skip('real Stage 19 DB readiness skipped explicitly: credentials_missing')
+    try:
+        config = db_config(os.environ)
+    except db_isolation.DbIsolationError as exc:
+        pytest.skip(f'real Stage 19 DB readiness skipped explicitly: unsafe_target:{exc}')
 
     try:
         import psycopg2  # noqa: PLC0415
@@ -48,7 +48,7 @@ def real_stage19_conn() -> Iterator[object]:
 
     conn = None
     try:
-        conn = psycopg2.connect(build_dsn(config), cursor_factory=psycopg2.extras.RealDictCursor)
+        conn = psycopg2.connect(str(config['database_url']), cursor_factory=psycopg2.extras.RealDictCursor)
         conn.set_session(readonly=True, autocommit=False)
     except Exception as exc:
         if conn is not None:
@@ -142,40 +142,6 @@ def test_approved_stage19ar_baseline_is_present_in_real_local_postgres(real_stag
         'rows_with_marker': 25,
         'rows_with_canonical_write_blocked': 25,
     }
-
-
-def build_dsn(config: Mapping[str, object]) -> str:
-    if config.get('database_url'):
-        return str(config['database_url'])
-    password = os.environ.get('PGPASSWORD') or os.environ.get('POSTGRES_PASSWORD')
-    return ' '.join((
-        f'host={config["host"]}',
-        f'port={config["port"]}',
-        f'dbname={config["database"]}',
-        f'user={config["user"]}',
-        f'password={password}',
-        'sslmode=disable',
-    ))
-
-
-def parse_database_url(value: str | None) -> dict[str, object]:
-    if not value:
-        return {}
-    parsed = urlsplit(value)
-    return {
-        'host': parsed.hostname,
-        'port': str(parsed.port) if parsed.port is not None else None,
-        'database': parsed.path.lstrip('/') or None,
-        'user': parsed.username,
-        'password_present': parsed.password is not None,
-    }
-
-
-def first_text(*values: object) -> str:
-    for value in values:
-        if value is not None and str(value):
-            return str(value)
-    return 'unknown'
 
 
 def connection_skip_reason(exc: Exception) -> str:

--- a/tests/test_station_type_canonical_pilot_postgres.py
+++ b/tests/test_station_type_canonical_pilot_postgres.py
@@ -2,9 +2,10 @@ import os
 import sys
 import uuid
 from pathlib import Path
-from urllib.parse import quote, urlparse, urlunparse
 
 import pytest
+
+from tests.helpers import db_isolation
 
 
 os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
@@ -16,10 +17,6 @@ if str(IMPORTER_SRC) not in sys.path:
     sys.path.insert(0, str(IMPORTER_SRC))
 
 import station_type_canonical_pilot as pilot  # noqa: E402
-
-
-ALLOWED_TEST_HOSTS = {'localhost', '127.0.0.1', '::1', 'postgres'}
-PRODUCTION_MARKERS = {'prod', 'production', 'live', 'hetzner'}
 
 
 def test_postgres_rehearsal_applies_only_station_type_and_emits_artifacts(pg_env):
@@ -234,32 +231,11 @@ class _PgEnv:
 
 
 def _canonical_test_dsn_or_skip():
-    dsn = os.getenv('EDFINDER_CANONICAL_TEST_DSN')
-    confirm = os.getenv('EDFINDER_CONFIRM_CANONICAL_TEST_DB')
-    if not dsn:
-        pytest.skip('EDFINDER_CANONICAL_TEST_DSN is not set; skipping disposable canonical Postgres rehearsal')
-    if confirm != 'yes':
-        pytest.skip('EDFINDER_CONFIRM_CANONICAL_TEST_DB must be exactly yes for disposable canonical Postgres rehearsal')
-    _assert_safe_test_dsn(dsn)
-    return dsn
-
-
-def _assert_safe_test_dsn(dsn):
-    parsed = urlparse(dsn)
-    if parsed.scheme:
-        host = parsed.hostname
-        dbname = parsed.path.lstrip('/')
-    else:
-        parts = dict(part.split('=', 1) for part in dsn.split() if '=' in part)
-        host = parts.get('host')
-        dbname = parts.get('dbname')
-    if host not in ALLOWED_TEST_HOSTS:
-        pytest.fail(f'Unsafe canonical test DSN host {host!r}; expected local disposable host')
-    haystack = f'{dsn} {dbname or ""}'.lower()
-    if any(marker in haystack for marker in PRODUCTION_MARKERS):
-        pytest.fail('Unsafe canonical test DSN contains production-like marker')
-    if not dbname:
-        pytest.fail('Unsafe canonical test DSN has no database name')
+    return db_isolation.confirmed_target_or_skip(
+        dsn_env='EDFINDER_CANONICAL_TEST_DSN',
+        confirm_env='EDFINDER_CONFIRM_CANONICAL_TEST_DB',
+        purpose='disposable canonical Postgres rehearsal',
+    ).dsn
 
 
 def _create_schema(cur, sql, env):


### PR DESCRIPTION
## Summary
- Recreated the DB isolation bundle from authoritative `origin/main` (`1d7ba8a80a9b7c45a827b89ee60aa897fcdd6b79`) on `fix/test-env-db-isolation`.
- Added shared fail-closed DB isolation helper in `tests/helpers/db_isolation.py` with safe target validation, redacted DSN summaries, safe schema names, rollback transaction helper, local/disposable host checks, and explicit destructive-reset opt-in.
- Updated integration and optional Postgres smoke tests to route disposable DB targeting through the shared helper.
- Documented the DB isolation rules in the test environment, test double inventory, and Stage 19AR baseline notes.

## Files changed
- `Makefile`
- `docs/colonisation-redesign/stage-19ar-canonical-baseline.md`
- `docs/development/test-double-inventory.md`
- `docs/development/test-environment.md`
- `tests/helpers/__init__.py`
- `tests/helpers/db_isolation.py`
- `tests/integration/conftest.py`
- `tests/test_db_isolation_guardrails.py`
- `tests/test_enrichment_body_ring_staging_loader_postgres_smoke.py`
- `tests/test_enrichment_staging_db_loader_postgres_smoke.py`
- `tests/test_enrichment_staging_reconciliation_postgres_smoke.py`
- `tests/test_stage19_real_postgres_readiness.py`
- `tests/test_station_type_canonical_pilot_postgres.py`

## Validation
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_db_isolation_guardrails.py -p no:cacheprovider` -> 14 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19_real_postgres_readiness.py -p no:cacheprovider -rs` -> 1 passed, 2 skipped explicitly (`postgres_unavailable`)
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m py_compile scripts/dev/resolve_project_state.py scripts/dev/test_env_preflight.py tests/helpers/db_isolation.py` -> passed
- `git diff --check` -> passed

## Safety confirmations
- DB isolation helper added for local/disposable database tests.
- Safe target validation is present.
- Production-like DSNs are rejected.
- No silent host Postgres `5432` default is used.
- Destructive reset requires explicit opt-in or CI.
- No-secret logging is preserved through redacted helper summaries and test output.
- Unsafe DB targets fail closed.
- No production DB access.
- No imports run.
- No migrations run.
- No scheduler or timer enablement.
- No staging writes.
- No canonical writes.
- No canonical apply.
- Stage 19 remains paused.
- Stage 19AS-AU expansion was not attempted.