### PR TITLE
Refresh Stage 19AM closeout docs

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -553,6 +553,14 @@ These Grok ideas reinforce the next Stage 19 priorities:
 6. planner/map E2E coverage;
 7. UI performance work once warehouse-backed views grow.
 
+## Stage 19AM bounded multi-row EDSM staging rehearsal closeout
+
+Stage 19AM is historical closeout content recovered from old PR #186 and refreshed against current main. It records a bounded three-row local-file EDSM staging rehearsal with one `source_runs` row, one `enrichment_source_runs` bridge row, three diagnostic-only `staging_edsm_stations` rows, zero scheduler/timer enablement, zero canonical writes, and zero canonical apply.
+
+Current authority remains `docs/colonisation-redesign/stage-19-state-authority.json`: Stage 19 is paused, Stage 19AS-AU has not run, and this refresh did not execute Stage 19.
+
+Closeout: `docs/colonisation-redesign/stage-19am-multi-row-edsm-staging-rehearsal-closeout.md`.
+
 ## Stage 19AN-R warehouse-derived EDSM staging rehearsal closeout
 
 Stage 19AN-R used the reviewed operator script from PR #187 to run a bounded five-row warehouse-derived EDSM staging rehearsal.

--- a/docs/colonisation-redesign/stage-19am-multi-row-edsm-staging-rehearsal-closeout.md
+++ b/docs/colonisation-redesign/stage-19am-multi-row-edsm-staging-rehearsal-closeout.md
@@ -1,0 +1,90 @@
+# Stage 19AM bounded multi-row EDSM staging rehearsal closeout
+
+## Current refresh note
+
+This document refreshes historical closeout content recovered from old PR #186 against current `origin/main`.
+
+No Stage 19 command, import, migration, DB write, staging write, scheduler/timer enablement, canonical write, or canonical apply was run during this docs refresh.
+
+Current authority remains `docs/colonisation-redesign/stage-19-state-authority.json`: Stage 19 is paused, and Stage 19AS-AU has not run.
+
+## Historical scope
+
+The original Stage 19AM closeout recorded a bounded three-row local-file EDSM staging rehearsal.
+
+The historical rehearsal reported:
+
+- one `source_runs` row;
+- one `enrichment_source_runs` compatibility bridge row;
+- three `staging_edsm_stations` rows;
+- three diagnostic-only marks;
+- no bulk import;
+- no scheduler/timer enablement;
+- no migrations;
+- no canonical writes;
+- no canonical apply.
+
+The historical value of this closeout is evidence that the bounded local-file staging path had already been exercised with multiple diagnostic-only rows before later Stage 19 work continued.
+
+## Historical rehearsal identity
+
+| Field | Value |
+|---|---|
+| Source run key | `stage19am-edsm-multi-staging-20260606T083509Z` |
+| Legacy bridge key | `source_runs:stage19am-edsm-multi-staging-20260606T083509Z` |
+| Source run id | `8` |
+| Legacy bridge id | `10` |
+| Rows read | `3` |
+| Rows staged | `3` |
+| Staging rows inserted | `3` |
+| Staging rows marked diagnostic-only | `3` |
+
+## Historical artifact chain
+
+| Artifact | Schema | SHA-256 | Integrity |
+|---|---|---|---|
+| `edsm_multi_station_fixture_20260606T083509Z.json` | `fixture` | `7ed888c85289a01e26044c6e47948888c9f1e92888854c77eec577ad5c7e34d9` | `n/a` |
+| `edsm_multi_station_import_artifact_20260606T083509Z.json` | `stage_19t_edsm_station_import_mvp/v1` | `985826575492ff283a6af94a6053b6c939afdc1ca69ea7db6d8e3af93f654f0a` | `e29af5be4f640b0e2f1f123e0b9a70b756fbfca37af937c9238c9dcf78d4a73e` |
+| `edsm_multi_station_rehearsal_bundle_20260606T083509Z.json` | `edsm_multi_row_staging_rehearsal_bundle/v1` | `3fcc1cc1354e50587e4415757116b69b232d46647753dfe6ccbf07ce6ade6ef4` | `448fa0847fba3245add4699d2ed6e6ed25daca97ffbc1c2b20fe6745c4bb10e4` |
+
+## Historical verification summary
+
+The original closeout reported these verification checks as passing:
+
+| Check | Historical result |
+|---|---|
+| `preflight_no_existing_stage19am_rows` | true |
+| `source_run_committed` | true |
+| `source_run_succeeded` | true |
+| `source_run_counts_three` | true |
+| `legacy_bridge_committed` | true |
+| `legacy_bridge_dry_run_false` | true |
+| `three_staging_rows_inserted` | true |
+| `three_staging_rows_marked` | true |
+| `all_staging_rows_use_legacy_bridge` | true |
+| `all_staging_rows_diagnostic_only` | true |
+| `all_staging_rows_preserve_markers` | true |
+| `counts_incremented_as_expected` | true |
+| `import_artifact_integrity_valid` | true |
+| `source_run_artifact_file_sha_matches` | true |
+| `source_run_artifact_integrity_matches` | true |
+
+## Historical safety boundary
+
+The original closeout recorded these boundaries:
+
+- no bulk production import;
+- no scheduler/timer enablement;
+- no migrations;
+- no canonical writes;
+- no canonical apply;
+- all staged rows were diagnostic-only;
+- provenance preserved `canonical_write_allowed=false`.
+
+This refresh does not expand those boundaries. It only restores useful closeout documentation so the project history remains visible from current main.
+
+## Current status
+
+Stage 19AM is historical closeout content. It is not current execution authority.
+
+Current execution authority is `docs/colonisation-redesign/stage-19-state-authority.json`. As of this refresh, Stage 19 remains paused, Stage 19AS-AU has not run, and no Stage 19 execution happened while recovering this document.


### PR DESCRIPTION
## Summary

- Recovered useful unique Stage 19AM closeout content from old PR #186.
- Refreshed the closeout against current main.
- Added a minimal roadmap pointer to the recovered historical closeout.

## Safety

- Stage 19 remains paused.
- Stage 19AS-AU was not run.
- Current state authority remains the source of truth: `docs/colonisation-redesign/stage-19-state-authority.json`.
- No Stage 19 commands, imports, migrations, scheduler/timer enablement, DB mutation, staging writes, canonical writes, or canonical apply were run during this refresh.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -B scripts/dev/resolve_project_state.py --strict`
- `PYTHONDONTWRITEBYTECODE=1 python -B -m pytest tests/test_project_state_resolver.py -p no:cacheprovider`
- `git diff --check`