### PR TITLE
Archive Stage 18J historical reports

### DIFF
--- a/docs/archive/stage-18j-p12-bounded-external-identity-load-plan-review.md
+++ b/docs/archive/stage-18j-p12-bounded-external-identity-load-plan-review.md
@@ -1,0 +1,164 @@
+# Stage 18J-P12 bounded external identity load-plan review
+
+This document is historical evidence only.
+It is not current operational guidance.
+For current project state, use docs/colonisation-redesign/stage-19-state-authority.json.
+Stage 19 is currently paused.
+Stage 19AS-AU has not run.
+Do not use this document to authorize writes, canonical apply, production DB actions, or Stage 19 execution.
+
+## Archive source
+
+This archive preserves useful historical documentation from PR #133:
+
+- PR: https://github.com/brianstewart377-rgb/ed-finder/pull/133
+- Branch: `stage-18j-p12-bounded-external-identity-load-plan-review`
+- Head: `3a617fc1c3c69dc65cf007027f8e4ff4263ffb93`
+- Original title: `Stage 18J-P12 bounded external identity load-plan review`
+
+The original PR also changed active roadmap and runbook files. Those active sequencing updates are intentionally not restored here as current guidance.
+
+## Historical purpose
+
+Stage 18J-P12 reviewed a bounded no-write external station identity load-plan artifact generated on Hetzner after Stage 18J-P11.
+
+The original review was docs/review only. It recorded that it did not run production commands from Codex, touch the production database from Codex, load identity evidence, write to `station_external_identity`, run imports, run reconciliation, run the summarizer against production artifacts, run station-type dry-run, run canonical apply, create approval records, or start Stage 18K.
+
+## Historical artifact reviewed
+
+| Field | Historical value |
+|---|---|
+| Artifact type | `station_external_identity_load_plan/v1` |
+| Path | `/var/lib/ed-finder/operator-artifacts/stage-18j/station_external_identity_load_plan_20260603T071913Z.json` |
+| Size | `349K` |
+| Artifact SHA-256 | `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1` |
+| Artifact integrity SHA-256 | `f8cf7260425ba82b1fc476d3cd239dbf41e2b246040ad9b461750ae4322a544f` |
+| Source | `edsm_nightly_stations` |
+| Source run key | `6ad44d1ad04d53c958ba7f5877b01752a22e29d9e905627c7feba5bb9eca2db1` |
+| Source file key | `76f5c8aa5e55d267c96c16da026ff5cbfae58f1d63575d47759c9bf3aaa37c19` |
+| Max rows | `20` |
+
+## Historical safety result
+
+The artifact reported:
+
+- `dry_run = true`;
+- `read_only = true`;
+- `report_only = true`;
+- `canonical_writes_planned = 0`;
+- `station_type_writes_planned = 0`;
+- `identity_rows_planned = 20`;
+- `identity_rows_written = 0`.
+
+The original review recorded these post-checks:
+
+- secret/path sanity check: clean;
+- `station_external_identity` row count after artifact generation: `0`;
+- no identity rows were loaded;
+- no station-type dry-run was run;
+- no canonical apply was run.
+
+Historical conclusion: the artifact was safe as a no-write planning artifact. It did not approve or perform any insert into `station_external_identity`.
+
+## Historical load-plan counts
+
+| Field | Count |
+|---|---:|
+| `total_candidates_seen` | `298177` |
+| `eligible_confirmed_candidates_seen` | `261938` |
+| `planned_rows_count` | `20` |
+| `identity_rows_written` | `0` |
+
+The bounded plan selected only the first `20` eligible confirmed candidates for review. It did not plan the full eligible candidate set.
+
+## Historical planned row scope
+
+The original planned row scope was intentionally small:
+
+- planned rows in artifact: `20`;
+- sample non-planned candidates in artifact: `100`;
+- `max_rows = 20`;
+- source was restricted to `edsm_nightly_stations`;
+- source run/file filters matched the reviewed Stage 18J-P10 candidate artifact;
+- planned rows were candidate `station_external_identity` inserts for manual review only;
+- planned rows did not imply station-type canonical truth;
+- planned rows did not authorize station-type writes.
+
+The original artifact could support a later manual review packet, but it was not itself an approval packet for a controlled insert.
+
+## Historical skipped and rejected counts
+
+| Reason | Count |
+|---|---:|
+| `eligible_beyond_max_rows` | `261918` |
+| `source_only_no_canonical_station_match` | `35981` |
+| `ambiguous_canonical_station_match` | `258` |
+
+The `eligible_beyond_max_rows` rows remained unplanned only because of the bounded first-review cap. The source-only and ambiguous rows remained blocked from confirmed identity use.
+
+## Historical candidate status counts
+
+| Status | Count |
+|---|---:|
+| `confirmed_candidate` | `261938` |
+| `conflicting` | `258` |
+| `proposed` | `0` |
+| `rejected` | `35981` |
+
+`confirmed_candidate` was a planning status from the read-only matching workflow. It was not a production-confirmed external identity row.
+
+## Historical artifact integrity
+
+The artifact included both file-level and internal integrity checks:
+
+- file SHA-256: `3da39530223f92e89d7129d447944d39199b6510eee473ba1e84ceeb168c9db1`;
+- artifact integrity SHA-256: `f8cf7260425ba82b1fc476d3cd239dbf41e2b246040ad9b461750ae4322a544f`.
+
+The original review stated that any later review or load stage had to reference these exact hashes and source filters. That statement is preserved as historical context only and is not current authorization to run a load.
+
+## Historical not-run list
+
+P12 recorded that:
+
+- no production commands were run from Codex;
+- no production DB was touched from Codex;
+- no identity evidence was loaded;
+- no writes to `station_external_identity` occurred;
+- no imports were run;
+- no reconciliation was run;
+- no summarizer was run against production artifacts;
+- no station-type dry-run was run;
+- no canonical apply was run;
+- no approval record was created;
+- Stage 18K was not started.
+
+## Historical readiness verdict
+
+The original verdict was: `Ready only after extra review`.
+
+The artifact safely planned only `20` rows and wrote `0` rows. The original review said that was enough to proceed to a manual planned-row review packet, but not enough to authorize loading those rows. The planned rows themselves still needed review before any future insert into `station_external_identity`.
+
+## Historical manual review boundaries
+
+The original review said that before any controlled identity evidence load, a manual review packet should check every planned row:
+
+- canonical station ID is the intended station;
+- `system_id64` matches the intended canonical system;
+- station name is the intended source/canonical station;
+- source is `edsm_nightly_stations`;
+- at least one external ID is present;
+- no `market_id` is inferred from `stations.id`;
+- no `station_body_links.market_id` is used as general identity proof;
+- source run/file/hash provenance is present;
+- `identity_status = 'confirmed'` is appropriate for the selected row;
+- `conflict_reason = null` is appropriate;
+- no row implies station-type truth;
+- no row is ambiguous, rejected, proposed, or source-only.
+
+These checks are preserved as historical safety context only. They do not authorize current writes, current production DB work, canonical apply, or Stage 19 execution.
+
+## Stale sequencing caveat
+
+The original PR included recommended next stages and active roadmap/runbook edits for Stage 18J-P13 through Stage 18J-P17. Those old sequencing updates are not restored as current guidance.
+
+Current project state is governed by `docs/colonisation-redesign/stage-19-state-authority.json`: Stage 19 is paused, Stage 19AS-AU has not run, and this archive recovery did not execute Stage 19.

--- a/docs/archive/stage-18j-r-station-type-nonprod-rehearsal.md
+++ b/docs/archive/stage-18j-r-station-type-nonprod-rehearsal.md
@@ -1,0 +1,175 @@
+# Stage 18J-R station type non-production rehearsal
+
+This document is historical evidence only.
+It is not current operational guidance.
+For current project state, use docs/colonisation-redesign/stage-19-state-authority.json.
+Stage 19 is currently paused.
+Stage 19AS-AU has not run.
+Do not use this document to authorize writes, canonical apply, production DB actions, or Stage 19 execution.
+
+## Archive source
+
+This archive preserves useful historical documentation from PR #105:
+
+- PR: https://github.com/brianstewart377-rgb/ed-finder/pull/105
+- Branch: `stage-18j-r-station-type-nonprod-rehearsal`
+- Head: `14dc9aef0a16203fb407073a03aecba126ab8dfa`
+- Original title: `docs: Stage 18J-R station type non-production rehearsal report`
+
+The original PR also changed active roadmap and runbook files. Those active links and operational pointers are intentionally not restored here as current guidance.
+
+## Historical purpose
+
+Stage 18J-R rehearsed the Stage 18J station type canonical pilot without touching production data, creating production artifacts, starting broad backfill, or advancing beyond station-type-only scope.
+
+The historical rehearsal existed to show that the pilot tooling could build a deterministic dry-run artifact, exercise the guarded apply path against disposable fixture data, emit audit and rollback evidence, verify post-apply state, and keep every non-approved canonical table and downstream planner surface untouched.
+
+The original report stated that it was a rehearsal report, not production approval. The only canonical field in scope was `stations.station_type`; every other canonical field, derived product state, scheduler path, live crawler, and Docker invocation remained out of scope.
+
+## Historical preconditions
+
+The original report said the Stage 18J implementation was present on `main` through merge commit `acf7b88222ac1f0d20136815aa741f48dd426ec6`.
+
+Before any real apply command was considered, the operator had to confirm the DSN pointed only to a disposable or staging database. The rehearsal did not pass any DSN to the apply CLI and did not connect to Postgres. The guarded apply behavior was exercised only by `tests/test_station_type_canonical_pilot.py` through an in-memory `FakeApplyConn`.
+
+| Precondition | Historical rehearsal state |
+|---|---|
+| Stage 18J code present | Confirmed by branch history including merge commit `acf7b88`. |
+| Production apply forbidden | Confirmed; no production apply command was run. |
+| Production artifact forbidden | Confirmed; no artifact was produced from production data. |
+| Disposable or non-production data only | Confirmed; guarded apply used `FakeApplyConn` fixture rows only. |
+| Narrow scope | Confirmed; the pilot code and tests targeted only `stations.station_type`. |
+| Warehouse loaders remain non-canonical | Confirmed by boundary and loader tests in the validation set. |
+
+## Historical rehearsal environment
+
+| Environment item | Historical value |
+|---|---|
+| Branch | `stage-18j-r-station-type-nonprod-rehearsal` |
+| Base | `origin/main` at Stage 18J merge commit `acf7b88` |
+| Data source | Local pytest fixtures and in-memory fake connection |
+| Apply target | `FakeApplyConn`, not a real database |
+| Production DB | Not touched |
+| Production artifact | Not created |
+
+The original report included local branch-preparation commands. Those commands are intentionally not reproduced here as current instructions.
+
+## Historical validation commands and results
+
+The original report recorded these validation results:
+
+| Command group | Historical result |
+|---|---|
+| Stage 18J focused pytest | Passed: `26 passed in 0.10s`. |
+| Stage 18J plus warehouse boundary pytest set | Passed: `81 passed in 0.27s`. |
+| `py_compile` | Passed: no output. |
+| `git diff --check` | Passed: no output. |
+
+These results are preserved as historical evidence only. They are not current CI status and do not authorize current production apply.
+
+## Historical dry-run artifact result
+
+The rehearsal dry-run path was exercised by `test_dry_run_builds_deterministic_station_type_artifact` and `test_cli_writes_dry_run_json_artifact`.
+
+The dry-run builder produced `station_type_canonical_pilot_dry_run/v1`, marked the artifact as `dry_run = true`, recorded the canonical table as `stations`, recorded the canonical field as `station_type`, and embedded a canonical JSON SHA-256 checksum recomputed in the test.
+
+| Dry-run check | Historical rehearsal result |
+|---|---|
+| Versioned artifact | `station_type_canonical_pilot_dry_run/v1` |
+| Default dry-run behavior | Confirmed through builder and CLI tests. |
+| Approved table | `stations` only. |
+| Approved field | `station_type` only. |
+| Artifact checksum | Recomputed and matched through `pilot.artifact_sha256(...)`. |
+| Row limit behavior | Explicit limit accepted and first-pilot maximum enforced by code. |
+| Unsafe evidence handling | Blocked rows included explicit `blocking_reasons`. |
+
+## Historical guarded apply result
+
+The guarded apply path was exercised only against `FakeApplyConn` fixture data. The successful rehearsal constructed a dry-run artifact, approved its exact checksum, candidate count, table, field, source run, source file, approval ID, confirmation flag, and `max_rows = 1`, then called `apply_station_type_pilot(...)`.
+
+The fake database row began as `station_type = 'Unknown'` and ended as `station_type = 'Orbis'`.
+
+The apply rehearsal selected by canonical primary key plus `system_id64`, verified station name and station type pre-image, then updated only `stations.station_type`. The test inspected recorded SQL and confirmed that `distance_from_star` and `station_body_links` did not appear in the apply SQL.
+
+| Apply guard | Historical rehearsal result |
+|---|---|
+| Explicit confirmation required | Confirmed by parser and apply validation tests. |
+| Approval ID required | Confirmed by validation contract. |
+| Artifact checksum required | Confirmed; mismatched checksum failed closed. |
+| Candidate count approval required | Confirmed; count mismatch failed closed. |
+| Table and field approval required | Confirmed; non-`station_type` field failed closed. |
+| Explicit max row approval required | Confirmed; missing `max_rows` failed closed. |
+| Pre-image validation | Confirmed; changed station type rolled back. |
+| Identity pre-image validation | Confirmed; renamed station rolled back. |
+
+## Historical audit, rollback, and verification evidence
+
+The successful guarded apply rehearsal emitted an apply audit artifact with schema `station_type_canonical_pilot_apply/v1`. The audit included the apply run ID, dry-run artifact checksum, approval metadata, row-level old and new values, and summary counts.
+
+It also contained a rollback pre-image artifact with schema `station_type_canonical_pilot_rollback_preimage/v1` and a post-apply verification artifact with schema `station_type_canonical_pilot_verification/v1`.
+
+| Artifact | Historical evidence |
+|---|---|
+| Dry-run artifact | Versioned, checksumed, deterministic station-type-only artifact. |
+| Apply audit | `station_type_canonical_pilot_apply/v1`, summary `applied = 1`. |
+| Rollback pre-image | `station_type_canonical_pilot_rollback_preimage/v1`, old value captured before apply. |
+| Post-apply verification | `station_type_canonical_pilot_verification/v1`, summary `ok = true`. |
+| Secrets hygiene | No DSN, API key, or private path emitted by fixture artifacts. |
+
+The rollback pre-image row recorded `pre_image_value = 'Unknown'` and `applied_value = 'Orbis'`. The verification artifact confirmed that the row had the expected approved station type and that the verification summary was `ok = true`.
+
+## Historical tables confirmed untouched
+
+| Object or surface | Historical rehearsal status |
+|---|---|
+| `stations.station_type` | Only approved mutation in fixture apply. |
+| `systems` | Untouched. |
+| `bodies` | Untouched. |
+| `station_body_links` | Untouched and absent from apply SQL. |
+| `body_rings` | Untouched. |
+| `body_scan_facts` | Untouched. |
+| Distance fields | Untouched; `distance_from_star` absent from apply SQL. |
+| Services, economies, faction, government, allegiance | Untouched. |
+| Planner, scoring, Simulation Preview, optimiser, role, Build Plan state | Untouched. |
+| Live EDSM/API and Docker paths | Not invoked. |
+| Production scheduler wiring | Not added. |
+
+## Historical failure and stop conditions tested
+
+The fixture-backed rehearsal covered failure cases that were intended to remain stop conditions:
+
+- missing or mismatched stable external identity;
+- name-only identity;
+- internal primary-key-only identity;
+- ambiguous canonical matches;
+- mismatched `system_id64`;
+- station-name mismatch;
+- transient or unsupported station types;
+- known canonical values that should not be overwritten;
+- stale, volatile, source-only, or report-only evidence;
+- undated evidence without exception;
+- multi-field differences.
+
+The apply contract blocked unsupported write aliases, missing approval parameters, missing explicit confirmation, checksum mismatch, unapproved table or field, missing `max_rows`, changed canonical station type pre-image, and changed station identity pre-image. The pre-image failure cases rolled back the fake transaction and left fixture data unchanged.
+
+## Historical production blocks
+
+The original report said Stage 18J-R was not production approval. A production apply remained blocked until a separate production-specific approval confirmed the production DSN, row limit, artifact checksum, source run/file, operator approval ID, database boundary, role permissions, backup and rollback ownership, artifact storage, and post-apply verification procedure.
+
+| Production block | Historical status after rehearsal |
+|---|---|
+| Production apply | Still blocked; not run. |
+| Production artifact | Still blocked; not created. |
+| Broad canonical backfill | Still blocked. |
+| Non-station canonical writes | Still blocked. |
+| Live EDSM/API crawl | Still blocked. |
+| Docker invocation from UI/API | Still blocked. |
+| Production scheduler wiring | Still blocked. |
+| Ordinary warehouse loaders writing canonical tables | Still blocked. |
+| Migration | Not added; stop if future rehearsal could not run without one. |
+
+## Current authority caveat
+
+The original report's recommendation and active-doc links are preserved here only as historical evidence. They are not current operational guidance.
+
+Current project state is governed by `docs/colonisation-redesign/stage-19-state-authority.json`: Stage 19 is paused, Stage 19AS-AU has not run, and this archive recovery did not execute Stage 19.


### PR DESCRIPTION
## Summary

- Recovers unique historical documentation from PR #133 and PR #105.
- Adds archive-only copies of the Stage 18J-P12 bounded external identity load-plan review and the Stage 18J-R station type non-production rehearsal report.
- Keeps the recovered material in `docs/archive/` as historical evidence only.

## Safety

- Archive-only, not active operational guidance.
- Old roadmap/runbook sequencing was not restored as current guidance.
- Stage 19 remains paused.
- Stage 19AS-AU was not run.
- State authority remains the source of truth: `docs/colonisation-redesign/stage-19-state-authority.json`.
- No Stage 19 commands, imports, migrations, DB mutation, staging writes, canonical writes, or canonical apply were run.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -B scripts/dev/resolve_project_state.py --strict`
- `PYTHONDONTWRITEBYTECODE=1 python -B -m pytest tests/test_project_state_resolver.py -p no:cacheprovider`
- `git diff --check`
- `git diff --cached --check`