### PR TITLE
Stage 19AS.2 operator script contract

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -771,6 +771,12 @@ Next decisions only after the 25-row pilot is verified:
   pilots;
 - decide whether to formalize operator script contracts.
 
+Stage 19AS.2 now formalizes the operator-script contract as a repo-only
+docs/static-test checkpoint in
+`docs/colonisation-redesign/stage-19as2-operator-script-contract.md`. It does
+not run Stage 19 operator commands, connect to a database, write staging rows,
+write canonical tables, rebaseline, or run canonical apply.
+
 ### Deferred Stage 19AS.1 - Test Fortress / CI parity
 
 Deferred: this is important safety work, but it should not block the immediate
@@ -866,7 +872,7 @@ Deferred: eventually automate checks for:
 
 #### Operator script contract
 
-Deferred: future operator scripts should follow this contract:
+Stage 19AS.2 records this contract for future operator scripts:
 
 - dry-run default;
 - explicit `--commit` required for writes;

--- a/docs/colonisation-redesign/stage-19as2-operator-script-contract.md
+++ b/docs/colonisation-redesign/stage-19as2-operator-script-contract.md
@@ -1,0 +1,119 @@
+# Stage 19AS.2 - Operator Script Contract Formalization
+
+## Purpose
+
+Stage 19AS.2 turns the deferred Stage 19 operator-script contract into a
+repo-only safety checkpoint. It records the minimum contract future Stage 19
+operator scripts must satisfy before any wider pilot, scheduler work, canonical
+write lane, or canonical apply lane is considered.
+
+This checkpoint is documentation and static/unit test coverage only. It does
+not run Stage 19 operator commands. It does not connect to a database or create
+a new source run.
+
+## Current Authority
+
+Active authority remains
+`docs/colonisation-redesign/stage-19-state-authority.json`.
+
+- Stage 19AS-AU is complete and recorded.
+- Stage 19AS.1 is complete and recorded.
+- Stage 19 remains paused.
+- The approved Stage 19AR baseline remains the 5f777 source run, b617 artifact,
+  and 25 diagnostic rows.
+- The Stage 19AS-AU checkpoint remains the 100-row source run
+  `stage19as-au-edsm-100-row-controlled-expansion-1843ccf903dfa6c9`.
+- No canonical apply is complete.
+- No rebaseline is complete.
+
+## Operator Script Contract
+
+Stage 19 operator scripts must keep these boundaries explicit:
+
+- dry-run or read-only mode is the default;
+- writes require an explicit `--commit` opt-in;
+- pilot and rehearsal paths expose a bounded `--limit`;
+- hard maximum limits are required for committed expansion paths;
+- artifact output behavior is explicit through either a required
+  `--artifact-dir` or a documented default operator artifact directory;
+- preflight checks run before writes and detect unsafe leftovers where the path
+  can create Stage 19 rows;
+- writes produce an operator artifact with source-run, bridge, import artifact,
+  validation, and safety-summary fields;
+- post-run validation verifies diagnostic staging, bridge usage, artifact
+  hashes, artifact integrity, and canonical-write blocking;
+- error paths roll back the transaction before returning failure;
+- scheduler, timer, service-manager, canonical apply, and production import
+  dispatches stay out of these scripts;
+- shell mega-scripts must not replace repo operator scripts when a typed repo
+  script can express the safety boundary.
+
+## Known Script Notes
+
+`scripts/operator/stage19ar_edsm_25_row_staging_pilot.py` and
+`scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py` are the
+current bounded committed-pilot contract examples. They use explicit commit
+gates, hard limits, preflight checks, rollback behavior, operator artifacts,
+post-run validation, and canonical-write blocking.
+
+Stage 19AN-R
+(`scripts/operator/stage19anr_warehouse_derived_staging_rehearsal.py`) is older
+rehearsal code. It keeps the required `--artifact-dir`, explicit `--commit`,
+dry-run rollback, operator artifact, and canonical-write blocking boundaries,
+but it has only a lower-bound `--limit` check. Future committed expansion
+scripts should not copy that lower-bound-only limit behavior.
+
+`scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py` includes a
+read-only `--preflight-db` helper for operator target verification. Stage
+19AS.2 did not run it. Future use still requires an explicitly safe local or
+disposable target and must not target host `5432` directly for committed Stage
+19 work.
+
+## Added Coverage
+
+`tests/test_stage19as2_operator_script_contract.py` covers:
+
+- Stage 19AS-AU and Stage 19AS.1 remain recorded while Stage 19 stays paused;
+- Stage 19AS.2 is documented as repo-only static/unit coverage;
+- operator CLIs keep `--commit` opt-in and `--limit` controls;
+- artifact directory behavior is explicit;
+- committed-pilot scripts keep hard maximum limits;
+- operator scripts keep rollback, validation, artifact summary, and
+  no-canonical-write reporting;
+- scheduler, service-manager, canonical apply, production import dispatch, and
+  shell execution patterns are absent from Stage 19 operator scripts;
+- local CI parity includes the new static contract test without adding operator
+  commands.
+
+## Safety Boundary
+
+Stage 19AS.2 does not:
+
+- run Stage 19 operator expansion commands;
+- run Stage 19AR with `--commit`;
+- run Stage 19AS-AU with `--commit`;
+- run a full source batch;
+- connect to a database;
+- write staging rows;
+- write canonical tables;
+- run canonical apply;
+- rebaseline;
+- enable scheduler, timer, or service units;
+- target production-like DBs;
+- use host `5432` as a direct committed Stage 19 target;
+- print secrets;
+- commit runtime source JSON or operator artifact JSON.
+
+## Validation
+
+Expected focused validation:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19as2_operator_script_contract.py -p no:cacheprovider
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_project_state_resolver.py tests/test_stage19as1_disposable_postgres_constraints.py tests/test_stage19aq1_test_fortress_guardrails.py tests/test_stage19ar_operator_script.py -p no:cacheprovider
+git diff --check
+```
+
+These checks are repo-local and static/unit-only for AS.2. They must not run
+operator scripts or DB commands.

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -93,6 +93,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage19ap_operator_visibility.py \
     tests/test_stage19anr_operator_script.py \
     tests/test_stage19as1_disposable_postgres_constraints.py \
+    tests/test_stage19as2_operator_script_contract.py \
     tests/test_stage19aq1_test_fortress_guardrails.py \
     -q
 )

--- a/tests/test_stage19as2_operator_script_contract.py
+++ b/tests/test_stage19as2_operator_script_contract.py
@@ -1,0 +1,189 @@
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+ROADMAP_PATH = DOCS / 'stage-19-data-warehouse-utopia-roadmap.md'
+CONTRACT_DOC_PATH = DOCS / 'stage-19as2-operator-script-contract.md'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+
+OPERATOR_SCRIPTS = {
+    'Stage 19AR': ROOT / 'scripts' / 'operator' / 'stage19ar_edsm_25_row_staging_pilot.py',
+    'Stage 19AS-AU': ROOT / 'scripts' / 'operator' / 'stage19as_au_edsm_100_row_controlled_expansion.py',
+    'Stage 19AN-R': ROOT / 'scripts' / 'operator' / 'stage19anr_warehouse_derived_staging_rehearsal.py',
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+def _ast_value(node: ast.AST) -> object:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        return node.id
+    return ast.unparse(node)
+
+
+def _parser_options(path: Path) -> dict[str, dict[str, object]]:
+    tree = ast.parse(_read(path), filename=str(path))
+    options: dict[str, dict[str, object]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != 'add_argument':
+            continue
+        names = [
+            arg.value
+            for arg in node.args
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+        ]
+        keywords = {
+            keyword.arg: _ast_value(keyword.value)
+            for keyword in node.keywords
+            if keyword.arg is not None
+        }
+        for name in names:
+            options[name] = keywords
+    return options
+
+
+@pytest.mark.unit
+def test_stage19as2_authority_keeps_asau_and_as1_recorded_while_paused():
+    authority = json.loads(_read(AUTHORITY_PATH))
+    as1_doc = _read(DOCS / 'stage-19as1-disposable-postgres-constraint-tests.md')
+
+    assert authority['stage19'] == {
+        'status': 'paused',
+        'stage19as_au_status': 'completed',
+    }
+    assert authority['stage19as_au_completed_checkpoint']['status'] == 'completed'
+    assert authority['stage19as_au_completed_checkpoint']['canonical_writes_performed'] is False
+    assert authority['stage19as_au_completed_checkpoint']['stage19_remains_paused'] is True
+
+    assert 'Stage 19AS.1 adds the next safety-test checkpoint' in as1_doc
+    assert 'Stage 19 remains paused.' in as1_doc
+    assert 'No canonical apply is complete.' in as1_doc
+    assert 'No rebaseline is complete.' in as1_doc
+
+
+@pytest.mark.unit
+def test_stage19as2_contract_doc_records_repo_only_safety_boundary():
+    contract_doc = _read(CONTRACT_DOC_PATH)
+    compact_contract_doc = _squash(contract_doc)
+    roadmap = _read(ROADMAP_PATH)
+
+    for fragment in (
+        'Stage 19AS.2 - Operator Script Contract Formalization',
+        'Stage 19AS-AU is complete and recorded.',
+        'Stage 19AS.1 is complete and recorded.',
+        'Stage 19 remains paused.',
+        'No canonical apply is complete.',
+        'No rebaseline is complete.',
+        'does not run Stage 19 operator commands',
+        'connect to a database',
+        'use host `5432` as a direct committed Stage 19 target',
+    ):
+        assert fragment in compact_contract_doc
+
+    assert 'Stage 19AS.2 now formalizes the operator-script contract' in roadmap
+    assert 'stage-19as2-operator-script-contract.md' in roadmap
+
+
+@pytest.mark.unit
+def test_operator_script_cli_contracts_are_commit_gated_and_artifact_explicit():
+    for stage, path in OPERATOR_SCRIPTS.items():
+        options = _parser_options(path)
+
+        assert options['--commit']['action'] == 'store_true', stage
+        assert options['--commit'].get('default') is not True, stage
+        assert '--limit' in options, stage
+        assert '--artifact-dir' in options, stage
+
+        artifact = options['--artifact-dir']
+        assert artifact.get('required') is True or 'default' in artifact, stage
+
+        for db_option in ('--db-host', '--db-port', '--db-name', '--db-user'):
+            assert db_option in options, f'{stage} missing {db_option}'
+
+        source = _read(path)
+        assert 'commit=args.commit' in source, stage
+        assert 'set_connection_mode(conn, commit=args.commit)' in source, stage
+        assert re.search(r'\brollback\(conn\)|\bpilot\.rollback\(conn\)', source), stage
+
+
+@pytest.mark.unit
+def test_committed_pilot_scripts_keep_hard_limits_and_validation_contracts():
+    stage19ar = _read(OPERATOR_SCRIPTS['Stage 19AR'])
+    stage19as_au = _read(OPERATOR_SCRIPTS['Stage 19AS-AU'])
+    stage19anr = _read(OPERATOR_SCRIPTS['Stage 19AN-R'])
+    contract_doc = _read(CONTRACT_DOC_PATH)
+
+    assert 'HARD_MAX_LIMIT = 25' in stage19ar
+    assert 'if args.limit > HARD_MAX_LIMIT' in stage19ar
+    assert 'if commit and limit != profile.default_limit' in stage19ar
+    assert 'verify_artifact_directory_writable' in stage19ar
+
+    assert 'hard_max_limit=100' in stage19as_au
+    assert 'if args.limit > STAGE19AS_AU_PROFILE.hard_max_limit' in stage19as_au
+    assert 'verify_canonical_stage19ar_baseline(conn)' in stage19as_au
+    assert "secrets_values_printed': False" in stage19as_au
+
+    assert "parser.add_argument('--artifact-dir', required=True" in stage19anr
+    assert 'Stage 19AN-R' in contract_doc
+    assert 'only a lower-bound `--limit` check' in contract_doc
+
+    for stage, source in (
+        ('Stage 19AR', stage19ar),
+        ('Stage 19AN-R', stage19anr),
+    ):
+        for fragment in (
+            'write_operator_artifact',
+            '_summary_for_stdout',
+            'validation_checks',
+            "'canonical_table_writes_performed_by_script': False",
+            'assert_validation_passes',
+            'source_run_artifact_hash_matches',
+            'source_run_artifact_integrity_matches',
+            'staging_rows_preserve_canonical_write_block',
+        ):
+            assert fragment in source, f'{stage} missing {fragment}'
+
+    assert 'pilot.run_pilot(' in stage19as_au
+    assert 'STAGE19AS_AU_PROFILE' in stage19as_au
+
+
+@pytest.mark.unit
+def test_operator_scripts_do_not_add_scheduler_canonical_apply_or_shell_dispatches():
+    disallowed = [
+        re.compile(r'\bsystemctl\b', re.IGNORECASE),
+        re.compile(r'(?<![A-Za-z0-9_])\.(?:timer|service)(?![A-Za-z0-9_])', re.IGNORECASE),
+        re.compile(r'\bcanonical_apply\b', re.IGNORECASE),
+        re.compile(r'\bshell\s*=\s*True\b'),
+        re.compile(r'\bproduction_import_run\s*:\s*True\b'),
+    ]
+
+    for stage, path in OPERATOR_SCRIPTS.items():
+        source = _read(path)
+        for pattern in disallowed:
+            assert not pattern.search(source), f'{stage} matched {pattern.pattern}'
+
+
+@pytest.mark.unit
+def test_local_ci_parity_includes_as2_without_operator_commands():
+    parity = _read(LOCAL_CI_PARITY)
+
+    assert 'tests/test_stage19as2_operator_script_contract.py' in parity
+    assert 'scripts/operator/stage19' not in parity
+    assert '--commit' not in parity


### PR DESCRIPTION
## Summary

- adds the Stage 19AS.2 operator-script contract checkpoint documentation
- adds static/unit coverage for Stage 19 operator-script contract expectations
- registers the new AS.2 test in local CI parity
- updates the Stage 19 roadmap breadcrumb for the AS.2 repo-only checkpoint

## Safety

- Stage 19AS-AU remains recorded
- Stage 19AS.1 remains recorded
- Stage 19 remains paused
- no Stage 19 operator commands run
- no DB commands run and no DB mutation performed
- no canonical apply
- no rebaseline
- no production-like DB target
- no host 5432 direct target
- no runtime artifacts or secrets touched

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19as2_operator_script_contract.py -p no:cacheprovider` - passed, 6 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict` - passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_project_state_resolver.py tests/test_stage19as1_disposable_postgres_constraints.py tests/test_stage19aq1_test_fortress_guardrails.py tests/test_stage19ar_operator_script.py -p no:cacheprovider` - passed, 50 passed, 1 skipped
- `git diff --check` - passed
- `git diff --cached --check` - passed before commit