### PR TITLE
Stage 19AT paused-state operator decision gate

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -777,6 +777,14 @@ docs/static-test checkpoint in
 not run Stage 19 operator commands, connect to a database, write staging rows,
 write canonical tables, rebaseline, or run canonical apply.
 
+Stage 19AT is the current paused-state decision gate after Stage 19AS.2. It is
+recorded in
+`docs/colonisation-redesign/stage-19at-paused-state-next-operator-decision.md`
+as docs/static-test coverage only. It does not approve a wider pilot, Stage 19
+operator command, DB mutation, scheduler/service work, canonical apply,
+rebaseline, production-like DB target, or direct host `5432` target. The next
+operational lane still requires explicit operator approval.
+
 ### Deferred Stage 19AS.1 - Test Fortress / CI parity
 
 Deferred: this is important safety work, but it should not block the immediate

--- a/docs/colonisation-redesign/stage-19at-paused-state-next-operator-decision.md
+++ b/docs/colonisation-redesign/stage-19at-paused-state-next-operator-decision.md
@@ -1,0 +1,89 @@
+# Stage 19AT - Paused-State Next Operator Decision
+
+## Purpose
+
+Stage 19AT records the next Stage 19 checkpoint after Stage 19AS.2 as a
+paused-state operator decision gate. It is a documentation and static-test
+checkpoint only.
+
+Stage 19AT does not choose, approve, or execute the next operational lane. Any
+wider pilot, scheduler work, canonical write lane, canonical apply lane,
+rebaseline, or production-like database target still requires explicit operator
+approval in a later checkpoint.
+
+## Current Authority
+
+Active authority remains
+`docs/colonisation-redesign/stage-19-state-authority.json`.
+
+- Stage 19AS-AU is complete and recorded.
+- Stage 19AS.1 is complete and recorded.
+- Stage 19AS.2 is complete and recorded.
+- Stage 19 remains paused.
+- The approved Stage 19AR baseline remains the 5f777 source run, b617 artifact,
+  and 25 diagnostic rows.
+- The Stage 19AS-AU checkpoint remains the 100-row source run
+  `stage19as-au-edsm-100-row-controlled-expansion-1843ccf903dfa6c9`.
+- No canonical apply is complete.
+- No rebaseline is complete.
+
+## Decision Boundary
+
+Stage 19AT is a decision checkpoint, not an execution checkpoint.
+
+It records that the next operational lane must be selected and approved before
+any new Stage 19 execution happens. The decision may later choose a docs-only
+design, read-only verification, staging-only write, controlled write, or another
+test-environment gate, but Stage 19AT itself approves none of those executions.
+
+The next operational lane still requires explicit operator approval.
+
+## Blocked Work
+
+Stage 19AT keeps these actions blocked:
+
+- wider pilot execution;
+- Stage 19 operator commands;
+- Stage 19AR with `--commit`;
+- Stage 19AS-AU with `--commit`;
+- full source batch execution;
+- database mutation;
+- staging row writes;
+- canonical table writes;
+- canonical apply;
+- rebaseline;
+- scheduler, timer, or service-manager work;
+- production-like database targets;
+- host `5432` as a direct Stage 19 target;
+- secrets access or printing;
+- runtime source JSON or operator artifact JSON commits.
+
+No Stage 19 operator command is authorized by this checkpoint. No DB mutation is
+authorized by this checkpoint.
+
+## Added Coverage
+
+`tests/test_stage19at_paused_state_next_operator_decision.py` covers:
+
+- Stage 19 remains paused in active authority;
+- Stage 19AS-AU remains complete and recorded;
+- Stage 19AS.1 remains recorded;
+- Stage 19AS.2 remains recorded;
+- Stage 19AT is documented as docs/static-test only;
+- no canonical apply or rebaseline is marked complete;
+- wider pilot execution and database execution remain unauthorized;
+- forbidden actions remain documented.
+
+## Validation
+
+Expected focused validation:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19at_paused_state_next_operator_decision.py -p no:cacheprovider
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19as2_operator_script_contract.py tests/test_stage19as1_disposable_postgres_constraints.py -p no:cacheprovider
+git diff --check
+```
+
+These checks are repo-local and static/unit-only for Stage 19AT. They must not
+run operator scripts or DB commands.

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -94,6 +94,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage19anr_operator_script.py \
     tests/test_stage19as1_disposable_postgres_constraints.py \
     tests/test_stage19as2_operator_script_contract.py \
+    tests/test_stage19at_paused_state_next_operator_decision.py \
     tests/test_stage19aq1_test_fortress_guardrails.py \
     -q
 )

--- a/tests/test_stage19at_paused_state_next_operator_decision.py
+++ b/tests/test_stage19at_paused_state_next_operator_decision.py
@@ -1,0 +1,114 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+ROADMAP_PATH = DOCS / 'stage-19-data-warehouse-utopia-roadmap.md'
+AS1_DOC_PATH = DOCS / 'stage-19as1-disposable-postgres-constraint-tests.md'
+AS2_DOC_PATH = DOCS / 'stage-19as2-operator-script-contract.md'
+AT_DOC_PATH = DOCS / 'stage-19at-paused-state-next-operator-decision.md'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+@pytest.mark.unit
+def test_stage19at_keeps_active_authority_paused_and_asau_recorded():
+    authority = json.loads(_read(AUTHORITY_PATH))
+    asau_checkpoint = authority['stage19as_au_completed_checkpoint']
+
+    assert authority['stage19'] == {
+        'status': 'paused',
+        'stage19as_au_status': 'completed',
+    }
+    assert asau_checkpoint['status'] == 'completed'
+    assert asau_checkpoint['rows_read'] == 100
+    assert asau_checkpoint['rows_staged'] == 100
+    assert asau_checkpoint['canonical_writes_performed'] is False
+    assert asau_checkpoint['approved_stage19ar_baseline_preserved'] is True
+    assert asau_checkpoint['stage19_remains_paused'] is True
+
+
+@pytest.mark.unit
+def test_stage19at_records_as1_as2_and_paused_decision_gate():
+    at_doc = _squash(_read(AT_DOC_PATH))
+    as1_doc = _squash(_read(AS1_DOC_PATH))
+    as2_doc = _squash(_read(AS2_DOC_PATH))
+    roadmap = _squash(_read(ROADMAP_PATH))
+
+    for fragment in (
+        'Stage 19AT - Paused-State Next Operator Decision',
+        'Stage 19AS-AU is complete and recorded.',
+        'Stage 19AS.1 is complete and recorded.',
+        'Stage 19AS.2 is complete and recorded.',
+        'Stage 19 remains paused.',
+        'Stage 19AT is a decision checkpoint, not an execution checkpoint.',
+        'The next operational lane still requires explicit operator approval.',
+        'documentation and static-test checkpoint only',
+    ):
+        assert fragment in at_doc
+
+    assert 'Stage 19AS.1 adds the next safety-test checkpoint' in as1_doc
+    assert 'Stage 19AS.2 - Operator Script Contract Formalization' in as2_doc
+    assert 'Stage 19AT is the current paused-state decision gate after Stage 19AS.2' in roadmap
+    assert 'stage-19at-paused-state-next-operator-decision.md' in roadmap
+
+
+@pytest.mark.unit
+def test_stage19at_does_not_mark_canonical_apply_or_rebaseline_complete():
+    at_doc = _squash(_read(AT_DOC_PATH))
+    as2_doc = _squash(_read(AS2_DOC_PATH))
+
+    for source in (at_doc, as2_doc):
+        assert 'No canonical apply is complete.' in source
+        assert 'No rebaseline is complete.' in source
+
+    assert 'canonical apply is complete.' not in at_doc.replace('No canonical apply is complete.', '')
+    assert 'rebaseline is complete.' not in at_doc.replace('No rebaseline is complete.', '')
+
+
+@pytest.mark.unit
+def test_stage19at_blocks_wider_pilot_db_execution_and_forbidden_actions():
+    at_doc = _read(AT_DOC_PATH)
+    compact_at_doc = _squash(at_doc)
+
+    for fragment in (
+        'wider pilot execution',
+        'Stage 19 operator commands',
+        'Stage 19AR with `--commit`',
+        'Stage 19AS-AU with `--commit`',
+        'full source batch execution',
+        'database mutation',
+        'staging row writes',
+        'canonical table writes',
+        'canonical apply',
+        'rebaseline',
+        'scheduler, timer, or service-manager work',
+        'production-like database targets',
+        'host `5432` as a direct Stage 19 target',
+        'secrets access or printing',
+        'runtime source JSON or operator artifact JSON commits',
+        'No Stage 19 operator command is authorized by this checkpoint.',
+        'No DB mutation is authorized by this checkpoint.',
+    ):
+        assert fragment in compact_at_doc
+
+
+@pytest.mark.unit
+def test_stage19at_local_ci_parity_registration_is_static_only():
+    parity = _read(LOCAL_CI_PARITY)
+
+    assert 'tests/test_stage19at_paused_state_next_operator_decision.py' in parity
+    assert 'scripts/operator/stage19' not in parity
+    assert '--commit' not in parity


### PR DESCRIPTION
## Summary

- adds the Stage 19AT paused-state decision checkpoint
- records Stage 19AT as a docs/static-test operator decision gate after Stage 19AS.2
- adds static coverage for the paused-state decision boundary
- registers the new static test in local CI parity

## Safety

- Stage 19AS-AU remains recorded
- Stage 19AS.1 remains recorded
- Stage 19AS.2 remains recorded
- Stage 19 remains paused
- no Stage 19 operator commands run
- no DB mutation
- no canonical apply
- no rebaseline
- no scheduler/service work
- no production-like DB target or host 5432 direct target

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict` - passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19at_paused_state_next_operator_decision.py -p no:cacheprovider` - passed, 5 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19as2_operator_script_contract.py tests/test_stage19as1_disposable_postgres_constraints.py -p no:cacheprovider` - passed, 11 passed, 1 skipped
- `git diff --check` - passed