### PR TITLE
Stage 19AU read-only AS-AU safety gate

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -785,6 +785,15 @@ operator command, DB mutation, scheduler/service work, canonical apply,
 rebaseline, production-like DB target, or direct host `5432` target. The next
 operational lane still requires explicit operator approval.
 
+Stage 19AU is the read-only AS-AU safety-gate checkpoint after Stage 19AT. It
+is recorded in
+`docs/colonisation-redesign/stage-19au-readonly-asau-safety-gate.md` as
+docs/static-test coverage for the recorded Stage 19AR and Stage 19AS-AU state.
+It does not authorize Stage 19 operator commands, DB mutation, a wider pilot,
+scheduler/service work, canonical apply, rebaseline, production-like DB targets,
+or direct host `5432` targets. DB verification is `not_run` for this repo PR
+because no explicit safe local/disposable read-only DB target was provided.
+
 ### Deferred Stage 19AS.1 - Test Fortress / CI parity
 
 Deferred: this is important safety work, but it should not block the immediate

--- a/docs/colonisation-redesign/stage-19au-readonly-asau-safety-gate.md
+++ b/docs/colonisation-redesign/stage-19au-readonly-asau-safety-gate.md
@@ -1,0 +1,120 @@
+# Stage 19AU - Read-Only AS-AU Safety Gate
+
+## Purpose
+
+Stage 19AU records the next Stage 19 checkpoint after Stage 19AT as a
+read-only AS-AU safety-gate checkpoint. Its purpose is to keep the recorded
+Stage 19AR and Stage 19AS-AU state inspectable before any new Stage 19 write,
+wider pilot, scheduler work, or canonical path is considered.
+
+This checkpoint is documentation and static/unit test coverage in this PR. It
+does not run Stage 19 operator commands, connect to a database, create a source
+run, write staging rows, enable scheduler work, rebaseline, or run canonical
+apply.
+
+## Current Authority
+
+Active authority remains
+`docs/colonisation-redesign/stage-19-state-authority.json`.
+
+- Stage 19AS-AU is complete and recorded.
+- Stage 19AS.1 is complete and recorded.
+- Stage 19AS.2 is complete and recorded.
+- Stage 19AT is complete and recorded.
+- Stage 19 remains paused.
+- The approved Stage 19AR baseline remains the 5f777 source run, b617 artifact,
+  and 25 diagnostic rows.
+- The Stage 19AS-AU checkpoint remains the 100-row source run
+  `stage19as-au-edsm-100-row-controlled-expansion-1843ccf903dfa6c9`.
+- No canonical apply is complete.
+- No rebaseline is complete.
+
+## Verification Boundary
+
+Stage 19AU is read-only verification only. It does not authorize a write-capable
+lane.
+
+This PR did not run DB verification because no explicit safe local or disposable
+read-only DB target was supplied. That is recorded as:
+
+```text
+db_verification:
+not_run
+
+db_verification_reason:
+No explicit safe local/disposable DB target was provided for this checkpoint.
+The repo changes are docs/static-test only.
+```
+
+A future non-skipped DB verification must remain read-only, must use existing
+local/disposable guardrails, must redact secrets, and must stop on production-
+like DSNs or direct host `5432` targets.
+
+Allowed future read-only checks may verify only:
+
+- the approved Stage 19AR `source_run_key`, bridge key, artifact hash, and 25
+  row baseline;
+- the Stage 19AS-AU `source_run_key`, bridge key, artifact hash, and operator
+  artifact hash;
+- AS-AU row counts of 100 read, 100 staged, 0 rejected, and 0 skipped;
+- diagnostic isolation and canonical-write blocking for AS-AU staging evidence;
+- absence of active or failed Stage 19 source runs that block the next lane;
+- absence of canonical apply or canonical-write evidence in checked Stage 19
+  artifacts.
+
+## Blocked Work
+
+Stage 19AU keeps these actions blocked:
+
+- wider pilot execution;
+- Stage 19 operator commands;
+- Stage 19AR with `--commit`;
+- Stage 19AS-AU with `--commit`;
+- full source batch execution;
+- database mutation;
+- staging row writes;
+- canonical table writes;
+- canonical apply;
+- rebaseline;
+- scheduler, timer, or service-manager work;
+- production-like database targets;
+- host `5432` as a direct Stage 19 target;
+- secrets access or printing;
+- runtime source JSON or operator artifact JSON commits.
+
+No wider pilot is authorized by Stage 19AU. No DB mutation is authorized by
+Stage 19AU. No scheduler or service work is authorized by Stage 19AU. No
+canonical apply or rebaseline is authorized by Stage 19AU.
+
+Any future write-capable lane requires a separate explicit operator decision.
+
+## Added Coverage
+
+`tests/test_stage19au_readonly_asau_safety_gate.py` covers:
+
+- Stage 19 remains paused in active authority;
+- Stage 19AS-AU remains complete and recorded;
+- Stage 19AS.1 remains recorded;
+- Stage 19AS.2 remains recorded;
+- Stage 19AT remains recorded;
+- Stage 19AU is documented as read-only docs/static-test coverage for this PR;
+- DB verification is recorded as `not_run` unless an explicit safe target is
+  provided in a later checkpoint;
+- no canonical apply or rebaseline is marked complete;
+- wider pilot execution, scheduler/service work, DB mutation, and Stage 19
+  operator execution remain unauthorized;
+- forbidden actions remain documented.
+
+## Validation
+
+Expected focused validation:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19au_readonly_asau_safety_gate.py -p no:cacheprovider
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19at_paused_state_next_operator_decision.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19as1_disposable_postgres_constraints.py -p no:cacheprovider
+git diff --check
+```
+
+These checks are repo-local and static/unit-focused for Stage 19AU. They must
+not run Stage 19 operator commands or mutate a database.

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -95,6 +95,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage19as1_disposable_postgres_constraints.py \
     tests/test_stage19as2_operator_script_contract.py \
     tests/test_stage19at_paused_state_next_operator_decision.py \
+    tests/test_stage19au_readonly_asau_safety_gate.py \
     tests/test_stage19aq1_test_fortress_guardrails.py \
     -q
 )

--- a/tests/test_stage19au_readonly_asau_safety_gate.py
+++ b/tests/test_stage19au_readonly_asau_safety_gate.py
@@ -1,0 +1,141 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+ROADMAP_PATH = DOCS / 'stage-19-data-warehouse-utopia-roadmap.md'
+AS1_DOC_PATH = DOCS / 'stage-19as1-disposable-postgres-constraint-tests.md'
+AS2_DOC_PATH = DOCS / 'stage-19as2-operator-script-contract.md'
+AT_DOC_PATH = DOCS / 'stage-19at-paused-state-next-operator-decision.md'
+AU_DOC_PATH = DOCS / 'stage-19au-readonly-asau-safety-gate.md'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+@pytest.mark.unit
+def test_stage19au_keeps_authority_paused_and_asau_recorded():
+    authority = json.loads(_read(AUTHORITY_PATH))
+    asau_checkpoint = authority['stage19as_au_completed_checkpoint']
+
+    assert authority['stage19'] == {
+        'status': 'paused',
+        'stage19as_au_status': 'completed',
+    }
+    assert authority['approved_stage19ar_baseline'] == {
+        'source_run_key': 'stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034',
+        'bridge_key': 'source_runs:stage19ar-edsm-25-row-staging-pilot-5f777958b81bd034',
+        'artifact': 'b617d0239b7458b5b881895b564d091c771394b555c88a5bae942fd9d2c10e5e',
+        'rows': 25,
+    }
+    assert asau_checkpoint['status'] == 'completed'
+    assert asau_checkpoint['source_run_key'] == 'stage19as-au-edsm-100-row-controlled-expansion-1843ccf903dfa6c9'
+    assert asau_checkpoint['bridge_key'] == 'source_runs:stage19as-au-edsm-100-row-controlled-expansion-1843ccf903dfa6c9'
+    assert asau_checkpoint['rows_read'] == 100
+    assert asau_checkpoint['rows_staged'] == 100
+    assert asau_checkpoint['rows_rejected'] == 0
+    assert asau_checkpoint['rows_skipped'] == 0
+    assert asau_checkpoint['canonical_writes_performed'] is False
+    assert asau_checkpoint['approved_stage19ar_baseline_preserved'] is True
+    assert asau_checkpoint['stage19_remains_paused'] is True
+
+
+@pytest.mark.unit
+def test_stage19au_records_as1_as2_at_and_readonly_gate():
+    au_doc = _squash(_read(AU_DOC_PATH))
+    as1_doc = _squash(_read(AS1_DOC_PATH))
+    as2_doc = _squash(_read(AS2_DOC_PATH))
+    at_doc = _squash(_read(AT_DOC_PATH))
+    roadmap = _squash(_read(ROADMAP_PATH))
+
+    for fragment in (
+        'Stage 19AU - Read-Only AS-AU Safety Gate',
+        'Stage 19AS-AU is complete and recorded.',
+        'Stage 19AS.1 is complete and recorded.',
+        'Stage 19AS.2 is complete and recorded.',
+        'Stage 19AT is complete and recorded.',
+        'Stage 19 remains paused.',
+        'Stage 19AU is read-only verification only.',
+        'documentation and static/unit test coverage in this PR',
+        'Any future write-capable lane requires a separate explicit operator decision.',
+    ):
+        assert fragment in au_doc
+
+    assert 'Stage 19AS.1 adds the next safety-test checkpoint' in as1_doc
+    assert 'Stage 19AS.2 - Operator Script Contract Formalization' in as2_doc
+    assert 'Stage 19AT - Paused-State Next Operator Decision' in at_doc
+    assert 'Stage 19AU is the read-only AS-AU safety-gate checkpoint after Stage 19AT.' in roadmap
+    assert 'stage-19au-readonly-asau-safety-gate.md' in roadmap
+
+
+@pytest.mark.unit
+def test_stage19au_records_db_verification_not_run_without_safe_target():
+    au_doc = _squash(_read(AU_DOC_PATH))
+
+    for fragment in (
+        'This PR did not run DB verification because no explicit safe local or disposable read-only DB target was supplied.',
+        'db_verification: not_run',
+        'No explicit safe local/disposable DB target was provided for this checkpoint.',
+        'The repo changes are docs/static-test only.',
+        'must stop on production- like DSNs or direct host `5432` targets',
+    ):
+        assert fragment in au_doc
+
+
+@pytest.mark.unit
+def test_stage19au_does_not_mark_canonical_apply_or_rebaseline_complete():
+    au_doc = _squash(_read(AU_DOC_PATH))
+    as2_doc = _squash(_read(AS2_DOC_PATH))
+    at_doc = _squash(_read(AT_DOC_PATH))
+
+    for source in (au_doc, as2_doc, at_doc):
+        assert 'No canonical apply is complete.' in source
+        assert 'No rebaseline is complete.' in source
+
+    assert 'canonical apply is complete.' not in au_doc.replace('No canonical apply is complete.', '')
+    assert 'rebaseline is complete.' not in au_doc.replace('No rebaseline is complete.', '')
+
+
+@pytest.mark.unit
+def test_stage19au_blocks_write_capable_lanes_and_forbidden_actions():
+    au_doc = _squash(_read(AU_DOC_PATH))
+
+    for fragment in (
+        'No wider pilot is authorized by Stage 19AU.',
+        'No DB mutation is authorized by Stage 19AU.',
+        'No scheduler or service work is authorized by Stage 19AU.',
+        'No canonical apply or rebaseline is authorized by Stage 19AU.',
+        'Stage 19 operator commands',
+        'Stage 19AR with `--commit`',
+        'Stage 19AS-AU with `--commit`',
+        'full source batch execution',
+        'database mutation',
+        'staging row writes',
+        'canonical table writes',
+        'scheduler, timer, or service-manager work',
+        'production-like database targets',
+        'host `5432` as a direct Stage 19 target',
+        'secrets access or printing',
+        'runtime source JSON or operator artifact JSON commits',
+    ):
+        assert fragment in au_doc
+
+
+@pytest.mark.unit
+def test_stage19au_local_ci_parity_registration_is_static_only():
+    parity = _read(LOCAL_CI_PARITY)
+
+    assert 'tests/test_stage19au_readonly_asau_safety_gate.py' in parity
+    assert 'scripts/operator/stage19' not in parity
+    assert '--commit' not in parity


### PR DESCRIPTION
## Summary

- adds the Stage 19AU read-only safety-gate checkpoint
- records AU as docs/static-test coverage for the recorded Stage 19AR and Stage 19AS-AU state
- adds static coverage for the AU no-write/no-execution boundary
- registers the new static test in local CI parity

## Safety

- Stage 19AS-AU remains recorded
- Stage 19AS.1 remains recorded
- Stage 19AS.2 remains recorded
- Stage 19AT remains recorded
- Stage 19 remains paused
- no Stage 19 operator commands run
- no DB mutation
- DB verification status: not_run
- no canonical apply
- no rebaseline
- no scheduler/service work
- no production-like DB target or host 5432 direct target

## Validation

- `pwd` - passed
- `git status --short --branch` - passed, expected AU branch with only scoped changes before commit
- `git fetch --all --prune` - passed
- `git rev-parse origin/main` - `d11109aac8b08c78c64b477b02c6583162611511`
- `gh pr list --state open` - passed, no open PRs before this PR
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict` - passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19au_readonly_asau_safety_gate.py -p no:cacheprovider` - passed, 6 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19at_paused_state_next_operator_decision.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19as1_disposable_postgres_constraints.py -p no:cacheprovider` - passed, 16 passed, 1 skipped
- `git diff --check` - passed