### PR TITLE
Record Stage 19AU read-only DB verification

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -793,6 +793,13 @@ It does not authorize Stage 19 operator commands, DB mutation, a wider pilot,
 scheduler/service work, canonical apply, rebaseline, production-like DB targets,
 or direct host `5432` targets. DB verification is `not_run` for this repo PR
 because no explicit safe local/disposable read-only DB target was provided.
+The follow-up Stage 19AU read-only DB verification passed against the approved
+safe local target `127.0.0.1:55432`. It verified the Stage 19AR baseline, the
+Stage 19AS-AU checkpoint, the AS-AU artifact checksum, diagnostic-only staging
+isolation, absence of active or failed blocking Stage 19 source runs, and
+absence of canonical apply/write evidence. Stage 19 remains paused, with no
+rebaseline, scheduler/service work, wider pilot, canonical apply, or new write
+lane authorized.
 
 ### Deferred Stage 19AS.1 - Test Fortress / CI parity
 

--- a/docs/colonisation-redesign/stage-19au-readonly-asau-safety-gate.md
+++ b/docs/colonisation-redesign/stage-19au-readonly-asau-safety-gate.md
@@ -7,10 +7,11 @@ read-only AS-AU safety-gate checkpoint. Its purpose is to keep the recorded
 Stage 19AR and Stage 19AS-AU state inspectable before any new Stage 19 write,
 wider pilot, scheduler work, or canonical path is considered.
 
-This checkpoint is documentation and static/unit test coverage in this PR. It
-does not run Stage 19 operator commands, connect to a database, create a source
-run, write staging rows, enable scheduler work, rebaseline, or run canonical
-apply.
+This checkpoint started as documentation and static/unit test coverage. The
+follow-up Stage 19AU read-only DB verification used the approved safe local
+target `127.0.0.1:55432` and did not run Stage 19 operator commands, create a
+source run, write staging rows, enable scheduler work, rebaseline, or run
+canonical apply.
 
 ## Current Authority
 
@@ -34,8 +35,8 @@ Active authority remains
 Stage 19AU is read-only verification only. It does not authorize a write-capable
 lane.
 
-This PR did not run DB verification because no explicit safe local or disposable
-read-only DB target was supplied. That is recorded as:
+The Stage 19AU implementation PR did not run DB verification because no explicit
+safe local or disposable read-only DB target was supplied. That was recorded as:
 
 ```text
 db_verification:
@@ -46,9 +47,40 @@ No explicit safe local/disposable DB target was provided for this checkpoint.
 The repo changes are docs/static-test only.
 ```
 
-A future non-skipped DB verification must remain read-only, must use existing
-local/disposable guardrails, must redact secrets, and must stop on production-
-like DSNs or direct host `5432` targets.
+The follow-up read-only DB verification passed against the approved safe local
+target `127.0.0.1:55432`. The connection resolved to database `edfinder` as
+user `edfinder`, with container port `5432` reached only through the safe host
+mapping `127.0.0.1:55432`.
+
+```text
+db_verification:
+passed
+
+db_verification_target:
+127.0.0.1:55432
+```
+
+The follow-up verification confirmed:
+
+- the approved Stage 19AR baseline source run, bridge key, b617 artifact, and
+  25 diagnostic rows;
+- the Stage 19AS-AU source run, bridge key, 7f6 artifact checksum, and row
+  counts of 100 read, 100 staged, 0 rejected, and 0 skipped;
+- every checked Stage 19AR and Stage 19AS-AU staging row remains diagnostic-only,
+  uses the legacy `enrichment_source_runs.id` bridge, avoids `source_runs.id`,
+  and preserves `canonical_write_allowed=false`;
+- no active or failed Stage 19 source run blocks the next lane;
+- source-run safety boundaries keep canonical apply disabled, canonical writes
+  planned at zero, scheduler/service work disabled, and production DB access
+  false;
+- the AS-AU artifact file checksum matches the recorded
+  `7f6f20a4d01b543d8ef12072891d8fda749bcc1b6633c26bc9ec178a40b8f84e` value;
+- the prerequisite staging evidence remains separate from the Stage 19AS-AU
+  completion source run.
+
+Any future DB verification must remain read-only, must use existing
+local/disposable guardrails, must redact secrets, and must stop on
+production-like DSNs or direct host `5432` targets.
 
 Allowed future read-only checks may verify only:
 

--- a/tests/test_stage19au_readonly_asau_safety_gate.py
+++ b/tests/test_stage19au_readonly_asau_safety_gate.py
@@ -67,7 +67,7 @@ def test_stage19au_records_as1_as2_at_and_readonly_gate():
         'Stage 19AT is complete and recorded.',
         'Stage 19 remains paused.',
         'Stage 19AU is read-only verification only.',
-        'documentation and static/unit test coverage in this PR',
+        'This checkpoint started as documentation and static/unit test coverage.',
         'Any future write-capable lane requires a separate explicit operator decision.',
     ):
         assert fragment in au_doc
@@ -80,17 +80,35 @@ def test_stage19au_records_as1_as2_at_and_readonly_gate():
 
 
 @pytest.mark.unit
-def test_stage19au_records_db_verification_not_run_without_safe_target():
+def test_stage19au_records_db_verification_history_and_passed_followup():
     au_doc = _squash(_read(AU_DOC_PATH))
+    roadmap = _squash(_read(ROADMAP_PATH))
 
     for fragment in (
-        'This PR did not run DB verification because no explicit safe local or disposable read-only DB target was supplied.',
+        'The Stage 19AU implementation PR did not run DB verification because no explicit safe local or disposable read-only DB target was supplied.',
         'db_verification: not_run',
         'No explicit safe local/disposable DB target was provided for this checkpoint.',
         'The repo changes are docs/static-test only.',
-        'must stop on production- like DSNs or direct host `5432` targets',
+        'The follow-up read-only DB verification passed against the approved safe local target `127.0.0.1:55432`.',
+        'db_verification: passed',
+        'db_verification_target: 127.0.0.1:55432',
+        'the approved Stage 19AR baseline source run, bridge key, b617 artifact, and 25 diagnostic rows',
+        'the Stage 19AS-AU source run, bridge key, 7f6 artifact checksum, and row counts of 100 read, 100 staged, 0 rejected, and 0 skipped',
+        'preserves `canonical_write_allowed=false`',
+        'no active or failed Stage 19 source run blocks the next lane',
+        'canonical apply disabled, canonical writes planned at zero, scheduler/service work disabled, and production DB access false',
+        'the AS-AU artifact file checksum matches the recorded `7f6f20a4d01b543d8ef12072891d8fda749bcc1b6633c26bc9ec178a40b8f84e` value',
+        'must stop on production-like DSNs or direct host `5432` targets',
     ):
         assert fragment in au_doc
+
+    for fragment in (
+        'The follow-up Stage 19AU read-only DB verification passed against the approved safe local target `127.0.0.1:55432`.',
+        'absence of active or failed blocking Stage 19 source runs',
+        'absence of canonical apply/write evidence',
+        'Stage 19 remains paused',
+    ):
+        assert fragment in roadmap
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Records the Stage 19AU read-only DB verification as passed against safe target `127.0.0.1:55432`
- Confirms the Stage 19AR baseline and Stage 19AS-AU checkpoint remain inspectable and isolated
- Updates AU static coverage for the recorded follow-up verification evidence

## Verification Evidence

- Stage 19AU read-only DB verification passed
- Safe target used: `127.0.0.1:55432`
- Stage 19AR baseline verified
- Stage 19AS-AU checkpoint verified
- AS-AU artifact checksum verified
- No active or failed blocking Stage 19 runs found
- No Stage 19 operator commands run
- No DB mutation
- No canonical apply
- No rebaseline
- Stage 19 remains paused

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict` passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19au_readonly_asau_safety_gate.py -p no:cacheprovider` passed: 6 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19at_paused_state_next_operator_decision.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19as1_disposable_postgres_constraints.py -p no:cacheprovider` passed: 16 passed, 1 skipped
- `git diff --check` passed