### PR TITLE
Stage 19AV expanded source-run staging pilot

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -801,6 +801,17 @@ absence of canonical apply/write evidence. Stage 19 remains paused, with no
 rebaseline, scheduler/service work, wider pilot, canonical apply, or new write
 lane authorized.
 
+Stage 19AV is the selected expanded controlled source-run staging pilot lane
+after Stage 19AU. It is prepared in
+`docs/colonisation-redesign/stage-19av-expanded-source-run-staging-pilot.md`
+and `scripts/operator/stage19av_expanded_source_run_staging_pilot.py`. This
+preparation checkpoint does not run the AV bounded write. The prepared wrapper
+uses a new Stage 19AV source-run prefix, diagnostic marker, artifact namespace,
+`--preflight-db`, explicit `--commit`, explicit `--confirm-stage19av`, and an
+exact 250-row default/hard cap. Stage 19 remains paused, with no canonical
+apply, no rebaseline, no scheduler/service work, no production-like DB target,
+and no direct host `5432` target authorized.
+
 ### Deferred Stage 19AS.1 - Test Fortress / CI parity
 
 Deferred: this is important safety work, but it should not block the immediate

--- a/docs/colonisation-redesign/stage-19as2-operator-script-contract.md
+++ b/docs/colonisation-redesign/stage-19as2-operator-script-contract.md
@@ -69,6 +69,14 @@ read-only `--preflight-db` helper for operator target verification. Stage
 disposable target and must not target host `5432` directly for committed Stage
 19 work.
 
+Stage 19AV
+(`scripts/operator/stage19av_expanded_source_run_staging_pilot.py`) extends the
+same contract for the next prepared expansion lane. It has its own source-run
+prefix, diagnostic marker, artifact namespace, exact 250-row default/hard cap,
+`--preflight-db`, explicit `--commit`, and an additional
+`--confirm-stage19av` guard. The wrapper refuses `DATABASE_URL` so the operator
+must pass the safe local target explicitly.
+
 ## Added Coverage
 
 `tests/test_stage19as2_operator_script_contract.py` covers:
@@ -78,6 +86,8 @@ disposable target and must not target host `5432` directly for committed Stage
 - operator CLIs keep `--commit` opt-in and `--limit` controls;
 - artifact directory behavior is explicit;
 - committed-pilot scripts keep hard maximum limits;
+- the prepared Stage 19AV wrapper keeps its stage-specific hard cap,
+  preflight, confirmation, and prerequisite checks;
 - operator scripts keep rollback, validation, artifact summary, and
   no-canonical-write reporting;
 - scheduler, service-manager, canonical apply, production import dispatch, and

--- a/docs/colonisation-redesign/stage-19av-expanded-source-run-staging-pilot.md
+++ b/docs/colonisation-redesign/stage-19av-expanded-source-run-staging-pilot.md
@@ -1,0 +1,109 @@
+# Stage 19AV - Expanded Source-Run Staging Pilot
+
+## Purpose
+
+Stage 19AV is the selected bounded write lane after Stage 19AU. It prepares an
+expanded controlled source-run staging pilot that extends the Stage 19AS-AU
+path without canonical writes.
+
+This checkpoint prepares the Stage 19AV operator wrapper, documentation, and
+static/unit coverage only. The Stage 19AV bounded write was not run in this
+checkpoint because a dedicated stage-specific wrapper and review gate were
+required before the first AV write.
+
+## Current Authority
+
+Active authority remains
+`docs/colonisation-redesign/stage-19-state-authority.json`.
+
+- Stage 19AS-AU is complete and recorded.
+- Stage 19AS.1 is complete and recorded.
+- Stage 19AS.2 is complete and recorded.
+- Stage 19AT is complete and recorded.
+- Stage 19AU read-only DB verification is complete and recorded.
+- Stage 19 remains paused.
+- No canonical apply is complete.
+- No rebaseline is complete.
+- Scheduler and wider service work remain unauthorized.
+
+## Prepared Operator Boundary
+
+The prepared Stage 19AV wrapper is
+`scripts/operator/stage19av_expanded_source_run_staging_pilot.py`.
+
+The wrapper reuses the proven Stage 19AR/AS-AU staging helper with a new
+stage-specific profile:
+
+- source-run prefix:
+  `stage19av-expanded-source-run-staging-pilot-`;
+- bridge prefix:
+  `source_runs:stage19av-expanded-source-run-staging-pilot-`;
+- provenance marker:
+  `stage19av_expanded_source_run_staging_pilot`;
+- default and hard maximum row count: `250`;
+- exact committed row count requirement: `250`;
+- artifact namespace:
+  `/var/lib/ed-finder/operator-artifacts/stage-19av`;
+- safe local target for a future approved run: `127.0.0.1:55432`.
+
+The wrapper keeps the existing contract:
+
+- dry-run/non-commit mode is the default;
+- `--commit` is required before any DB write;
+- `--confirm-stage19av` is also required with `--commit`;
+- commit mode requires the exact Stage 19AV row count;
+- `--preflight-db` authenticates and verifies prerequisites without writes or
+  artifacts;
+- `DATABASE_URL` must be unset for Stage 19AV operator commands;
+- a direct local host `5432` target is rejected by the wrapper;
+- passwords and secrets are redacted from preflight output;
+- production-like DB targets and direct host `5432` targets remain blocked by
+  the operator procedure.
+
+## Required Future Gates
+
+Before the Stage 19AV pilot can run, the operator must complete a separate
+review/merge gate for this prepared wrapper and then rerun the Stage 19AV task
+from current main.
+
+The future run must confirm:
+
+- Stage 19AR baseline remains preserved;
+- Stage 19AS-AU checkpoint remains preserved;
+- Stage 19AU read-only verification remains preserved;
+- no active or failed Stage 19 source run blocks the lane;
+- safe target is `127.0.0.1:55432`;
+- `DATABASE_URL` is unset;
+- `PGPASSWORD` is present but not printed;
+- artifact output goes to an operator artifact directory and is not committed.
+
+If the future pilot succeeds, a later checkpoint must record:
+
+- Stage 19AV source run key;
+- bridge key;
+- import artifact path and checksum;
+- operator artifact path and checksum;
+- rows read, staged, rejected, and skipped;
+- post-run verification summary;
+- canonical writes performed as `false`;
+- Stage 19 still paused unless a separate operator decision changes that.
+
+## Blocked Work
+
+Stage 19AV preparation does not authorize:
+
+- running the AV bounded write before this wrapper is reviewed and merged;
+- Stage 19AR with `--commit`;
+- Stage 19AS-AU with `--commit`;
+- unbounded source batches;
+- canonical table writes;
+- canonical apply;
+- rebaseline;
+- scheduler, timer, or service-manager work;
+- production-like DB targets;
+- host `5432` as a direct Stage 19 target;
+- secrets access or printing;
+- runtime source JSON or operator artifact JSON commits.
+
+Any future write-capable lane after Stage 19AV requires a separate explicit
+operator decision.

--- a/docs/colonisation-redesign/stage-19av-expanded-source-run-staging-pilot.md
+++ b/docs/colonisation-redesign/stage-19av-expanded-source-run-staging-pilot.md
@@ -40,7 +40,8 @@ stage-specific profile:
   `source_runs:stage19av-expanded-source-run-staging-pilot-`;
 - provenance marker:
   `stage19av_expanded_source_run_staging_pilot`;
-- default and hard maximum row count: `250`;
+- profile default and hard maximum row count: `250`;
+- CLI invocations must provide an explicit `--limit`;
 - exact committed row count requirement: `250`;
 - artifact namespace:
   `/var/lib/ed-finder/operator-artifacts/stage-19av`;
@@ -55,10 +56,14 @@ The wrapper keeps the existing contract:
 - `--preflight-db` authenticates and verifies prerequisites without writes or
   artifacts;
 - `DATABASE_URL` must be unset for Stage 19AV operator commands;
-- a direct local host `5432` target is rejected by the wrapper;
+- the only accepted future DB target is exactly `127.0.0.1:55432`;
+- local `5432` targets, including `127.0.0.1:5432`, `localhost:5432`,
+  `::1:5432`, and `0.0.0.0:5432`, are rejected by the wrapper;
+- non-local hosts, hostnames, private-network IPs, public IPs, and
+  production-like DB targets are rejected by the wrapper;
 - passwords and secrets are redacted from preflight output;
-- production-like DB targets and direct host `5432` targets remain blocked by
-  the operator procedure.
+- environment-driven DB target overrides are accepted only when they still
+  resolve to exactly `127.0.0.1:55432`.
 
 ## Required Future Gates
 
@@ -72,7 +77,7 @@ The future run must confirm:
 - Stage 19AS-AU checkpoint remains preserved;
 - Stage 19AU read-only verification remains preserved;
 - no active or failed Stage 19 source run blocks the lane;
-- safe target is `127.0.0.1:55432`;
+- safe target is exactly `127.0.0.1:55432`;
 - `DATABASE_URL` is unset;
 - `PGPASSWORD` is present but not printed;
 - artifact output goes to an operator artifact directory and is not committed.
@@ -101,6 +106,7 @@ Stage 19AV preparation does not authorize:
 - rebaseline;
 - scheduler, timer, or service-manager work;
 - production-like DB targets;
+- non-local DB hosts or any target other than `127.0.0.1:55432`;
 - host `5432` as a direct Stage 19 target;
 - secrets access or printing;
 - runtime source JSON or operator artifact JSON commits.

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -96,6 +96,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage19as2_operator_script_contract.py \
     tests/test_stage19at_paused_state_next_operator_decision.py \
     tests/test_stage19au_readonly_asau_safety_gate.py \
+    tests/test_stage19av_expanded_source_run_staging_pilot.py \
     tests/test_stage19aq1_test_fortress_guardrails.py \
     -q
 )

--- a/scripts/operator/stage19av_expanded_source_run_staging_pilot.py
+++ b/scripts/operator/stage19av_expanded_source_run_staging_pilot.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+"""Stage 19AV expanded controlled source-run staging pilot.
+
+This wrapper prepares the next bounded Stage 19 staging-only write lane after
+Stage 19AU. It reuses the verified Stage 19AR/AS-AU staging helper with a new
+stage-specific source-run prefix, diagnostic marker, artifact namespace, and an
+exact 250-row commit boundary.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+OPERATOR_SCRIPTS = Path(__file__).resolve().parent
+if str(OPERATOR_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(OPERATOR_SCRIPTS))
+
+import stage19ar_edsm_25_row_staging_pilot as pilot  # noqa: E402
+import stage19as_au_edsm_100_row_controlled_expansion as as_au  # noqa: E402
+
+
+STAGE19AV_LIMIT = 250
+STAGE19AS_AU_SOURCE_RUN_KEY = 'stage19as-au-edsm-100-row-controlled-expansion-1843ccf903dfa6c9'
+STAGE19AS_AU_BRIDGE_KEY = f'{pilot.source_run_compatibility.LEGACY_SOURCE_RUN_KEY_PREFIX}{STAGE19AS_AU_SOURCE_RUN_KEY}'
+STAGE19AS_AU_ARTIFACT_SHA256 = '7f6f20a4d01b543d8ef12072891d8fda749bcc1b6633c26bc9ec178a40b8f84e'
+STAGE19AS_AU_MARKER = 'stage19as_au_controlled_100_row_expansion'
+
+STAGE19AV_PROFILE = pilot.BoundedPilotProfile(
+    schema_version='stage19av_expanded_source_run_staging_pilot/v1',
+    stager_name='stage19av_expanded_source_run_staging_stager',
+    stager_version='v1',
+    source_run_key_prefix='stage19av-expanded-source-run-staging-pilot-',
+    source_run_prefixes=('stage19av-', 'stage-19av-'),
+    provenance_marker_key='stage19av_expanded_source_run_staging_pilot',
+    trigger_context='stage19av_expanded_source_run_staging_pilot',
+    artifact_dir=Path('/var/lib/ed-finder/operator-artifacts/stage-19av'),
+    default_limit=STAGE19AV_LIMIT,
+    hard_max_limit=STAGE19AV_LIMIT,
+    stage_label='Stage 19AV',
+    operator_stage='19av',
+    row_count_label=str(STAGE19AV_LIMIT),
+    sample_file_prefix='stage19av_edsm_sample',
+    import_file_prefix='stage19av_edsm_import',
+    operator_artifact_prefix='stage19av_operator_expanded_staging_pilot',
+    write_probe_name='.stage19av-write-probe',
+    diagnostic_reason='Stage 19AV expanded controlled source-run staging pilot',
+    existing_rows_key='existing_stage19av_rows',
+    marker_validation_check='staging_rows_have_stage19av_marker',
+    bridge_metadata={
+        'expanded_controlled_source_run_staging_pilot': True,
+        'stage19ar_known_good_spine': True,
+        'stage19as_au_checkpoint_preserved': True,
+        'stage19au_readonly_db_verification_required': True,
+        'rows_expected': STAGE19AV_LIMIT,
+    },
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Prepare or run the Stage 19AV expanded controlled source-run staging pilot.',
+    )
+    parser.add_argument('--limit', type=int, default=STAGE19AV_LIMIT, help='Exact number of staging rows to pilot.')
+    parser.add_argument(
+        '--artifact-dir',
+        default=str(STAGE19AV_PROFILE.artifact_dir),
+        help='Directory for sample, import, and operator artifacts.',
+    )
+    parser.add_argument('--git-head', default='auto', help='Git SHA for source_runs, or "auto".')
+    parser.add_argument(
+        '--trigger-context',
+        default=STAGE19AV_PROFILE.trigger_context,
+        help='source_runs trigger context.',
+    )
+    parser.add_argument('--commit', action='store_true', help='Opt in to the bounded staging-only DB write.')
+    parser.add_argument(
+        '--confirm-stage19av',
+        action='store_true',
+        help='Required with --commit so Stage 19AV cannot be run by a generic committed invocation.',
+    )
+    parser.add_argument('--db-host', default='127.0.0.1', help='Local Postgres host.')
+    parser.add_argument('--db-port', default='5432', help='Local Postgres port.')
+    parser.add_argument('--db-name', default='edfinder', help='Local Postgres database name.')
+    parser.add_argument('--db-user', default='edfinder', help='Local Postgres user.')
+    parser.add_argument(
+        '--secrets-file',
+        default=None,
+        help='Optional dotenv-style secrets file to load before DB connection construction.',
+    )
+    parser.add_argument(
+        '--preflight-db',
+        action='store_true',
+        help='Authenticate with the configured DB and verify Stage 19 prerequisites without writes or artifacts.',
+    )
+    args = parser.parse_args(argv)
+    if args.limit < 1:
+        parser.error('--limit must be >= 1')
+    if args.limit > STAGE19AV_PROFILE.hard_max_limit:
+        parser.error(f'--limit must be <= {STAGE19AV_PROFILE.hard_max_limit} for Stage 19AV')
+    if args.commit and not args.confirm_stage19av:
+        parser.error('--confirm-stage19av is required with --commit')
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.preflight_db:
+        result = run_db_preflight(args)
+        print(json.dumps(result, sort_keys=True, indent=2))
+        return 0 if result['auth_success'] and result.get('stage19av_prerequisites_ok') else 2
+
+    conn = None
+    try:
+        secrets = as_au.load_secrets_for_args(args)
+        if args.secrets_file and not secrets['detected']:
+            raise pilot.Stage19ArPilotError('secrets file was not found')
+        if secrets['tracked_by_git']:
+            raise pilot.Stage19ArPilotError('refusing to load a secrets file tracked by git')
+        git_head = pilot.resolve_git_head(args.git_head)
+        dsn = build_db_dsn(args)
+        conn = pilot.connect_operator_db(dsn)
+        pilot.set_connection_mode(conn, commit=args.commit)
+        prereqs = verify_stage19av_prerequisites(conn)
+        assert_stage19av_prerequisites(prereqs)
+        result = pilot.run_pilot(
+            conn,
+            limit=args.limit,
+            artifact_dir=Path(args.artifact_dir),
+            git_head=git_head,
+            trigger_context=args.trigger_context,
+            commit=args.commit,
+            profile=STAGE19AV_PROFILE,
+        )
+    except (OSError, pilot.Stage19ArPilotError, pilot.edsm_station_import.EdsmStationImportError) as exc:
+        if conn is not None:
+            pilot.rollback(conn)
+        print(f'stage19av pilot failed: {exc}', file=sys.stderr)
+        return 2
+    finally:
+        if conn is not None:
+            pilot.close_connection(conn)
+
+    print(json.dumps(pilot._summary_for_stdout(result), sort_keys=True, indent=2))
+    return 0
+
+
+def build_db_dsn(args: argparse.Namespace, env: Mapping[str, str] | None = None) -> str:
+    source_env = env if env is not None else os.environ
+    if source_env.get('DATABASE_URL'):
+        raise pilot.Stage19ArPilotError('DATABASE_URL must be unset for Stage 19AV operator commands')
+    assert_safe_stage19av_target(args, env=source_env)
+    return as_au.build_db_dsn(args, env=source_env)
+
+
+def assert_safe_stage19av_target(args: argparse.Namespace, env: Mapping[str, str] | None = None) -> None:
+    source_env = env if env is not None else os.environ
+    host = str(source_env.get('PGHOST') or args.db_host)
+    port = str(source_env.get('PGPORT') or args.db_port)
+    if host in {'127.0.0.1', 'localhost', '::1'} and port == '5432':
+        raise pilot.Stage19ArPilotError('direct host 5432 target is blocked for Stage 19AV')
+
+
+def run_db_preflight(args: argparse.Namespace, *, env: Mapping[str, str] | None = None) -> dict[str, Any]:
+    source_env = env if env is not None else os.environ
+    secrets = as_au.load_secrets_for_args(args) if env is None else {
+        'detected': bool(getattr(args, 'secrets_file', None)),
+        'used': bool(getattr(args, 'secrets_file', None)),
+        'path': 'not reported',
+        'tracked_by_git': False,
+        'keys': [],
+    }
+    config = as_au.redacted_db_config(args, env=source_env, secrets=secrets)
+    if source_env.get('DATABASE_URL'):
+        return db_preflight_result(
+            config,
+            secrets,
+            auth_success=False,
+            failure_category='database_url_must_be_unset',
+        )
+    if secrets['tracked_by_git']:
+        return db_preflight_result(config, secrets, auth_success=False, failure_category='secrets_file_tracked_by_git')
+    if getattr(args, 'secrets_file', None) and not secrets['detected']:
+        return db_preflight_result(config, secrets, auth_success=False, failure_category='secrets_file_missing')
+
+    conn = None
+    try:
+        dsn = build_db_dsn(args, env=source_env)
+        conn = pilot.connect_operator_db(dsn)
+        pilot.set_connection_mode(conn, commit=False)
+        prereqs = verify_stage19av_prerequisites(conn)
+        pilot.rollback(conn)
+        return {
+            **db_preflight_result(config, secrets, auth_success=True, failure_category=None),
+            'stage19av_prerequisites': prereqs,
+            'stage19av_prerequisites_ok': all(bool(value) for value in prereqs['checks'].values()),
+        }
+    except Exception as exc:
+        if conn is not None:
+            pilot.rollback(conn)
+        if isinstance(exc, pilot.Stage19ArPilotError) and 'direct host 5432 target' in str(exc):
+            failure_category = 'host_5432_direct_target_blocked'
+        else:
+            failure_category = as_au.db_failure_category(exc)
+        return db_preflight_result(
+            config,
+            secrets,
+            auth_success=False,
+            failure_category=failure_category,
+        )
+    finally:
+        if conn is not None:
+            pilot.close_connection(conn)
+
+
+def db_preflight_result(
+    config: Mapping[str, Any],
+    secrets: Mapping[str, Any],
+    *,
+    auth_success: bool,
+    failure_category: str | None,
+) -> dict[str, Any]:
+    return {
+        **as_au.secrets_result(secrets),
+        'db_config': dict(config),
+        'db_config_loaded': bool(config.get('password_present')),
+        'auth_success': auth_success,
+        'performed_no_writes': True,
+        'secrets_redacted': True,
+        'failure_category': failure_category,
+        'stage19av_prerequisites_ok': False if failure_category else None,
+    }
+
+
+def verify_stage19av_prerequisites(conn: Any) -> dict[str, Any]:
+    stage19ar_baseline = as_au.verify_canonical_stage19ar_baseline(conn)
+    stage19as_au = verify_stage19as_au_checkpoint(conn)
+    no_blocking_runs = count_blocking_stage19_runs(conn) == 0
+    checks = {
+        'stage19ar_baseline_preserved': all(stage19ar_baseline['checks'].values()),
+        'stage19as_au_checkpoint_preserved': all(stage19as_au['checks'].values()),
+        'stage19au_verification_preserved': (
+            all(stage19ar_baseline['checks'].values())
+            and all(stage19as_au['checks'].values())
+            and no_blocking_runs
+        ),
+        'no_blocking_stage19_runs': no_blocking_runs,
+    }
+    return {
+        'stage19ar_baseline': stage19ar_baseline['checks'],
+        'stage19as_au_checkpoint': stage19as_au['checks'],
+        'checks': checks,
+    }
+
+
+def assert_stage19av_prerequisites(prereqs: Mapping[str, Any]) -> None:
+    checks = prereqs.get('checks') or {}
+    failed = sorted(key for key, passed in checks.items() if not passed)
+    if failed:
+        raise pilot.Stage19ArPilotError(f'Stage 19AV prerequisites failed: {failed}')
+
+
+def verify_stage19as_au_checkpoint(conn: Any) -> dict[str, Any]:
+    source_run = pilot.fetch_source_run(conn, STAGE19AS_AU_SOURCE_RUN_KEY)
+    bridge = pilot.fetch_legacy_bridge(conn, STAGE19AS_AU_BRIDGE_KEY)
+    source_run_id = int(source_run['id']) if source_run and source_run.get('id') is not None else None
+    legacy_source_run_id = int(bridge['id']) if bridge and bridge.get('id') is not None else None
+    counts = staging_counts_for_bridge(
+        conn,
+        source_run_id=source_run_id,
+        legacy_source_run_id=legacy_source_run_id,
+        marker_key=STAGE19AS_AU_MARKER,
+    )
+    safety = source_run_safety_flags(conn, source_run_key=STAGE19AS_AU_SOURCE_RUN_KEY)
+    checks = {
+        'source_run_key_present': source_run is not None
+        and source_run.get('source_run_key') == STAGE19AS_AU_SOURCE_RUN_KEY,
+        'bridge_key_present': bridge is not None and bridge.get('source_run_key') == STAGE19AS_AU_BRIDGE_KEY,
+        'artifact_checksum_matches': source_run is not None
+        and source_run.get('artifact_sha256') == STAGE19AS_AU_ARTIFACT_SHA256,
+        'row_counts_match_100': source_run is not None
+        and source_run.get('rows_read') == 100
+        and source_run.get('rows_staged') == 100
+        and source_run.get('rows_rejected') == 0
+        and source_run.get('rows_skipped') == 0,
+        'staging_rows_match_100': counts['rows_total'] == 100,
+        'diagnostic_isolation': counts['rows_diagnostic_only'] == 100
+        and counts['rows_using_source_runs_id'] == 0
+        and counts['rows_using_legacy_bridge_id'] == 100,
+        'provenance_complete': counts['rows_with_marker'] == 100,
+        'canonical_write_block_complete': counts['rows_with_canonical_write_blocked'] == 100,
+        'canonical_scheduler_prod_flags_absent': all(safety.values()),
+    }
+    return {
+        'source_run': source_run,
+        'bridge': bridge,
+        'staging_counts': counts,
+        'safety_flags': safety,
+        'checks': checks,
+    }
+
+
+def staging_counts_for_bridge(
+    conn: Any,
+    *,
+    source_run_id: int | None,
+    legacy_source_run_id: int | None,
+    marker_key: str,
+) -> dict[str, int]:
+    if source_run_id is None or legacy_source_run_id is None:
+        return {
+            'rows_total': 0,
+            'rows_diagnostic_only': 0,
+            'rows_using_legacy_bridge_id': 0,
+            'rows_using_source_runs_id': 0,
+            'rows_with_marker': 0,
+            'rows_with_canonical_write_blocked': 0,
+        }
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT
+              COUNT(*)::int AS rows_total,
+              COUNT(*) FILTER (WHERE source_class = %s AND confidence = %s)::int
+                AS rows_diagnostic_only,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_legacy_bridge_id,
+              COUNT(*) FILTER (WHERE source_run_id = %s)::int AS rows_using_source_runs_id,
+              COUNT(*) FILTER (WHERE provenance ? %s)::int AS rows_with_marker,
+              COUNT(*) FILTER (WHERE provenance->>%s = 'false')::int
+                AS rows_with_canonical_write_blocked
+            FROM staging_edsm_stations
+            WHERE source_run_id = %s
+            """,
+            (
+                pilot.DIAGNOSTIC_ONLY,
+                pilot.DIAGNOSTIC_ONLY,
+                legacy_source_run_id,
+                source_run_id,
+                marker_key,
+                'canonical_write_allowed',
+                legacy_source_run_id,
+            ),
+        )
+        row = pilot._fetchone_dict(cur) or {}
+    finally:
+        pilot.close_cursor(cur)
+    return {
+        'rows_total': int(row.get('rows_total') or 0),
+        'rows_diagnostic_only': int(row.get('rows_diagnostic_only') or 0),
+        'rows_using_legacy_bridge_id': int(row.get('rows_using_legacy_bridge_id') or 0),
+        'rows_using_source_runs_id': int(row.get('rows_using_source_runs_id') or 0),
+        'rows_with_marker': int(row.get('rows_with_marker') or 0),
+        'rows_with_canonical_write_blocked': int(row.get('rows_with_canonical_write_blocked') or 0),
+    }
+
+
+def source_run_safety_flags(conn: Any, *, source_run_key: str) -> dict[str, bool]:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT safety_boundary
+            FROM source_runs
+            WHERE source_run_key = %s
+            """,
+            (source_run_key,),
+        )
+        row = pilot._fetchone_dict(cur) or {}
+    finally:
+        pilot.close_cursor(cur)
+    safety = row.get('safety_boundary') if isinstance(row.get('safety_boundary'), Mapping) else {}
+    return {
+        'canonical_apply_disabled': safety.get('canonical_apply_enabled') is False,
+        'canonical_writes_zero': int(safety.get('canonical_writes_planned') or 0) == 0,
+        'scheduler_disabled': safety.get('scheduled_import_enabled') is False,
+        'service_disabled': safety.get('service_enabled') is False,
+        'timer_disabled': safety.get('timer_enabled') is False,
+        'production_db_access_false': safety.get('production_db_connection_opened') is False,
+    }
+
+
+def count_blocking_stage19_runs(conn: Any) -> int:
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT COUNT(*)::int AS blocking_runs
+            FROM source_runs
+            WHERE (source_run_key LIKE 'stage19%' OR source_run_key LIKE 'stage-19%')
+              AND status IN ('running', 'failed', 'active', 'pending')
+            """,
+        )
+        row = pilot._fetchone_dict(cur) or {}
+    finally:
+        pilot.close_cursor(cur)
+    return int(row.get('blocking_runs') or 0)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/operator/stage19av_expanded_source_run_staging_pilot.py
+++ b/scripts/operator/stage19av_expanded_source_run_staging_pilot.py
@@ -30,6 +30,9 @@ STAGE19AS_AU_SOURCE_RUN_KEY = 'stage19as-au-edsm-100-row-controlled-expansion-18
 STAGE19AS_AU_BRIDGE_KEY = f'{pilot.source_run_compatibility.LEGACY_SOURCE_RUN_KEY_PREFIX}{STAGE19AS_AU_SOURCE_RUN_KEY}'
 STAGE19AS_AU_ARTIFACT_SHA256 = '7f6f20a4d01b543d8ef12072891d8fda749bcc1b6633c26bc9ec178a40b8f84e'
 STAGE19AS_AU_MARKER = 'stage19as_au_controlled_100_row_expansion'
+STAGE19AV_APPROVED_DB_HOST = '127.0.0.1'
+STAGE19AV_APPROVED_DB_PORT = '55432'
+STAGE19AV_DIRECT_HOST_5432_HOSTS = frozenset({'127.0.0.1', 'localhost', '::1', '0.0.0.0'})
 
 STAGE19AV_PROFILE = pilot.BoundedPilotProfile(
     schema_version='stage19av_expanded_source_run_staging_pilot/v1',
@@ -66,7 +69,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description='Prepare or run the Stage 19AV expanded controlled source-run staging pilot.',
     )
-    parser.add_argument('--limit', type=int, default=STAGE19AV_LIMIT, help='Exact number of staging rows to pilot.')
+    parser.add_argument('--limit', type=int, required=True, help='Exact number of staging rows to pilot.')
     parser.add_argument(
         '--artifact-dir',
         default=str(STAGE19AV_PROFILE.artifact_dir),
@@ -84,8 +87,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action='store_true',
         help='Required with --commit so Stage 19AV cannot be run by a generic committed invocation.',
     )
-    parser.add_argument('--db-host', default='127.0.0.1', help='Local Postgres host.')
-    parser.add_argument('--db-port', default='5432', help='Local Postgres port.')
+    parser.add_argument('--db-host', default=STAGE19AV_APPROVED_DB_HOST, help='Approved local Postgres host.')
+    parser.add_argument('--db-port', default=STAGE19AV_APPROVED_DB_PORT, help='Approved local Postgres port.')
     parser.add_argument('--db-name', default='edfinder', help='Local Postgres database name.')
     parser.add_argument('--db-user', default='edfinder', help='Local Postgres user.')
     parser.add_argument(
@@ -160,10 +163,15 @@ def build_db_dsn(args: argparse.Namespace, env: Mapping[str, str] | None = None)
 
 def assert_safe_stage19av_target(args: argparse.Namespace, env: Mapping[str, str] | None = None) -> None:
     source_env = env if env is not None else os.environ
-    host = str(source_env.get('PGHOST') or args.db_host)
-    port = str(source_env.get('PGPORT') or args.db_port)
-    if host in {'127.0.0.1', 'localhost', '::1'} and port == '5432':
+    host = str(source_env.get('PGHOST') or args.db_host).strip()
+    port = str(source_env.get('PGPORT') or args.db_port).strip()
+    if host in STAGE19AV_DIRECT_HOST_5432_HOSTS and port == '5432':
         raise pilot.Stage19ArPilotError('direct host 5432 target is blocked for Stage 19AV')
+    if host != STAGE19AV_APPROVED_DB_HOST or port != STAGE19AV_APPROVED_DB_PORT:
+        raise pilot.Stage19ArPilotError(
+            'Stage 19AV DB target must be exactly 127.0.0.1:55432; '
+            'non-local and production-like targets are blocked'
+        )
 
 
 def run_db_preflight(args: argparse.Namespace, *, env: Mapping[str, str] | None = None) -> dict[str, Any]:
@@ -205,6 +213,8 @@ def run_db_preflight(args: argparse.Namespace, *, env: Mapping[str, str] | None 
             pilot.rollback(conn)
         if isinstance(exc, pilot.Stage19ArPilotError) and 'direct host 5432 target' in str(exc):
             failure_category = 'host_5432_direct_target_blocked'
+        elif isinstance(exc, pilot.Stage19ArPilotError) and 'exactly 127.0.0.1:55432' in str(exc):
+            failure_category = 'stage19av_safe_target_required'
         else:
             failure_category = as_au.db_failure_category(exc)
         return db_preflight_result(

--- a/tests/test_stage19as2_operator_script_contract.py
+++ b/tests/test_stage19as2_operator_script_contract.py
@@ -153,6 +153,7 @@ def test_committed_pilot_scripts_keep_hard_limits_and_validation_contracts():
     assert '--confirm-stage19av is required with --commit' in stage19av
     assert 'DATABASE_URL must be unset for Stage 19AV operator commands' in stage19av
     assert 'direct host 5432 target is blocked for Stage 19AV' in stage19av
+    assert 'Stage 19AV DB target must be exactly 127.0.0.1:55432' in stage19av
     assert 'verify_stage19av_prerequisites(conn)' in stage19av
     assert 'stage19av_expanded_source_run_staging_pilot.py' in contract_doc
 

--- a/tests/test_stage19as2_operator_script_contract.py
+++ b/tests/test_stage19as2_operator_script_contract.py
@@ -17,6 +17,7 @@ OPERATOR_SCRIPTS = {
     'Stage 19AR': ROOT / 'scripts' / 'operator' / 'stage19ar_edsm_25_row_staging_pilot.py',
     'Stage 19AS-AU': ROOT / 'scripts' / 'operator' / 'stage19as_au_edsm_100_row_controlled_expansion.py',
     'Stage 19AN-R': ROOT / 'scripts' / 'operator' / 'stage19anr_warehouse_derived_staging_rehearsal.py',
+    'Stage 19AV': ROOT / 'scripts' / 'operator' / 'stage19av_expanded_source_run_staging_pilot.py',
 }
 
 
@@ -128,6 +129,7 @@ def test_committed_pilot_scripts_keep_hard_limits_and_validation_contracts():
     stage19ar = _read(OPERATOR_SCRIPTS['Stage 19AR'])
     stage19as_au = _read(OPERATOR_SCRIPTS['Stage 19AS-AU'])
     stage19anr = _read(OPERATOR_SCRIPTS['Stage 19AN-R'])
+    stage19av = _read(OPERATOR_SCRIPTS['Stage 19AV'])
     contract_doc = _read(CONTRACT_DOC_PATH)
 
     assert 'HARD_MAX_LIMIT = 25' in stage19ar
@@ -143,6 +145,16 @@ def test_committed_pilot_scripts_keep_hard_limits_and_validation_contracts():
     assert "parser.add_argument('--artifact-dir', required=True" in stage19anr
     assert 'Stage 19AN-R' in contract_doc
     assert 'only a lower-bound `--limit` check' in contract_doc
+
+    assert 'STAGE19AV_LIMIT = 250' in stage19av
+    assert 'hard_max_limit=STAGE19AV_LIMIT' in stage19av
+    assert 'if args.limit > STAGE19AV_PROFILE.hard_max_limit' in stage19av
+    assert "'--confirm-stage19av'" in stage19av
+    assert '--confirm-stage19av is required with --commit' in stage19av
+    assert 'DATABASE_URL must be unset for Stage 19AV operator commands' in stage19av
+    assert 'direct host 5432 target is blocked for Stage 19AV' in stage19av
+    assert 'verify_stage19av_prerequisites(conn)' in stage19av
+    assert 'stage19av_expanded_source_run_staging_pilot.py' in contract_doc
 
     for stage, source in (
         ('Stage 19AR', stage19ar),

--- a/tests/test_stage19av_expanded_source_run_staging_pilot.py
+++ b/tests/test_stage19av_expanded_source_run_staging_pilot.py
@@ -31,6 +31,16 @@ def _squash(text: str) -> str:
     return re.sub(r'\s+', ' ', text)
 
 
+def _db_args(host: str = '127.0.0.1', port: str = '55432') -> argparse.Namespace:
+    return argparse.Namespace(
+        db_host=host,
+        db_port=port,
+        db_name='edfinder',
+        db_user='edfinder',
+        secrets_file=None,
+    )
+
+
 @pytest.mark.unit
 def test_stage19av_keeps_authority_paused_until_pilot_succeeds():
     authority = json.loads(_read(AUTHORITY_PATH))
@@ -54,11 +64,13 @@ def test_stage19av_keeps_authority_paused_until_pilot_succeeds():
 @pytest.mark.unit
 def test_stage19av_wrapper_has_stage_specific_bounded_profile():
     profile = stage19av.STAGE19AV_PROFILE
-    args = stage19av.parse_args(['--git-head', 'abc1234'])
+    args = stage19av.parse_args(['--git-head', 'abc1234', '--limit', '250'])
 
     assert args.commit is False
     assert args.confirm_stage19av is False
     assert args.limit == 250
+    assert args.db_host == '127.0.0.1'
+    assert args.db_port == '55432'
     assert args.trigger_context == 'stage19av_expanded_source_run_staging_pilot'
     assert profile.default_limit == 250
     assert profile.hard_max_limit == 250
@@ -74,12 +86,15 @@ def test_stage19av_wrapper_has_stage_specific_bounded_profile():
 @pytest.mark.unit
 def test_stage19av_rejects_unbounded_or_unconfirmed_committed_invocations():
     with pytest.raises(SystemExit):
+        stage19av.parse_args([])
+
+    with pytest.raises(SystemExit):
         stage19av.parse_args(['--limit', '251'])
 
     with pytest.raises(SystemExit):
-        stage19av.parse_args(['--commit'])
+        stage19av.parse_args(['--limit', '250', '--commit'])
 
-    args = stage19av.parse_args(['--commit', '--confirm-stage19av'])
+    args = stage19av.parse_args(['--limit', '250', '--commit', '--confirm-stage19av'])
 
     assert args.commit is True
     assert args.confirm_stage19av is True
@@ -88,13 +103,7 @@ def test_stage19av_rejects_unbounded_or_unconfirmed_committed_invocations():
 
 @pytest.mark.unit
 def test_stage19av_refuses_database_url_and_keeps_preflight_redacted():
-    args = argparse.Namespace(
-        db_host='127.0.0.1',
-        db_port='55432',
-        db_name='edfinder',
-        db_user='edfinder',
-        secrets_file=None,
-    )
+    args = _db_args()
     env = {
         'DATABASE_URL': 'postgresql://edfinder:do-not-print-this@127.0.0.1:55432/edfinder',
         'POSTGRES_PASSWORD': 'do-not-print-this',
@@ -113,6 +122,42 @@ def test_stage19av_refuses_database_url_and_keeps_preflight_redacted():
     assert 'do-not-print-this' not in encoded
     assert 'postgresql://' not in encoded
 
+
+@pytest.mark.unit
+def test_stage19av_accepts_only_the_approved_safe_local_target():
+    args = _db_args()
+    env = {
+        'POSTGRES_PASSWORD': 'do-not-print-this',
+    }
+
+    stage19av.assert_safe_stage19av_target(args, env=env)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ('host', 'port', 'match'),
+    [
+        ('127.0.0.1', '5432', 'direct host 5432 target'),
+        ('localhost', '5432', 'direct host 5432 target'),
+        ('::1', '5432', 'direct host 5432 target'),
+        ('0.0.0.0', '5432', 'direct host 5432 target'),
+        ('localhost', '55432', 'exactly 127.0.0.1:55432'),
+        ('::1', '55432', 'exactly 127.0.0.1:55432'),
+        ('10.0.0.10', '55432', 'exactly 127.0.0.1:55432'),
+        ('192.168.1.10', '55432', 'exactly 127.0.0.1:55432'),
+        ('203.0.113.10', '55432', 'exactly 127.0.0.1:55432'),
+        ('prod-db.internal', '55432', 'exactly 127.0.0.1:55432'),
+        ('127.0.0.1', '5433', 'exactly 127.0.0.1:55432'),
+    ],
+)
+def test_stage19av_rejects_direct_5432_non_local_and_production_like_targets(host, port, match):
+    with pytest.raises(stage19av.pilot.Stage19ArPilotError, match=match):
+        stage19av.assert_safe_stage19av_target(_db_args(host=host, port=port), env={})
+
+
+@pytest.mark.unit
+def test_stage19av_rejects_environment_driven_unsafe_targets():
+    args = _db_args()
     unsafe_env = {
         'POSTGRES_PASSWORD': 'do-not-print-this',
         'PGHOST': '127.0.0.1',
@@ -128,6 +173,20 @@ def test_stage19av_refuses_database_url_and_keeps_preflight_redacted():
     assert unsafe_result['performed_no_writes'] is True
     assert unsafe_result['failure_category'] == 'host_5432_direct_target_blocked'
     assert 'do-not-print-this' not in unsafe_encoded
+
+    production_like_env = {
+        'POSTGRES_PASSWORD': 'do-not-print-this',
+        'PGHOST': 'prod-db.internal',
+        'PGPORT': '55432',
+    }
+    with pytest.raises(stage19av.pilot.Stage19ArPilotError, match='exactly 127.0.0.1:55432'):
+        stage19av.build_db_dsn(args, env=production_like_env)
+
+    production_like_result = stage19av.run_db_preflight(args, env=production_like_env)
+
+    assert production_like_result['auth_success'] is False
+    assert production_like_result['performed_no_writes'] is True
+    assert production_like_result['failure_category'] == 'stage19av_safe_target_required'
 
 
 @pytest.mark.unit
@@ -157,6 +216,8 @@ def test_stage19av_docs_and_script_keep_forbidden_work_blocked():
         'assert_stage19av_prerequisites(prereqs)',
         'DATABASE_URL must be unset for Stage 19AV operator commands',
         'direct host 5432 target is blocked for Stage 19AV',
+        'Stage 19AV DB target must be exactly 127.0.0.1:55432',
+        'stage19av_safe_target_required',
         'host_5432_direct_target_blocked',
         "'canonical_writes_zero'",
         "'scheduler_disabled'",

--- a/tests/test_stage19av_expanded_source_run_staging_pilot.py
+++ b/tests/test_stage19av_expanded_source_run_staging_pilot.py
@@ -1,0 +1,177 @@
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+OPERATOR_SCRIPTS = ROOT / 'scripts' / 'operator'
+if str(OPERATOR_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(OPERATOR_SCRIPTS))
+
+import stage19av_expanded_source_run_staging_pilot as stage19av  # noqa: E402
+
+
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+ROADMAP_PATH = DOCS / 'stage-19-data-warehouse-utopia-roadmap.md'
+AV_DOC_PATH = DOCS / 'stage-19av-expanded-source-run-staging-pilot.md'
+AV_SCRIPT_PATH = OPERATOR_SCRIPTS / 'stage19av_expanded_source_run_staging_pilot.py'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+@pytest.mark.unit
+def test_stage19av_keeps_authority_paused_until_pilot_succeeds():
+    authority = json.loads(_read(AUTHORITY_PATH))
+    av_doc = _squash(_read(AV_DOC_PATH))
+    roadmap = _squash(_read(ROADMAP_PATH))
+
+    assert authority['stage19'] == {
+        'status': 'paused',
+        'stage19as_au_status': 'completed',
+    }
+    assert 'stage19av_completed_checkpoint' not in authority
+    assert 'Stage 19AV is the selected bounded write lane after Stage 19AU.' in av_doc
+    assert 'The Stage 19AV bounded write was not run in this checkpoint' in av_doc
+    assert 'Stage 19 remains paused.' in av_doc
+    assert 'No canonical apply is complete.' in av_doc
+    assert 'No rebaseline is complete.' in av_doc
+    assert 'Stage 19AV is the selected expanded controlled source-run staging pilot lane after Stage 19AU.' in roadmap
+    assert 'This preparation checkpoint does not run the AV bounded write.' in roadmap
+
+
+@pytest.mark.unit
+def test_stage19av_wrapper_has_stage_specific_bounded_profile():
+    profile = stage19av.STAGE19AV_PROFILE
+    args = stage19av.parse_args(['--git-head', 'abc1234'])
+
+    assert args.commit is False
+    assert args.confirm_stage19av is False
+    assert args.limit == 250
+    assert args.trigger_context == 'stage19av_expanded_source_run_staging_pilot'
+    assert profile.default_limit == 250
+    assert profile.hard_max_limit == 250
+    assert profile.source_run_key_prefix == 'stage19av-expanded-source-run-staging-pilot-'
+    assert profile.source_run_prefixes == ('stage19av-', 'stage-19av-')
+    assert profile.provenance_marker_key == 'stage19av_expanded_source_run_staging_pilot'
+    assert profile.artifact_dir == Path('/var/lib/ed-finder/operator-artifacts/stage-19av')
+    assert profile.bridge_metadata['stage19as_au_checkpoint_preserved'] is True
+    assert profile.bridge_metadata['stage19au_readonly_db_verification_required'] is True
+    assert profile.bridge_metadata['rows_expected'] == 250
+
+
+@pytest.mark.unit
+def test_stage19av_rejects_unbounded_or_unconfirmed_committed_invocations():
+    with pytest.raises(SystemExit):
+        stage19av.parse_args(['--limit', '251'])
+
+    with pytest.raises(SystemExit):
+        stage19av.parse_args(['--commit'])
+
+    args = stage19av.parse_args(['--commit', '--confirm-stage19av'])
+
+    assert args.commit is True
+    assert args.confirm_stage19av is True
+    assert args.limit == 250
+
+
+@pytest.mark.unit
+def test_stage19av_refuses_database_url_and_keeps_preflight_redacted():
+    args = argparse.Namespace(
+        db_host='127.0.0.1',
+        db_port='55432',
+        db_name='edfinder',
+        db_user='edfinder',
+        secrets_file=None,
+    )
+    env = {
+        'DATABASE_URL': 'postgresql://edfinder:do-not-print-this@127.0.0.1:55432/edfinder',
+        'POSTGRES_PASSWORD': 'do-not-print-this',
+    }
+
+    with pytest.raises(stage19av.pilot.Stage19ArPilotError, match='DATABASE_URL must be unset'):
+        stage19av.build_db_dsn(args, env=env)
+
+    result = stage19av.run_db_preflight(args, env=env)
+    encoded = json.dumps(result, sort_keys=True)
+
+    assert result['auth_success'] is False
+    assert result['performed_no_writes'] is True
+    assert result['secrets_redacted'] is True
+    assert result['failure_category'] == 'database_url_must_be_unset'
+    assert 'do-not-print-this' not in encoded
+    assert 'postgresql://' not in encoded
+
+    unsafe_env = {
+        'POSTGRES_PASSWORD': 'do-not-print-this',
+        'PGHOST': '127.0.0.1',
+        'PGPORT': '5432',
+    }
+    with pytest.raises(stage19av.pilot.Stage19ArPilotError, match='direct host 5432 target'):
+        stage19av.build_db_dsn(args, env=unsafe_env)
+
+    unsafe_result = stage19av.run_db_preflight(args, env=unsafe_env)
+    unsafe_encoded = json.dumps(unsafe_result, sort_keys=True)
+
+    assert unsafe_result['auth_success'] is False
+    assert unsafe_result['performed_no_writes'] is True
+    assert unsafe_result['failure_category'] == 'host_5432_direct_target_blocked'
+    assert 'do-not-print-this' not in unsafe_encoded
+
+
+@pytest.mark.unit
+def test_stage19av_docs_and_script_keep_forbidden_work_blocked():
+    av_doc = _squash(_read(AV_DOC_PATH))
+    source = _read(AV_SCRIPT_PATH)
+
+    for fragment in (
+        'Stage 19AR with `--commit`',
+        'Stage 19AS-AU with `--commit`',
+        'unbounded source batches',
+        'canonical table writes',
+        'canonical apply',
+        'rebaseline',
+        'scheduler, timer, or service-manager work',
+        'production-like DB targets',
+        'host `5432` as a direct Stage 19 target',
+        'runtime source JSON or operator artifact JSON commits',
+        'Any future write-capable lane after Stage 19AV requires a separate explicit operator decision.',
+    ):
+        assert fragment in av_doc
+
+    for fragment in (
+        'pilot.run_pilot(',
+        'profile=STAGE19AV_PROFILE',
+        'verify_stage19av_prerequisites(conn)',
+        'assert_stage19av_prerequisites(prereqs)',
+        'DATABASE_URL must be unset for Stage 19AV operator commands',
+        'direct host 5432 target is blocked for Stage 19AV',
+        'host_5432_direct_target_blocked',
+        "'canonical_writes_zero'",
+        "'scheduler_disabled'",
+        "'production_db_access_false'",
+    ):
+        assert fragment in source
+
+    assert 'systemctl' not in source.lower()
+    assert re.search(r'(?<![A-Za-z0-9_])\.(?:timer|service)(?![A-Za-z0-9_])', source) is None
+
+
+@pytest.mark.unit
+def test_stage19av_local_ci_parity_registration_is_static_only():
+    parity = _read(LOCAL_CI_PARITY)
+
+    assert 'tests/test_stage19av_expanded_source_run_staging_pilot.py' in parity
+    assert 'scripts/operator/stage19' not in parity
+    assert '--commit' not in parity


### PR DESCRIPTION
## Summary

- Selected lane: expanded controlled source-run staging pilot
- Prepared a Stage 19AV wrapper, checkpoint doc, and static/unit coverage
- Pilot was not run because the lane needed a dedicated wrapper/test/doc checkpoint before the first AV write

## Stage 19AV Boundary

- Prepared wrapper: `scripts/operator/stage19av_expanded_source_run_staging_pilot.py`
- Exact bounded limit: 250 rows
- Requires `--commit` and `--confirm-stage19av` before any staging write
- Provides `--preflight-db` prerequisite verification
- Refuses `DATABASE_URL` and direct local host `5432` targets for Stage 19AV commands
- Safe target for a future approved run: `127.0.0.1:55432`

## Safety

- Stage 19AR baseline preserved by authority; not re-run
- Stage 19AS-AU checkpoint preserved by authority; not re-run
- Stage 19AU verification preserved by authority
- No Stage 19AV pilot attempted
- No Stage 19 operator commands run
- No DB mutation
- No canonical apply
- No rebaseline
- No scheduler/service enablement
- No secrets printed
- No runtime source files or operator artifacts committed

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict` passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19av_expanded_source_run_staging_pilot.py -p no:cacheprovider` passed: 6 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19au_readonly_asau_safety_gate.py tests/test_stage19at_paused_state_next_operator_decision.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19as1_disposable_postgres_constraints.py -p no:cacheprovider` passed: 22 passed, 1 skipped
- `git diff --check` passed
- `git diff --cached --check` passed