### PR TITLE
Add Stage 19AW post-AV decision checkpoint

### DIFF
--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -817,6 +817,14 @@ counts of 250 read, 250 staged, 0 rejected, and 0 skipped. Stage 19 remains
 paused, with no canonical apply, no rebaseline, no scheduler/service work, no
 production-like DB target, and no direct host `5432` target authorized.
 
+Stage 19AW is the post-AV paused-state decision checkpoint. It is recorded in
+`docs/colonisation-redesign/stage-19aw-post-av-paused-state-decision.md` as
+docs/static coverage only. Stage 19AW keeps Stage 19 paused after the completed
+Stage 19AV pilot and does not authorize read-only DB verification, bounded
+write preparation, bounded write execution, scheduler/service work, canonical
+apply, rebaseline, Stage 19 closeout, or test environment closeout. The next
+lane must be selected by a separate explicit operator decision.
+
 ### Deferred Stage 19AS.1 - Test Fortress / CI parity
 
 Deferred: this is important safety work, but it should not block the immediate

--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -57,6 +57,28 @@
     "post_run_live_verification_passed": true,
     "stage19_remains_paused": true
   },
+  "stage19aw_decision_checkpoint": {
+    "status": "recorded",
+    "checkpoint_type": "post_av_paused_state_decision",
+    "recorded_at": "2026-06-15",
+    "docs_static_only": true,
+    "stage19av_checkpoint_preserved": true,
+    "stage19_remains_paused": true,
+    "next_execution_lane_authorized": false,
+    "read_only_db_verification_authorized": false,
+    "bounded_write_preparation_authorized": false,
+    "bounded_write_execution_authorized": false,
+    "scheduler_service_authorized": false,
+    "canonical_apply_authorized": false,
+    "rebaseline_authorized": false,
+    "stage19_closeout_authorized": false,
+    "test_environment_closeout_authorized": false,
+    "db_work_recorded": false,
+    "source_acquisition_recorded": false,
+    "stage19_operator_commands_recorded": false,
+    "runtime_source_files_are_authority": false,
+    "operator_artifact_json_committed_as_authority": false
+  },
   "retired_stage19ar_baseline": {
     "source_run_key": "stage19ar-edsm-25-row-staging-pilot-381a609ed62b80fd",
     "artifact": "418bc0db66978623c460aa8cc46a8ab14811098f39cb99a16274d9d181f19417",

--- a/docs/colonisation-redesign/stage-19aw-post-av-paused-state-decision.md
+++ b/docs/colonisation-redesign/stage-19aw-post-av-paused-state-decision.md
@@ -1,0 +1,113 @@
+# Stage 19AW - Post-AV Paused-State Decision
+
+## Purpose
+
+Stage 19AW records the paused-state decision checkpoint after Stage 19AV. It is
+a docs/static checkpoint only: it summarizes the current authority, keeps Stage
+19 paused, and requires a separate explicit operator decision before any next
+lane is selected.
+
+Stage 19AW does not run Stage 19 operator commands, connect to a database,
+acquire source input, run a staging loader, write staging rows, write canonical
+tables, run canonical apply, run rebaseline, or enable scheduler/service work.
+
+## Current Authority
+
+Active authority remains
+`docs/colonisation-redesign/stage-19-state-authority.json`.
+
+- Stage 19AS-AU is complete and recorded.
+- Stage 19AS.1 is complete and recorded.
+- Stage 19AS.2 is complete and recorded.
+- Stage 19AT is complete and recorded.
+- Stage 19AU read-only DB verification is complete and recorded.
+- Stage 19AV expanded source-run staging pilot is complete and recorded.
+- Stage 19 remains paused.
+- No canonical apply is complete.
+- No rebaseline is complete.
+- Scheduler and wider service work remain unauthorized.
+
+## Stage 19AV Proof Preserved
+
+Stage 19AV remains recorded with this proof:
+
+- source run:
+  `stage19av-expanded-source-run-staging-pilot-48688d9d46067867`;
+- bridge:
+  `source_runs:stage19av-expanded-source-run-staging-pilot-48688d9d46067867`;
+- import artifact checksum:
+  `09652a1c6e6ad661415f535a713432b0d3a76aef5b8c931c0b1874e1c52604f4`;
+- rows read: `250`;
+- rows staged: `250`;
+- rows rejected: `0`;
+- rows skipped: `0`;
+- canonical writes performed: `false`;
+- Stage 19AR baseline preserved: `true`;
+- Stage 19AS-AU checkpoint preserved: `true`;
+- Stage 19AU verification preserved: `true`;
+- Stage 19 paused after run: `true`.
+
+Runtime source files and operator artifact JSON files remain evidence only. They
+are not committed authority.
+
+## Decision Boundary
+
+Stage 19AW records that no next execution lane is authorized yet. A future lane
+must be selected by a separate explicit operator decision before any work starts.
+
+The required decision applies to:
+
+- read-only DB verification lane;
+- bounded write preparation lane;
+- bounded write execution lane;
+- scheduler/service lane;
+- canonical apply lane;
+- rebaseline lane;
+- Stage 19 closeout lane;
+- test environment closeout lane.
+
+## Blocked Work
+
+Stage 19AW does not authorize:
+
+- read-only DB verification;
+- bounded write preparation;
+- bounded write execution;
+- Stage 19 operator commands;
+- Stage 19AR with `--commit`;
+- Stage 19AS-AU with `--commit`;
+- Stage 19AV with `--commit`;
+- source acquisition;
+- staging loader execution;
+- full source batch execution;
+- database mutation;
+- staging row writes;
+- canonical table writes;
+- canonical apply;
+- rebaseline;
+- scheduler, timer, or service-manager work;
+- production-like database targets;
+- host `5432` as a direct Stage 19 target;
+- secrets access or printing;
+- runtime source JSON or operator artifact JSON commits;
+- Stage 19 closeout;
+- test environment closeout.
+
+Any future Stage 19 lane after AW requires a separate explicit operator
+decision.
+
+## Static Coverage
+
+`tests/test_stage19aw_post_av_paused_state_decision.py` covers:
+
+- Stage 19AV is complete and recorded;
+- Stage 19AW is present as a paused-state decision checkpoint;
+- Stage 19 remains paused;
+- no next execution lane is authorized;
+- canonical apply remains incomplete and unauthorized;
+- rebaseline remains incomplete and unauthorized;
+- scheduler/service work remains unauthorized;
+- AW does not record DB work, source acquisition, staging loader execution, or
+  Stage 19 operator command execution;
+- runtime source files and operator artifact JSON files are not committed
+  authority.

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -97,6 +97,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage19at_paused_state_next_operator_decision.py \
     tests/test_stage19au_readonly_asau_safety_gate.py \
     tests/test_stage19av_expanded_source_run_staging_pilot.py \
+    tests/test_stage19aw_post_av_paused_state_decision.py \
     tests/test_stage19aq1_test_fortress_guardrails.py \
     -q
 )

--- a/tests/test_stage19aw_post_av_paused_state_decision.py
+++ b/tests/test_stage19aw_post_av_paused_state_decision.py
@@ -1,0 +1,149 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+ROADMAP_PATH = DOCS / 'stage-19-data-warehouse-utopia-roadmap.md'
+AV_DOC_PATH = DOCS / 'stage-19av-expanded-source-run-staging-pilot.md'
+AW_DOC_PATH = DOCS / 'stage-19aw-post-av-paused-state-decision.md'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+@pytest.mark.unit
+def test_stage19aw_records_post_av_decision_checkpoint_without_unpausing_stage19():
+    authority = json.loads(_read(AUTHORITY_PATH))
+    av_checkpoint = authority['stage19av_completed_checkpoint']
+    aw_checkpoint = authority['stage19aw_decision_checkpoint']
+
+    assert authority['stage19'] == {
+        'status': 'paused',
+        'stage19as_au_status': 'completed',
+    }
+    assert av_checkpoint['status'] == 'completed'
+    assert av_checkpoint['source_run_key'] == 'stage19av-expanded-source-run-staging-pilot-48688d9d46067867'
+    assert av_checkpoint['bridge_key'] == 'source_runs:stage19av-expanded-source-run-staging-pilot-48688d9d46067867'
+    assert av_checkpoint['artifact'] == '09652a1c6e6ad661415f535a713432b0d3a76aef5b8c931c0b1874e1c52604f4'
+    assert av_checkpoint['rows_read'] == 250
+    assert av_checkpoint['rows_staged'] == 250
+    assert av_checkpoint['rows_rejected'] == 0
+    assert av_checkpoint['rows_skipped'] == 0
+    assert av_checkpoint['canonical_writes_performed'] is False
+    assert av_checkpoint['approved_stage19ar_baseline_preserved'] is True
+    assert av_checkpoint['stage19as_au_checkpoint_preserved'] is True
+    assert av_checkpoint['stage19au_verification_preserved'] is True
+    assert av_checkpoint['stage19_remains_paused'] is True
+
+    assert aw_checkpoint == {
+        'status': 'recorded',
+        'checkpoint_type': 'post_av_paused_state_decision',
+        'recorded_at': '2026-06-15',
+        'docs_static_only': True,
+        'stage19av_checkpoint_preserved': True,
+        'stage19_remains_paused': True,
+        'next_execution_lane_authorized': False,
+        'read_only_db_verification_authorized': False,
+        'bounded_write_preparation_authorized': False,
+        'bounded_write_execution_authorized': False,
+        'scheduler_service_authorized': False,
+        'canonical_apply_authorized': False,
+        'rebaseline_authorized': False,
+        'stage19_closeout_authorized': False,
+        'test_environment_closeout_authorized': False,
+        'db_work_recorded': False,
+        'source_acquisition_recorded': False,
+        'stage19_operator_commands_recorded': False,
+        'runtime_source_files_are_authority': False,
+        'operator_artifact_json_committed_as_authority': False,
+    }
+
+
+@pytest.mark.unit
+def test_stage19aw_doc_and_roadmap_require_explicit_operator_decision_for_next_lane():
+    aw_doc = _squash(_read(AW_DOC_PATH))
+    av_doc = _squash(_read(AV_DOC_PATH))
+    roadmap = _squash(_read(ROADMAP_PATH))
+
+    for fragment in (
+        'Stage 19AW - Post-AV Paused-State Decision',
+        'Stage 19AW records the paused-state decision checkpoint after Stage 19AV.',
+        'Stage 19AV expanded source-run staging pilot is complete and recorded.',
+        'Stage 19 remains paused.',
+        'No canonical apply is complete.',
+        'No rebaseline is complete.',
+        'Scheduler and wider service work remain unauthorized.',
+        'no next execution lane is authorized yet',
+        'must be selected by a separate explicit operator decision',
+        'read-only DB verification lane',
+        'bounded write preparation lane',
+        'bounded write execution lane',
+        'scheduler/service lane',
+        'canonical apply lane',
+        'rebaseline lane',
+        'Stage 19 closeout lane',
+        'test environment closeout lane',
+    ):
+        assert fragment in aw_doc
+
+    assert 'Stage 19AV was run on `2026-06-15T06:21:02Z`' in av_doc
+    assert 'Stage 19AW is the post-AV paused-state decision checkpoint.' in roadmap
+    assert 'docs/static coverage only' in roadmap
+    assert 'The next lane must be selected by a separate explicit operator decision.' in roadmap
+
+
+@pytest.mark.unit
+def test_stage19aw_blocks_db_operator_canonical_rebaseline_scheduler_and_runtime_authority():
+    aw_doc = _squash(_read(AW_DOC_PATH))
+
+    for fragment in (
+        'does not run Stage 19 operator commands',
+        'connect to a database',
+        'acquire source input',
+        'run a staging loader',
+        'write staging rows',
+        'write canonical tables',
+        'run canonical apply',
+        'run rebaseline',
+        'enable scheduler/service work',
+        'read-only DB verification',
+        'bounded write preparation',
+        'bounded write execution',
+        'Stage 19 operator commands',
+        'Stage 19AR with `--commit`',
+        'Stage 19AS-AU with `--commit`',
+        'Stage 19AV with `--commit`',
+        'source acquisition',
+        'staging loader execution',
+        'full source batch execution',
+        'database mutation',
+        'scheduler, timer, or service-manager work',
+        'production-like database targets',
+        'host `5432` as a direct Stage 19 target',
+        'secrets access or printing',
+        'runtime source JSON or operator artifact JSON commits',
+    ):
+        assert fragment in aw_doc
+
+    assert 'canonical apply is complete.' not in aw_doc.replace('No canonical apply is complete.', '')
+    assert 'rebaseline is complete.' not in aw_doc.replace('No rebaseline is complete.', '')
+
+
+@pytest.mark.unit
+def test_stage19aw_local_ci_parity_registration_is_static_only():
+    parity = _read(LOCAL_CI_PARITY)
+
+    assert 'tests/test_stage19aw_post_av_paused_state_decision.py' in parity
+    assert 'scripts/operator/stage19' not in parity
+    assert '--commit' not in parity


### PR DESCRIPTION
## Summary

- Adds Stage 19AW as a post-AV paused-state decision checkpoint.
- Preserves Stage 19AV completion proof and keeps Stage 19 paused.
- Records that no next lane is authorized until a separate explicit operator decision.
- Keeps canonical apply not complete, rebaseline not complete, and scheduler/service disabled.
- Adds static coverage and local CI parity registration for the AW checkpoint.

## Safety

- No DB commands were run.
- No Stage 19 operator commands were run.
- No source acquisition or staging loader was run.
- No canonical apply or rebaseline was run.
- No scheduler/service work was enabled.
- Runtime source files and operator artifact JSON are not committed authority.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict` passed.
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_project_state_resolver.py -p no:cacheprovider` passed: 13 passed.
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19aw_post_av_paused_state_decision.py -p no:cacheprovider` passed: 4 passed.
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest tests/test_stage19av_expanded_source_run_staging_pilot.py tests/test_stage19au_readonly_asau_safety_gate.py tests/test_stage19at_paused_state_next_operator_decision.py -p no:cacheprovider` passed: 30 passed.
- `git diff --check` passed.