### PR TITLE
Fix planner workspace act warnings

### DIFF
--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   api,
@@ -18,6 +18,7 @@ import {
 } from '@/lib/api';
 import type { FacilityTemplate, SimulationSummary, SystemDetail } from '@/types/api';
 import { ColonyPlannerWorkspace } from './ColonyPlannerWorkspace';
+import { useColonyProjectStore } from './colonyProjectStore';
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -120,9 +121,12 @@ const slotMapSystem = {
   bodies: [{ id: 1, name: 'Body 1', body_type: 'Planet', is_landable: true }],
 } as unknown as SystemDetail;
 
-function renderWorkspace() {
+async function renderWorkspace() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  await act(async () => {
+    await useColonyProjectStore.persist.rehydrate();
+  });
+  const view = render(
     <QueryClientProvider client={client}>
       <ColonyPlannerWorkspace
         id64={123}
@@ -131,6 +135,17 @@ function renderWorkspace() {
       />
     </QueryClientProvider>,
   );
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+  return view;
+}
+
+async function click(element: HTMLElement) {
+  await act(async () => {
+    fireEvent.click(element);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
 }
 
 function provenanceResponse() {
@@ -253,7 +268,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       errors: [],
     });
 
-    renderWorkspace();
+    await renderWorkspace();
 
     expect((await screen.findAllByText('Passive Workspace')).length).toBeGreaterThan(0);
     expect(screen.getByTestId('planner-warehouse-evidence')).toBeTruthy();
@@ -276,7 +291,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(screen.queryByTestId('advanced-planner-content')).toBeNull();
 
     await waitFor(() => expect(mockedGetSimulationSummary).toHaveBeenCalled());
-    fireEvent.click(screen.getByTestId('topology-body-button-body1'));
+    await click(screen.getByTestId('topology-body-button-body1'));
     expect(screen.getByTestId('raven-real-body-row-body1').getAttribute('data-selected')).toBe('true');
     expect(screen.queryByTestId('raven-inline-body-expansion-body1')).toBeNull();
     expect(screen.queryByText('Body slot planner')).toBeNull();
@@ -346,10 +361,10 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       errors: [],
     });
 
-    renderWorkspace();
+    await renderWorkspace();
 
     await screen.findByTestId('raven-real-body-row-1');
-    fireEvent.click(screen.getByTestId('topology-body-button-1'));
+    await click(screen.getByTestId('topology-body-button-1'));
     await waitFor(() => {
       expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
       expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
@@ -363,15 +378,15 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       expect(screen.getByTestId('1-ground-add')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByTestId('1-orbital-add'));
-    fireEvent.click(await screen.findByTestId('body-structure-template-orbital_port'));
+    await click(screen.getByTestId('1-orbital-add'));
+    await click(await screen.findByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
       expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
       expect(screen.getByTestId('1-orbital-slot-0').textContent).toMatch(/Orbital|Port/i);
     });
 
-    fireEvent.click(screen.getByTestId('1-ground-add'));
-    fireEvent.click(await screen.findByTestId('body-structure-template-surface_hub'));
+    await click(screen.getByTestId('1-ground-add'));
+    await click(await screen.findByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('workspace-economy-ledger')).getByText(/Agri/i)).toBeTruthy();
@@ -411,16 +426,16 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       ],
     } as any);
 
-    renderWorkspace();
+    await renderWorkspace();
 
     await screen.findByTestId('raven-real-body-row-1');
-    fireEvent.click(screen.getByTestId('topology-body-button-1'));
+    await click(screen.getByTestId('topology-body-button-1'));
     await waitFor(() => {
       expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
       expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByTestId('1-orbital-add'));
+    await click(screen.getByTestId('1-orbital-add'));
     const orbitalPicker = await screen.findByTestId('body-structure-picker');
     expect(orbitalPicker).toBeTruthy();
     expect(within(orbitalPicker).getByRole('heading', { name: 'Add to Body 1' })).toBeTruthy();
@@ -428,18 +443,18 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(within(orbitalPicker).getByTestId('canvas-picker-compatible-count').textContent).toContain('1 compatible option');
     expect(screen.getByTestId('body-structure-template-orbital_port')).toBeTruthy();
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
+    await click(screen.getByRole('button', { name: /Close structure picker/i }));
 
-    fireEvent.click(screen.getByTestId('1-ground-add'));
+    await click(screen.getByTestId('1-ground-add'));
     const surfaceAddPicker = await screen.findByTestId('body-structure-picker');
     expect(surfaceAddPicker).toBeTruthy();
     expect(within(surfaceAddPicker).getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
     expect(screen.getByTestId('body-structure-template-surface_hub')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: /Close structure picker/i }));
+    await click(screen.getByRole('button', { name: /Close structure picker/i }));
 
-    fireEvent.click(screen.getByTestId('1-orbital-add'));
+    await click(screen.getByTestId('1-orbital-add'));
     expect(within(await screen.findByTestId('body-structure-picker')).getAllByText(/Orbit lane/i).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
+    await click(screen.getByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
       expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Added Orbital Port to Body 1 / Orbit.');
       expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '')).toMatch(/Orbital|Port/i);
@@ -448,9 +463,9 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       expect(within(screen.getByTestId('planner-status-strip')).getByText('Unsaved changes')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByTestId('1-ground-add'));
+    await click(screen.getByTestId('1-ground-add'));
     expect(within(await screen.findByTestId('body-structure-picker')).getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByTestId('body-structure-template-surface_hub'));
+    await click(screen.getByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
       expect((screen.getByTestId('1-ground-slot-0').textContent ?? '')).toMatch(/Surface|Hub/i);
       expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Body 1 / Surface');
@@ -462,7 +477,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /Copy to Build Plan/i })).toBeNull();
 
-    fireEvent.click(screen.getByTestId('advanced-workspace-toggle'));
+    await click(screen.getByTestId('advanced-workspace-toggle'));
     const advanced = await screen.findByTestId('advanced-planner-content');
     expect(within(advanced).getByText('2 placements in Build Plan')).toBeTruthy();
     expect(within(advanced).getAllByText(/Orbital Port/i).length).toBeGreaterThan(0);

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FacilityTemplate, SimulationSummary, SlotPredictionResponse, SystemDetail } from '@/types/api';
 import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
@@ -252,9 +252,15 @@ const slotPredictions: SlotPredictionResponse = {
   ],
 };
 
-function renderPlanner(props?: Partial<Parameters<typeof ColonyPlannerWorkspace>[0]>) {
+async function renderPlanner(
+  props?: Partial<Parameters<typeof ColonyPlannerWorkspace>[0]>,
+  options?: { settle?: boolean },
+) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
+  await act(async () => {
+    await useColonyProjectStore.persist.rehydrate();
+  });
+  const view = render(
     <QueryClientProvider client={client}>
       <ColonyPlannerWorkspace
         id64={123}
@@ -264,6 +270,29 @@ function renderPlanner(props?: Partial<Parameters<typeof ColonyPlannerWorkspace>
       />
     </QueryClientProvider>,
   );
+  await act(async () => {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+  if (options?.settle !== false) {
+    await screen.findByTestId('planner-summary-panel');
+    await screen.findByTestId('workspace-economy-ledger');
+    await screen.findByTestId('planner-warehouse-evidence');
+  }
+  return view;
+}
+
+async function click(element: HTMLElement) {
+  await act(async () => {
+    fireEvent.click(element);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function change(element: HTMLElement, value: Parameters<typeof fireEvent.change>[1]) {
+  await act(async () => {
+    fireEvent.change(element, value);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
 }
 
 function storedProjectByName(projectName: string) {
@@ -299,24 +328,22 @@ describe('ColonyPlannerWorkspace', () => {
     mockedGetProvenanceCockpit.mockReset();
     mockedGetSimulationSummary.mockReset();
     mockedGetSlotPredictions.mockReset();
-    localStorage.clear();
-    useColonyProjectStore.setState({ projects: {} });
   });
 
-  it('renders a no-system state for direct #colony-planner visits', () => {
+  it('renders a no-system state for direct #colony-planner visits', async () => {
     const onBackToFinder = vi.fn();
 
-    renderPlanner({ id64: null, onBackToFinder });
+    await renderPlanner({ id64: null, onBackToFinder }, { settle: false });
 
     expect(screen.getByTestId('colony-planner-workspace')).toBeTruthy();
     expect(screen.getByText('No system selected for Colony Planner.')).toBeTruthy();
     expect(screen.getByText(/Choose Evaluate in Colony Planner from Finder or Advanced Search Tuning/i)).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: /Back to Finder/i }));
+    await click(screen.getByRole('button', { name: /Back to Finder/i }));
     expect(onBackToFinder).toHaveBeenCalledTimes(1);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });
 
-  it('renders the loading state without mounting the planner', () => {
+  it('renders the loading state without mounting the planner', async () => {
     mockedUseSystemDetail.mockReturnValue({
       data: null,
       loading: true,
@@ -324,14 +351,14 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner(undefined, { settle: false });
 
     expect(screen.getByText('Loading Colony Planner...')).toBeTruthy();
     expect(mockedUseSystemDetail).toHaveBeenCalledWith(123);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });
 
-  it('renders the error state with retry and Back to Finder', () => {
+  it('renders the error state with retry and Back to Finder', async () => {
     const onBackToFinder = vi.fn();
     const refetch = vi.fn();
     mockedUseSystemDetail.mockReturnValue({
@@ -341,12 +368,12 @@ describe('ColonyPlannerWorkspace', () => {
       refetch,
     });
 
-    renderPlanner({ onBackToFinder });
+    await renderPlanner({ onBackToFinder }, { settle: false });
 
     expect(screen.getByText('Failed to load Colony Planner.')).toBeTruthy();
     expect(screen.getByText('network failed')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: /Retry/i }));
-    fireEvent.click(screen.getAllByRole('button', { name: /Back to Finder/i })[1]);
+    await click(screen.getByRole('button', { name: /Retry/i }));
+    await click(screen.getAllByRole('button', { name: /Back to Finder/i })[1]);
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(onBackToFinder).toHaveBeenCalledTimes(1);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
@@ -361,7 +388,7 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner({ onOpenSystemDetail });
+    await renderPlanner({ onOpenSystemDetail });
 
     expect(screen.getAllByText('Workspace System').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Refinery').length).toBeGreaterThan(0);
@@ -375,10 +402,10 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.getByTestId('planner-telemetry-region').getAttribute('data-mobile-dock')).toBe('closed');
     expect(screen.getByTestId('planner-telemetry-dock-toggle')).toBeTruthy();
     expect(screen.getByTestId('planner-telemetry-dock-content').getAttribute('data-open')).toBe('false');
-    fireEvent.click(screen.getByTestId('planner-telemetry-dock-toggle'));
-    expect(screen.getByTestId('planner-telemetry-region').getAttribute('data-mobile-dock')).toBe('open');
-    expect(screen.getByTestId('planner-telemetry-dock-content').getAttribute('data-open')).toBe('true');
-    expect(screen.getByTestId('raven-real-telemetry-panel')).toBeTruthy();
+    await click(screen.getByTestId('planner-telemetry-dock-toggle'));
+    await waitFor(() => expect(screen.getByTestId('planner-telemetry-region').getAttribute('data-mobile-dock')).toBe('open'));
+    await waitFor(() => expect(screen.getByTestId('planner-telemetry-dock-content').getAttribute('data-open')).toBe('true'));
+    expect(await screen.findByTestId('raven-real-telemetry-panel')).toBeTruthy();
     expect(screen.getByTestId('planner-summary-panel')).toBeTruthy();
     expect(await screen.findByTestId('planner-warehouse-evidence')).toBeTruthy();
     expect(await screen.findByText(/Canonical writes planned:\s*0\./)).toBeTruthy();
@@ -400,11 +427,11 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.queryByText('Reused Colony Planner panel')).toBeNull();
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
     expect(screen.getByText('Planner summary')).toBeTruthy();
-    fireEvent.click(screen.getByTestId('summary-rail-collapse-toggle'));
-    expect(screen.getByTestId('project-card')).toBeTruthy();
-    expect(screen.getByTestId('plan-health-card')).toBeTruthy();
-    expect(screen.getByTestId('selection-card')).toBeTruthy();
-    expect(screen.getByTestId('preview-suggested-card')).toBeTruthy();
+    await click(screen.getByTestId('summary-rail-collapse-toggle'));
+    expect(await screen.findByTestId('project-card')).toBeTruthy();
+    expect(await screen.findByTestId('plan-health-card')).toBeTruthy();
+    expect(await screen.findByTestId('selection-card')).toBeTruthy();
+    expect(await screen.findByTestId('preview-suggested-card')).toBeTruthy();
     expect(screen.getByTestId('topology-body-button-body1').getAttribute('title')).toBe('Workspace System A 1');
     expect(screen.getByText(/Saved locally in this browser/i)).toBeTruthy();
     const summaryPanel = screen.getByTestId('planner-summary-panel');
@@ -416,9 +443,9 @@ describe('ColonyPlannerWorkspace', () => {
     expect(document.body.textContent).not.toMatch(/Stage 15|15H|15I|deferred to next stages/i);
     expect(screen.queryByText('Attached Structures')).toBeNull();
 
-    fireEvent.click(screen.getByTestId('topology-body-button-body1'));
-    expect(screen.getByText(/Planning focus: Workspace System A 1/i)).toBeTruthy();
-    expect(screen.getByTestId('raven-real-body-row-body1').getAttribute('data-selected')).toBe('true');
+    await click(screen.getByTestId('topology-body-button-body1'));
+    expect(await screen.findByText(/Planning focus: Workspace System A 1/i)).toBeTruthy();
+    await waitFor(() => expect(screen.getByTestId('raven-real-body-row-body1').getAttribute('data-selected')).toBe('true'));
     expect(await screen.findByTestId('body1-orbital-slot-3')).toBeTruthy();
     expect(within(screen.getByTestId('raven-real-planner-canvas')).queryByTestId('raven-inline-body-expansion-body1')).toBeNull();
     expect(screen.queryByTestId('selected-role-summary-card')).toBeNull();
@@ -433,7 +460,7 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.queryByRole('combobox', { name: 'Declared role' })).toBeNull();
     expect(screen.queryByRole('textbox', { name: /role/i })).toBeNull();
 
-    fireEvent.click(screen.getByTestId('advanced-workspace-toggle'));
+    await click(screen.getByTestId('advanced-workspace-toggle'));
     expect(await screen.findByTestId('advanced-planner-content')).toBeTruthy();
     expect(screen.getByText('Reused Colony Planner panel')).toBeTruthy();
     expect((await screen.findAllByTestId('raven-projected-ghost-structure')).length).toBeGreaterThan(0);
@@ -455,7 +482,7 @@ describe('ColonyPlannerWorkspace', () => {
       undefined,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Back to system detail/i }));
+    await click(screen.getByRole('button', { name: /Back to system detail/i }));
     expect(onOpenSystemDetail).toHaveBeenCalledTimes(1);
     expect(onOpenSystemDetail).toHaveBeenCalledWith(123);
   });
@@ -468,10 +495,10 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
-    fireEvent.click(await screen.findByTestId('topology-body-button-body1'));
-    fireEvent.click(screen.getByTestId('body1-orbital-add'));
+    await click(await screen.findByTestId('topology-body-button-body1'));
+    await click(screen.getByTestId('body1-orbital-add'));
 
     const picker = screen.getByTestId('body-structure-picker');
     expect(picker).toBeTruthy();
@@ -480,7 +507,7 @@ describe('ColonyPlannerWorkspace', () => {
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
     expect(screen.getByTestId('body-structure-template-flex_lab')).toBeTruthy();
     expect(within(picker).getByTestId('canvas-picker-compatibility-summary').textContent).toContain('1 incompatible hidden');
-    fireEvent.click(screen.getByTestId('body-structure-template-orbital_port'));
+    await click(screen.getByTestId('body-structure-template-orbital_port'));
 
     expect((screen.getByTestId('body1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
     expect(screen.getByTestId('body1-orbital-slot-0').textContent).toMatch(/Orbital|Port/i);
@@ -496,9 +523,9 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
-    fireEvent.click(await screen.findByTestId('topology-body-button-body1'));
+    await click(await screen.findByTestId('topology-body-button-body1'));
     expect(screen.queryByTestId('selected-body-planner-canvas')).toBeNull();
     expect(screen.queryByText('Body slot planner')).toBeNull();
     expect(screen.getByTestId('raven-real-body-row-body1').getAttribute('data-selected')).toBe('true');
@@ -518,9 +545,9 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
-    fireEvent.click(await screen.findByTestId('topology-body-button-body1'));
+    await click(await screen.findByTestId('topology-body-button-body1'));
     expect(screen.queryByRole('combobox', { name: 'Declared role' })).toBeNull();
     expect(screen.queryByText('Role conflict: Tourism + Heavy Industrial')).toBeNull();
     expect(screen.queryByText('Observed: not recorded')).toBeNull();
@@ -534,12 +561,12 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
     const summary = await screen.findByTestId('planner-summary-panel');
     expect(within(summary).getByTestId('summary-rail-compact-view')).toBeTruthy();
     expect(within(summary).getByTestId('summary-rail-collapse-toggle')).toBeTruthy();
-    fireEvent.click(within(summary).getByTestId('summary-rail-collapse-toggle'));
+    await click(within(summary).getByTestId('summary-rail-collapse-toggle'));
     expect(within(summary).getByTestId('preview-suggested-card')).toBeTruthy();
     expect(within(summary).queryByRole('button', { name: 'Evidence' })).toBeNull();
     expect(within(summary).queryByRole('button', { name: 'Validation' })).toBeNull();
@@ -553,36 +580,39 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
-    fireEvent.click((await screen.findByTestId('summary-rail-collapse-toggle')));
+    await click((await screen.findByTestId('summary-rail-collapse-toggle')));
     expect(await screen.findByTestId('project-card')).toBeTruthy();
     expect(screen.getByTestId('project-unsaved-indicator').textContent).toContain('Saved');
 
-    fireEvent.change(screen.getByLabelText('Project name'), { target: { value: 'Local starter' } });
-    fireEvent.click(screen.getByTestId('project-details-toggle'));
-    fireEvent.change(screen.getByLabelText('Project notes'), { target: { value: 'Check Architect mode before final placement.' } });
-    fireEvent.click(screen.getByTestId('topology-body-button-body1'));
-    fireEvent.click(screen.getByTestId('body1-orbital-add'));
-    fireEvent.click(await screen.findByTestId('body-structure-template-orbital_port'));
-    fireEvent.click(screen.getByRole('button', { name: 'Save project' }));
+    await change(screen.getByLabelText('Project name'), { target: { value: 'Local starter' } });
+    await waitFor(() => expect((screen.getByLabelText('Project name') as HTMLInputElement).value).toBe('Local starter'));
+    await click(screen.getByTestId('project-details-toggle'));
+    await change(screen.getByLabelText('Project notes'), { target: { value: 'Check Architect mode before final placement.' } });
+    await click(screen.getByTestId('topology-body-button-body1'));
+    await click(screen.getByTestId('body1-orbital-add'));
+    await click(await screen.findByTestId('body-structure-template-orbital_port'));
+    await waitFor(() => expect(screen.getByTestId('project-unsaved-indicator').textContent).toContain('Unsaved'));
+    await click(screen.getByRole('button', { name: 'Save project' }));
 
     expect(screen.getByTestId('project-unsaved-indicator').textContent).toContain('Saved');
+    await waitFor(() => expect(storedProjectByName('Local starter')).toBeTruthy());
     expect(storedProjectByName('Local starter')?.build_plan_placements).toHaveLength(1);
     expect(storedProjectByName('Local starter')?.declared_roles).toEqual([]);
 
-    fireEvent.change(screen.getByLabelText('Project name'), { target: { value: 'Renamed local starter' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Rename project' }));
-    expect(storedProjectByName('Renamed local starter')).toBeTruthy();
+    await change(screen.getByLabelText('Project name'), { target: { value: 'Renamed local starter' } });
+    await click(screen.getByRole('button', { name: 'Rename project' }));
+    await waitFor(() => expect(storedProjectByName('Renamed local starter')).toBeTruthy());
 
-    fireEvent.click(screen.getByRole('button', { name: 'Duplicate project' }));
-    expect(storedProjectByName('Renamed local starter copy')).toBeTruthy();
+    await click(screen.getByRole('button', { name: 'Duplicate project' }));
+    await waitFor(() => expect(storedProjectByName('Renamed local starter copy')).toBeTruthy());
     expect(storedProjectByName('Renamed local starter copy')?.declared_roles).toEqual([]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete / archive project' }));
+    await click(screen.getByRole('button', { name: 'Delete / archive project' }));
     expect(screen.getByText(/Archive this local project/)).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Archive project' }));
-    expect(storedProjectByName('Renamed local starter copy')?.archived_at).toBeTruthy();
+    await click(screen.getByRole('button', { name: 'Archive project' }));
+    await waitFor(() => expect(storedProjectByName('Renamed local starter copy')?.archived_at).toBeTruthy());
   });
 
   it('loads old local projects without declared roles safely', async () => {
@@ -611,9 +641,9 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
-    fireEvent.click((await screen.findByTestId('summary-rail-collapse-toggle')));
+    await click((await screen.findByTestId('summary-rail-collapse-toggle')));
     expect((await screen.findAllByText('Old project')).length).toBeGreaterThan(0);
     expect(screen.queryByTestId('selected-body-planner-canvas')).toBeNull();
   });
@@ -636,11 +666,11 @@ describe('ColonyPlannerWorkspace', () => {
       refetch: vi.fn(),
     });
 
-    renderPlanner();
+    await renderPlanner();
 
-    fireEvent.click((await screen.findByTestId('summary-rail-collapse-toggle')));
+    await click((await screen.findByTestId('summary-rail-collapse-toggle')));
     expect((await screen.findAllByText('Reloaded project')).length).toBeGreaterThan(0);
-    fireEvent.click(screen.getByTestId('topology-body-button-body1'));
+    await click(screen.getByTestId('topology-body-button-body1'));
     expect((await screen.findByTestId('body1-ground-slot-0')).textContent).toMatch(/Surface Hub/i);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });

--- a/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
@@ -50,6 +50,12 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   const [structurePicker, setStructurePicker] = useState<{ bodyId: string; lane: BodyPlannerLane } | null>(null);
   const [structureAddFeedback, setStructureAddFeedback] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const appliedProjectFingerprint = useRef<string | null>(null);
+  const hasMountedSystemReset = useRef(false);
+  const placementsRef = useRef<SimulateBuildPlacement[]>(placements);
+
+  useEffect(() => {
+    placementsRef.current = placements;
+  }, [placements]);
 
   const templatesQuery = useQuery<FacilityTemplate[], Error>({
     queryKey: ['facility-templates'],
@@ -76,6 +82,10 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     ?? 'refinery_industrial';
 
   useEffect(() => {
+    if (!hasMountedSystemReset.current) {
+      hasMountedSystemReset.current = true;
+      return;
+    }
     setSelection({ type: 'system' });
     setPlacements([]);
     setPlacementLaneHints({});
@@ -87,9 +97,9 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   }, [system.economy_suggestion, system.id64, system.primary_economy]);
 
   useEffect(() => {
-    if (placements.length > 0) return;
-    setTargetArchetype((current) => current || suggestedArchetype);
-  }, [placements.length, suggestedArchetype]);
+    if (placements.length > 0 || targetArchetype) return;
+    setTargetArchetype(suggestedArchetype);
+  }, [placements.length, suggestedArchetype, targetArchetype]);
 
   useEffect(() => {
     if (!structureAddFeedback || structureAddFeedback.tone !== 'success') return undefined;
@@ -123,16 +133,32 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     }) : null,
     [projectState.projectRequest],
   );
+  const currentPlanFingerprint = useMemo(
+    () => JSON.stringify({
+      target_archetype: targetArchetype,
+      placements: resequence(placements).map((placement) => ({
+        facility_template_id: placement.facility_template_id,
+        local_body_id: placement.local_body_id ?? null,
+        is_primary_port: Boolean(placement.is_primary_port),
+        build_order: placement.build_order,
+      })),
+    }),
+    [placements, targetArchetype],
+  );
 
   useEffect(() => {
     if (!projectState.projectRequest || !projectRequestFingerprint) return;
     if (appliedProjectFingerprint.current === projectRequestFingerprint) return;
+    if (projectRequestFingerprint === currentPlanFingerprint) {
+      appliedProjectFingerprint.current = projectRequestFingerprint;
+      return;
+    }
     appliedProjectFingerprint.current = projectRequestFingerprint;
     setTargetArchetype(projectState.projectRequest.target_archetype);
     setPlacements(resequence(projectState.projectRequest.placements));
     setPlacementLaneHints({});
     setProjection(null);
-  }, [projectRequestFingerprint, projectState.projectRequest]);
+  }, [currentPlanFingerprint, projectRequestFingerprint, projectState.projectRequest]);
 
   const selectedContext = useMemo(
     () => describeTopologySelection(selection, system, planSnapshot),
@@ -183,20 +209,18 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     if (!templateMatchesLane(template, lane) || !templateCanFitBody(template, body, lane)) {
       return { ok: false as const, message: `${templateDisplayName(template)} is not compatible with this ${lane === 'orbital' ? 'orbit' : 'surface'} lane.` };
     }
+    const nextPlacements = resequence([
+      ...placementsRef.current,
+      {
+        facility_template_id: template.id,
+        local_body_id: bodyId,
+        is_primary_port: template.is_port && !placementsRef.current.some((placement) => placement.is_primary_port),
+        build_order: placementsRef.current.length + 1,
+      },
+    ]);
     setSelection({ type: 'body', bodyId });
-    setPlacements((current) => {
-      const next = resequence([
-        ...current,
-        {
-          facility_template_id: template.id,
-          local_body_id: bodyId,
-          is_primary_port: template.is_port && !current.some((placement) => placement.is_primary_port),
-          build_order: current.length + 1,
-        },
-      ]);
-      setPlacementLaneHints((currentHints) => ({ ...currentHints, [next.length - 1]: lane }));
-      return next;
-    });
+    setPlacements(nextPlacements);
+    setPlacementLaneHints((currentHints) => ({ ...currentHints, [nextPlacements.length - 1]: lane }));
     return {
       ok: true as const,
       message: `Added ${templateDisplayName(template)} to ${describePlacementTarget(body, lane)}.`,
@@ -218,11 +242,10 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
   }, []);
 
   const handleAdvancedPlanSnapshotChange = useCallback((snapshot: TopologyPlanSnapshot) => {
-    setPlacements((current) => {
-      if (placementsEqual(current, snapshot.placements)) return current;
+    if (!placementsEqual(placementsRef.current, snapshot.placements)) {
+      setPlacements(resequence(snapshot.placements));
       setPlacementLaneHints({});
-      return resequence(snapshot.placements);
-    });
+    }
     setTargetArchetype((current) => current === snapshot.targetArchetype ? current : snapshot.targetArchetype);
     setProjection((current) => projectionEqual(current, snapshot.projection) ? current : snapshot.projection ?? null);
   }, []);

--- a/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
+++ b/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SystemDetail } from '@/types/api';
 import { sameBodyId } from '@/features/system-detail/simulation-preview/bodyIdUtils';
 import type { TopologyPlanSnapshot } from './ColonyTopologyRail';
@@ -25,27 +25,39 @@ export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: Top
 
   const projects = useMemo(() => Object.values(projectRecord), [projectRecord]);
   const systemProjects = useMemo(() => activeProjectsForSystem(projects, system.id64), [projects, system.id64]);
-  const [activeProjectId, setActiveProjectId] = useState<string | null>(() => systemProjects[0]?.id ?? null);
-  const [pendingProjectId, setPendingProjectId] = useState<string>('');
-  const [projectName, setProjectName] = useState(`${system.name || 'Colony'} project`);
-  const [projectNotes, setProjectNotes] = useState('');
-  const [declaredRoles, setDeclaredRoles] = useState<DeclaredColonyRole[]>([]);
+  const initialProject = systemProjects[0] ?? null;
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(() => initialProject?.id ?? null);
+  const [pendingProjectId, setPendingProjectId] = useState<string>(() => initialProject?.id ?? '');
+  const [projectName, setProjectName] = useState(() => initialProject?.project_name ?? `${system.name || 'Colony'} project`);
+  const [projectNotes, setProjectNotes] = useState(() => initialProject?.notes ?? '');
+  const [declaredRoles, setDeclaredRoles] = useState<DeclaredColonyRole[]>(() => normaliseDeclaredRoles(initialProject?.declared_roles));
   const [confirmArchive, setConfirmArchive] = useState(false);
+  const hasMountedProjectSync = useRef(false);
 
   const activeProject = systemProjects.find((project) => project.id === activeProjectId) ?? null;
 
   useEffect(() => {
     if (activeProjectId && systemProjects.some((project) => project.id === activeProjectId)) return;
     const next = systemProjects[0] ?? null;
+    if ((next?.id ?? null) === activeProjectId) return;
     setActiveProjectId(next?.id ?? null);
   }, [activeProjectId, systemProjects]);
 
   useEffect(() => {
-    setPendingProjectId(activeProjectId ?? '');
-    setProjectName(activeProject?.project_name ?? `${system.name || 'Colony'} project`);
-    setProjectNotes(activeProject?.notes ?? '');
-    setDeclaredRoles(normaliseDeclaredRoles(activeProject?.declared_roles));
-    setConfirmArchive(false);
+    if (!hasMountedProjectSync.current) {
+      hasMountedProjectSync.current = true;
+      return;
+    }
+    const nextPendingProjectId = activeProjectId ?? '';
+    const nextProjectName = activeProject?.project_name ?? `${system.name || 'Colony'} project`;
+    const nextProjectNotes = activeProject?.notes ?? '';
+    const nextDeclaredRoles = normaliseDeclaredRoles(activeProject?.declared_roles);
+
+    if (pendingProjectId !== nextPendingProjectId) setPendingProjectId(nextPendingProjectId);
+    if (projectName !== nextProjectName) setProjectName(nextProjectName);
+    if (projectNotes !== nextProjectNotes) setProjectNotes(nextProjectNotes);
+    if (JSON.stringify(declaredRoles) !== JSON.stringify(nextDeclaredRoles)) setDeclaredRoles(nextDeclaredRoles);
+    if (confirmArchive) setConfirmArchive(false);
   }, [activeProject, activeProjectId, system.name]);
 
   const unsavedChanges = !projectMatchesSnapshot(


### PR DESCRIPTION
## Summary
- remove redundant planner and project-state sync that triggered late no-op state updates
- stabilize the planner workspace test harness and move persisted store reset out of afterEach so mounted components are not updated outside act
- keep the project save/rename/archive test flow aligned with actual user-visible state while preserving existing coverage

## Validation
- yarn vitest run src/features/colony-planner/ColonyPlannerWorkspace.test.tsx src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx --reporter verbose
- yarn typecheck
- git diff --check