### PR TITLE
Fix remaining frontend test warnings

### DIFF
--- a/frontend-v2/src/features/map/MapTab.test.tsx
+++ b/frontend-v2/src/features/map/MapTab.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MapTab } from './MapTab';
 import { useMapLayers } from './useMapLayers';
 import type { SystemResult } from '@/types/api';
@@ -7,6 +7,26 @@ import type { SystemResult } from '@/types/api';
 vi.mock('./useMapLayers');
 
 const reference = { name: 'Sol', x: 0, z: 0 };
+let getContextSpy: { mockRestore: () => void };
+
+function makeCanvasContext(): RenderingContext {
+  const gradient = { addColorStop: vi.fn() };
+  const target: Record<string, unknown> = {
+    createRadialGradient: vi.fn(() => gradient),
+    createLinearGradient: vi.fn(() => gradient),
+    measureText: vi.fn(() => ({ width: 0 })),
+  };
+  return new Proxy(target, {
+    get(current, prop: string) {
+      if (!(prop in current)) current[prop] = vi.fn();
+      return current[prop];
+    },
+    set(current, prop: string, value) {
+      current[prop] = value;
+      return true;
+    },
+  }) as unknown as RenderingContext;
+}
 
 function makeSystem(overrides: Partial<SystemResult> = {}): SystemResult {
   return {
@@ -34,6 +54,11 @@ const defaultLayers = {
 
 beforeEach(() => {
   vi.mocked(useMapLayers).mockReturnValue(defaultLayers);
+  getContextSpy = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(makeCanvasContext());
+});
+
+afterEach(() => {
+  getContextSpy.mockRestore();
 });
 
 describe('MapTab', () => {

--- a/frontend-v2/src/features/system-detail/RatingRadar.test.tsx
+++ b/frontend-v2/src/features/system-detail/RatingRadar.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { SystemDetail } from '@/types/api';
@@ -9,6 +10,16 @@ vi.stubGlobal('ResizeObserver', class {
   observe() {}
   unobserve() {}
   disconnect() {}
+});
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<typeof import('recharts')>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+      <div style={{ width: 420, height: 420 }}>{children}</div>
+    ),
+  };
 });
 
 const baseSys = {


### PR DESCRIPTION
## Summary
- mock `ResponsiveContainer` in `RatingRadar.test.tsx` so Recharts no longer emits zero-size warnings under jsdom
- strengthen the `MapTab.test.tsx` canvas context stub so the full suite can render `GalacticMap` without jsdom canvas warnings or missing-method failures
- keep the runtime components unchanged while making the frontend test output fully quiet

## Validation
- yarn vitest run src/features/system-detail/RatingRadar.test.tsx --reporter verbose
- yarn vitest run src/features/map/MapTab.test.tsx --reporter verbose
- yarn test --run
- yarn typecheck
- git diff --check