### PR TITLE
Record Stage 18I.5 boundary review completion

### DIFF
--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -22,9 +22,10 @@ Start here for any new colonisation work:
 14. [`stage-18h4-warehouse-evidence-ux-clarification.md`](./stage-18h4-warehouse-evidence-ux-clarification.md) - Stage 18H.4 UX clarification for warehouse evidence freshness, review status, and source posture.
 15. [`stage-18i-canonical-write-design-review.md`](./stage-18i-canonical-write-design-review.md) - Stage 18I design-only review for any future warehouse-to-canonical promotion path.
 16. [`stage-18i5-warehouse-database-boundary-review.md`](./stage-18i5-warehouse-database-boundary-review.md) - Stage 18I.5 boundary review covering the preferred warehouse database separation.
-17. [`engine-roadmap.md`](./engine-roadmap.md) - broad engine history and delivered stage summaries.
-18. [`enrichment-roadmap.md`](./enrichment-roadmap.md) - station/body/ring enrichment, warehouse, and operator-roadmap work.
-19. Specific historical stage docs only when the task directly touches that feature.
+17. [`stage-18j-station-type-canonical-pilot-plan.md`](./stage-18j-station-type-canonical-pilot-plan.md) - Stage 18J pilot plan for a strict station-type-only canonical write path.
+18. [`engine-roadmap.md`](./engine-roadmap.md) - broad engine history and delivered stage summaries.
+19. [`enrichment-roadmap.md`](./enrichment-roadmap.md) - station/body/ring enrichment, warehouse, and operator-roadmap work.
+20. Specific historical stage docs only when the task directly touches that feature.
 
 If an older document's "recommended next stage" conflicts with Stage 17P, follow Stage 17P unless intentionally researching historical context.
 
@@ -47,6 +48,8 @@ If an older document's "recommended next stage" conflicts with Stage 17P, follow
 [`stage-18i-canonical-write-design-review.md`](./stage-18i-canonical-write-design-review.md) records the Stage 18I design-only review for any future canonical apply path. It explicitly does not authorize writes, recommends exact station type promotion as the first narrow future pilot, and requires Stage 18I.5 to settle the database boundary first.
 
 [`stage-18i5-warehouse-database-boundary-review.md`](./stage-18i5-warehouse-database-boundary-review.md) records the Stage 18I.5 boundary decision and preferred Option B direction: a separate `edfinder_enrichment` database on the same Postgres stack if feasible, while staying documentation-only.
+
+[`stage-18j-station-type-canonical-pilot-plan.md`](./stage-18j-station-type-canonical-pilot-plan.md) records the next follow-on pilot plan: a strict station-type-only canonical path that begins with dry-run artifacts and approval/audit/rollback contracts rather than immediate apply.
 
 [`stage-20-roadmap.md`](./stage-20-roadmap.md) is the completed Stage 20 planning baseline. It records the provenance-backed planning cockpit objective, five Stage 20 checkpoints, and the boundaries preserved while that work landed.
 
@@ -77,6 +80,7 @@ It supersedes the old assumption that the project should simply continue from St
 | [`stage-18h4-warehouse-evidence-ux-clarification.md`](./stage-18h4-warehouse-evidence-ux-clarification.md) | Active Stage 18H.4 UX clarification | Defines the planner-card freshness, review-status, warning, and source-posture clarification while staying read-only. |
 | [`stage-18i-canonical-write-design-review.md`](./stage-18i-canonical-write-design-review.md) | Active Stage 18I design review | Defines the future canonical write boundary, recommended first pilot, banned writes, approval/audit/rollback rules, and the requirement that Stage 18I.5 complete first. |
 | [`stage-18i5-warehouse-database-boundary-review.md`](./stage-18i5-warehouse-database-boundary-review.md) | Active Stage 18I.5 boundary review | Defines the preferred separate-warehouse-database boundary and keeps the decision documentation-only. |
+| [`stage-18j-station-type-canonical-pilot-plan.md`](./stage-18j-station-type-canonical-pilot-plan.md) | Active Stage 18J pilot plan | Defines the strict station-type-only canonical pilot scope and makes dry-run-only first steps explicit. |
 | [`stage-20-roadmap.md`](./stage-20-roadmap.md) | Completed Stage 20 control | Planning baseline, primary objective, workstreams, checkpoints, and Stage 19 deferred-production boundaries for the completed cockpit. |
 | [`stage-20a-provenance-cockpit-implementation-contract.md`](./stage-20a-provenance-cockpit-implementation-contract.md) | Completed Stage 20A contract | First provenance cockpit contract set, fixture plan, route/component ownership, and Stage 20B handoff. |
 | [`stage-20b-readonly-evidence-status-surfaces.md`](./stage-20b-readonly-evidence-status-surfaces.md) | Completed Stage 20B implementation record | First read-only provenance cockpit route and Evidence Workspace surface, still bounded away from DB writes and operator execution. |

--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -231,7 +231,7 @@
     "primary_objective": "Turn the completed Stage 20 cockpit into a trustworthy, operational, provenance-aware planning surface by closing the highest-value planner trust gaps, replacing fixture-only read paths where safe, and reconciling the roadmap into one explicit post-20 control document without reopening deferred Stage 19 production lanes.",
     "first_executable_checkpoint": "Stage 21A - Post-20 roadmap reconciliation and authority lock",
     "current_checkpoint": "Stage 21 closeout",
-    "next_checkpoint": "Stage 18I.5 - Warehouse database boundary review",
+    "next_checkpoint": "Stage 18J - Station type canonical write pilot",
     "roadmap": "docs/colonisation-redesign/stage-21-roadmap.md",
     "stage20_complete": true,
     "stage21a_roadmap_reconciliation_completed": true,
@@ -441,6 +441,18 @@
     "stage18i5_required_before_stage18j": true,
     "write_path_implemented": false,
     "canonical_writes_authorized": false,
+    "db_writes_authorized": false,
+    "production_like_db_execution_authorized": false
+  },
+  "stage18i5": {
+    "status": "completed",
+    "checkpoint_type": "boundary_review",
+    "document": "docs/colonisation-redesign/stage-18i5-warehouse-database-boundary-review.md",
+    "design_only": true,
+    "preferred_boundary_option": "option_b_same_stack_separate_database",
+    "recommended_database_name": "edfinder_enrichment",
+    "stage18j_apply_authorized": false,
+    "warehouse_boundary_implemented": false,
     "db_writes_authorized": false,
     "production_like_db_execution_authorized": false
   },

--- a/docs/colonisation-redesign/stage-21-closeout.md
+++ b/docs/colonisation-redesign/stage-21-closeout.md
@@ -34,6 +34,8 @@ The Stage 17 and Stage 18 backlog is now reconciled for the current baseline:
   planner-side fetch with provenance fallback, and clearer warehouse evidence
   freshness/review/source posture in the UI.
 - Stage 18I is complete as a documentation-only canonical write design review.
+- Stage 18I.5 is complete as a documentation-only warehouse database boundary
+  review, with Option B preferred if the boundary is later implemented.
 
 ## Validation
 
@@ -61,6 +63,6 @@ Stage 21 does not authorize:
 
 ## Next Roadmap Position
 
-The next meaningful work should continue from Stage 18I.5 — Warehouse Database
-Boundary Review and the later Stage 18 follow-on path, not by reopening
+The next meaningful work should continue from Stage 18J — Station Type
+Canonical Write Pilot and the later Stage 18 follow-on path, not by reopening
 already-burned-down Stage 17 backlog items.

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -107,6 +107,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage18h3_planner_warehouse_fetch_fallback.py \
     tests/test_stage18h4_warehouse_evidence_ux_clarification.py \
     tests/test_stage18i_canonical_write_design_review.py \
+    tests/test_stage18i5_warehouse_database_boundary_review.py \
     tests/test_stage20a_implementation_contract.py \
     tests/test_stage20b_readonly_status_surfaces.py \
     tests/test_stage20c_map_foundation.py \

--- a/tests/test_stage18h1_planner_evidence_contract.py
+++ b/tests/test_stage18h1_planner_evidence_contract.py
@@ -51,7 +51,7 @@ def test_stage18h1_docs_define_contract_and_link_from_stage18h_and_readme():
     readme = _squash(_read(README_PATH))
 
     assert STAGE18H1_PATH.exists()
-    assert authority['stage21']['next_checkpoint'] == 'Stage 18I.5 - Warehouse database boundary review'
+    assert authority['stage21']['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
     assert 'warehouse_planner_evidence/v1' in stage18h1
     assert 'This slice is intentionally contract-first.' in stage18h1
     assert 'live endpoint' in stage18h1

--- a/tests/test_stage18h2_warehouse_planner_evidence_endpoint.py
+++ b/tests/test_stage18h2_warehouse_planner_evidence_endpoint.py
@@ -39,7 +39,7 @@ def test_stage18h2_authority_records_readonly_endpoint_scaffold():
     stage18h2 = authority['stage18h2']
 
     assert STAGE18H2_PATH.exists()
-    assert authority['stage21']['next_checkpoint'] == 'Stage 18I.5 - Warehouse database boundary review'
+    assert authority['stage21']['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
 
     assert stage18h1['status'] == 'completed'
     assert stage18h1['implementation_started'] is True

--- a/tests/test_stage18h3_planner_warehouse_fetch_fallback.py
+++ b/tests/test_stage18h3_planner_warehouse_fetch_fallback.py
@@ -25,7 +25,7 @@ def test_stage18h3_authority_records_fetch_then_fallback_planner_integration():
     stage18h3 = authority['stage18h3']
 
     assert STAGE18H3_PATH.exists()
-    assert authority['stage21']['next_checkpoint'] == 'Stage 18I.5 - Warehouse database boundary review'
+    assert authority['stage21']['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
     assert stage18h3['status'] == 'completed'
     assert stage18h3['checkpoint_type'] == 'planner_fetch_integration'
     assert stage18h3['document'] == 'docs/colonisation-redesign/stage-18h3-planner-warehouse-fetch-fallback.md'

--- a/tests/test_stage18h4_warehouse_evidence_ux_clarification.py
+++ b/tests/test_stage18h4_warehouse_evidence_ux_clarification.py
@@ -25,7 +25,7 @@ def test_stage18h4_authority_records_readonly_ux_clarification():
     stage18h4 = authority['stage18h4']
 
     assert STAGE18H4_PATH.exists()
-    assert authority['stage21']['next_checkpoint'] == 'Stage 18I.5 - Warehouse database boundary review'
+    assert authority['stage21']['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
     assert stage18h4['status'] == 'completed'
     assert stage18h4['checkpoint_type'] == 'ux_clarification'
     assert stage18h4['document'] == 'docs/colonisation-redesign/stage-18h4-warehouse-evidence-ux-clarification.md'

--- a/tests/test_stage18i5_warehouse_database_boundary_review.py
+++ b/tests/test_stage18i5_warehouse_database_boundary_review.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+README_PATH = DOCS / 'README.md'
+STAGE18I5_PATH = DOCS / 'stage-18i5-warehouse-database-boundary-review.md'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _json(path: Path):
+    return json.loads(_read(path))
+
+
+def test_stage18i5_authority_records_boundary_review_and_stage18j_handoff():
+    authority = _json(AUTHORITY_PATH)
+    stage18i5 = authority['stage18i5']
+
+    assert STAGE18I5_PATH.exists()
+    assert authority['stage21']['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
+    assert stage18i5['status'] == 'completed'
+    assert stage18i5['checkpoint_type'] == 'boundary_review'
+    assert stage18i5['document'] == 'docs/colonisation-redesign/stage-18i5-warehouse-database-boundary-review.md'
+    assert stage18i5['design_only'] is True
+    assert stage18i5['preferred_boundary_option'] == 'option_b_same_stack_separate_database'
+    assert stage18i5['recommended_database_name'] == 'edfinder_enrichment'
+    assert stage18i5['stage18j_apply_authorized'] is False
+    assert stage18i5['warehouse_boundary_implemented'] is False
+    assert stage18i5['db_writes_authorized'] is False
+    assert stage18i5['production_like_db_execution_authorized'] is False
+
+
+def test_stage18i5_docs_and_ci_parity_record_the_boundary_review():
+    document = _read(STAGE18I5_PATH)
+    readme = _read(README_PATH)
+    parity = _read(LOCAL_CI_PARITY)
+
+    for fragment in (
+        'Stage 18I.5 is a documentation and design review only.',
+        'Stage 18I.5 recommends Option B now if feasible',
+        'edfinder_enrichment',
+        'Stage 18J cannot start',
+        'Do not implement Option B in this stage.',
+    ):
+        assert fragment in document
+
+    assert 'stage-18i5-warehouse-database-boundary-review.md' in readme
+    assert 'stage-18j-station-type-canonical-pilot-plan.md' in readme
+    assert 'tests/test_stage18i5_warehouse_database_boundary_review.py' in parity

--- a/tests/test_stage18i_canonical_write_design_review.py
+++ b/tests/test_stage18i_canonical_write_design_review.py
@@ -25,7 +25,7 @@ def test_stage18i_authority_records_design_only_checkpoint_and_stage18i5_depende
     stage18i = authority['stage18i']
 
     assert STAGE18I_PATH.exists()
-    assert authority['stage21']['next_checkpoint'] == 'Stage 18I.5 - Warehouse database boundary review'
+    assert authority['stage21']['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
     assert stage18i['status'] == 'completed'
     assert stage18i['checkpoint_type'] == 'design_review'
     assert stage18i['document'] == 'docs/colonisation-redesign/stage-18i-canonical-write-design-review.md'

--- a/tests/test_stage21_planning_baseline.py
+++ b/tests/test_stage21_planning_baseline.py
@@ -54,7 +54,7 @@ def test_stage21_authority_prepares_a_post20_control_baseline_without_reopening_
     assert stage21['primary_objective'] == PRIMARY_OBJECTIVE
     assert stage21['first_executable_checkpoint'] == FIRST_CHECKPOINT
     assert stage21['current_checkpoint'] == 'Stage 21 closeout'
-    assert stage21['next_checkpoint'] == 'Stage 18I.5 - Warehouse database boundary review'
+    assert stage21['next_checkpoint'] == 'Stage 18J - Station type canonical write pilot'
     assert stage21['roadmap'] == 'docs/colonisation-redesign/stage-21-roadmap.md'
     assert stage21['stage20_complete'] is True
     assert stage21['stage21a_roadmap_reconciliation_completed'] is True


### PR DESCRIPTION
## Summary
- record the existing Stage 18I.5 warehouse database boundary review as a completed documentation-only checkpoint in the Stage 19 authority state
- update the roadmap pointer and closeout/README wording so the repo now points to Stage 18J as the next checkpoint
- add focused static coverage for Stage 18I.5 and align the older Stage 18H/18I/Stage 21 tests with the new authority chain

## Validation
- python3 -m pytest tests/test_stage18h1_planner_evidence_contract.py tests/test_stage18h2_warehouse_planner_evidence_endpoint.py tests/test_stage18h3_planner_warehouse_fetch_fallback.py tests/test_stage18h4_warehouse_evidence_ux_clarification.py tests/test_stage18i_canonical_write_design_review.py tests/test_stage18i5_warehouse_database_boundary_review.py tests/test_stage21_planning_baseline.py -p no:cacheprovider
- git diff --check