### PR TITLE
Fix explicit DB isolation environment handling

### DIFF
--- a/tests/helpers/db_isolation.py
+++ b/tests/helpers/db_isolation.py
@@ -77,7 +77,8 @@ def default_database_url() -> str:
 
 
 def default_target(env: Mapping[str, str] | None = None) -> DbTarget:
-    return validate_test_db_target(default_database_url(), env=env or {}, source='default_test_db')
+    source_env = {} if env is None else env
+    return validate_test_db_target(default_database_url(), env=source_env, source='default_test_db')
 
 
 def target_from_env(
@@ -86,14 +87,14 @@ def target_from_env(
     dsn_env: str = 'DATABASE_URL',
     source: str | None = None,
 ) -> DbTarget:
-    source_env = env or os.environ
+    source_env = os.environ if env is None else env
     if source_env.get(dsn_env):
         return validate_test_db_target(source_env[dsn_env], env=source_env, source=source or dsn_env)
     return target_from_pg_env(source_env, source=source or 'pg_env')
 
 
 def target_from_pg_env(env: Mapping[str, str] | None = None, *, source: str = 'pg_env') -> DbTarget:
-    source_env = env or os.environ
+    source_env = os.environ if env is None else env
     host = _first_text(source_env.get('PGHOST'), DEFAULT_TEST_DB_HOST)
     port = _first_text(source_env.get('PGPORT'), DEFAULT_TEST_DB_PORT)
     database = _first_text(source_env.get('PGDATABASE'), DEFAULT_TEST_DB_NAME)
@@ -116,7 +117,7 @@ def confirmed_target_or_skip(
 ) -> DbTarget:
     import pytest
 
-    source_env = env or os.environ
+    source_env = os.environ if env is None else env
     dsn = source_env.get(dsn_env)
     confirmed = source_env.get(confirm_env) == 'yes'
     if not dsn or not confirmed:
@@ -133,7 +134,7 @@ def validate_test_db_target(
     env: Mapping[str, str] | None = None,
     source: str = 'dsn',
 ) -> DbTarget:
-    source_env = env or os.environ
+    source_env = os.environ if env is None else env
     parsed = parse_dsn(dsn)
     host = _first_text(parsed.get('host'), '')
     port = _first_text(parsed.get('port'), DEFAULT_TEST_DB_PORT)
@@ -217,7 +218,7 @@ def redact_dsn(dsn: str) -> str:
 
 
 def require_destructive_reset_opt_in(env: Mapping[str, str] | None = None) -> None:
-    source_env = env or os.environ
+    source_env = os.environ if env is None else env
     if source_env.get(DESTRUCTIVE_RESET_OPT_IN_ENV) == 'yes':
         return
     if source_env.get('CI') == 'true':
@@ -268,7 +269,7 @@ def rollback_transaction(
 
 
 def host_5432_is_allowed(env: Mapping[str, str] | None = None) -> bool:
-    source_env = env or os.environ
+    source_env = os.environ if env is None else env
     return source_env.get(HOST_5432_OPT_IN_ENV) == 'yes' or source_env.get('CI') == 'true'
 
 

--- a/tests/test_db_isolation_guardrails.py
+++ b/tests/test_db_isolation_guardrails.py
@@ -78,6 +78,103 @@ def test_destructive_reset_requires_explicit_opt_in():
     })
 
 
+def test_explicit_empty_env_does_not_inherit_ambient_ci(monkeypatch):
+    monkeypatch.setenv('CI', 'true')
+
+    with pytest.raises(db_isolation.DbIsolationError, match='localhost:5432'):
+        db_isolation.validate_test_db_target(
+            'postgresql://edfinder:secret@127.0.0.1:5432/edfinder',
+            env={},
+        )
+
+    assert db_isolation.host_5432_is_allowed({}) is False
+
+
+def test_explicit_empty_env_does_not_inherit_ambient_destructive_reset_opt_in(monkeypatch):
+    monkeypatch.setenv(db_isolation.DESTRUCTIVE_RESET_OPT_IN_ENV, 'yes')
+
+    with pytest.raises(db_isolation.DbIsolationError, match='destructive reset requires'):
+        db_isolation.require_destructive_reset_opt_in({})
+
+
+def test_explicit_ci_mapping_preserves_documented_ci_behavior():
+    target = db_isolation.validate_test_db_target(
+        'postgresql://edfinder:secret@127.0.0.1:5432/edfinder',
+        env={'CI': 'true'},
+    )
+
+    assert target.host_postgres_5432_targeted is True
+    assert target.host_5432_allowed is True
+    assert db_isolation.host_5432_is_allowed({'CI': 'true'}) is True
+
+
+def test_custom_mapping_does_not_inherit_unrelated_ambient_values(monkeypatch):
+    monkeypatch.setenv('CI', 'true')
+    monkeypatch.setenv(db_isolation.HOST_5432_OPT_IN_ENV, 'yes')
+    monkeypatch.setenv(db_isolation.DESTRUCTIVE_RESET_OPT_IN_ENV, 'yes')
+
+    with pytest.raises(db_isolation.DbIsolationError, match='localhost:5432'):
+        db_isolation.validate_test_db_target(
+            'postgresql://edfinder:secret@127.0.0.1:5432/edfinder',
+            env={'UNRELATED': '1'},
+        )
+
+    with pytest.raises(db_isolation.DbIsolationError, match='destructive reset requires'):
+        db_isolation.require_destructive_reset_opt_in({'UNRELATED': '1'})
+
+    assert db_isolation.host_5432_is_allowed({'UNRELATED': '1'}) is False
+
+
+def test_none_env_still_uses_ambient_environment(monkeypatch):
+    monkeypatch.setenv('CI', 'true')
+    monkeypatch.delenv(db_isolation.HOST_5432_OPT_IN_ENV, raising=False)
+
+    target = db_isolation.validate_test_db_target(
+        'postgresql://edfinder:secret@localhost:5432/edfinder',
+        env=None,
+    )
+
+    assert target.host_postgres_5432_targeted is True
+    assert target.host_5432_allowed is True
+    assert db_isolation.host_5432_is_allowed(None) is True
+
+
+def test_none_env_uses_ambient_destructive_reset_opt_in(monkeypatch):
+    monkeypatch.setenv(db_isolation.DESTRUCTIVE_RESET_OPT_IN_ENV, 'yes')
+    db_isolation.require_destructive_reset_opt_in(None)
+
+
+def test_target_from_env_and_pg_env_respect_explicit_empty_mapping(monkeypatch):
+    monkeypatch.setenv('DATABASE_URL', 'postgresql://edfinder:secret@localhost:5432/edfinder')
+    monkeypatch.setenv('PGHOST', 'localhost')
+    monkeypatch.setenv('PGPORT', '5432')
+    monkeypatch.setenv('PGDATABASE', 'edfinder')
+    monkeypatch.setenv('PGUSER', 'edfinder')
+    monkeypatch.setenv('PGPASSWORD', 'secret')
+    monkeypatch.setenv('CI', 'true')
+
+    target = db_isolation.target_from_env({})
+    assert target.host == '127.0.0.1'
+    assert target.port == '55432'
+    assert target.host_5432_allowed is False
+
+    target = db_isolation.target_from_pg_env({})
+    assert target.host == '127.0.0.1'
+    assert target.port == '55432'
+    assert target.host_5432_allowed is False
+
+
+def test_default_target_remains_isolated_from_ambient_ci(monkeypatch):
+    monkeypatch.setenv('CI', 'true')
+
+    target = db_isolation.default_target()
+
+    assert target.host == '127.0.0.1'
+    assert target.port == '55432'
+    assert target.host_postgres_5432_targeted is False
+    assert target.host_5432_allowed is False
+
+
 def test_safe_schema_names_are_generated_and_validated():
     schema = db_isolation.safe_schema_name('Stage 19 AR', token='abc123')
 


### PR DESCRIPTION
## Summary
- fix `tests/helpers/db_isolation.py` so explicit empty or custom environment mappings are respected exactly instead of falling back to ambient `os.environ`
- preserve the existing deliberate `CI=true` and explicit opt-in behavior only when those values are supplied through `env=None` or an explicit mapping
- add regression coverage proving ambient `CI=true` and destructive-reset opt-ins no longer leak into `env={}` or unrelated custom mappings

## Root cause
Several helper paths used truthiness fallback like `env or os.environ`. That treated an explicitly supplied empty mapping `{}` as if no mapping had been supplied, so ambient `CI=true` or reset opt-ins could silently bypass fail-closed tests.

## Validation
- `python3 -m pytest tests/test_db_isolation_guardrails.py -p no:cacheprovider`
- `python3 -m pytest tests/test_project_state_resolver.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19av_expanded_source_run_staging_pilot.py -p no:cacheprovider`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/dev/resolve_project_state.py --strict`
- `git diff --check`

## Safety notes
- no DB command was run
- no DB mutation occurred
- no Stage 19 execution occurred
- no Stage 19BA execution occurred
- no production staging activation began