### PR TITLE
Authorize Stage 19BB bounded staging execution

### DIFF
--- a/apps/importer/src/edsm_station_import.py
+++ b/apps/importer/src/edsm_station_import.py
@@ -78,6 +78,7 @@ def run_edsm_station_import(
     finished_at: datetime | None = None,
     station_stager: Callable[..., int] | None = None,
     cancel_requested: bool = False,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     """Run the local-file staging wrapper against a caller-owned connection."""
     source_path = Path(source_file)
@@ -107,6 +108,7 @@ def run_edsm_station_import(
                 source_uri=source_uri,
                 source_input_sha256=source_input_sha256,
                 file_format=file_format,
+                limit=limit,
             )
 
             if cancel_requested:
@@ -243,6 +245,7 @@ def build_edsm_station_import_plan(
     source_uri: str,
     source_input_sha256: str,
     file_format: Mapping[str, Any] | None = None,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     """Parse and validate a local EDSM station file into staging-ready rows."""
     source_path = Path(source_file)
@@ -256,6 +259,7 @@ def build_edsm_station_import_plan(
     source_run = {'source_run_key': source_run_key}
 
     rows_read = 0
+    raw_records: list[dict[str, Any]] = []
     staged_rows: list[dict[str, Any]] = []
     rejected_rows: list[dict[str, Any]] = []
     skipped_rows: list[dict[str, Any]] = []
@@ -266,8 +270,12 @@ def build_edsm_station_import_plan(
         source=normalised_source,
         source_run=source_run,
         source_file_summary=source_file_summary,
+        limit=limit,
     ):
         rows_read += 1
+        raw_record = entry.get('raw_record')
+        if isinstance(raw_record, Mapping):
+            raw_records.append(dict(raw_record))
         staged_rows.extend(_copy_rows(entry.get('staged_rows', ())))
         warnings.extend(_copy_rows(entry.get('warnings', ())))
         for skipped in _copy_rows(entry.get('skipped_rows', ())):
@@ -294,6 +302,7 @@ def build_edsm_station_import_plan(
         'rows_staged': len(staged_rows),
         'rows_rejected': len(rejected_rows),
         'rows_skipped': len(skipped_rows),
+        'raw_records': raw_records,
         'staged_rows': staged_rows,
         'rejected_rows': rejected_rows,
         'skipped_rows': skipped_rows,
@@ -321,6 +330,7 @@ def empty_import_plan(
         'rows_staged': 0,
         'rows_rejected': 0,
         'rows_skipped': 0,
+        'raw_records': [],
         'staged_rows': [],
         'rejected_rows': [],
         'skipped_rows': [],

--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -8,25 +8,26 @@ Start here for any new colonisation work:
 
 1. [`stage-23-roadmap.md`](./stage-23-roadmap.md) - active post-22 roadmap and current control baseline.
 2. [`stage-23a-first-live-per-system-evidence-provider.md`](./stage-23a-first-live-per-system-evidence-provider.md) - completed Stage 23A first live per-system evidence provider slice.
-3. [`stage-19-bounded-production-staging-activation.md`](./stage-19-bounded-production-staging-activation.md) - separate Stage 19 operational dependency baseline for a future bounded production-staging activation.
-4. [`stage-22-roadmap.md`](./stage-22-roadmap.md) - completed post-18/20/21 roadmap and prior control baseline.
-5. [`stage-22b-current-state-planner-evidence-hardening.md`](./stage-22b-current-state-planner-evidence-hardening.md) - completed Stage 22B planner/provenance/warehouse evidence hardening slice.
-6. [`stage-22c-operator-artifact-review-and-audit-surfaces.md`](./stage-22c-operator-artifact-review-and-audit-surfaces.md) - completed Stage 22C operator artifact review and export audit surface slice.
-7. [`stage-22d-export-and-documentation-governance-consolidation.md`](./stage-22d-export-and-documentation-governance-consolidation.md) - completed Stage 22D export-pack governance and documentation-consolidation slice.
-8. [`stage-22e-deferred-stage19-decision-gate-and-closeout.md`](./stage-22e-deferred-stage19-decision-gate-and-closeout.md) - completed Stage 22E closeout and explicit deferred-Stage-19 decision gate.
-9. [`stage-21-closeout.md`](./stage-21-closeout.md) - Stage 21 completion record and validation summary.
-10. [`stage-21-roadmap.md`](./stage-21-roadmap.md) - completed post-20 roadmap and trust/operationalisation plan.
-11. [`stage-21b-to-21f-stage17-stage18-burn-down.md`](./stage-21b-to-21f-stage17-stage18-burn-down.md) - Stage 21 progress record showing how Stage 17 and Stage 18 backlog items were burned down or reclassified.
-12. [`stage-20-roadmap.md`](./stage-20-roadmap.md) - completed Stage 20 roadmap and checkpoint plan.
-13. [`stage-20a-provenance-cockpit-implementation-contract.md`](./stage-20a-provenance-cockpit-implementation-contract.md) - Stage 20A implementation-contract checkpoint for the first provenance cockpit slice.
-14. [`stage-20b-readonly-evidence-status-surfaces.md`](./stage-20b-readonly-evidence-status-surfaces.md) - Stage 20B read-only provenance cockpit implementation slice in the Evidence Workspace.
-15. [`stage-20c-map-planning-surface-foundation.md`](./stage-20c-map-planning-surface-foundation.md) - Stage 20C planner map foundation and timeline-layer ownership.
-16. [`stage-20d-planner-sequence-cp-curve-cockpit.md`](./stage-20d-planner-sequence-cp-curve-cockpit.md) - Stage 20D planner sequence and CP tradeoff cockpit.
-17. [`stage-20e-export-operator-pack-closeout-readiness.md`](./stage-20e-export-operator-pack-closeout-readiness.md) - Stage 20 export pack, closeout readiness, and completion record.
-18. [`stage-17p-current-state-forward-plan.md`](./stage-17p-current-state-forward-plan.md) - Colony Planner product-boundary baseline and continuing mechanics constraints.
-19. [`engine-roadmap.md`](./engine-roadmap.md) - broad engine history and delivered stage summaries.
-20. [`enrichment-roadmap.md`](./enrichment-roadmap.md) - station/body/ring enrichment, warehouse, and operator-roadmap work.
-21. Specific historical stage docs only when the task directly touches that feature.
+3. [`stage-19bb-first-production-staging-activation.md`](./stage-19bb-first-production-staging-activation.md) - exact Stage 19BB authorization for the first real bounded production-staging execution lane.
+4. [`stage-19-bounded-production-staging-activation.md`](./stage-19-bounded-production-staging-activation.md) - Stage 19BA control-baseline shorthand that Stage 19BB later corrects to the exact five-table execution boundary.
+5. [`stage-22-roadmap.md`](./stage-22-roadmap.md) - completed post-18/20/21 roadmap and prior control baseline.
+6. [`stage-22b-current-state-planner-evidence-hardening.md`](./stage-22b-current-state-planner-evidence-hardening.md) - completed Stage 22B planner/provenance/warehouse evidence hardening slice.
+7. [`stage-22c-operator-artifact-review-and-audit-surfaces.md`](./stage-22c-operator-artifact-review-and-audit-surfaces.md) - completed Stage 22C operator artifact review and export audit surface slice.
+8. [`stage-22d-export-and-documentation-governance-consolidation.md`](./stage-22d-export-and-documentation-governance-consolidation.md) - completed Stage 22D export-pack governance and documentation-consolidation slice.
+9. [`stage-22e-deferred-stage19-decision-gate-and-closeout.md`](./stage-22e-deferred-stage19-decision-gate-and-closeout.md) - completed Stage 22E closeout and explicit deferred-Stage-19 decision gate.
+10. [`stage-21-closeout.md`](./stage-21-closeout.md) - Stage 21 completion record and validation summary.
+11. [`stage-21-roadmap.md`](./stage-21-roadmap.md) - completed post-20 roadmap and trust/operationalisation plan.
+12. [`stage-21b-to-21f-stage17-stage18-burn-down.md`](./stage-21b-to-21f-stage17-stage18-burn-down.md) - Stage 21 progress record showing how Stage 17 and Stage 18 backlog items were burned down or reclassified.
+13. [`stage-20-roadmap.md`](./stage-20-roadmap.md) - completed Stage 20 roadmap and checkpoint plan.
+14. [`stage-20a-provenance-cockpit-implementation-contract.md`](./stage-20a-provenance-cockpit-implementation-contract.md) - Stage 20A implementation-contract checkpoint for the first provenance cockpit slice.
+15. [`stage-20b-readonly-evidence-status-surfaces.md`](./stage-20b-readonly-evidence-status-surfaces.md) - Stage 20B read-only provenance cockpit implementation slice in the Evidence Workspace.
+16. [`stage-20c-map-planning-surface-foundation.md`](./stage-20c-map-planning-surface-foundation.md) - Stage 20C planner map foundation and timeline-layer ownership.
+17. [`stage-20d-planner-sequence-cp-curve-cockpit.md`](./stage-20d-planner-sequence-cp-curve-cockpit.md) - Stage 20D planner sequence and CP tradeoff cockpit.
+18. [`stage-20e-export-operator-pack-closeout-readiness.md`](./stage-20e-export-operator-pack-closeout-readiness.md) - Stage 20 export pack, closeout readiness, and completion record.
+19. [`stage-17p-current-state-forward-plan.md`](./stage-17p-current-state-forward-plan.md) - Colony Planner product-boundary baseline and continuing mechanics constraints.
+20. [`engine-roadmap.md`](./engine-roadmap.md) - broad engine history and delivered stage summaries.
+21. [`enrichment-roadmap.md`](./enrichment-roadmap.md) - station/body/ring enrichment, warehouse, and operator-roadmap work.
+22. Specific historical stage docs only when the task directly touches that feature.
 
 If an older document's "recommended next stage" conflicts with Stage 17P, follow Stage 17P unless intentionally researching historical context.
 
@@ -35,6 +36,8 @@ If an older document's "recommended next stage" conflicts with Stage 17P, follow
 [`stage-23-roadmap.md`](./stage-23-roadmap.md) is the active post-22 control document. It starts the next read-only sequence after Stage 22 closeout and introduces the first bounded live per-system planner-evidence provider while keeping Stage 19 separately gated.
 
 [`stage-23a-first-live-per-system-evidence-provider.md`](./stage-23a-first-live-per-system-evidence-provider.md) records the completed Stage 23A slice: the dedicated evidence endpoint now has a first live selected-system provider using existing canonical and observed data while keeping unsupported systems unknown.
+
+[`stage-19bb-first-production-staging-activation.md`](./stage-19bb-first-production-staging-activation.md) records the exact Stage 19BB authorization: approved source acquisition facts, the reviewed isolated staging target fingerprint, the exact five permitted tables, and the bounded `100 -> 1,000 -> 10,000` execution policy that only becomes runnable after merge.
 
 [`stage-19-bounded-production-staging-activation.md`](./stage-19-bounded-production-staging-activation.md) records the next separate Stage 19 operational dependency: a bounded manual EDSM production-staging activation contract that stays staging-only, keeps Stage 23 active, and still does not authorize execution in this checkpoint.
 
@@ -102,6 +105,7 @@ It supersedes the old assumption that the project should simply continue from St
 |---|---|---|
 | [`stage-23-roadmap.md`](./stage-23-roadmap.md) | Active Stage 23 control | Starts the next read-only control sequence after Stage 22 closeout and ranks the bounded live per-system evidence work without reopening Stage 19. |
 | [`stage-23a-first-live-per-system-evidence-provider.md`](./stage-23a-first-live-per-system-evidence-provider.md) | Completed Stage 23A implementation record | Records the first live selected-system evidence provider built from existing canonical and observed sources under the dedicated endpoint. |
+| [`stage-19bb-first-production-staging-activation.md`](./stage-19bb-first-production-staging-activation.md) | Stage 19BB exact authorization record | Records the approved EDSM source SHA-256, exact five-table execution boundary, approved isolated target fingerprint, and the post-merge bounded execution policy. |
 | [`stage-19-bounded-production-staging-activation.md`](./stage-19-bounded-production-staging-activation.md) | Separate Stage 19 operational dependency baseline | Records the bounded future production-staging activation contract while keeping Stage 23 as the active product/evidence roadmap and keeping execution unauthorized. |
 | [`stage-22-roadmap.md`](./stage-22-roadmap.md) | Completed Stage 22 control | Records the finished Stage 22 control sequence and the preserved deferred-production boundaries that Stage 23 inherits. |
 | [`stage-22b-current-state-planner-evidence-hardening.md`](./stage-22b-current-state-planner-evidence-hardening.md) | Completed Stage 22B implementation record | Records runtime fixture isolation, conservative freshness semantics, and the separation between selected-system evidence and global authority state. |

--- a/docs/colonisation-redesign/stage-19-bounded-production-staging-activation.md
+++ b/docs/colonisation-redesign/stage-19-bounded-production-staging-activation.md
@@ -69,6 +69,19 @@ The initial bounded activation is staging-only and may write only these tables:
 - `enrichment_source_runs`;
 - `staging_edsm_stations`.
 
+This three-table description is the original Stage 19BA control-baseline
+shorthand. A later executable loader audit in Stage 19BB established that the
+real tested loader path also depends on two additional non-canonical support
+tables:
+
+- `enrichment_source_files`;
+- `enrichment_raw_records`.
+
+That Stage 19BB correction does not rewrite Stage 19BA history and does not
+claim Stage 19BA previously authorized five-table execution. It records that
+the real execution boundary for the later exact authorization lane is five
+tables, not three, while canonical tables remain forbidden.
+
 Everything else is forbidden for this lane. In particular, this checkpoint does
 not authorize writes to:
 
@@ -182,8 +195,11 @@ Before any future execution:
 
 Any future approved execution must verify:
 
-- staging writes occurred only in `source_runs`, `enrichment_source_runs`, and
-  `staging_edsm_stations`;
+- staging writes occurred only in the exact later-reviewed boundary for the
+  selected execution lane;
+- Stage 19BB's exact execution lane narrows that executable boundary to:
+  `source_runs`, `enrichment_source_runs`, `enrichment_source_files`,
+  `enrichment_raw_records`, and `staging_edsm_stations`;
 - row counts match the approved cap and source-run ledger;
 - the audit artifact checksum matches the ledger record;
 - no canonical table write occurred;

--- a/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
+++ b/docs/colonisation-redesign/stage-19-data-warehouse-utopia-roadmap.md
@@ -1190,3 +1190,30 @@ contract for a future manual EDSM staging-only run:
 
 This keeps Stage 23 as the active product/evidence roadmap while making the
 warehouse dependency explicit instead of implicit.
+
+## Stage 19BB authorization dependency
+
+Stage 19BB is the exact source-and-target authorization checkpoint for the
+first real bounded production-staging execution lane. It is recorded in
+`docs/colonisation-redesign/stage-19bb-first-production-staging-activation.md`.
+
+Stage 19BB does not execute a staging import in the authorization PR. It
+records:
+
+- the approved official EDSM station snapshot identity;
+- approved source SHA-256
+  `09225e43323464e332a792f8716a6e4264ef5999ce1544f1157bfc60f406f4a2`;
+- approved eligible row count `713624`;
+- exact five-table execution boundary:
+  `source_runs`, `enrichment_source_runs`, `enrichment_source_files`,
+  `enrichment_raw_records`, and `staging_edsm_stations`;
+- approved isolated target fingerprint
+  `fb59921a3c4f913c318e12709e602261450edf3632e8e20e0b669fd8f1622753`;
+- the reviewed formula mismatch versus the earlier setup-reported fingerprint,
+  treated as formula drift rather than target drift;
+- the only authorized successful batch sizes: `100`, `1,000`, and `10,000`.
+
+Stage 19BB also corrects the earlier Stage 19BA shorthand by recording that the
+real executable loader path requires `enrichment_source_files` and
+`enrichment_raw_records` in addition to the previously named three tables. This
+is a dependency-map correction, not permission for arbitrary warehouse writes.

--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -203,11 +203,25 @@
     "manual_operator_invocation_only": true,
     "source_identity_required": true,
     "source_hash_required": true,
+    "original_three_table_shorthand": true,
     "permitted_tables": [
       "source_runs",
       "enrichment_source_runs",
       "staging_edsm_stations"
     ],
+    "loader_dependency_audit_completed_in_stage19bb": true,
+    "loader_support_tables_identified": [
+      "enrichment_source_files",
+      "enrichment_raw_records"
+    ],
+    "exact_execution_boundary_deferred_to_stage19bb": [
+      "source_runs",
+      "enrichment_source_runs",
+      "enrichment_source_files",
+      "enrichment_raw_records",
+      "staging_edsm_stations"
+    ],
+    "historical_stage19ba_execution_authorized_for_five_tables": false,
     "forbidden_tables_exactly_bounded": true,
     "initial_row_cap": 100,
     "hard_max_rows": 100,
@@ -233,6 +247,78 @@
     "db_commands_run": false,
     "db_mutation_performed": false,
     "production_like_db_execution_authorized": false,
+    "runtime_source_files_are_authority": false,
+    "operator_artifact_json_committed_as_authority": false
+  },
+  "stage19bb_first_production_staging_activation": {
+    "status": "authorized_after_merge",
+    "checkpoint_type": "first_production_staging_activation_authorization",
+    "prepared_at": "2026-06-18T16:00:00Z",
+    "document": "docs/colonisation-redesign/stage-19bb-first-production-staging-activation.md",
+    "operator_wrapper": "scripts/operator/stage19bb_first_production_staging_activation.py",
+    "authorization_pr_contains_execution_evidence": false,
+    "source_acquisition_completed": true,
+    "source_name": "edsm",
+    "source_batch_label": "edsm-stations-20260618T145715Z",
+    "source_reference_sanitized": "https://www.edsm.net/dump/stations.json.gz",
+    "source_basename": "stations.json.gz",
+    "approved_source_sha256": "09225e43323464e332a792f8716a6e4264ef5999ce1544f1157bfc60f406f4a2",
+    "approved_source_size_bytes": 2614426684,
+    "approved_eligible_source_rows": 713624,
+    "approved_source_format": "json",
+    "approved_source_record_stream_shape": "json_array",
+    "approved_source_compression": "gzip",
+    "source_acquired_at": "2026-06-18T14:52:50.594163Z",
+    "reported_target_fingerprint": "759499c54f9d41cd636b4b5aa54e9bda1e4435c49e7a9a9bc34450b8671945b2",
+    "approved_target_fingerprint": "fb59921a3c4f913c318e12709e602261450edf3632e8e20e0b669fd8f1622753",
+    "target_fingerprint_formula_reviewed": true,
+    "target_fingerprint_formula_mismatch_not_target_drift": true,
+    "target_type": "isolated_persistent_local_staging",
+    "target_identity": {
+      "host": "127.0.0.1",
+      "port": 56432,
+      "database": "edfinder_stage19_staging",
+      "role": "stage19_loader"
+    },
+    "permitted_tables": [
+      "source_runs",
+      "enrichment_source_runs",
+      "enrichment_source_files",
+      "enrichment_raw_records",
+      "staging_edsm_stations"
+    ],
+    "canonical_tables_absent": true,
+    "canonical_tables_forbidden": [
+      "systems",
+      "stations",
+      "bodies",
+      "body_rings",
+      "station_body_links",
+      "body_scan_facts",
+      "observed_facts"
+    ],
+    "restricted_loader_verified": true,
+    "default_mode_dry_run": true,
+    "commit_confirmation_required": true,
+    "merged_authority_required_for_execution": true,
+    "approved_batch_limits": [
+      100,
+      1000,
+      10000
+    ],
+    "batch_runtime_caps_seconds": {
+      "100": 900,
+      "1000": 1800,
+      "10000": 3600
+    },
+    "stage19_execution_performed": false,
+    "staging_import_performed": false,
+    "runtime_source_run_created": false,
+    "runtime_artifact_created": false,
+    "canonical_apply_authorized": false,
+    "rebaseline_authorized": false,
+    "scheduler_service_authorized": false,
+    "production_automation_complete": false,
     "runtime_source_files_are_authority": false,
     "operator_artifact_json_committed_as_authority": false
   },

--- a/docs/colonisation-redesign/stage-19bb-first-production-staging-activation.md
+++ b/docs/colonisation-redesign/stage-19bb-first-production-staging-activation.md
@@ -1,0 +1,171 @@
+# Stage 19BB - First Production-Staging Activation
+
+## Purpose
+
+Stage 19BB is the exact authorization checkpoint for the first real bounded
+production-staging execution lane. It authorizes a later merged wrapper to run
+only the reviewed EDSM staging-only path against the approved isolated local
+staging target.
+
+This checkpoint authorizes source resolution, source fingerprinting, read-only
+target preflight, wrapper/docs/tests preparation, and merge of the reviewed
+authorization PR. The authority status recorded for this checkpoint is
+`authorized_after_merge`. It does not execute a staging import in this PR.
+
+## Approved source
+
+- source name: `edsm`;
+- logical batch label: `edsm-stations-20260618T145715Z`;
+- sanitized source reference: `https://www.edsm.net/dump/stations.json.gz`;
+- basename: `stations.json.gz`;
+- approved SHA-256:
+  `09225e43323464e332a792f8716a6e4264ef5999ce1544f1157bfc60f406f4a2`;
+- size bytes: `2614426684`;
+- eligible station rows: `713624`;
+- format: `json`;
+- record stream shape: `json_array`;
+- compression: `gzip`;
+- acquisition timestamp: `2026-06-18T14:52:50.594163Z`.
+
+Source acquisition completed before this PR was merged. The source file itself
+is not committed, private full paths are not committed, and signed or secret
+query parameters are not recorded.
+
+## Approved target
+
+- target type: `isolated_persistent_local_staging`;
+- host: `127.0.0.1`;
+- port: `56432`;
+- database: `edfinder_stage19_staging`;
+- role: `stage19_loader`;
+- setup-reported fingerprint:
+  `759499c54f9d41cd636b4b5aa54e9bda1e4435c49e7a9a9bc34450b8671945b2`;
+- recomputed Stage 19BB fingerprint:
+  `fb59921a3c4f913c318e12709e602261450edf3632e8e20e0b669fd8f1622753`.
+
+The fingerprint mismatch was reviewed as a formula mismatch, not target drift.
+The stricter Stage 19BB fingerprint input includes:
+
+- target type;
+- host;
+- port;
+- database;
+- role;
+- sorted exact required table set;
+- canonical-table-absence result;
+- restricted-loader result.
+
+The approved runtime fingerprint for Stage 19BB is therefore
+`fb59921a3c4f913c318e12709e602261450edf3632e8e20e0b669fd8f1622753`.
+
+## Exact boundary
+
+The factual Stage 19BB execution boundary is exactly these five non-canonical
+tables:
+
+- `source_runs`;
+- `enrichment_source_runs`;
+- `enrichment_source_files`;
+- `enrichment_raw_records`;
+- `staging_edsm_stations`.
+
+Canonical application tables must remain absent from the isolated target:
+
+- `systems`;
+- `stations`;
+- `bodies`;
+- `body_rings`;
+- `station_body_links`;
+- `body_scan_facts`;
+- `observed_facts`.
+
+No broader warehouse, canonical, or scheduler boundary is authorized.
+
+## Stage 19BA correction
+
+Stage 19BA recorded a control-baseline shorthand of three tables:
+
+- `source_runs`;
+- `enrichment_source_runs`;
+- `staging_edsm_stations`.
+
+The later executable loader audit established that the real tested loader path
+also depends on two additional non-canonical support tables:
+
+- `enrichment_source_files`;
+- `enrichment_raw_records`.
+
+This is a correction to the executable dependency map, not a rewrite of Stage
+19BA history and not permission for arbitrary warehouse writes. Stage 19BA did
+not execute and did not previously authorize a five-table run.
+
+## Authorized scale
+
+After merge, Stage 19BB authorizes no more than these successful runs:
+
+- `100` rows with a maximum runtime of `900` seconds;
+- `1,000` rows with a maximum runtime of `1,800` seconds;
+- `10,000` rows with a maximum runtime of `3,600` seconds.
+
+Because the approved eligible source count is above `10,000`, the third run is
+exactly `10,000` rows rather than full-under-10,000.
+
+No other successful batch size is authorized. No run above `10,000` rows is
+authorized.
+
+## Wrapper contract
+
+The merged wrapper at
+`scripts/operator/stage19bb_first_production_staging_activation.py` must:
+
+- default to dry-run and read-only target preflight;
+- require `--commit`;
+- require `--confirm-stage19bb`;
+- require merged authority on `origin/main` before execution;
+- require `EDSM_STATION_SNAPSHOT`;
+- require `EDFINDER_STAGING_DSN`;
+- require `SAFE_ARTIFACT_DIR`;
+- require the exact approved source SHA-256 on every run;
+- require the exact approved target fingerprint on every run;
+- approve localhost only for the reviewed fingerprinted target;
+- reject arbitrary localhost targets;
+- enforce the exact five-table boundary;
+- fail closed on schema drift;
+- fail closed on overlap;
+- fail on malformed or rejected rows in the selected batch;
+- block canonical apply;
+- block rebaseline;
+- block scheduler/service dispatch;
+- stop after one selected batch.
+
+The wrapper reuses the existing parser and staging helpers. It does not invent a
+competing loader.
+
+## Preflight proof
+
+Read-only preflight confirmed:
+
+- PostgreSQL server reachable on the approved host/port;
+- exact required five tables present;
+- expected columns, constraints, and indexes present;
+- canonical application tables absent;
+- no blocking active or failed Stage 19 run present;
+- restricted loader role proven;
+- create-database, create-role, schema-create, and unrelated-table creation
+  privileges absent.
+
+## This PR does not do
+
+This authorization PR does not:
+
+- execute a staging import;
+- create a runtime `source_runs` row;
+- create a runtime artifact;
+- write EDSM rows into the staging target;
+- perform canonical writes;
+- run canonical apply;
+- run rebaseline;
+- enable a scheduler or service.
+
+The authorization PR contains no execution evidence. Runtime source files and
+runtime artifacts remain evidence only and are not committed authority.

--- a/docs/colonisation-redesign/stage-23-roadmap.md
+++ b/docs/colonisation-redesign/stage-23-roadmap.md
@@ -23,6 +23,9 @@ writes, operator commands, or production-like DB execution.
   `unavailable`/`unknown`.
 - The next recommended checkpoint is `Stage 23B - Safe per-system warehouse join
   expansion`.
+- Stage 19BB authorization is now the separate operational dependency for any
+  future bounded warehouse-evidence execution lane; Stage 23 itself remains
+  read-only.
 
 ## Source Order
 
@@ -53,6 +56,9 @@ Only if a safe and explicit selected-system warehouse join is already available,
 expand the provider to include per-system warehouse evidence without guessing.
 This remains operationally dependent on the separate bounded Stage 19
 production-staging activation contract rather than inferred warehouse truth.
+That separate dependency is now pinned to the merged Stage 19BB authorization
+checkpoint, which approves only the reviewed EDSM source, the reviewed isolated
+staging target fingerprint, and the `100 -> 1,000 -> 10,000` bounded ladder.
 
 ### Stage 23C
 

--- a/scripts/checks/local-ci-parity.sh
+++ b/scripts/checks/local-ci-parity.sh
@@ -101,6 +101,7 @@ section "Stage 19/source-run/operator focused tests"
     tests/test_stage19ax_readonly_av_safety_gate.py \
     tests/test_stage19ay_test_environment_closeout.py \
     tests/test_stage19ba_bounded_production_staging_activation.py \
+    tests/test_stage19bb_first_production_staging_activation.py \
     tests/test_stage20_planning_baseline.py \
     tests/test_stage21_planning_baseline.py \
     tests/test_stage18h1_planner_evidence_contract.py \

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -32,5 +32,11 @@ Current scripts:
   source hash, sanitized source-reference display, target-shape, row-cap, and
   runtime-cap checks, creates no artifact directory during dry-run, and does
   not authorize execution by itself.
+- `stage19bb_first_production_staging_activation.py`: prepares or runs the exact
+  Stage 19BB first production-staging activation lane. It defaults to dry-run,
+  requires merged authority plus `--commit --confirm-stage19bb` for execution,
+  pins the approved EDSM source SHA-256 and approved isolated target
+  fingerprint, enforces the exact five-table write boundary, and blocks
+  canonical apply, rebaseline, and scheduler/service dispatch.
 
 Production artifacts are private operator files and should not be committed.

--- a/scripts/operator/stage19bb_first_production_staging_activation.py
+++ b/scripts/operator/stage19bb_first_production_staging_activation.py
@@ -1,0 +1,1074 @@
+#!/usr/bin/env python3
+"""Stage 19BB first production-staging activation wrapper.
+
+This wrapper authorizes only the exact reviewed bounded production-staging lane
+for the approved EDSM station snapshot and the approved isolated local staging
+target. It defaults to dry-run/read-only preflight, requires explicit commit
+flags, and fails closed unless the merged Stage 19BB authority is present on
+``origin/main``.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parents[2]
+OPERATOR_SCRIPTS = Path(__file__).resolve().parent
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+AUTHORITY_PATH = ROOT / 'docs' / 'colonisation-redesign' / 'stage-19-state-authority.json'
+REPO_ROOT = ROOT
+
+for candidate in (OPERATOR_SCRIPTS, IMPORTER_SRC):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+import artifact_utils  # noqa: E402
+import edsm_station_import  # noqa: E402
+import enrichment_warehouse_repository as warehouse_repository  # noqa: E402
+import source_run_artifacts  # noqa: E402
+import source_run_compatibility  # noqa: E402
+from enrichment_snapshot_loader import source_file_format_metadata  # noqa: E402
+import stage19ar_edsm_25_row_staging_pilot as pilot  # noqa: E402
+
+
+APPROVED_SOURCE_NAME = 'edsm'
+APPROVED_SOURCE_BATCH_LABEL = 'edsm-stations-20260618T145715Z'
+APPROVED_SOURCE_REFERENCE = 'https://www.edsm.net/dump/stations.json.gz'
+APPROVED_SOURCE_BASENAME = 'stations.json.gz'
+APPROVED_SOURCE_SHA256 = '09225e43323464e332a792f8716a6e4264ef5999ce1544f1157bfc60f406f4a2'
+APPROVED_SOURCE_SIZE_BYTES = 2614426684
+APPROVED_ELIGIBLE_SOURCE_ROWS = 713624
+APPROVED_SOURCE_FORMAT = 'json'
+APPROVED_SOURCE_RECORD_STREAM_SHAPE = 'json_array'
+APPROVED_SOURCE_COMPRESSION = 'gzip'
+
+REPORTED_TARGET_FINGERPRINT = '759499c54f9d41cd636b4b5aa54e9bda1e4435c49e7a9a9bc34450b8671945b2'
+APPROVED_TARGET_FINGERPRINT = 'fb59921a3c4f913c318e12709e602261450edf3632e8e20e0b669fd8f1622753'
+APPROVED_TARGET_TYPE = 'isolated_persistent_local_staging'
+APPROVED_TARGET_HOST = '127.0.0.1'
+APPROVED_TARGET_PORT = 56432
+APPROVED_TARGET_DATABASE = 'edfinder_stage19_staging'
+APPROVED_TARGET_ROLE = 'stage19_loader'
+
+APPROVED_LIMITS = {
+    100: 900,
+    1000: 1800,
+    10000: 3600,
+}
+PERMITTED_TABLES = [
+    'source_runs',
+    'enrichment_source_runs',
+    'enrichment_source_files',
+    'enrichment_raw_records',
+    'staging_edsm_stations',
+]
+CANONICAL_TABLES = [
+    'systems',
+    'stations',
+    'bodies',
+    'body_rings',
+    'station_body_links',
+    'body_scan_facts',
+    'observed_facts',
+]
+LOCALHOST_HOSTS = frozenset({'127.0.0.1', 'localhost', '::1', '0.0.0.0'})
+MALFORMED_REASON_MARKERS = frozenset({
+    'invalid_station_snapshot_record',
+    'record_is_not_object',
+    'unsupported_source_shape',
+})
+
+EXPECTED_COLUMNS = {
+    'source_runs': [
+        'id',
+        'source_run_key',
+        'source_name',
+        'source_category',
+        'domain',
+        'import_scope',
+        'status',
+        'source_uri',
+        'source_input_sha256',
+        'source_manifest_sha256',
+        'started_at',
+        'finished_at',
+        'duration_ms',
+        'git_commit_sha',
+        'importer_name',
+        'importer_version',
+        'trigger_context',
+        'artifact_path',
+        'artifact_sha256',
+        'artifact_integrity_sha256',
+        'rows_read',
+        'rows_staged',
+        'rows_rejected',
+        'rows_skipped',
+        'error_code',
+        'error_summary',
+        'safety_boundary',
+        'metadata',
+        'created_at',
+        'updated_at',
+    ],
+    'enrichment_source_runs': [
+        'id',
+        'source_run_key',
+        'source',
+        'adapter_name',
+        'adapter_version',
+        'source_kind',
+        'source_class',
+        'run_label',
+        'dry_run',
+        'source_started_at',
+        'source_completed_at',
+        'imported_at',
+        'metadata',
+    ],
+    'enrichment_source_files': [
+        'id',
+        'source_run_id',
+        'source_file_key',
+        'source_path',
+        'source_file_name',
+        'content_type',
+        'compression',
+        'file_size_bytes',
+        'file_sha256',
+        'source_updated_at',
+        'imported_at',
+        'metadata',
+    ],
+    'enrichment_raw_records': [
+        'id',
+        'source_run_id',
+        'source_file_id',
+        'record_index',
+        'source_record_key',
+        'source_record_hash',
+        'source_updated_at',
+        'imported_at',
+        'raw_payload',
+        'validation_status',
+        'validation_warnings',
+    ],
+    'staging_edsm_stations': [
+        'id',
+        'source_run_id',
+        'source_file_id',
+        'raw_record_id',
+        'source_record_key',
+        'source_record_hash',
+        'system_id64',
+        'system_name',
+        'market_id',
+        'edsm_station_id',
+        'station_name',
+        'station_type',
+        'distance_to_arrival',
+        'body_name',
+        'services',
+        'economies',
+        'controlling_faction',
+        'allegiance',
+        'government',
+        'source_class',
+        'confidence',
+        'freshness_class',
+        'source_updated_at',
+        'imported_at',
+        'raw_payload',
+        'provenance',
+    ],
+}
+EXPECTED_INDEXES = {
+    'source_runs': [
+        'idx_source_runs_artifact_sha256',
+        'idx_source_runs_one_running_per_source_domain_scope',
+        'idx_source_runs_source_domain_started',
+        'idx_source_runs_source_input_sha256',
+        'idx_source_runs_source_status',
+        'idx_source_runs_status_started',
+        'source_runs_pkey',
+        'source_runs_source_run_key_key',
+    ],
+    'enrichment_source_runs': [
+        'enrichment_source_runs_pkey',
+        'enrichment_source_runs_source_run_key_key',
+        'idx_enrichment_source_runs_class',
+        'idx_enrichment_source_runs_source',
+    ],
+    'enrichment_source_files': [
+        'enrichment_source_files_pkey',
+        'enrichment_source_files_source_run_id_source_file_key_key',
+        'idx_enrichment_source_files_run',
+        'idx_enrichment_source_files_sha',
+    ],
+    'enrichment_raw_records': [
+        'enrichment_raw_records_pkey',
+        'idx_enrichment_raw_records_run',
+        'idx_enrichment_raw_records_run_file_hash',
+        'idx_enrichment_raw_records_run_file_index',
+        'idx_enrichment_raw_records_source_updated',
+    ],
+    'staging_edsm_stations': [
+        'idx_staging_edsm_stations_market_id',
+        'idx_staging_edsm_stations_run',
+        'idx_staging_edsm_stations_run_hash',
+        'idx_staging_edsm_stations_source_updated',
+        'idx_staging_edsm_stations_station_name',
+        'idx_staging_edsm_stations_system_id64',
+        'idx_staging_edsm_stations_system_name',
+        'staging_edsm_stations_pkey',
+    ],
+}
+EXPECTED_CONSTRAINTS = {
+    'source_runs': [
+        'chk_source_runs_domain',
+        'chk_source_runs_duration_non_negative',
+        'chk_source_runs_finished_window',
+        'chk_source_runs_import_scope',
+        'chk_source_runs_rows_read_non_negative',
+        'chk_source_runs_rows_rejected_non_negative',
+        'chk_source_runs_rows_skipped_non_negative',
+        'chk_source_runs_rows_staged_non_negative',
+        'chk_source_runs_source_category',
+        'chk_source_runs_source_name',
+        'chk_source_runs_status',
+        'source_runs_pkey',
+        'source_runs_source_run_key_key',
+    ],
+    'enrichment_source_runs': [
+        'enrichment_source_runs_pkey',
+        'enrichment_source_runs_source_class_check',
+        'enrichment_source_runs_source_run_key_key',
+    ],
+    'enrichment_source_files': [
+        'enrichment_source_files_pkey',
+        'enrichment_source_files_source_run_id_fkey',
+        'enrichment_source_files_source_run_id_source_file_key_key',
+    ],
+    'enrichment_raw_records': [
+        'enrichment_raw_records_pkey',
+        'enrichment_raw_records_source_file_id_fkey',
+        'enrichment_raw_records_source_run_id_fkey',
+        'enrichment_raw_records_validation_status_check',
+    ],
+    'staging_edsm_stations': [
+        'staging_edsm_stations_pkey',
+        'staging_edsm_stations_raw_record_id_fkey',
+        'staging_edsm_stations_source_class_check',
+        'staging_edsm_stations_source_file_id_fkey',
+        'staging_edsm_stations_source_run_id_fkey',
+    ],
+}
+
+
+class Stage19BbActivationError(RuntimeError):
+    """Raised when the Stage 19BB wrapper must fail closed."""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Prepare or run the Stage 19BB first production-staging activation.'
+    )
+    parser.add_argument('--limit', type=int, required=True, help='Approved batch size: 100, 1000, or 10000.')
+    parser.add_argument(
+        '--artifact-dir',
+        default=None,
+        help='Optional external runtime artifact directory. Defaults to SAFE_ARTIFACT_DIR.',
+    )
+    parser.add_argument('--git-head', default='auto', help='Git SHA for runtime source_runs rows, or "auto".')
+    parser.add_argument(
+        '--trigger-context',
+        default='stage19bb_first_production_staging_activation',
+        help='source_runs trigger context for an authorized commit run.',
+    )
+    parser.add_argument('--commit', action='store_true', help='Opt in to the bounded Stage 19BB staging write.')
+    parser.add_argument(
+        '--confirm-stage19bb',
+        action='store_true',
+        help='Required with --commit so Stage 19BB cannot be executed accidentally.',
+    )
+    args = parser.parse_args(argv)
+    if args.limit not in APPROVED_LIMITS:
+        parser.error('--limit must be exactly one of: 100, 1000, 10000.')
+    if args.commit and not args.confirm_stage19bb:
+        parser.error('--commit requires --confirm-stage19bb.')
+    return args
+
+
+def approved_runtime_cap(limit: int) -> int:
+    return APPROVED_LIMITS[limit]
+
+
+def sanitize_path_reference(path: Path) -> str:
+    return f'<redacted>/{path.name}'
+
+
+def sha256_file(path: Path) -> str:
+    return artifact_utils.sha256_file(path)
+
+
+def load_authority(path: Path = AUTHORITY_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def authority_stage19bb(authority: Mapping[str, Any]) -> Mapping[str, Any]:
+    checkpoint = authority.get('stage19bb_first_production_staging_activation')
+    if not isinstance(checkpoint, Mapping):
+        raise Stage19BbActivationError('Stage 19BB authority checkpoint is missing.')
+    return checkpoint
+
+
+def verify_stage19bb_merged_to_origin_main() -> bool:
+    head = subprocess.run(
+        ['git', 'rev-parse', 'HEAD'],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    origin_main = subprocess.run(
+        ['git', 'rev-parse', 'origin/main'],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if head.returncode != 0 or origin_main.returncode != 0:
+        return False
+    return (
+        subprocess.run(
+            ['git', 'merge-base', '--is-ancestor', head.stdout.strip(), 'origin/main'],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        ).returncode
+        == 0
+    )
+
+
+def ensure_execution_authorized_after_merge() -> Mapping[str, Any]:
+    authority = load_authority()
+    checkpoint = authority_stage19bb(authority)
+    if checkpoint.get('status') != 'authorized_after_merge':
+        raise Stage19BbActivationError('Stage 19BB execution is not authorized by the merged authority state.')
+    if checkpoint.get('approved_source_sha256') != APPROVED_SOURCE_SHA256:
+        raise Stage19BbActivationError('Merged authority does not match the approved Stage 19BB source SHA-256.')
+    if checkpoint.get('approved_target_fingerprint') != APPROVED_TARGET_FINGERPRINT:
+        raise Stage19BbActivationError('Merged authority does not match the approved Stage 19BB target fingerprint.')
+    if not verify_stage19bb_merged_to_origin_main():
+        raise Stage19BbActivationError('Stage 19BB execution requires merged authority on origin/main.')
+    return checkpoint
+
+
+def resolve_runtime_inputs(
+    args: argparse.Namespace,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    source_env = dict(env if env is not None else os.environ)
+    snapshot_value = source_env.get('EDSM_STATION_SNAPSHOT')
+    dsn = source_env.get('EDFINDER_STAGING_DSN')
+    safe_artifact_dir = source_env.get('SAFE_ARTIFACT_DIR')
+    if not snapshot_value:
+        raise Stage19BbActivationError('EDSM_STATION_SNAPSHOT is required.')
+    if not dsn:
+        raise Stage19BbActivationError('EDFINDER_STAGING_DSN is required.')
+    if not safe_artifact_dir:
+        raise Stage19BbActivationError('SAFE_ARTIFACT_DIR is required.')
+
+    snapshot_path = Path(snapshot_value).expanduser().resolve(strict=False)
+    if not snapshot_path.is_file():
+        raise Stage19BbActivationError('EDSM_STATION_SNAPSHOT must reference an existing file.')
+
+    artifact_dir_value = args.artifact_dir or safe_artifact_dir
+    artifact_dir = Path(artifact_dir_value).expanduser().resolve(strict=False)
+    validate_external_artifact_dir(artifact_dir)
+
+    return {
+        'snapshot_path': snapshot_path,
+        'staging_dsn': dsn,
+        'artifact_dir': artifact_dir,
+        'snapshot_display_name': snapshot_path.name,
+        'artifact_dir_display_name': artifact_dir.name or '<redacted>',
+    }
+
+
+def validate_external_artifact_dir(path: Path) -> None:
+    if not path.is_absolute():
+        raise Stage19BbActivationError('artifact directory must be an absolute external path.')
+    try:
+        path.relative_to(REPO_ROOT)
+    except ValueError:
+        pass
+    else:
+        raise Stage19BbActivationError('artifact directory must be external to the repository.')
+    if path.exists() and not path.is_dir():
+        raise Stage19BbActivationError('artifact directory path exists but is not a directory.')
+
+
+def build_source_preview(
+    snapshot_path: Path,
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    source_sha256 = sha256_file(snapshot_path)
+    file_format = source_file_format_metadata(snapshot_path)
+    plan = edsm_station_import.build_edsm_station_import_plan(
+        source_file=snapshot_path,
+        source_run_key='stage19bb-dry-run-preflight',
+        source_uri=APPROVED_SOURCE_REFERENCE,
+        source_input_sha256=source_sha256,
+        file_format=file_format,
+        limit=limit,
+    )
+    return {
+        'snapshot_basename': snapshot_path.name,
+        'source_sha256': source_sha256,
+        'file_size_bytes': snapshot_path.stat().st_size,
+        'file_format': dict(file_format),
+        'compression': detect_compression(snapshot_path),
+        'plan': plan,
+    }
+
+
+def assert_source_preview_ok(preview: Mapping[str, Any], *, limit: int) -> None:
+    if preview.get('source_sha256') != APPROVED_SOURCE_SHA256:
+        raise Stage19BbActivationError('approved EDSM source SHA-256 mismatch')
+    if preview.get('file_size_bytes') != APPROVED_SOURCE_SIZE_BYTES:
+        raise Stage19BbActivationError('approved EDSM source size mismatch')
+    if preview.get('snapshot_basename') != APPROVED_SOURCE_BASENAME:
+        raise Stage19BbActivationError('unexpected EDSM snapshot basename')
+
+    file_format = dict(preview.get('file_format') or {})
+    if file_format.get('source_format') != APPROVED_SOURCE_FORMAT:
+        raise Stage19BbActivationError('Stage 19BB requires the approved JSON station-object snapshot format.')
+    if file_format.get('record_stream_shape') != APPROVED_SOURCE_RECORD_STREAM_SHAPE:
+        raise Stage19BbActivationError('Stage 19BB requires the approved JSON array station snapshot stream shape.')
+    if preview.get('compression') != APPROVED_SOURCE_COMPRESSION:
+        raise Stage19BbActivationError('Stage 19BB requires the approved gzip-compressed source snapshot.')
+
+    plan = dict(preview.get('plan') or {})
+    if int(plan.get('rows_read') or 0) != limit:
+        raise Stage19BbActivationError('source parser did not read the exact approved Stage 19BB batch size.')
+    if int(plan.get('rows_staged') or 0) != limit:
+        raise Stage19BbActivationError('source parser did not produce the exact approved Stage 19BB batch size.')
+    if int(plan.get('rows_rejected') or 0) != 0:
+        raise Stage19BbActivationError('Stage 19BB refuses rejected rows in the selected batch.')
+    if _contains_malformed_reason_counts(plan):
+        raise Stage19BbActivationError('Stage 19BB refuses malformed rows in the selected batch.')
+
+
+def _contains_malformed_reason_counts(plan: Mapping[str, Any]) -> bool:
+    for key in ('warning_reason_counts', 'rejection_reason_counts', 'skipped_reason_counts'):
+        values = dict(plan.get(key) or {})
+        for reason, count in values.items():
+            if reason in MALFORMED_REASON_MARKERS and int(count or 0) > 0:
+                return True
+    return False
+
+
+def parse_target_identity(dsn: str) -> dict[str, Any]:
+    parsed = urlparse(dsn)
+    return {
+        'host': parsed.hostname or '',
+        'port': int(parsed.port or 0),
+        'database': parsed.path.lstrip('/'),
+        'role': parsed.username or '',
+    }
+
+
+def detect_compression(path: Path) -> str:
+    with path.open('rb') as handle:
+        header = handle.read(2)
+    if header == b'\x1f\x8b':
+        return 'gzip'
+    return 'none'
+
+
+def _query_one(conn: Any, sql: str, params: Sequence[Any] | None = None) -> dict[str, Any] | None:
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, tuple(params or ()))
+        return pilot._fetchone_dict(cur)
+    finally:
+        pilot.close_cursor(cur)
+
+
+def _query_rows(conn: Any, sql: str, params: Sequence[Any] | None = None) -> list[dict[str, Any]]:
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, tuple(params or ()))
+        return pilot._fetchall_dicts(cur)
+    finally:
+        pilot.close_cursor(cur)
+
+
+def run_target_preflight(dsn: str) -> dict[str, Any]:
+    identity = parse_target_identity(dsn)
+    conn = None
+    try:
+        conn = pilot.connect_operator_db(dsn)
+        pilot.set_connection_mode(conn, commit=False)
+        tables = _query_rows(
+            conn,
+            """
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+            ORDER BY table_name
+            """,
+        )
+        columns = _query_rows(
+            conn,
+            """
+            SELECT table_name, column_name, ordinal_position
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+            ORDER BY table_name, ordinal_position
+            """,
+        )
+        indexes = _query_rows(
+            conn,
+            """
+            SELECT tablename AS table_name, indexname
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+            ORDER BY tablename, indexname
+            """,
+        )
+        constraints = _query_rows(
+            conn,
+            """
+            SELECT t.relname AS table_name, c.conname
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            WHERE n.nspname = 'public'
+            ORDER BY t.relname, c.conname
+            """,
+        )
+        canonical_absent_row = _query_one(
+            conn,
+            """
+            SELECT CASE
+                WHEN to_regclass('public.systems') IS NULL
+                 AND to_regclass('public.stations') IS NULL
+                 AND to_regclass('public.bodies') IS NULL
+                 AND to_regclass('public.body_rings') IS NULL
+                 AND to_regclass('public.station_body_links') IS NULL
+                 AND to_regclass('public.body_scan_facts') IS NULL
+                 AND to_regclass('public.observed_facts') IS NULL
+                THEN true ELSE false END AS canonical_tables_absent
+            """,
+        )
+        blockers = _query_one(
+            conn,
+            """
+            SELECT COUNT(*)::int AS blocking_runs
+            FROM source_runs
+            WHERE (source_run_key LIKE 'stage19%%' OR source_run_key LIKE 'stage-19%%')
+              AND status IN ('running', 'failed', 'active', 'pending')
+            """,
+        )
+        loader_caps = _query_one(
+            conn,
+            """
+            SELECT
+              rolcreatedb::text AS rolcreatedb,
+              rolcreaterole::text AS rolcreaterole,
+              rolsuper::text AS rolsuper,
+              has_schema_privilege(%s, 'public', 'CREATE')::text AS schema_create,
+              has_database_privilege(%s, current_database(), 'CREATE')::text AS database_create
+            FROM pg_roles
+            WHERE rolname = %s
+            """,
+            (APPROVED_TARGET_ROLE, APPROVED_TARGET_ROLE, APPROVED_TARGET_ROLE),
+        )
+        extension_rows = _query_rows(
+            conn,
+            """
+            SELECT extname
+            FROM pg_extension
+            ORDER BY extname
+            """,
+        )
+    except Exception as exc:
+        if conn is not None:
+            pilot.rollback(conn)
+        raise Stage19BbActivationError(f'target preflight failed: {type(exc).__name__}') from None
+    finally:
+        if conn is not None:
+            pilot.rollback(conn)
+            pilot.close_connection(conn)
+
+    table_names = [str(row['table_name']) for row in tables]
+    columns_by_table: dict[str, list[str]] = {}
+    for row in columns:
+        columns_by_table.setdefault(str(row['table_name']), []).append(str(row['column_name']))
+    indexes_by_table: dict[str, list[str]] = {}
+    for row in indexes:
+        indexes_by_table.setdefault(str(row['table_name']), []).append(str(row['indexname']))
+    constraints_by_table: dict[str, list[str]] = {}
+    for row in constraints:
+        constraints_by_table.setdefault(str(row['table_name']), []).append(str(row['conname']))
+
+    restricted_loader = loader_caps == {
+        'rolcreatedb': 'false',
+        'rolcreaterole': 'false',
+        'rolsuper': 'false',
+        'schema_create': 'false',
+        'database_create': 'false',
+    }
+    fingerprint_input = {
+        'target_type': APPROVED_TARGET_TYPE,
+        'host': identity['host'],
+        'port': identity['port'],
+        'database': identity['database'],
+        'role': identity['role'],
+        'required_tables': sorted(PERMITTED_TABLES),
+        'canonical_tables_absent': bool(canonical_absent_row and canonical_absent_row['canonical_tables_absent']),
+        'restricted_loader': restricted_loader,
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(fingerprint_input, sort_keys=True, separators=(',', ':')).encode('utf-8')
+    ).hexdigest()
+
+    return {
+        'identity': identity,
+        'tables_present': table_names,
+        'columns': columns_by_table,
+        'indexes': indexes_by_table,
+        'constraints': constraints_by_table,
+        'canonical_tables_absent': bool(canonical_absent_row and canonical_absent_row['canonical_tables_absent']),
+        'blocking_runs': int((blockers or {}).get('blocking_runs') or 0),
+        'loader_caps': dict(loader_caps or {}),
+        'restricted_loader': restricted_loader,
+        'extensions': [str(row['extname']) for row in extension_rows],
+        'fingerprint_input': fingerprint_input,
+        'recomputed_target_fingerprint': fingerprint,
+    }
+
+
+def assert_target_preflight_ok(preflight: Mapping[str, Any]) -> None:
+    identity = dict(preflight.get('identity') or {})
+    host = str(identity.get('host') or '')
+    port = int(identity.get('port') or 0)
+    database = str(identity.get('database') or '')
+    role = str(identity.get('role') or '')
+    fingerprint = str(preflight.get('recomputed_target_fingerprint') or '')
+
+    if host in LOCALHOST_HOSTS and fingerprint != APPROVED_TARGET_FINGERPRINT:
+        raise Stage19BbActivationError('arbitrary localhost targets are blocked unless the exact reviewed fingerprint matches')
+    if (
+        host != APPROVED_TARGET_HOST
+        or port != APPROVED_TARGET_PORT
+        or database != APPROVED_TARGET_DATABASE
+        or role != APPROVED_TARGET_ROLE
+    ):
+        raise Stage19BbActivationError('Stage 19BB requires the exact approved isolated local staging target identity.')
+    if sorted(preflight.get('tables_present') or []) != sorted(PERMITTED_TABLES):
+        raise Stage19BbActivationError('Stage 19BB requires exactly the reviewed five-table staging boundary.')
+    for table_name, expected_columns in EXPECTED_COLUMNS.items():
+        if list(preflight.get('columns', {}).get(table_name) or []) != expected_columns:
+            raise Stage19BbActivationError(f'schema drift detected for required columns in {table_name}.')
+    for table_name, expected_indexes in EXPECTED_INDEXES.items():
+        if sorted(preflight.get('indexes', {}).get(table_name) or []) != sorted(expected_indexes):
+            raise Stage19BbActivationError(f'schema drift detected for required indexes in {table_name}.')
+    for table_name, expected_constraints in EXPECTED_CONSTRAINTS.items():
+        if sorted(preflight.get('constraints', {}).get(table_name) or []) != sorted(expected_constraints):
+            raise Stage19BbActivationError(f'schema drift detected for required constraints in {table_name}.')
+    if preflight.get('canonical_tables_absent') is not True:
+        raise Stage19BbActivationError('canonical application tables must remain absent from the Stage 19BB target.')
+    if int(preflight.get('blocking_runs') or 0) != 0:
+        raise Stage19BbActivationError('Stage 19BB refuses execution while blocking Stage 19 source runs exist.')
+    if preflight.get('restricted_loader') is not True:
+        raise Stage19BbActivationError('Stage 19BB requires a restricted loader role without broad database privileges.')
+    caps = dict(preflight.get('loader_caps') or {})
+    if caps.get('schema_create') != 'false':
+        raise Stage19BbActivationError('Stage 19BB refuses a loader role that can create schemas or tables.')
+    if caps.get('database_create') != 'false':
+        raise Stage19BbActivationError('Stage 19BB refuses a loader role that can create databases.')
+    if fingerprint != APPROVED_TARGET_FINGERPRINT:
+        raise Stage19BbActivationError('Stage 19BB target fingerprint mismatch.')
+
+
+def build_dry_run_payload(
+    args: argparse.Namespace,
+    runtime_inputs: Mapping[str, Any],
+    preview: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        'stage': 'stage19bb',
+        'mode': 'dry_run',
+        'commit_requested': False,
+        'limit': args.limit,
+        'runtime_cap_seconds': approved_runtime_cap(args.limit),
+        'source': {
+            'name': APPROVED_SOURCE_NAME,
+            'batch_label': APPROVED_SOURCE_BATCH_LABEL,
+            'reference': APPROVED_SOURCE_REFERENCE,
+            'basename': runtime_inputs['snapshot_display_name'],
+            'sha256': preview['source_sha256'],
+            'eligible_rows': APPROVED_ELIGIBLE_SOURCE_ROWS,
+            'format': APPROVED_SOURCE_FORMAT,
+            'compression': APPROVED_SOURCE_COMPRESSION,
+            'env_present': True,
+        },
+        'target': {
+            'type': APPROVED_TARGET_TYPE,
+            'host': APPROVED_TARGET_HOST,
+            'port': APPROVED_TARGET_PORT,
+            'database': APPROVED_TARGET_DATABASE,
+            'role': APPROVED_TARGET_ROLE,
+            'reported_fingerprint': REPORTED_TARGET_FINGERPRINT,
+            'approved_fingerprint': APPROVED_TARGET_FINGERPRINT,
+            'recomputed_fingerprint': preflight['recomputed_target_fingerprint'],
+            'canonical_tables_absent': preflight['canonical_tables_absent'],
+            'restricted_loader': preflight['restricted_loader'],
+        },
+        'policy': {
+            'permitted_tables': list(PERMITTED_TABLES),
+            'canonical_tables_forbidden': list(CANONICAL_TABLES),
+            'default_dry_run': True,
+            'merged_authority_required_for_execution': True,
+            'artifact_dir_external': True,
+            'canonical_apply_authorized': False,
+            'rebaseline_authorized': False,
+            'scheduler_service_authorized': False,
+        },
+    }
+
+
+def build_runtime_source_run_key(*, limit: int, generated_at: datetime) -> str:
+    return f'stage19bb-edsm-{limit}-row-bounded-staging-{generated_at.strftime("%Y%m%dT%H%M%SZ")}'
+
+
+def stage19bb_safety_boundary(*, limit: int, runtime_cap_seconds: int) -> dict[str, Any]:
+    return {
+        'stage19bb_authorized_after_merge': True,
+        'target_type': APPROVED_TARGET_TYPE,
+        'target_fingerprint': APPROVED_TARGET_FINGERPRINT,
+        'approved_source_sha256': APPROVED_SOURCE_SHA256,
+        'approved_source_reference': APPROVED_SOURCE_REFERENCE,
+        'approved_limit': limit,
+        'runtime_cap_seconds': runtime_cap_seconds,
+        'permitted_tables': list(PERMITTED_TABLES),
+        'canonical_tables_absent_required': True,
+        'canonical_writes_planned': 0,
+        'station_type_mapping_writes_planned': 0,
+        'scheduled_import_enabled': False,
+        'timer_enabled': False,
+        'service_enabled': False,
+        'canonical_apply_enabled': False,
+        'rebaseline_enabled': False,
+        'localhost_target_allowed_only_by_exact_fingerprint': True,
+    }
+
+
+def build_stage19bb_artifact_payload(
+    *,
+    source_run_kwargs: Mapping[str, Any],
+    generated_at: datetime,
+    limit: int,
+    runtime_cap_seconds: int,
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    summary = {
+        'status': 'succeeded',
+        'rows_read': int(plan['rows_read']),
+        'rows_staged': int(plan['rows_staged']),
+        'rows_rejected': int(plan['rows_rejected']),
+        'rows_skipped': int(plan['rows_skipped']),
+        'warning_reason_counts': dict(plan.get('warning_reason_counts') or {}),
+        'rejection_reason_counts': dict(plan.get('rejection_reason_counts') or {}),
+        'skipped_reason_counts': dict(plan.get('skipped_reason_counts') or {}),
+        'approved_limit': limit,
+        'runtime_cap_seconds': runtime_cap_seconds,
+        'staging_target_tables': list(PERMITTED_TABLES),
+        'canonical_writes_performed': False,
+    }
+    return source_run_artifacts.build_artifact_payload_shell(
+        schema_version='stage19bb_first_production_staging_activation/v1',
+        source_run_key=str(source_run_kwargs['source_run_key']),
+        source_name=str(source_run_kwargs['source_name']),
+        source_category=str(source_run_kwargs['source_category']),
+        domain=str(source_run_kwargs['domain']),
+        import_scope=str(source_run_kwargs['import_scope']),
+        git_commit_sha=str(source_run_kwargs['git_commit_sha']),
+        importer_name=str(source_run_kwargs['importer_name']),
+        importer_version=str(source_run_kwargs['importer_version']),
+        trigger_context=str(source_run_kwargs['trigger_context']),
+        generated_at=generated_at,
+        source_uri=APPROVED_SOURCE_REFERENCE,
+        source_input_sha256=APPROVED_SOURCE_SHA256,
+        safety_boundary=source_run_kwargs['safety_boundary'],
+        metadata=dict(source_run_kwargs.get('metadata') or {}),
+        summary=summary,
+        payload={
+            'approved_source_batch_label': APPROVED_SOURCE_BATCH_LABEL,
+            'approved_target_fingerprint': APPROVED_TARGET_FINGERPRINT,
+            'raw_record_count': len(plan.get('raw_records') or []),
+            'five_table_boundary_exact': True,
+        },
+    )
+
+
+class CompatibleStage19BbStationStager:
+    """Explicit stager that writes the full five-table Stage 19BB boundary."""
+
+    def __init__(
+        self,
+        *,
+        snapshot_path: Path,
+        source_sha256: str,
+        generated_at: datetime,
+        limit: int,
+        raw_records: Sequence[Mapping[str, Any]],
+    ) -> None:
+        self.snapshot_path = snapshot_path
+        self.source_sha256 = source_sha256
+        self.generated_at = generated_at
+        self.limit = limit
+        self.raw_records = [dict(row) for row in raw_records]
+        self.inserted_row_ids: list[int] = []
+        self.legacy_source_run_id: int | None = None
+        self.bridge_key: str | None = None
+        self.source_file_id: int | None = None
+
+    def __call__(self, conn: Any, *, source_run: Mapping[str, Any], rows: Sequence[Mapping[str, Any]]) -> int:
+        context = source_run_compatibility.get_or_create_legacy_staging_context(
+            conn,
+            source_run,
+            source='edsm',
+            adapter_name='stage19bb_first_production_staging_activation',
+            adapter_version='v1',
+            source_kind='offline_snapshot',
+            dry_run=False,
+            metadata={
+                'operator_stage': '19bb',
+                'exact_five_table_boundary': True,
+                'approved_source_sha256': APPROVED_SOURCE_SHA256,
+                'approved_target_fingerprint': APPROVED_TARGET_FINGERPRINT,
+                'batch_limit': self.limit,
+                'staging_rows_written_by_explicit_stager': True,
+                'canonical_table_writes_planned': 0,
+            },
+        )
+        legacy_source_run_id = int(context['legacy_source_run_id'])
+        self.legacy_source_run_id = legacy_source_run_id
+        self.bridge_key = str(context['enrichment_source_run']['source_run_key'])
+
+        file_format = source_file_format_metadata(self.snapshot_path)
+        source_file_row = {
+            'source_file_key': artifact_utils.sha256_text(
+                f'{edsm_station_import.SOURCE_ADAPTER}:{self.source_sha256}'
+            ),
+            'source_path': self.snapshot_path.resolve().as_uri(),
+            'source_file_name': self.snapshot_path.name,
+            'content_type': 'application/json',
+            'compression': file_format.get('compression'),
+            'file_size_bytes': self.snapshot_path.stat().st_size,
+            'file_sha256': self.source_sha256,
+            'source_updated_at': None,
+            'metadata': {
+                'stage': '19bb',
+                'approved_source_reference': APPROVED_SOURCE_REFERENCE,
+                'approved_source_batch_label': APPROVED_SOURCE_BATCH_LABEL,
+                'source_format': file_format.get('source_format'),
+                'record_stream_shape': file_format.get('record_stream_shape'),
+            },
+        }
+
+        cur = conn.cursor()
+        try:
+            source_file_id = warehouse_repository.upsert_source_file(cur, legacy_source_run_id, source_file_row)
+            self.source_file_id = source_file_id
+            raw_ids_by_hash: dict[str, int] = {}
+            for raw_record in self.raw_records:
+                raw_record_id = warehouse_repository.upsert_raw_record(
+                    cur,
+                    legacy_source_run_id,
+                    source_file_id,
+                    raw_record,
+                )
+                raw_ids_by_hash[str(raw_record['source_record_hash'])] = raw_record_id
+            for row in rows:
+                record_hash = str(row['source_record_hash'])
+                parent_record_hash = str(
+                    (row.get('provenance') or {}).get('parent_source_record_hash') or ''
+                )
+                inserted_id = warehouse_repository.upsert_staging_station(
+                    cur,
+                    legacy_source_run_id,
+                    source_file_id,
+                    raw_ids_by_hash.get(record_hash) or raw_ids_by_hash.get(parent_record_hash),
+                    row,
+                )
+                self.inserted_row_ids.append(int(inserted_id))
+        finally:
+            pilot.close_cursor(cur)
+        return len(rows)
+
+
+def run_authorized_commit(
+    args: argparse.Namespace,
+    *,
+    runtime_inputs: Mapping[str, Any],
+    preview: Mapping[str, Any],
+    preflight: Mapping[str, Any],
+) -> dict[str, Any]:
+    ensure_execution_authorized_after_merge()
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0)
+    runtime_cap_seconds = approved_runtime_cap(args.limit)
+    source_run_key = build_runtime_source_run_key(limit=args.limit, generated_at=generated_at)
+    artifact_dir = Path(runtime_inputs['artifact_dir'])
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / f'stage19bb_edsm_import_{generated_at.strftime("%Y%m%dT%H%M%SZ")}.json'
+    git_head = pilot.resolve_git_head(args.git_head)
+
+    source_run_kwargs = edsm_station_import.build_source_run_kwargs(
+        source_run_key=source_run_key,
+        source_uri=APPROVED_SOURCE_REFERENCE,
+        source_input_sha256=APPROVED_SOURCE_SHA256,
+        git_commit_sha=git_head,
+        trigger_context=args.trigger_context,
+        file_format=preview['file_format'],
+    )
+    source_run_kwargs['safety_boundary'] = stage19bb_safety_boundary(
+        limit=args.limit,
+        runtime_cap_seconds=runtime_cap_seconds,
+    )
+    metadata = dict(source_run_kwargs.get('metadata') or {})
+    metadata.update(
+        {
+            'stage': '19bb',
+            'approved_source_batch_label': APPROVED_SOURCE_BATCH_LABEL,
+            'approved_eligible_source_rows': APPROVED_ELIGIBLE_SOURCE_ROWS,
+            'approved_target_fingerprint': APPROVED_TARGET_FINGERPRINT,
+            'reported_target_fingerprint': REPORTED_TARGET_FINGERPRINT,
+            'target_fingerprint_formula_mismatch_not_target_drift': True,
+            'permitted_tables': list(PERMITTED_TABLES),
+        }
+    )
+    source_run_kwargs['metadata'] = metadata
+
+    conn = None
+    started = time.monotonic()
+    try:
+        conn = pilot.connect_operator_db(runtime_inputs['staging_dsn'])
+        pilot.set_connection_mode(conn, commit=True)
+        cur = conn.cursor()
+        try:
+            cur.execute('SET LOCAL statement_timeout = %s', (runtime_cap_seconds * 1000,))
+        finally:
+            pilot.close_cursor(cur)
+
+        stager = CompatibleStage19BbStationStager(
+            snapshot_path=Path(runtime_inputs['snapshot_path']),
+            source_sha256=APPROVED_SOURCE_SHA256,
+            generated_at=generated_at,
+            limit=args.limit,
+            raw_records=preview['plan']['raw_records'],
+        )
+
+        def operation(source_run: Mapping[str, Any]) -> source_run_artifacts.SourceRunArtifactOutcome:
+            rows_staged = edsm_station_import.run_explicit_station_stager(
+                conn,
+                source_run=source_run,
+                rows=preview['plan']['staged_rows'],
+                station_stager=stager,
+            )
+            if rows_staged != args.limit:
+                raise Stage19BbActivationError('Stage 19BB commit run did not stage the exact approved batch size.')
+            return source_run_artifacts.SourceRunArtifactOutcome(
+                payload=build_stage19bb_artifact_payload(
+                    source_run_kwargs=source_run_kwargs,
+                    generated_at=generated_at,
+                    limit=args.limit,
+                    runtime_cap_seconds=runtime_cap_seconds,
+                    plan=preview['plan'],
+                ),
+                status='succeeded',
+                rows_read=int(preview['plan']['rows_read']),
+                rows_staged=rows_staged,
+                rows_rejected=0,
+                rows_skipped=int(preview['plan']['rows_skipped']),
+                metadata={
+                    'stage': '19bb',
+                    'batch_limit': args.limit,
+                    'legacy_bridge_key': stager.bridge_key,
+                },
+                finished_at=generated_at,
+                duration_ms=int((time.monotonic() - started) * 1000),
+            )
+
+        result = source_run_artifacts.run_source_run_artifact_flow(
+            conn,
+            source_run_kwargs=source_run_kwargs,
+            artifact_path=artifact_path,
+            operation=operation,
+        )
+        if time.monotonic() - started > runtime_cap_seconds:
+            raise Stage19BbActivationError('Stage 19BB runtime cap exceeded before commit.')
+        pilot.commit_connection(conn)
+        return {
+            'source_run_key': source_run_key,
+            'bridge_key': stager.bridge_key,
+            'artifact_path': sanitize_path_reference(artifact_path),
+            'artifact_sha256': result['artifact_record']['artifact_sha256'],
+            'rows_staged': args.limit,
+        }
+    except Exception:
+        if conn is not None:
+            pilot.rollback(conn)
+        raise
+    finally:
+        if conn is not None:
+            pilot.close_connection(conn)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        runtime_inputs = resolve_runtime_inputs(args)
+        preview = build_source_preview(Path(runtime_inputs['snapshot_path']), limit=args.limit)
+        assert_source_preview_ok(preview, limit=args.limit)
+        preflight = run_target_preflight(str(runtime_inputs['staging_dsn']))
+        assert_target_preflight_ok(preflight)
+
+        if not args.commit:
+            print(json.dumps(build_dry_run_payload(args, runtime_inputs, preview, preflight), indent=2, sort_keys=True))
+            return 0
+
+        result = run_authorized_commit(
+            args,
+            runtime_inputs=runtime_inputs,
+            preview=preview,
+            preflight=preflight,
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except Stage19BbActivationError as exc:
+        print(f'ERROR: {exc}', file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_stage19bb_first_production_staging_activation.py
+++ b/tests/test_stage19bb_first_production_staging_activation.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+README_PATH = DOCS / 'README.md'
+STAGE19BA_PATH = DOCS / 'stage-19-bounded-production-staging-activation.md'
+STAGE19BB_PATH = DOCS / 'stage-19bb-first-production-staging-activation.md'
+STAGE19_ROADMAP_PATH = DOCS / 'stage-19-data-warehouse-utopia-roadmap.md'
+STAGE23_PATH = DOCS / 'stage-23-roadmap.md'
+LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
+WRAPPER_PATH = ROOT / 'scripts' / 'operator' / 'stage19bb_first_production_staging_activation.py'
+OPERATOR_README_PATH = ROOT / 'scripts' / 'operator' / 'README.md'
+
+if str(WRAPPER_PATH.parent) not in sys.path:
+    sys.path.insert(0, str(WRAPPER_PATH.parent))
+
+import stage19bb_first_production_staging_activation as stage19bb  # noqa: E402
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _json(path: Path):
+    return json.loads(_read(path))
+
+
+def _approved_preview(limit: int) -> dict[str, object]:
+    return {
+        'snapshot_basename': stage19bb.APPROVED_SOURCE_BASENAME,
+        'source_sha256': stage19bb.APPROVED_SOURCE_SHA256,
+        'file_size_bytes': stage19bb.APPROVED_SOURCE_SIZE_BYTES,
+        'file_format': {
+            'source_format': stage19bb.APPROVED_SOURCE_FORMAT,
+            'record_stream_shape': stage19bb.APPROVED_SOURCE_RECORD_STREAM_SHAPE,
+        },
+        'compression': stage19bb.APPROVED_SOURCE_COMPRESSION,
+        'plan': {
+            'rows_read': limit,
+            'rows_staged': limit,
+            'rows_rejected': 0,
+            'rows_skipped': 0,
+            'raw_records': [],
+            'staged_rows': [],
+            'warning_reason_counts': {},
+            'rejection_reason_counts': {},
+            'skipped_reason_counts': {},
+        },
+    }
+
+
+def _approved_preflight() -> dict[str, object]:
+    return {
+        'identity': {
+            'host': stage19bb.APPROVED_TARGET_HOST,
+            'port': stage19bb.APPROVED_TARGET_PORT,
+            'database': stage19bb.APPROVED_TARGET_DATABASE,
+            'role': stage19bb.APPROVED_TARGET_ROLE,
+        },
+        'tables_present': list(stage19bb.PERMITTED_TABLES),
+        'columns': dict(stage19bb.EXPECTED_COLUMNS),
+        'indexes': dict(stage19bb.EXPECTED_INDEXES),
+        'constraints': dict(stage19bb.EXPECTED_CONSTRAINTS),
+        'canonical_tables_absent': True,
+        'blocking_runs': 0,
+        'loader_caps': {
+            'rolcreatedb': 'false',
+            'rolcreaterole': 'false',
+            'rolsuper': 'false',
+            'schema_create': 'false',
+            'database_create': 'false',
+        },
+        'restricted_loader': True,
+        'recomputed_target_fingerprint': stage19bb.APPROVED_TARGET_FINGERPRINT,
+    }
+
+
+@pytest.mark.unit
+def test_stage19bb_authority_docs_and_indexes_record_exact_authorized_after_merge_boundary():
+    authority = _json(AUTHORITY_PATH)
+    checkpoint = authority['stage19bb_first_production_staging_activation']
+    stage19ba = authority['stage19ba_bounded_production_staging_activation']
+    readme = _read(README_PATH)
+    operator_readme = _read(OPERATOR_README_PATH)
+    stage19ba_doc = _read(STAGE19BA_PATH)
+    stage19bb_doc = _read(STAGE19BB_PATH)
+    stage19_roadmap = _read(STAGE19_ROADMAP_PATH)
+    stage23 = _read(STAGE23_PATH)
+    parity = _read(LOCAL_CI_PARITY)
+
+    assert checkpoint['status'] == 'authorized_after_merge'
+    assert checkpoint['approved_source_sha256'] == stage19bb.APPROVED_SOURCE_SHA256
+    assert checkpoint['approved_eligible_source_rows'] == stage19bb.APPROVED_ELIGIBLE_SOURCE_ROWS
+    assert checkpoint['approved_target_fingerprint'] == stage19bb.APPROVED_TARGET_FINGERPRINT
+    assert checkpoint['target_type'] == stage19bb.APPROVED_TARGET_TYPE
+    assert checkpoint['permitted_tables'] == stage19bb.PERMITTED_TABLES
+    assert checkpoint['canonical_tables_absent'] is True
+    assert checkpoint['restricted_loader_verified'] is True
+    assert checkpoint['authorization_pr_contains_execution_evidence'] is False
+    assert checkpoint['stage19_execution_performed'] is False
+    assert checkpoint['canonical_apply_authorized'] is False
+    assert checkpoint['rebaseline_authorized'] is False
+    assert checkpoint['scheduler_service_authorized'] is False
+
+    assert stage19ba['permitted_tables'] == [
+        'source_runs',
+        'enrichment_source_runs',
+        'staging_edsm_stations',
+    ]
+    assert stage19ba['loader_support_tables_identified'] == [
+        'enrichment_source_files',
+        'enrichment_raw_records',
+    ]
+    assert stage19ba['historical_stage19ba_execution_authorized_for_five_tables'] is False
+
+    assert 'stage-19bb-first-production-staging-activation.md' in readme
+    assert 'stage19bb_first_production_staging_activation.py' in operator_readme
+    assert 'five-table' in stage19ba_doc
+    assert 'authorized_after_merge' in stage19bb_doc
+    assert stage19bb.APPROVED_SOURCE_SHA256 in stage19bb_doc
+    assert stage19bb.APPROVED_TARGET_FINGERPRINT in stage19bb_doc
+    assert 'formula mismatch' in stage19bb_doc
+    assert 'Stage 19BB authorization dependency' in stage19_roadmap
+    assert 'Stage 19BB authorization' in stage23
+    assert 'tests/test_stage19bb_first_production_staging_activation.py' in parity
+
+
+@pytest.mark.unit
+def test_stage19bb_parse_requires_approved_limits_and_commit_confirmation():
+    args = stage19bb.parse_args(['--limit', '100'])
+    assert args.limit == 100
+    assert args.commit is False
+    assert args.confirm_stage19bb is False
+
+    with pytest.raises(SystemExit):
+        stage19bb.parse_args(['--limit', '250'])
+
+    with pytest.raises(SystemExit):
+        stage19bb.parse_args(['--limit', '100', '--commit'])
+
+
+@pytest.mark.unit
+def test_stage19bb_runtime_inputs_require_snapshot_dsn_and_external_artifact_dir(tmp_path: Path):
+    snapshot = tmp_path / 'stations.json.gz'
+    snapshot.write_bytes(b'{}')
+    external_artifacts = tmp_path / 'external-artifacts'
+    env = {
+        'EDSM_STATION_SNAPSHOT': str(snapshot),
+        'EDFINDER_STAGING_DSN': 'dsn-redacted',
+        'SAFE_ARTIFACT_DIR': str(external_artifacts),
+    }
+
+    args = stage19bb.parse_args(['--limit', '100'])
+    resolved = stage19bb.resolve_runtime_inputs(args, env=env)
+
+    assert resolved['snapshot_display_name'] == 'stations.json.gz'
+    assert resolved['artifact_dir'] == external_artifacts.resolve()
+
+    with pytest.raises(stage19bb.Stage19BbActivationError):
+        stage19bb.resolve_runtime_inputs(args, env={'EDFINDER_STAGING_DSN': 'dsn-redacted'})
+
+    with pytest.raises(stage19bb.Stage19BbActivationError):
+        stage19bb.resolve_runtime_inputs(
+            stage19bb.parse_args(['--limit', '100', '--artifact-dir', str(ROOT / 'artifacts')]),
+            env=env,
+        )
+
+
+@pytest.mark.unit
+def test_stage19bb_source_preview_requires_exact_hash_format_and_no_malformed_rows():
+    stage19bb.assert_source_preview_ok(_approved_preview(100), limit=100)
+
+    bad_hash = _approved_preview(100)
+    bad_hash['source_sha256'] = 'b' * 64
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='SHA-256 mismatch'):
+        stage19bb.assert_source_preview_ok(bad_hash, limit=100)
+
+    malformed = _approved_preview(100)
+    malformed['plan']['rejection_reason_counts'] = {'invalid_station_snapshot_record': 1}
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='malformed rows'):
+        stage19bb.assert_source_preview_ok(malformed, limit=100)
+
+
+@pytest.mark.unit
+def test_stage19bb_target_preflight_allows_only_exact_fingerprinted_localhost_target():
+    approved = _approved_preflight()
+    stage19bb.assert_target_preflight_ok(approved)
+
+    mismatched = _approved_preflight()
+    mismatched['recomputed_target_fingerprint'] = '0' * 64
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='arbitrary localhost targets|fingerprint mismatch'):
+        stage19bb.assert_target_preflight_ok(mismatched)
+
+    canonical_present = _approved_preflight()
+    canonical_present['canonical_tables_absent'] = False
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='canonical application tables'):
+        stage19bb.assert_target_preflight_ok(canonical_present)
+
+    broad_loader = _approved_preflight()
+    broad_loader['restricted_loader'] = False
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='restricted loader role'):
+        stage19bb.assert_target_preflight_ok(broad_loader)
+
+    schema_create = _approved_preflight()
+    schema_create['loader_caps'] = {
+        'rolcreatedb': 'false',
+        'rolcreaterole': 'false',
+        'rolsuper': 'false',
+        'schema_create': 'true',
+        'database_create': 'false',
+    }
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='create schemas or tables'):
+        stage19bb.assert_target_preflight_ok(schema_create)
+
+    overlap = _approved_preflight()
+    overlap['blocking_runs'] = 1
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='blocking Stage 19 source runs'):
+        stage19bb.assert_target_preflight_ok(overlap)
+
+
+@pytest.mark.unit
+def test_stage19bb_execution_requires_merged_authority(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(stage19bb, 'load_authority', lambda: {
+        'stage19bb_first_production_staging_activation': {
+            'status': 'authorized_after_merge',
+            'approved_source_sha256': stage19bb.APPROVED_SOURCE_SHA256,
+            'approved_target_fingerprint': stage19bb.APPROVED_TARGET_FINGERPRINT,
+        }
+    })
+    monkeypatch.setattr(stage19bb, 'verify_stage19bb_merged_to_origin_main', lambda: False)
+
+    with pytest.raises(stage19bb.Stage19BbActivationError, match='merged authority'):
+        stage19bb.ensure_execution_authorized_after_merge()
+
+
+@pytest.mark.unit
+def test_stage19bb_main_dry_run_keeps_output_sanitized_and_secret_free(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    args = stage19bb.parse_args(['--limit', '100'])
+    runtime_inputs = {
+        'snapshot_path': Path('/private/stage19/stations.json.gz'),
+        'staging_dsn': 'REDACTED_STAGING_DSN_VALUE',
+        'artifact_dir': Path('/private/artifacts'),
+        'snapshot_display_name': 'stations.json.gz',
+        'artifact_dir_display_name': 'artifacts',
+    }
+    preview = _approved_preview(100)
+    preflight = _approved_preflight()
+
+    monkeypatch.setattr(stage19bb, 'parse_args', lambda _argv=None: args)
+    monkeypatch.setattr(stage19bb, 'resolve_runtime_inputs', lambda _args: runtime_inputs)
+    monkeypatch.setattr(stage19bb, 'build_source_preview', lambda *_args, **_kwargs: preview)
+    monkeypatch.setattr(stage19bb, 'assert_source_preview_ok', lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(stage19bb, 'run_target_preflight', lambda _dsn: preflight)
+    monkeypatch.setattr(stage19bb, 'assert_target_preflight_ok', lambda _preflight: None)
+
+    exit_code = stage19bb.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload['mode'] == 'dry_run'
+    assert payload['source']['reference'] == stage19bb.APPROVED_SOURCE_REFERENCE
+    assert payload['source']['basename'] == stage19bb.APPROVED_SOURCE_BASENAME
+    assert 'REDACTED_STAGING_DSN_VALUE' not in captured.out
+    assert '/private/stage19' not in captured.out
+    assert '/private/artifacts' not in captured.out
+    assert captured.err == ''
+
+
+@pytest.mark.unit
+def test_stage19bb_script_source_blocks_scheduler_service_and_canonical_apply_paths():
+    source = _read(WRAPPER_PATH)
+
+    assert 'systemctl' not in source.lower()
+    assert '.timer' not in source
+    assert '.service' not in source
+    assert 'scheduler_service_authorized' in source
+    assert 'canonical_apply_authorized' in source
+    assert 'rebaseline_authorized' in source
+    assert "['git', 'merge-base', '--is-ancestor'" in source


### PR DESCRIPTION
## Summary

- authorize the merged Stage 19BB bounded production-staging execution lane
- pin the approved official EDSM station snapshot and exact source SHA-256
- pin the reviewed isolated local staging target fingerprint
- add the fail-closed Stage 19BB wrapper, authority update, docs correction, and focused tests

## Approved source

- source name: `edsm`
- logical batch label: `edsm-stations-20260618T145715Z`
- sanitized source identity: `https://www.edsm.net/dump/stations.json.gz`
- basename: `stations.json.gz`
- exact approved source SHA-256: `09225e43323464e332a792f8716a6e4264ef5999ce1544f1157bfc60f406f4a2`
- source size bytes: `2614426684`
- eligible source rows: `713624`
- source format: `json`
- source record stream shape: `json_array`
- source compression: `gzip`

## Approved target

- target type: `isolated_persistent_local_staging`
- approved target fingerprint: `fb59921a3c4f913c318e12709e602261450edf3632e8e20e0b669fd8f1622753`
- earlier setup-reported fingerprint: `759499c54f9d41cd636b4b5aa54e9bda1e4435c49e7a9a9bc34450b8671945b2`
- fingerprint difference reviewed as a stricter canonical formula change rather than target drift
- canonical tables absent: `true`
- restricted-role proof: `true`

## Exact permitted tables

- `source_runs`
- `enrichment_source_runs`
- `enrichment_source_files`
- `enrichment_raw_records`
- `staging_edsm_stations`

## Scale policy

- `100` rows, max `900` seconds
- `1,000` rows, max `1,800` seconds
- `10,000` rows, max `3,600` seconds

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/dev/resolve_project_state.py --strict` -> passed
- `python3 -m pytest tests/test_stage19bb_first_production_staging_activation.py tests/test_stage19ba_bounded_production_staging_activation.py tests/test_db_isolation_guardrails.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19av_expanded_source_run_staging_pilot.py tests/test_stage19ay_test_environment_closeout.py tests/test_stage23_planning_baseline.py -p no:cacheprovider` -> passed
- `git diff --check` -> passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/operator/stage19bb_first_production_staging_activation.py --limit 100` -> passed dry-run read-only preflight against the approved source and isolated staging target

## Explicit non-execution statement

- source was acquired
- read-only preflight occurred
- no staging import occurred
- no runtime source-run record was created
- no runtime artifact was created
- no canonical write occurred
