### PR TITLE
Fix Stage 19BB EDSM station updateTime normalization

### DIFF
--- a/apps/importer/src/enrichment_snapshot_loader.py
+++ b/apps/importer/src/enrichment_snapshot_loader.py
@@ -33,6 +33,7 @@ from enrichment_staging import (
     normalise_source_adapter,
     normalise_source_file_metadata,
     normalise_source_run_metadata,
+    source_updated_at_from_record,
     read_float,
     read_int,
     read_text,
@@ -904,20 +905,6 @@ def iter_json_records(
                         json.loads(line),
                         expand_station_collections=expand_station_collections,
                     )
-
-
-def source_updated_at_from_record(record: Mapping[str, Any]) -> str | None:
-    return read_text(first_present(
-        record,
-        'updatedAt',
-        'updated_at',
-        'updateTime',
-        'lastUpdate',
-        'lastUpdated',
-        'date',
-    ))
-
-
 def file_digest(path: Path) -> tuple[str, int]:
     hasher = hashlib.sha256()
     size = 0

--- a/apps/importer/src/enrichment_staging.py
+++ b/apps/importer/src/enrichment_staging.py
@@ -403,6 +403,18 @@ def read_text(value: Any) -> str | None:
     return text or None
 
 
+def normalise_source_updated_at_value(value: Any) -> str | None:
+    if isinstance(value, Mapping):
+        for field_name in ('information', 'market', 'shipyard', 'outfitting'):
+            candidate = read_text(value.get(field_name))
+            if candidate is not None:
+                return candidate
+        return None
+    if isinstance(value, (list, tuple, set)):
+        return None
+    return read_text(value)
+
+
 def read_int(value: Any) -> int | None:
     if isinstance(value, bool) or value is None:
         return None
@@ -619,7 +631,7 @@ def normalise_edsm_body_ring_snapshot_records(
 
 
 def source_updated_at_from_record(record: Mapping[str, Any]) -> str | None:
-    return read_text(first_present(
+    return normalise_source_updated_at_value(first_present(
         record,
         'updatedAt',
         'updated_at',

--- a/tests/test_enrichment_snapshot_loader.py
+++ b/tests/test_enrichment_snapshot_loader.py
@@ -153,6 +153,118 @@ def test_normalisation_accepts_edsm_station_snapshot_shapes():
     assert row['source_record_hash']
 
 
+def test_update_time_object_normalises_to_scalar_source_updated_at_and_preserves_raw_payload(tmp_path):
+    update_time = {
+        'information': '2017-04-21 07:06:46',
+        'market': None,
+        'shipyard': None,
+        'outfitting': None,
+    }
+    source_file = tmp_path / 'update-time-object.json'
+    source_file.write_text(json.dumps([
+        {
+            'systemName': 'Sol',
+            'systemId64': 10477373803,
+            'marketId': 322,
+            'id': 1234,
+            'name': 'Galileo',
+            'type': 'Coriolis Starport',
+            'updateTime': update_time,
+        }
+    ]), encoding='utf-8')
+
+    report = loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+    )
+
+    raw_record = report['raw_records_planned'][0]
+    station_row = report['staged_rows'][0]
+    assert raw_record['source_updated_at'] == '2017-04-21 07:06:46'
+    assert station_row['source_updated_at'] == '2017-04-21 07:06:46'
+    assert raw_record['raw_payload']['updateTime'] == update_time
+    assert station_row['raw_payload']['updateTime'] == update_time
+    assert isinstance(raw_record['source_updated_at'], str)
+    assert isinstance(station_row['source_updated_at'], str)
+
+
+def test_update_time_object_falls_back_to_market_when_information_missing(tmp_path):
+    source_file = tmp_path / 'update-time-market-fallback.json'
+    source_file.write_text(json.dumps([
+        {
+            'systemName': 'Fallback System',
+            'marketId': 400,
+            'id': 400,
+            'name': 'Fallback Port',
+            'type': 'Outpost',
+            'updateTime': {
+                'information': None,
+                'market': '2018-01-02 03:04:05',
+                'shipyard': None,
+                'outfitting': None,
+            },
+        }
+    ]), encoding='utf-8')
+
+    report = loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+    )
+
+    assert report['raw_records_planned'][0]['source_updated_at'] == '2018-01-02 03:04:05'
+    assert report['staged_rows'][0]['source_updated_at'] == '2018-01-02 03:04:05'
+
+
+def test_update_time_object_with_no_valid_timestamp_uses_none(tmp_path):
+    source_file = tmp_path / 'update-time-none.json'
+    source_file.write_text(json.dumps([
+        {
+            'systemName': 'Unknown Freshness',
+            'marketId': 500,
+            'id': 500,
+            'name': 'Archive Station',
+            'type': 'Outpost',
+            'updateTime': {
+                'information': None,
+                'market': None,
+                'shipyard': None,
+                'outfitting': None,
+            },
+        }
+    ]), encoding='utf-8')
+
+    report = loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+    )
+
+    assert report['raw_records_planned'][0]['source_updated_at'] is None
+    assert report['staged_rows'][0]['source_updated_at'] is None
+    assert report['staged_rows'][0]['freshness_class'] == 'file_snapshot'
+
+
+def test_scalar_update_time_string_still_works(tmp_path):
+    source_file = tmp_path / 'update-time-scalar.json'
+    source_file.write_text(json.dumps([
+        {
+            'systemName': 'Scalar Freshness',
+            'marketId': 600,
+            'id': 600,
+            'name': 'Scalar Port',
+            'type': 'Outpost',
+            'updateTime': '2019-02-03 04:05:06',
+        }
+    ]), encoding='utf-8')
+
+    report = loader.build_snapshot_load_report(
+        source_file=source_file,
+        source='edsm_nightly_stations',
+    )
+
+    assert report['raw_records_planned'][0]['source_updated_at'] == '2019-02-03 04:05:06'
+    assert report['staged_rows'][0]['source_updated_at'] == '2019-02-03 04:05:06'
+
+
 def test_report_output_is_deterministic_for_fixed_fixture():
     first = loader.build_snapshot_load_report(
         source_file=FIXTURE,

--- a/tests/test_enrichment_staging.py
+++ b/tests/test_enrichment_staging.py
@@ -33,6 +33,7 @@ from enrichment_staging import (  # noqa: E402
     classify_source_adapter,
     classify_source_field,
     idempotency_key,
+    normalise_source_updated_at_value,
     normalise_station_type_label,
     normalise_source_file_metadata,
     normalise_source_run_metadata,
@@ -81,6 +82,29 @@ def test_null_missing_and_scalar_read_helpers_are_safe():
     assert read_int(True) is None
     assert read_int('42') == 42
     assert read_float('503.2') == 503.2
+
+
+def test_source_updated_at_normaliser_prefers_information_then_market_then_shipyard_then_outfitting():
+    assert normalise_source_updated_at_value({
+        'information': '2017-04-21 07:06:46',
+        'market': '2017-04-20 07:06:46',
+        'shipyard': '2017-04-19 07:06:46',
+        'outfitting': '2017-04-18 07:06:46',
+    }) == '2017-04-21 07:06:46'
+    assert normalise_source_updated_at_value({
+        'information': None,
+        'market': '2017-04-20 07:06:46',
+        'shipyard': '2017-04-19 07:06:46',
+        'outfitting': '2017-04-18 07:06:46',
+    }) == '2017-04-20 07:06:46'
+    assert normalise_source_updated_at_value({
+        'information': None,
+        'market': None,
+        'shipyard': None,
+        'outfitting': None,
+    }) is None
+    assert normalise_source_updated_at_value('2017-04-21 07:06:46') == '2017-04-21 07:06:46'
+    assert normalise_source_updated_at_value(['2017-04-21 07:06:46']) is None
 
 
 def test_idempotency_and_source_file_keys_are_deterministic():


### PR DESCRIPTION
## Root cause

The first real Stage 19BB 100-row write attempt failed because an EDSM station
`updateTime` object reached `enrichment_raw_records.source_updated_at`.

The exact failing shape was:

```json
{
  "information": "2017-04-21 07:06:46",
  "market": null,
  "shipyard": null,
  "outfitting": null
}
```

`source_updated_at` must be a scalar timestamp string or `NULL`, but the old
helper treated `updateTime` like a generic scalar field and stringified the
dict.

## Fix summary

- add a narrow source timestamp normaliser in `enrichment_staging.py`
- for dict-shaped `updateTime`, extract the first non-empty value in this order:
  `information`, `market`, `shipyard`, `outfitting`
- keep returning scalar strings unchanged
- return `None` for dict/list/object shapes with no usable timestamp
- preserve the full original `updateTime` object in `raw_payload`
- route `enrichment_snapshot_loader.py` through the shared helper so both
  raw-record planning and station-row planning use the same scalar-only logic

## Tests run

- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/dev/resolve_project_state.py --strict`
- `python3 -m pytest tests/test_enrichment_staging.py tests/test_enrichment_snapshot_loader.py tests/test_edsm_station_import.py -p no:cacheprovider`
- `python3 -m pytest tests/test_stage19bb_first_production_staging_activation.py tests/test_stage19ba_bounded_production_staging_activation.py tests/test_db_isolation_guardrails.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19av_expanded_source_run_staging_pilot.py -p no:cacheprovider`
- `git diff --check`

## Safety confirmation

- no Stage 19BB execution was rerun
- no rows were imported
- no runtime source-run records were created
- no runtime artifacts were created
- no canonical writes occurred
