### PR TITLE
Fix Stage 19BB source-run completion timestamp ordering

### DIFF
--- a/apps/importer/src/source_run_ledger.py
+++ b/apps/importer/src/source_run_ledger.py
@@ -409,7 +409,7 @@ def supersede_source_run(
         UPDATE {SOURCE_RUNS_TABLE}
         SET
             status = %s,
-            finished_at = COALESCE(finished_at, %s),
+            finished_at = COALESCE(finished_at, GREATEST(%s, started_at)),
             metadata = metadata || %s::jsonb,
             updated_at = NOW()
         WHERE source_run_key = %s
@@ -514,7 +514,7 @@ def _complete_source_run(
         UPDATE {SOURCE_RUNS_TABLE}
         SET
             status = %s,
-            finished_at = %s,
+            finished_at = GREATEST(%s, started_at),
             duration_ms = COALESCE(%s, duration_ms),
             rows_read = COALESCE(%s, rows_read),
             rows_staged = COALESCE(%s, rows_staged),

--- a/tests/test_source_run_artifacts.py
+++ b/tests/test_source_run_artifacts.py
@@ -71,8 +71,8 @@ class FakeConn:
         return cursor
 
 
-def valid_source_run_kwargs():
-    return {
+def valid_source_run_kwargs(**overrides):
+    kwargs = {
         'source_run_key': 'stage-19r-run',
         'source_name': 'edsm',
         'source_category': 'source_of_evidence',
@@ -85,6 +85,8 @@ def valid_source_run_kwargs():
         'status': 'running',
         'metadata': {'stage': '19r'},
     }
+    kwargs.update(overrides)
+    return kwargs
 
 
 def assert_sql_only_touches_source_runs(conn):
@@ -213,6 +215,34 @@ def test_run_source_run_artifact_flow_creates_writes_and_completes_success(tmp_p
     assert metadata['artifact_record']['file_sha256'] == result['artifact_record']['file_sha256']
     assert update_params[13] == 'stage-19r-run'
     assert update_params[14] == ['planned', 'running']
+    assert_sql_only_touches_source_runs(conn)
+
+
+def test_run_source_run_artifact_flow_clamps_fast_finished_at_in_source_run_completion_sql(tmp_path):
+    conn = FakeConn()
+    artifact_path = tmp_path / 'runs' / 'stage-19r-fast-success.json'
+    started_at = datetime(2026, 1, 2, 3, 4, 5, 721498, tzinfo=timezone.utc)
+    finished_at = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+    result = artifacts.run_source_run_artifact_flow(
+        conn,
+        source_run_kwargs=valid_source_run_kwargs(started_at=started_at),
+        artifact_path=artifact_path,
+        operation=lambda _source_run: artifacts.SourceRunArtifactOutcome(
+            payload=payload_shell(),
+            rows_read=1,
+            rows_staged=1,
+            rows_rejected=0,
+            rows_skipped=0,
+            finished_at=finished_at,
+            duration_ms=0,
+        ),
+    )
+
+    update_sql, update_params = conn.statements[1]
+    assert 'finished_at = GREATEST(%s, started_at)' in update_sql
+    assert update_params[1] == finished_at
+    assert result['completion']['status'] == 'succeeded'
     assert_sql_only_touches_source_runs(conn)
 
 

--- a/tests/test_source_run_ledger.py
+++ b/tests/test_source_run_ledger.py
@@ -241,7 +241,7 @@ def test_success_completion_records_finished_counts_and_artifact_fields():
     assert row['status'] == 'succeeded'
     sql, params = conn.statements[0]
     assert 'UPDATE source_runs' in sql
-    assert 'finished_at = %s' in sql
+    assert 'finished_at = GREATEST(%s, started_at)' in sql
     assert params[:13] == (
         'succeeded',
         NOW,
@@ -265,6 +265,7 @@ def test_success_completion_records_finished_counts_and_artifact_fields():
 @pytest.mark.parametrize('complete_func,status', [
     (ledger.complete_source_run_failed, 'failed'),
     (ledger.complete_source_run_rejected, 'rejected'),
+    (ledger.complete_source_run_cancelled, 'cancelled'),
 ])
 def test_failed_and_rejected_completion_record_error_code_and_summary(complete_func, status):
     conn = FakeConn()
@@ -280,14 +281,21 @@ def test_failed_and_rejected_completion_record_error_code_and_summary(complete_f
     )
 
     assert row['status'] == status
-    _sql, params = conn.statements[0]
+    sql, params = conn.statements[0]
+    assert 'finished_at = GREATEST(%s, started_at)' in sql
     assert params[0] == status
     assert params[3] == 3
     assert params[5] == 3
-    assert params[10:12] == (
-        'source_schema_mismatch',
-        'source schema did not match expected fields',
-    )
+    if status == 'cancelled':
+        assert params[10:12] == (
+            'source_schema_mismatch',
+            'source schema did not match expected fields',
+        )
+    else:
+        assert params[10:12] == (
+            'source_schema_mismatch',
+            'source schema did not match expected fields',
+        )
     assert_helper_sql_only_touches_source_runs(conn)
 
 
@@ -321,6 +329,8 @@ def test_cancelled_and_superseded_transitions_are_explicit():
         finished_at=NOW,
     )
     assert cancelled['status'] == 'cancelled'
+    cancel_sql, _cancel_params = cancel_conn.statements[0]
+    assert 'finished_at = GREATEST(%s, started_at)' in cancel_sql
 
     supersede_conn = FakeConn()
     superseded = ledger.supersede_source_run(
@@ -330,9 +340,43 @@ def test_cancelled_and_superseded_transitions_are_explicit():
         metadata={'replaced_by': 'run-new'},
     )
     assert superseded['status'] == 'superseded'
+    supersede_sql, supersede_params = supersede_conn.statements[0]
+    assert 'finished_at = COALESCE(finished_at, GREATEST(%s, started_at))' in supersede_sql
+    assert supersede_params[0] == 'superseded'
     assert supersede_conn.statements[0][1][-1] == ['succeeded']
     assert_helper_sql_only_touches_source_runs(cancel_conn)
     assert_helper_sql_only_touches_source_runs(supersede_conn)
+
+
+@pytest.mark.parametrize('complete_func,status', [
+    (ledger.complete_source_run_success, 'succeeded'),
+    (ledger.complete_source_run_failed, 'failed'),
+    (ledger.complete_source_run_rejected, 'rejected'),
+    (ledger.complete_source_run_cancelled, 'cancelled'),
+])
+def test_terminal_completion_sql_clamps_finished_at_against_started_at(complete_func, status):
+    conn = FakeConn()
+    kwargs = {
+        'finished_at': NOW.replace(microsecond=0),
+        'duration_ms': 0,
+    }
+    if status == 'succeeded':
+        kwargs.update(rows_read=1, rows_staged=1, rows_rejected=0, rows_skipped=0)
+    else:
+        kwargs.update(
+            error_code='state_transition_test',
+            error_summary='verify finished_at clamp',
+            rows_read=1,
+            rows_rejected=1 if status == 'rejected' else 0,
+        )
+
+    complete_func(conn, 'run-key', **kwargs)
+
+    sql, params = conn.statements[0]
+    assert 'finished_at = GREATEST(%s, started_at)' in sql
+    assert params[1] == NOW.replace(microsecond=0)
+    if status == 'succeeded':
+        assert params[2] == 0
 
 
 def test_active_run_helpers_read_and_block_duplicate_running_run():


### PR DESCRIPTION
## Root cause

The latest real Stage 19BB 100-row retry reached the successful completion path,
but the `source_runs` update failed the database invariant:

```sql
CHECK (finished_at IS NULL OR finished_at >= started_at)
```

For very fast runs, the wrapper supplied a second-rounded `finished_at` while
the inserted `started_at` still had microsecond precision, which made
`finished_at` compare earlier than `started_at`.

Failure class:

- `finished_at_before_started_at`

## Failure summary

- Stage 19BB dry-run and preflight passed
- the first real 100-row write staged inside the approved boundary
- source-run finalization then failed on `chk_source_runs_finished_window`
- the transaction rolled back completely
- no Stage 19BB runtime rows or artifacts remained

## Invariant preserved

This change keeps the database constraint exactly as-is.

It does **not** remove or weaken:

```sql
finished_at IS NULL OR finished_at >= started_at
```

## Implementation approach

- fix the shared source-run ledger completion SQL itself
- clamp terminal completion writes with `GREATEST(%s, started_at)`
- apply the same monotonic behavior to the supersede path while preserving any
  already-set `finished_at`
- keep `duration_ms` semantics unchanged except preserving the existing
  non-negative guard

## Tests run

- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/dev/resolve_project_state.py --strict`
- `python3 -m pytest tests/test_source_run_ledger.py tests/test_stage19bb_first_production_staging_activation.py tests/test_db_isolation_guardrails.py tests/test_stage19as2_operator_script_contract.py tests/test_stage19av_expanded_source_run_staging_pilot.py -p no:cacheprovider`
- `python3 -m pytest tests/test_source_run_compatibility.py tests/test_source_runs_migration.py tests/test_source_run_artifacts.py -p no:cacheprovider`
- `git diff --check`

## Safety confirmation

- no Stage 19BB execution was rerun
- no rows were imported
- no runtime source-run records were created
- no runtime artifacts were created
- no canonical writes occurred
