### PR TITLE
Close Stage 24 read-only evidence adoption programme

### DIFF
--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -6,11 +6,12 @@ This folder contains the planning, architecture, forensic-review, and implementa
 
 Start here for any new colonisation work:
 
-1. [`stage-24c-cross-surface-evidence-consistency.md`](./stage-24c-cross-surface-evidence-consistency.md) - completed Stage 24C adjacent read-only evidence-consistency slice.
-2. [`stage-24b-planner-evidence-discoverability.md`](./stage-24b-planner-evidence-discoverability.md) - completed Stage 24B planner evidence discoverability implementation slice.
-3. [`stage-24a-readonly-evidence-adoption-contract.md`](./stage-24a-readonly-evidence-adoption-contract.md) - completed Stage 24A contract-only checkpoint for read-only evidence adoption.
-4. [`stage-23e-readonly-evidence-closeout.md`](./stage-23e-readonly-evidence-closeout.md) - completed Stage 23E closeout for the read-only planner evidence programme.
-5. [`stage-24-roadmap.md`](./stage-24-roadmap.md) - active post-Stage-23 control baseline for read-only evidence adoption and governance planning.
+1. [`stage-24d-readonly-evidence-adoption-closeout.md`](./stage-24d-readonly-evidence-adoption-closeout.md) - completed Stage 24D closeout for the read-only evidence adoption and governance programme.
+2. [`stage-24-roadmap.md`](./stage-24-roadmap.md) - completed Stage 24 control baseline and closeout summary for read-only evidence adoption and governance.
+3. [`stage-24c-cross-surface-evidence-consistency.md`](./stage-24c-cross-surface-evidence-consistency.md) - completed Stage 24C adjacent read-only evidence-consistency slice.
+4. [`stage-24b-planner-evidence-discoverability.md`](./stage-24b-planner-evidence-discoverability.md) - completed Stage 24B planner evidence discoverability implementation slice.
+5. [`stage-24a-readonly-evidence-adoption-contract.md`](./stage-24a-readonly-evidence-adoption-contract.md) - completed Stage 24A contract-only checkpoint for read-only evidence adoption.
+6. [`stage-23e-readonly-evidence-closeout.md`](./stage-23e-readonly-evidence-closeout.md) - completed Stage 23E closeout for the read-only planner evidence programme.
 5. [`stage-23-roadmap.md`](./stage-23-roadmap.md) - latest completed Stage 23 control document and closeout baseline.
 5. [`stage-23d-planner-evidence-ux-follow-through.md`](./stage-23d-planner-evidence-ux-follow-through.md) - completed Stage 23D planner evidence UX follow-through slice.
 6. [`stage-23c-evidence-envelope-governance.md`](./stage-23c-evidence-envelope-governance.md) - completed Stage 23C evidence envelope governance and source semantics slice.
@@ -41,13 +42,15 @@ If an older document's "recommended next stage" conflicts with Stage 17P, follow
 
 ## Current Control Documents
 
-[`stage-24c-cross-surface-evidence-consistency.md`](./stage-24c-cross-surface-evidence-consistency.md) records the completed Stage 24C slice: the system-detail Evidence mode provenance cockpit panel now uses the same governed evidence semantics and dedicated-endpoint preference for its warehouse-evidence subsection while staying read-only and leaving Stage 24D as the next checkpoint.
+[`stage-24d-readonly-evidence-adoption-closeout.md`](./stage-24d-readonly-evidence-adoption-closeout.md) records the completed Stage 24D closeout: Stage 24 closes as the read-only evidence adoption and governance programme, Stage 24A/24B/24C remain complete, and any future work now requires a new explicit post-Stage-24 control document.
+
+[`stage-24-roadmap.md`](./stage-24-roadmap.md) is the completed post-Stage-23 control baseline. It records the completed Stage 24A, Stage 24B, Stage 24C, and Stage 24D sequence while keeping Stage 19 execution, DB writes, canonical apply, rebaseline, and scheduler/service activation unauthorized.
+
+[`stage-24c-cross-surface-evidence-consistency.md`](./stage-24c-cross-surface-evidence-consistency.md) records the completed Stage 24C slice: the system-detail Evidence mode provenance cockpit panel now uses the same governed evidence semantics and dedicated-endpoint preference for its warehouse-evidence subsection while staying read-only and handing off to Stage 24D closeout.
 
 [`stage-24b-planner-evidence-discoverability.md`](./stage-24b-planner-evidence-discoverability.md) records the completed Stage 24B slice: the primary planner workspace and planner evidence card now make the read-only evidence posture easier to find and scan while preserving the dedicated endpoint preference, fallback-only provenance bridge behavior, and bounded staging limits.
 
 [`stage-24a-readonly-evidence-adoption-contract.md`](./stage-24a-readonly-evidence-adoption-contract.md) records the completed Stage 24A contract checkpoint: the repo now has an explicit surfaces inventory, ownership map, evidence-state language contract, fixture/test plan, and Stage 24B implementation boundary for adopting the Stage 23 read-only evidence baseline.
-
-[`stage-24-roadmap.md`](./stage-24-roadmap.md) is the active post-Stage-23 control baseline. It selects read-only evidence adoption and governance as the primary objective, records Stage 24A, Stage 24B, and Stage 24C as complete, names Stage 24D as the next checkpoint, and keeps Stage 19 execution, DB writes, canonical apply, rebaseline, and scheduler/service activation unauthorized.
 
 [`stage-23e-readonly-evidence-closeout.md`](./stage-23e-readonly-evidence-closeout.md) records the completed Stage 23 closeout: the read-only planner evidence baseline is complete, bounded staging remains report-only and non-canonical, and Stage 24 is now the explicit successor control.
 
@@ -129,10 +132,11 @@ It supersedes the old assumption that the project should simply continue from St
 
 | Document | Status | Purpose |
 |---|---|---|
+| [`stage-24d-readonly-evidence-adoption-closeout.md`](./stage-24d-readonly-evidence-adoption-closeout.md) | Completed Stage 24D closeout record | Records that Stage 24 is closed, that Stage 24A/24B/24C remain complete, and that any future work requires a new explicit post-Stage-24 control document. |
+| [`stage-24-roadmap.md`](./stage-24-roadmap.md) | Completed Stage 24 control | Records the completed post-Stage-23 read-only evidence adoption and governance sequence and preserved no-write boundaries. |
 | [`stage-24c-cross-surface-evidence-consistency.md`](./stage-24c-cross-surface-evidence-consistency.md) | Completed Stage 24C implementation record | Records the narrow adjacent-surface consistency slice, selecting the system-detail provenance cockpit panel and keeping evidence semantics read-only, distinct, and non-canonical. |
 | [`stage-24b-planner-evidence-discoverability.md`](./stage-24b-planner-evidence-discoverability.md) | Completed Stage 24B implementation record | Records the first narrow planner-surface discoverability implementation slice, keeping the evidence posture read-only, non-canonical, and selected-system-only. |
 | [`stage-24a-readonly-evidence-adoption-contract.md`](./stage-24a-readonly-evidence-adoption-contract.md) | Completed Stage 24A contract | Defines the read-only evidence adoption surfaces, ownership seams, language contract, fixture expectations, and Stage 24B boundaries without mixing in implementation. |
-| [`stage-24-roadmap.md`](./stage-24-roadmap.md) | Active Stage 24 control | Records the post-Stage-23 read-only evidence adoption and governance baseline, chosen workstream, first executable checkpoint, and preserved no-write boundaries. |
 | [`stage-23e-readonly-evidence-closeout.md`](./stage-23e-readonly-evidence-closeout.md) | Completed Stage 23E closeout record | Records that the Stage 23 read-only planner evidence programme is complete and that any future follow-on requires a new explicit control document. |
 | [`stage-23-roadmap.md`](./stage-23-roadmap.md) | Completed Stage 23 control | Records the completed Stage 23A, Stage 23B, Stage 23C, Stage 23D, and Stage 23E read-only evidence sequence without reopening Stage 19. |
 | [`stage-23d-planner-evidence-ux-follow-through.md`](./stage-23d-planner-evidence-ux-follow-through.md) | Completed Stage 23D implementation record | Records the user-visible adoption of the governed evidence envelope, including explicit unavailable / not-evaluated / unknown wording and bounded staging limits. |

--- a/docs/colonisation-redesign/stage-19-state-authority.json
+++ b/docs/colonisation-redesign/stage-19-state-authority.json
@@ -808,14 +808,14 @@
     "production_automation_complete": false
   },
   "stage24": {
-    "status": "in_progress",
+    "status": "completed",
     "planning_authorized": true,
     "implementation_started": true,
     "implementation_authorized": true,
     "primary_objective": "Turn the completed Stage 23 read-only planner evidence baseline into a discoverable, explainable, and consistently governed product surface without authorizing Stage 19 execution, DB writes, canonical apply, rebaseline, or scheduler/service activation.",
     "first_executable_checkpoint": "Stage 24A - Read-only evidence adoption implementation contract",
-    "current_checkpoint": "Stage 24C - Cross-surface evidence consistency",
-    "next_checkpoint": "Stage 24D - Closeout or next-control decision",
+    "current_checkpoint": "Stage 24D - Closeout",
+    "next_checkpoint": null,
     "roadmap": "docs/colonisation-redesign/stage-24-roadmap.md",
     "stage23_closed": true,
     "stage23_readonly_baseline_complete": true,
@@ -828,7 +828,7 @@
       "ux_product_adoption_of_readonly_evidence_baseline",
       "data_quality_source_governance_control"
     ],
-    "docs_static_only": false,
+    "docs_static_only": true,
     "write_capable_lane_authorized": false,
     "stage19_execution_authorized": false,
     "canonical_apply_authorized": false,
@@ -841,12 +841,18 @@
     "stage24b_implementation_completed": true,
     "stage24c_implementation_started": true,
     "stage24c_implementation_completed": true,
-    "stage24d_implementation_started": false,
+    "stage24d_implementation_started": true,
     "source_files_committed": false,
-    "runtime_artifacts_committed": false
+    "runtime_artifacts_committed": false,
+    "stage24_closed": true,
+    "future_control_document_required": true,
+    "future_control_document_scope": "post_stage24_explicit_control_required",
+    "no_new_implementation_mixed_in": true,
+    "closeout_mode": "closeout",
+    "closeout_document": "docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md"
   },
   "stage24_planning_baseline": {
-    "status": "prepared",
+    "status": "completed",
     "checkpoint_type": "planning_baseline",
     "docs_static_only": true,
     "roadmap": "docs/colonisation-redesign/stage-24-roadmap.md",
@@ -880,7 +886,10 @@
     "source_acquisition_run": false,
     "source_files_committed": false,
     "runtime_artifacts_committed": false,
-    "implementation_started": false
+    "implementation_started": false,
+    "closeout_checkpoint": "Stage 24D - Closeout",
+    "stage24_closed": true,
+    "future_control_document_required": true
   },
   "stage24a": {
     "status": "completed",
@@ -1752,5 +1761,31 @@
     "source_of_truth_unavailable_is_hard_stop": true,
     "db_credentials_missing_is_hard_stop_for_db_work": true,
     "docs_checkpoint_required_after_material_state_change": true
+  },
+  "stage24d": {
+    "status": "completed",
+    "checkpoint_type": "readonly_evidence_adoption_closeout",
+    "document": "docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md",
+    "mode": "closeout",
+    "stage24_closed": true,
+    "stage24a_completed": true,
+    "stage24b_completed": true,
+    "stage24c_completed": true,
+    "future_control_document_required": true,
+    "stage23_remains_closed": true,
+    "stage19_remains_separately_gated": true,
+    "no_stage19bb_execution_occurred": true,
+    "write_capable_lane_authorized": false,
+    "db_writes_authorized": false,
+    "db_writes_performed": false,
+    "canonical_apply_authorized": false,
+    "canonical_apply_performed": false,
+    "rebaseline_authorized": false,
+    "rebaseline_performed": false,
+    "scheduler_enabled": false,
+    "scheduler_service_authorized": false,
+    "source_files_committed": false,
+    "runtime_artifacts_committed": false,
+    "no_new_implementation_mixed_in": true
   }
 }

--- a/docs/colonisation-redesign/stage-24-roadmap.md
+++ b/docs/colonisation-redesign/stage-24-roadmap.md
@@ -10,7 +10,10 @@ Stage 24B is complete as the first narrow discoverability implementation slice.
 
 Stage 24C is complete as the narrow adjacent-surface consistency slice.
 
-Stage 24D is the next checkpoint.
+Stage 24D is complete as the closeout checkpoint.
+
+Stage 24 is closed as the read-only evidence adoption and governance
+programme.
 
 ## Background From Stage 23
 
@@ -162,7 +165,7 @@ That contract document:
 | Stage 24A - Read-only evidence adoption implementation contract | Define exact Stage 24 contract scope before implementation spreads. | Stage 24A contract doc, fixture/test plan, ownership map, guardrail assertions. | Complete. One primary contract set is named; no write-capable lane is authorized; the next implementation slice is reviewable. |
 | Stage 24B - Planner evidence discoverability surfaces | Apply read-only evidence explanation patterns to the most important planner surfaces. | Narrow planner/doc/test slice only. | Complete. Users can locate and interpret evidence posture more easily without implying canonical truth. |
 | Stage 24C - Cross-surface evidence consistency | Align wording and review posture between planner evidence surfaces and adjacent read-only views. | Narrow contract/UI/doc/test slice only. | Complete. Source semantics remain consistent, explicit, and non-canonical across read-only surfaces. |
-| Stage 24D - Closeout or next-control decision | Close Stage 24 or explicitly hand off to a later control if needed. | Closeout or handoff doc, authority updates, tests. | Stage 24 ends without silently authorizing writes or reopening Stage 19. |
+| Stage 24D - Closeout or next-control decision | Close Stage 24 and require a later explicit control before any follow-on work. | Closeout doc, authority updates, README update, tests. | Complete. Stage 24 closes without silently authorizing writes or reopening Stage 19. |
 
 ## Acceptance Criteria
 
@@ -202,7 +205,23 @@ That implementation slice:
 - reuses governed evidence semantics instead of inventing a second local model;
 - keeps the dedicated endpoint preferred for the warehouse-evidence subsection;
 - keeps provenance fallback fallback-only on endpoint-read failure;
-- leaves Stage 24D as the next closeout-or-handoff checkpoint.
+- leaves Stage 24D as the closeout checkpoint.
+
+Stage 24D is now recorded in
+`docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md`.
+
+That closeout checkpoint:
+
+- runs in `closeout` mode;
+- closes Stage 24 as the read-only evidence adoption and governance programme;
+- preserves Stage 24A, Stage 24B, and Stage 24C as completed checkpoints;
+- requires any future work to begin under a new explicit post-Stage-24 control
+  document;
+- keeps Stage 23 closed and Stage 19 separately gated;
+- keeps no write-capable lane authorized;
+- keeps canonical apply unauthorized;
+- keeps rebaseline unauthorized;
+- keeps scheduler/service activation disabled.
 
 ## Risks And Mitigations
 
@@ -262,4 +281,6 @@ Stage 24 can close only when:
 - Stage 19 remains separately gated unless another later control explicitly
   changes that state;
 - no write-capable lane has been silently authorized by Stage 24 planning or
-  implementation checkpoints.
+  implementation checkpoints;
+- any future work is required to begin under a new explicit post-Stage-24
+  control document.

--- a/docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md
+++ b/docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md
@@ -1,0 +1,109 @@
+# Stage 24D Read-only Evidence Adoption Closeout
+
+## Purpose
+
+Stage 24D closes Stage 24 as the read-only evidence adoption and governance
+programme.
+
+The Stage 24 sequence now has a completed adoption baseline and does not need
+another Stage 24 implementation slice. Any further work must begin under a new
+explicit post-Stage-24 control document rather than being inferred from the
+closed Stage 24 roadmap.
+
+## Mode
+
+Stage 24D runs in `closeout` mode.
+
+This checkpoint is docs/static-test-only and does not authorize any new
+implementation, execution, or operational activity.
+
+## Completed checkpoints
+
+Stage 24 closes with these completed checkpoints:
+
+- `Stage 24A` defined the read-only evidence adoption contract;
+- `Stage 24B` applied the first planner-surface discoverability slice;
+- `Stage 24C` aligned one adjacent read-only surface with the governed
+  evidence semantics;
+- `Stage 24D` closes the sequence and preserves the no-write boundaries.
+
+## Closeout result
+
+Stage 24 closes as the read-only evidence adoption and governance programme.
+
+The completed Stage 24 sequence now provides:
+
+- planner-surface evidence discoverability built on the Stage 23 baseline;
+- one adjacent read-only evidence surface using the same governed semantics;
+- preserved dedicated-endpoint preference for warehouse evidence;
+- preserved fallback-only provenance bridge behavior on endpoint-read failure;
+- explicit documentation and authority state showing that the programme is
+  complete.
+
+## Preserved completed checkpoints
+
+The closeout preserves these completed checkpoint states without reopening them:
+
+- `Stage 24A` remains complete;
+- `Stage 24B` remains complete;
+- `Stage 24C` remains complete.
+
+## Stage 23 and Stage 19 relationship
+
+Stage 23 remains closed.
+
+Stage 19 remains separately gated.
+
+Stage 24 closeout does not authorize:
+
+- Stage 19BB execution;
+- any new Stage 19 operator command lane;
+- DB commands or DB writes;
+- canonical apply;
+- rebaseline;
+- scheduler, service, or timer activation.
+
+## No-write and no-new-implementation rule
+
+No write-capable lane is authorized by Stage 24 closeout.
+
+This closeout also records that:
+
+- no DB writes occurred;
+- no canonical apply occurred;
+- no rebaseline occurred;
+- no source files were committed as authority;
+- no runtime artifacts were committed as authority;
+- no new implementation was mixed into the closeout checkpoint.
+
+## Future-control handoff
+
+Future work requires a new explicit post-Stage-24 control document.
+
+That later control must define its own:
+
+- purpose and authorization statement;
+- scope and safety boundaries;
+- acceptance criteria;
+- validation plan;
+- explicit default state for any write-capable lane.
+
+Until such a document exists:
+
+- Stage 24 remains closed;
+- Stage 23 remains historical and closed;
+- Stage 19 remains separately gated;
+- canonical apply remains unauthorized;
+- rebaseline remains unauthorized;
+- scheduler/service activation remains disabled.
+
+## Completion criteria
+
+Stage 24 is complete when read as one sequence:
+
+- the Stage 23 read-only evidence baseline remains intact;
+- the Stage 24A, Stage 24B, and Stage 24C slices remain complete;
+- no write-capable lane has been silently authorized;
+- no Stage 19 execution lane has been reopened;
+- future work is required to begin under a new explicit post-Stage-24 control
+  document.

--- a/tests/test_stage24_planning_baseline.py
+++ b/tests/test_stage24_planning_baseline.py
@@ -20,7 +20,7 @@ PRIMARY_OBJECTIVE = (
     'scheduler/service activation.'
 )
 FIRST_CHECKPOINT = 'Stage 24A - Read-only evidence adoption implementation contract'
-NEXT_CHECKPOINT = 'Stage 24D - Closeout or next-control decision'
+FINAL_CHECKPOINT = 'Stage 24D - Closeout'
 SELECTED_WORKSTREAM = 'ux_product_adoption_of_readonly_evidence_baseline'
 
 
@@ -37,7 +37,7 @@ def _squash(text: str) -> str:
 
 
 @pytest.mark.unit
-def test_stage24_authority_establishes_a_planning_only_post_stage23_control():
+def test_stage24_authority_records_the_closed_post_stage23_control():
     authority = _json(AUTHORITY_PATH)
     stage23 = authority['stage23']
     stage23e = authority['stage23e']
@@ -48,19 +48,19 @@ def test_stage24_authority_establishes_a_planning_only_post_stage23_control():
     assert stage23['stage23_closed'] is True
     assert stage23e['stage23_closed'] is True
 
-    assert stage24['status'] == 'in_progress'
+    assert stage24['status'] == 'completed'
     assert stage24['planning_authorized'] is True
     assert stage24['implementation_started'] is True
     assert stage24['implementation_authorized'] is True
     assert stage24['primary_objective'] == PRIMARY_OBJECTIVE
     assert stage24['first_executable_checkpoint'] == FIRST_CHECKPOINT
-    assert stage24['current_checkpoint'] == 'Stage 24C - Cross-surface evidence consistency'
-    assert stage24['next_checkpoint'] == NEXT_CHECKPOINT
+    assert stage24['current_checkpoint'] == FINAL_CHECKPOINT
+    assert stage24['next_checkpoint'] is None
     assert stage24['roadmap'] == 'docs/colonisation-redesign/stage-24-roadmap.md'
     assert stage24['stage23_closed'] is True
     assert stage24['stage23_readonly_baseline_complete'] is True
     assert stage24['selected_workstream'] == SELECTED_WORKSTREAM
-    assert stage24['docs_static_only'] is False
+    assert stage24['docs_static_only'] is True
     assert stage24['write_capable_lane_authorized'] is False
     assert stage24['stage19_execution_authorized'] is False
     assert stage24['canonical_apply_authorized'] is False
@@ -73,11 +73,18 @@ def test_stage24_authority_establishes_a_planning_only_post_stage23_control():
     assert stage24['stage24b_implementation_completed'] is True
     assert stage24['stage24c_implementation_started'] is True
     assert stage24['stage24c_implementation_completed'] is True
-    assert stage24['stage24d_implementation_started'] is False
+    assert stage24['stage24d_implementation_started'] is True
+    assert stage24['stage24_closed'] is True
+    assert stage24['future_control_document_required'] is True
+    assert stage24['closeout_mode'] == 'closeout'
+    assert stage24['closeout_document'] == (
+        'docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md'
+    )
+    assert stage24['no_new_implementation_mixed_in'] is True
     assert stage24['source_files_committed'] is False
     assert stage24['runtime_artifacts_committed'] is False
 
-    assert baseline['status'] == 'prepared'
+    assert baseline['status'] == 'completed'
     assert baseline['checkpoint_type'] == 'planning_baseline'
     assert baseline['docs_static_only'] is True
     assert baseline['roadmap'] == 'docs/colonisation-redesign/stage-24-roadmap.md'
@@ -87,6 +94,9 @@ def test_stage24_authority_establishes_a_planning_only_post_stage23_control():
     assert baseline['checkpoint_count'] == 4
     assert len(baseline['checkpoints']) == 4
     assert baseline['checkpoints'][0] == FIRST_CHECKPOINT
+    assert baseline['closeout_checkpoint'] == FINAL_CHECKPOINT
+    assert baseline['stage24_closed'] is True
+    assert baseline['future_control_document_required'] is True
     assert baseline['stage23_remains_closed'] is True
     assert baseline['read_only_baseline_preserved'] is True
     assert baseline['bounded_staging_report_only'] is True
@@ -171,8 +181,8 @@ def test_stage24_is_discoverable_from_stage23_closeout_and_index():
     assert 'docs/colonisation-redesign/stage-24-roadmap.md' in stage23_roadmap
     assert 'Any further work must begin under a new explicit control document' in stage23e
     assert 'stage-24-roadmap.md' in readme
-    assert 'active post-Stage-23 control baseline' in readme
-    assert 'Active Stage 24 control' in readme
+    assert 'completed post-Stage-23 control baseline' in readme
+    assert 'Completed Stage 24 control' in readme
 
 
 @pytest.mark.unit
@@ -183,8 +193,11 @@ def test_stage24_first_executable_checkpoint_and_closeout_criteria_are_explicit(
     assert 'Stage 24A is now recorded in' in roadmap
     assert 'Stage 24B is complete as the first narrow discoverability implementation slice.' in roadmap
     assert 'Stage 24C is complete as the narrow adjacent-surface consistency slice.' in roadmap
-    assert NEXT_CHECKPOINT in roadmap
+    assert 'Stage 24D is complete as the closeout checkpoint.' in roadmap
+    assert 'Stage 24 is closed as the read-only evidence adoption and governance' in roadmap
     assert '## Proposed Checkpoint Plan' in roadmap
     assert 'Stage 24D - Closeout or next-control decision' in roadmap
+    assert 'stage-24d-readonly-evidence-adoption-closeout.md' in roadmap
     assert '## Closeout Criteria' in roadmap
     assert 'no write-capable lane has been silently authorized' in roadmap
+    assert 'new explicit post-Stage-24' in roadmap

--- a/tests/test_stage24a_evidence_adoption_contract.py
+++ b/tests/test_stage24a_evidence_adoption_contract.py
@@ -35,14 +35,15 @@ def test_stage24a_authority_records_a_completed_contract_only_checkpoint():
     assert stage23['status'] == 'completed'
     assert stage23['stage23_closed'] is True
 
-    assert stage24['current_checkpoint'] == 'Stage 24C - Cross-surface evidence consistency'
-    assert stage24['next_checkpoint'] == 'Stage 24D - Closeout or next-control decision'
+    assert stage24['current_checkpoint'] == 'Stage 24D - Closeout'
+    assert stage24['next_checkpoint'] is None
     assert stage24['stage24a_contract_completed'] is True
     assert stage24['stage24b_implementation_started'] is True
     assert stage24['stage24b_implementation_completed'] is True
     assert stage24['stage24c_implementation_started'] is True
     assert stage24['stage24c_implementation_completed'] is True
-    assert stage24['stage24d_implementation_started'] is False
+    assert stage24['stage24d_implementation_started'] is True
+    assert stage24['stage24_closed'] is True
 
     assert stage24a['status'] == 'completed'
     assert stage24a['checkpoint_type'] == 'implementation_contract'
@@ -150,6 +151,7 @@ def test_stage24a_is_discoverable_from_stage24_roadmap_and_readme():
 
     assert 'docs/colonisation-redesign/stage-24a-readonly-evidence-adoption-contract.md' in roadmap
     assert 'Stage 24B is complete as the first narrow discoverability implementation slice.' in roadmap
+    assert 'Stage 24D is complete as the closeout checkpoint.' in roadmap
     assert 'stage-24a-readonly-evidence-adoption-contract.md' in readme
     assert 'completed Stage 24A contract checkpoint' in readme
     assert 'Completed Stage 24A contract' in readme

--- a/tests/test_stage24b_planner_evidence_discoverability.py
+++ b/tests/test_stage24b_planner_evidence_discoverability.py
@@ -32,18 +32,19 @@ def test_stage24b_authority_records_a_narrow_in_scope_discoverability_slice():
     stage24a = authority['stage24a']
     stage24b = authority['stage24b']
 
-    assert stage24['status'] == 'in_progress'
+    assert stage24['status'] == 'completed'
     assert stage24['implementation_started'] is True
     assert stage24['implementation_authorized'] is True
-    assert stage24['current_checkpoint'] == 'Stage 24C - Cross-surface evidence consistency'
-    assert stage24['next_checkpoint'] == 'Stage 24D - Closeout or next-control decision'
-    assert stage24['docs_static_only'] is False
+    assert stage24['current_checkpoint'] == 'Stage 24D - Closeout'
+    assert stage24['next_checkpoint'] is None
+    assert stage24['docs_static_only'] is True
     assert stage24['stage24a_contract_completed'] is True
     assert stage24['stage24b_implementation_started'] is True
     assert stage24['stage24b_implementation_completed'] is True
     assert stage24['stage24c_implementation_started'] is True
     assert stage24['stage24c_implementation_completed'] is True
-    assert stage24['stage24d_implementation_started'] is False
+    assert stage24['stage24d_implementation_started'] is True
+    assert stage24['stage24_closed'] is True
 
     assert stage24a['status'] == 'completed'
     assert stage24a['contract_only'] is True
@@ -130,7 +131,7 @@ def test_stage24b_is_discoverable_from_roadmap_and_readme():
     assert 'Stage 24B is complete as the first narrow discoverability implementation slice.' in roadmap
     assert 'docs/colonisation-redesign/stage-24b-planner-evidence-discoverability.md' in roadmap
     assert 'Stage 24C is complete as the narrow adjacent-surface consistency slice.' in roadmap
-    assert 'Stage 24D is the next checkpoint.' in roadmap
+    assert 'Stage 24D is complete as the closeout checkpoint.' in roadmap
     assert 'stage-24b-planner-evidence-discoverability.md' in readme
     assert 'completed Stage 24B slice' in readme
     assert 'Completed Stage 24B implementation record' in readme

--- a/tests/test_stage24c_cross_surface_evidence_consistency.py
+++ b/tests/test_stage24c_cross_surface_evidence_consistency.py
@@ -27,12 +27,13 @@ def test_stage24c_authority_records_one_narrow_adjacent_surface_slice():
     stage24b = authority['stage24b']
     stage24c = authority['stage24c']
 
-    assert stage24['current_checkpoint'] == 'Stage 24C - Cross-surface evidence consistency'
-    assert stage24['next_checkpoint'] == 'Stage 24D - Closeout or next-control decision'
+    assert stage24['current_checkpoint'] == 'Stage 24D - Closeout'
+    assert stage24['next_checkpoint'] is None
     assert stage24['stage24b_implementation_completed'] is True
     assert stage24['stage24c_implementation_started'] is True
     assert stage24['stage24c_implementation_completed'] is True
-    assert stage24['stage24d_implementation_started'] is False
+    assert stage24['stage24d_implementation_started'] is True
+    assert stage24['stage24_closed'] is True
 
     assert stage24b['status'] == 'completed'
     assert stage24b['in_scope_surfaces_only'] is True
@@ -99,7 +100,7 @@ def test_stage24c_is_discoverable_from_roadmap_and_readme():
 
     assert 'Stage 24C is complete as the narrow adjacent-surface consistency slice.' in roadmap
     assert 'docs/colonisation-redesign/stage-24c-cross-surface-evidence-consistency.md' in roadmap
-    assert 'Stage 24D is the next checkpoint.' in roadmap
+    assert 'Stage 24D is complete as the closeout checkpoint.' in roadmap
     assert 'stage-24c-cross-surface-evidence-consistency.md' in readme
     assert 'completed Stage 24C slice' in readme
     assert 'Completed Stage 24C implementation record' in readme

--- a/tests/test_stage24d_closeout_handoff.py
+++ b/tests/test_stage24d_closeout_handoff.py
@@ -1,0 +1,99 @@
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+AUTHORITY_PATH = DOCS / 'stage-19-state-authority.json'
+STAGE24_PATH = DOCS / 'stage-24-roadmap.md'
+STAGE24D_PATH = DOCS / 'stage-24d-readonly-evidence-adoption-closeout.md'
+README_PATH = DOCS / 'README.md'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _json(path: Path):
+    return json.loads(_read(path))
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+@pytest.mark.unit
+def test_stage24d_authority_closes_stage24_without_reopening_write_lanes():
+    authority = _json(AUTHORITY_PATH)
+    stage24 = authority['stage24']
+    stage24d = authority['stage24d']
+
+    assert stage24['status'] == 'completed'
+    assert stage24['current_checkpoint'] == 'Stage 24D - Closeout'
+    assert stage24['next_checkpoint'] is None
+    assert stage24['stage24_closed'] is True
+    assert stage24['future_control_document_required'] is True
+    assert stage24['write_capable_lane_authorized'] is False
+    assert stage24['db_writes_authorized'] is False
+    assert stage24['canonical_apply_authorized'] is False
+    assert stage24['rebaseline_authorized'] is False
+    assert stage24['scheduler_service_authorized'] is False
+    assert stage24['no_new_implementation_mixed_in'] is True
+
+    assert stage24d['status'] == 'completed'
+    assert stage24d['checkpoint_type'] == 'readonly_evidence_adoption_closeout'
+    assert stage24d['document'] == (
+        'docs/colonisation-redesign/stage-24d-readonly-evidence-adoption-closeout.md'
+    )
+    assert stage24d['mode'] == 'closeout'
+    assert stage24d['stage24_closed'] is True
+    assert stage24d['stage24a_completed'] is True
+    assert stage24d['stage24b_completed'] is True
+    assert stage24d['stage24c_completed'] is True
+    assert stage24d['future_control_document_required'] is True
+    assert stage24d['stage23_remains_closed'] is True
+    assert stage24d['stage19_remains_separately_gated'] is True
+    assert stage24d['no_stage19bb_execution_occurred'] is True
+    assert stage24d['write_capable_lane_authorized'] is False
+    assert stage24d['db_writes_performed'] is False
+    assert stage24d['canonical_apply_performed'] is False
+    assert stage24d['rebaseline_performed'] is False
+    assert stage24d['scheduler_enabled'] is False
+    assert stage24d['source_files_committed'] is False
+    assert stage24d['runtime_artifacts_committed'] is False
+    assert stage24d['no_new_implementation_mixed_in'] is True
+
+
+@pytest.mark.unit
+def test_stage24d_document_records_closeout_mode_and_future_control_handoff():
+    text = _read(STAGE24D_PATH)
+
+    assert STAGE24D_PATH.exists()
+    assert 'Stage 24D runs in `closeout` mode.' in text
+    assert 'Stage 24 closes as the read-only evidence adoption and governance' in text
+    assert 'Stage 24A` remains complete' in text
+    assert 'Stage 24B` remains complete' in text
+    assert 'Stage 24C` remains complete' in text
+    assert 'Future work requires a new explicit post-Stage-24 control document.' in text
+    assert 'Stage 23 remains closed.' in text
+    assert 'Stage 19 remains separately gated.' in text
+    assert 'no DB writes occurred' in text
+    assert 'no canonical apply occurred' in text
+    assert 'no rebaseline occurred' in text
+    assert 'no new implementation was mixed into the closeout checkpoint' in text
+
+
+@pytest.mark.unit
+def test_stage24d_is_discoverable_from_roadmap_and_readme():
+    roadmap = _squash(_read(STAGE24_PATH))
+    readme = _read(README_PATH)
+
+    assert 'Stage 24D is complete as the closeout checkpoint.' in roadmap
+    assert 'stage-24d-readonly-evidence-adoption-closeout.md' in roadmap
+    assert 'new explicit post-Stage-24 control document' in roadmap
+    assert 'stage-24d-readonly-evidence-adoption-closeout.md' in readme
+    assert 'completed Stage 24D closeout' in readme
+    assert 'Completed Stage 24D closeout record' in readme


### PR DESCRIPTION
 - Stage 24D mode: closeout
- Stage 24A, Stage 24B, and Stage 24C are complete
- Stage 24 closes as the read-only evidence adoption and governance programme
- future work requires: New explicit post-Stage-24 control document required
- Stage 19 remains separately gated
- no Stage 19BB execution occurred
- no DB writes occurred
- no canonical apply occurred
- no rebaseline occurred
- scheduler/service activation remains disabled
- no source files or runtime artifacts were committed
- no new implementation was mixed in