### PR TITLE
Establish Stage 25 cockpit and map product baseline

### DIFF
--- a/docs/colonisation-redesign/stage-25-roadmap.md
+++ b/docs/colonisation-redesign/stage-25-roadmap.md
@@ -97,6 +97,15 @@ compatible with evidence-heavy review surfaces.
 
 Stage 25 preserves evidence-language discipline:
 
+- evidence must be player-facing first: clear enough to support a planning
+  decision, concise enough not to overwhelm normal use, and paired with an
+  understandable next action;
+- that simplification must remain technically honest and must never hide
+  uncertainty, freshness, provenance, report-only status, bounded or incomplete
+  coverage, unavailable data, unknown state, or non-canonical status;
+- player-facing wording may progressively disclose technical provenance and
+  implementation detail, but it must never convert a weak, unavailable,
+  observed, bounded, or report-only signal into apparent canonical truth;
 - evidence must remain explicit rather than atmospheric;
 - dense evidence surfaces must stay legible before decorative chrome;
 - review posture must remain compatible with provenance-heavy planning work;

--- a/docs/colonisation-redesign/stage-25-roadmap.md
+++ b/docs/colonisation-redesign/stage-25-roadmap.md
@@ -1,0 +1,154 @@
+# Stage 25 - Cockpit, Map, And Visual-System Baseline
+
+## Status
+
+Stage 24 is closed.
+
+Stage 25 is the new explicit post-Stage-24 control.
+
+Stage 25A is prepared as the current-state audit, map product decision, and
+visual-system baseline checkpoint.
+
+Stage 25B remains unstarted.
+
+Stage 25C remains unstarted.
+
+Stage 25D remains unstarted.
+
+Stage 25E remains unstarted.
+
+## Current Product Recovery State
+
+PR #257 fixed the Firefox map scroll/zoom crash.
+
+Map status is `stable_after_pr257_manual_firefox_verification`.
+
+The map is retained as a secondary Explore surface only.
+
+Its current product value is low and must be proven before any deeper planner
+integration is considered.
+
+The map may later become a Candidate Systems Map, but that is not authorized or
+implemented here.
+
+## Primary Objective
+
+Stage 25 has exactly one primary objective:
+
+> Establish a restrained cockpit-oriented product and visual baseline for the
+> canonical player journey while keeping the recovered map live only as a
+> secondary Explore surface, preserving the current Colony Planner runtime, and
+> authorizing no database or operational write lane.
+
+## Canonical Player Journey
+
+The canonical player journey is:
+
+`Explore → Inspect → Plan → Simulate/Sequence → Review Evidence → Export/Share`
+
+Stage 25 planning treats this journey as the product-ordering baseline for
+later work.
+
+## Product Inventory Baseline
+
+The current inventory status is:
+
+- Colony Planner: `canonical_live`
+- simulation-preview: `reusable_but_unwired`
+- map: `canonical_live` as a secondary Explore surface
+
+This control does not wire simulation-preview into live routes.
+
+This control does not redesign the map.
+
+This control does not alter Colony Planner runtime behaviour.
+
+## Map Product Decision
+
+The map remains live because PR #257 recovered baseline interaction safety after
+manual Firefox verification.
+
+That recovery does not make the map a primary planning surface.
+
+The map is therefore retained only as a secondary Explore surface until its
+value is proven by later evidence.
+
+No Stage 25A work authorizes:
+
+- deeper planner-map integration;
+- map-led planning workflows;
+- renderer replacement;
+- new map features, layers, or overlays;
+- Candidate Systems Map implementation.
+
+## Visual-System Direction
+
+Stage 25 adopts a restrained cockpit-oriented visual-system refresh.
+
+Glass or translucency is limited to workspace chrome only, or absent entirely.
+
+Glass is not authorized on dense evidence cards, tables, planning canvases, map
+labels, or technical provenance surfaces.
+
+The visual baseline must keep the product readable, operationally serious, and
+compatible with evidence-heavy review surfaces.
+
+## Evidence Language Principles
+
+Stage 25 preserves evidence-language discipline:
+
+- evidence must remain explicit rather than atmospheric;
+- dense evidence surfaces must stay legible before decorative chrome;
+- review posture must remain compatible with provenance-heavy planning work;
+- current-state statements must not overclaim certainty or readiness.
+
+## Explicit Deferrals
+
+Mission intelligence remains deferred and unauthorized in Stage 25A.
+
+Ring/mining work remains deferred and unauthorized in Stage 25A.
+
+Stage 25B, Stage 25C, Stage 25D, and Stage 25E remain unstarted.
+
+## Relationship To Earlier Controls
+
+Stage 24 is closed and remains historical.
+
+Stage 19 remains separately gated.
+
+No database or operational write lane is authorized by Stage 25A.
+
+Stage 25A does not authorize:
+
+- Stage 19 execution;
+- database commands or database writes;
+- canonical apply;
+- rebaseline;
+- scheduler, service, or timer activation;
+- source acquisition;
+- operator activity.
+
+## Checkpoint Plan
+
+| Checkpoint | Purpose |
+| --- | --- |
+| Stage 25A | Current-state audit, map product decision and visual-system baseline |
+| Stage 25B | Evidence language and visual-system primitives |
+| Stage 25C | Unified cockpit entry and shared context |
+| Stage 25D | Selected planner and simulation integration |
+| Stage 25E | Consolidation and closeout |
+
+## Acceptance Boundaries
+
+Stage 25A is acceptable only if:
+
+- Stage 24 remains closed;
+- PR #257 is recorded as the map recovery point;
+- the map remains a secondary Explore surface only;
+- the canonical player journey is explicit;
+- the visual direction stays restrained and cockpit-oriented;
+- dense content remains non-glass by default;
+- mission intelligence remains deferred;
+- ring/mining remains deferred;
+- Stage 19 remains separately gated;
+- no database or operational write lane is authorized.

--- a/docs/colonisation-redesign/stage-25a-current-state-map-product-visual-baseline.md
+++ b/docs/colonisation-redesign/stage-25a-current-state-map-product-visual-baseline.md
@@ -93,6 +93,15 @@ The visual system must stay legible, evidence-first, and operationally serious.
 
 Stage 25A preserves evidence-language principles:
 
+- evidence must be presented in player-facing language first: clear enough to
+  support a planning decision, concise enough not to overwhelm normal use, and
+  paired with an understandable next action;
+- that simplification must remain technically honest and must never hide
+  uncertainty, freshness, provenance, report-only status, bounded or incomplete
+  coverage, unavailable data, unknown state, or non-canonical status;
+- player-facing wording may progressively disclose technical provenance and
+  implementation detail, but it must never convert a weak, unavailable,
+  observed, bounded, or report-only signal into apparent canonical truth;
 - evidence language must stay explicit and reviewable;
 - decorative styling must not compete with technical provenance;
 - dense evidence surfaces must prioritize clarity over ambience;

--- a/docs/colonisation-redesign/stage-25a-current-state-map-product-visual-baseline.md
+++ b/docs/colonisation-redesign/stage-25a-current-state-map-product-visual-baseline.md
@@ -1,0 +1,144 @@
+# Stage 25A Current-State Map Product Visual Baseline
+
+## Purpose
+
+Stage 25A records the real current-state audit, the map product decision, and
+the visual-system baseline that follow the Stage 24 closeout.
+
+Stage 25 is a new explicit post-Stage-24 control.
+
+This checkpoint is docs/static-test-only and does not implement Stage 25B,
+Stage 25C, Stage 25D, or Stage 25E.
+
+## Preserved Prior State
+
+Stage 24 is closed.
+
+PR #257 fixed the Firefox map scroll/zoom crash.
+
+Map status is `stable_after_pr257_manual_firefox_verification`.
+
+The recovered map remains live, but only as a secondary Explore surface.
+
+Its product value is currently low and must be proven before deeper planner
+integration is considered.
+
+The map may later become a Candidate Systems Map, but that is not authorized or
+implemented here.
+
+## Stage 25 Primary Objective
+
+Stage 25 has exactly one primary objective:
+
+> Define the restrained cockpit-oriented product baseline for the canonical
+> player journey, preserve the recovered map as a secondary Explore surface,
+> and keep all deeper planner integration, write-capable lanes, and operational
+> work explicitly unauthorized.
+
+## Canonical Journey
+
+The canonical player journey is:
+
+`Explore → Inspect → Plan → Simulate/Sequence → Review Evidence → Export/Share`
+
+The map is retained only inside the `Explore` portion of that journey unless a
+later control explicitly proves and authorizes more.
+
+## Current Inventory Verdict
+
+The current inventory status is:
+
+- Colony Planner: `canonical_live`
+- simulation-preview: `reusable_but_unwired`
+- map: `canonical_live` as a secondary Explore surface
+
+This means:
+
+- Colony Planner remains the canonical live planning surface;
+- simulation-preview is reusable implementation inventory, but is still
+  unwired to live routes;
+- the map stays live as a secondary Explore surface, not a primary planning
+  cockpit.
+
+## Map Product Decision
+
+Stage 25A records a restrained product verdict:
+
+`retain_as_secondary_explore_surface`
+
+That verdict preserves the recovered map without turning it into the centre of
+the product.
+
+This checkpoint does not authorize:
+
+- map redesign;
+- renderer replacement;
+- new map controls, layers, or product features;
+- planner-map workflow coupling;
+- Candidate Systems Map implementation.
+
+## Visual-System Baseline
+
+Stage 25A adopts a restrained cockpit-oriented visual-system refresh.
+
+Any glass or translucency is limited to workspace chrome only or omitted
+entirely.
+
+Glass is explicitly disallowed for dense evidence cards, tables, planning
+canvases, map labels, and technical provenance surfaces.
+
+The visual system must stay legible, evidence-first, and operationally serious.
+
+## Evidence-Language Principles
+
+Stage 25A preserves evidence-language principles:
+
+- evidence language must stay explicit and reviewable;
+- decorative styling must not compete with technical provenance;
+- dense evidence surfaces must prioritize clarity over ambience;
+- product language must distinguish current state, deferred work, and future
+  possibility without overclaiming.
+
+## Explicit Deferrals
+
+Mission intelligence remains deferred and unauthorized.
+
+Ring/mining work remains deferred and unauthorized.
+
+Stage 25B through Stage 25E remain unstarted and unimplemented.
+
+## Safety Boundaries
+
+Stage 19 remains separately gated.
+
+No database or operational write lane is authorized.
+
+This checkpoint does not authorize:
+
+- Stage 19 execution;
+- database commands;
+- database writes;
+- canonical apply;
+- rebaseline;
+- scheduler, service, or timer activation;
+- source acquisition;
+- operator activity.
+
+## Checkpoint Table
+
+| Checkpoint | Purpose |
+| ---------- | -------------------------------------------------------------------- |
+| Stage 25A  | Current-state audit, map product decision and visual-system baseline |
+| Stage 25B  | Evidence language and visual-system primitives                       |
+| Stage 25C  | Unified cockpit entry and shared context                             |
+| Stage 25D  | Selected planner and simulation integration                          |
+| Stage 25E  | Consolidation and closeout                                           |
+
+## Outcome
+
+Stage 25A establishes the baseline only.
+
+It does not start Stage 25B, Stage 25C, Stage 25D, or Stage 25E.
+
+It does not authorize any database, canonical, scheduler, source-acquisition,
+or other operational write-capable lane.

--- a/tests/test_stage25_current_state_map_product_visual_baseline.py
+++ b/tests/test_stage25_current_state_map_product_visual_baseline.py
@@ -62,6 +62,26 @@ def test_stage25_docs_define_visual_direction_and_reject_glass_for_dense_content
 
 
 @pytest.mark.unit
+def test_stage25_docs_require_player_facing_but_technically_honest_evidence_language():
+    combined = _squash(f'{_read(ROADMAP_PATH)} {_read(BASELINE_PATH)}').lower()
+
+    assert 'player-facing' in combined
+    assert 'planning decision' in combined
+    assert 'understandable next action' in combined
+    assert 'technically honest' in combined
+    assert 'uncertainty' in combined
+    assert 'freshness' in combined
+    assert 'provenance' in combined
+    assert 'report-only status' in combined
+    assert 'bounded or incomplete coverage' in combined
+    assert 'unavailable data' in combined
+    assert 'unknown state' in combined
+    assert 'non-canonical status' in combined
+    assert 'apparent canonical truth' in combined
+    assert 'weak, unavailable, observed, bounded, or report-only signal' in combined
+
+
+@pytest.mark.unit
 def test_stage25_docs_preserve_closed_and_deferred_boundaries():
     combined = _squash(f'{_read(ROADMAP_PATH)} {_read(BASELINE_PATH)}')
 

--- a/tests/test_stage25_current_state_map_product_visual_baseline.py
+++ b/tests/test_stage25_current_state_map_product_visual_baseline.py
@@ -1,0 +1,82 @@
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / 'docs' / 'colonisation-redesign'
+ROADMAP_PATH = DOCS / 'stage-25-roadmap.md'
+BASELINE_PATH = DOCS / 'stage-25a-current-state-map-product-visual-baseline.md'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _squash(text: str) -> str:
+    return re.sub(r'\s+', ' ', text)
+
+
+@pytest.mark.unit
+def test_stage25_docs_exist_and_define_primary_objective_and_recovery_state():
+    roadmap = _read(ROADMAP_PATH)
+    baseline = _read(BASELINE_PATH)
+    combined = _squash(f'{roadmap} {baseline}')
+
+    assert ROADMAP_PATH.exists()
+    assert BASELINE_PATH.exists()
+    assert combined.count('Stage 25 has exactly one primary objective:') == 2
+    assert 'PR #257 fixed the Firefox map scroll/zoom crash.' in combined
+    assert 'stable_after_pr257_manual_firefox_verification' in combined
+    assert 'Stage 24 is closed.' in combined
+    assert 'Stage 25 is a new explicit post-Stage-24 control.' in combined
+
+
+@pytest.mark.unit
+def test_stage25_docs_record_map_inventory_and_canonical_player_journey():
+    combined = _squash(f'{_read(ROADMAP_PATH)} {_read(BASELINE_PATH)}')
+
+    assert 'The map is retained as a secondary Explore surface only.' in combined
+    assert 'retain_as_secondary_explore_surface' in combined
+    assert 'Colony Planner: `canonical_live`' in combined
+    assert 'simulation-preview: `reusable_but_unwired`' in combined
+    assert 'map: `canonical_live` as a secondary Explore surface' in combined
+    assert 'Explore → Inspect → Plan → Simulate/Sequence → Review Evidence → Export/Share' in combined
+    assert 'Candidate Systems Map' in combined
+    assert 'not authorized or implemented here' in combined
+
+
+@pytest.mark.unit
+def test_stage25_docs_define_visual_direction_and_reject_glass_for_dense_content():
+    combined = _squash(f'{_read(ROADMAP_PATH)} {_read(BASELINE_PATH)}')
+
+    assert 'restrained cockpit-oriented' in combined
+    assert 'Glass or translucency is limited to workspace chrome only' in combined or (
+        'glass or translucency is limited to workspace chrome only' in combined
+    )
+    assert 'Glass is not authorized on dense evidence cards, tables, planning canvases, map labels, or technical provenance surfaces.' in combined
+    assert 'Glass is explicitly disallowed for dense evidence cards, tables, planning canvases, map labels, and technical provenance surfaces.' in combined
+    assert 'evidence-language discipline' in combined
+    assert 'evidence-language principles' in combined
+
+
+@pytest.mark.unit
+def test_stage25_docs_preserve_closed_and_deferred_boundaries():
+    combined = _squash(f'{_read(ROADMAP_PATH)} {_read(BASELINE_PATH)}')
+
+    assert 'Stage 19 remains separately gated.' in combined
+    assert 'No database or operational write lane is authorized' in combined
+    assert 'Stage 19 execution;' in combined
+    assert 'database commands' in combined
+    assert 'database writes' in combined
+    assert 'canonical apply' in combined
+    assert 'rebaseline' in combined
+    assert 'scheduler, service, or timer activation' in combined
+    assert 'Mission intelligence remains deferred and unauthorized' in combined
+    assert 'Ring/mining work remains deferred and unauthorized' in combined
+    assert 'Stage 25B remains unstarted.' in combined
+    assert 'Stage 25C remains unstarted.' in combined
+    assert 'Stage 25D remains unstarted.' in combined
+    assert 'Stage 25E remains unstarted.' in combined
+    assert 'Stage 25B through Stage 25E remain unstarted and unimplemented.' in combined


### PR DESCRIPTION
## Summary
- Stage 25 is a new explicit post-Stage-24 control.
- PR #257 merged and Firefox map interaction is manually verified stable.
- This PR records the map product decision but does not redesign the map.
- The map is retained only as a secondary Explore surface until value is proven.
- The canonical player journey is `Explore -> Inspect -> Plan -> Simulate/Sequence -> Review Evidence -> Export/Share`.
- The visual-system direction is restrained and cockpit-oriented, with glass/translucency limited to workspace chrome only or omitted entirely.
- `simulation-preview` remains reusable but unwired.
- Mining/ring and mission intelligence remain deferred.
- Stage 25B, Stage 25C, Stage 25D, and Stage 25E are not implemented.
- No Stage 19, database, canonical apply, rebaseline, scheduler, source acquisition, or operator activity occurred.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 -B scripts/dev/resolve_project_state.py --strict` -> passed
- `PYTHONDONTWRITEBYTECODE=1 ./.venv/bin/python -B -m pytest tests/test_stage25_current_state_map_product_visual_baseline.py tests/test_stage24d_closeout_handoff.py tests/test_stage24_planning_baseline.py tests/test_stage20c_map_foundation.py tests/test_stage20d_sequence_cp_cockpit.py tests/test_stage20e_export_closeout.py tests/test_project_state_resolver.py -p no:cacheprovider` -> passed (`34 passed`)
- `git diff --check` -> passed

## Scope Notes
- Records the Stage 25 roadmap and Stage 25A current-state baseline only.
- Keeps the map as a secondary Explore surface and does not start deeper planner integration.
- Does not wire `simulation-preview` into live routes.
- Does not add runtime implementation code.
