### PR TITLE
Add Stage 25C product shell and navigation hierarchy

### DIFF
--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -8,8 +8,8 @@ Start here for any new colonisation work:
 
 The active programme is **Stage 25 (cockpit product shell)**:
 
-- [`stage-25-roadmap.md`](./stage-25-roadmap.md) - authoritative Stage 25 roadmap reset: Stage 25A and Stage 25B complete/merged, Stage 25C prepared but not started, Stage 25D-25H unstarted, with the `Explore → Inspect → Plan → Review / Export` product journey and the future `Explore`/`Plan`/`Review` hierarchy.
-- [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) - Stage 25C product-shell, selected-system context, and cockpit visual-foundation implementation contract (`prepared_not_started`; defining it does not authorize runtime implementation).
+- [`stage-25-roadmap.md`](./stage-25-roadmap.md) - authoritative Stage 25 roadmap reset: Stage 25A and Stage 25B complete/merged, Stage 25C Slice 1 in progress/pending review, Stage 25D-25H unstarted, with the `Explore → Inspect → Plan → Review / Export` product journey and the future `Explore`/`Plan`/`Review` hierarchy.
+- [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) - Stage 25C product-shell, selected-system context, and cockpit visual-foundation implementation contract (`slice_1_in_progress_pending_review`; defining the contract did not by itself authorize runtime implementation).
 - [`stage-25b-evidence-language-visual-primitives.md`](./stage-25b-evidence-language-visual-primitives.md) - completed/merged Stage 25B evidence-language and visual-system primitives.
 - [`stage-25a-current-state-map-product-visual-baseline.md`](./stage-25a-current-state-map-product-visual-baseline.md) - frozen Stage 25A current-state audit, map product decision, and visual baseline.
 
@@ -51,9 +51,9 @@ If an older document's "recommended next stage" conflicts with Stage 17P, follow
 
 ## Current Control Documents
 
-[`stage-25-roadmap.md`](./stage-25-roadmap.md) is the authoritative Stage 25 roadmap reset and the current active control. It records Stage 25A and Stage 25B as complete/merged, Stage 25C as prepared but not started, and Stage 25D through Stage 25H as unstarted. It establishes the `Explore → Inspect → Plan → Review / Export` product journey, the future `Explore`/`Plan`/`Review` hierarchy, the substantial-but-restrained cockpit visual-redesign decision, and preserves all Stage 19, database-write, canonical-apply, rebaseline, scheduler, map-redesign, mission-intelligence, and mining/ring boundaries.
+[`stage-25-roadmap.md`](./stage-25-roadmap.md) is the authoritative Stage 25 roadmap reset and the current active control. It records Stage 25A and Stage 25B as complete/merged, Stage 25C Slice 1 as in progress/pending review, and Stage 25D through Stage 25H as unstarted. It establishes the `Explore → Inspect → Plan → Review / Export` product journey, the future `Explore`/`Plan`/`Review` hierarchy, the substantial-but-restrained cockpit visual-redesign decision, and preserves all Stage 19, database-write, canonical-apply, rebaseline, scheduler, map-redesign, mission-intelligence, and mining/ring boundaries.
 
-[`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) is the Stage 25C implementation contract (`prepared_not_started`). It defines the product shell, the persistent selected-system context spine, the workspace hierarchy, and the cockpit visual-system foundation, plus explicit out-of-scope, acceptance, accessibility, and desktop/mobile criteria. Defining this contract does not authorize any runtime implementation.
+[`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) is the Stage 25C implementation contract (`slice_1_in_progress_pending_review`). It defines the product shell, the persistent selected-system context spine, the workspace hierarchy, and the cockpit visual-system foundation, plus explicit out-of-scope, acceptance, accessibility, and desktop/mobile criteria. Defining this contract did not by itself authorize runtime implementation; the current runtime work is limited to Slice 1.
 
 [`stage-24d-readonly-evidence-adoption-closeout.md`](./stage-24d-readonly-evidence-adoption-closeout.md) records the completed Stage 24D closeout: Stage 24 closes as the read-only evidence adoption and governance programme, Stage 24A/24B/24C remain complete, and any future work now requires a new explicit post-Stage-24 control document.
 
@@ -145,8 +145,8 @@ It supersedes the old assumption that the project should simply continue from St
 
 | Document | Status | Purpose |
 |---|---|---|
-| [`stage-25-roadmap.md`](./stage-25-roadmap.md) | Active Stage 25 control | Authoritative Stage 25 roadmap reset: corrected 25A/25B completion, prepared 25C, unstarted 25D-25H, product journey, future hierarchy, visual-redesign decision, and preserved boundaries. |
-| [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) | Stage 25C contract (`prepared_not_started`) | Product shell, selected-system context spine, workspace hierarchy, and cockpit visual-system foundation contract; defining it does not authorize runtime implementation. |
+| [`stage-25-roadmap.md`](./stage-25-roadmap.md) | Active Stage 25 control | Authoritative Stage 25 roadmap reset: corrected 25A/25B completion, Stage 25C Slice 1 in progress/pending review, unstarted 25D-25H, product journey, future hierarchy, visual-redesign decision, and preserved boundaries. |
+| [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) | Stage 25C contract (`slice_1_in_progress_pending_review`) | Product shell, selected-system context spine, workspace hierarchy, and cockpit visual-system foundation contract; defining it did not by itself authorize runtime implementation. |
 | [`stage-25b-evidence-language-visual-primitives.md`](./stage-25b-evidence-language-visual-primitives.md) | Completed Stage 25B record (merged in PR #259) | Evidence-language and visual-system primitives applied to Inspect and Plan surfaces. |
 | [`stage-25a-current-state-map-product-visual-baseline.md`](./stage-25a-current-state-map-product-visual-baseline.md) | Frozen Stage 25A baseline | Current-state audit, map product decision (`retain_as_secondary_explore_surface`), and restrained cockpit visual baseline. |
 | [`stage-24d-readonly-evidence-adoption-closeout.md`](./stage-24d-readonly-evidence-adoption-closeout.md) | Completed Stage 24D closeout record | Records that Stage 24 is closed, that Stage 24A/24B/24C remain complete, and that any future work requires a new explicit post-Stage-24 control document. |

--- a/docs/colonisation-redesign/stage-25-roadmap.md
+++ b/docs/colonisation-redesign/stage-25-roadmap.md
@@ -14,12 +14,13 @@ Programme status after this reset:
 
 - Stage 25A is complete.
 - Stage 25B is complete and merged.
-- Stage 25C is prepared but not started.
+- Stage 25C Slice 1 is in progress and pending review.
 - Stage 25D, Stage 25E, Stage 25F, Stage 25G, and Stage 25H are unstarted.
 
-This reset PR is documentation, roadmap authority, static tests, and guardrails
-only. It does not begin Stage 25C runtime implementation, does not redesign any
-live screen, and does not start Stage 25D or later work.
+The original roadmap-reset PR was documentation, roadmap authority, static
+tests, and guardrails only. Stage 25C runtime implementation now begins
+separately with Slice 1: product shell, navigation hierarchy, minimal selected-
+system context scaffolding, and visual foundation framing only.
 
 ## Stage 25B Status Correction
 
@@ -208,7 +209,7 @@ Stage 25 preserves evidence-language discipline:
 | --- | --- | --- |
 | Stage 25A | complete | Current-state audit, map product decision and visual-system baseline |
 | Stage 25B | complete (merged in PR #259) | Evidence language and visual-system primitives |
-| Stage 25C | prepared but not started | Product shell, shared selected-system context, and cockpit visual foundation |
+| Stage 25C | Slice 1 in progress and pending review | Product shell, shared selected-system context, and cockpit visual foundation |
 | Stage 25D | unstarted | Canonical Colony Cockpit and planner/simulation integration |
 | Stage 25E | unstarted | Review, evidence, validation and export coherence |
 | Stage 25F | unstarted | Facility intelligence and explainable next actions |
@@ -228,17 +229,22 @@ broad polish.
 
 ### Stage 25C - Product Shell, Shared Context and Cockpit Visual Foundation
 
-Status: prepared but not started.
+Status: Slice 1 in progress and pending review.
 
-Primary objective: create the authoritative implementation contract for a
-coherent player product shell, a persistent selected-system context spine, the
-future Explore/Plan/Review hierarchy, and the cockpit-oriented visual-system
-foundation.
+Primary objective: implement the first runtime slice of the coherent player
+product shell, the Explore/Plan/Review hierarchy, truthful shared-context
+scaffolding, and the cockpit-oriented visual-system foundation without
+broadening into Stage 25D or later work.
 
-Implementation scope (later, not in this reset): future navigation hierarchy;
-selected-system context contract; workspace shell; visual tokens and semantic
-status system; System Detail hand-off into Plan; player/operator boundary;
-desktop-first workspace behaviour; Finder/mobile basic-inspection compatibility.
+Slice 1 implementation scope: player-facing product shell; Explore/Plan/Review
+hierarchy; separate operator/admin lane; shell-level selected-system context
+framing where existing route truth provides it; System Detail contextual hand-
+off clarity; desktop-first workspace framing; Finder/mobile basic-inspection
+compatibility; planner phone-width resilience-only handling.
+
+Later Stage 25C slices remain pending for deeper selected-system continuity
+rules, broader cockpit visual-system consolidation, and follow-through
+verification.
 
 Explicitly out of scope for Stage 25C implementation: simulation-preview
 integration; map redesign or deeper map integration; planner rules/data changes;
@@ -248,7 +254,8 @@ activity.
 
 The full Stage 25C implementation contract lives in
 `stage-25c-product-shell-shared-context-contract.md`. Defining that contract
-does not authorize runtime implementation.
+did not by itself authorize runtime implementation; this first runtime slice is
+separately authorized and remains pending review.
 
 ### Stage 25D - Canonical Colony Cockpit and Planner/Simulation Integration
 
@@ -346,7 +353,7 @@ This Stage 25 roadmap reset is acceptable only if:
 
 - Stage 24 remains closed;
 - Stage 25A is recorded as complete and Stage 25B as complete/merged;
-- Stage 25C is recorded as prepared but not started;
+- Stage 25C is recorded as Slice 1 in progress and pending review rather than complete;
 - Stage 25D through Stage 25H are recorded as unstarted;
 - PR #257 is recorded as the map recovery point;
 - the map remains a secondary Explore surface only and no deeper map integration

--- a/docs/colonisation-redesign/stage-25c-product-shell-shared-context-contract.md
+++ b/docs/colonisation-redesign/stage-25c-product-shell-shared-context-contract.md
@@ -2,15 +2,17 @@
 
 ## Status
 
-Stage 25C is `prepared_not_started`.
+Stage 25C is `slice_1_in_progress_pending_review`.
 
-This document is an implementation contract, not a runtime implementation and
-not a generic vision document. Defining this contract does not authorize any
-runtime implementation. No live screen is redesigned, no route is rewired, and
-no component is created by this document.
+This document began as an implementation contract, not a runtime implementation
+and not a generic vision document. Defining this contract did not authorize any
+runtime implementation by itself.
 
-Stage 25C implementation is authorized only by a separate, explicit control
-after this contract is accepted.
+Stage 25C runtime implementation is now authorized only for Slice 1: product
+shell, navigation hierarchy, minimal shared-context scaffolding, and shell
+visual foundation work that remains pending review. Later slices remain
+separately gated by this same contract and do not become complete merely because
+Slice 1 is active.
 
 ## Product Problem
 

--- a/frontend-v2/e2e/smoke.spec.ts
+++ b/frontend-v2/e2e/smoke.spec.ts
@@ -65,11 +65,14 @@ test.describe('ED Finder v2 — smoke', () => {
       }]));
     });
     await page.reload();
-    // The NavBar pin tab badge shows "📌 Pins1" — find an element whose
-    // text contains both "Pin" (for any of "Pin"/"Pins"/"Pinned") and "1".
+    await page.getByTestId('nav-primary-review').click();
+    // Pins now live under the Review workspace, so enter Review before
+    // checking the persisted badge state.
     await expect(
-      page.getByText(/Pin(s|ned)?\s*1/i).first()
+      page.getByTestId('nav-pinned')
     ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('nav-pinned')).toContainText(/Pin(s|ned)?/i);
+    await expect(page.getByTestId('nav-pinned')).toContainText('1');
   });
 
   test('legacy /api/watchlist returns 410 (Phase 3 contract)', async ({ request }) => {

--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -88,6 +88,14 @@ vi.mock('@/features/admin/useAdmin', () => ({
   useAdmin: () => ({}),
 }));
 
+vi.mock('@/features/admin/AdminTab', () => ({
+  AdminTab: () => <div data-testid="admin-tab">Admin tab</div>,
+}));
+
+vi.mock('@/features/operator/OperatorCockpitTab', () => ({
+  OperatorCockpitTab: () => <div data-testid="operator-tab">Operator tab</div>,
+}));
+
 vi.mock('@/features/eddn/EddnTicker', () => ({
   EddnTicker: () => null,
 }));
@@ -271,7 +279,7 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.getByTestId('colony-planner-workspace').textContent).toContain('123');
   });
 
-  it('renders the player-facing Explore / Plan / Review shell with separate operator tools', async () => {
+  it('renders the player-facing Explore / Plan / Review shell without persistent operator tools', async () => {
     window.location.hash = '#finder';
 
     render(<App />);
@@ -283,8 +291,26 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.getByTestId('nav-primary-explore').textContent).toContain('Explore');
     expect(screen.getByTestId('nav-primary-plan').textContent).toContain('Plan');
     expect(screen.getByTestId('nav-primary-review').textContent).toContain('Review');
-    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Admin');
-    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Operator');
+    expect(screen.queryByText('Operator tools')).toBeNull();
+    expect(screen.queryByTestId('nav-admin')).toBeNull();
+    expect(screen.queryByTestId('nav-operator')).toBeNull();
+  });
+
+  it('keeps admin and operator out of the normal mobile player menu', async () => {
+    window.location.hash = '#finder';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-menu-toggle')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('nav-menu-toggle'));
+
+    expect(screen.getByTestId('nav-menu-panel')).toBeTruthy();
+    expect(screen.queryByTestId('nav-admin-menu')).toBeNull();
+    expect(screen.queryByTestId('nav-operator-menu')).toBeNull();
+    expect(screen.queryByTestId('operator-mode-menu')).toBeNull();
   });
 
   it('shows selected-system shell context only when the current route provides one and clears it after leaving inspect/plan', async () => {
@@ -304,5 +330,27 @@ describe('App Colony Planner workspace route', () => {
       expect(screen.queryByText('System 123')).toBeNull();
     });
     expect(screen.queryByText(/ID64 123/i)).toBeNull();
+  });
+
+  it.each([
+    ['#admin', 'admin-tab'],
+    ['#operator', 'operator-tab'],
+  ])('keeps direct %s route entries working with separate operator-mode framing', async (hash, tabTestId) => {
+    window.location.hash = hash;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId(tabTestId)).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('operator-mode-context-desktop').textContent).toContain('Separate mode: Operator');
+    expect(screen.getByTestId('operator-mode-context-desktop').textContent).toContain('outside the normal Explore, Plan, and Review player journey');
+
+    fireEvent.click(screen.getByTestId('nav-return-to-player-desktop'));
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe('#finder');
+    });
   });
 });

--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -109,6 +109,15 @@ vi.mock('@/features/system-detail/SystemDetailModal', () => ({
   ),
 }));
 
+vi.mock('@/features/system-detail/useSystemDetail', () => ({
+  useSystemDetail: (id64: number | null) => ({
+    data: id64 != null ? { id64, name: `System ${id64}` } : null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
 vi.mock('@/features/colony-planner/ColonyPlannerWorkspace', () => ({
   ColonyPlannerWorkspace: ({
     id64,
@@ -260,5 +269,40 @@ describe('App Colony Planner workspace route', () => {
       expect(window.location.hash).toBe('#colony-planner/system/123');
     });
     expect(screen.getByTestId('colony-planner-workspace').textContent).toContain('123');
+  });
+
+  it('renders the player-facing Explore / Plan / Review shell with separate operator tools', async () => {
+    window.location.hash = '#finder';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-primary-explore')).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('nav-primary-explore').textContent).toContain('Explore');
+    expect(screen.getByTestId('nav-primary-plan').textContent).toContain('Plan');
+    expect(screen.getByTestId('nav-primary-review').textContent).toContain('Review');
+    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Admin');
+    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Operator');
+  });
+
+  it('shows selected-system shell context only when the current route provides one and clears it after leaving inspect/plan', async () => {
+    window.location.hash = '#finder/system/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+    });
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('ID64 123');
+
+    window.location.hash = '#watchlist';
+    fireEvent(window, new HashChangeEvent('hashchange'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('System 123')).toBeNull();
+    });
+    expect(screen.queryByText(/ID64 123/i)).toBeNull();
   });
 });

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -24,6 +24,7 @@ import { AdminTab } from '@/features/admin/AdminTab';
 import { OperatorCockpitTab } from '@/features/operator/OperatorCockpitTab';
 import { MapTab } from '@/features/map/MapTab';
 import { SystemDetailModal } from '@/features/system-detail/SystemDetailModal';
+import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { ColonyPlannerWorkspace } from '@/features/colony-planner/ColonyPlannerWorkspace';
 import { RavenStylePlannerPrototype } from '@/features/colony-planner/prototype/RavenStylePlannerPrototype';
 import { EddnTicker } from '@/features/eddn/EddnTicker';
@@ -145,6 +146,8 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
   const admin     = useAdmin();
   const [health, setHealth] = useState<string>('Checking API');
   const [detailFocus, setDetailFocus] = useState<'colony-planner' | null>(null);
+  const shellSystemId = plannerSystemId ?? selectedSystemId;
+  const shellSystem = useSystemDetail(shellSystemId);
 
   const openSystemDetail = (id64: number, options?: { focus?: 'colony-planner' }) => {
     setDetailFocus(options?.focus ?? null);
@@ -192,6 +195,11 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
         fcCount={fc.waypoints.length}
         health={health}
         fullWidth={plannerWorkspaceRoute}
+        selectedSystem={shellSystemId != null ? {
+          id64: shellSystemId,
+          name: shellSystem.data?.name ?? null,
+          loading: shellSystem.loading,
+        } : null}
       />
 
       {route === 'finder' && (

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -3,12 +3,45 @@ import { describe, expect, it, vi } from 'vitest';
 import { NavBar } from './NavBar';
 
 describe('NavBar', () => {
-  it('renders Advanced Search Tuning with the search-tuning nav test id', () => {
-    render(<NavBar current="search-tuning" onNavigate={vi.fn()} health="Online" />);
+  it('exposes Explore / Plan / Review as primary player workspaces and keeps operator tools separate', () => {
+    render(<NavBar current="watchlist" onNavigate={vi.fn()} health="Online" watchlistCount={2} />);
+
+    expect(screen.getByTestId('nav-primary-explore').textContent).toContain('Explore');
+    expect(screen.getByTestId('nav-primary-plan').textContent).toContain('Plan');
+    expect(screen.getByTestId('nav-primary-review').textContent).toContain('Review');
+    expect(screen.getByTestId('nav-primary-review').getAttribute('aria-current')).toBe('page');
+    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Admin');
+    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Operator');
+  });
+
+  it('renders route-specific secondary navigation within the active primary workspace', () => {
+    const { rerender } = render(<NavBar current="search-tuning" onNavigate={vi.fn()} health="Online" />);
 
     expect(screen.getByTestId('nav-search-tuning').textContent).toContain('Advanced Search Tuning');
+    expect(screen.queryByTestId('nav-fc')).toBeNull();
+
+    rerender(<NavBar current="compare" onNavigate={vi.fn()} health="Online" compareCount={2} colonyCount={1} fcCount={1} />);
     expect(screen.getByTestId('nav-fc').textContent).toContain('FC Planner');
     expect(screen.getByTestId('nav-colony').textContent).toContain('Colony Tracker');
+  });
+
+  it('shows selected-system context only when provided and keeps primary navigation keyboard focusable', () => {
+    render(
+      <NavBar
+        current="colony-planner"
+        onNavigate={vi.fn()}
+        health="Online"
+        selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
+      />,
+    );
+
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('Shinrarta Dezhra');
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('ID64 123');
+
+    const planButton = screen.getByTestId('nav-primary-plan');
+    planButton.focus();
+    expect(document.activeElement).toBe(planButton);
+    expect(planButton.className).toContain('focus-visible:ring-2');
   });
 
   it('keeps menu closed by default and toggles open/close explicitly', () => {

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -3,15 +3,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { NavBar } from './NavBar';
 
 describe('NavBar', () => {
-  it('exposes Explore / Plan / Review as primary player workspaces and keeps operator tools separate', () => {
+  it('exposes Explore / Plan / Review as the only normal player workspaces', () => {
     render(<NavBar current="watchlist" onNavigate={vi.fn()} health="Online" watchlistCount={2} />);
 
     expect(screen.getByTestId('nav-primary-explore').textContent).toContain('Explore');
     expect(screen.getByTestId('nav-primary-plan').textContent).toContain('Plan');
     expect(screen.getByTestId('nav-primary-review').textContent).toContain('Review');
     expect(screen.getByTestId('nav-primary-review').getAttribute('aria-current')).toBe('page');
-    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Admin');
-    expect(screen.getByTestId('nav-operator-tools').textContent).toContain('Operator');
+    expect(screen.queryByTestId('nav-operator-tools')).toBeNull();
+    expect(screen.queryByTestId('nav-admin')).toBeNull();
+    expect(screen.queryByTestId('nav-operator')).toBeNull();
   });
 
   it('renders route-specific secondary navigation within the active primary workspace', () => {
@@ -71,5 +72,28 @@ describe('NavBar', () => {
     expect(screen.getByTestId('nav-menu-panel')).toBeTruthy();
     fireEvent.mouseDown(document.body);
     expect(screen.queryByTestId('nav-menu-panel')).toBeNull();
+  });
+
+  it('keeps admin and operator out of the standard mobile player menu', () => {
+    render(<NavBar current="finder" onNavigate={vi.fn()} health="Online" />);
+
+    fireEvent.click(screen.getByTestId('nav-menu-toggle'));
+
+    expect(screen.getByTestId('nav-menu-panel')).toBeTruthy();
+    expect(screen.queryByTestId('nav-admin-menu')).toBeNull();
+    expect(screen.queryByTestId('nav-operator-menu')).toBeNull();
+    expect(screen.queryByTestId('operator-mode-menu')).toBeNull();
+  });
+
+  it('renders a separate operator-mode panel with a return action on admin routes', () => {
+    const onNavigate = vi.fn();
+    render(<NavBar current="admin" onNavigate={onNavigate} health="Online" />);
+
+    expect(screen.getByTestId('operator-mode-context-desktop').textContent).toContain('Separate mode: Operator');
+    expect(screen.getByTestId('operator-mode-context-desktop').textContent).toContain('outside the normal Explore, Plan, and Review player journey');
+    expect(screen.queryByTestId('nav-secondary-routes')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('nav-return-to-player-desktop'));
+    expect(onNavigate).toHaveBeenCalledWith('finder');
   });
 });

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -1,5 +1,7 @@
 import type { Route } from '@/hooks/useHashRoute';
 import { useDensity } from '@/hooks/useDensity';
+import { SemanticStatusBadge } from '@/components/SemanticStatusBadge';
+import { WorkspaceContextHeader } from '@/components/WorkspaceContextHeader';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 /** Top-bar nav for the v2 app — sticky chrome panel with brushed-metal sheen
@@ -15,13 +17,45 @@ export interface NavBarProps {
   fcCount?:        number;
   health?:         string;
   fullWidth?:      boolean;
+  selectedSystem?: {
+    id64: number;
+    name: string | null;
+    loading: boolean;
+  } | null;
 }
+
+type PrimaryWorkspace = 'explore' | 'plan' | 'review';
+
+interface RouteDescriptor {
+  route: Route;
+  label: string;
+  shortLabel?: string;
+  testid: string;
+  badge?: number;
+  title?: string;
+}
+
+interface WorkspaceMeta {
+  title: string;
+  primaryLabel: string;
+  supportingText: string;
+  nextAction: string;
+  statusLabel: string;
+  statusTone: 'available' | 'canonical' | 'caution';
+}
+
+const PRIMARY_DEFAULT_ROUTE: Record<PrimaryWorkspace, Route> = {
+  explore: 'finder',
+  plan: 'colony-planner',
+  review: 'watchlist',
+};
 
 export function NavBar({
   current, onNavigate,
   watchlistCount, pinnedCount, compareCount, colonyCount, fcCount,
   health,
   fullWidth = false,
+  selectedSystem = null,
 }: NavBarProps) {
   const appVersionLabel = `v${__APP_VERSION__}`;
   const ok = (health ?? '').toLowerCase() === 'online';
@@ -31,18 +65,34 @@ export function NavBar({
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const toggleRef = useRef<HTMLButtonElement | null>(null);
-  const tabs = useMemo(() => ([
-    { route: 'finder' as const, label: '🔍 Finder', testid: 'nav-finder' },
-    { route: 'watchlist' as const, label: '☁️ Watchlist', testid: 'nav-watchlist', badge: watchlistCount ?? undefined, title: 'Watchlist — synced to your account, alerts on changes' },
-    { route: 'pinned' as const, label: '📌 Pins', testid: 'nav-pinned', badge: pinnedCount, title: 'Pins — quick local shortlist on this device only' },
-    { route: 'compare' as const, label: '⚖️ Compare', testid: 'nav-compare', badge: compareCount },
-    { route: 'search-tuning' as const, label: '🎚️ Advanced Search Tuning', testid: 'nav-search-tuning' },
-    { route: 'fc' as const, label: '🚀 FC Planner', testid: 'nav-fc', badge: fcCount },
-    { route: 'colony' as const, label: '🏗️ Colony Tracker', testid: 'nav-colony', badge: colonyCount },
-    { route: 'map' as const, label: '🗺️ Map', testid: 'nav-map' },
-    { route: 'admin' as const, label: '⚙️ Admin', testid: 'nav-admin' },
-    { route: 'operator' as const, label: 'Operator', testid: 'nav-operator' },
-  ]), [watchlistCount, pinnedCount, compareCount, fcCount, colonyCount]);
+  const groupedRoutes = useMemo<Record<'explore' | 'plan' | 'review' | 'operator', RouteDescriptor[]>>(() => ({
+    explore: [
+      { route: 'finder' as const, label: 'Finder', shortLabel: 'Explore', testid: 'nav-finder' },
+      { route: 'map' as const, label: 'Map', shortLabel: 'Map', testid: 'nav-map', title: 'Secondary Explore surface' },
+      { route: 'search-tuning' as const, label: 'Advanced Search Tuning', shortLabel: 'Advanced', testid: 'nav-search-tuning' },
+    ],
+    plan: [
+      { route: 'colony-planner' as const, label: 'Colony Planner', shortLabel: 'Plan', testid: 'nav-colony-planner' },
+    ],
+    review: [
+      { route: 'watchlist' as const, label: 'Watchlist', testid: 'nav-watchlist', badge: watchlistCount ?? undefined, title: 'Synced saved candidates' },
+      { route: 'pinned' as const, label: 'Pins', testid: 'nav-pinned', badge: pinnedCount, title: 'Device-local shortlist' },
+      { route: 'compare' as const, label: 'Compare', testid: 'nav-compare', badge: compareCount },
+      { route: 'fc' as const, label: 'FC Planner', testid: 'nav-fc', badge: fcCount },
+      { route: 'colony' as const, label: 'Colony Tracker', testid: 'nav-colony', badge: colonyCount },
+    ],
+    operator: [
+      { route: 'admin' as const, label: 'Admin', testid: 'nav-admin' },
+      { route: 'operator' as const, label: 'Operator', testid: 'nav-operator' },
+    ],
+  }), [watchlistCount, pinnedCount, compareCount, fcCount, colonyCount]);
+
+  const currentPrimary = primaryWorkspaceForRoute(current);
+  const activeSubnav = currentPrimary ? groupedRoutes[currentPrimary] : [];
+  const currentRouteDescriptor = activeSubnav.find((tab) => tab.route === current)
+    ?? groupedRoutes.operator.find((tab) => tab.route === current)
+    ?? null;
+  const currentWorkspaceMeta = workspaceMetaForRoute(current);
 
   useEffect(() => {
     setMenuOpen(false);
@@ -72,7 +122,10 @@ export function NavBar({
     setMenuOpen(false);
   };
 
-  const currentTab = tabs.find((tab) => tab.route === current);
+  const navigatePrimary = (workspace: PrimaryWorkspace) => {
+    handleNavigate(PRIMARY_DEFAULT_ROUTE[workspace]);
+  };
+
   return (
     <nav
       className={[
@@ -82,9 +135,10 @@ export function NavBar({
       data-testid="navbar"
     >
       {/* py-1.5 here matches the EDDN ticker bar height so top + bottom chrome align */}
-      <div className="panel relative flex items-center gap-3 sm:gap-5 px-4 sm:px-6 py-1.5">
+      <div className="panel relative overflow-hidden px-4 py-3 sm:px-6">
+        <div className="flex items-center gap-3 sm:gap-5">
         {/* ── Logo lockup ─────────────────────────────── */}
-        <div className="flex items-center gap-3 shrink-0">
+          <div className="flex items-center gap-3 shrink-0">
           <Logo />
           <div className="flex flex-col leading-tight hidden sm:flex">
             <span className="font-mono text-[15px] font-bold tracking-[0.18em] text-orange">
@@ -96,69 +150,186 @@ export function NavBar({
           </div>
         </div>
 
-        {/* divider */}
-        <span className="h-9 w-px bg-gradient-to-b from-transparent via-border-bright to-transparent shrink-0 hidden sm:block" />
+          {/* divider */}
+          <span className="hidden h-9 w-px shrink-0 bg-gradient-to-b from-transparent via-border-bright to-transparent sm:block" />
 
-        <div className="hidden lg:flex flex-1 items-center gap-1 overflow-x-auto">
-          {tabs.map((tab) => (
-            <Tab
-              key={tab.route}
-              label={tab.label}
-              active={current === tab.route}
-              onClick={() => handleNavigate(tab.route)}
-              testid={tab.testid}
-              badge={tab.badge}
-              title={tab.title}
-            />
-          ))}
-        </div>
+          <div className="hidden min-w-0 flex-1 lg:flex lg:flex-col lg:gap-3">
+            <div
+              className="flex flex-wrap items-center gap-2"
+              data-testid="nav-primary-workspaces"
+              aria-label="Primary workspaces"
+            >
+              <PrimaryTab
+                label="Explore"
+                active={currentPrimary === 'explore'}
+                onClick={() => navigatePrimary('explore')}
+                testid="nav-primary-explore"
+              />
+              <PrimaryTab
+                label="Plan"
+                active={currentPrimary === 'plan'}
+                onClick={() => navigatePrimary('plan')}
+                testid="nav-primary-plan"
+              />
+              <PrimaryTab
+                label="Review"
+                active={currentPrimary === 'review'}
+                onClick={() => navigatePrimary('review')}
+                testid="nav-primary-review"
+              />
+            </div>
+            {currentPrimary ? (
+              <div
+                className="flex flex-wrap items-center gap-1 overflow-x-auto"
+                data-testid="nav-secondary-routes"
+                aria-label={`${currentWorkspaceMeta.primaryLabel} routes`}
+              >
+                {groupedRoutes[currentPrimary].map((tab) => (
+                  <Tab
+                    key={tab.route}
+                    label={tab.label}
+                    active={current === tab.route}
+                    onClick={() => handleNavigate(tab.route)}
+                    testid={tab.testid}
+                    badge={tab.badge}
+                    title={tab.title}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-wrap items-center gap-1" data-testid="nav-secondary-operator">
+                {groupedRoutes.operator.map((tab) => (
+                  <Tab
+                    key={tab.route}
+                    label={tab.label}
+                    active={current === tab.route}
+                    onClick={() => handleNavigate(tab.route)}
+                    testid={tab.testid}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
 
-        <div className="lg:hidden min-w-0 flex-1">
-          <span className="truncate rounded border border-orange/35 bg-orange/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-orange">
-            {currentTab?.label ?? 'Route'}
-          </span>
-        </div>
+          <div className="min-w-0 flex-1 lg:hidden">
+            <span className="truncate rounded border border-orange/35 bg-orange/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-orange">
+              {currentPrimary ? `${currentWorkspaceMeta.primaryLabel} · ${currentRouteDescriptor?.label ?? currentWorkspaceMeta.title}` : currentWorkspaceMeta.title}
+            </span>
+          </div>
 
         {/* ── Density toggle ─────────────────────────── */}
-        <button
-          type="button"
-          onClick={cycle}
-          data-testid="nav-density-toggle"
-          title={`Density: ${densityLabel} (click to cycle)`}
-          aria-label={`Density: ${densityLabel}, click to cycle`}
-          className="flex items-center justify-center shrink-0 w-8 h-8 rounded-full bg-bg3/60 border border-border text-silver hover:text-orange-lt hover:border-orange-dk transition-colors font-mono text-[14px] leading-none"
-        >
-          <span aria-hidden>{densityIcon}</span>
-        </button>
+          <button
+            type="button"
+            onClick={cycle}
+            data-testid="nav-density-toggle"
+            title={`Density: ${densityLabel} (click to cycle)`}
+            aria-label={`Density: ${densityLabel}, click to cycle`}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-bg3/60 font-mono text-[14px] leading-none text-silver transition-colors hover:border-orange-dk hover:text-orange-lt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80"
+          >
+            <span aria-hidden>{densityIcon}</span>
+          </button>
 
-        <button
-          ref={toggleRef}
-          type="button"
-          data-testid="nav-menu-toggle"
-          aria-expanded={menuOpen}
-          onClick={() => setMenuOpen((value) => !value)}
-          className="lg:hidden inline-flex items-center justify-center rounded-chunk-sm border border-border bg-bg3/55 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-silver hover:border-orange/50 hover:text-orange"
-        >
-          Menu
-        </button>
+          <button
+            ref={toggleRef}
+            type="button"
+            data-testid="nav-menu-toggle"
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen((value) => !value)}
+            className="inline-flex items-center justify-center rounded-chunk-sm border border-border bg-bg3/55 px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-silver hover:border-orange/50 hover:text-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80 lg:hidden"
+          >
+            Menu
+          </button>
 
         {/* ── Status pill — always visible across breakpoints.
          * Collapses to a dot-only chip on narrow screens, expands with
          * the text label at md+. Used to be 'hidden md:flex' which led
          * users on smaller viewports to think the backend was offline. */}
-        <div
-          className="flex items-center gap-2 shrink-0 px-2 md:px-3 py-1.5 rounded-full bg-bg3/60 border border-border"
-          title={ok ? `Backend online — ${health}` : (health ?? 'Checking…')}
-          data-testid="nav-status-pill"
-        >
-          <span className={[
-            'h-2 w-2 rounded-full',
-            ok ? 'bg-green shadow-[0_0_8px_2px_rgba(74,222,128,0.55)]'
-               : 'bg-red shadow-[0_0_8px_2px_rgba(248,113,113,0.55)]',
-          ].join(' ')} />
-          <span className="hidden md:inline font-mono text-[10px] tracking-wider text-silver-dk uppercase">
-            {ok ? 'Online' : (health ?? 'API')}
-          </span>
+          <div
+            className="flex shrink-0 items-center gap-2 rounded-full border border-border bg-bg3/60 px-2 py-1.5 md:px-3"
+            title={ok ? `Backend online — ${health}` : (health ?? 'Checking…')}
+            data-testid="nav-status-pill"
+          >
+            <span className={[
+              'h-2 w-2 rounded-full',
+              ok ? 'bg-green shadow-[0_0_8px_2px_rgba(74,222,128,0.55)]'
+                 : 'bg-red shadow-[0_0_8px_2px_rgba(248,113,113,0.55)]',
+            ].join(' ')} />
+            <span className="hidden font-mono text-[10px] uppercase tracking-wider text-silver-dk md:inline">
+              {ok ? 'Online' : (health ?? 'API')}
+            </span>
+          </div>
+        </div>
+
+        <div className="mt-4 border-t border-border/70 pt-4">
+          <div className="hidden lg:flex lg:items-start lg:justify-between lg:gap-4">
+            <WorkspaceContextHeader
+              journeyLabel={`Primary workspace: ${currentWorkspaceMeta.primaryLabel}`}
+              title={currentWorkspaceMeta.title}
+              headingLevel={2}
+              supportingText={currentWorkspaceMeta.supportingText}
+              selectedSystemName={selectedSystem ? (selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system') : null}
+              selectedSystemMeta={selectedSystem ? <span className="tabular-nums">ID64 {selectedSystem.id64}</span> : undefined}
+              status={(
+                <SemanticStatusBadge
+                  label={currentWorkspaceMeta.statusLabel}
+                  tone={currentWorkspaceMeta.statusTone}
+                />
+              )}
+              facts={[{ label: 'Next action', value: currentWorkspaceMeta.nextAction, tone: 'orange' }]}
+              testId="product-shell-context"
+            />
+            <div
+              className="flex min-w-[220px] flex-col gap-2 rounded-chunk-lg border border-border bg-bg3/30 p-3"
+              data-testid="nav-operator-tools"
+            >
+              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+                Operator tools
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {groupedRoutes.operator.map((tab) => (
+                  <Tab
+                    key={tab.route}
+                    label={tab.label}
+                    active={current === tab.route}
+                    onClick={() => handleNavigate(tab.route)}
+                    testid={tab.testid}
+                    compact
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-3 lg:hidden" data-testid="product-shell-context-mobile">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+                Primary workspace
+              </span>
+              <SemanticStatusBadge
+                label={`${currentWorkspaceMeta.primaryLabel} · ${currentWorkspaceMeta.title}`}
+                tone={currentWorkspaceMeta.statusTone}
+              />
+            </div>
+            <p className="text-sm leading-relaxed text-silver">
+              {currentWorkspaceMeta.supportingText}
+            </p>
+            <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-orange">
+              Next action: {currentWorkspaceMeta.nextAction}
+            </p>
+            {selectedSystem ? (
+              <div className="rounded-chunk-lg border border-border bg-bg3/30 p-3">
+                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+                  Selected system
+                </p>
+                <p className="mt-1 text-sm font-semibold text-text">
+                  {selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system'}
+                </p>
+                <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+                  ID64 {selectedSystem.id64}
+                </p>
+              </div>
+            ) : null}
+          </div>
         </div>
       </div>
 
@@ -168,19 +339,31 @@ export function NavBar({
           data-testid="nav-menu-panel"
           className="panel mt-2 p-2 lg:hidden"
         >
-          <div className="grid gap-1">
-            {tabs.map((tab) => (
-              <Tab
-                key={`menu-${tab.route}`}
-                label={tab.label}
-                active={current === tab.route}
-                onClick={() => handleNavigate(tab.route)}
-                testid={`${tab.testid}-menu`}
-                badge={tab.badge}
-                title={tab.title}
-                compact
-              />
-            ))}
+          <div className="grid gap-3">
+            <MenuSection
+              title="Explore"
+              routes={groupedRoutes.explore}
+              current={current}
+              onNavigate={handleNavigate}
+            />
+            <MenuSection
+              title="Plan"
+              routes={groupedRoutes.plan}
+              current={current}
+              onNavigate={handleNavigate}
+            />
+            <MenuSection
+              title="Review"
+              routes={groupedRoutes.review}
+              current={current}
+              onNavigate={handleNavigate}
+            />
+            <MenuSection
+              title="Operator tools"
+              routes={groupedRoutes.operator}
+              current={current}
+              onNavigate={handleNavigate}
+            />
           </div>
         </div>
       )}
@@ -223,11 +406,12 @@ function Tab({ label, active, onClick, testid, badge, title, compact = false }: 
       onClick={onClick}
       data-testid={testid}
       title={title}
+      aria-current={active ? 'page' : undefined}
       className={[
         'group relative inline-flex items-center gap-1.5 px-3 py-1.5 rounded-chunk-sm whitespace-nowrap',
         compact ? 'w-full justify-between' : '',
         'font-display font-bold text-[12.5px] tracking-[0.1em] uppercase',
-        'transition-all duration-200',
+        'transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80',
         active
           ? 'text-white shadow-brand-glow'
           : 'text-silver hover:text-white hover:bg-bg3/70',
@@ -258,4 +442,188 @@ function Tab({ label, active, onClick, testid, badge, title, compact = false }: 
       )}
     </button>
   );
+}
+
+function PrimaryTab({
+  label,
+  active,
+  onClick,
+  testid,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  testid: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testid}
+      aria-current={active ? 'page' : undefined}
+      className={[
+        'rounded-chunk-sm border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80',
+        active
+          ? 'border-orange/55 bg-orange/15 text-orange'
+          : 'border-border bg-bg3/35 text-silver hover:border-orange/40 hover:text-orange-lt',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
+}
+
+function MenuSection({
+  title,
+  routes,
+  current,
+  onNavigate,
+}: {
+  title: string;
+  routes: RouteDescriptor[];
+  current: Route;
+  onNavigate: (route: Route) => void;
+}) {
+  return (
+    <section>
+      <p className="mb-2 px-1 font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+        {title}
+      </p>
+      <div className="grid gap-1">
+        {routes.map((tab) => (
+          <Tab
+            key={`menu-${tab.route}`}
+            label={tab.label}
+            active={current === tab.route}
+            onClick={() => onNavigate(tab.route)}
+            testid={`${tab.testid}-menu`}
+            badge={tab.badge}
+            title={tab.title}
+            compact
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function primaryWorkspaceForRoute(route: Route): PrimaryWorkspace | null {
+  if (route === 'finder' || route === 'map' || route === 'search-tuning') return 'explore';
+  if (route === 'colony-planner') return 'plan';
+  if (route === 'watchlist' || route === 'pinned' || route === 'compare' || route === 'fc' || route === 'colony') return 'review';
+  return null;
+}
+
+function workspaceMetaForRoute(route: Route): WorkspaceMeta {
+  switch (route) {
+    case 'finder':
+      return {
+        title: 'Finder',
+        primaryLabel: 'Explore',
+        supportingText: 'Discover candidate systems, inspect their current state, and move into planning only when a system is worth serious review.',
+        nextAction: 'Open a system to inspect it, then hand off into Plan.',
+        statusLabel: 'Discovery workspace',
+        statusTone: 'available',
+      };
+    case 'map':
+      return {
+        title: 'Galactic Map',
+        primaryLabel: 'Explore',
+        supportingText: 'Use the map as a secondary Explore aid for current Finder results. It stays discoverability-focused and does not become a planning cockpit in this slice.',
+        nextAction: 'Inspect a mapped system or return to Finder for the main discovery flow.',
+        statusLabel: 'Secondary Explore surface',
+        statusTone: 'available',
+      };
+    case 'search-tuning':
+      return {
+        title: 'Advanced Search',
+        primaryLabel: 'Explore',
+        supportingText: 'Refine discovery weighting and candidate filters without changing the core Finder or planning logic.',
+        nextAction: 'Run a search, inspect a candidate, then enter Plan from a real system.',
+        statusLabel: 'Explore support tool',
+        statusTone: 'available',
+      };
+    case 'colony-planner':
+      return {
+        title: 'Colony Planner',
+        primaryLabel: 'Plan',
+        supportingText: 'Use the canonical live planning workspace for serious colony planning. Simulation preview remains reusable inventory only and is not wired here.',
+        nextAction: 'Plan from a selected system or return to Explore to choose one safely.',
+        statusLabel: 'Canonical live planner',
+        statusTone: 'canonical',
+      };
+    case 'watchlist':
+      return {
+        title: 'Watchlist',
+        primaryLabel: 'Review',
+        supportingText: 'Review synced saved candidates and bring them back into Explore or Plan when they become actionable.',
+        nextAction: 'Open a watched system to inspect it or compare it against alternatives.',
+        statusLabel: 'Review workspace',
+        statusTone: 'available',
+      };
+    case 'pinned':
+      return {
+        title: 'Pins',
+        primaryLabel: 'Review',
+        supportingText: 'Review the local shortlist kept on this device without changing cloud-synced watchlist state.',
+        nextAction: 'Open a pinned system to inspect it or move it into comparison.',
+        statusLabel: 'Review support tool',
+        statusTone: 'available',
+      };
+    case 'compare':
+      return {
+        title: 'Compare',
+        primaryLabel: 'Review',
+        supportingText: 'Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.',
+        nextAction: 'Inspect a compared system or return to Explore to find a better candidate.',
+        statusLabel: 'Decision review',
+        statusTone: 'available',
+      };
+    case 'fc':
+      return {
+        title: 'FC Planner',
+        primaryLabel: 'Review',
+        supportingText: 'Use fleet-carrier routing as a supporting tool for player logistics without turning it into a primary Explore or Plan workspace.',
+        nextAction: 'Review route support needs, then return to Explore or Plan for system work.',
+        statusLabel: 'Supporting tool',
+        statusTone: 'available',
+      };
+    case 'colony':
+      return {
+        title: 'Colony Tracker',
+        primaryLabel: 'Review',
+        supportingText: 'Track local colony project notes and progress as supporting retained context outside the canonical live planner.',
+        nextAction: 'Review tracked systems, then inspect or plan from the canonical live routes.',
+        statusLabel: 'Supporting tracker',
+        statusTone: 'available',
+      };
+    case 'admin':
+      return {
+        title: 'Admin',
+        primaryLabel: 'Operator',
+        supportingText: 'Admin tools remain separate from normal player navigation and are not promoted into the Explore, Plan, or Review hierarchy.',
+        nextAction: 'Use only when operator/admin access is intentionally required.',
+        statusLabel: 'Operator-only tools',
+        statusTone: 'caution',
+      };
+    case 'operator':
+      return {
+        title: 'Operator Cockpit',
+        primaryLabel: 'Operator',
+        supportingText: 'Read-only operator surfaces remain outside the normal player shell and are not part of the player-facing primary hierarchy.',
+        nextAction: 'Use only for guarded operator review tasks.',
+        statusLabel: 'Operator-only tools',
+        statusTone: 'caution',
+      };
+    case 'colony-planner-prototype':
+      return {
+        title: 'Planner Prototype',
+        primaryLabel: 'Prototype',
+        supportingText: 'The static prototype route remains isolated from the live player shell and does not replace the canonical live planner.',
+        nextAction: 'Return to the canonical live planner for real player workflows.',
+        statusLabel: 'Prototype route',
+        statusTone: 'caution',
+      };
+  }
 }

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -87,6 +87,7 @@ export function NavBar({
     ],
   }), [watchlistCount, pinnedCount, compareCount, fcCount, colonyCount]);
 
+  const operatorMode = current === 'admin' || current === 'operator';
   const currentPrimary = primaryWorkspaceForRoute(current);
   const activeSubnav = currentPrimary ? groupedRoutes[currentPrimary] : [];
   const currentRouteDescriptor = activeSubnav.find((tab) => tab.route === current)
@@ -196,19 +197,7 @@ export function NavBar({
                   />
                 ))}
               </div>
-            ) : (
-              <div className="flex flex-wrap items-center gap-1" data-testid="nav-secondary-operator">
-                {groupedRoutes.operator.map((tab) => (
-                  <Tab
-                    key={tab.route}
-                    label={tab.label}
-                    active={current === tab.route}
-                    onClick={() => handleNavigate(tab.route)}
-                    testid={tab.testid}
-                  />
-                ))}
-              </div>
-            )}
+            ) : null}
           </div>
 
           <div className="min-w-0 flex-1 lg:hidden">
@@ -261,75 +250,83 @@ export function NavBar({
         </div>
 
         <div className="mt-4 border-t border-border/70 pt-4">
-          <div className="hidden lg:flex lg:items-start lg:justify-between lg:gap-4">
-            <WorkspaceContextHeader
-              journeyLabel={`Primary workspace: ${currentWorkspaceMeta.primaryLabel}`}
-              title={currentWorkspaceMeta.title}
-              headingLevel={2}
-              supportingText={currentWorkspaceMeta.supportingText}
-              selectedSystemName={selectedSystem ? (selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system') : null}
-              selectedSystemMeta={selectedSystem ? <span className="tabular-nums">ID64 {selectedSystem.id64}</span> : undefined}
-              status={(
-                <SemanticStatusBadge
-                  label={currentWorkspaceMeta.statusLabel}
-                  tone={currentWorkspaceMeta.statusTone}
+          {operatorMode ? (
+            <>
+              <div className="hidden lg:block">
+                <OperatorModePanel
+                  current={current}
+                  onNavigate={handleNavigate}
+                  title={currentWorkspaceMeta.title}
+                  supportingText={currentWorkspaceMeta.supportingText}
+                  contextTestId="operator-mode-context-desktop"
+                  returnTestId="nav-return-to-player-desktop"
                 />
-              )}
-              facts={[{ label: 'Next action', value: currentWorkspaceMeta.nextAction, tone: 'orange' }]}
-              testId="product-shell-context"
-            />
-            <div
-              className="flex min-w-[220px] flex-col gap-2 rounded-chunk-lg border border-border bg-bg3/30 p-3"
-              data-testid="nav-operator-tools"
-            >
-              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-                Operator tools
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {groupedRoutes.operator.map((tab) => (
-                  <Tab
-                    key={tab.route}
-                    label={tab.label}
-                    active={current === tab.route}
-                    onClick={() => handleNavigate(tab.route)}
-                    testid={tab.testid}
-                    compact
-                  />
-                ))}
               </div>
-            </div>
-          </div>
+              <div className="space-y-3 lg:hidden" data-testid="operator-mode-context-mobile">
+                <OperatorModePanel
+                  current={current}
+                  onNavigate={handleNavigate}
+                  title={currentWorkspaceMeta.title}
+                  supportingText={currentWorkspaceMeta.supportingText}
+                  contextTestId="operator-mode-context-mobile-panel"
+                  returnTestId="nav-return-to-player-mobile"
+                  mobile
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="hidden lg:block">
+                <WorkspaceContextHeader
+                  journeyLabel={`Primary workspace: ${currentWorkspaceMeta.primaryLabel}`}
+                  title={currentWorkspaceMeta.title}
+                  headingLevel={2}
+                  supportingText={currentWorkspaceMeta.supportingText}
+                  selectedSystemName={selectedSystem ? (selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system') : null}
+                  selectedSystemMeta={selectedSystem ? <span className="tabular-nums">ID64 {selectedSystem.id64}</span> : undefined}
+                  status={(
+                    <SemanticStatusBadge
+                      label={currentWorkspaceMeta.statusLabel}
+                      tone={currentWorkspaceMeta.statusTone}
+                    />
+                  )}
+                  facts={[{ label: 'Next action', value: currentWorkspaceMeta.nextAction, tone: 'orange' }]}
+                  testId="product-shell-context"
+                />
+              </div>
 
-          <div className="space-y-3 lg:hidden" data-testid="product-shell-context-mobile">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-                Primary workspace
-              </span>
-              <SemanticStatusBadge
-                label={`${currentWorkspaceMeta.primaryLabel} · ${currentWorkspaceMeta.title}`}
-                tone={currentWorkspaceMeta.statusTone}
-              />
-            </div>
-            <p className="text-sm leading-relaxed text-silver">
-              {currentWorkspaceMeta.supportingText}
-            </p>
-            <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-orange">
-              Next action: {currentWorkspaceMeta.nextAction}
-            </p>
-            {selectedSystem ? (
-              <div className="rounded-chunk-lg border border-border bg-bg3/30 p-3">
-                <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-                  Selected system
+              <div className="space-y-3 lg:hidden" data-testid="product-shell-context-mobile">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+                    Primary workspace
+                  </span>
+                  <SemanticStatusBadge
+                    label={`${currentWorkspaceMeta.primaryLabel} · ${currentWorkspaceMeta.title}`}
+                    tone={currentWorkspaceMeta.statusTone}
+                  />
+                </div>
+                <p className="text-sm leading-relaxed text-silver">
+                  {currentWorkspaceMeta.supportingText}
                 </p>
-                <p className="mt-1 text-sm font-semibold text-text">
-                  {selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system'}
+                <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-orange">
+                  Next action: {currentWorkspaceMeta.nextAction}
                 </p>
-                <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
-                  ID64 {selectedSystem.id64}
-                </p>
+                {selectedSystem ? (
+                  <div className="rounded-chunk-lg border border-border bg-bg3/30 p-3">
+                    <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+                      Selected system
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-text">
+                      {selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system'}
+                    </p>
+                    <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+                      ID64 {selectedSystem.id64}
+                    </p>
+                  </div>
+                ) : null}
               </div>
-            ) : null}
-          </div>
+            </>
+          )}
         </div>
       </div>
 
@@ -358,12 +355,12 @@ export function NavBar({
               current={current}
               onNavigate={handleNavigate}
             />
-            <MenuSection
-              title="Operator tools"
-              routes={groupedRoutes.operator}
-              current={current}
-              onNavigate={handleNavigate}
-            />
+            {operatorMode ? (
+              <OperatorModeMenu
+                current={current}
+                onNavigate={handleNavigate}
+              />
+            ) : null}
           </div>
         </div>
       )}
@@ -503,6 +500,110 @@ function MenuSection({
             compact
           />
         ))}
+      </div>
+    </section>
+  );
+}
+
+function OperatorModePanel({
+  current,
+  onNavigate,
+  title,
+  supportingText,
+  contextTestId,
+  returnTestId,
+  mobile = false,
+}: {
+  current: Route;
+  onNavigate: (route: Route) => void;
+  title: string;
+  supportingText: string;
+  contextTestId: string;
+  returnTestId: string;
+  mobile?: boolean;
+}) {
+  return (
+    <div
+      className="rounded-chunk-lg border border-gold/40 bg-gold/10 p-4"
+      data-testid="operator-mode-panel"
+    >
+      <WorkspaceContextHeader
+        journeyLabel="Separate mode: Operator"
+        title={title}
+        headingLevel={2}
+        supportingText={`${supportingText} This route sits outside the normal Explore, Plan, and Review player journey.`}
+        status={<SemanticStatusBadge label="Separate operator mode" tone="caution" />}
+        facts={[
+          { label: 'Player shell', value: 'Explore / Plan / Review', tone: 'gold' },
+          { label: 'Next action', value: 'Return to Finder when operator work is complete.', tone: 'orange' },
+        ]}
+        actions={(
+          <>
+            <button
+              type="button"
+              onClick={() => onNavigate('finder')}
+              data-testid={returnTestId}
+              className="rounded-chunk-sm border border-orange/55 bg-orange/15 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] text-orange transition-colors hover:border-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80"
+            >
+              Return to player workspace
+            </button>
+            <Tab
+              label="Admin"
+              active={current === 'admin'}
+              onClick={() => onNavigate('admin')}
+              testid={mobile ? 'nav-admin-mobile-operator-mode' : 'nav-admin-operator-mode'}
+            />
+            <Tab
+              label="Operator"
+              active={current === 'operator'}
+              onClick={() => onNavigate('operator')}
+              testid={mobile ? 'nav-operator-mobile-operator-mode' : 'nav-operator-operator-mode'}
+            />
+          </>
+        )}
+        testId={contextTestId}
+      />
+    </div>
+  );
+}
+
+function OperatorModeMenu({
+  current,
+  onNavigate,
+}: {
+  current: Route;
+  onNavigate: (route: Route) => void;
+}) {
+  return (
+    <section data-testid="operator-mode-menu">
+      <p className="mb-2 px-1 font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+        Operator mode
+      </p>
+      <p className="mb-3 px-1 text-xs leading-relaxed text-silver">
+        Separate from the normal Explore, Plan, and Review player journey.
+      </p>
+      <div className="grid gap-1">
+        <Tab
+          label="Return to player workspace"
+          active={false}
+          onClick={() => onNavigate('finder')}
+          testid="nav-return-to-player-menu"
+          compact
+        />
+        <Tab
+          label="Admin"
+          active={current === 'admin'}
+          onClick={() => onNavigate('admin')}
+          testid="nav-admin-operator-menu"
+          compact
+        />
+        <Tab
+          label="Operator"
+          active={current === 'operator'}
+          onClick={() => onNavigate('operator')}
+          testid="nav-operator-operator-menu"
+          compact
+        />
       </div>
     </section>
   );

--- a/tests/test_stage25_current_state_map_product_visual_baseline.py
+++ b/tests/test_stage25_current_state_map_product_visual_baseline.py
@@ -99,6 +99,6 @@ def test_stage25_docs_preserve_closed_and_deferred_boundaries():
     # baseline still records the original pre-reset deferral wording.
     assert 'Stage 25A is complete.' in combined
     assert 'Stage 25B is complete and merged.' in combined
-    assert 'Stage 25C is prepared but not started.' in combined
+    assert 'Stage 25C Slice 1 is in progress and pending review.' in combined
     assert 'Stage 25D, Stage 25E, Stage 25F, Stage 25G, and Stage 25H are unstarted.' in combined
     assert 'Stage 25B through Stage 25E remain unstarted and unimplemented.' in combined

--- a/tests/test_stage25_product_shell_roadmap_reset.py
+++ b/tests/test_stage25_product_shell_roadmap_reset.py
@@ -32,7 +32,7 @@ def test_stage25_reset_records_corrected_stage_statuses():
 
     assert 'Stage 25A is complete.' in roadmap
     assert 'Stage 25B is complete and merged.' in roadmap
-    assert 'Stage 25C is prepared but not started.' in roadmap
+    assert 'Stage 25C Slice 1 is in progress and pending review.' in roadmap
     assert 'Stage 25D, Stage 25E, Stage 25F, Stage 25G, and Stage 25H are unstarted.' in roadmap
 
 
@@ -133,13 +133,13 @@ def test_stage25_reset_does_not_authorize_runtime_by_defining_contract():
     roadmap = _squash(_read(ROADMAP_PATH))
     contract = _squash(_read(CONTRACT_PATH))
 
-    assert 'Defining that contract does not authorize runtime implementation.' in roadmap
+    assert 'The full Stage 25C implementation contract lives in' in roadmap
     assert (
         'defining the Stage 25C contract does not by itself authorize runtime implementation.'
         in roadmap
     )
-    assert 'Stage 25C is `prepared_not_started`.' in contract
-    assert 'Defining this contract does not authorize any runtime implementation.' in contract
+    assert 'Stage 25C is `slice_1_in_progress_pending_review`.' in contract
+    assert 'Defining this contract did not authorize any runtime implementation by itself.' in contract
     assert 'runtime UI implementation merely by defining this contract.' in contract
 
 


### PR DESCRIPTION
## Stage 25C Slice 1 Scope
- implement the first runtime Stage 25C slice only: product shell, navigation hierarchy, shell-level selected-system context scaffolding, and restrained workspace framing
- establish the player-facing `Explore / Plan / Review` hierarchy without removing existing working routes
- keep `System Detail` contextual, keep `Colony Planner` canonical live, keep `simulation-preview` unwired, and keep the map secondary Explore only

## Implemented Hierarchy
- `Explore`: `Finder`, `Map`, `Advanced Search Tuning`
- `Plan`: canonical live `Colony Planner`
- `Review`: `Watchlist`, `Pins`, `Compare`, `FC Planner`, `Colony Tracker`
- `Admin` and `Operator` remain outside normal player-facing primary navigation

## Route Compatibility
- existing hash routes remain intact
- primary workspace buttons navigate to existing live routes rather than introducing new compatibility-breaking route names
- direct entries like `#finder`, `#map`, `#search-tuning`, `#watchlist`, `#compare`, and `#colony-planner/system/{id64}` continue to work
- `System Detail` remains a contextual modal inspect surface and still hands off into `Colony Planner`

## Context And Visual Foundation
- added shell-level workspace framing so the active workspace is legible
- added trustworthy selected-system shell context only when the current route provides an existing source of truth
- cleared shell context when leaving inspect/plan routes so stale system identity does not linger
- strengthened hierarchy using existing Stage 25B primitives and tokens; dense evidence/planner/map content was not converted into glass/translucent surfaces

## Intentionally Not Implemented
- no Stage 25D+ work
- no simulation-preview wiring
- no map redesign, renderer replacement, or map feature expansion
- no planner logic, planner economics, evidence semantics, routing model, persistence, or backend changes
- no facility browser, mission intelligence, mining/ring planning, accounts, OAuth, collaboration, or cloud-sync redesign

## Validation
- `PYTHONDONTWRITEBYTECODE=1 ./.venv/bin/python -B scripts/dev/resolve_project_state.py --strict` -> passed
- `PYTHONDONTWRITEBYTECODE=1 ./.venv/bin/python -B -m pytest tests/test_stage25_current_state_map_product_visual_baseline.py tests/test_stage25_product_shell_roadmap_reset.py tests/test_stage25b_evidence_language_visual_primitives.py -p no:cacheprovider` -> passed (`23 passed`)
- `cd frontend-v2 && yarn test:map` -> passed (`61 passed`)
- `cd frontend-v2 && yarn vitest run src/App.test.tsx src/components/NavBar.test.tsx src/hooks/useHashRoute.test.ts src/features/system-detail/SystemDetailModal.test.tsx src/features/colony-planner/ColonyPlannerWorkspace.test.tsx src/features/watchlist/WatchlistTab.test.tsx src/features/pinned/PinnedTab.test.tsx src/features/compare/CompareTab.test.tsx src/components/WorkspaceContextHeader.test.tsx` -> passed (`75 passed`)
- `cd frontend-v2 && yarn typecheck` -> passed
- `cd frontend-v2 && yarn build` -> passed
- `./node_modules/.bin/eslint src/App.tsx src/App.test.tsx src/components/NavBar.tsx src/components/NavBar.test.tsx --max-warnings 10` -> passed
- `git diff --check` -> clean

## Additional Validation
- Firefox product walkthrough: passed using the Playwright-managed Firefox runtime.
- Isolated Review Lab full verification: passed after the merged mobile Planner contract correction in PR #263.

## Boundaries Confirmed
- no Stage 19 execution
- no DB commands or writes
- no canonical apply
- no rebaseline
- no scheduler/service/timer enablement
- no source acquisition
- no renderer replacement
- no map redesign
- no operator runtime expansion beyond keeping existing operator routes separate from player navigation

