### PR TITLE
Implement My Work workspace and planner resume flow

### DIFF
--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -1,6 +1,18 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
+import { useColonyProjectStore } from '@/features/colony-planner/colonyProjectStore';
+import { useMyWorkStore } from '@/features/my-work/myWorkStore';
+
+const {
+  mockWatchlistAdd,
+  mockWatchlistRemove,
+  mockWatchlistHas,
+} = vi.hoisted(() => ({
+  mockWatchlistAdd: vi.fn(),
+  mockWatchlistRemove: vi.fn(),
+  mockWatchlistHas: vi.fn(() => false),
+}));
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -32,9 +44,9 @@ vi.mock('@/features/watchlist/useWatchlist', () => ({
     loading: false,
     error: null,
     refresh: vi.fn(),
-    add: vi.fn(),
-    remove: vi.fn(),
-    has: vi.fn(() => false),
+    add: mockWatchlistAdd,
+    remove: mockWatchlistRemove,
+    has: mockWatchlistHas,
   }),
 }));
 
@@ -103,15 +115,76 @@ vi.mock('@/features/eddn/EddnTicker', () => ({
 vi.mock('@/features/system-detail/SystemDetailModal', () => ({
   SystemDetailModal: ({
     id64,
-    onOpenColonyPlanner,
+    onToggleSaveForLater,
+    onStartPlan,
   }: {
     id64: number;
-    onOpenColonyPlanner?: (id64: number) => void;
+    onToggleSaveForLater?: (system: {
+      id64: number;
+      name: string;
+      x: number;
+      y: number;
+      z: number;
+      population: number | null;
+      is_colonised: boolean;
+      score: number | null;
+      primary_economy: string | null;
+      economy_suggestion: string | null;
+    }) => void;
+    onStartPlan?: (system: {
+      id64: number;
+      name: string;
+      x: number;
+      y: number;
+      z: number;
+      population: number | null;
+      is_colonised: boolean;
+      score: number | null;
+      primary_economy: string | null;
+      economy_suggestion: string | null;
+    }, planStart: {
+      objective: 'materials_coverage';
+      startApproach: 'manual';
+    }) => void;
   }) => (
     <div data-testid="system-detail-modal">
       System detail {id64}
-      <button type="button" onClick={() => onOpenColonyPlanner?.(id64)}>
-        Open Colony Planner
+      <button
+        type="button"
+        onClick={() => onToggleSaveForLater?.({
+          id64,
+          name: `System ${id64}`,
+          x: 1,
+          y: 2,
+          z: 3,
+          population: 0,
+          is_colonised: false,
+          score: 77,
+          primary_economy: 'Agriculture',
+          economy_suggestion: 'Refinery',
+        })}
+      >
+        Save for later
+      </button>
+      <button
+        type="button"
+        onClick={() => onStartPlan?.({
+          id64,
+          name: `System ${id64}`,
+          x: 1,
+          y: 2,
+          z: 3,
+          population: 0,
+          is_colonised: false,
+          score: 77,
+          primary_economy: 'Agriculture',
+          economy_suggestion: 'Refinery',
+        }, {
+          objective: 'materials_coverage',
+          startApproach: 'manual',
+        })}
+      >
+        Create manual draft
       </button>
     </div>
   ),
@@ -129,15 +202,17 @@ vi.mock('@/features/system-detail/useSystemDetail', () => ({
 vi.mock('@/features/colony-planner/ColonyPlannerWorkspace', () => ({
   ColonyPlannerWorkspace: ({
     id64,
+    projectId,
     onBackToFinder,
     onOpenSystemDetail,
   }: {
     id64: number | null;
+    projectId?: string | null;
     onBackToFinder: () => void;
     onOpenSystemDetail: (id64: number) => void;
   }) => (
     <div data-testid="colony-planner-workspace">
-      Colony Planner workspace {id64 ?? 'none'}
+      Colony Planner workspace {id64 ?? 'none'} / {projectId ?? 'no-project'}
       <button type="button" onClick={onBackToFinder}>Back to Finder</button>
       <button type="button" onClick={() => id64 != null && onOpenSystemDetail(id64)}>Open full system detail</button>
     </div>
@@ -146,8 +221,15 @@ vi.mock('@/features/colony-planner/ColonyPlannerWorkspace', () => ({
 
 afterEach(() => {
   window.location.hash = '';
+  localStorage.clear();
+  useColonyProjectStore.setState({ projects: {} });
+  useMyWorkStore.setState({ systems: {} });
   document.documentElement.style.removeProperty('--coalsack-bg-2560');
   document.documentElement.style.removeProperty('--coalsack-bg-1600');
+  mockWatchlistAdd.mockReset();
+  mockWatchlistRemove.mockReset();
+  mockWatchlistHas.mockReset();
+  mockWatchlistHas.mockReturnValue(false);
   vi.unstubAllGlobals();
 });
 
@@ -271,12 +353,61 @@ describe('App Colony Planner workspace route', () => {
       expect(screen.getByTestId('system-detail-modal').textContent).toContain('123');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Open Colony Planner/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Create manual draft/i }));
 
     await waitFor(() => {
-      expect(window.location.hash).toBe('#colony-planner/system/123');
+      expect(window.location.hash).toMatch(/^#colony-planner\/system\/123\/project\//);
     });
     expect(screen.getByTestId('colony-planner-workspace').textContent).toContain('123');
+    const projects = Object.values(useColonyProjectStore.getState().projects);
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toEqual(expect.objectContaining({
+      system_id64: 123,
+      project_name: 'System 123 - Materials coverage',
+      objective: 'materials_coverage',
+      start_approach: 'manual',
+      created_from: 'system_detail',
+      status: 'draft',
+    }));
+    expect(screen.getByTestId('colony-planner-workspace').textContent).toContain(projects[0].id);
+  });
+
+  it('renders My Work as the player-facing Plan destination and keeps Watchlist as a safe compatibility route', async () => {
+    window.location.hash = '#watchlist';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('my-work-workspace')).toBeTruthy();
+    });
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('My Work');
+    expect(screen.getByTestId('my-work-workspace').textContent).toContain('Watchlist now opens the Saved Systems view inside My Work');
+  });
+
+  it('saves a system for later without creating a draft', async () => {
+    window.location.hash = '#finder/system/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('system-detail-modal')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Save for later/i }));
+
+    await waitFor(() => {
+      expect(mockWatchlistAdd).toHaveBeenCalledTimes(1);
+    });
+    expect(mockWatchlistAdd).toHaveBeenCalledWith(123, expect.objectContaining({
+      name: 'System 123',
+      x: 1,
+      y: 2,
+      z: 3,
+      population: 0,
+      is_colonised: false,
+      score: 77,
+    }));
+    expect(Object.values(useColonyProjectStore.getState().projects)).toHaveLength(0);
   });
 
   it('renders the player-facing Explore / Plan / Review shell without persistent operator tools', async () => {
@@ -323,7 +454,7 @@ describe('App Colony Planner workspace route', () => {
     });
     expect(screen.getByTestId('product-shell-context').textContent).toContain('ID64 123');
 
-    window.location.hash = '#watchlist';
+    window.location.hash = '#my-work';
     fireEvent(window, new HashChangeEvent('hashchange'));
 
     await waitFor(() => {

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '@/lib/queryClient';
@@ -8,9 +8,8 @@ import { NavBar } from '@/components/NavBar';
 import { SearchForm } from '@/features/search/SearchForm';
 import { useSearch } from '@/features/search/useSearch';
 import { useWatchlist } from '@/features/watchlist/useWatchlist';
-import { WatchlistTab } from '@/features/watchlist/WatchlistTab';
 import { usePinned } from '@/features/pinned/usePinned';
-import { PinnedTab, toPinnedEntry } from '@/features/pinned/PinnedTab';
+import { toPinnedEntry } from '@/features/pinned/PinnedTab';
 import { useCompare } from '@/features/compare/useCompare';
 import { CompareTab } from '@/features/compare/CompareTab';
 import { useSearchTuning } from '@/features/search-tuning/useSearchTuning';
@@ -27,6 +26,14 @@ import { SystemDetailModal } from '@/features/system-detail/SystemDetailModal';
 import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { ColonyPlannerWorkspace } from '@/features/colony-planner/ColonyPlannerWorkspace';
 import { RavenStylePlannerPrototype } from '@/features/colony-planner/prototype/RavenStylePlannerPrototype';
+import { useColonyProjectStore } from '@/features/colony-planner/colonyProjectStore';
+import {
+  defaultDraftProjectName,
+  type ColonyProjectObjective,
+  type ColonyProjectStartApproach,
+} from '@/features/colony-planner/plannerDraftContext';
+import { archetypeFromEconomy } from '@/features/system-detail/simulation-preview/utils/placementHelpers';
+import { MyWorkWorkspace } from '@/features/my-work/MyWorkWorkspace';
 import { EddnTicker } from '@/features/eddn/EddnTicker';
 import { useHashRoute, type HashRoute } from '@/hooks/useHashRoute';
 import './index.css';
@@ -135,7 +142,7 @@ function PrototypeAppShell({ navigate }: { navigate: HashRoute['navigate'] }) {
 }
 
 function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
-  const { route, selectedSystemId, plannerSystemId, navigate, openSystem, openColonyPlanner, closeSystem } = hashRoute;
+  const { route, selectedSystemId, plannerSystemId, plannerProjectId, navigate, openSystem, openColonyPlanner, closeSystem } = hashRoute;
   const search    = useSearch();
   const watchlist = useWatchlist();
   const pinned    = usePinned();
@@ -144,6 +151,7 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
   const colony    = useColony();
   const fc        = useFcPlanner();
   const admin     = useAdmin();
+  const saveProject = useColonyProjectStore((state) => state.saveProject);
   const [health, setHealth] = useState<string>('Checking API');
   const [detailFocus, setDetailFocus] = useState<'colony-planner' | null>(null);
   const shellSystemId = plannerSystemId ?? selectedSystemId;
@@ -165,6 +173,57 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
     setDetailFocus(null);
     closeSystem();
   };
+
+  const toggleSavedSystem = useCallback(async (
+    id64: number,
+    hint: {
+      name?: string | null;
+      x?: number | null;
+      y?: number | null;
+      z?: number | null;
+      population?: number | null;
+      is_colonised?: boolean;
+      score?: number | null;
+    },
+  ) => {
+    if (watchlist.has(id64)) {
+      await watchlist.remove(id64);
+      return;
+    }
+    await watchlist.add(id64, {
+      name: hint.name ?? `System ${id64}`,
+      x: hint.x ?? null,
+      y: hint.y ?? null,
+      z: hint.z ?? null,
+      population: hint.population ?? null,
+      is_colonised: hint.is_colonised ?? false,
+      score: hint.score ?? null,
+    });
+  }, [watchlist]);
+
+  const startPlanFromSystemDetail = useCallback((
+    system: import('@/types/api').SystemDetail,
+    planStart: {
+      objective: ColonyProjectObjective;
+      startApproach: ColonyProjectStartApproach;
+    },
+  ) => {
+    const targetArchetype = archetypeFromEconomy(system.economy_suggestion ?? system.primary_economy) ?? 'refinery_industrial';
+    const saved = saveProject(null, {
+      system_id64: system.id64,
+      system_name: system.name || 'Unknown system',
+      project_name: defaultDraftProjectName(system.name || 'Unknown system', planStart.objective),
+      build_plan_placements: [],
+      target_archetype: targetArchetype,
+      notes: '',
+      status: 'draft',
+      objective: planStart.objective,
+      start_approach: planStart.startApproach,
+      created_from: 'system_detail',
+    });
+    setDetailFocus(null);
+    openColonyPlanner(system.id64, { projectId: saved.id });
+  }, [openColonyPlanner, saveProject]);
 
   // First-paint: health + default search.
   useEffect(() => {
@@ -210,27 +269,17 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
           compare={compare}
           onShowOnMap={() => navigate('map')}
           onOpenDetail={openSystemDetail}
-          onOpenColonyPlanner={openColonyPlannerWorkspace}
         />
       )}
 
-      {route === 'watchlist' && (
-        <WatchlistTab
-          entries={watchlist.entries}
-          loading={watchlist.loading}
-          error={watchlist.error}
-          onRefresh={watchlist.refresh}
-          onRemove={watchlist.remove}
-          onShowOnMap={() => navigate('map')}
-          onOpenDetail={openSystemDetail}
-        />
-      )}
-
-      {route === 'pinned' && (
-        <PinnedTab
+      {(route === 'my-work' || route === 'watchlist' || route === 'pinned') && (
+        <MyWorkWorkspace
+          initialSection="saved-systems"
+          routeSource={route === 'my-work' ? 'my-work' : route}
+          watchlist={watchlist}
           pinned={pinned}
-          onShowOnMap={() => navigate('map')}
           onOpenDetail={openSystemDetail}
+          onOpenPlanner={openColonyPlanner}
         />
       )}
 
@@ -253,6 +302,7 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
       {route === 'colony-planner' && (
         <ColonyPlannerWorkspace
           id64={plannerSystemId}
+          projectId={plannerProjectId}
           onBackToFinder={() => navigate('finder')}
           onOpenSystemDetail={openSystemDetail}
         />
@@ -294,40 +344,21 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
           id64={selectedSystemId}
           focusIntent={detailFocus}
           onClose={closeSystemDetail}
-          onOpenColonyPlanner={openColonyPlannerWorkspace}
+          savedForLater={shellSystem.data ? watchlist.has(shellSystem.data.id64) : false}
+          onToggleSaveForLater={(system) => {
+            void toggleSavedSystem(system.id64, {
+              name: system.name,
+              x: system.x,
+              y: system.y,
+              z: system.z,
+              population: system.population ?? null,
+              is_colonised: !!system.is_colonised,
+              score: system.score ?? null,
+            });
+          }}
+          onStartPlan={startPlanFromSystemDetail}
           renderActions={(sys) => (
             <>
-              <button
-                type="button"
-                disabled={!sys}
-                onClick={() => {
-                  if (!sys) return;
-                  if (watchlist.has(sys.id64)) {
-                    void watchlist.remove(sys.id64);
-                  } else {
-                    void watchlist.add(sys.id64, {
-                      name:         sys.name,
-                      x:            sys.x,
-                      y:            sys.y,
-                      z:            sys.z,
-                      population:   sys.population ?? null,
-                      is_colonised: !!sys.is_colonised,
-                      score:        sys.score ?? null,
-                    });
-                  }
-                }}
-                data-testid="modal-watchlist-toggle"
-                className={[
-                  'px-2 py-1 rounded font-mono text-[11px] border transition-colors',
-                  sys && watchlist.has(sys.id64)
-                    ? 'bg-orange/20 border-orange text-orange'
-                    : 'bg-bg4 border-border text-text-dim hover:text-orange hover:border-orange-dk',
-                  !sys && 'opacity-40 cursor-not-allowed',
-                ].filter(Boolean).join(' ')}
-              >
-                {sys && watchlist.has(sys.id64) ? '★ Saved — remove' : '☆ Save to Watchlist'}
-              </button>
-
               <button
                 type="button"
                 disabled={!sys}
@@ -436,7 +467,7 @@ function toCompareSnapshot(sys: import('@/types/api').SystemDetail): import('@/t
 // ─────────────────────────────────────────────────────────────────────────
 
 function FinderView({
-  search, watchlist, pinned, compare, onShowOnMap, onOpenDetail, onOpenColonyPlanner,
+  search, watchlist, pinned, compare, onShowOnMap, onOpenDetail,
 }: {
   search:    ReturnType<typeof useSearch>;
   watchlist: ReturnType<typeof useWatchlist>;
@@ -444,7 +475,6 @@ function FinderView({
   compare:   ReturnType<typeof useCompare>;
   onShowOnMap:  () => void;
   onOpenDetail: (id64: number, options?: { focus?: 'colony-planner' }) => void;
-  onOpenColonyPlanner: (id64: number) => void;
 }) {
   const { filters, setFilters, reset, run, state, results } = search;
 
@@ -506,20 +536,26 @@ function FinderView({
                       index={i}
                       isPinned={pinned.has(sys.id64)}
                       isCompared={compare.has(sys.id64)}
-                      onWatch={(id) => void watchlist.add(id, {
-                        name:       sys.name,
-                        x:          sys.coords?.x ?? null,
-                        y:          sys.coords?.y ?? null,
-                        z:          sys.coords?.z ?? null,
-                        population: sys.population ?? null,
-                        is_colonised: !!sys.is_colonised,
-                        score:      sys._rating?.score ?? null,
-                      })}
+                      isSavedForLater={watchlist.has(sys.id64)}
+                      onToggleSavedForLater={(id) => {
+                        if (watchlist.has(id)) {
+                          void watchlist.remove(id);
+                          return;
+                        }
+                        void watchlist.add(id, {
+                          name:       sys.name,
+                          x:          sys.coords?.x ?? null,
+                          y:          sys.coords?.y ?? null,
+                          z:          sys.coords?.z ?? null,
+                          population: sys.population ?? null,
+                          is_colonised: !!sys.is_colonised,
+                          score:      sys._rating?.score ?? null,
+                        });
+                      }}
                       onShowOnMap={onShowOnMap}
                       onPin={() => pinned.toggle(toPinnedEntry(sys))}
                       onCompare={() => compare.toggle(sys)}
                       onOpenDetail={onOpenDetail}
-                      onOpenColonyPlanner={onOpenColonyPlanner}
                     />
                   </li>
                 ))}

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -4,26 +4,31 @@ import { NavBar } from './NavBar';
 
 describe('NavBar', () => {
   it('exposes Explore / Plan / Review as the only normal player workspaces', () => {
-    render(<NavBar current="watchlist" onNavigate={vi.fn()} health="Online" watchlistCount={2} />);
+    render(<NavBar current="my-work" onNavigate={vi.fn()} health="Online" watchlistCount={2} />);
 
     expect(screen.getByTestId('nav-primary-explore').textContent).toContain('Explore');
     expect(screen.getByTestId('nav-primary-plan').textContent).toContain('Plan');
     expect(screen.getByTestId('nav-primary-review').textContent).toContain('Review');
-    expect(screen.getByTestId('nav-primary-review').getAttribute('aria-current')).toBe('page');
+    expect(screen.getByTestId('nav-primary-plan').getAttribute('aria-current')).toBe('page');
     expect(screen.queryByTestId('nav-operator-tools')).toBeNull();
     expect(screen.queryByTestId('nav-admin')).toBeNull();
     expect(screen.queryByTestId('nav-operator')).toBeNull();
   });
 
   it('renders route-specific secondary navigation within the active primary workspace', () => {
-    const { rerender } = render(<NavBar current="search-tuning" onNavigate={vi.fn()} health="Online" />);
+    const { rerender } = render(<NavBar current="my-work" onNavigate={vi.fn()} health="Online" />);
 
+    expect(screen.getByTestId('nav-my-work').textContent).toContain('My Work');
+    expect(screen.queryByTestId('nav-watchlist')).toBeNull();
+    expect(screen.queryByTestId('nav-pinned')).toBeNull();
+
+    rerender(<NavBar current="search-tuning" onNavigate={vi.fn()} health="Online" />);
     expect(screen.getByTestId('nav-search-tuning').textContent).toContain('Advanced Search Tuning');
-    expect(screen.queryByTestId('nav-fc')).toBeNull();
+    expect(screen.queryByTestId('nav-my-work')).toBeNull();
 
     rerender(<NavBar current="compare" onNavigate={vi.fn()} health="Online" compareCount={2} colonyCount={1} fcCount={1} />);
     expect(screen.getByTestId('nav-fc').textContent).toContain('FC Planner');
-    expect(screen.getByTestId('nav-colony').textContent).toContain('Colony Tracker');
+    expect(screen.queryByTestId('nav-colony')).toBeNull();
   });
 
   it('shows selected-system context only when provided and keeps primary navigation keyboard focusable', () => {

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -46,13 +46,13 @@ interface WorkspaceMeta {
 
 const PRIMARY_DEFAULT_ROUTE: Record<PrimaryWorkspace, Route> = {
   explore: 'finder',
-  plan: 'colony-planner',
-  review: 'watchlist',
+  plan: 'my-work',
+  review: 'compare',
 };
 
 export function NavBar({
   current, onNavigate,
-  watchlistCount, pinnedCount, compareCount, colonyCount, fcCount,
+  compareCount, fcCount,
   health,
   fullWidth = false,
   selectedSystem = null,
@@ -72,20 +72,18 @@ export function NavBar({
       { route: 'search-tuning' as const, label: 'Advanced Search Tuning', shortLabel: 'Advanced', testid: 'nav-search-tuning' },
     ],
     plan: [
+      { route: 'my-work' as const, label: 'My Work', shortLabel: 'My Work', testid: 'nav-my-work' },
       { route: 'colony-planner' as const, label: 'Colony Planner', shortLabel: 'Plan', testid: 'nav-colony-planner' },
     ],
     review: [
-      { route: 'watchlist' as const, label: 'Watchlist', testid: 'nav-watchlist', badge: watchlistCount ?? undefined, title: 'Synced saved candidates' },
-      { route: 'pinned' as const, label: 'Pins', testid: 'nav-pinned', badge: pinnedCount, title: 'Device-local shortlist' },
       { route: 'compare' as const, label: 'Compare', testid: 'nav-compare', badge: compareCount },
       { route: 'fc' as const, label: 'FC Planner', testid: 'nav-fc', badge: fcCount },
-      { route: 'colony' as const, label: 'Colony Tracker', testid: 'nav-colony', badge: colonyCount },
     ],
     operator: [
       { route: 'admin' as const, label: 'Admin', testid: 'nav-admin' },
       { route: 'operator' as const, label: 'Operator', testid: 'nav-operator' },
     ],
-  }), [watchlistCount, pinnedCount, compareCount, fcCount, colonyCount]);
+  }), [compareCount, fcCount]);
 
   const operatorMode = current === 'admin' || current === 'operator';
   const currentPrimary = primaryWorkspaceForRoute(current);
@@ -611,8 +609,8 @@ function OperatorModeMenu({
 
 function primaryWorkspaceForRoute(route: Route): PrimaryWorkspace | null {
   if (route === 'finder' || route === 'map' || route === 'search-tuning') return 'explore';
-  if (route === 'colony-planner') return 'plan';
-  if (route === 'watchlist' || route === 'pinned' || route === 'compare' || route === 'fc' || route === 'colony') return 'review';
+  if (route === 'my-work' || route === 'watchlist' || route === 'pinned' || route === 'colony' || route === 'colony-planner') return 'plan';
+  if (route === 'compare' || route === 'fc') return 'review';
   return null;
 }
 
@@ -654,22 +652,31 @@ function workspaceMetaForRoute(route: Route): WorkspaceMeta {
         statusLabel: 'Canonical live planner',
         statusTone: 'canonical',
       };
+    case 'my-work':
+      return {
+        title: 'My Work',
+        primaryLabel: 'Plan',
+        supportingText: 'Return to saved systems, local plans, and established colony work without splitting that context between Watchlist, Pins, and the planner.',
+        nextAction: 'Resume a saved system, continue a plan, or review established colony work.',
+        statusLabel: 'Player planning home',
+        statusTone: 'available',
+      };
     case 'watchlist':
       return {
-        title: 'Watchlist',
-        primaryLabel: 'Review',
-        supportingText: 'Review synced saved candidates and bring them back into Explore or Plan when they become actionable.',
-        nextAction: 'Open a watched system to inspect it or compare it against alternatives.',
-        statusLabel: 'Review workspace',
+        title: 'My Work',
+        primaryLabel: 'Plan',
+        supportingText: 'Watchlist now feeds the Saved Systems view in My Work so synced saved candidates sit beside local planning context.',
+        nextAction: 'Inspect a saved system or start planning from a deliberate hand-off.',
+        statusLabel: 'Player planning home',
         statusTone: 'available',
       };
     case 'pinned':
       return {
-        title: 'Pins',
-        primaryLabel: 'Review',
-        supportingText: 'Review the local shortlist kept on this device without changing cloud-synced watchlist state.',
-        nextAction: 'Open a pinned system to inspect it or move it into comparison.',
-        statusLabel: 'Review support tool',
+        title: 'My Work',
+        primaryLabel: 'Plan',
+        supportingText: 'Pins now feed the Saved Systems view in My Work so local shortlist context stays beside saved systems and plans.',
+        nextAction: 'Inspect a saved system or continue from active planning work.',
+        statusLabel: 'Player planning home',
         statusTone: 'available',
       };
     case 'compare':
@@ -693,9 +700,9 @@ function workspaceMetaForRoute(route: Route): WorkspaceMeta {
     case 'colony':
       return {
         title: 'Colony Tracker',
-        primaryLabel: 'Review',
-        supportingText: 'Track local colony project notes and progress as supporting retained context outside the canonical live planner.',
-        nextAction: 'Review tracked systems, then inspect or plan from the canonical live routes.',
+        primaryLabel: 'Plan',
+        supportingText: 'Legacy colony tracking remains available by route while My Work becomes the calm player-facing home for saved systems, plans, and colonies.',
+        nextAction: 'Use My Work for the current player flow, or inspect tracked systems directly.',
         statusLabel: 'Supporting tracker',
         statusTone: 'available',
       };

--- a/frontend-v2/src/components/ResultCard.test.tsx
+++ b/frontend-v2/src/components/ResultCard.test.tsx
@@ -18,13 +18,12 @@ const system = {
   },
 } as unknown as SystemResult;
 
-describe('ResultCard Colony Planner action', () => {
-  it('opens normal detail and dedicated Colony Planner without double-calling or collapsing the card', () => {
+describe('ResultCard actions', () => {
+  it('offers Save for later and Inspect system without exposing a direct planner action', () => {
     const onOpenDetail = vi.fn();
-    const onOpenColonyPlanner = vi.fn();
     const onPin = vi.fn();
     const onCompare = vi.fn();
-    const onWatch = vi.fn();
+    const onToggleSavedForLater = vi.fn();
     const onShowOnMap = vi.fn();
     render(
       <ResultCard
@@ -32,50 +31,43 @@ describe('ResultCard Colony Planner action', () => {
         index={0}
         onPin={onPin}
         onCompare={onCompare}
-        onWatch={onWatch}
+        onToggleSavedForLater={onToggleSavedForLater}
         onShowOnMap={onShowOnMap}
         onOpenDetail={onOpenDetail}
-        onOpenColonyPlanner={onOpenColonyPlanner}
       />,
     );
 
     fireEvent.click(screen.getByText('Handoff'));
-    fireEvent.click(screen.getByRole('button', { name: /Details/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Evaluate in Colony Planner/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Watch/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Inspect system/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Save for later/i }));
     fireEvent.click(screen.getByRole('button', { name: /Map/i }));
     fireEvent.click(screen.getByTestId('result-card-pin-42'));
     fireEvent.click(screen.getByTestId('result-card-compare-42'));
 
     expect(onOpenDetail).toHaveBeenCalledTimes(1);
     expect(onOpenDetail.mock.calls[0]).toEqual([42]);
-    expect(onOpenColonyPlanner).toHaveBeenCalledTimes(1);
-    expect(onOpenColonyPlanner).toHaveBeenCalledWith(42);
-    expect(onWatch).toHaveBeenCalledWith(42);
+    expect(onToggleSavedForLater).toHaveBeenCalledTimes(1);
+    expect(onToggleSavedForLater).toHaveBeenCalledWith(42);
     expect(onShowOnMap).toHaveBeenCalledWith(42);
     expect(onPin).toHaveBeenCalledWith(42);
     expect(onCompare).toHaveBeenCalledWith(42);
+    expect(screen.queryByRole('button', { name: /Evaluate in Colony Planner/i })).toBeNull();
     const scoreBar = screen.getByLabelText('Rating score: 82/100');
     expect(scoreBar).toBeTruthy();
     expect(scoreBar.getAttribute('title')).toBe('Rating score: 82/100');
   });
 
-  it('falls back to focused detail handoff when no Colony Planner workspace callback is provided', () => {
-    const onOpenDetail = vi.fn();
-
+  it('shows reversible saved state copy for save-for-later systems', () => {
     render(
       <ResultCard
         system={system}
         index={0}
-        onOpenDetail={onOpenDetail}
+        isSavedForLater
       />,
     );
 
     fireEvent.click(screen.getByText('Handoff'));
-    fireEvent.click(screen.getByRole('button', { name: /Evaluate in Colony Planner/i }));
-
-    expect(onOpenDetail).toHaveBeenCalledTimes(1);
-    expect(onOpenDetail).toHaveBeenCalledWith(42, { focus: 'colony-planner' });
+    expect(screen.getByRole('button', { name: /Saved - remove/i })).toBeTruthy();
   });
 
   it('copies the system name without toggling the expanded card', () => {

--- a/frontend-v2/src/components/ResultCard.tsx
+++ b/frontend-v2/src/components/ResultCard.tsx
@@ -12,15 +12,14 @@ import {
 import { displayRationale } from '@/lib/rationale';
 import {
   Pin, Scale, Eye, Map, Copy, ChevronDown, Search,
-  Rocket,
 } from 'lucide-react';
 
 /**
  * One row in the search-results list — chunky brushed-metal card with
  * collapsible body.
  *
- * Stateless: parents pass action callbacks (onPin / onWatch / onCompare /
- * onOpenDetail / onOpenColonyPlanner / onShowOnMap). The card only owns the
+ * Stateless: parents pass action callbacks (onPin / onToggleSavedForLater /
+ * onCompare / onOpenDetail / onShowOnMap). The card only owns the
  * open/closed toggle.
  */
 export interface ResultCardProps {
@@ -28,17 +27,18 @@ export interface ResultCardProps {
   index:  number;
   isPinned?: boolean;
   isCompared?: boolean;
+  isSavedForLater?: boolean;
   onPin?:     (id64: number) => void;
   onCompare?: (id64: number) => void;
-  onWatch?:   (id64: number) => void;
+  onToggleSavedForLater?: (id64: number) => void;
   onShowOnMap?:  (id64: number) => void;
-  onOpenDetail?: (id64: number, options?: { focus?: 'colony-planner' }) => void;
-  onOpenColonyPlanner?: (id64: number) => void;
+  onOpenDetail?: (id64: number) => void;
 }
 
 export function ResultCard({
   system, index, isPinned = false, isCompared = false,
-  onPin, onCompare, onWatch, onShowOnMap, onOpenDetail, onOpenColonyPlanner,
+  isSavedForLater = false,
+  onPin, onCompare, onToggleSavedForLater, onShowOnMap, onOpenDetail,
 }: ResultCardProps) {
   const [open, setOpen] = useState(false);
 
@@ -53,14 +53,6 @@ export function ResultCard({
   const status     = systemStatusLabel(system);
   const systemId64 = Number(system.id64);
   const hasValidSystemId = Number.isFinite(systemId64) && systemId64 > 0;
-  const openColonyPlanner = () => {
-    if (!hasValidSystemId) return;
-    if (onOpenColonyPlanner) {
-      onOpenColonyPlanner(systemId64);
-    } else {
-      onOpenDetail?.(systemId64, { focus: 'colony-planner' });
-    }
-  };
 
   return (
     <article
@@ -229,24 +221,18 @@ export function ResultCard({
           ) : null}
 
           <div className="flex flex-wrap gap-2 pt-1">
-            {onOpenDetail && (
-              <ActionButton onClick={() => onOpenDetail(system.id64)} primary>
-                <Search size={13} className="mr-1.5" /> Details
-              </ActionButton>
-            )}
-            {(onOpenColonyPlanner || onOpenDetail) && (
-              <ActionButton
-                onClick={() => {
-                  openColonyPlanner();
-                }}
-                disabled={!hasValidSystemId}
-              >
-                <Rocket size={13} className="mr-1.5" /> Evaluate in Colony Planner
-              </ActionButton>
-            )}
-            <ActionButton onClick={() => onWatch?.(system.id64)}>
-              <Eye size={13} className="mr-1.5" /> Watch
+            <ActionButton
+              onClick={() => onToggleSavedForLater?.(system.id64)}
+              active={isSavedForLater}
+            >
+              <Eye size={13} className="mr-1.5" />
+              {isSavedForLater ? 'Saved - remove' : 'Save for later'}
             </ActionButton>
+            {onOpenDetail && (
+              <ActionButton onClick={() => onOpenDetail(system.id64)} primary disabled={!hasValidSystemId}>
+                <Search size={13} className="mr-1.5" /> Inspect system
+              </ActionButton>
+            )}
             <ActionButton onClick={() => onShowOnMap?.(system.id64)}>
               <Map size={13} className="mr-1.5" /> Map
             </ActionButton>
@@ -303,12 +289,13 @@ function IconToggle({
 }
 
 function ActionButton({
-  onClick, children, primary, disabled = false,
+  onClick, children, primary, disabled = false, active = false,
 }: {
   onClick: () => void;
   children: React.ReactNode;
   primary?: boolean;
   disabled?: boolean;
+  active?: boolean;
 }) {
   return (
     <button
@@ -316,7 +303,7 @@ function ActionButton({
       disabled={disabled}
       onClick={(e) => { e.stopPropagation(); onClick(); }}
       className={[
-        primary ? 'btn-primary' : 'btn-metal',
+        primary ? 'btn-primary' : active ? 'btn-primary' : 'btn-metal',
         'inline-flex items-center text-[11px] py-1.5 px-3',
         disabled ? 'cursor-not-allowed opacity-45' : '',
       ].join(' ')}

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -395,7 +395,7 @@ describe('ColonyPlannerWorkspace', () => {
 
     expect(screen.getByTestId('colony-planner-workspace')).toBeTruthy();
     expect(screen.getByText('No system selected for Colony Planner.')).toBeTruthy();
-    expect(screen.getByText(/Choose Evaluate in Colony Planner from Finder or Advanced Search Tuning/i)).toBeTruthy();
+    expect(screen.getByText(/Open System Detail from Explore and start a plan there/i)).toBeTruthy();
     await click(screen.getByRole('button', { name: /Back to Finder/i }));
     expect(onBackToFinder).toHaveBeenCalledTimes(1);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
@@ -748,13 +748,13 @@ describe('ColonyPlannerWorkspace', () => {
     await waitFor(() => expect(storedProjectByName('Renamed local starter')).toBeTruthy());
 
     await click(screen.getByRole('button', { name: 'Duplicate project' }));
-    await waitFor(() => expect(storedProjectByName('Renamed local starter copy')).toBeTruthy());
-    expect(storedProjectByName('Renamed local starter copy')?.declared_roles).toEqual([]);
+    await waitFor(() => expect(storedProjectByName('Renamed local starter - Copy')).toBeTruthy());
+    expect(storedProjectByName('Renamed local starter - Copy')?.declared_roles).toEqual([]);
 
     await click(screen.getByRole('button', { name: 'Delete / archive project' }));
     expect(screen.getByText(/Archive this local project/)).toBeTruthy();
     await click(screen.getByRole('button', { name: 'Archive project' }));
-    await waitFor(() => expect(storedProjectByName('Renamed local starter copy')?.archived_at).toBeTruthy());
+    await waitFor(() => expect(storedProjectByName('Renamed local starter - Copy')?.archived_at).toBeTruthy());
   });
 
   it('loads old local projects without declared roles safely', async () => {
@@ -814,6 +814,40 @@ describe('ColonyPlannerWorkspace', () => {
     expect((await screen.findAllByText('Reloaded project')).length).toBeGreaterThan(0);
     await click(screen.getByTestId('topology-body-button-body1'));
     expect((await screen.findByTestId('body1-ground-slot-0')).textContent).toMatch(/Surface Hub/i);
+    expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
+  });
+
+  it('shows draft arrival context for projects created from the new start-plan flow without auto-running advanced planner actions', async () => {
+    useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 123,
+      system_name: 'Workspace System',
+      project_name: 'Workspace System - Materials coverage',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      objective: 'materials_coverage',
+      start_approach: 'recommendation_assisted',
+      created_from: 'system_detail',
+      status: 'draft',
+    });
+    mockedUseSystemDetail.mockReturnValue({
+      data: system,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    await renderPlanner();
+
+    expect(screen.getByTestId('planner-arrival-context')).toBeTruthy();
+    expect(screen.getByTestId('planner-project-name').textContent).toContain('Workspace System - Materials coverage');
+    expect(screen.getByTestId('planner-objective-context').textContent).toContain('Materials coverage');
+    expect(screen.getByTestId('planner-start-approach-context').textContent).toContain('ED-Finder recommendation');
+    expect(screen.getByTestId('planner-project-status').textContent).toContain('Draft');
+    expect(screen.getByTestId('planner-local-save-state').textContent).toContain('Saved locally');
+    expect(screen.getByTestId('planner-next-action').textContent).toContain(
+      'Start by reviewing suitable build approaches for this objective.',
+    );
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Rocket } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { getProvenanceCockpit, getWarehousePlannerEvidence } from '@/lib/api';
@@ -9,18 +9,28 @@ import { WholeSystemColonyPlanner } from './WholeSystemColonyPlanner';
 import { WarehouseEvidenceCard } from './WarehouseEvidenceCard';
 import { WorkspaceHeader, WorkspaceHeaderSkeleton } from './WorkspaceHeader';
 import { toWarehouseEvidenceFromContract, toWarehouseEvidenceFromProvenance } from './warehouseEvidenceBridge';
+import type { ColonyProject } from './colonyProjectStore';
 
 export interface ColonyPlannerWorkspaceProps {
   id64: number | null;
+  projectId?: string | null;
   onBackToFinder: () => void;
   onOpenSystemDetail: (id64: number) => void;
 }
 
 export function ColonyPlannerWorkspace({
   id64,
+  projectId = null,
   onBackToFinder,
   onOpenSystemDetail,
 }: ColonyPlannerWorkspaceProps) {
+  const [projectContext, setProjectContext] = useState<{
+    activeProject: ColonyProject | null;
+    unsavedChanges: boolean;
+  }>({
+    activeProject: null,
+    unsavedChanges: false,
+  });
   const { data, loading, error, refetch } = useSystemDetail(id64);
   const warehouseEvidenceQuery = useQuery({
     queryKey: ['planner-workspace-warehouse-planner-evidence', id64],
@@ -97,8 +107,14 @@ export function ColonyPlannerWorkspace({
         system={data}
         onBackToFinder={onBackToFinder}
         onOpenSystemDetail={onOpenSystemDetail}
+        activeProject={projectContext.activeProject}
+        unsavedChanges={projectContext.unsavedChanges}
       />
-      <WholeSystemColonyPlanner system={data} />
+      <WholeSystemColonyPlanner
+        system={data}
+        initialProjectId={projectId}
+        onProjectContextChange={setProjectContext}
+      />
       {/*
        * Stage 18H.3: fetch the dedicated read-only warehouse planner evidence
        * contract first, then fall back to the existing provenance cockpit
@@ -153,7 +169,7 @@ function EmptyWorkspace({ onBackToFinder }: { onBackToFinder: () => void }) {
         No system selected for Colony Planner.
       </h1>
       <p className="mx-auto mt-2 max-w-xl font-mono text-xs leading-relaxed text-silver-dk">
-        Choose Evaluate in Colony Planner from Finder or Advanced Search Tuning.
+        Open System Detail from Explore and start a plan there, or continue with an existing direct planner route.
       </p>
       <button
         type="button"

--- a/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
+++ b/frontend-v2/src/features/colony-planner/WholeSystemColonyPlanner.tsx
@@ -34,7 +34,18 @@ import {
   templateMatchesLane,
 } from './structurePlanningRules';
 
-export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
+export function WholeSystemColonyPlanner({
+  system,
+  initialProjectId = null,
+  onProjectContextChange,
+}: {
+  system: SystemDetail;
+  initialProjectId?: string | null;
+  onProjectContextChange?: (context: {
+    activeProject: ReturnType<typeof useWorkspaceProjectState>['activeProject'];
+    unsavedChanges: boolean;
+  }) => void;
+}) {
   const [selection, setSelection] = useState<TopologySelection>({ type: 'system' });
   const [placements, setPlacements] = useState<SimulateBuildPlacement[]>([]);
   const [placementLaneHints, setPlacementLaneHints] = useState<Record<number, BodyPlannerLane>>({});
@@ -120,7 +131,13 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
     [planSnapshot, system],
   );
 
-  const projectState = useWorkspaceProjectState(system, planSnapshot);
+  const projectState = useWorkspaceProjectState(system, planSnapshot, initialProjectId);
+  useEffect(() => {
+    onProjectContextChange?.({
+      activeProject: projectState.activeProject,
+      unsavedChanges: projectState.unsavedChanges,
+    });
+  }, [onProjectContextChange, projectState.activeProject, projectState.unsavedChanges]);
   const projectRequestFingerprint = useMemo(
     () => projectState.projectRequest ? JSON.stringify({
       target_archetype: projectState.projectRequest.target_archetype,
@@ -225,7 +242,7 @@ export function WholeSystemColonyPlanner({ system }: { system: SystemDetail }) {
       ok: true as const,
       message: `Added ${templateDisplayName(template)} to ${describePlacementTarget(body, lane)}.`,
     };
-  }, [planSnapshot, system, system.bodies, templates]);
+  }, [planSnapshot, system, templates]);
 
   const pickStructureTemplate = useCallback((templateId: string) => {
     if (!structurePicker) return;

--- a/frontend-v2/src/features/colony-planner/WorkspaceHeader.tsx
+++ b/frontend-v2/src/features/colony-planner/WorkspaceHeader.tsx
@@ -3,6 +3,19 @@ import { formatCoords, formatPopulationForSystem, systemStatusLabel } from '@/li
 import type { SystemDetail } from '@/types/api';
 import { SemanticStatusBadge } from '@/components/SemanticStatusBadge';
 import { WorkspaceContextHeader } from '@/components/WorkspaceContextHeader';
+import type { ColonyProject } from './colonyProjectStore';
+import {
+  objectiveSummaryLabel,
+  plannerNextActionCopy,
+  startApproachLabel,
+} from './plannerDraftContext';
+
+function projectStatusLabel(status?: ColonyProject['status'] | null) {
+  if (status === 'ready_to_build') return 'Ready to build';
+  if (status === 'building') return 'Building';
+  if (status === 'established') return 'Established';
+  return 'Draft';
+}
 
 export function WorkspaceHeaderSkeleton({
   id64,
@@ -39,10 +52,14 @@ export function WorkspaceHeader({
   system,
   onBackToFinder,
   onOpenSystemDetail,
+  activeProject,
+  unsavedChanges,
 }: {
   system: SystemDetail;
   onBackToFinder: () => void;
   onOpenSystemDetail: (id64: number) => void;
+  activeProject?: ColonyProject | null;
+  unsavedChanges?: boolean;
 }) {
   const population = formatPopulationForSystem(system);
   const status = systemStatusLabel(system);
@@ -90,6 +107,70 @@ export function WorkspaceHeader({
           </>
         )}
       />
+      {activeProject ? (
+        <div
+          data-testid="planner-arrival-context"
+          className="mt-4 grid gap-3 rounded-chunk-lg border border-orange/30 bg-bg3/30 p-3 lg:grid-cols-[minmax(0,1fr)_auto]"
+        >
+          <div className="min-w-0 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">
+                Active draft
+              </span>
+              <SemanticStatusBadge label="Draft" tone="available" />
+              <span
+                data-testid="planner-local-save-state"
+                className={[
+                  'rounded border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em]',
+                  unsavedChanges
+                    ? 'border-gold/40 bg-gold/10 text-gold'
+                    : 'border-green/35 bg-green/10 text-green',
+                ].join(' ')}
+              >
+                {unsavedChanges ? 'Unsaved local changes' : 'Saved locally'}
+              </span>
+            </div>
+            <div>
+              <h2
+                data-testid="planner-project-name"
+                className="truncate font-display text-lg tracking-[0.08em] text-orange-lt"
+              >
+                {activeProject.project_name}
+              </h2>
+              <p
+                data-testid="planner-next-action"
+                className="mt-1 max-w-3xl text-sm leading-relaxed text-silver"
+              >
+                {plannerNextActionCopy(activeProject.start_approach)}
+              </p>
+            </div>
+          </div>
+          <dl className="grid gap-2 text-[11px] font-mono sm:grid-cols-2 lg:min-w-[22rem]">
+            <div className="rounded border border-border bg-bg2/60 px-2 py-1.5">
+              <dt className="uppercase tracking-[0.14em] text-silver-dk">Objective</dt>
+              <dd data-testid="planner-objective-context" className="mt-1 text-text">
+                {objectiveSummaryLabel(activeProject.objective)}
+              </dd>
+            </div>
+            <div className="rounded border border-border bg-bg2/60 px-2 py-1.5">
+              <dt className="uppercase tracking-[0.14em] text-silver-dk">Start</dt>
+              <dd data-testid="planner-start-approach-context" className="mt-1 text-text">
+                {startApproachLabel(activeProject.start_approach)}
+              </dd>
+            </div>
+            <div className="rounded border border-border bg-bg2/60 px-2 py-1.5">
+              <dt className="uppercase tracking-[0.14em] text-silver-dk">Project status</dt>
+              <dd data-testid="planner-project-status" className="mt-1 text-text">
+                {projectStatusLabel(activeProject.status)}
+              </dd>
+            </div>
+            <div className="rounded border border-border bg-bg2/60 px-2 py-1.5">
+              <dt className="uppercase tracking-[0.14em] text-silver-dk">Saved in</dt>
+              <dd className="mt-1 text-text">This browser</dd>
+            </div>
+          </dl>
+        </div>
+      ) : null}
     </header>
   );
 }

--- a/frontend-v2/src/features/colony-planner/colonyProjectStore.test.ts
+++ b/frontend-v2/src/features/colony-planner/colonyProjectStore.test.ts
@@ -47,11 +47,17 @@ describe('colonyProjectStore', () => {
       }],
       target_archetype: 'refinery_industrial',
       notes: '',
+      objective: 'balanced',
+      start_approach: 'manual',
+      created_from: 'system_detail',
     });
 
     expect(saved.declared_roles).toEqual([
       expect.objectContaining({ body_id: 'body1', role_id: 'main_station_body', source: 'declared' }),
     ]);
+    expect(saved.objective).toBe('balanced');
+    expect(saved.start_approach).toBe('manual');
+    expect(saved.created_from).toBe('system_detail');
     expect(projectMatchesSnapshot(saved, [placement], 'refinery_industrial', '', 'Role project', saved.declared_roles)).toBe(true);
     expect(projectMatchesSnapshot(saved, [placement], 'refinery_industrial', '', 'Role project', [])).toBe(false);
 
@@ -59,8 +65,14 @@ describe('colonyProjectStore', () => {
       ...saved,
       id: 'old-shape',
       declared_roles: undefined,
+      objective: undefined,
+      start_approach: undefined,
+      created_from: undefined,
     } as never;
     expect(activeProjectsForSystem([oldProject], 123)[0].declared_roles).toEqual([]);
+    expect(activeProjectsForSystem([oldProject], 123)[0].objective).toBeNull();
+    expect(activeProjectsForSystem([oldProject], 123)[0].start_approach).toBeNull();
+    expect(activeProjectsForSystem([oldProject], 123)[0].created_from).toBeNull();
   });
 
   it('renames, duplicates, and archives projects without deleting the source data shape', () => {
@@ -71,15 +83,25 @@ describe('colonyProjectStore', () => {
       build_plan_placements: [placement],
       target_archetype: 'refinery_industrial',
       notes: '',
+      objective: 'materials_coverage',
+      start_approach: 'recommendation_assisted',
+      created_from: 'system_detail',
     });
 
     useColonyProjectStore.getState().renameProject(saved.id, 'Renamed project');
     expect(useColonyProjectStore.getState().projects[saved.id].project_name).toBe('Renamed project');
 
+    useColonyProjectStore.getState().updateProjectStatus(saved.id, 'ready_to_build');
+    expect(useColonyProjectStore.getState().projects[saved.id].status).toBe('ready_to_build');
+
     const duplicate = useColonyProjectStore.getState().duplicateProject(saved.id);
-    expect(duplicate?.project_name).toBe('Renamed project copy');
+    expect(duplicate?.project_name).toBe('Renamed project - Copy');
     expect(duplicate?.id).not.toBe(saved.id);
     expect(duplicate?.build_plan_placements).toEqual([placement]);
+    expect(duplicate?.objective).toBe('materials_coverage');
+    expect(duplicate?.start_approach).toBe('recommendation_assisted');
+    expect(duplicate?.created_from).toBe('system_detail');
+    expect(duplicate?.status).toBe('draft');
 
     useColonyProjectStore.getState().archiveProject(saved.id);
     const projects = useColonyProjectStore.getState().projects;
@@ -98,7 +120,10 @@ describe('colonyProjectStore', () => {
       declared_roles: undefined,
       target_archetype: 'refinery_industrial',
       notes: '',
-      status: 'draft',
+      status: 'validated',
+      objective: undefined,
+      start_approach: undefined,
+      created_from: undefined,
       created_at: '2026-05-01T00:00:00.000Z',
       updated_at: '2026-05-01T00:00:00.000Z',
       archived_at: null,
@@ -112,6 +137,10 @@ describe('colonyProjectStore', () => {
 
     expect(useColonyProjectStore.getState().projects['legacy-project'].project_name).toBe('Legacy project');
     expect(useColonyProjectStore.getState().projects['legacy-project'].declared_roles).toEqual([]);
+    expect(useColonyProjectStore.getState().projects['legacy-project'].objective).toBeNull();
+    expect(useColonyProjectStore.getState().projects['legacy-project'].start_approach).toBeNull();
+    expect(useColonyProjectStore.getState().projects['legacy-project'].created_from).toBeNull();
+    expect(useColonyProjectStore.getState().projects['legacy-project'].status).toBe('draft');
 
     useColonyProjectStore.getState().deleteProject('legacy-project');
     expect(useColonyProjectStore.getState().projects['legacy-project']).toBeUndefined();

--- a/frontend-v2/src/features/colony-planner/colonyProjectStore.ts
+++ b/frontend-v2/src/features/colony-planner/colonyProjectStore.ts
@@ -2,8 +2,13 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import type { SimulateBuildPlacement } from '@/types/api';
 import { normaliseDeclaredRoles, type DeclaredColonyRole } from './colonyRoles';
+import type {
+  ColonyProjectCreatedFrom,
+  ColonyProjectObjective,
+  ColonyProjectStartApproach,
+} from './plannerDraftContext';
 
-export type ColonyProjectStatus = 'draft' | 'previewed' | 'validated';
+export type ColonyProjectStatus = 'draft' | 'ready_to_build' | 'building' | 'established';
 
 export interface ColonyProject {
   id: string;
@@ -16,6 +21,9 @@ export interface ColonyProject {
   target_archetype: string;
   notes: string;
   status: ColonyProjectStatus;
+  objective?: ColonyProjectObjective | null;
+  start_approach?: ColonyProjectStartApproach | null;
+  created_from?: ColonyProjectCreatedFrom | null;
   created_at: string;
   updated_at: string;
   archived_at?: string | null;
@@ -30,12 +38,16 @@ export interface ColonyProjectInput {
   target_archetype: string;
   notes: string;
   status?: ColonyProjectStatus;
+  objective?: ColonyProjectObjective | null;
+  start_approach?: ColonyProjectStartApproach | null;
+  created_from?: ColonyProjectCreatedFrom | null;
 }
 
 interface ColonyProjectState {
   projects: Record<string, ColonyProject>;
   saveProject: (projectId: string | null, input: ColonyProjectInput) => ColonyProject;
   renameProject: (projectId: string, name: string) => void;
+  updateProjectStatus: (projectId: string, status: ColonyProjectStatus) => void;
   duplicateProject: (projectId: string) => ColonyProject | null;
   archiveProject: (projectId: string) => void;
   deleteProject: (projectId: string) => void;
@@ -61,6 +73,9 @@ export const useColonyProjectStore = create<ColonyProjectState>()(
           target_archetype: input.target_archetype,
           notes: input.notes,
           status: input.status ?? existing?.status ?? 'draft',
+          objective: input.objective ?? existing?.objective ?? null,
+          start_approach: input.start_approach ?? existing?.start_approach ?? null,
+          created_from: input.created_from ?? existing?.created_from ?? null,
           created_at: existing?.created_at ?? now,
           updated_at: now,
           archived_at: null,
@@ -81,6 +96,18 @@ export const useColonyProjectStore = create<ColonyProjectState>()(
           },
         }));
       },
+      updateProjectStatus: (projectId, status) => {
+        const project = get().projects[projectId];
+        if (!project) return;
+        const nextStatus = normaliseProjectStatus(status);
+        const now = new Date().toISOString();
+        set((state) => ({
+          projects: {
+            ...state.projects,
+            [projectId]: { ...project, status: nextStatus, updated_at: now },
+          },
+        }));
+      },
       duplicateProject: (projectId) => {
         const source = get().projects[projectId];
         if (!source) return null;
@@ -88,7 +115,7 @@ export const useColonyProjectStore = create<ColonyProjectState>()(
         const duplicate: ColonyProject = {
           ...source,
           id: createProjectId(source.system_id64),
-          project_name: `${source.project_name} copy`,
+          project_name: `${source.project_name} - Copy`,
           build_plan_placements: clonePlacements(source.build_plan_placements),
           selected_body_assignments: { ...source.selected_body_assignments },
           declared_roles: normaliseDeclaredRoles(source.declared_roles),
@@ -122,7 +149,7 @@ export const useColonyProjectStore = create<ColonyProjectState>()(
     {
       name: STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
-      version: 2,
+      version: 3,
       migrate: (persistedState) => ({
         ...(persistedState as Partial<ColonyProjectState> | undefined),
         projects: normaliseProjectRecord((persistedState as { projects?: unknown } | undefined)?.projects),
@@ -146,6 +173,10 @@ export function activeProjectsForSystem(projects: ColonyProject[], systemId64: n
         ? project.selected_body_assignments
         : {},
       declared_roles: normaliseDeclaredRoles(project.declared_roles),
+      objective: project.objective ?? null,
+      start_approach: project.start_approach ?? null,
+      created_from: project.created_from ?? null,
+      status: normaliseProjectStatus(project.status),
     }))
     .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
 }
@@ -212,10 +243,21 @@ function normaliseProjectRecord(projects: unknown): Record<string, ColonyProject
         ? candidate.selected_body_assignments
         : {},
       declared_roles: normaliseDeclaredRoles(candidate.declared_roles),
+      objective: candidate.objective ?? null,
+      start_approach: candidate.start_approach ?? null,
+      created_from: candidate.created_from ?? null,
+      status: normaliseProjectStatus(candidate.status),
       archived_at: candidate.archived_at ?? null,
     };
     return record;
   }, {});
+}
+
+function normaliseProjectStatus(status: unknown): ColonyProjectStatus {
+  if (status === 'ready_to_build' || status === 'building' || status === 'established') {
+    return status;
+  }
+  return 'draft';
 }
 
 function createProjectId(systemId64: number) {

--- a/frontend-v2/src/features/colony-planner/plannerDraftContext.ts
+++ b/frontend-v2/src/features/colony-planner/plannerDraftContext.ts
@@ -1,0 +1,125 @@
+export type ColonyProjectObjective =
+  | 'materials_coverage'
+  | 'industry_economy'
+  | 'extraction_mining_support'
+  | 'missions_services'
+  | 'personal_base_custom_goal'
+  | 'balanced'
+  | 'decide_later';
+
+export type ColonyProjectStartApproach = 'recommendation_assisted' | 'manual';
+
+export type ColonyProjectCreatedFrom = 'system_detail';
+
+export interface PlannerObjectiveOption {
+  value: ColonyProjectObjective;
+  label: string;
+  description: string;
+}
+
+export const PLANNER_OBJECTIVE_OPTIONS: PlannerObjectiveOption[] = [
+  {
+    value: 'materials_coverage',
+    label: 'Materials coverage',
+    description: 'Focus on practical coverage for colony-building materials and support needs.',
+  },
+  {
+    value: 'industry_economy',
+    label: 'Industry / economy',
+    description: 'Start from a system-level economy and infrastructure perspective.',
+  },
+  {
+    value: 'extraction_mining_support',
+    label: 'Extraction / mining support',
+    description: 'Shape the draft around extraction and mining support decisions.',
+  },
+  {
+    value: 'missions_services',
+    label: 'Missions / services',
+    description: 'Prioritise mission-facing and service-facing capability planning.',
+  },
+  {
+    value: 'personal_base_custom_goal',
+    label: 'Personal base / custom goal',
+    description: 'Start a flexible draft for a personal base or another custom goal.',
+  },
+  {
+    value: 'balanced',
+    label: 'Balanced',
+    description: 'Keep the draft broad and adaptable while you explore trade-offs.',
+  },
+  {
+    value: 'decide_later',
+    label: "I'll decide later",
+    description: 'Create the draft now and decide on the objective inside the planner.',
+  },
+];
+
+export function objectiveLabel(value: ColonyProjectObjective | null | undefined): string {
+  switch (value) {
+    case 'materials_coverage':
+      return 'Materials coverage';
+    case 'industry_economy':
+      return 'Industry / economy';
+    case 'extraction_mining_support':
+      return 'Extraction / mining support';
+    case 'missions_services':
+      return 'Missions / services';
+    case 'personal_base_custom_goal':
+      return 'Personal base / custom goal';
+    case 'balanced':
+      return 'Balanced';
+    case 'decide_later':
+      return "I'll decide later";
+    default:
+      return 'Objective not set';
+  }
+}
+
+export function objectiveSummaryLabel(value: ColonyProjectObjective | null | undefined): string {
+  if (!value || value === 'decide_later') {
+    return 'Objective not set';
+  }
+  return objectiveLabel(value);
+}
+
+export function startApproachLabel(value: ColonyProjectStartApproach | null | undefined): string {
+  if (value === 'recommendation_assisted') {
+    return 'ED-Finder recommendation';
+  }
+  if (value === 'manual') {
+    return 'Build my own plan';
+  }
+  return 'Approach not set';
+}
+
+export function plannerNextActionCopy(value: ColonyProjectStartApproach | null | undefined): string {
+  if (value === 'recommendation_assisted') {
+    return 'Start by reviewing suitable build approaches for this objective.';
+  }
+  return 'Start by choosing a body and adding your first structure.';
+}
+
+export function defaultDraftProjectName(
+  systemName: string,
+  objective: ColonyProjectObjective,
+): string {
+  const safeSystemName = systemName.trim() || 'Unknown system';
+  switch (objective) {
+    case 'materials_coverage':
+      return `${safeSystemName} - Materials coverage`;
+    case 'industry_economy':
+      return `${safeSystemName} - Industry plan`;
+    case 'extraction_mining_support':
+      return `${safeSystemName} - Extraction support`;
+    case 'missions_services':
+      return `${safeSystemName} - Mission services`;
+    case 'personal_base_custom_goal':
+      return `${safeSystemName} - New plan`;
+    case 'balanced':
+      return `${safeSystemName} - Balanced plan`;
+    case 'decide_later':
+    default:
+      return `${safeSystemName} - New plan`;
+  }
+}

--- a/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
+++ b/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
@@ -16,7 +16,11 @@ import {
 } from './colonyProjectStore';
 import { projectRequestFromProject } from './workspaceUtils';
 
-export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: TopologyPlanSnapshot) {
+export function useWorkspaceProjectState(
+  system: SystemDetail,
+  planSnapshot: TopologyPlanSnapshot,
+  initialProjectId: string | null = null,
+) {
   const projectRecord = useColonyProjectStore((state) => state.projects);
   const saveProject = useColonyProjectStore((state) => state.saveProject);
   const renameProject = useColonyProjectStore((state) => state.renameProject);
@@ -25,7 +29,7 @@ export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: Top
 
   const projects = useMemo(() => Object.values(projectRecord), [projectRecord]);
   const systemProjects = useMemo(() => activeProjectsForSystem(projects, system.id64), [projects, system.id64]);
-  const initialProject = systemProjects[0] ?? null;
+  const initialProject = systemProjects.find((project) => project.id === initialProjectId) ?? systemProjects[0] ?? null;
   const [activeProjectId, setActiveProjectId] = useState<string | null>(() => initialProject?.id ?? null);
   const [pendingProjectId, setPendingProjectId] = useState<string>(() => initialProject?.id ?? '');
   const [projectName, setProjectName] = useState(() => initialProject?.project_name ?? `${system.name || 'Colony'} project`);
@@ -35,6 +39,15 @@ export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: Top
   const hasMountedProjectSync = useRef(false);
 
   const activeProject = systemProjects.find((project) => project.id === activeProjectId) ?? null;
+
+  useEffect(() => {
+    if (!initialProjectId) return;
+    const targetProject = systemProjects.find((project) => project.id === initialProjectId) ?? null;
+    if (!targetProject) return;
+    if (activeProjectId === targetProject.id) return;
+    setActiveProjectId(targetProject.id);
+    setPendingProjectId(targetProject.id);
+  }, [activeProjectId, initialProjectId, systemProjects]);
 
   useEffect(() => {
     if (activeProjectId && systemProjects.some((project) => project.id === activeProjectId)) return;
@@ -53,11 +66,13 @@ export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: Top
     const nextProjectNotes = activeProject?.notes ?? '';
     const nextDeclaredRoles = normaliseDeclaredRoles(activeProject?.declared_roles);
 
-    if (pendingProjectId !== nextPendingProjectId) setPendingProjectId(nextPendingProjectId);
-    if (projectName !== nextProjectName) setProjectName(nextProjectName);
-    if (projectNotes !== nextProjectNotes) setProjectNotes(nextProjectNotes);
-    if (JSON.stringify(declaredRoles) !== JSON.stringify(nextDeclaredRoles)) setDeclaredRoles(nextDeclaredRoles);
-    if (confirmArchive) setConfirmArchive(false);
+    setPendingProjectId((current) => (current === nextPendingProjectId ? current : nextPendingProjectId));
+    setProjectName((current) => (current === nextProjectName ? current : nextProjectName));
+    setProjectNotes((current) => (current === nextProjectNotes ? current : nextProjectNotes));
+    setDeclaredRoles((current) => (
+      JSON.stringify(current) === JSON.stringify(nextDeclaredRoles) ? current : nextDeclaredRoles
+    ));
+    setConfirmArchive((current) => (current ? false : current));
   }, [activeProject, activeProjectId, system.name]);
 
   const unsavedChanges = !projectMatchesSnapshot(
@@ -80,10 +95,10 @@ export function useWorkspaceProjectState(system: SystemDetail, planSnapshot: Top
       declared_roles: declaredRoles,
       target_archetype: planSnapshot.targetArchetype,
       notes: projectNotes,
-      status: 'draft',
+      status: activeProject?.status ?? 'draft',
     });
     setActiveProjectId(saved.id);
-  }, [activeProject?.id, declaredRoles, planSnapshot.placements, planSnapshot.targetArchetype, projectName, projectNotes, saveProject, system.id64, system.name]);
+  }, [activeProject?.id, activeProject?.status, declaredRoles, planSnapshot.placements, planSnapshot.targetArchetype, projectName, projectNotes, saveProject, system.id64, system.name]);
 
   const handleRenameProject = useCallback(() => {
     if (!activeProject) return;

--- a/frontend-v2/src/features/my-work/MyWorkWorkspace.test.tsx
+++ b/frontend-v2/src/features/my-work/MyWorkWorkspace.test.tsx
@@ -1,0 +1,327 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MyWorkWorkspace } from './MyWorkWorkspace';
+import { useColonyProjectStore } from '@/features/colony-planner/colonyProjectStore';
+import { useMyWorkStore } from './myWorkStore';
+import type { UseWatchlist } from '@/features/watchlist/useWatchlist';
+import type { UsePinned } from '@/features/pinned/usePinned';
+
+function makeWatchlist(overrides: Partial<UseWatchlist> = {}): UseWatchlist {
+  return {
+    entries: [],
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    add: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue(undefined),
+    has: vi.fn(() => false),
+    ...overrides,
+  };
+}
+
+function makePinned(overrides: Partial<UsePinned> = {}): UsePinned {
+  return {
+    entries: [],
+    has: vi.fn(() => false),
+    toggle: vi.fn(() => true),
+    remove: vi.fn(),
+    clear: vi.fn(),
+    exportJson: vi.fn(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  useColonyProjectStore.setState({ projects: {} });
+  useMyWorkStore.setState({ systems: {} });
+});
+
+describe('MyWorkWorkspace', () => {
+  it('merges existing Watchlist, Pins, and local ready-to-plan labels into Saved Systems', async () => {
+    const watchlist = makeWatchlist({
+      entries: [{
+        system_id64: 101,
+        name: 'Wregoe',
+        x: 1,
+        y: 2,
+        z: 3,
+        population: 0,
+        is_colonised: false,
+        added_at: '2026-06-22T10:00:00.000Z',
+        score: 77,
+        economy_suggestion: 'Refinery',
+      }],
+      has: vi.fn((id64: number) => id64 === 101),
+    });
+    const pinned = makePinned({
+      entries: [{
+        id64: 101,
+        name: 'Wregoe',
+        x: 1,
+        y: 2,
+        z: 3,
+        population: 0,
+        is_colonised: false,
+        distance: null,
+        rating: 77,
+        economy: 'Refinery',
+        pinned_at: '2026-06-22T11:00:00.000Z',
+      }],
+      has: vi.fn((id64: number) => id64 === 101),
+    });
+    useMyWorkStore.getState().setLabel({
+      id64: 101,
+      name: 'Wregoe',
+      x: 1,
+      y: 2,
+      z: 3,
+      population: 0,
+      is_colonised: false,
+    }, 'ready_to_plan', true);
+
+    render(
+      <MyWorkWorkspace
+        watchlist={watchlist}
+        pinned={pinned}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('saved-system-101').textContent).toContain('Wregoe');
+    expect(screen.getByTestId('saved-system-101').textContent).toContain('Considering');
+    expect(screen.getByTestId('saved-system-101').textContent).toContain('Favourite');
+    expect(screen.getByTestId('saved-system-101').textContent).toContain('Ready to plan');
+  });
+
+  it('removes saved systems safely across Watchlist, Pins, and local saved labels', async () => {
+    const watchlistRemove = vi.fn().mockResolvedValue(undefined);
+    const pinnedRemove = vi.fn();
+    const watchlist = makeWatchlist({
+      entries: [{
+        system_id64: 101,
+        name: 'Wregoe',
+        x: 1,
+        y: 2,
+        z: 3,
+        population: 0,
+        is_colonised: false,
+        added_at: '2026-06-22T10:00:00.000Z',
+      }],
+      remove: watchlistRemove,
+      has: vi.fn((id64: number) => id64 === 101),
+    });
+    const pinned = makePinned({
+      entries: [{
+        id64: 101,
+        name: 'Wregoe',
+        x: 1,
+        y: 2,
+        z: 3,
+        population: 0,
+        is_colonised: false,
+        rating: null,
+        economy: null,
+        pinned_at: '2026-06-22T11:00:00.000Z',
+      }],
+      remove: pinnedRemove,
+      has: vi.fn((id64: number) => id64 === 101),
+    });
+    useMyWorkStore.getState().setLabel({
+      id64: 101,
+      name: 'Wregoe',
+      x: 1,
+      y: 2,
+      z: 3,
+      population: 0,
+      is_colonised: false,
+    }, 'ready_to_plan', true);
+
+    render(
+      <MyWorkWorkspace
+        watchlist={watchlist}
+        pinned={pinned}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Remove from saved/i }));
+
+    await waitFor(() => {
+      expect(watchlistRemove).toHaveBeenCalledWith(101);
+    });
+    expect(pinnedRemove).toHaveBeenCalledWith(101);
+    expect(Object.values(useColonyProjectStore.getState().projects)).toHaveLength(0);
+  });
+
+  it('groups plans by system, supports rename, duplication, status changes, and continue-plan routing', async () => {
+    const onOpenPlanner = vi.fn();
+    useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 200,
+      system_name: 'HIP 200',
+      project_name: 'HIP 200 - Balanced plan',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      status: 'draft',
+      objective: 'balanced',
+      start_approach: 'manual',
+      created_from: 'system_detail',
+    });
+    const projectB = useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 200,
+      system_name: 'HIP 200',
+      project_name: 'HIP 200 - Materials coverage',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      status: 'draft',
+      objective: 'materials_coverage',
+      start_approach: 'recommendation_assisted',
+      created_from: 'system_detail',
+    });
+    useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 300,
+      system_name: 'HIP 300',
+      project_name: 'Legacy project',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+    });
+
+    render(
+      <MyWorkWorkspace
+        initialSection="plans"
+        watchlist={makeWatchlist()}
+        pinned={makePinned()}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={onOpenPlanner}
+      />,
+    );
+
+    expect(screen.getByTestId('my-work-plans').textContent).toContain('HIP 200');
+    expect(screen.getByTestId('my-work-plans').textContent).toContain('2 plans');
+    expect(screen.getByTestId(`plan-card-${projectB.id}`).textContent).toContain('ED-Finder recommendation');
+    expect(screen.getByTestId('my-work-plans').textContent).toContain('Objective not set');
+
+    fireEvent.click(withinPlan(projectB.id, /Rename/i));
+    fireEvent.change(screen.getByDisplayValue('HIP 200 - Materials coverage'), { target: { value: 'HIP 200 - Final draft' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save name/i }));
+    expect(useColonyProjectStore.getState().projects[projectB.id]?.project_name).toBe('HIP 200 - Final draft');
+
+    fireEvent.change(screen.getByTestId(`plan-status-${projectB.id}`), { target: { value: 'building' } });
+    expect(useColonyProjectStore.getState().projects[projectB.id]?.status).toBe('building');
+
+    fireEvent.click(withinPlan(projectB.id, /Duplicate/i));
+    expect(Object.values(useColonyProjectStore.getState().projects).some((project) => project.project_name === 'HIP 200 - Final draft - Copy')).toBe(true);
+
+    fireEvent.click(withinPlan(projectB.id, /Continue plan/i));
+    expect(onOpenPlanner).toHaveBeenCalledWith(200, { projectId: projectB.id });
+  });
+
+  it('shows established plans in My Colonies and updates safely when status changes', async () => {
+    const project = useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 400,
+      system_name: 'Established System',
+      project_name: 'Established System - New plan',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      status: 'established',
+      objective: 'decide_later',
+      start_approach: 'manual',
+      created_from: 'system_detail',
+    });
+
+    render(
+      <MyWorkWorkspace
+        initialSection="my-colonies"
+        watchlist={makeWatchlist()}
+        pinned={makePinned()}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('my-work-colonies').textContent).toContain('player-managed planning state');
+    expect(screen.getByTestId('my-work-colonies').textContent).toContain('Established System');
+
+    fireEvent.click(screen.getByTestId('my-work-section-plans'));
+    fireEvent.change(screen.getByTestId(`plan-status-${project.id}`), { target: { value: 'building' } });
+    fireEvent.click(screen.getByTestId('my-work-section-my-colonies'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('my-work-colonies').textContent).toContain('No colonies marked yet');
+    });
+  });
+
+  it('prefers the most recently updated active plan for continuation and falls back to a recent saved system', () => {
+    const activePlan = useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 500,
+      system_name: 'Recent Plan',
+      project_name: 'Recent Plan - New plan',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      status: 'draft',
+    });
+    useColonyProjectStore.setState((state) => ({
+      projects: {
+        ...state.projects,
+        [activePlan.id]: {
+          ...state.projects[activePlan.id],
+          updated_at: '2026-06-23T15:00:00.000Z',
+        },
+      },
+    }));
+
+    const { rerender } = render(
+      <MyWorkWorkspace
+        watchlist={makeWatchlist()}
+        pinned={makePinned()}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('my-work-continuation').textContent).toContain('Continue planning');
+    expect(screen.getByTestId('my-work-continuation').textContent).toContain('Recent Plan - Recent Plan - New plan');
+
+    useColonyProjectStore.setState({ projects: {} });
+    rerender(
+      <MyWorkWorkspace
+        watchlist={makeWatchlist({
+          entries: [{
+            system_id64: 501,
+            name: 'Saved System',
+            x: null,
+            y: null,
+            z: null,
+            population: null,
+            is_colonised: false,
+            added_at: '2026-06-23T16:00:00.000Z',
+          }],
+          has: vi.fn((id64: number) => id64 === 501),
+        })}
+        pinned={makePinned()}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('my-work-continuation').textContent).toContain('Ready to revisit');
+    expect(screen.getByTestId('my-work-continuation').textContent).toContain('Saved System');
+  });
+});
+
+function withinPlan(projectId: string, name: RegExp) {
+  const card = screen.getByTestId(`plan-card-${projectId}`);
+  const buttons = card.querySelectorAll('button');
+  const match = Array.from(buttons).find((button) => name.test(button.textContent ?? ''));
+  if (!match) {
+    throw new Error(`No button matching ${name} for plan ${projectId}`);
+  }
+  return match as HTMLButtonElement;
+}

--- a/frontend-v2/src/features/my-work/MyWorkWorkspace.tsx
+++ b/frontend-v2/src/features/my-work/MyWorkWorkspace.tsx
@@ -1,0 +1,990 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { WatchlistEntry } from '@/lib/api';
+import type { UseWatchlist } from '@/features/watchlist/useWatchlist';
+import type { UsePinned, PinnedEntry } from '@/features/pinned/usePinned';
+import {
+  useColonyProjectStore,
+  type ColonyProject,
+  type ColonyProjectStatus,
+} from '@/features/colony-planner/colonyProjectStore';
+import {
+  objectiveSummaryLabel,
+  startApproachLabel,
+} from '@/features/colony-planner/plannerDraftContext';
+import { humanizeArchetype } from '@/features/colony-planner/workspaceUtils';
+import {
+  useMyWorkStore,
+  type MyWorkSystemRecord,
+  type SavedSystemLabel,
+  type SavedSystemSnapshot,
+} from './myWorkStore';
+
+type MyWorkSection = 'saved-systems' | 'plans' | 'my-colonies';
+
+interface MyWorkWorkspaceProps {
+  initialSection?: MyWorkSection;
+  routeSource?: 'my-work' | 'watchlist' | 'pinned' | 'colony';
+  watchlist: UseWatchlist;
+  pinned: UsePinned;
+  onOpenDetail: (id64: number, options?: { focus?: 'colony-planner' }) => void;
+  onOpenPlanner: (id64: number, options?: { projectId?: string | null }) => void;
+}
+
+interface SavedSystemViewModel extends SavedSystemSnapshot {
+  labels: SavedSystemLabel[];
+  planCount: number;
+  latestPlanActivity: string | null;
+  latestSavedAt: string | null;
+  activeProject: ColonyProject | null;
+  establishedProject: ColonyProject | null;
+  explicitColonisedAt: string | null;
+  isColonised: boolean;
+  watchlistEntry: WatchlistEntry | null;
+  pinnedEntry: PinnedEntry | null;
+  localRecord: MyWorkSystemRecord | null;
+}
+
+interface ColonyViewModel {
+  id64: number;
+  systemName: string;
+  plan: ColonyProject | null;
+  objective: string;
+  colonisedAt: string | null;
+}
+
+const SECTION_OPTIONS: Array<{ id: MyWorkSection; label: string }> = [
+  { id: 'saved-systems', label: 'Saved Systems' },
+  { id: 'plans', label: 'Plans' },
+  { id: 'my-colonies', label: 'My Colonies' },
+];
+
+const SAVED_LABEL_FILTERS: Array<{ id: 'all' | SavedSystemLabel; label: string }> = [
+  { id: 'all', label: 'All saved' },
+  { id: 'considering', label: 'Considering' },
+  { id: 'favourite', label: 'Favourite' },
+  { id: 'ready_to_plan', label: 'Ready to plan' },
+];
+
+export function MyWorkWorkspace({
+  initialSection = 'saved-systems',
+  routeSource = 'my-work',
+  watchlist,
+  pinned,
+  onOpenDetail,
+  onOpenPlanner,
+}: MyWorkWorkspaceProps) {
+  const [activeSection, setActiveSection] = useState<MyWorkSection>(initialSection);
+  const [savedFilter, setSavedFilter] = useState<'all' | SavedSystemLabel>('all');
+  const [editingPlanId, setEditingPlanId] = useState<string | null>(null);
+  const [editingPlanName, setEditingPlanName] = useState('');
+  const projectsRecord = useColonyProjectStore((state) => state.projects);
+  const renameProject = useColonyProjectStore((state) => state.renameProject);
+  const duplicateProject = useColonyProjectStore((state) => state.duplicateProject);
+  const archiveProject = useColonyProjectStore((state) => state.archiveProject);
+  const updateProjectStatus = useColonyProjectStore((state) => state.updateProjectStatus);
+  const localSystems = useMyWorkStore((state) => state.systems);
+  const rememberSystem = useMyWorkStore((state) => state.rememberSystem);
+  const setLabel = useMyWorkStore((state) => state.setLabel);
+  const setExplicitColonised = useMyWorkStore((state) => state.setExplicitColonised);
+  const clearSystemMetadata = useMyWorkStore((state) => state.clearSystemMetadata);
+
+  const activeProjects = useMemo(
+    () => Object.values(projectsRecord).filter((project) => !project.archived_at),
+    [projectsRecord],
+  );
+
+  useEffect(() => {
+    setActiveSection((current) => (current === initialSection ? current : initialSection));
+  }, [initialSection]);
+
+  const savedSystems = useMemo(
+    () => buildSavedSystems({ watchlistEntries: watchlist.entries, pinnedEntries: pinned.entries, localSystems, projects: activeProjects }),
+    [watchlist.entries, pinned.entries, localSystems, activeProjects],
+  );
+  const filteredSavedSystems = useMemo(
+    () => savedSystems.filter((system) => savedFilter === 'all' || system.labels.includes(savedFilter)),
+    [savedFilter, savedSystems],
+  );
+  const groupedPlans = useMemo(() => groupPlansBySystem(activeProjects), [activeProjects]);
+  const myColonies = useMemo(
+    () => buildColonies({ savedSystems, localSystems, projects: activeProjects }),
+    [activeProjects, localSystems, savedSystems],
+  );
+  const continuation = useMemo(
+    () => selectContinuation({ savedSystems, projects: activeProjects }),
+    [savedSystems, activeProjects],
+  );
+
+  const aliasNotice = routeSource !== 'my-work'
+    ? routeSource === 'watchlist'
+      ? 'Watchlist now opens the Saved Systems view inside My Work.'
+      : routeSource === 'pinned'
+        ? 'Pins now open the Saved Systems view inside My Work.'
+        : 'Colony Tracker remains available by route, while My Work now holds the player-facing colonies overview.'
+    : null;
+
+  const handleInspectSystem = (id64: number, options?: { focus?: 'colony-planner' }) => {
+    onOpenDetail(id64, options);
+  };
+
+  const handleContinuePlan = (project: ColonyProject) => {
+    onOpenPlanner(project.system_id64, { projectId: project.id });
+  };
+
+  const handleToggleConsidering = async (system: SavedSystemViewModel, enabled: boolean) => {
+    if (enabled && !system.watchlistEntry) {
+      await watchlist.add(system.id64, system);
+      return;
+    }
+    if (!enabled && system.watchlistEntry) {
+      await watchlist.remove(system.id64);
+    }
+  };
+
+  const handleToggleFavourite = (system: SavedSystemViewModel, enabled: boolean) => {
+    if (enabled && system.pinnedEntry) return;
+    if (!enabled && system.pinnedEntry) {
+      pinned.remove(system.id64);
+      return;
+    }
+    if (!enabled) return;
+    pinned.toggle({
+      id64: system.id64,
+      name: system.name,
+      x: system.x,
+      y: system.y,
+      z: system.z,
+      population: system.population,
+      is_colonised: system.is_colonised,
+      distance: null,
+      rating: null,
+      economy: null,
+      pinned_at: new Date().toISOString(),
+    });
+  };
+
+  const handleToggleReadyToPlan = (system: SavedSystemViewModel, enabled: boolean) => {
+    rememberSystem(system);
+    setLabel(system, 'ready_to_plan', enabled);
+    if (!enabled && !system.watchlistEntry && !system.pinnedEntry && !system.explicitColonisedAt) {
+      clearSystemMetadata(system.id64);
+    }
+  };
+
+  const handleRemoveFromSaved = async (system: SavedSystemViewModel) => {
+    if (system.watchlistEntry) {
+      await watchlist.remove(system.id64);
+    }
+    if (system.pinnedEntry) {
+      pinned.remove(system.id64);
+    }
+    if (system.localRecord?.labels.includes('ready_to_plan')) {
+      setLabel(system, 'ready_to_plan', false);
+    }
+    if (!system.explicitColonisedAt) {
+      clearSystemMetadata(system.id64);
+    }
+  };
+
+  const beginRename = (project: ColonyProject) => {
+    setEditingPlanId(project.id);
+    setEditingPlanName(project.project_name);
+  };
+
+  const saveRename = () => {
+    if (!editingPlanId) return;
+    renameProject(editingPlanId, editingPlanName);
+    setEditingPlanId(null);
+    setEditingPlanName('');
+  };
+
+  return (
+    <section data-testid="my-work-workspace" className="space-y-5">
+      <header className="panel space-y-4 p-4 sm:p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+              Player workspace
+            </p>
+            <h1 className="font-display text-xl tracking-[0.14em] text-orange">
+              My Work
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm leading-relaxed text-silver">
+              One calm place to return to saved systems, active plans, and established colony work without guessing which tool last held the context.
+            </p>
+          </div>
+          <div className="rounded border border-border/60 bg-bg3/35 px-3 py-2 font-mono text-[11px] text-silver-dk">
+            Saved systems {savedSystems.length} · Plans {activeProjects.length} · Colonies {myColonies.length}
+          </div>
+        </div>
+        {aliasNotice ? (
+          <div className="rounded border border-cyan/30 bg-cyan/8 px-3 py-2 text-sm text-cyan">
+            {aliasNotice}
+          </div>
+        ) : null}
+        {continuation ? (
+          <ContinueWhereLeftOff
+            continuation={continuation}
+            onInspectSystem={handleInspectSystem}
+            onContinuePlan={handleContinuePlan}
+          />
+        ) : null}
+        <div
+          className="flex flex-wrap gap-2"
+          data-testid="my-work-section-tabs"
+        >
+          {SECTION_OPTIONS.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              data-testid={`my-work-section-${option.id}`}
+              onClick={() => setActiveSection(option.id)}
+              className={[
+                'rounded-chunk-sm border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.14em] transition-colors',
+                activeSection === option.id
+                  ? 'border-orange/55 bg-orange/15 text-orange'
+                  : 'border-border bg-bg3/35 text-silver hover:border-orange/40 hover:text-orange-lt',
+              ].join(' ')}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {activeSection === 'saved-systems' ? (
+        <section className="space-y-4" data-testid="my-work-saved-systems">
+          <div className="flex flex-wrap items-center gap-2">
+            {SAVED_LABEL_FILTERS.map((filter) => (
+              <button
+                key={filter.id}
+                type="button"
+                data-testid={`saved-systems-filter-${filter.id}`}
+                onClick={() => setSavedFilter(filter.id)}
+                className={[
+                  'rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors',
+                  savedFilter === filter.id
+                    ? 'border-orange/50 bg-orange/12 text-orange'
+                    : 'border-border bg-bg3/35 text-silver-dk hover:border-orange/35 hover:text-orange-lt',
+                ].join(' ')}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+          {filteredSavedSystems.length === 0 ? (
+            <EmptyPanel
+              title="No saved systems yet"
+              body="Saved systems from Watchlist, Pins, and Ready to plan labels appear here automatically."
+            />
+          ) : (
+            <ul className="space-y-3">
+              {filteredSavedSystems.map((system) => (
+                <SavedSystemCard
+                  key={system.id64}
+                  system={system}
+                  onInspect={() => handleInspectSystem(system.id64)}
+                  onStartPlan={() => handleInspectSystem(system.id64, { focus: 'colony-planner' })}
+                  onContinuePlan={() => system.activeProject && handleContinuePlan(system.activeProject)}
+                  onToggleConsidering={(enabled) => void handleToggleConsidering(system, enabled)}
+                  onToggleFavourite={(enabled) => handleToggleFavourite(system, enabled)}
+                  onToggleReadyToPlan={(enabled) => handleToggleReadyToPlan(system, enabled)}
+                  onRemove={() => void handleRemoveFromSaved(system)}
+                />
+              ))}
+            </ul>
+          )}
+        </section>
+      ) : null}
+
+      {activeSection === 'plans' ? (
+        <section className="space-y-4" data-testid="my-work-plans">
+          {groupedPlans.length === 0 ? (
+            <EmptyPanel
+              title="No plans yet"
+              body="Start a plan from System Detail and it will appear here with its objective, start approach, and local draft context."
+            />
+          ) : (
+            <div className="space-y-4">
+              {groupedPlans.map((group) => (
+                <section key={group.systemId64} className="panel space-y-3 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <h2 className="font-display text-base tracking-[0.12em] text-orange-lt">
+                        {group.systemName}
+                      </h2>
+                      <p className="mt-1 font-mono text-[11px] text-silver-dk">
+                        {group.plans.length} plan{group.plans.length === 1 ? '' : 's'}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleInspectSystem(group.systemId64)}
+                      className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver hover:border-orange/35 hover:text-orange-lt"
+                    >
+                      Inspect system
+                    </button>
+                  </div>
+                  <div className="space-y-3">
+                    {group.plans.map((project) => (
+                      <PlanCard
+                        key={project.id}
+                        project={project}
+                        isEditing={editingPlanId === project.id}
+                        editingName={editingPlanName}
+                        onEditNameChange={setEditingPlanName}
+                        onBeginRename={() => beginRename(project)}
+                        onSaveRename={saveRename}
+                        onCancelRename={() => {
+                          setEditingPlanId(null);
+                          setEditingPlanName('');
+                        }}
+                        onDuplicate={() => duplicateProject(project.id)}
+                        onArchive={() => archiveProject(project.id)}
+                        onStatusChange={(status) => updateProjectStatus(project.id, status)}
+                        onContinue={() => handleContinuePlan(project)}
+                        onInspectSystem={() => handleInspectSystem(project.system_id64)}
+                        onToggleColonised={(enabled) => {
+                          const snapshot = {
+                            id64: project.system_id64,
+                            name: project.system_name,
+                            x: null,
+                            y: null,
+                            z: null,
+                            population: null,
+                            is_colonised: project.status === 'established',
+                          };
+                          rememberSystem(snapshot);
+                          setExplicitColonised(snapshot, enabled);
+                          if (!enabled) {
+                            const local = localSystems[String(project.system_id64)];
+                            if (local && local.labels.length === 0) {
+                              clearSystemMetadata(project.system_id64);
+                            }
+                          }
+                        }}
+                        isExplicitlyColonised={Boolean(localSystems[String(project.system_id64)]?.explicit_colonised_at)}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
+
+      {activeSection === 'my-colonies' ? (
+        <section className="space-y-4" data-testid="my-work-colonies">
+          <div className="rounded border border-violet/30 bg-violet/8 px-3 py-2 text-sm text-silver">
+            My Colonies is player-managed planning state. It does not claim live Architect, journal, EDMC, or in-game verification.
+          </div>
+          {myColonies.length === 0 ? (
+            <EmptyPanel
+              title="No colonies marked yet"
+              body="Plans marked Established, or systems you explicitly mark as colonised, appear here."
+            />
+          ) : (
+            <ul className="space-y-3">
+              {myColonies.map((colony) => (
+                <li key={`${colony.id64}-${colony.plan?.id ?? 'explicit'}`} className="panel flex flex-wrap items-start justify-between gap-3 p-4">
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded border border-violet/35 bg-violet/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-violet">
+                        Player-managed colony
+                      </span>
+                      <span className="font-mono text-[11px] text-silver-dk">
+                        {colony.colonisedAt ? `Established ${formatTimestamp(colony.colonisedAt)}` : 'Colonised date unavailable'}
+                      </span>
+                    </div>
+                    <h2 className="font-display text-base tracking-[0.1em] text-orange-lt">
+                      {colony.systemName}
+                    </h2>
+                    <p className="text-sm text-silver">
+                      {colony.plan ? colony.plan.project_name : 'No linked plan'}
+                    </p>
+                    <p className="font-mono text-[11px] text-silver-dk">
+                      Objective: {colony.objective}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {colony.plan ? (
+                      <button
+                        type="button"
+                        onClick={() => handleContinuePlan(colony.plan!)}
+                        className="rounded border border-orange/45 bg-orange/10 px-3 py-1.5 font-mono text-[11px] font-bold text-orange hover:bg-orange/20"
+                      >
+                        Open plan
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => handleInspectSystem(colony.id64)}
+                      className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver hover:border-orange/35 hover:text-orange-lt"
+                    >
+                      Inspect system
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      ) : null}
+    </section>
+  );
+}
+
+function ContinueWhereLeftOff({
+  continuation,
+  onInspectSystem,
+  onContinuePlan,
+}: {
+  continuation: ReturnType<typeof selectContinuation>;
+  onInspectSystem: (id64: number) => void;
+  onContinuePlan: (project: ColonyProject) => void;
+}) {
+  if (!continuation) return null;
+  if (continuation.kind === 'plan') {
+    return (
+      <section data-testid="my-work-continuation" className="rounded-chunk-lg border border-orange/35 bg-orange/8 p-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-orange">Continue planning</p>
+        <h2 className="mt-2 font-display text-lg tracking-[0.1em] text-orange-lt">
+          {continuation.project.system_name} - {continuation.project.project_name}
+        </h2>
+        <p className="mt-1 text-sm text-silver">
+          {projectStatusLabel(continuation.project.status)} · Updated {formatRecentActivity(continuation.project.updated_at)}
+        </p>
+        <button
+          type="button"
+          onClick={() => onContinuePlan(continuation.project)}
+          className="mt-3 rounded border border-orange/45 bg-orange/10 px-3 py-1.5 font-mono text-[11px] font-bold text-orange hover:bg-orange/20"
+        >
+          Continue plan
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section data-testid="my-work-continuation" className="rounded-chunk-lg border border-cyan/35 bg-cyan/8 p-4">
+      <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-cyan">Ready to revisit</p>
+      <h2 className="mt-2 font-display text-lg tracking-[0.1em] text-orange-lt">
+        {continuation.system.name}
+      </h2>
+      <p className="mt-1 text-sm text-silver">
+        Saved as {continuation.system.labels.map(labelText).join(' · ')} · No plan yet
+      </p>
+      <button
+        type="button"
+        onClick={() => onInspectSystem(continuation.system.id64)}
+        className="mt-3 rounded border border-cyan/45 bg-cyan/10 px-3 py-1.5 font-mono text-[11px] font-bold text-cyan hover:bg-cyan/20"
+      >
+        Inspect system
+      </button>
+    </section>
+  );
+}
+
+function SavedSystemCard({
+  system,
+  onInspect,
+  onStartPlan,
+  onContinuePlan,
+  onToggleConsidering,
+  onToggleFavourite,
+  onToggleReadyToPlan,
+  onRemove,
+}: {
+  system: SavedSystemViewModel;
+  onInspect: () => void;
+  onStartPlan: () => void;
+  onContinuePlan: () => void;
+  onToggleConsidering: (enabled: boolean) => void;
+  onToggleFavourite: (enabled: boolean) => void;
+  onToggleReadyToPlan: (enabled: boolean) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <li data-testid={`saved-system-${system.id64}`} className="panel flex flex-wrap items-start justify-between gap-4 p-4">
+      <div className="min-w-0 flex-1 space-y-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-display text-base tracking-[0.1em] text-orange-lt">
+              {system.name}
+            </h2>
+            {system.activeProject ? (
+              <span className="rounded border border-orange/35 bg-orange/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-orange">
+                Has active plan
+              </span>
+            ) : null}
+            {system.isColonised ? (
+              <span className="rounded border border-violet/35 bg-violet/10 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-violet">
+                Colonised
+              </span>
+            ) : null}
+          </div>
+          <p className="mt-1 font-mono text-[11px] text-silver-dk">
+            {system.planCount} associated plan{system.planCount === 1 ? '' : 's'}
+            {system.latestPlanActivity ? ` · latest plan update ${formatTimestamp(system.latestPlanActivity)}` : ''}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <LabelToggle
+            active={system.labels.includes('considering')}
+            label="Considering"
+            onClick={() => onToggleConsidering(!system.labels.includes('considering'))}
+          />
+          <LabelToggle
+            active={system.labels.includes('favourite')}
+            label="Favourite"
+            onClick={() => onToggleFavourite(!system.labels.includes('favourite'))}
+          />
+          <LabelToggle
+            active={system.labels.includes('ready_to_plan')}
+            label="Ready to plan"
+            onClick={() => onToggleReadyToPlan(!system.labels.includes('ready_to_plan'))}
+          />
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onInspect}
+          className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver hover:border-orange/35 hover:text-orange-lt"
+        >
+          Inspect
+        </button>
+        {system.activeProject ? (
+          <button
+            type="button"
+            onClick={onContinuePlan}
+            className="rounded border border-orange/45 bg-orange/10 px-3 py-1.5 font-mono text-[11px] font-bold text-orange hover:bg-orange/20"
+          >
+            Continue plan
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onStartPlan}
+            className="rounded border border-orange/45 bg-orange/10 px-3 py-1.5 font-mono text-[11px] font-bold text-orange hover:bg-orange/20"
+          >
+            Start plan
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onRemove}
+          className="rounded border border-red/40 bg-red/10 px-3 py-1.5 font-mono text-[11px] text-red hover:bg-red/20"
+        >
+          Remove from saved
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function PlanCard({
+  project,
+  isEditing,
+  editingName,
+  onEditNameChange,
+  onBeginRename,
+  onSaveRename,
+  onCancelRename,
+  onDuplicate,
+  onArchive,
+  onStatusChange,
+  onContinue,
+  onInspectSystem,
+  onToggleColonised,
+  isExplicitlyColonised,
+}: {
+  project: ColonyProject;
+  isEditing: boolean;
+  editingName: string;
+  onEditNameChange: (value: string) => void;
+  onBeginRename: () => void;
+  onSaveRename: () => void;
+  onCancelRename: () => void;
+  onDuplicate: () => void;
+  onArchive: () => void;
+  onStatusChange: (status: ColonyProjectStatus) => void;
+  onContinue: () => void;
+  onInspectSystem: () => void;
+  onToggleColonised: (enabled: boolean) => void;
+  isExplicitlyColonised: boolean;
+}) {
+  return (
+    <article data-testid={`plan-card-${project.id}`} className="rounded border border-border/70 bg-bg3/30 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-2">
+          {isEditing ? (
+            <div className="flex flex-wrap gap-2">
+              <input
+                value={editingName}
+                onChange={(event) => onEditNameChange(event.target.value)}
+                className="min-w-[18rem] flex-1 rounded border border-border/70 bg-bg2 px-2 py-1.5 font-mono text-xs text-silver"
+              />
+              <button
+                type="button"
+                onClick={onSaveRename}
+                className="rounded border border-orange/45 bg-orange/10 px-3 py-1.5 font-mono text-[11px] text-orange"
+              >
+                Save name
+              </button>
+              <button
+                type="button"
+                onClick={onCancelRename}
+                className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <h3 className="truncate font-display text-sm tracking-[0.1em] text-orange-lt">
+              {project.project_name}
+            </h3>
+          )}
+          <div className="flex flex-wrap gap-2 font-mono text-[11px] text-silver-dk">
+            <span>Objective: {objectiveSummaryLabel(project.objective)}</span>
+            <span>Start: {startApproachLabel(project.start_approach)}</span>
+            <span>Saved locally</span>
+            <span>Updated {formatTimestamp(project.updated_at)}</span>
+          </div>
+          <div className="grid gap-2 text-[11px] font-mono text-silver sm:grid-cols-2">
+            <div className="rounded border border-border/60 bg-bg2/40 px-2 py-1.5">
+              Plan health: {project.build_plan_placements.length} placements · {humanizeArchetype(project.target_archetype)}
+            </div>
+            <div className="rounded border border-border/60 bg-bg2/40 px-2 py-1.5">
+              Status: {projectStatusLabel(project.status)}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={onContinue}
+            className="rounded border border-orange/45 bg-orange/10 px-3 py-1.5 font-mono text-[11px] font-bold text-orange hover:bg-orange/20"
+          >
+            Continue plan
+          </button>
+          <button
+            type="button"
+            onClick={onInspectSystem}
+            className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver hover:border-orange/35 hover:text-orange-lt"
+          >
+            Inspect system
+          </button>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <label className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+          Status
+        </label>
+        <select
+          data-testid={`plan-status-${project.id}`}
+          value={project.status}
+          onChange={(event) => onStatusChange(event.target.value as ColonyProjectStatus)}
+          className="rounded border border-border/70 bg-bg2 px-2 py-1.5 font-mono text-[11px] text-silver"
+        >
+          <option value="draft">Draft</option>
+          <option value="ready_to_build">Ready to build</option>
+          <option value="building">Building</option>
+          <option value="established">Established</option>
+        </select>
+        <button
+          type="button"
+          onClick={onBeginRename}
+          className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver hover:border-cyan/35 hover:text-cyan"
+        >
+          Rename
+        </button>
+        <button
+          type="button"
+          onClick={onDuplicate}
+          className="rounded border border-border bg-bg3/35 px-3 py-1.5 font-mono text-[11px] text-silver hover:border-cyan/35 hover:text-cyan"
+        >
+          Duplicate
+        </button>
+        <button
+          type="button"
+          onClick={onArchive}
+          className="rounded border border-gold/35 bg-gold/10 px-3 py-1.5 font-mono text-[11px] text-gold hover:bg-gold/20"
+        >
+          Archive
+        </button>
+      </div>
+      {project.status === 'established' ? (
+        <div className="mt-3 rounded border border-violet/30 bg-violet/8 px-3 py-2 text-sm text-silver">
+          <p>
+            Established is still player-managed planning state. Use the action below if you also want this system to appear in My Colonies as explicitly colonised.
+          </p>
+          <button
+            type="button"
+            onClick={() => onToggleColonised(!isExplicitlyColonised)}
+            className="mt-2 rounded border border-violet/35 bg-violet/12 px-3 py-1.5 font-mono text-[11px] text-violet hover:bg-violet/20"
+          >
+            {isExplicitlyColonised ? 'Remove colonised mark' : 'Mark system colonised'}
+          </button>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function LabelToggle({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'rounded border px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors',
+        active
+          ? 'border-orange/50 bg-orange/12 text-orange'
+          : 'border-border bg-bg3/35 text-silver-dk hover:border-orange/35 hover:text-orange-lt',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
+}
+
+function EmptyPanel({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="panel px-4 py-12 text-center">
+      <h2 className="font-display text-sm tracking-[0.12em] text-orange">{title}</h2>
+      <p className="mx-auto mt-2 max-w-lg text-sm leading-relaxed text-silver-dk">{body}</p>
+    </div>
+  );
+}
+
+function buildSavedSystems({
+  watchlistEntries,
+  pinnedEntries,
+  localSystems,
+  projects,
+}: {
+  watchlistEntries: WatchlistEntry[];
+  pinnedEntries: PinnedEntry[];
+  localSystems: Record<string, MyWorkSystemRecord>;
+  projects: ColonyProject[];
+}): SavedSystemViewModel[] {
+  const bySystem = new Map<number, SavedSystemViewModel>();
+  const projectsBySystem = new Map<number, ColonyProject[]>();
+  for (const project of projects) {
+    const existing = projectsBySystem.get(project.system_id64) ?? [];
+    existing.push(project);
+    projectsBySystem.set(project.system_id64, existing);
+  }
+
+  const register = (snapshot: SavedSystemSnapshot, partial: Partial<SavedSystemViewModel>) => {
+    const existing = bySystem.get(snapshot.id64);
+    const localRecord = partial.localRecord ?? existing?.localRecord ?? localSystems[String(snapshot.id64)] ?? null;
+    const watchlistEntry = partial.watchlistEntry ?? existing?.watchlistEntry ?? null;
+    const pinnedEntry = partial.pinnedEntry ?? existing?.pinnedEntry ?? null;
+    const systemProjects = (projectsBySystem.get(snapshot.id64) ?? []).slice().sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const activeProject = systemProjects.find((project) => project.status !== 'established') ?? null;
+    const establishedProject = systemProjects.find((project) => project.status === 'established') ?? null;
+    const labels = new Set<SavedSystemLabel>([
+      ...(localRecord?.labels ?? []),
+      ...(watchlistEntry ? ['considering'] as const : []),
+      ...(pinnedEntry ? ['favourite'] as const : []),
+    ]);
+    bySystem.set(snapshot.id64, {
+      id64: snapshot.id64,
+      name: snapshot.name,
+      x: snapshot.x,
+      y: snapshot.y,
+      z: snapshot.z,
+      population: snapshot.population,
+      is_colonised: snapshot.is_colonised,
+      labels: Array.from(labels),
+      planCount: systemProjects.length,
+      latestPlanActivity: systemProjects[0]?.updated_at ?? null,
+      latestSavedAt: latestTimestamp([
+        watchlistEntry?.added_at ?? null,
+        pinnedEntry?.pinned_at ?? null,
+        localRecord?.updated_at ?? null,
+      ]),
+      activeProject,
+      establishedProject,
+      explicitColonisedAt: localRecord?.explicit_colonised_at ?? null,
+      isColonised: Boolean(establishedProject || localRecord?.explicit_colonised_at),
+      watchlistEntry,
+      pinnedEntry,
+      localRecord,
+      ...existing,
+      ...partial,
+    });
+  };
+
+  for (const entry of watchlistEntries) {
+    register({
+      id64: entry.system_id64,
+      name: entry.name,
+      x: entry.x,
+      y: entry.y,
+      z: entry.z,
+      population: entry.population,
+      is_colonised: entry.is_colonised,
+    }, {
+      watchlistEntry: entry,
+    });
+  }
+
+  for (const entry of pinnedEntries) {
+    register({
+      id64: entry.id64,
+      name: entry.name,
+      x: entry.x,
+      y: entry.y,
+      z: entry.z,
+      population: entry.population,
+      is_colonised: entry.is_colonised,
+    }, {
+      pinnedEntry: entry,
+    });
+  }
+
+  for (const record of Object.values(localSystems)) {
+    register(record, {
+      localRecord: record,
+    });
+  }
+
+  return Array.from(bySystem.values())
+    .filter((system) => system.labels.length > 0)
+    .sort((a, b) => (b.latestSavedAt ?? '').localeCompare(a.latestSavedAt ?? ''));
+}
+
+function groupPlansBySystem(projects: ColonyProject[]) {
+  const groups = new Map<number, { systemId64: number; systemName: string; plans: ColonyProject[]; latestUpdatedAt: string }>();
+  for (const project of projects) {
+    const existing = groups.get(project.system_id64);
+    if (existing) {
+      existing.plans.push(project);
+      if (project.updated_at > existing.latestUpdatedAt) existing.latestUpdatedAt = project.updated_at;
+      continue;
+    }
+    groups.set(project.system_id64, {
+      systemId64: project.system_id64,
+      systemName: project.system_name,
+      plans: [project],
+      latestUpdatedAt: project.updated_at,
+    });
+  }
+  return Array.from(groups.values())
+    .map((group) => ({
+      ...group,
+      plans: group.plans.slice().sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+    }))
+    .sort((a, b) => b.latestUpdatedAt.localeCompare(a.latestUpdatedAt));
+}
+
+function buildColonies({
+  savedSystems,
+  localSystems,
+  projects,
+}: {
+  savedSystems: SavedSystemViewModel[];
+  localSystems: Record<string, MyWorkSystemRecord>;
+  projects: ColonyProject[];
+}): ColonyViewModel[] {
+  const establishedBySystem = new Map<number, ColonyProject>();
+  for (const project of projects) {
+    if (project.status !== 'established') continue;
+    const current = establishedBySystem.get(project.system_id64);
+    if (!current || project.updated_at > current.updated_at) {
+      establishedBySystem.set(project.system_id64, project);
+    }
+  }
+
+  const colonies = new Map<number, ColonyViewModel>();
+  for (const system of savedSystems) {
+    const establishedProject = establishedBySystem.get(system.id64) ?? system.establishedProject ?? null;
+    if (!establishedProject && !system.explicitColonisedAt) continue;
+    colonies.set(system.id64, {
+      id64: system.id64,
+      systemName: system.name,
+      plan: establishedProject,
+      objective: objectiveSummaryLabel(establishedProject?.objective ?? null),
+      colonisedAt: latestTimestamp([establishedProject?.updated_at ?? null, system.explicitColonisedAt]),
+    });
+  }
+
+  for (const record of Object.values(localSystems)) {
+    if (!record.explicit_colonised_at || colonies.has(record.id64)) continue;
+    colonies.set(record.id64, {
+      id64: record.id64,
+      systemName: record.name,
+      plan: establishedBySystem.get(record.id64) ?? null,
+      objective: objectiveSummaryLabel(establishedBySystem.get(record.id64)?.objective ?? null),
+      colonisedAt: latestTimestamp([record.explicit_colonised_at, establishedBySystem.get(record.id64)?.updated_at ?? null]),
+    });
+  }
+
+  for (const project of projects) {
+    if (project.status !== 'established' || colonies.has(project.system_id64)) continue;
+    colonies.set(project.system_id64, {
+      id64: project.system_id64,
+      systemName: project.system_name,
+      plan: project,
+      objective: objectiveSummaryLabel(project.objective),
+      colonisedAt: project.updated_at,
+    });
+  }
+
+  return Array.from(colonies.values()).sort((a, b) => (b.colonisedAt ?? '').localeCompare(a.colonisedAt ?? ''));
+}
+
+function selectContinuation({
+  savedSystems,
+  projects,
+}: {
+  savedSystems: SavedSystemViewModel[];
+  projects: ColonyProject[];
+}) {
+  const latestActivePlan = projects
+    .filter((project) => project.status !== 'established')
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at))[0] ?? null;
+  if (latestActivePlan) {
+    return { kind: 'plan' as const, project: latestActivePlan };
+  }
+  const recentSavedSystem = savedSystems
+    .filter((system) => system.planCount === 0)
+    .sort((a, b) => (b.latestSavedAt ?? '').localeCompare(a.latestSavedAt ?? ''))[0] ?? null;
+  if (recentSavedSystem) {
+    return { kind: 'saved-system' as const, system: recentSavedSystem };
+  }
+  return null;
+}
+
+function latestTimestamp(values: Array<string | null | undefined>) {
+  return values.filter((value): value is string => Boolean(value)).sort().slice(-1)[0] ?? null;
+}
+
+function formatTimestamp(value: string) {
+  return new Date(value).toLocaleString();
+}
+
+function formatRecentActivity(value: string) {
+  const deltaMs = Date.now() - new Date(value).getTime();
+  if (deltaMs < 60_000) return 'just now';
+  if (deltaMs < 60 * 60_000) return `${Math.max(1, Math.floor(deltaMs / 60_000))}m ago`;
+  if (deltaMs < 24 * 60 * 60_000) return `${Math.max(1, Math.floor(deltaMs / (60 * 60_000)))}h ago`;
+  return formatTimestamp(value);
+}
+
+function projectStatusLabel(status: ColonyProjectStatus) {
+  if (status === 'ready_to_build') return 'Ready to build';
+  if (status === 'building') return 'Building';
+  if (status === 'established') return 'Established';
+  return 'Draft';
+}
+
+function labelText(label: SavedSystemLabel) {
+  if (label === 'considering') return 'Considering';
+  if (label === 'favourite') return 'Favourite';
+  return 'Ready to plan';
+}

--- a/frontend-v2/src/features/my-work/myWorkStore.ts
+++ b/frontend-v2/src/features/my-work/myWorkStore.ts
@@ -1,0 +1,150 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+export type SavedSystemLabel = 'considering' | 'favourite' | 'ready_to_plan';
+
+export interface SavedSystemSnapshot {
+  id64: number;
+  name: string;
+  x: number | null;
+  y: number | null;
+  z: number | null;
+  population: number | null;
+  is_colonised: boolean;
+}
+
+export interface MyWorkSystemRecord extends SavedSystemSnapshot {
+  labels: SavedSystemLabel[];
+  explicit_colonised_at: string | null;
+  updated_at: string;
+}
+
+interface MyWorkState {
+  systems: Record<string, MyWorkSystemRecord>;
+  rememberSystem: (snapshot: SavedSystemSnapshot) => void;
+  setLabel: (snapshot: SavedSystemSnapshot, label: SavedSystemLabel, enabled: boolean) => void;
+  setExplicitColonised: (snapshot: SavedSystemSnapshot, enabled: boolean) => void;
+  clearSystemMetadata: (id64: number) => void;
+}
+
+const STORAGE_KEY = 'ed_my_work_v1';
+
+export const useMyWorkStore = create<MyWorkState>()(
+  persist(
+    (set, get) => ({
+      systems: {},
+      rememberSystem: (snapshot) => {
+        const key = String(snapshot.id64);
+        const existing = get().systems[key];
+        const next = normaliseRecord({
+          ...(existing ?? { labels: [], explicit_colonised_at: null, updated_at: new Date().toISOString() }),
+          ...snapshot,
+          updated_at: existing?.updated_at ?? new Date().toISOString(),
+        });
+        set((state) => ({
+          systems: {
+            ...state.systems,
+            [key]: next,
+          },
+        }));
+      },
+      setLabel: (snapshot, label, enabled) => {
+        const key = String(snapshot.id64);
+        const existing = get().systems[key];
+        const labelSet = new Set(existing?.labels ?? []);
+        if (enabled) {
+          labelSet.add(label);
+        } else {
+          labelSet.delete(label);
+        }
+        const next = normaliseRecord({
+          ...(existing ?? { explicit_colonised_at: null, updated_at: new Date().toISOString() }),
+          ...snapshot,
+          labels: Array.from(labelSet),
+          updated_at: new Date().toISOString(),
+        });
+        set((state) => ({
+          systems: {
+            ...state.systems,
+            [key]: next,
+          },
+        }));
+      },
+      setExplicitColonised: (snapshot, enabled) => {
+        const key = String(snapshot.id64);
+        const existing = get().systems[key];
+        const next = normaliseRecord({
+          ...(existing ?? { labels: [], updated_at: new Date().toISOString() }),
+          ...snapshot,
+          explicit_colonised_at: enabled ? new Date().toISOString() : null,
+          updated_at: new Date().toISOString(),
+        });
+        set((state) => ({
+          systems: {
+            ...state.systems,
+            [key]: next,
+          },
+        }));
+      },
+      clearSystemMetadata: (id64) => {
+        const key = String(id64);
+        set((state) => {
+          const systems = { ...state.systems };
+          delete systems[key];
+          return { systems };
+        });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      version: 1,
+      migrate: (persistedState) => ({
+        ...(persistedState as Partial<MyWorkState> | undefined),
+        systems: normaliseSystemRecord((persistedState as { systems?: unknown } | undefined)?.systems),
+      }),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        ...(persistedState as Partial<MyWorkState> | undefined),
+        systems: normaliseSystemRecord((persistedState as { systems?: unknown } | undefined)?.systems),
+      }),
+    },
+  ),
+);
+
+function normaliseRecord(record: Partial<MyWorkSystemRecord> & Pick<MyWorkSystemRecord, 'id64'>): MyWorkSystemRecord {
+  return {
+    id64: record.id64,
+    name: record.name?.trim() || `System ${record.id64}`,
+    x: record.x ?? null,
+    y: record.y ?? null,
+    z: record.z ?? null,
+    population: record.population ?? null,
+    is_colonised: Boolean(record.is_colonised),
+    labels: normaliseLabels(record.labels),
+    explicit_colonised_at: record.explicit_colonised_at ?? null,
+    updated_at: record.updated_at ?? new Date().toISOString(),
+  };
+}
+
+function normaliseSystemRecord(value: unknown): Record<string, MyWorkSystemRecord> {
+  const entries = value && typeof value === 'object' ? Object.values(value) : [];
+  return entries.reduce<Record<string, MyWorkSystemRecord>>((record, candidate) => {
+    if (!candidate || typeof candidate !== 'object') return record;
+    const system = candidate as Partial<MyWorkSystemRecord>;
+    if (!system.id64 || !Number.isFinite(system.id64)) return record;
+    record[String(system.id64)] = normaliseRecord(system as Partial<MyWorkSystemRecord> & Pick<MyWorkSystemRecord, 'id64'>);
+    return record;
+  }, {});
+}
+
+function normaliseLabels(labels: unknown): SavedSystemLabel[] {
+  if (!Array.isArray(labels)) return [];
+  const unique = new Set<SavedSystemLabel>();
+  for (const candidate of labels) {
+    if (candidate === 'considering' || candidate === 'favourite' || candidate === 'ready_to_plan') {
+      unique.add(candidate);
+    }
+  }
+  return Array.from(unique);
+}

--- a/frontend-v2/src/features/system-detail/SystemDetailModal.test.tsx
+++ b/frontend-v2/src/features/system-detail/SystemDetailModal.test.tsx
@@ -9,25 +9,6 @@ vi.mock('./useSystemDetail', () => ({
 }));
 
 vi.mock('./RatingRadar', () => ({ RatingRadar: () => <div>Rating radar</div> }));
-const {
-  mockBuildabilityPanel,
-  mockSlotPredictionPanel,
-  mockRecommendedBuildsPanel,
-  mockSimulationPreviewPanel,
-  mockRegionalPositionPanel,
-} = vi.hoisted(() => ({
-  mockBuildabilityPanel: vi.fn(() => <div>Buildability panel</div>),
-  mockSlotPredictionPanel: vi.fn(() => <div>Slot prediction panel</div>),
-  mockRecommendedBuildsPanel: vi.fn(() => <div>Recommended builds panel</div>),
-  mockSimulationPreviewPanel: vi.fn(() => <div>Embedded Colony Planner</div>),
-  mockRegionalPositionPanel: vi.fn(() => <div>Regional position panel</div>),
-}));
-
-vi.mock('./BuildabilityPanel', () => ({ BuildabilityPanel: mockBuildabilityPanel }));
-vi.mock('./SlotPredictionPanel', () => ({ SlotPredictionPanel: mockSlotPredictionPanel }));
-vi.mock('./RecommendedBuildsPanel', () => ({ RecommendedBuildsPanel: mockRecommendedBuildsPanel }));
-vi.mock('./SimulationPreviewPanel', () => ({ SimulationPreviewPanel: mockSimulationPreviewPanel }));
-vi.mock('./RegionalPositionPanel', () => ({ RegionalPositionPanel: mockRegionalPositionPanel }));
 
 const mockedUseSystemDetail = vi.mocked(useSystemDetail);
 
@@ -53,80 +34,90 @@ function mockLoadedSystem(overrides: Partial<SystemDetail> = {}) {
 describe('SystemDetailModal Colony Planner entry point', () => {
   afterEach(() => {
     mockedUseSystemDetail.mockReset();
-    mockBuildabilityPanel.mockClear();
-    mockSlotPredictionPanel.mockClear();
-    mockRecommendedBuildsPanel.mockClear();
-    mockSimulationPreviewPanel.mockClear();
-    mockRegionalPositionPanel.mockClear();
     vi.restoreAllMocks();
   });
 
-  it('renders a compact Colony Planner entry card on System Detail', () => {
+  it('renders the new save-or-start planning entry point on System Detail', () => {
     mockLoadedSystem();
 
     render(
       <SystemDetailModal
         id64={123}
         onClose={() => undefined}
-        onOpenColonyPlanner={() => undefined}
+        onStartPlan={() => undefined}
       />,
     );
 
     expect(screen.getByTestId('colony-planner-entry-card')).toBeTruthy();
-    expect(screen.getByText('Workspace available')).toBeTruthy();
+    expect(screen.getByText('Planning available')).toBeTruthy();
     expect(
       screen.getByText(
-        /Open the canonical planning workspace for this system/i,
+        /Assess this system, save it for later if needed, then create an intentional draft/i,
       ),
     ).toBeTruthy();
-    expect(screen.getByText(/review report-only evidence separately before you commit to assumptions/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Save for later/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Start a plan/i })).toBeTruthy();
     expect(screen.getAllByText('Test System').length).toBeGreaterThan(0);
     expect(screen.getAllByText('ID64 123').length).toBeGreaterThan(0);
   });
 
-  it('opens the dedicated Colony Planner workspace through the existing route handler', () => {
-    const onOpenColonyPlanner = vi.fn();
+  it('creates a draft only after explicit objective and manual start confirmation', () => {
+    const onStartPlan = vi.fn();
     mockLoadedSystem();
 
     render(
       <SystemDetailModal
         id64={123}
         onClose={() => undefined}
-        onOpenColonyPlanner={onOpenColonyPlanner}
+        onStartPlan={onStartPlan}
       />,
     );
 
-    fireEvent.click(screen.getByTestId('open-colony-planner'));
+    fireEvent.click(screen.getByTestId('open-plan-start'));
+    expect(screen.getByTestId('plan-start-panel')).toBeTruthy();
+    expect(onStartPlan).not.toHaveBeenCalled();
 
-    expect(onOpenColonyPlanner).toHaveBeenCalledTimes(1);
-    expect(onOpenColonyPlanner).toHaveBeenCalledWith(123);
+    fireEvent.click(screen.getByTestId('plan-objective-materials_coverage'));
+    fireEvent.click(screen.getByTestId('plan-approach-manual'));
+    expect(screen.getByText('Test System - Materials coverage')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('confirm-start-plan'));
+
+    expect(onStartPlan).toHaveBeenCalledTimes(1);
+    expect(onStartPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ id64: 123, name: 'Test System' }),
+      {
+        objective: 'materials_coverage',
+        startApproach: 'manual',
+      },
+    );
   });
 
-  it('does not render the full planner stack inline on System Detail', () => {
+  it('accepts decide-later plus recommendation-assisted as a valid plan start', () => {
+    const onStartPlan = vi.fn();
     mockLoadedSystem();
 
     render(
       <SystemDetailModal
         id64={123}
         onClose={() => undefined}
-        onOpenColonyPlanner={() => undefined}
+        onStartPlan={onStartPlan}
       />,
     );
 
-    expect(screen.queryByText('Buildability panel')).toBeNull();
-    expect(screen.queryByText('Regional position panel')).toBeNull();
-    expect(screen.queryByText('Recommended builds panel')).toBeNull();
-    expect(screen.queryByText('Embedded Colony Planner')).toBeNull();
-    expect(screen.queryByText('Slot prediction panel')).toBeNull();
-    expect(screen.queryByText('Colony Planning')).toBeNull();
-    expect(screen.queryByText('Observed Evidence')).toBeNull();
-    expect(screen.queryByText('Validation')).toBeNull();
-    expect(screen.queryByTestId('colony-planner-focus-target')).toBeNull();
-    expect(mockBuildabilityPanel).not.toHaveBeenCalled();
-    expect(mockRegionalPositionPanel).not.toHaveBeenCalled();
-    expect(mockRecommendedBuildsPanel).not.toHaveBeenCalled();
-    expect(mockSimulationPreviewPanel).not.toHaveBeenCalled();
-    expect(mockSlotPredictionPanel).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('open-plan-start'));
+    fireEvent.click(screen.getByTestId('plan-objective-decide_later'));
+    fireEvent.click(screen.getByTestId('plan-approach-recommendation'));
+    fireEvent.click(screen.getByTestId('confirm-start-plan'));
+
+    expect(onStartPlan).toHaveBeenCalledTimes(1);
+    expect(onStartPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ id64: 123 }),
+      {
+        objective: 'decide_later',
+        startApproach: 'recommendation_assisted',
+      },
+    );
   });
 
   it('keeps the normal System Detail overview visible', () => {
@@ -136,7 +127,7 @@ describe('SystemDetailModal Colony Planner entry point', () => {
       <SystemDetailModal
         id64={123}
         onClose={() => undefined}
-        onOpenColonyPlanner={() => undefined}
+        onStartPlan={() => undefined}
       />,
     );
 
@@ -207,7 +198,7 @@ describe('SystemDetailModal Colony Planner entry point', () => {
       <SystemDetailModal
         id64={123}
         onClose={() => undefined}
-        onOpenColonyPlanner={() => undefined}
+        onStartPlan={() => undefined}
       />,
     );
 
@@ -235,7 +226,28 @@ describe('SystemDetailModal Colony Planner entry point', () => {
 
     expect(screen.getByText('Planner unavailable')).toBeTruthy();
     expect(screen.getByText(/Planner routing is unavailable for this system record/i)).toBeTruthy();
-    expect((screen.getByTestId('open-colony-planner') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId('open-plan-start') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('saving a system does not create a plan', () => {
+    const onStartPlan = vi.fn();
+    const onToggleSaveForLater = vi.fn();
+    mockLoadedSystem();
+
+    render(
+      <SystemDetailModal
+        id64={123}
+        onClose={() => undefined}
+        onToggleSaveForLater={onToggleSaveForLater}
+        onStartPlan={onStartPlan}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('system-detail-save-for-later'));
+
+    expect(onToggleSaveForLater).toHaveBeenCalledTimes(1);
+    expect(onToggleSaveForLater).toHaveBeenCalledWith(expect.objectContaining({ id64: 123 }));
+    expect(onStartPlan).not.toHaveBeenCalled();
   });
 
   it('does not expose raw backend errors in the compact System Detail error state', () => {
@@ -260,11 +272,10 @@ describe('SystemDetailModal Colony Planner entry point', () => {
       <SystemDetailModal
         id64={123}
         onClose={onClose}
-        onOpenColonyPlanner={() => undefined}
+        onStartPlan={() => undefined}
       />,
     );
 
-    expect(screen.queryByTestId('colony-planner-focus-target')).toBeNull();
     fireEvent.click(screen.getByTestId('system-detail-close'));
     expect(onClose).toHaveBeenCalledTimes(1);
 

--- a/frontend-v2/src/features/system-detail/SystemDetailModal.tsx
+++ b/frontend-v2/src/features/system-detail/SystemDetailModal.tsx
@@ -1,10 +1,17 @@
-import { useEffect } from 'react';
-import { Rocket, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Bookmark, Compass, Rocket, X } from 'lucide-react';
 import type { SystemDetail, SystemBody, SystemStation } from '@/types/api';
 import { distanceFromSol, formatCoords, formatPopulationForSystem, systemStatusLabel } from '@/lib/format';
 import { displayRationale } from '@/lib/rationale';
 import { compareBodiesByHierarchy } from '@/lib/bodyHierarchySort';
 import { transientStationPlanningReason } from '@/features/colony-planner/existingInfrastructure';
+import {
+  defaultDraftProjectName,
+  objectiveLabel,
+  PLANNER_OBJECTIVE_OPTIONS,
+  type ColonyProjectObjective,
+  type ColonyProjectStartApproach,
+} from '@/features/colony-planner/plannerDraftContext';
 import { SemanticStatusBadge } from '@/components/SemanticStatusBadge';
 import { WorkspaceContextHeader } from '@/components/WorkspaceContextHeader';
 import { useSystemDetail } from './useSystemDetail';
@@ -14,7 +21,15 @@ export interface SystemDetailModalProps {
   id64:    number;
   onClose: () => void;
   focusIntent?: 'colony-planner' | null;
-  onOpenColonyPlanner?: (id64: number) => void;
+  savedForLater?: boolean;
+  onToggleSaveForLater?: (system: SystemDetail) => void;
+  onStartPlan?: (
+    system: SystemDetail,
+    planStart: {
+      objective: ColonyProjectObjective;
+      startApproach: ColonyProjectStartApproach;
+    },
+  ) => void;
   /** Renders alongside Spansh / Inara / EDSM so callers can wire up
    *  Watchlist / Pin / Compare / Show-on-map without this component knowing
    *  about those features. Receives the loaded SystemDetail or null while
@@ -35,10 +50,17 @@ export interface SystemDetailModalProps {
 export function SystemDetailModal({
   id64,
   onClose,
-  onOpenColonyPlanner,
+  focusIntent = null,
+  savedForLater = false,
+  onToggleSaveForLater,
+  onStartPlan,
   renderActions,
 }: SystemDetailModalProps) {
   const { data, loading, error, refetch } = useSystemDetail(id64);
+  const [planStartOpen, setPlanStartOpen] = useState(false);
+  const [selectedObjective, setSelectedObjective] = useState<ColonyProjectObjective | null>(null);
+  const [selectedStartApproach, setSelectedStartApproach] = useState<ColonyProjectStartApproach | null>(null);
+  const loadedSystemId = data?.id64 ?? null;
 
   // Esc closes the modal. Body scroll lock only fires if we're actually
   // mounted (id64 changes between mounts so this is per-open).
@@ -52,6 +74,13 @@ export function SystemDetailModal({
       document.body.style.overflow = prevOverflow;
     };
   }, [onClose]);
+
+  useEffect(() => {
+    if (loadedSystemId == null) return;
+    setPlanStartOpen(focusIntent === 'colony-planner' && Boolean(onStartPlan));
+    setSelectedObjective(null);
+    setSelectedStartApproach(null);
+  }, [focusIntent, loadedSystemId, onStartPlan]);
 
   return (
     <div
@@ -120,7 +149,15 @@ export function SystemDetailModal({
             <>
               <ColonyPlannerEntryPoint
                 system={data}
-                onOpen={onOpenColonyPlanner}
+                savedForLater={savedForLater}
+                planningOpen={planStartOpen}
+                selectedObjective={selectedObjective}
+                selectedStartApproach={selectedStartApproach}
+                onToggleSaveForLater={onToggleSaveForLater}
+                onTogglePlanStart={() => setPlanStartOpen((open) => !open)}
+                onSelectObjective={setSelectedObjective}
+                onSelectStartApproach={setSelectedStartApproach}
+                onStartPlan={onStartPlan}
               />
               <Section title="Rating signals">
                 <RatingRadar sys={data} />
@@ -146,12 +183,38 @@ export function SystemDetailModal({
 
 function ColonyPlannerEntryPoint({
   system,
-  onOpen,
+  savedForLater,
+  planningOpen,
+  selectedObjective,
+  selectedStartApproach,
+  onToggleSaveForLater,
+  onTogglePlanStart,
+  onSelectObjective,
+  onSelectStartApproach,
+  onStartPlan,
 }: {
   system: SystemDetail;
-  onOpen?: (id64: number) => void;
+  savedForLater: boolean;
+  planningOpen: boolean;
+  selectedObjective: ColonyProjectObjective | null;
+  selectedStartApproach: ColonyProjectStartApproach | null;
+  onToggleSaveForLater?: (system: SystemDetail) => void;
+  onTogglePlanStart: () => void;
+  onSelectObjective: (value: ColonyProjectObjective) => void;
+  onSelectStartApproach: (value: ColonyProjectStartApproach) => void;
+  onStartPlan?: (
+    system: SystemDetail,
+    planStart: {
+      objective: ColonyProjectObjective;
+      startApproach: ColonyProjectStartApproach;
+    },
+  ) => void;
 }) {
-  const canOpenPlanner = Number.isFinite(system.id64) && system.id64 > 0 && !!onOpen;
+  const canStartPlan = Number.isFinite(system.id64) && system.id64 > 0 && !!onStartPlan;
+  const defaultDraftName = useMemo(
+    () => defaultDraftProjectName(system.name || 'Unknown system', selectedObjective ?? 'decide_later'),
+    [selectedObjective, system.name],
+  );
 
   return (
     <section
@@ -160,33 +223,204 @@ function ColonyPlannerEntryPoint({
     >
       <WorkspaceContextHeader
         journeyLabel="Next step: Plan"
-        title="Colony Planner"
+        title="Start a plan"
         headingLevel={3}
-        supportingText={canOpenPlanner
-          ? 'Open the canonical planning workspace for this system, then review report-only evidence separately before you commit to assumptions.'
+        supportingText={canStartPlan
+          ? 'Assess this system, save it for later if needed, then create an intentional draft when you are ready to enter the canonical planner.'
           : 'Planner routing is unavailable for this system record, so continue reviewing system detail here or return to Explore.'}
         selectedSystemName={system.name || 'Unknown system'}
         selectedSystemMeta={<span className="tabular-nums">ID64 {Number.isFinite(system.id64) ? system.id64 : 'unknown'}</span>}
         status={(
           <SemanticStatusBadge
-            label={canOpenPlanner ? 'Workspace available' : 'Planner unavailable'}
-            tone={canOpenPlanner ? 'available' : 'unavailable'}
+            label={canStartPlan ? 'Planning available' : 'Planner unavailable'}
+            tone={canStartPlan ? 'available' : 'unavailable'}
           />
         )}
         actions={(
-          <button
-            type="button"
-            onClick={() => onOpen?.(system.id64)}
-            disabled={!canOpenPlanner}
-            data-testid="open-colony-planner"
-            className="inline-flex items-center gap-2 rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-2 text-xs font-mono font-bold text-orange hover:bg-orange/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80 disabled:cursor-not-allowed disabled:border-border disabled:bg-bg3/60 disabled:text-silver-dk"
-          >
-            <Rocket size={14} />
-            Open Colony Planner
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={() => onToggleSaveForLater?.(system)}
+              data-testid="system-detail-save-for-later"
+              className={[
+                'inline-flex items-center gap-2 rounded-chunk-sm border px-3 py-2 text-xs font-mono font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80',
+                savedForLater
+                  ? 'border-orange/50 bg-orange/15 text-orange hover:bg-orange/25'
+                  : 'border-border bg-bg4 text-silver hover:border-orange/45 hover:text-orange',
+              ].join(' ')}
+            >
+              <Bookmark size={14} />
+              {savedForLater ? 'Saved - remove' : 'Save for later'}
+            </button>
+            <button
+              type="button"
+              onClick={onTogglePlanStart}
+              disabled={!canStartPlan}
+              data-testid="open-plan-start"
+              className="inline-flex items-center gap-2 rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-2 text-xs font-mono font-bold text-orange hover:bg-orange/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80 disabled:cursor-not-allowed disabled:border-border disabled:bg-bg3/60 disabled:text-silver-dk"
+            >
+              <Rocket size={14} />
+              {planningOpen ? 'Hide plan start' : 'Start a plan'}
+            </button>
+          </>
         )}
       />
+      {planningOpen ? (
+        <PlanStartPanel
+          systemName={system.name || 'Unknown system'}
+          selectedObjective={selectedObjective}
+          selectedStartApproach={selectedStartApproach}
+          draftName={defaultDraftName}
+          onSelectObjective={onSelectObjective}
+          onSelectStartApproach={onSelectStartApproach}
+          onConfirm={() => {
+            if (!selectedObjective || !selectedStartApproach) return;
+            onStartPlan?.(system, {
+              objective: selectedObjective,
+              startApproach: selectedStartApproach,
+            });
+          }}
+        />
+      ) : null}
     </section>
+  );
+}
+
+function PlanStartPanel({
+  systemName,
+  selectedObjective,
+  selectedStartApproach,
+  draftName,
+  onSelectObjective,
+  onSelectStartApproach,
+  onConfirm,
+}: {
+  systemName: string;
+  selectedObjective: ColonyProjectObjective | null;
+  selectedStartApproach: ColonyProjectStartApproach | null;
+  draftName: string;
+  onSelectObjective: (value: ColonyProjectObjective) => void;
+  onSelectStartApproach: (value: ColonyProjectStartApproach) => void;
+  onConfirm: () => void;
+}) {
+  const readyToCreate = selectedObjective != null && selectedStartApproach != null;
+
+  return (
+    <div
+      data-testid="plan-start-panel"
+      className="mt-4 rounded-chunk-lg border border-orange/30 bg-bg2/85 p-4 space-y-4"
+    >
+      <div className="space-y-1">
+        <h4 className="font-display text-base tracking-[0.1em] text-orange-lt">
+          Start a real local draft
+        </h4>
+        <p className="text-sm leading-relaxed text-silver">
+          Choose an objective, choose how you want to begin, then enter the canonical planner for {systemName}.
+        </p>
+      </div>
+
+      <section className="space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">Step 1</span>
+          <h5 className="font-mono text-[11px] uppercase tracking-[0.14em] text-silver">Objective</h5>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {PLANNER_OBJECTIVE_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onSelectObjective(option.value)}
+              data-testid={`plan-objective-${option.value}`}
+              aria-pressed={selectedObjective === option.value}
+              className={[
+                'rounded border px-3 py-3 text-left transition-colors',
+                selectedObjective === option.value
+                  ? 'border-orange/50 bg-orange/10'
+                  : 'border-border bg-bg3/35 hover:border-orange/35',
+              ].join(' ')}
+            >
+              <div className="font-semibold text-text">{option.label}</div>
+              <p className="mt-1 text-xs leading-relaxed text-silver-dk">{option.description}</p>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-orange">Step 2</span>
+          <h5 className="font-mono text-[11px] uppercase tracking-[0.14em] text-silver">Starting approach</h5>
+        </div>
+        <div className="grid gap-2 lg:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => onSelectStartApproach('recommendation_assisted')}
+            data-testid="plan-approach-recommendation"
+            aria-pressed={selectedStartApproach === 'recommendation_assisted'}
+            className={[
+              'rounded border px-3 py-3 text-left transition-colors',
+              selectedStartApproach === 'recommendation_assisted'
+                ? 'border-cyan/45 bg-cyan/10'
+                : 'border-border bg-bg3/35 hover:border-cyan/35',
+            ].join(' ')}
+          >
+            <div className="flex items-center gap-2 font-semibold text-text">
+              <Compass size={15} className="text-cyan" />
+              Start with ED-Finder recommendation
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-silver-dk">
+              ED-Finder will help compare suitable approaches in the planner. No recommendation is generated yet.
+            </p>
+          </button>
+          <button
+            type="button"
+            onClick={() => onSelectStartApproach('manual')}
+            data-testid="plan-approach-manual"
+            aria-pressed={selectedStartApproach === 'manual'}
+            className={[
+              'rounded border px-3 py-3 text-left transition-colors',
+              selectedStartApproach === 'manual'
+                ? 'border-orange/45 bg-orange/10'
+                : 'border-border bg-bg3/35 hover:border-orange/35',
+            ].join(' ')}
+          >
+            <div className="flex items-center gap-2 font-semibold text-text">
+              <Rocket size={15} className="text-orange" />
+              Build my own plan
+            </div>
+            <p className="mt-1 text-xs leading-relaxed text-silver-dk">
+              Start with an empty editable draft and shape the plan manually in the planner.
+            </p>
+          </button>
+        </div>
+      </section>
+
+      <div className="rounded border border-border/60 bg-bg3/35 px-3 py-2">
+        <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Draft preview</div>
+        <div className="mt-1 text-sm text-text">{draftName}</div>
+        <div className="mt-1 text-xs text-silver-dk">
+          {selectedObjective ? objectiveLabel(selectedObjective) : 'Choose an objective'} / Draft
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={!readyToCreate}
+          data-testid="confirm-start-plan"
+          className="inline-flex items-center gap-2 rounded-chunk-sm border border-orange/50 bg-orange/15 px-3 py-2 text-xs font-mono font-bold text-orange hover:bg-orange/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80 disabled:cursor-not-allowed disabled:border-border disabled:bg-bg3/60 disabled:text-silver-dk"
+        >
+          <Rocket size={14} />
+          Create draft and open planner
+        </button>
+        {!readyToCreate ? (
+          <p className="text-xs text-silver-dk">
+            Choose one objective and one starting approach to continue.
+          </p>
+        ) : null}
+      </div>
+    </div>
   );
 }
 

--- a/frontend-v2/src/hooks/useHashRoute.ts
+++ b/frontend-v2/src/hooks/useHashRoute.ts
@@ -10,7 +10,9 @@ import { useEffect, useState } from 'react';
  *   #search-tuning                → route='search-tuning', selectedSystemId=null
  *   #optimizer                    → route='search-tuning', selectedSystemId=null (legacy alias)
  *   #system/12345678              → route='finder',    selectedSystemId=12345678   (deep-link from external)
+ *   #my-work                      → route='my-work', selectedSystemId=null
  *   #colony-planner/system/123    → route='colony-planner', plannerSystemId=123
+ *   #colony-planner/system/123/project/abc → route='colony-planner', plannerSystemId=123, plannerProjectId='abc'
  *   #operator                     → route='operator', selectedSystemId=null
  *   #colony-planner               → route='colony-planner', plannerSystemId=null
  *   #colony-planner-prototype     → route='colony-planner-prototype', static visual prototype
@@ -27,13 +29,14 @@ import { useEffect, useState } from 'react';
  * The route set is still simple enough that this hand-rolled parser beats
  * pulling in react-router. Re-evaluate that trade-off if nested routes grow.
  */
-export type Route = 'finder' | 'watchlist' | 'pinned' | 'compare' | 'map' | 'search-tuning' | 'fc' | 'colony' | 'admin' | 'operator' | 'colony-planner' | 'colony-planner-prototype';
-const VALID_ROUTES: Route[] = ['finder', 'watchlist', 'pinned', 'compare', 'map', 'search-tuning', 'fc', 'colony', 'admin', 'operator', 'colony-planner', 'colony-planner-prototype'];
+export type Route = 'finder' | 'my-work' | 'watchlist' | 'pinned' | 'compare' | 'map' | 'search-tuning' | 'fc' | 'colony' | 'admin' | 'operator' | 'colony-planner' | 'colony-planner-prototype';
+const VALID_ROUTES: Route[] = ['finder', 'my-work', 'watchlist', 'pinned', 'compare', 'map', 'search-tuning', 'fc', 'colony', 'admin', 'operator', 'colony-planner', 'colony-planner-prototype'];
 
 export interface ParsedHash {
   route:            Route;
   selectedSystemId: number | null;
   plannerSystemId:  number | null;
+  plannerProjectId: string | null;
 }
 
 function parsePositiveId(value: string | undefined): number | null {
@@ -47,7 +50,7 @@ function parseHash(): ParsedHash {
   const parts = raw.split('/').filter(Boolean);
 
   if (parts.length === 0) {
-    return { route: 'finder', selectedSystemId: null, plannerSystemId: null };
+    return { route: 'finder', selectedSystemId: null, plannerSystemId: null, plannerProjectId: null };
   }
 
   let route: Route = 'finder';
@@ -62,16 +65,20 @@ function parseHash(): ParsedHash {
 
   let selectedSystemId: number | null = null;
   let plannerSystemId: number | null = null;
+  let plannerProjectId: string | null = null;
   if (parts[i] === 'system') {
     const id64 = parsePositiveId(parts[i + 1]);
     if (route === 'colony-planner') {
       plannerSystemId = id64;
+      if (parts[i + 2] === 'project' && parts[i + 3]) {
+        plannerProjectId = parts[i + 3];
+      }
     } else {
       selectedSystemId = id64;
     }
   }
 
-  return { route, selectedSystemId, plannerSystemId };
+  return { route, selectedSystemId, plannerSystemId, plannerProjectId };
 }
 
 function buildHash(route: Route, selectedSystemId: number | null): string {
@@ -80,21 +87,24 @@ function buildHash(route: Route, selectedSystemId: number | null): string {
   return selectedSystemId != null ? `${base}/system/${selectedSystemId}` : base;
 }
 
-function buildPlannerHash(plannerSystemId: number | null): string {
+function buildPlannerHash(plannerSystemId: number | null, plannerProjectId: string | null = null): string {
   const base = '#colony-planner';
-  return plannerSystemId != null ? `${base}/system/${plannerSystemId}` : base;
+  if (plannerSystemId == null) return base;
+  if (plannerProjectId) return `${base}/system/${plannerSystemId}/project/${encodeURIComponent(plannerProjectId)}`;
+  return `${base}/system/${plannerSystemId}`;
 }
 
 export interface HashRoute {
   route:            Route;
   selectedSystemId: number | null;
   plannerSystemId:  number | null;
+  plannerProjectId: string | null;
   /** Navigate to a tab. Preserves any open system modal. */
   navigate:    (r: Route) => void;
   /** Open the system detail modal on top of the current tab. */
   openSystem:  (id64: number) => void;
   /** Open the dedicated Colony Planner workspace for a system. */
-  openColonyPlanner: (id64: number) => void;
+  openColonyPlanner: (id64: number, options?: { projectId?: string | null }) => void;
   /** Close the modal — pops back to the current tab. */
   closeSystem: () => void;
 }
@@ -109,24 +119,26 @@ export function useHashRoute(): HashRoute {
   }, []);
 
   const navigate = (r: Route) => {
-    window.location.hash = r === 'colony-planner'
-      ? buildPlannerHash(parsed.plannerSystemId)
-      : buildHash(r, parsed.selectedSystemId);
+    if (r === 'colony-planner') {
+      window.location.hash = buildPlannerHash(parsed.plannerSystemId, parsed.plannerProjectId);
+      return;
+    }
+    window.location.hash = buildHash(r, parsed.selectedSystemId);
   };
 
   const openSystem = (id64: number) => {
     window.location.hash = buildHash(parsed.route, id64);
   };
 
-  const openColonyPlanner = (id64: number) => {
+  const openColonyPlanner = (id64: number, options?: { projectId?: string | null }) => {
     const systemId64 = Number(id64);
     if (!Number.isFinite(systemId64) || systemId64 <= 0) return;
-    window.location.hash = buildPlannerHash(systemId64);
+    window.location.hash = buildPlannerHash(systemId64, options?.projectId ?? null);
   };
 
   const closeSystem = () => {
     window.location.hash = parsed.route === 'colony-planner'
-      ? buildPlannerHash(parsed.plannerSystemId)
+      ? buildPlannerHash(parsed.plannerSystemId, parsed.plannerProjectId)
       : buildHash(parsed.route, null);
   };
 
@@ -134,6 +146,7 @@ export function useHashRoute(): HashRoute {
     route:            parsed.route,
     selectedSystemId: parsed.selectedSystemId,
     plannerSystemId:  parsed.plannerSystemId,
+    plannerProjectId: parsed.plannerProjectId,
     navigate, openSystem, openColonyPlanner, closeSystem,
   };
 }


### PR DESCRIPTION
## Summary
- add My Work as the player-facing Plan home with Saved Systems, Plans, and My Colonies
- add additive local saved-system metadata and project-aware planner resume routing
- extend local project lifecycle status and update focused tests for Slice 1 and Slice 2 flow coverage

## Validation
- yarn typecheck
- yarn lint
- yarn vitest run src/App.test.tsx src/components/NavBar.test.tsx src/components/ResultCard.test.tsx src/features/system-detail/SystemDetailModal.test.tsx src/features/my-work/MyWorkWorkspace.test.tsx src/features/colony-planner/colonyProjectStore.test.ts src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
- yarn vitest run