### PR TITLE
Clean up planner nav and Finder shell

### DIFF
--- a/frontend-v2/e2e/smoke.spec.ts
+++ b/frontend-v2/e2e/smoke.spec.ts
@@ -65,14 +65,11 @@ test.describe('ED Finder v2 — smoke', () => {
       }]));
     });
     await page.reload();
-    await page.getByTestId('nav-primary-review').click();
-    // Pins now live under the Review workspace, so enter Review before
-    // checking the persisted badge state.
-    await expect(
-      page.getByTestId('nav-pinned')
-    ).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId('nav-pinned')).toContainText(/Pin(s|ned)?/i);
-    await expect(page.getByTestId('nav-pinned')).toContainText('1');
+    await page.getByTestId('nav-primary-plan').click();
+    // Pins now feed the Saved Systems view inside My Work.
+    await expect(page.getByTestId('my-work-workspace')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('saved-system-12345')).toContainText('Persisted');
+    await expect(page.getByTestId('saved-system-12345')).toContainText('Favourite');
   });
 
   test('legacy /api/watchlist returns 410 (Phase 3 contract)', async ({ request }) => {

--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -273,7 +273,7 @@ describe('App Colony Planner workspace route', () => {
     expect(fetchMock).toHaveBeenCalledWith('/v2/bg/coalsack-1600.jpg?v=2', { method: 'HEAD', cache: 'no-cache' });
   });
 
-  it('renders the dedicated workspace without opening the System Detail modal', async () => {
+  it('renders the dedicated workspace without the global product-shell context or System Detail modal', async () => {
     window.location.hash = '#colony-planner/system/123';
 
     render(<App />);
@@ -281,6 +281,9 @@ describe('App Colony Planner workspace route', () => {
     await waitFor(() => {
       expect(screen.getByTestId('colony-planner-workspace').textContent).toContain('123');
     });
+    expect(screen.getByTestId('navbar')).toBeTruthy();
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
     expect(screen.queryByTestId('system-detail-modal')).toBeNull();
   });
 
@@ -304,7 +307,7 @@ describe('App Colony Planner workspace route', () => {
     expect(finderMain?.className).toContain('max-w-[1840px]');
   });
 
-  it('renders the workspace no-system state for #colony-planner', async () => {
+  it('renders the workspace no-system state for #colony-planner without duplicate shell context', async () => {
     window.location.hash = '#colony-planner';
 
     render(<App />);
@@ -312,6 +315,8 @@ describe('App Colony Planner workspace route', () => {
     await waitFor(() => {
       expect(screen.getByTestId('colony-planner-workspace').textContent).toContain('none');
     });
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
     expect(screen.queryByTestId('system-detail-modal')).toBeNull();
   });
 
@@ -410,7 +415,7 @@ describe('App Colony Planner workspace route', () => {
     expect(Object.values(useColonyProjectStore.getState().projects)).toHaveLength(0);
   });
 
-  it('renders the player-facing Explore / Plan / Review shell without persistent operator tools', async () => {
+  it('renders the compact player-facing Finder intro without internal shell labels', async () => {
     window.location.hash = '#finder';
 
     render(<App />);
@@ -422,6 +427,15 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.getByTestId('nav-primary-explore').textContent).toContain('Explore');
     expect(screen.getByTestId('nav-primary-plan').textContent).toContain('Plan');
     expect(screen.getByTestId('nav-primary-review').textContent).toContain('Review');
+    expect(screen.getByTestId('finder-page-heading').textContent).toContain('Finder');
+    expect(screen.getByTestId('finder-page-heading').textContent).toContain(
+      'Find promising systems. Save them for later or inspect them before starting a plan.',
+    );
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByText('Primary workspace')).toBeNull();
+    expect(screen.queryByText('Discovery workspace')).toBeNull();
+    expect(screen.queryByText('Next action')).toBeNull();
+    expect(screen.queryByText(/hand off into Plan/i)).toBeNull();
     expect(screen.queryByText('Operator tools')).toBeNull();
     expect(screen.queryByTestId('nav-admin')).toBeNull();
     expect(screen.queryByTestId('nav-operator')).toBeNull();
@@ -444,15 +458,19 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.queryByTestId('operator-mode-menu')).toBeNull();
   });
 
-  it('shows selected-system shell context only when the current route provides one and clears it after leaving inspect/plan', async () => {
+  it('keeps Finder inspect routes compact and clears selected-system context after leaving inspect/plan', async () => {
     window.location.hash = '#finder/system/123';
 
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+      expect(screen.getByTestId('system-detail-modal').textContent).toContain('123');
     });
-    expect(screen.getByTestId('product-shell-context').textContent).toContain('ID64 123');
+    expect(screen.getByTestId('finder-page-heading').textContent).toContain(
+      'Find promising systems. Save them for later or inspect them before starting a plan.',
+    );
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByText('Primary workspace')).toBeNull();
 
     window.location.hash = '#my-work';
     fireEvent(window, new HashChangeEvent('hashchange'));

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -479,8 +479,18 @@ function FinderView({
   const { filters, setFilters, reset, run, state, results } = search;
 
   return (
-    <div className="grid lg:grid-cols-[340px_1fr] gap-6">
-      <aside className="panel overflow-hidden lg:sticky lg:top-20 lg:self-start lg:max-h-[calc(100vh-11rem)] flex flex-col">
+    <div className="space-y-4">
+      <header data-testid="finder-page-heading" className="max-w-4xl">
+        <h1 className="font-display text-2xl tracking-[0.12em] text-orange sm:text-3xl">
+          Finder
+        </h1>
+        <p className="mt-1 max-w-2xl text-sm leading-relaxed text-silver sm:text-base">
+          Find promising systems. Save them for later or inspect them before starting a plan.
+        </p>
+      </header>
+
+      <div className="grid lg:grid-cols-[340px_1fr] gap-6">
+        <aside className="panel overflow-hidden lg:sticky lg:top-20 lg:self-start lg:max-h-[calc(100vh-11rem)] flex flex-col">
         <div className="overflow-y-auto flex-1 p-1">
           <SearchForm
             filters={filters}
@@ -563,7 +573,8 @@ function FinderView({
             )}
           </>
         )}
-      </section>
+        </section>
+      </div>
     </div>
   );
 }

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -31,10 +31,10 @@ describe('NavBar', () => {
     expect(screen.queryByTestId('nav-colony')).toBeNull();
   });
 
-  it('shows selected-system context only when provided and keeps primary navigation keyboard focusable', () => {
+  it('shows selected-system context only when the active route uses the global context panel', () => {
     render(
       <NavBar
-        current="colony-planner"
+        current="map"
         onNavigate={vi.fn()}
         health="Online"
         selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
@@ -48,6 +48,42 @@ describe('NavBar', () => {
     planButton.focus();
     expect(document.activeElement).toBe(planButton);
     expect(planButton.className).toContain('focus-visible:ring-2');
+  });
+
+  it('keeps Finder and Colony Planner free of the global product-shell context panel', () => {
+    const { rerender } = render(<NavBar current="finder" onNavigate={vi.fn()} health="Online" />);
+
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
+    expect(screen.queryByText('Primary workspace')).toBeNull();
+    expect(screen.queryByText('Discovery workspace')).toBeNull();
+    expect(screen.queryByText('Next action')).toBeNull();
+
+    rerender(
+      <NavBar
+        current="colony-planner"
+        onNavigate={vi.fn()}
+        health="Online"
+        selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
+      />,
+    );
+
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
+    expect(screen.queryByText('Shinrarta Dezhra')).toBeNull();
+  });
+
+  it('renders primary and active secondary desktop navigation in one route strip', () => {
+    render(<NavBar current="colony-planner" onNavigate={vi.fn()} health="Online" />);
+
+    const routeStrip = screen.getByTestId('nav-desktop-route-strip');
+    expect(routeStrip.contains(screen.getByTestId('nav-primary-explore'))).toBe(true);
+    expect(routeStrip.contains(screen.getByTestId('nav-primary-plan'))).toBe(true);
+    expect(routeStrip.contains(screen.getByTestId('nav-primary-review'))).toBe(true);
+    expect(routeStrip.contains(screen.getByTestId('nav-my-work'))).toBe(true);
+    expect(routeStrip.contains(screen.getByTestId('nav-colony-planner'))).toBe(true);
+    expect(screen.getByTestId('nav-primary-plan').getAttribute('aria-current')).toBe('page');
+    expect(screen.getByTestId('nav-colony-planner').getAttribute('aria-current')).toBe('page');
   });
 
   it('keeps menu closed by default and toggles open/close explicitly', () => {

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -86,6 +86,7 @@ export function NavBar({
   }), [compareCount, fcCount]);
 
   const operatorMode = current === 'admin' || current === 'operator';
+  const showPlayerContext = current !== 'finder' && current !== 'colony-planner';
   const currentPrimary = primaryWorkspaceForRoute(current);
   const activeSubnav = currentPrimary ? groupedRoutes[currentPrimary] : [];
   const currentRouteDescriptor = activeSubnav.find((tab) => tab.route === current)
@@ -152,9 +153,12 @@ export function NavBar({
           {/* divider */}
           <span className="hidden h-9 w-px shrink-0 bg-gradient-to-b from-transparent via-border-bright to-transparent sm:block" />
 
-          <div className="hidden min-w-0 flex-1 lg:flex lg:flex-col lg:gap-3">
+          <div
+            className="hidden min-w-0 flex-1 items-center gap-3 lg:flex"
+            data-testid="nav-desktop-route-strip"
+          >
             <div
-              className="flex flex-wrap items-center gap-2"
+              className="flex shrink-0 flex-wrap items-center gap-2"
               data-testid="nav-primary-workspaces"
               aria-label="Primary workspaces"
             >
@@ -178,23 +182,29 @@ export function NavBar({
               />
             </div>
             {currentPrimary ? (
-              <div
-                className="flex flex-wrap items-center gap-1 overflow-x-auto"
-                data-testid="nav-secondary-routes"
-                aria-label={`${currentWorkspaceMeta.primaryLabel} routes`}
-              >
-                {groupedRoutes[currentPrimary].map((tab) => (
-                  <Tab
-                    key={tab.route}
-                    label={tab.label}
-                    active={current === tab.route}
-                    onClick={() => handleNavigate(tab.route)}
-                    testid={tab.testid}
-                    badge={tab.badge}
-                    title={tab.title}
-                  />
-                ))}
-              </div>
+              <>
+                <span
+                  className="hidden h-7 w-px shrink-0 bg-gradient-to-b from-transparent via-border-bright to-transparent xl:block"
+                  aria-hidden
+                />
+                <div
+                  className="flex min-w-0 flex-wrap items-center gap-1 overflow-x-auto"
+                  data-testid="nav-secondary-routes"
+                  aria-label={`${currentWorkspaceMeta.primaryLabel} routes`}
+                >
+                  {groupedRoutes[currentPrimary].map((tab) => (
+                    <Tab
+                      key={tab.route}
+                      label={tab.label}
+                      active={current === tab.route}
+                      onClick={() => handleNavigate(tab.route)}
+                      testid={tab.testid}
+                      badge={tab.badge}
+                      title={tab.title}
+                    />
+                  ))}
+                </div>
+              </>
             ) : null}
           </div>
 
@@ -247,6 +257,7 @@ export function NavBar({
           </div>
         </div>
 
+        {operatorMode || showPlayerContext ? (
         <div className="mt-4 border-t border-border/70 pt-4">
           {operatorMode ? (
             <>
@@ -272,11 +283,11 @@ export function NavBar({
                 />
               </div>
             </>
-          ) : (
+          ) : showPlayerContext ? (
             <>
               <div className="hidden lg:block">
                 <WorkspaceContextHeader
-                  journeyLabel={`Primary workspace: ${currentWorkspaceMeta.primaryLabel}`}
+                  journeyLabel={currentWorkspaceMeta.primaryLabel}
                   title={currentWorkspaceMeta.title}
                   headingLevel={2}
                   supportingText={currentWorkspaceMeta.supportingText}
@@ -288,7 +299,6 @@ export function NavBar({
                       tone={currentWorkspaceMeta.statusTone}
                     />
                   )}
-                  facts={[{ label: 'Next action', value: currentWorkspaceMeta.nextAction, tone: 'orange' }]}
                   testId="product-shell-context"
                 />
               </div>
@@ -296,7 +306,7 @@ export function NavBar({
               <div className="space-y-3 lg:hidden" data-testid="product-shell-context-mobile">
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-                    Primary workspace
+                    Workspace
                   </span>
                   <SemanticStatusBadge
                     label={`${currentWorkspaceMeta.primaryLabel} · ${currentWorkspaceMeta.title}`}
@@ -305,9 +315,6 @@ export function NavBar({
                 </div>
                 <p className="text-sm leading-relaxed text-silver">
                   {currentWorkspaceMeta.supportingText}
-                </p>
-                <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-orange">
-                  Next action: {currentWorkspaceMeta.nextAction}
                 </p>
                 {selectedSystem ? (
                   <div className="rounded-chunk-lg border border-border bg-bg3/30 p-3">
@@ -324,8 +331,9 @@ export function NavBar({
                 ) : null}
               </div>
             </>
-          )}
+          ) : null}
         </div>
+        ) : null}
       </div>
 
       {menuOpen && (
@@ -620,9 +628,9 @@ function workspaceMetaForRoute(route: Route): WorkspaceMeta {
       return {
         title: 'Finder',
         primaryLabel: 'Explore',
-        supportingText: 'Discover candidate systems, inspect their current state, and move into planning only when a system is worth serious review.',
-        nextAction: 'Open a system to inspect it, then hand off into Plan.',
-        statusLabel: 'Discovery workspace',
+        supportingText: 'Find promising systems. Save them for later or inspect them before starting a plan.',
+        nextAction: 'Save systems for later or inspect them before starting a plan.',
+        statusLabel: 'Finder',
         statusTone: 'available',
       };
     case 'map':

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -437,6 +437,25 @@ describe('ColonyPlannerWorkspace', () => {
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });
 
+  it('renders one planner-local identity header without internal journey wording', async () => {
+    mockedUseSystemDetail.mockReturnValue({
+      data: system,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    await renderPlanner(undefined, { settle: false });
+
+    const headers = await screen.findAllByTestId('workspace-context-header');
+    expect(headers).toHaveLength(1);
+    expect(headers[0].textContent).toContain('Plan');
+    expect(headers[0].textContent).toContain('Colony Planner');
+    expect(headers[0].textContent).toContain('Workspace System');
+    expect(headers[0].textContent).toContain('ID64 123');
+    expect(screen.queryByText(/Journey stage/i)).toBeNull();
+  });
+
   it('renders the new whole-system planner by default and keeps Advanced Planner collapsed', async () => {
     const onOpenSystemDetail = vi.fn();
     mockedUseSystemDetail.mockReturnValue({

--- a/frontend-v2/src/features/colony-planner/WorkspaceHeader.tsx
+++ b/frontend-v2/src/features/colony-planner/WorkspaceHeader.tsx
@@ -27,7 +27,7 @@ export function WorkspaceHeaderSkeleton({
   return (
     <header className="panel overflow-hidden p-4 sm:p-5">
       <WorkspaceContextHeader
-        journeyLabel="Journey stage: Plan"
+        journeyLabel="Plan"
         title="Colony Planner"
         supportingText="Build and review a canonical plan while the selected-system evidence lane stays read-only."
         selectedSystemName="Loading system..."
@@ -74,7 +74,7 @@ export function WorkspaceHeader({
     <header className="panel overflow-hidden p-4 sm:p-5">
       <WorkspaceContextHeader
         testId="workspace-context-header"
-        journeyLabel="Journey stage: Plan"
+        journeyLabel="Plan"
         title="Colony Planner"
         supportingText="Build the selected system with canonical planner data, then review read-only evidence separately before committing to assumptions."
         selectedSystemName={system.name || 'Unknown system'}


### PR DESCRIPTION
## Summary
- remove the duplicated product-shell context from Finder and Colony Planner routes
- compact the desktop navigation into one primary/secondary route strip
- add player-facing Finder intro copy and simplify planner-local header wording
- update focused shell, Finder, planner, desktop nav, and mobile nav tests

## Validation
- yarn.cmd typecheck
- yarn.cmd lint (0 errors, existing 10 warnings)
- yarn.cmd vitest run src/components/NavBar.test.tsx src/features/colony-planner/ColonyPlannerWorkspace.test.tsx src/App.test.tsx
- git diff --check
- manual browser pass at desktop and narrow widths for Finder, Colony Planner, project Planner, My Work, and Map

## Notes
- Local backend was not running during browser verification, so live data panes were checked in API-issue/loading states while shell layout and copy were verified.