### PR TITLE
Remove duplicate My Work shell header

### DIFF
--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -377,16 +377,33 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.getByTestId('colony-planner-workspace').textContent).toContain(projects[0].id);
   });
 
-  it('renders My Work as the player-facing Plan destination and keeps Watchlist as a safe compatibility route', async () => {
-    window.location.hash = '#watchlist';
+  it.each([
+    ['#my-work', null],
+    ['#watchlist', 'Watchlist now opens the Saved Systems view inside My Work'],
+    ['#pinned', 'Pins now open the Saved Systems view inside My Work'],
+  ])('renders My Work with one local header and no shell context for %s', async (hash, aliasNotice) => {
+    window.location.hash = hash;
 
     render(<App />);
 
     await waitFor(() => {
       expect(screen.getByTestId('my-work-workspace')).toBeTruthy();
     });
-    expect(screen.getByTestId('product-shell-context').textContent).toContain('My Work');
-    expect(screen.getByTestId('my-work-workspace').textContent).toContain('Watchlist now opens the Saved Systems view inside My Work');
+
+    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
+    expect(screen.getAllByRole('heading', { name: 'My Work' })).toHaveLength(1);
+    expect(screen.getByTestId('my-work-workspace').textContent).toContain('Saved systems, plans, and colonies in one place.');
+    expect(screen.getByTestId('my-work-section-tabs').textContent).toContain('Saved Systems');
+    expect(screen.getByTestId('my-work-section-tabs').textContent).toContain('Plans');
+    expect(screen.getByTestId('my-work-section-tabs').textContent).toContain('My Colonies');
+    expect(screen.getByTestId('my-work-saved-systems')).toBeTruthy();
+
+    if (aliasNotice) {
+      expect(screen.getByTestId('my-work-workspace').textContent).toContain(aliasNotice);
+    } else {
+      expect(screen.getByTestId('my-work-workspace').textContent).not.toContain('now opens the Saved Systems view inside My Work');
+    }
   });
 
   it('saves a system for later without creating a draft', async () => {

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -50,7 +50,7 @@ describe('NavBar', () => {
     expect(planButton.className).toContain('focus-visible:ring-2');
   });
 
-  it('keeps Finder and Colony Planner free of the global product-shell context panel', () => {
+  it('keeps Finder, Colony Planner, and My Work routes free of the global product-shell context panel', () => {
     const { rerender } = render(<NavBar current="finder" onNavigate={vi.fn()} health="Online" />);
 
     expect(screen.queryByTestId('product-shell-context')).toBeNull();
@@ -71,6 +71,22 @@ describe('NavBar', () => {
     expect(screen.queryByTestId('product-shell-context')).toBeNull();
     expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
     expect(screen.queryByText('Shinrarta Dezhra')).toBeNull();
+
+    for (const route of ['my-work', 'watchlist', 'pinned'] as const) {
+      rerender(
+        <NavBar
+          current={route}
+          onNavigate={vi.fn()}
+          health="Online"
+          selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
+        />,
+      );
+
+      expect(screen.queryByTestId('product-shell-context')).toBeNull();
+      expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
+      expect(screen.queryByText('Shinrarta Dezhra')).toBeNull();
+      expect(screen.getByTestId('nav-primary-plan').getAttribute('aria-current')).toBe('page');
+    }
   });
 
   it('renders primary and active secondary desktop navigation in one route strip', () => {

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -86,7 +86,7 @@ export function NavBar({
   }), [compareCount, fcCount]);
 
   const operatorMode = current === 'admin' || current === 'operator';
-  const showPlayerContext = current !== 'finder' && current !== 'colony-planner';
+  const showPlayerContext = !['finder', 'colony-planner', 'my-work', 'watchlist', 'pinned'].includes(current);
   const currentPrimary = primaryWorkspaceForRoute(current);
   const activeSubnav = currentPrimary ? groupedRoutes[currentPrimary] : [];
   const currentRouteDescriptor = activeSubnav.find((tab) => tab.route === current)

--- a/frontend-v2/src/features/my-work/MyWorkWorkspace.test.tsx
+++ b/frontend-v2/src/features/my-work/MyWorkWorkspace.test.tsx
@@ -38,6 +38,23 @@ afterEach(() => {
 });
 
 describe('MyWorkWorkspace', () => {
+  it('keeps the local My Work header concise with section tabs intact', () => {
+    render(
+      <MyWorkWorkspace
+        watchlist={makeWatchlist()}
+        pinned={makePinned()}
+        onOpenDetail={vi.fn()}
+        onOpenPlanner={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'My Work' })).toBeTruthy();
+    expect(screen.queryByText('Player workspace')).toBeNull();
+    expect(screen.getByText('Saved systems, plans, and colonies in one place.')).toBeTruthy();
+    expect(screen.getByTestId('my-work-section-tabs').textContent).toContain('Saved Systems');
+    expect(screen.getByTestId('my-work-section-tabs').textContent).toContain('Plans');
+    expect(screen.getByTestId('my-work-section-tabs').textContent).toContain('My Colonies');
+  });
   it('merges existing Watchlist, Pins, and local ready-to-plan labels into Saved Systems', async () => {
     const watchlist = makeWatchlist({
       entries: [{

--- a/frontend-v2/src/features/my-work/MyWorkWorkspace.tsx
+++ b/frontend-v2/src/features/my-work/MyWorkWorkspace.tsx
@@ -203,14 +203,11 @@ export function MyWorkWorkspace({
       <header className="panel space-y-4 p-4 sm:p-5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-              Player workspace
-            </p>
             <h1 className="font-display text-xl tracking-[0.14em] text-orange">
               My Work
             </h1>
             <p className="mt-2 max-w-3xl text-sm leading-relaxed text-silver">
-              One calm place to return to saved systems, active plans, and established colony work without guessing which tool last held the context.
+              Saved systems, plans, and colonies in one place.
             </p>
           </div>
           <div className="rounded border border-border/60 bg-bg3/35 px-3 py-2 font-mono text-[11px] text-silver-dk">


### PR DESCRIPTION
## Summary
- suppress the global player context shell on My Work and legacy Watchlist/Pins routes
- keep the local My Work header, tabs, counts, and alias notices as the authoritative workspace surface
- shorten the My Work header copy

## Validation
- yarn.cmd typecheck
- yarn.cmd lint
- yarn.cmd vitest run src/components/NavBar.test.tsx src/App.test.tsx src/features/my-work/MyWorkWorkspace.test.tsx
- git diff --check
- manual rendered check for My Work, Watchlist, Pins, Map, and narrow viewport