### PR TITLE
Let shared page intros use full width

### DIFF
--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 import { useColonyProjectStore } from '@/features/colony-planner/colonyProjectStore';
@@ -59,6 +59,7 @@ vi.mock('@/features/pinned/usePinned', () => ({
 }));
 
 vi.mock('@/features/compare/useCompare', () => ({
+  COMPARE_MAX: 4,
   useCompare: () => ({
     entries: [],
     has: vi.fn(() => false),
@@ -475,6 +476,19 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.queryByTestId('operator-mode-menu')).toBeNull();
   });
 
+  it('renders Compare with the full existing shared-header supporting text', async () => {
+    window.location.hash = '#compare';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context')).toBeTruthy();
+    });
+
+    const supportingText = within(screen.getByTestId('product-shell-context')).getByText('Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.');
+    expect(supportingText.className).toContain('max-w-none');
+    expect(supportingText.className).not.toContain('max-w-3xl');
+  });
   it('keeps Finder inspect routes compact and clears selected-system context after leaving inspect/plan', async () => {
     window.location.hash = '#finder/system/123';
 

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { NavBar } from './NavBar';
 
@@ -50,6 +50,15 @@ describe('NavBar', () => {
     expect(planButton.className).toContain('focus-visible:ring-2');
   });
 
+  it('uses full-width supporting text for Compare when there is no right rail', () => {
+    render(<NavBar current="compare" onNavigate={vi.fn()} health="Online" />);
+
+    const context = screen.getByTestId('product-shell-context');
+    const supportingText = within(context).getByText('Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.');
+    expect(context.textContent).toContain('Compare');
+    expect(supportingText.className).toContain('max-w-none');
+    expect(supportingText.className).not.toContain('max-w-3xl');
+  });
   it('keeps Finder, Colony Planner, and My Work routes free of the global product-shell context panel', () => {
     const { rerender } = render(<NavBar current="finder" onNavigate={vi.fn()} health="Online" />);
 

--- a/frontend-v2/src/components/WorkspaceContextHeader.test.tsx
+++ b/frontend-v2/src/components/WorkspaceContextHeader.test.tsx
@@ -4,7 +4,22 @@ import { SemanticStatusBadge } from './SemanticStatusBadge';
 import { WorkspaceContextHeader } from './WorkspaceContextHeader';
 
 describe('WorkspaceContextHeader', () => {
-  it('renders journey context, selected system identity, facts, and actions together', () => {
+  it('lets supporting text use the full width when there is no right rail', () => {
+    render(
+      <WorkspaceContextHeader
+        journeyLabel="Review"
+        title="Compare"
+        supportingText="Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace."
+        status={<SemanticStatusBadge label="Ready" tone="available" />}
+      />,
+    );
+
+    const supportingText = screen.getByText('Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.');
+    expect(supportingText.className).toContain('max-w-none');
+    expect(supportingText.className).not.toContain('max-w-3xl');
+  });
+
+  it('renders journey context, selected system identity, facts, actions, and constrained supporting text together', () => {
     render(
       <WorkspaceContextHeader
         journeyLabel="Journey stage: Plan"
@@ -21,6 +36,7 @@ describe('WorkspaceContextHeader', () => {
       />,
     );
 
+    const supportingText = screen.getByText('Build the selected system with canonical planner data.');
     expect(screen.getByText('Journey stage: Plan')).toBeTruthy();
     expect(screen.getByText('Colony Planner')).toBeTruthy();
     expect(screen.getByText('Selected system')).toBeTruthy();
@@ -29,5 +45,7 @@ describe('WorkspaceContextHeader', () => {
     expect(screen.getByText('Coords')).toBeTruthy();
     expect(screen.getByText('Refinery')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Open system detail' })).toBeTruthy();
+    expect(supportingText.className).toContain('max-w-3xl');
+    expect(supportingText.className).not.toContain('max-w-none');
   });
 });

--- a/frontend-v2/src/components/WorkspaceContextHeader.tsx
+++ b/frontend-v2/src/components/WorkspaceContextHeader.tsx
@@ -42,6 +42,7 @@ export function WorkspaceContextHeader({
   testId,
 }: WorkspaceContextHeaderProps) {
   const HeadingTag = headingLevel === 1 ? 'h1' : headingLevel === 2 ? 'h2' : 'h3';
+  const hasRightRail = Boolean(selectedSystemName || selectedSystemMeta || actions);
 
   return (
     <header
@@ -64,7 +65,7 @@ export function WorkspaceContextHeader({
             {title}
           </HeadingTag>
           {supportingText ? (
-            <p className="max-w-3xl text-sm leading-relaxed text-silver">
+            <p className={[hasRightRail ? 'max-w-3xl' : 'max-w-none', 'text-sm leading-relaxed text-silver'].join(' ')}>
               {supportingText}
             </p>
           ) : null}


### PR DESCRIPTION
## Summary
- let WorkspaceContextHeader supporting text use full available width when there is no selected-system rail or action area
- keep the constrained width when selected-system context or actions are present, preserving planner-style layouts
- add focused coverage for Compare copy and both header width variants

## Validation
- yarn.cmd typecheck
- yarn.cmd lint
- yarn.cmd vitest run src/components/WorkspaceContextHeader.test.tsx src/components/NavBar.test.tsx src/App.test.tsx
- git diff --check
- manual rendered check for Compare, Map, and a loaded Planner route at desktop and narrow widths