### PR TITLE
Remove redundant Compare review eyebrow

### DIFF
--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -485,7 +485,11 @@ describe('App Colony Planner workspace route', () => {
       expect(screen.getByTestId('product-shell-context')).toBeTruthy();
     });
 
-    const supportingText = within(screen.getByTestId('product-shell-context')).getByText('Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.');
+    const context = screen.getByTestId('product-shell-context');
+    const supportingText = within(context).getByText('Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.');
+    expect(context.textContent).toContain('Decision review');
+    expect(context.textContent).toContain('Compare');
+    expect(within(context).queryByText(/^Review$/i)).toBeNull();
     expect(supportingText.className).toContain('max-w-none');
     expect(supportingText.className).not.toContain('max-w-3xl');
   });

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -50,14 +50,19 @@ describe('NavBar', () => {
     expect(planButton.className).toContain('focus-visible:ring-2');
   });
 
-  it('uses full-width supporting text for Compare when there is no right rail', () => {
-    render(<NavBar current="compare" onNavigate={vi.fn()} health="Online" />);
+  it('uses full-width supporting text for Compare and removes its redundant Review eyebrow', () => {
+    const { rerender } = render(<NavBar current="compare" onNavigate={vi.fn()} health="Online" />);
 
     const context = screen.getByTestId('product-shell-context');
     const supportingText = within(context).getByText('Review candidate systems side by side before committing to a plan. This remains a decision-support surface, not a planning workspace.');
+    expect(context.textContent).toContain('Decision review');
     expect(context.textContent).toContain('Compare');
+    expect(within(context).queryByText(/^Review$/i)).toBeNull();
     expect(supportingText.className).toContain('max-w-none');
     expect(supportingText.className).not.toContain('max-w-3xl');
+
+    rerender(<NavBar current="map" onNavigate={vi.fn()} health="Online" />);
+    expect(within(screen.getByTestId('product-shell-context')).getByText(/^Explore$/i)).toBeTruthy();
   });
   it('keeps Finder, Colony Planner, and My Work routes free of the global product-shell context panel', () => {
     const { rerender } = render(<NavBar current="finder" onNavigate={vi.fn()} health="Online" />);

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -287,7 +287,7 @@ export function NavBar({
             <>
               <div className="hidden lg:block">
                 <WorkspaceContextHeader
-                  journeyLabel={currentWorkspaceMeta.primaryLabel}
+                  journeyLabel={current === 'compare' ? undefined : currentWorkspaceMeta.primaryLabel}
                   title={currentWorkspaceMeta.title}
                   headingLevel={2}
                   supportingText={currentWorkspaceMeta.supportingText}

--- a/frontend-v2/src/components/WorkspaceContextHeader.tsx
+++ b/frontend-v2/src/components/WorkspaceContextHeader.tsx
@@ -7,7 +7,7 @@ export interface WorkspaceContextFact {
 }
 
 export interface WorkspaceContextHeaderProps {
-  journeyLabel: string;
+  journeyLabel?: string;
   title: string;
   supportingText?: string;
   selectedSystemName?: string | null;
@@ -54,9 +54,11 @@ export function WorkspaceContextHeader({
     >
       <div className="min-w-0 space-y-3">
         <div className="flex flex-wrap items-center gap-2">
-          <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
-            {journeyLabel}
-          </p>
+          {journeyLabel ? (
+            <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-silver-dk">
+              {journeyLabel}
+            </p>
+          ) : null}
           {status}
         </div>
 


### PR DESCRIPTION
## Summary
- suppress the separate grey Review eyebrow on the Compare shared header
- keep the Decision review badge, Compare title, description, and width behavior unchanged
- keep other shared-header route labels, such as Map Explore, intact

## Validation
- yarn.cmd typecheck
- yarn.cmd lint
- yarn.cmd vitest run src/components/NavBar.test.tsx src/App.test.tsx
- git diff --check