### PR TITLE
Add hosted Hetzner review environment support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,11 +281,12 @@ jobs:
         run: |
           set -e
           # Build a temporary tree that mimics the docker mount layout.
-          mkdir -p /tmp/ngx/snippets /tmp/ngx/www /tmp/ngx/v2
+          mkdir -p /tmp/ngx/snippets /tmp/ngx/www /tmp/ngx/v2 /tmp/ngx/logs
           cp config/nginx.conf            /tmp/ngx/nginx.conf
           cp config/security-headers.conf /tmp/ngx/snippets/security-headers.conf
           # Patch paths that wouldn't exist in the runner sandbox.
           sed -i 's|/etc/nginx/snippets/security-headers.conf|/tmp/ngx/snippets/security-headers.conf|g' /tmp/ngx/nginx.conf
+          sed -i 's|/var/log/nginx-review/|/tmp/ngx/logs/|g' /tmp/ngx/nginx.conf
           # Replace upstream + comment out HTTPS server block (no certs in CI).
           sed -i 's|server api:8000;|server 127.0.0.1:8000;|' /tmp/ngx/nginx.conf
           python3 - <<'PY'

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ credentials.json
 *.pem
 *.key
 .credentials
+.secrets/
+.review/

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -51,6 +51,7 @@ http {
     # Rate limiting
     limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
     limit_req_zone $binary_remote_addr zone=search:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=review_api:10m rate=30r/s;
 
     # ── Upstream definition ──────────────────────────────────────────────────
     # Using an upstream block instead of set $variable + proxy_pass.
@@ -148,6 +149,84 @@ http {
         # ./frontend:/var/www/html mount.)
         location / {
             return 301 https://$host/v2/;
+        }
+    }
+
+    # ── Hosted review server ─────────────────────────────────────────────────
+    # Hosted review lane for draft PR branches.
+    #
+    # Cloudflare Flexible SSL terminates public TLS and forwards HTTP to this
+    # origin, matching the production edge pattern without adding a new certbot
+    # workflow. The review API is isolated on edfinder-review-edge and is not
+    # the production api_backend upstream.
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name review.ed-finder.app;
+
+        access_log /var/log/nginx-review/review-access.log main buffer=32k flush=5s;
+        error_log  /var/log/nginx-review/review-error.log warn;
+
+        include /etc/nginx/snippets/security-headers.conf;
+
+        auth_basic "ED Finder hosted review";
+        auth_basic_user_file /etc/nginx/review.htpasswd;
+
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $review_api_origin http://review-api:8000;
+
+        root /var/www/review;
+        index index.html;
+
+        # Review administrative/cache mutation endpoints are not exposed at
+        # the public edge, even behind basic auth.
+        location ^~ /api/admin/ {
+            return 403;
+        }
+
+        location = /api/cache/clear {
+            return 403;
+        }
+
+        location = /api/metrics {
+            return 403;
+        }
+
+        location /api/ {
+            limit_req zone=review_api burst=60 nodelay;
+
+            proxy_pass         $review_api_origin;
+            proxy_http_version 1.1;
+            proxy_set_header   Connection        "";
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
+
+            proxy_connect_timeout 10s;
+            proxy_read_timeout    300s;
+            proxy_send_timeout    60s;
+        }
+
+        location ^~ /assets/ {
+            try_files $uri =404;
+            expires 7d;
+            add_header Cache-Control "public, max-age=604800, immutable";
+            include /etc/nginx/snippets/security-headers.conf;
+        }
+
+        location = /index.html {
+            try_files /index.html =404;
+            expires -1;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+            include /etc/nginx/snippets/security-headers.conf;
+        }
+
+        location / {
+            try_files $uri $uri/ /index.html;
+            expires -1;
+            add_header Cache-Control "no-store, no-cache, must-revalidate, max-age=0" always;
+            include /etc/nginx/snippets/security-headers.conf;
         }
     }
 

--- a/docker-compose.review-hosted.yml
+++ b/docker-compose.review-hosted.yml
@@ -1,0 +1,32 @@
+services:
+  review-postgres:
+    mem_limit: 2g
+    cpus: 2.0
+
+  review-redis:
+    mem_limit: 256m
+    cpus: 0.5
+
+  review-api:
+    mem_limit: 1g
+    cpus: 1.0
+    environment:
+      CORS_ORIGINS: https://review.ed-finder.app
+    networks:
+      - review
+      - review-edge
+
+networks:
+  review:
+    name: edfinder-review-hosted-network
+
+  review-edge:
+    name: edfinder-review-edge
+    external: true
+
+volumes:
+  review_postgres_data:
+    name: edfinder_review_hosted_postgres_data
+
+  review_redis_data:
+    name: edfinder_review_hosted_redis_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,6 +289,9 @@ services:
       - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./config/security-headers.conf:/etc/nginx/snippets/security-headers.conf:ro
       - ./frontend-v2/dist:/var/www/v2:ro   # v2 (Vite/React) build output, mounted at /v2/
+      - /opt/ed-finder-review/frontend-v2/dist:/var/www/review:ro
+      - /opt/ed-finder-review/.secrets/review.htpasswd:/etc/nginx/review.htpasswd:ro
+      - /opt/ed-finder-review/.review/nginx-logs:/var/log/nginx-review
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - /var/lib/letsencrypt:/var/lib/letsencrypt:ro
       - /var/log/nginx:/var/log/nginx
@@ -310,6 +313,9 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
+    networks:
+      - default
+      - review-edge
 
   # ── Import runner (one-shot, run manually) ─────────────────────────────────
   # Always use docker compose --profile import run --rm importer <args>
@@ -455,3 +461,6 @@ volumes:
 networks:
   default:
     name: ed-finder_default
+  review-edge:
+    name: edfinder-review-edge
+    external: true

--- a/docs/operations/hosted-review-environment.md
+++ b/docs/operations/hosted-review-environment.md
@@ -1,0 +1,157 @@
+# Hosted Hetzner Review Environment
+
+This runbook activates and operates the persistent hosted review lane at:
+
+```text
+https://review.ed-finder.app
+```
+
+The review lane is for manually testing draft PR branches before they merge. It uses the production Dockerised Nginx edge, but its API, Postgres, Redis, volumes, and synthetic corpus are isolated from production data.
+
+## Safety Boundary
+
+- Do not deploy this automatically from GitHub, Git pushes, or PR changes.
+- Do not use production database URLs, Redis URLs, volumes, credentials, API containers, or logs.
+- Review data is synthetic and review-only.
+- Review drafts live in browser storage for `review.ed-finder.app`.
+- Review cannot alter Elite Dangerous or any live game state.
+- Only one active hosted review branch/ref is supported at a time.
+- The Raspberry Pi is not the primary PR review environment.
+
+## DNS And Edge Prerequisite
+
+`review.ed-finder.app` must point to the same Hetzner host as production and use the same Cloudflare/proxied Flexible SSL posture as `ed-finder.app`.
+
+Do not add a new public Nginx container, host-level Nginx config, Certbot workflow, or additional public host ports. Production `ed-nginx` remains the only public edge.
+
+## Initial Activation
+
+Run these commands manually on the Hetzner host. They are intentionally not automated by Git push or PR state.
+
+```bash
+cd /opt/ed-finder
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+```
+
+Create the dedicated edge network that only production `ed-nginx` and hosted `review-api` may join:
+
+```bash
+docker network create edfinder-review-edge
+```
+
+Create the review auth file. The helper prompts without echoing the password, writes a bcrypt htpasswd entry, and applies restrictive permissions:
+
+```bash
+cd /opt/ed-finder
+scripts/ops/create_review_auth_file.sh --user review
+```
+
+Deploy PR #271 as the first candidate only after the hosted review infrastructure is on `main`:
+
+1. Merge PR #272.
+2. Update Hetzner `main` with the merged hosted-review infrastructure.
+3. Rebase PR #271 onto the updated `main`.
+4. Push the rebased PR #271 branch.
+5. Deploy that rebased branch into `review.ed-finder.app`.
+
+```bash
+cd /opt/ed-finder
+scripts/ops/deploy_hosted_review.sh deploy \
+  --ref stage-25d-a2-planner-clarity \
+  --confirm-hosted-review
+```
+
+The deploy command creates `/opt/ed-finder-review/.review/nginx-logs` before production Nginx needs the review log mount.
+
+Before recreating the live production Nginx edge, validate the assembled production Compose and Nginx configuration in a throwaway Nginx container:
+
+```bash
+cd /opt/ed-finder
+docker compose config -q
+docker compose run --rm --no-deps nginx nginx -t
+```
+
+Only after both preflight commands pass, expose the review virtual host by recreating only production Nginx with the new mount/network configuration:
+
+```bash
+cd /opt/ed-finder
+docker compose up -d nginx
+docker compose exec nginx nginx -t
+docker compose exec nginx nginx -s reload
+```
+
+Verify the public review host and production health:
+
+```bash
+curl -I -H 'Host: review.ed-finder.app' http://127.0.0.1/
+curl -I -u review https://review.ed-finder.app/
+curl -fsS http://127.0.0.1/api/health
+curl -fsS https://ed-finder.app/api/health
+docker compose ps nginx api postgres redis
+```
+
+The first command should challenge with HTTP basic auth. The second command prompts for the review password and should reach the review React app after authentication.
+
+## Switching The Review Ref
+
+Deploy a different branch, PR ref, tag, or commit by running the same script with a new `--ref`. The script refuses dirty review checkout state outside `.secrets/` and `.review/`, records the requested ref and resolved commit, rebuilds the review frontend with `VITE_PUBLIC_BASE=/`, and updates only the hosted review compose project.
+
+```bash
+cd /opt/ed-finder
+scripts/ops/deploy_hosted_review.sh deploy \
+  --ref origin/some-review-branch \
+  --confirm-hosted-review
+```
+
+Deployment metadata is written to:
+
+```text
+/opt/ed-finder-review/.review/deployment.json
+```
+
+## Browser Review
+
+Open:
+
+```text
+https://review.ed-finder.app
+```
+
+Authenticate with the review-only HTTP basic-auth account. The review frontend is served from `/opt/ed-finder-review/frontend-v2/dist` at the hostname root. `/api/` is proxied only to the isolated `review-api` container on `edfinder-review-edge`.
+
+## Teardown And Rollback
+
+Standard review teardown stops only the isolated review Postgres, Redis, and API:
+
+```bash
+cd /opt/ed-finder
+scripts/ops/deploy_hosted_review.sh teardown --confirm-hosted-review
+```
+
+The review hostname remains configured on production Nginx and remains protected by HTTP basic auth. While review services are stopped, the review application or its API may be unavailable; production application traffic remains unaffected.
+
+Remove review-owned containers and volumes only when explicitly intended:
+
+```bash
+cd /opt/ed-finder
+scripts/ops/deploy_hosted_review.sh teardown \
+  --confirm-hosted-review \
+  --remove-volumes
+```
+
+Switching review branches uses `deploy`, which rebuilds the selected ref and starts a fresh review stack with clean synthetic volumes.
+
+Removing the review virtual host from the public edge is a separate, deliberate Nginx configuration rollback. It is not part of ordinary review teardown. Do not stop production Nginx as a review rollback step.
+
+Do not delete `/opt/ed-finder`. Do not run `docker compose down` for the production project as part of review rollback.
+
+## Implementation Notes
+
+- `docker-compose.review.yml` remains the disposable local Review Lab contract.
+- `docker-compose.review-hosted.yml` is the hosted overlay and adds only hosted concerns: exact review CORS, conservative limits, and the review edge network for `review-api`.
+- `docker-compose.yml` attaches only `nginx` to `edfinder-review-edge`, mounts the review frontend/auth files read-only, and mounts review-only Nginx logs under `/opt/ed-finder-review/.review/nginx-logs`.
+- `config/nginx.conf` serves only `review.ed-finder.app` from `/var/www/review` and proxies `/api/` to `review-api`, never to `api_backend`.
+- Review admin/cache mutation endpoints are blocked at the review vhost.
+- Hosted deploy resets the hosted review Compose project with `down -v --remove-orphans` only after preflight checks pass, then seeds a clean synthetic review database for the selected ref.

--- a/scripts/ops/create_review_auth_file.sh
+++ b/scripts/ops/create_review_auth_file.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REVIEW_REPO_DIR="${REVIEW_REPO_DIR:-/opt/ed-finder-review}"
+AUTH_FILE="${REVIEW_AUTH_FILE:-$REVIEW_REPO_DIR/.secrets/review.htpasswd}"
+USERNAME="${REVIEW_AUTH_USER:-review}"
+FORCE=0
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops/create_review_auth_file.sh [--user USERNAME] [--path AUTH_FILE] [--force]
+
+Creates the hosted-review HTTP basic-auth file with a bcrypt htpasswd entry.
+The password is prompted interactively and is not echoed.
+
+Defaults:
+  USERNAME  review
+  AUTH_FILE /opt/ed-finder-review/.secrets/review.htpasswd
+USAGE
+}
+
+die() {
+  printf '[ERROR] %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user)
+      USERNAME="$2"
+      shift 2
+      ;;
+    --path)
+      AUTH_FILE="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$USERNAME" =~ ^[A-Za-z0-9._-]+$ ]] || die 'username may contain only letters, numbers, dot, underscore, and dash'
+command -v htpasswd >/dev/null || die 'htpasswd is required; install apache2-utils and rerun'
+
+if [[ -e "$AUTH_FILE" && "$FORCE" -ne 1 ]]; then
+  die "$AUTH_FILE already exists; pass --force to replace it intentionally"
+fi
+
+printf 'Review username: %s\n' "$USERNAME"
+read -r -s -p 'Review password: ' PASSWORD
+printf '\n'
+read -r -s -p 'Confirm review password: ' PASSWORD_CONFIRM
+printf '\n'
+
+[[ -n "$PASSWORD" ]] || die 'password must not be empty'
+[[ "$PASSWORD" == "$PASSWORD_CONFIRM" ]] || die 'passwords did not match'
+
+AUTH_DIR="$(dirname "$AUTH_FILE")"
+umask 077
+mkdir -p "$AUTH_DIR"
+chmod 700 "$AUTH_DIR"
+
+TMP_FILE="$(mktemp "$AUTH_DIR/.review.htpasswd.XXXXXX")"
+trap 'rm -f "$TMP_FILE"' EXIT
+
+printf '%s\n' "$PASSWORD" | htpasswd -B -C 12 -i -c "$TMP_FILE" "$USERNAME" >/dev/null
+install -m 600 "$TMP_FILE" "$AUTH_FILE"
+
+unset PASSWORD PASSWORD_CONFIRM
+
+printf '[OK] wrote %s with mode 600\n' "$AUTH_FILE"

--- a/scripts/ops/deploy_hosted_review.sh
+++ b/scripts/ops/deploy_hosted_review.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRODUCTION_REPO_DIR="${PRODUCTION_REPO_DIR:-/opt/ed-finder}"
+REVIEW_REPO_DIR="${REVIEW_REPO_DIR:-/opt/ed-finder-review}"
+REVIEW_PROJECT="${REVIEW_PROJECT:-edfinder-review-hosted}"
+REVIEW_EDGE_NETWORK="${REVIEW_EDGE_NETWORK:-edfinder-review-edge}"
+REVIEW_HOSTNAME="${REVIEW_HOSTNAME:-review.ed-finder.app}"
+REVIEW_AUTH_FILE="${REVIEW_AUTH_FILE:-$REVIEW_REPO_DIR/.secrets/review.htpasswd}"
+REVIEW_METADATA_FILE="${REVIEW_METADATA_FILE:-$REVIEW_REPO_DIR/.review/deployment.json}"
+REVIEW_NGINX_LOG_DIR="${REVIEW_NGINX_LOG_DIR:-$REVIEW_REPO_DIR/.review/nginx-logs}"
+CONFIRM=0
+REMOVE_VOLUMES=0
+COMMAND=""
+DEPLOY_REF=""
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/ops/deploy_hosted_review.sh deploy --ref REF --confirm-hosted-review
+  scripts/ops/deploy_hosted_review.sh teardown --confirm-hosted-review [--remove-volumes]
+
+Deploys one branch/ref to the isolated hosted review stack at review.ed-finder.app.
+The script never switches branches in /opt/ed-finder and never runs production
+compose down. It starts only the review compose project.
+
+Environment overrides:
+  PRODUCTION_REPO_DIR=/opt/ed-finder
+  REVIEW_REPO_DIR=/opt/ed-finder-review
+  REVIEW_PROJECT=edfinder-review-hosted
+  REVIEW_EDGE_NETWORK=edfinder-review-edge
+  REVIEW_AUTH_FILE=/opt/ed-finder-review/.secrets/review.htpasswd
+  REVIEW_NGINX_LOG_DIR=/opt/ed-finder-review/.review/nginx-logs
+USAGE
+}
+
+say() { printf '\n[INFO] %s\n' "$*"; }
+ok() { printf '[OK]   %s\n' "$*"; }
+die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    deploy|teardown)
+      COMMAND="$1"
+      shift
+      ;;
+    --ref)
+      DEPLOY_REF="$2"
+      shift 2
+      ;;
+    --confirm-hosted-review)
+      CONFIRM=1
+      shift
+      ;;
+    --remove-volumes)
+      REMOVE_VOLUMES=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ "$CONFIRM" -eq 1 ]] || die 'mutating hosted review commands require --confirm-hosted-review'
+[[ -n "$COMMAND" ]] || die 'command is required: deploy or teardown'
+
+require_tool() {
+  command -v "$1" >/dev/null || die "$1 is required"
+}
+
+compose_args=(
+  -f "$REVIEW_REPO_DIR/docker-compose.review.yml"
+  -f "$REVIEW_REPO_DIR/docker-compose.review-hosted.yml"
+  -p "$REVIEW_PROJECT"
+)
+
+run_review_compose() {
+  docker compose "${compose_args[@]}" "$@"
+}
+
+require_auth_file() {
+  [[ -f "$REVIEW_AUTH_FILE" ]] || die "missing review auth file: $REVIEW_AUTH_FILE"
+  local mode other_digit
+  mode="$(stat -c '%a' "$REVIEW_AUTH_FILE")"
+  other_digit="${mode: -1}"
+  if (( other_digit & 4 )); then
+    die "review auth file must not be world-readable: $REVIEW_AUTH_FILE has mode $mode"
+  fi
+}
+
+ensure_edge_network() {
+  docker network inspect "$REVIEW_EDGE_NETWORK" >/dev/null || die "missing Docker edge network $REVIEW_EDGE_NETWORK; create it with: docker network create $REVIEW_EDGE_NETWORK"
+}
+
+ensure_review_nginx_log_dir() {
+  umask 027
+  mkdir -p "$REVIEW_NGINX_LOG_DIR"
+  chmod 750 "$REVIEW_REPO_DIR/.review" "$REVIEW_NGINX_LOG_DIR"
+}
+
+ensure_review_checkout() {
+  [[ -d "$PRODUCTION_REPO_DIR/.git" ]] || die "$PRODUCTION_REPO_DIR is not the production git checkout"
+  mkdir -p "$REVIEW_REPO_DIR"
+  local remote_url
+  remote_url="$(git -C "$PRODUCTION_REPO_DIR" remote get-url origin)"
+  if [[ ! -d "$REVIEW_REPO_DIR/.git" ]]; then
+    git -C "$REVIEW_REPO_DIR" init
+    git -C "$REVIEW_REPO_DIR" remote add origin "$remote_url"
+  else
+    git -C "$REVIEW_REPO_DIR" remote set-url origin "$remote_url"
+  fi
+}
+
+dirty_review_paths() {
+  git -C "$REVIEW_REPO_DIR" status --porcelain=v1 --untracked-files=all \
+    | grep -Ev '^(\?\? )?(\.secrets/|\.review/)' || true
+}
+
+require_clean_review_checkout() {
+  local dirty
+  dirty="$(dirty_review_paths)"
+  [[ -z "$dirty" ]] || die "review checkout contains uncommitted changes outside .secrets/.review:$'\n'$dirty"
+}
+
+require_hosted_review_infrastructure() {
+  local -a missing=()
+  local required_path
+  for required_path in \
+    docker-compose.review.yml \
+    docker-compose.review-hosted.yml \
+    scripts/dev/review_environment_seed.py
+  do
+    [[ -f "$REVIEW_REPO_DIR/$required_path" ]] || missing+=("$required_path")
+  done
+
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    printf '[ERROR] Selected review ref does not contain hosted review infrastructure.\n' >&2
+    printf '[ERROR] Missing required path(s): %s\n' "${missing[*]}" >&2
+    printf '[ERROR] Rebase this branch onto current main after the hosted review environment has been merged, then deploy it again.\n' >&2
+    exit 1
+  fi
+}
+
+resolve_ref() {
+  local requested_ref="$1"
+  if git -C "$REVIEW_REPO_DIR" fetch --tags origin "$requested_ref" >/dev/null 2>&1; then
+    git -C "$REVIEW_REPO_DIR" rev-parse --verify 'FETCH_HEAD^{commit}'
+    return
+  fi
+  git -C "$REVIEW_REPO_DIR" fetch --tags origin >/dev/null
+  git -C "$REVIEW_REPO_DIR" rev-parse --verify "$requested_ref^{commit}" 2>/dev/null \
+    || git -C "$REVIEW_REPO_DIR" rev-parse --verify "origin/$requested_ref^{commit}"
+}
+
+write_deployment_metadata() {
+  local requested_ref="$1"
+  local resolved_commit="$2"
+  mkdir -p "$(dirname "$REVIEW_METADATA_FILE")"
+  python3 - "$REVIEW_METADATA_FILE" "$requested_ref" "$resolved_commit" "$REVIEW_HOSTNAME" "$REVIEW_PROJECT" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+
+path, requested_ref, resolved_commit, hostname, project = sys.argv[1:6]
+payload = {
+    "review_hostname": hostname,
+    "requested_ref": requested_ref,
+    "resolved_commit": resolved_commit,
+    "deployed_at_utc": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "compose_project": project,
+    "compose_files": [
+        "docker-compose.review.yml",
+        "docker-compose.review-hosted.yml",
+    ],
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+}
+
+verify_compose_targets() {
+  local config_text
+  config_text="$(run_review_compose config)"
+  for forbidden in \
+    'postgresql://edfinder:' \
+    '@postgres:5432/edfinder' \
+    'redis://redis:6379' \
+    'ed-postgres' \
+    'ed-redis' \
+    'env_file:' \
+    '/opt/ed-finder/.env'
+  do
+    if grep -Fq "$forbidden" <<<"$config_text"; then
+      die "hosted review compose contains forbidden production reference: $forbidden"
+    fi
+  done
+  grep -Fq 'CORS_ORIGINS: https://review.ed-finder.app' <<<"$config_text" \
+    || die 'hosted review CORS origin is not constrained to https://review.ed-finder.app'
+}
+
+capture_production_container_state() {
+  for container in ed-api ed-postgres ed-redis; do
+    docker inspect -f "${container} {{.Id}} {{.RestartCount}}" "$container" 2>/dev/null || true
+  done
+}
+
+wait_for_postgres() {
+  for _ in {1..60}; do
+    if run_review_compose exec -T review-postgres pg_isready -U review_user -d edfinder_local_review >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  die 'review Postgres did not become ready'
+}
+
+wait_for_redis() {
+  for _ in {1..60}; do
+    if [[ "$(run_review_compose exec -T review-redis redis-cli ping 2>/dev/null || true)" == "PONG" ]]; then
+      return
+    fi
+    sleep 2
+  done
+  die 'review Redis did not become ready'
+}
+
+wait_for_api() {
+  for _ in {1..60}; do
+    if run_review_compose exec -T review-api curl -fsS http://127.0.0.1:8000/api/health >/dev/null 2>&1; then
+      return
+    fi
+    sleep 2
+  done
+  die 'review API health did not become ready internally'
+}
+
+bootstrap_schema() {
+  run_review_compose exec -T review-postgres sh -lc \
+    'set -eu; for f in $(ls -1 /workspace/sql/*.sql | sort); do case "$f" in */seed_preview.sql) continue ;; esac; psql -h 127.0.0.1 -U review_user -d edfinder_local_review -v ON_ERROR_STOP=1 -q -f "$f" >/dev/null; done'
+}
+
+verify_runtime_targets() {
+  run_review_compose exec -T review-api sh -lc \
+    'test "$DATABASE_URL" = "postgresql://review_user:review_password@review-postgres:5432/edfinder_local_review" && test "$REDIS_URL" = "redis://review-redis:6379/0"'
+}
+
+verify_edge_network_membership() {
+  local names unexpected=()
+  names="$(docker network inspect -f '{{range .Containers}}{{println .Name}}{{end}}' "$REVIEW_EDGE_NETWORK")"
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    case "$name" in
+      ed-nginx|"$REVIEW_PROJECT"-review-api-*)
+        ;;
+      *)
+        unexpected+=("$name")
+        ;;
+    esac
+  done <<<"$names"
+  if [[ "${#unexpected[@]}" -gt 0 ]]; then
+    die "unexpected container(s) on $REVIEW_EDGE_NETWORK: ${unexpected[*]}"
+  fi
+}
+
+reset_hosted_review_project() {
+  run_review_compose down -v --remove-orphans
+}
+
+deploy_review() {
+  [[ -n "$DEPLOY_REF" ]] || die 'deploy requires --ref REF'
+  require_tool git
+  require_tool docker
+  require_tool corepack
+  require_tool python3
+  require_auth_file
+  ensure_edge_network
+  ensure_review_checkout
+  require_clean_review_checkout
+
+  say "Resolve review ref $DEPLOY_REF"
+  local resolved_commit
+  resolved_commit="$(resolve_ref "$DEPLOY_REF")"
+  git -C "$REVIEW_REPO_DIR" checkout --detach "$resolved_commit"
+  require_clean_review_checkout
+  require_hosted_review_infrastructure
+  ok "review checkout at $resolved_commit"
+
+  say "Build review frontend at root path"
+  (
+    cd "$REVIEW_REPO_DIR/frontend-v2"
+    corepack yarn install --frozen-lockfile
+    VITE_PUBLIC_BASE=/ corepack yarn build
+  )
+  ok 'review frontend built'
+
+  say "Validate hosted review compose targets"
+  verify_compose_targets
+  ensure_review_nginx_log_dir
+  local production_before production_after
+  production_before="$(capture_production_container_state)"
+
+  say "Reset hosted review project to clean synthetic volumes"
+  reset_hosted_review_project
+
+  say "Start isolated review data services"
+  run_review_compose up -d review-postgres review-redis
+  wait_for_postgres
+  wait_for_redis
+  bootstrap_schema
+
+  say "Build, seed, and start isolated review API"
+  run_review_compose build review-api
+  run_review_compose run --rm review-api python /workspace/scripts/dev/review_environment_seed.py
+  run_review_compose up -d review-api
+  wait_for_api
+  verify_runtime_targets
+  verify_edge_network_membership
+
+  production_after="$(capture_production_container_state)"
+  [[ "$production_before" == "$production_after" ]] || die 'production API/Postgres/Redis container state changed during hosted review deploy'
+  write_deployment_metadata "$DEPLOY_REF" "$resolved_commit"
+
+  ok "hosted review deploy complete for $REVIEW_HOSTNAME"
+  printf '[OK]   metadata: %s\n' "$REVIEW_METADATA_FILE"
+}
+
+teardown_review() {
+  require_tool docker
+  [[ -f "$REVIEW_REPO_DIR/docker-compose.review.yml" ]] || die "missing review compose file in $REVIEW_REPO_DIR"
+  [[ -f "$REVIEW_REPO_DIR/docker-compose.review-hosted.yml" ]] || die "missing hosted review overlay in $REVIEW_REPO_DIR"
+  local down_args=(down --remove-orphans)
+  if [[ "$REMOVE_VOLUMES" -eq 1 ]]; then
+    down_args+=(-v)
+  fi
+  run_review_compose "${down_args[@]}"
+  ok "stopped hosted review compose project $REVIEW_PROJECT"
+}
+
+case "$COMMAND" in
+  deploy)
+    deploy_review
+    ;;
+  teardown)
+    teardown_review
+    ;;
+  *)
+    die "unsupported command: $COMMAND"
+    ;;
+esac

--- a/tests/test_hosted_review_environment.py
+++ b/tests/test_hosted_review_environment.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_REVIEW_COMPOSE = ROOT / 'docker-compose.review.yml'
+HOSTED_REVIEW_COMPOSE = ROOT / 'docker-compose.review-hosted.yml'
+PRODUCTION_COMPOSE = ROOT / 'docker-compose.yml'
+NGINX_CONFIG = ROOT / 'config' / 'nginx.conf'
+CI_WORKFLOW = ROOT / '.github' / 'workflows' / 'ci.yml'
+DEPLOY_SCRIPT = ROOT / 'scripts' / 'ops' / 'deploy_hosted_review.sh'
+AUTH_SCRIPT = ROOT / 'scripts' / 'ops' / 'create_review_auth_file.sh'
+HOSTED_DOC = ROOT / 'docs' / 'operations' / 'hosted-review-environment.md'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def _service_names(compose_text: str) -> list[str]:
+    names: list[str] = []
+    in_services = False
+    for line in compose_text.splitlines():
+        if line == 'services:':
+            in_services = True
+            continue
+        if in_services and line and not line.startswith(' '):
+            break
+        if in_services:
+            match = re.match(r'^  ([A-Za-z0-9_-]+):$', line)
+            if match:
+                names.append(match.group(1))
+    return names
+
+
+def _service_block(compose_text: str, service_name: str) -> str:
+    lines = compose_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line == f'  {service_name}:':
+            start = index
+            break
+    assert start is not None, f'missing service {service_name}'
+    collected: list[str] = [lines[start]]
+    for line in lines[start + 1:]:
+        if line.startswith('  ') and not line.startswith('    '):
+            break
+        if line and not line.startswith(' '):
+            break
+        collected.append(line)
+    return '\n'.join(collected)
+
+
+def _top_level_block(compose_text: str, key: str) -> str:
+    lines = compose_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line == f'{key}:':
+            start = index
+            break
+    assert start is not None, f'missing top-level {key}'
+    collected: list[str] = [lines[start]]
+    for line in lines[start + 1:]:
+        if line and not line.startswith(' '):
+            break
+        collected.append(line)
+    return '\n'.join(collected)
+
+
+def _child_block(block: str, child_name: str) -> str:
+    lines = block.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line == f'  {child_name}:':
+            start = index
+            break
+    assert start is not None, f'missing child {child_name}'
+    collected: list[str] = [lines[start]]
+    for line in lines[start + 1:]:
+        if line.startswith('  ') and not line.startswith('    '):
+            break
+        if line and not line.startswith(' '):
+            break
+        collected.append(line)
+    return '\n'.join(collected)
+
+
+def _named_resource_name(compose_text: str, section: str, resource: str) -> str:
+    block = _child_block(_top_level_block(compose_text, section), resource)
+    for line in block.splitlines():
+        if line.strip().startswith('name:'):
+            return line.split(':', 1)[1].strip()
+    raise AssertionError(f'missing name for {section}.{resource}')
+
+
+def _merged_named_resource_name(base_text: str, overlay_text: str, section: str, resource: str) -> str:
+    try:
+        return _named_resource_name(overlay_text, section, resource)
+    except AssertionError:
+        return _named_resource_name(base_text, section, resource)
+
+
+def _list_values(block: str, key: str) -> list[str]:
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() == f'{key}:':
+            indent = len(line) - len(line.lstrip(' '))
+            values: list[str] = []
+            for child in lines[index + 1:]:
+                if child.strip() == '':
+                    continue
+                child_indent = len(child) - len(child.lstrip(' '))
+                if child_indent <= indent:
+                    break
+                stripped = child.strip()
+                if stripped.startswith('- '):
+                    values.append(stripped[2:].split(' #', 1)[0])
+            return values
+    return []
+
+
+def _mapping_value(block: str, key: str, name: str) -> str | None:
+    lines = block.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() == f'{key}:':
+            indent = len(line) - len(line.lstrip(' '))
+            for child in lines[index + 1:]:
+                if child.strip() == '':
+                    continue
+                child_indent = len(child) - len(child.lstrip(' '))
+                if child_indent <= indent:
+                    break
+                stripped = child.strip()
+                if stripped.startswith(f'{name}:'):
+                    return stripped.split(':', 1)[1].strip()
+    return None
+
+
+def _server_blocks(nginx_text: str) -> list[str]:
+    blocks: list[str] = []
+    collecting = False
+    depth = 0
+    current: list[str] = []
+    for line in nginx_text.splitlines():
+        if not collecting and re.match(r'^\s*server\s+\{', line):
+            collecting = True
+        if collecting:
+            current.append(line)
+            depth += line.count('{') - line.count('}')
+            if depth == 0:
+                blocks.append('\n'.join(current))
+                current = []
+                collecting = False
+    return blocks
+
+
+def _server_for_name(nginx_text: str, server_name: str) -> str:
+    for block in _server_blocks(nginx_text):
+        if f'server_name {server_name};' in block:
+            return block
+    raise AssertionError(f'missing nginx server block for {server_name}')
+
+
+def test_local_review_compose_remains_disposable_local_only():
+    compose_text = _read(LOCAL_REVIEW_COMPOSE)
+
+    assert 'docker-compose.review-hosted.yml' not in compose_text
+    assert 'edfinder-review-edge' not in compose_text
+    assert 'external:' not in compose_text
+    assert 'env_file:' not in compose_text
+    assert 'ed-finder.app' not in compose_text
+    assert '127.0.0.1:8001:8000' in compose_text
+
+    assert 'ports:' not in _service_block(compose_text, 'review-postgres')
+    assert 'ports:' not in _service_block(compose_text, 'review-redis')
+    assert _list_values(_service_block(compose_text, 'review-postgres'), 'networks') == ['review']
+    assert _list_values(_service_block(compose_text, 'review-redis'), 'networks') == ['review']
+    assert _list_values(_service_block(compose_text, 'review-api'), 'networks') == ['review']
+
+
+def test_local_review_compose_resolves_existing_local_resource_names():
+    compose_text = _read(LOCAL_REVIEW_COMPOSE)
+
+    assert _named_resource_name(compose_text, 'networks', 'review') == 'edfinder-review-network'
+    assert _named_resource_name(compose_text, 'volumes', 'review_postgres_data') == 'edfinder_review_postgres_data'
+    assert _named_resource_name(compose_text, 'volumes', 'review_redis_data') == 'edfinder_review_redis_data'
+
+
+def test_hosted_review_overlay_adds_only_review_api_to_edge_network():
+    compose_text = _read(HOSTED_REVIEW_COMPOSE)
+
+    assert _list_values(_service_block(compose_text, 'review-api'), 'networks') == ['review', 'review-edge']
+    assert 'review-edge' not in _service_block(compose_text, 'review-postgres')
+    assert 'review-edge' not in _service_block(compose_text, 'review-redis')
+    assert _named_resource_name(compose_text, 'networks', 'review-edge') == 'edfinder-review-edge'
+    assert 'external: true' in _child_block(_top_level_block(compose_text, 'networks'), 'review-edge')
+
+
+def test_hosted_review_compose_merges_to_hosted_private_resource_names():
+    local_text = _read(LOCAL_REVIEW_COMPOSE)
+    hosted_text = _read(HOSTED_REVIEW_COMPOSE)
+
+    assert (
+        _merged_named_resource_name(local_text, hosted_text, 'networks', 'review')
+        == 'edfinder-review-hosted-network'
+    )
+    assert (
+        _merged_named_resource_name(local_text, hosted_text, 'volumes', 'review_postgres_data')
+        == 'edfinder_review_hosted_postgres_data'
+    )
+    assert (
+        _merged_named_resource_name(local_text, hosted_text, 'volumes', 'review_redis_data')
+        == 'edfinder_review_hosted_redis_data'
+    )
+
+
+def test_hosted_review_overlay_constrains_targets_cors_and_resources():
+    compose_text = _read(HOSTED_REVIEW_COMPOSE)
+    api_block = _service_block(compose_text, 'review-api')
+
+    assert 'env_file:' not in compose_text
+    assert '.env' not in compose_text
+    for forbidden in (
+        'postgresql://edfinder:',
+        '@postgres:5432/edfinder',
+        'redis://redis:6379',
+        'ed-postgres',
+        'ed-redis',
+    ):
+        assert forbidden not in compose_text
+
+    assert _mapping_value(api_block, 'environment', 'CORS_ORIGINS') == 'https://review.ed-finder.app'
+    assert 'mem_limit: 2g' in _service_block(compose_text, 'review-postgres')
+    assert 'cpus: 2.0' in _service_block(compose_text, 'review-postgres')
+    assert 'mem_limit: 256m' in _service_block(compose_text, 'review-redis')
+    assert 'cpus: 0.5' in _service_block(compose_text, 'review-redis')
+    assert 'mem_limit: 1g' in api_block
+    assert 'cpus: 1.0' in api_block
+
+
+def test_production_compose_attaches_only_nginx_to_review_edge():
+    compose_text = _read(PRODUCTION_COMPOSE)
+    nginx_block = _service_block(compose_text, 'nginx')
+
+    assert _list_values(nginx_block, 'networks') == ['default', 'review-edge']
+    for service_name in _service_names(compose_text):
+        if service_name != 'nginx':
+            assert 'review-edge' not in _service_block(compose_text, service_name)
+
+    volumes = _list_values(nginx_block, 'volumes')
+    assert '/opt/ed-finder-review/frontend-v2/dist:/var/www/review:ro' in volumes
+    assert '/opt/ed-finder-review/.secrets/review.htpasswd:/etc/nginx/review.htpasswd:ro' in volumes
+    assert '/opt/ed-finder-review/.review/nginx-logs:/var/log/nginx-review' in volumes
+    assert 'name: edfinder-review-edge' in compose_text
+    assert 'external: true' in compose_text
+
+
+def test_review_nginx_host_is_auth_protected_and_uses_review_static_root_api_logs_and_rate_limit():
+    nginx_text = _read(NGINX_CONFIG)
+    review_block = _server_for_name(nginx_text, 'review.ed-finder.app')
+
+    assert 'limit_req_zone $binary_remote_addr zone=review_api:10m rate=30r/s;' in nginx_text
+    assert 'auth_basic "ED Finder hosted review";' in review_block
+    assert 'auth_basic_user_file /etc/nginx/review.htpasswd;' in review_block
+    assert 'access_log /var/log/nginx-review/review-access.log main buffer=32k flush=5s;' in review_block
+    assert 'error_log  /var/log/nginx-review/review-error.log warn;' in review_block
+    assert 'root /var/www/review;' in review_block
+    assert 'try_files $uri $uri/ /index.html;' in review_block
+    assert 'resolver 127.0.0.11 valid=10s ipv6=off;' in review_block
+    assert 'set $review_api_origin http://review-api:8000;' in review_block
+    assert 'proxy_pass         $review_api_origin;' in review_block
+    assert 'limit_req zone=review_api burst=60 nodelay;' in review_block
+    assert 'limit_req zone=api' not in review_block
+    assert 'api_backend' not in review_block
+    assert 'location ^~ /api/admin/' in review_block
+    assert 'location = /api/cache/clear' in review_block
+    assert 'return 403;' in review_block
+
+
+def test_production_nginx_hosts_remain_intact():
+    nginx_text = _read(NGINX_CONFIG)
+    production_blocks = [
+        block for block in _server_blocks(nginx_text)
+        if 'server_name ed-finder.app www.ed-finder.app;' in block
+    ]
+
+    assert len(production_blocks) == 2
+    assert 'limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;' in nginx_text
+    assert 'limit_req_zone $binary_remote_addr zone=search:10m rate=10r/s;' in nginx_text
+    assert any('listen 80;' in block and 'location /api/' in block for block in production_blocks)
+    assert any('listen 443 ssl;' in block and 'location = /api/events/live' in block for block in production_blocks)
+    assert all('review-api:8000' not in block for block in production_blocks)
+    assert all('zone=review_api' not in block for block in production_blocks)
+    assert any('proxy_pass         http://api_backend;' in block for block in production_blocks)
+    assert any('limit_req zone=api burst=60 nodelay;' in block for block in production_blocks)
+    assert any('limit_req zone=search burst=20 nodelay;' in block for block in production_blocks)
+
+
+def test_ci_nginx_syntax_sandbox_maps_review_log_directory():
+    workflow = _read(CI_WORKFLOW)
+
+    assert 'Nginx config syntax' in workflow
+    assert 'mkdir -p /tmp/ngx/snippets /tmp/ngx/www /tmp/ngx/v2 /tmp/ngx/logs' in workflow
+    assert "sed -i 's|/var/log/nginx-review/|/tmp/ngx/logs/|g' /tmp/ngx/nginx.conf" in workflow
+
+
+def test_hosted_review_deploy_tool_has_required_safety_guards():
+    script = _read(DEPLOY_SCRIPT)
+
+    assert '--confirm-hosted-review' in script
+    assert 'mutating hosted review commands require --confirm-hosted-review' in script
+    assert 'missing review auth file' in script
+    assert 'must not be world-readable' in script
+    assert 'status --porcelain=v1 --untracked-files=all' in script
+    assert '/opt/ed-finder-review' in script
+    assert 'git -C "$PRODUCTION_REPO_DIR" checkout' not in script
+    assert 'git -C "$PRODUCTION_REPO_DIR" switch' not in script
+    assert 'VITE_PUBLIC_BASE=/ corepack yarn build' in script
+    assert 'docker compose "${compose_args[@]}"' in script
+    assert 'docker compose down' not in script
+    assert 'reset_hosted_review_project' in script
+    assert 'run_review_compose down -v --remove-orphans' in script
+    assert 'local down_args=(down --remove-orphans)' in script
+    assert 'postgresql://review_user:review_password@review-postgres:5432/edfinder_local_review' in script
+    assert 'redis://review-redis:6379/0' in script
+    assert 'postgresql://edfinder:' in script
+    assert 'redis://redis:6379' in script
+    assert 'capture_production_container_state' in script
+    assert 'verify_edge_network_membership' in script
+    assert 'ed-nginx|"$REVIEW_PROJECT"-review-api-*' in script
+    assert 'REVIEW_NGINX_LOG_DIR="${REVIEW_NGINX_LOG_DIR:-$REVIEW_REPO_DIR/.review/nginx-logs}"' in script
+    assert 'ensure_review_nginx_log_dir' in script
+    reset_call = script.index('say "Reset hosted review project to clean synthetic volumes"')
+    assert script.index('VITE_PUBLIC_BASE=/ corepack yarn build') < reset_call
+    assert script.index('say "Validate hosted review compose targets"') < reset_call
+    assert reset_call < script.index('run_review_compose up -d review-postgres review-redis')
+    assert script.index('production_before="$(capture_production_container_state)"') < reset_call
+    verify_call = script.index('  verify_edge_network_membership\n\n  production_after=')
+    assert script.index('write_deployment_metadata "$DEPLOY_REF" "$resolved_commit"') > verify_call
+
+
+def test_hosted_review_deploy_ref_guard_runs_after_checkout_before_mutations():
+    script = _read(DEPLOY_SCRIPT)
+    deploy_section = script[script.index('deploy_review() {'):script.index('\nteardown_review() {')]
+
+    assert 'require_hosted_review_infrastructure' in script
+    assert 'docker-compose.review.yml' in script
+    assert 'docker-compose.review-hosted.yml' in script
+    assert 'scripts/dev/review_environment_seed.py' in script
+    assert 'Selected review ref does not contain hosted review infrastructure.' in script
+    assert (
+        'Rebase this branch onto current main after the hosted review environment has been merged, '
+        'then deploy it again.'
+    ) in script
+
+    checkout_call = deploy_section.index('git -C "$REVIEW_REPO_DIR" checkout --detach "$resolved_commit"')
+    guard_call = deploy_section.index('  require_hosted_review_infrastructure')
+    build_call = deploy_section.index('VITE_PUBLIC_BASE=/ corepack yarn build')
+    compose_validation_call = deploy_section.index('  verify_compose_targets')
+    reset_call = deploy_section.index('  reset_hosted_review_project')
+    data_start_call = deploy_section.index('  run_review_compose up -d review-postgres review-redis')
+    bootstrap_call = deploy_section.index('  bootstrap_schema')
+    api_build_call = deploy_section.index('  run_review_compose build review-api')
+    seed_call = deploy_section.index(
+        '  run_review_compose run --rm review-api python /workspace/scripts/dev/review_environment_seed.py'
+    )
+    api_start_call = deploy_section.index('  run_review_compose up -d review-api')
+
+    assert checkout_call < guard_call
+    assert guard_call < build_call
+    assert guard_call < compose_validation_call
+    assert guard_call < reset_call
+    assert guard_call < data_start_call
+    assert guard_call < bootstrap_call
+    assert guard_call < api_build_call
+    assert guard_call < seed_call
+    assert guard_call < api_start_call
+
+
+def test_review_auth_helper_prompts_without_echo_and_uses_bcrypt_htpasswd():
+    script = _read(AUTH_SCRIPT)
+
+    assert 'read -r -s -p' in script
+    assert 'htpasswd -B -C 12 -i -c' in script
+    assert 'install -m 600' in script
+    assert '.secrets/review.htpasswd' in script
+    assert 'PASSWORD' not in re.sub(r'PASSWORD(_CONFIRM)?', '', script)
+
+
+def test_hosted_review_operations_doc_covers_activation_and_boundaries():
+    doc = _read(HOSTED_DOC)
+
+    for expected in (
+        'review.ed-finder.app',
+        'Cloudflare/proxied Flexible SSL',
+        'docker network create edfinder-review-edge',
+        'scripts/ops/create_review_auth_file.sh --user review',
+        'Merge PR #272',
+        'Update Hetzner `main` with the merged hosted-review infrastructure',
+        'Rebase PR #271 onto the updated `main`',
+        'Push the rebased PR #271 branch',
+        'Deploy that rebased branch into `review.ed-finder.app`',
+        'scripts/ops/deploy_hosted_review.sh deploy',
+        '--ref stage-25d-a2-planner-clarity',
+        'docker compose config -q',
+        'docker compose run --rm --no-deps nginx nginx -t',
+        'docker compose up -d nginx',
+        'scripts/ops/deploy_hosted_review.sh teardown',
+        'review hostname remains configured',
+        'Do not stop production Nginx as a review rollback step',
+        '.review/nginx-logs',
+        'Review data is synthetic',
+        'Review drafts live in browser storage',
+        'Review cannot alter Elite Dangerous',
+    ):
+        assert expected in doc
+    assert 'docker compose stop nginx' not in doc


### PR DESCRIPTION
﻿## Summary

- Adds a hosted review Compose overlay for `review.ed-finder.app` that keeps the existing local Review Lab compose file local-only and disposable.
- Gives the hosted lane private Docker resource names (`edfinder-review-hosted-network`, `edfinder_review_hosted_postgres_data`, `edfinder_review_hosted_redis_data`) so hosted resets cannot collide with local Review Lab resources.
- Extends production Docker/Nginx so only `ed-nginx` joins the dedicated `edfinder-review-edge` network, serves a separate review frontend root, requires review-only basic auth, writes review-only logs, uses a review-only rate-limit zone, and proxies review `/api/` only to isolated `review-api`.
- Adds human-triggered hosted review deployment/auth helpers, including a CI Nginx sandbox log-path fix and a post-checkout review-ref guard that stops before build/reset/bootstrap/seed/start when a selected branch lacks hosted review infrastructure.
- Documents the first PR #271 review-candidate order: merge PR #272, update Hetzner `main`, rebase and push PR #271, then deploy that rebased branch.

## Safety

- Does not deploy to Hetzner, modify DNS/Cloudflare, merge or rebase PR #271, or change PR #271 implementation.
- Does not add public review DB/Redis/API ports or a second public Nginx container.
- The deploy script requires `--confirm-hosted-review`, refuses missing/world-readable auth files, refuses dirty review checkout state, validates review DB/Redis targets, creates the review log directory, checks the selected review ref has hosted-review infrastructure after checkout, resets only the hosted review compose project with `down -v --remove-orphans` after preflights, verifies review-edge membership, and never runs production compose down.

## Validation

Passed:
- `corepack yarn typecheck` — passed.
- `corepack yarn lint` — passed with zero reported warnings/errors.
- `corepack yarn vitest run` — 93 files / 641 tests passed; existing React `act(...)` stderr remains.
- `corepack yarn build` — passed; existing Vite unresolved background asset and chunk-size warnings remain.
- `py -3.12 -m pytest -q tests/test_hosted_review_environment.py` — 13 passed.
- `git diff --check` — passed.

Local runner limitation:
- Best compatible local Review Lab run, `py -3.12 -m pytest -q tests/test_local_review_test_environment.py`, still fails on this Windows host: 5 failed, 61 passed, 1 skipped. Failures are POSIX/Docker environment assumptions (`os.getpgid` unavailable and Docker CLI unavailable for review-owned resource tests). The existing local Review Lab contract was not weakened.

