### PR TITLE
Fix hosted review auth file permissions

### DIFF
--- a/docs/operations/hosted-review-environment.md
+++ b/docs/operations/hosted-review-environment.md
@@ -41,7 +41,7 @@ Create the dedicated edge network that only production `ed-nginx` and hosted `re
 docker network create edfinder-review-edge
 ```
 
-Create the review auth file. The helper prompts without echoing the password, writes a bcrypt htpasswd entry, and applies restrictive permissions:
+Create the review auth file. The helper prompts without echoing the password, writes a bcrypt htpasswd entry as `root:<nginx-worker-group>` with mode `640`, and keeps the file non-public while allowing production Nginx to read it:
 
 ```bash
 cd /opt/ed-finder

--- a/scripts/ops/create_review_auth_file.sh
+++ b/scripts/ops/create_review_auth_file.sh
@@ -51,10 +51,22 @@ done
 
 [[ "$USERNAME" =~ ^[A-Za-z0-9._-]+$ ]] || die 'username may contain only letters, numbers, dot, underscore, and dash'
 command -v htpasswd >/dev/null || die 'htpasswd is required; install apache2-utils and rerun'
+command -v docker >/dev/null || die 'docker is required to resolve the production Nginx group id'
+
+resolve_nginx_group_id() {
+  local gid
+  gid="$(docker compose exec -T nginx sh -c 'id -g nginx' 2>/dev/null || true)"
+  if [[ ! "$gid" =~ ^[0-9]+$ ]]; then
+    die 'could not resolve numeric nginx group id from the running production Nginx container; ensure docker compose service nginx is running'
+  fi
+  printf '%s\n' "$gid"
+}
 
 if [[ -e "$AUTH_FILE" && "$FORCE" -ne 1 ]]; then
   die "$AUTH_FILE already exists; pass --force to replace it intentionally"
 fi
+
+NGINX_GROUP_ID="$(resolve_nginx_group_id)"
 
 printf 'Review username: %s\n' "$USERNAME"
 read -r -s -p 'Review password: ' PASSWORD
@@ -74,8 +86,8 @@ TMP_FILE="$(mktemp "$AUTH_DIR/.review.htpasswd.XXXXXX")"
 trap 'rm -f "$TMP_FILE"' EXIT
 
 printf '%s\n' "$PASSWORD" | htpasswd -B -C 12 -i -c "$TMP_FILE" "$USERNAME" >/dev/null
-install -m 600 "$TMP_FILE" "$AUTH_FILE"
+install -o root -g "$NGINX_GROUP_ID" -m 640 "$TMP_FILE" "$AUTH_FILE"
 
 unset PASSWORD PASSWORD_CONFIRM
 
-printf '[OK] wrote %s with mode 600\n' "$AUTH_FILE"
+printf '[OK] wrote %s as root:%s with mode 640\n' "$AUTH_FILE" "$NGINX_GROUP_ID"

--- a/tests/test_hosted_review_environment.py
+++ b/tests/test_hosted_review_environment.py
@@ -381,11 +381,24 @@ def test_hosted_review_deploy_ref_guard_runs_after_checkout_before_mutations():
 
 def test_review_auth_helper_prompts_without_echo_and_uses_bcrypt_htpasswd():
     script = _read(AUTH_SCRIPT)
+    file_modes = re.findall(r'-m\s+([0-7]{3})', script)
 
     assert 'read -r -s -p' in script
     assert 'htpasswd -B -C 12 -i -c' in script
-    assert 'install -m 600' in script
     assert '.secrets/review.htpasswd' in script
+    assert 'docker compose exec -T nginx' in script
+    assert 'id -g nginx' in script
+    assert 'getent group nginx' not in script
+    assert '[[ ! "$gid" =~ ^[0-9]+$ ]]' in script
+    assert 'NGINX_GROUP_ID="$(resolve_nginx_group_id)"' in script
+    assert 'install -o root -g "$NGINX_GROUP_ID" -m 640 "$TMP_FILE" "$AUTH_FILE"' in script
+    assert 'install -m 600' not in script
+    assert '640' in file_modes
+    assert '600' not in file_modes
+    assert all(mode[-1] == '0' for mode in file_modes)
+    assert 'mode 640' in script
+    assert 'root:%s' in script
+    assert 'already exists; pass --force to replace it intentionally' in script
     assert 'PASSWORD' not in re.sub(r'PASSWORD(_CONFIRM)?', '', script)
 
 


### PR DESCRIPTION
## Summary
- resolve the numeric nginx group id from the running production nginx Compose service using the proven \\id -g nginx\\ lookup
- install review.htpasswd as root:<nginx gid> with mode 640 instead of root-only 600
- keep bcrypt htpasswd generation, silent password prompts, non-world-readable file modes, and --force replacement guard
- keep the hosted-review runbook note for the non-public nginx-readable auth file

## Validation
- py -3.12 -m pytest -q tests/test_hosted_review_environment.py: passed (13 passed; pytest config warnings for unknown asyncio options)
- docker compose config -q: passed (local POSTGRES_PASSWORD warnings only)
- docker compose run --rm --no-deps nginx nginx -t: attempted exactly; blocked locally because external network edfinder-review-edge is not present on this workstation
- git diff --check: passed

No Hetzner commands, DNS changes, Cloudflare changes, production changes, review-environment deployment, PR #271 changes, Planner changes, fake certificates, or Docker configuration workarounds were performed.