### PR TITLE
docs: add AI continuity and chat handoff protocol

### DIFF
--- a/docs/ai/ACCEPTANCE_PROTOCOL.md
+++ b/docs/ai/ACCEPTANCE_PROTOCOL.md
@@ -1,0 +1,59 @@
+# Acceptance Checkpoint Protocol
+
+This protocol turns a reviewer acceptance into a durable recovery point.
+
+## What acceptance means
+
+A stage is not accepted merely because an assistant writes “approved” in chat. Before acceptance, the implementation must already be committed and pushed to a named branch, with the exact reviewed code commit identified.
+
+Acceptance does **not** merge, deploy, rebase, or change product code.
+
+## Automatic actions after acceptance
+
+When the reviewing assistant accepts a stage, it should perform these actions without waiting for a separate reminder:
+
+1. Confirm the accepted branch, pull request if any, and exact reviewed code commit SHA.
+2. Create a documentation-only acceptance checkpoint by updating `docs/ai/CURRENT_STAGE.md` on the accepted branch. The update must record:
+   - status: `Accepted`;
+   - accepted code commit SHA;
+   - acceptance date/time;
+   - branch and pull request reference, if any;
+   - evidence reviewed;
+   - caveats or follow-up work;
+   - next safe action.
+3. Add a top-level pull-request comment, when a pull request exists, containing the same acceptance summary and the SHA of the documentation-only checkpoint commit.
+4. State clearly in chat that the checkpoint was written and that merge/deployment remain separate decisions.
+
+The documentation-only checkpoint commit is allowed to follow the accepted code commit. It must modify only `docs/ai/` files. It does not reopen product-code review.
+
+## If the code is not pushed
+
+Do not create an acceptance checkpoint and do not call the stage accepted. Ask for the exact branch and pushed commit first.
+
+## If there is no pull request
+
+Create the documentation-only checkpoint on the named branch and report its commit SHA. The Git commit is still the durable acceptance record.
+
+## Standard acceptance record
+
+Use this structure in `CURRENT_STAGE.md`:
+
+```md
+## Acceptance checkpoint
+
+- Status: Accepted
+- Accepted code commit: `<full SHA>`
+- Acceptance checkpoint commit: `<full SHA once created>`
+- Branch: `<branch>`
+- Pull request: `<number or none>`
+- Evidence reviewed:
+  - `<tests/build/artifacts>`
+- Caveats:
+  - `<none or explicit items>`
+- Next safe action:
+  - `<merge, start next planning stage, or other explicit step>`
+```
+
+## New-chat recovery after acceptance
+
+A new agent must read `CURRENT_STAGE.md` first. It should treat the accepted code SHA as the reviewed baseline and the acceptance checkpoint commit as the durable handoff state. It must not infer that a merge or deployment occurred unless the record says so.

--- a/docs/ai/CHAT_HANDOFF_TEMPLATE.md
+++ b/docs/ai/CHAT_HANDOFF_TEMPLATE.md
@@ -1,0 +1,60 @@
+# New Chat Handoff Template
+
+Use this when closing a large chat and opening a new one. Before using it, update `CURRENT_STAGE.md` with the real branch, commit, worktree status, completed evidence, blockers, and next safe action. Commit and push that update.
+
+## Copy into the new agent chat
+
+```text
+You are taking over ED-Finder work after a planned chat handoff.
+
+Start in read-only recovery mode. Do not edit, create, move, delete, reset, stash, clean, restore, commit, amend, rebase, merge, push, deploy, or run code generation.
+
+Repository: brianstewart377-rgb/ed-finder
+Expected branch: <copy from docs/ai/CURRENT_STAGE.md>
+Expected current commit: <copy from docs/ai/CURRENT_STAGE.md>
+
+Read these repository files first:
+- docs/ai/README.md
+- docs/ai/PROJECT_CONTEXT.md
+- docs/ai/CURRENT_STAGE.md
+- docs/ai/DECISIONS.md
+- docs/ai/RECOVERY.md
+
+Then run the read-only recovery commands in docs/ai/RECOVERY.md.
+
+Return only:
+1. current repository root;
+2. branch and full HEAD SHA;
+3. Git working-tree state;
+4. whether this matches CURRENT_STAGE.md;
+5. the active goal, allowed files, evidence status, blockers, and next safe action.
+
+Do not make changes until I explicitly approve your recovery report.
+```
+
+## What to provide to ChatGPT or another non-repository agent
+
+Upload or paste, in this order:
+
+1. `docs/ai/PROJECT_CONTEXT.md`
+2. `docs/ai/CURRENT_STAGE.md`
+3. relevant recent entries from `docs/ai/DECISIONS.md`
+4. the branch name and full commit SHA
+5. the latest test/build/evidence output only if it is not already recorded in `CURRENT_STAGE.md`
+6. a link or patch for the specific diff under review, if applicable
+
+Avoid pasting an entire old conversation. The stage record and Git state should replace it.
+
+## Before closing a chat checklist
+
+- [ ] `CURRENT_STAGE.md` says exactly what is active and what is next.
+- [ ] Allowed files and non-goals are explicit.
+- [ ] Branch name, base SHA, and current SHA are recorded.
+- [ ] Test/build/evidence results are recorded or linked.
+- [ ] Known failures and unresolved choices are recorded.
+- [ ] Current work is committed and pushed, or the handoff explicitly says why it is not safe to stop yet.
+- [ ] No secrets or private credentials are present in commits or handoff files.
+
+## Size rule
+
+When the chat becomes hard to navigate, stop at a natural checkpoint. Update the stage record and start a new chat. Do not wait until the conversation is near a context limit.

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -1,0 +1,67 @@
+# Current Stage
+
+> **This is the authoritative working-point record.** Update it before an agent stops, before a chat is closed, and after any accepted decision or evidence run.
+
+## Status
+
+**Continuity protocol established. No product-code stage is currently authorised.**
+
+## Current branch and baseline
+
+- Continuity branch: `chore/ai-continuity-protocol`
+- Base branch at creation: `work/r1-canonical-body-evidence`
+- Base commit: `f9177b7c3e5dc4087144c416a8aed6cc57446df0`
+- Purpose of this branch: add durable AI handoff and recovery records only.
+
+## Active goal
+
+Make future AI-assisted work recoverable when an agent chat is closed, crashes, or becomes too large.
+
+## Allowed files for the continuity-protocol stage
+
+- `docs/ai/README.md`
+- `docs/ai/PROJECT_CONTEXT.md`
+- `docs/ai/CURRENT_STAGE.md`
+- `docs/ai/DECISIONS.md`
+- `docs/ai/RECOVERY.md`
+- `docs/ai/CHAT_HANDOFF_TEMPLATE.md`
+
+No product source, tests, configuration, workflow, or deployment files are authorised in this stage.
+
+## Known follow-on work
+
+### R1 Assessment Laboratory reconstruction
+
+- Status: **not started; no code authorised**.
+- Reason: the previously reviewed R1 lab source tree and its historical commit are not present in the current local checkout, Git reflog, available remote branches, or searched workspace.
+- Required first step: a read-only reconstruction-inventory and contract stage.
+- Do not guess old fixture semantics, assessment rules, report text, or test behaviour from memory alone.
+- Any reconstruction must use its own branch, explicit base SHA, accepted design contract, allowed-file list, and final evidence checklist.
+
+## Required evidence before leaving any future implementation stage
+
+Replace this checklist with stage-specific evidence, but keep the raw output or a durable CI link/reference:
+
+- exact branch name and full current commit SHA;
+- `git status --short`;
+- `git diff --stat`, `git diff --name-status`, and `git diff --check`;
+- tests required by the stage;
+- typecheck/build where relevant;
+- screenshots, artifacts, or preview checks where relevant;
+- a clear list of remaining blockers or the next safe action.
+
+## Last verified state
+
+- Repository baseline inspected on 2026-07-01.
+- Current application branch at that time: `work/r1-canonical-body-evidence`.
+- Frontend root: `frontend-v2`.
+- No `src/lab/r1-assessment-lab` directory exists in that checkout.
+- The continuity protocol is being added on a separate documentation-only branch.
+
+## Next safe action
+
+Review and merge the continuity-protocol documentation branch. After merge, begin any new substantive task by copying the template in `CHAT_HANDOFF_TEMPLATE.md` into a fresh agent chat and updating this file with the new stage details.
+
+## Recovery instruction
+
+If context is lost, do not edit code. Read the files in `docs/ai`, run the read-only commands in `RECOVERY.md`, and report the result. Continue only after the owner approves the recovered state.

--- a/docs/ai/DECISIONS.md
+++ b/docs/ai/DECISIONS.md
@@ -1,0 +1,65 @@
+# Accepted Decisions
+
+This file is append-only. Record decisions that affect more than one stage, a later reconstruction, or a recovery workflow.
+
+Use this format:
+
+```md
+## YYYY-MM-DD — Decision title
+
+**Decision**
+What was decided.
+
+**Reason**
+Why it was decided.
+
+**Invariant**
+What future work must preserve.
+
+**Evidence / reference**
+Branch, commit, issue, PR, test, or document.
+```
+
+---
+
+## 2026-07-01 — Durable AI continuity protocol
+
+**Decision**
+AI-assisted work must be recoverable from the repository without relying on a live agent conversation.
+
+**Reason**
+A previous agent chat and an uncommitted laboratory worktree were lost. The loss showed that chat history and local uncommitted state are not durable project memory.
+
+**Invariant**
+Every substantive stage must have a named branch, exact base commit, durable current-stage record, explicit allowed-file list, evidence checklist, and a pushed checkpoint before an agent stops.
+
+**Evidence / reference**
+`docs/ai/README.md`, `docs/ai/CURRENT_STAGE.md`, and `docs/ai/RECOVERY.md` on branch `chore/ai-continuity-protocol`.
+
+## 2026-07-01 — Chat handoff standard
+
+**Decision**
+When a chat becomes too large, the user may close it after updating and committing the stage handoff. A new agent chat must begin by reading the AI continuity files and inspecting Git state rather than relying on a manual recap.
+
+**Reason**
+A short, durable stage record is more reliable than a long chat summary and can be reviewed by any future agent.
+
+**Invariant**
+The new chat starts read-only. It may not edit, reset, stash, commit, merge, push, deploy, or delete files until it reports branch, commit, worktree status, and the active stage.
+
+**Evidence / reference**
+`docs/ai/CHAT_HANDOFF_TEMPLATE.md` and `docs/ai/RECOVERY.md`.
+
+## 2026-07-01 — R1 Assessment Laboratory is a future clean reconstruction
+
+**Decision**
+The R1 Assessment Laboratory will not be reconstructed by guessing from lost chat state or by editing the current application branch opportunistically.
+
+**Reason**
+The earlier lab source tree and historical commit were not recoverable from the available checkout, local Git object database, remote branches, reflog, or searched workspace.
+
+**Invariant**
+Any future R1 lab work begins with a read-only inventory and written reconstruction contract, then uses a dedicated branch and narrow staged implementation.
+
+**Evidence / reference**
+`docs/ai/CURRENT_STAGE.md` and the 2026-07-01 recovery inspection.

--- a/docs/ai/PROJECT_CONTEXT.md
+++ b/docs/ai/PROJECT_CONTEXT.md
@@ -1,0 +1,66 @@
+# ED-Finder project context
+
+## Repository and application
+
+- Repository: `brianstewart377-rgb/ed-finder`
+- Frontend project: `frontend-v2`
+- Main frontend entry: `frontend-v2/src/App.tsx`
+- Frontend stack: React, TypeScript, Vite, Vitest, jsdom, TanStack Query.
+- Imports use the `@/` alias for `frontend-v2/src`.
+
+## Current application shape
+
+The normal app is hash-routed through `src/hooks/useHashRoute.ts`.
+
+- Unknown hashes fall back to the Finder route.
+- `App.tsx` currently owns the normal React Query provider and normal shell/bootstrap tree.
+- Normal startup can include Coalsack background resolution, health checks, initial search work, stores, and route rendering.
+- Do not assume a DEV-only tool is isolated merely because it uses a special hash. If it must avoid normal startup effects, branch above the normal provider/bootstrap tree.
+
+## Safe engineering defaults
+
+- Prefer narrow, reversible changes.
+- Do not infer current branch state from an agent chat. Inspect Git.
+- Do not make broad formatting or unrelated cleanup changes during a narrow stage.
+- Treat an uncommitted worktree as temporary. It is not a recovery mechanism.
+- Use exact branch names and full commit SHAs in handoffs.
+- Stage explicit file paths; never use `git add -A` for AI-assisted work.
+- Keep test fixtures deterministic and local. Do not make tests depend on live network services.
+
+## Required preflight for any agent
+
+Before editing:
+
+```bash
+git branch --show-current
+git rev-parse HEAD
+git status --short
+git diff --stat
+git diff --check
+git ls-files --others --exclude-standard
+```
+
+Then read:
+
+```text
+docs/ai/PROJECT_CONTEXT.md
+docs/ai/CURRENT_STAGE.md
+docs/ai/DECISIONS.md
+docs/ai/RECOVERY.md
+```
+
+If the branch, commit, worktree status, or stage files do not match the expected stage, stop and report the discrepancy.
+
+## R1 Assessment Laboratory boundary
+
+The historical R1 Assessment Laboratory was a DEV-only fixture-backed planning/evaluation tool, not a public ED-Finder feature. Its previous local worktree and commit were not recoverable from the current repository checkout as of 2026-07-01.
+
+Any future reconstruction must begin as a new, explicitly authorised stage. It must preserve these high-level boundaries:
+
+- DEV-only access at an exact hash, never a normal route or navigation item.
+- No normal provider/bootstrap effects, app-data network activity, or persistence writes at that exact DEV entry.
+- Production must treat the hash as an ordinary unknown hash and fall back to Finder.
+- Production deployable JavaScript, CSS, and HTML must not contain laboratory-only identifiers or load a lab chunk.
+- Evaluation must be template/programme-specific; it must not create a universal score or public Finder ranking.
+
+Do not recreate this lab from partial memory. First create a written reconstruction contract and file inventory in `CURRENT_STAGE.md`.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -13,6 +13,7 @@ Chats are disposable. Git history and the files in this directory are the source
 5. Stage explicit paths only. Do not use `git add -A` for AI-assisted work.
 6. Never put passwords, tokens, API keys, private prompts, or customer data in these files.
 7. A chat transcript is supporting context, not the specification. Record accepted decisions in `DECISIONS.md` and stage-specific facts in `CURRENT_STAGE.md`.
+8. Reviewer acceptance triggers the automatic documentation checkpoint described in `ACCEPTANCE_PROTOCOL.md`. Acceptance never silently merges or deploys work.
 
 ## Files
 
@@ -21,6 +22,7 @@ Chats are disposable. Git history and the files in this directory are the source
 - `DECISIONS.md` — append-only accepted decisions and invariants.
 - `RECOVERY.md` — what an agent must do after context loss or a crash.
 - `CHAT_HANDOFF_TEMPLATE.md` — a short prompt for starting a new chat without losing the working point.
+- `ACCEPTANCE_PROTOCOL.md` — automatic durable record created when reviewed work is accepted.
 
 ## Normal workflow
 
@@ -30,7 +32,8 @@ Chats are disposable. Git history and the files in this directory are the source
 4. Run the evidence listed in `CURRENT_STAGE.md`.
 5. Update `CURRENT_STAGE.md` with actual results, blockers, commit SHA, and the next safe action.
 6. Commit and push the stage before leaving it.
-7. Start a new chat with the template if the current conversation becomes unwieldy.
+7. On reviewer acceptance, create the automatic acceptance checkpoint before merge or deployment.
+8. Start a new chat with the template if the current conversation becomes unwieldy.
 
 ## When a chat is too large
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -1,0 +1,37 @@
+# AI Continuity Protocol
+
+This directory is the durable handoff record for AI-assisted work on ED-Finder.
+
+Chats are disposable. Git history and the files in this directory are the source of truth.
+
+## Non-negotiable rules
+
+1. No meaningful stage may exist only in an agent chat or only as an uncommitted worktree.
+2. Before implementation, create or select a named branch and record the exact base commit in `CURRENT_STAGE.md`.
+3. Before an agent stops, update `CURRENT_STAGE.md`, commit the change with the work where practical, and push the branch.
+4. Agents must start in read-only recovery mode: read this directory, inspect Git state, and report before editing.
+5. Stage explicit paths only. Do not use `git add -A` for AI-assisted work.
+6. Never put passwords, tokens, API keys, private prompts, or customer data in these files.
+7. A chat transcript is supporting context, not the specification. Record accepted decisions in `DECISIONS.md` and stage-specific facts in `CURRENT_STAGE.md`.
+
+## Files
+
+- `PROJECT_CONTEXT.md` — stable architecture, project rules, and practical commands.
+- `CURRENT_STAGE.md` — the single authoritative record of the active stage and its next safe action.
+- `DECISIONS.md` — append-only accepted decisions and invariants.
+- `RECOVERY.md` — what an agent must do after context loss or a crash.
+- `CHAT_HANDOFF_TEMPLATE.md` — a short prompt for starting a new chat without losing the working point.
+
+## Normal workflow
+
+1. Read `PROJECT_CONTEXT.md`, `CURRENT_STAGE.md`, and the relevant entries in `DECISIONS.md`.
+2. Confirm branch, base commit, current commit, Git status, and allowed files.
+3. Do one narrow stage.
+4. Run the evidence listed in `CURRENT_STAGE.md`.
+5. Update `CURRENT_STAGE.md` with actual results, blockers, commit SHA, and the next safe action.
+6. Commit and push the stage before leaving it.
+7. Start a new chat with the template if the current conversation becomes unwieldy.
+
+## When a chat is too large
+
+Do not try to summarise the whole chat manually. Update `CURRENT_STAGE.md`, commit and push it, then open a new chat and use `CHAT_HANDOFF_TEMPLATE.md`. The new agent should inspect the repository rather than assume that chat history is correct.

--- a/docs/ai/RECOVERY.md
+++ b/docs/ai/RECOVERY.md
@@ -1,0 +1,82 @@
+# Recovery Protocol
+
+Use this protocol when an AI chat crashes, is closed, becomes too large, or returns with uncertain context.
+
+## Stop condition
+
+Until this protocol is complete, the agent must **not**:
+
+- edit, create, move, or delete files;
+- run formatting or code generation;
+- reset, restore, stash, clean, amend, rebase, merge, commit, push, or deploy;
+- claim that a worktree is clean unless the raw Git output proves it.
+
+## Read first
+
+From the repository root, read:
+
+```text
+docs/ai/README.md
+docs/ai/PROJECT_CONTEXT.md
+docs/ai/CURRENT_STAGE.md
+docs/ai/DECISIONS.md
+```
+
+Then run these read-only commands and preserve the raw output:
+
+```bash
+pwd
+git rev-parse --show-toplevel
+git branch --show-current
+git rev-parse HEAD
+git status --short
+git log --oneline -10
+git diff --stat
+git diff --name-status
+git diff --check
+git ls-files --others --exclude-standard
+```
+
+For frontend work, then inspect the actual project root before assuming paths:
+
+```bash
+find . -maxdepth 5 -type f -name package.json -print | sort
+find . -maxdepth 7 -type f -path '*/src/App.tsx' -print | sort
+```
+
+## Recovery report format
+
+Return only:
+
+1. Repository root and frontend root.
+2. Branch and full HEAD SHA.
+3. Modified and untracked files, exactly as Git reports them.
+4. Active stage status from `CURRENT_STAGE.md`.
+5. Whether the current worktree matches the stage record.
+6. Any mismatch, missing evidence, or blocker.
+7. The next safe action, without making changes.
+
+## If the expected branch or files are missing
+
+Do not recreate work from memory. First search, read-only:
+
+```bash
+git worktree list --porcelain
+git branch -a
+git reflog --all --date=iso || true
+git fsck --full --no-reflogs --unreachable || true
+git remote -v
+```
+
+Then report whether recovery is possible from:
+
+- the current checkout;
+- another local worktree;
+- a remote branch;
+- reflog/unreachable objects;
+- a pushed handoff/commit;
+- or whether reconstruction requires a new, approved stage.
+
+## Exit condition
+
+Only the project owner may approve moving from recovery mode to planning or implementation mode.


### PR DESCRIPTION
## Purpose

Adds a durable repository-based continuity protocol so AI-assisted work survives chat closure, agent crashes, and context resets.

## Included

- `docs/ai/README.md` — operating rules and workflow
- `docs/ai/PROJECT_CONTEXT.md` — durable project context
- `docs/ai/CURRENT_STAGE.md` — authoritative current-stage record
- `docs/ai/DECISIONS.md` — append-only decision log
- `docs/ai/RECOVERY.md` — read-only crash/context-loss procedure
- `docs/ai/CHAT_HANDOFF_TEMPLATE.md` — new-chat handoff prompt and checklist

## Scope

Documentation only. No application source, tests, configuration, or deployment behavior changed.

## Review focus

- Does the handoff material contain enough for a fresh chat to safely recover the current point?
- Are the recovery and branch/checkpoint rules practical for day-to-day Trae use?
- Is the R1 laboratory reconstruction boundary accurately recorded as not yet authorised?
