### PR TITLE
Stage 3B: DEV-only R1 assessment lab

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,163 +4,65 @@
 
 ## Status
 
-**Implementing — Stage 3B correction evidence gathered**
+**Accepted — automatic merge pending**
 
 ## Baseline
 
 - Base branch: `work/r1-canonical-body-evidence`
-- Branch: `feat/r1-assessment-lab-presentation`
-- Exact base SHA: `b6529e70ddbdcc26d46ce742eea793273138c635`
-- Last accepted implementation stage: Stage 2B pure R1 assessment-domain core.
-- Stage 2B PR: `#280`, merged.
-- Stage 2B merge commit: `220c870f89a5af7f98adb88578373dbc3a681a9c`.
-- Stage 3B implementation commit: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
-- Current head before correction: `e8e4ffed601ec3b0d952ee9a9c089c2c6fde4a4a`
-- Stage 3B correction implementation commit: `2c10872a82046949bc91cb53481b1cee2390a853`
+- Stage 3B branch: `feat/r1-assessment-lab-presentation`
+- Base SHA: `b6529e70ddbdcc26d46ce742eea793273138c635`
+- Review PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`
+- Last accepted implementation stage: Stage 2B pure R1 assessment-domain core, merged by PR `#280` at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 
-## Active goal
+## Accepted Stage 3B implementation
 
-DEV-only fixture-backed assessment-lab presentation.
+- Original presentation implementation: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
+- Final presentation-test hardening: `2c10872a82046949bc91cb53481b1cee2390a853`
+- Pre-acceptance evidence records:
+  - `0a664579163b7b14b08167dcd68ceaf94ffee3a5`
+  - `373841a740bc9a48ccff6f1c7b981ea6c64fa69b`
+- This commit records final acceptance before automatic merge.
 
-## Read before any Stage 3 work
+## Reviewed scope
 
-- `docs/ai/README.md`
-- `docs/ai/PROJECT_CONTEXT.md`
-- `docs/ai/CURRENT_STAGE.md`
-- `docs/ai/DECISIONS.md`
-- `docs/ai/RECOVERY.md`
-- `docs/ai/ACCEPTANCE_PROTOCOL.md`
-- `docs/ai/R1_RECONSTRUCTION_CONTRACT_V1.md`
-- the merged Stage 1 DEV boundary and Stage 2B core files.
-
-## Allowed files
+The PR changes only:
 
 - `docs/ai/CURRENT_STAGE.md`
+- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
 - `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx`
 
-No other files are authorised. Do not modify `R1AssessmentLabApp.tsx`, `App.tsx`, `src/main.tsx`, Stage 1 tests, Stage 2B core files or tests, routes, navigation, providers, stores, APIs, build/configuration files, stylesheets, or package files.
+Stage 3B is a DEV-only, fixture-backed assessment-lab presentation surface inside the existing Stage 1 entry boundary. It does not change `App.tsx`, production routing, normal application navigation, providers, stores, APIs, persistence, configuration, stylesheets, or Stage 2B evaluator semantics.
 
-## Correction requirements
+## Accepted behavior and invariants
 
-1. Replace the aggregate-only side-effect interaction check with explicit separate no-call proofs after each individual control change:
-   - fixture;
-   - lens kind;
-   - lens value;
-   - carrier mode.
+- The lab exposes exactly four closed local select controls: Fixture, Lens kind, Lens value, and Carrier mode.
+- Five fixture IDs and three carrier modes are selectable; the six approved fixture/scenario state rows are test assertions, not six fixtures.
+- The fixed template is displayed read-only.
+- The selected Role/Question lens is passed to the evaluator and visibly displayed as context only. Changing it does not alter fixture outcomes, conditions, requirement results, frozen evidence/provenance, state, or ordering in this slice.
+- The app synchronously evaluates fixed local data only and has no UI for invalid evaluator input.
+- Results render state, structured conditions, requirement trace, and frozen evidence/provenance. `compare_both` preserves `no_carrier` then `carrier_available` order.
+- State values are rendered neutrally without score, ranking, winner, preference, strategy, Plan Fit, or recommendation behavior.
 
-2. Strengthen the default compact-fixture rendering test to prove visible requirement trace and full frozen-evidence provenance in scoped assertions:
-   - requirement ID: `foundation_evidence`
-   - outcome: `met`
-   - matched evidence ID: `compact-foundation`
-   - evidence ID: `compact-foundation`
-   - fact key: `foundation-evidence`
-   - availability: `known`
-   - provenance fixture ID: `compact_sufficient_case`
-   - provenance fixture revision: `v1`
+## Final evidence reviewed
 
-## Required evidence before acceptance
+- Dedicated Stage 3B UI tests: 7 passed.
+- Unchanged Stage 1 regression tests: 9 passed across 4 files.
+- Unchanged Stage 2B core tests: 23 passed.
+- Typecheck passed.
+- Production build passed.
+- Production deployable JS/CSS/HTML scans reported zero matches for the seven Stage 1 lab-only identifiers and all approved Stage 3-only lab strings.
+- Final local worktree was reported clean.
+- Source review confirmed separate immediate no-side-effect assertions after each fixture, lens-kind, lens-value, and carrier-mode change, plus scoped trace and frozen-evidence provenance assertions.
 
-- `R1AssessmentLabApp.test.tsx` passes, including:
-  - separate immediate no-call proofs after each single control change
-  - scoped requirement-trace and frozen-evidence provenance assertions for the compact fixture
-  - the existing Stage 3B control/default/disclosure/state-coverage checks
-- `R1AssessmentLabApp.test.tsx` proves these exact state-coverage combinations:
-  - `compact_sufficient_case` + `no_carrier` => `supported`
-  - `incomplete_evidence_case` + `no_carrier` => `not_assessable`
-  - `contradictory_allocation_case` + `no_carrier` => `not_assessable`
-  - `fake_flexibility_case` + `no_carrier` => `not_supported`
-  - `remote_materials_carrier_case` + `no_carrier` => `conditionally_supported`
-  - `remote_materials_carrier_case` + `carrier_available` => `supported`
-  - `remote_materials_carrier_case` + `compare_both` => `no_carrier` then `carrier_available`
-- `R1AssessmentLabApp.test.tsx` proves the mandatory context-only lens test:
-  - select `remote_materials_carrier_case` and `compare_both`
-  - capture rendered scenario result content for state, conditions, requirement trace, and frozen evidence/provenance
-  - change lens kind and lens value
-  - prove selected lens context changed
-  - prove all captured scenario-result content is unchanged and remains in the same order
-- `R1AssessmentLabApp.test.tsx` proves `No structured conditions.` renders for condition-free scenarios.
-- `R1AssessmentLabApp.test.tsx` proves requirement trace and frozen evidence/provenance render visibly.
-- `R1AssessmentLabApp.test.tsx` proves no network or persistence activity after each control change: fixture, lens kind, lens value, and carrier mode.
-- `R1AssessmentLabApp.test.tsx` proves the rendered UI, case-insensitively, contains no `score`, `rank`, `best`, `plan_fit`, `plan fit`, `recommend`, `strategy`, `report`, `export`, or `download`.
-- unchanged regression gates must pass:
-  - `AppEntryIsolation.test.tsx`
-  - `R1AssessmentLabRoute.test.tsx`
-  - `noNetwork.test.tsx`
-  - `sourceBoundary.test.ts`
-  - `evaluateAssessment.test.ts`
-- `typecheck` and production `build`
-- production deployable `JS/CSS/HTML` scan returns zero matches for:
-  - the existing seven Stage 1 lab-only identifiers
-  - the Stage 3-only strings and identifiers:
-    - `R1 Lab — DEV-only fixture-backed reconstruction.`
-    - `R1 Lab — historic evaluator recovery is not claimed.`
-    - `R1 Lab — no production scoring or live system advice.`
-    - `R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.`
-    - `R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.`
-    - `Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)`
-    - `compact_sufficient_case`
-    - `incomplete_evidence_case`
-    - `contradictory_allocation_case`
-    - `fake_flexibility_case`
-    - `remote_materials_carrier_case`
-    - `no_carrier`
-    - `carrier_available`
-    - `compare_both`
-- explicit `git status --short`, `git diff --stat`, `git diff --name-status`, `git diff --check`, and `git diff --cached --check` evidence with a final clean worktree.
+## Caveats
 
-## Actual evidence
-
-- Branch: `feat/r1-assessment-lab-presentation`
-- Review PR: `#282`
-- Current implementation commit: `2c10872a82046949bc91cb53481b1cee2390a853`
-- Correction evidence commit: `0a664579163b7b14b08167dcd68ceaf94ffee3a5`
-- Stage 3B presentation test:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
-  - Result: `1 passed, 7 tests passed`
-- Stage 1 regression tests:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/AppEntryIsolation.test.tsx" "src/lab/r1-assessment-lab/R1AssessmentLabRoute.test.tsx" "src/lab/r1-assessment-lab/noNetwork.test.tsx" "src/lab/r1-assessment-lab/sourceBoundary.test.ts"`
-  - Result: `4 passed, 9 tests passed`
-- Stage 2B core regression test:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
-  - Result: `1 passed, 23 tests passed`
-- Typecheck:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" typecheck`
-  - Result: passed
-- Production build:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" build`
-  - Result: passed
-- Production artifact scans:
-  - existing seven Stage 1 strings → no matches
-  - full Stage 3-only scan → no matches
-- Git checks executed before final docs update:
-  - `git status --short`
-  - `git diff --stat`
-  - `git diff --name-status`
-  - `git diff --check`
-  - `git diff --cached --check`
-- Final worktree state: clean after final docs checkpoint
-
-## Raw outcome summary
-
-- Replaced the aggregate-only side-effect interaction proof with separate immediate no-call assertions after each individual control change.
-- Strengthened the default compact-fixture rendering test with scoped requirement-trace and frozen-evidence provenance assertions for `foundation_evidence` and `compact-foundation`.
-- Left `R1AssessmentLabApp.tsx`, Stage 1 tests, Stage 2B core files/tests, routes, stores, providers, APIs, configuration, and stylesheets unchanged.
-
-## Remaining caveats
-
-- The production build still emits the pre-existing Coalsack asset warnings and chunk-size warning; this correction did not change build policy or those asset paths.
-
-## Explicit non-goals
-
-- `App.tsx`, `src/main.tsx`, route, normal navigation, provider, store, API, build/configuration, stylesheet, or package changes;
-- Stage 2B evaluator, type, fixture, or semantic changes;
-- CSS work, inline styles, state-specific class names, visual statuses, icons, badges, or winner styling;
-- editable fixture data, JSON inputs, overrides, free-form inputs, template picker, or error workflow;
-- network, persistence, reports, exports, downloads, hashes, markdown output, strategy, Plan Fit, scores, ranking, recommendations, material planning, route planning, colonisation staging, or public UI.
+- The test, typecheck, build, and artifact-scan results are recorded local evidence. No GitHub Actions status is attached to the final pre-acceptance head.
+- Existing Coalsack asset-resolution and chunk-size build warnings remain outside Stage 3B scope.
+- The lab remains a fixture-backed reconstruction contract and does not claim recovery of the historic evaluator or provide live system advice.
 
 ## Next safe action
 
-Request final Stage 3B review on PR `#282`. Do not begin another stage.
+Merge PR `#282` automatically. Do not deploy. Do not begin Stage 4 until a separate written contract is accepted.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,19 +4,20 @@
 
 ## Status
 
-**Stage 3A design accepted — technical contract pending**
+**Implementing — Stage 3B authorised**
 
 ## Baseline
 
 - Base branch: `work/r1-canonical-body-evidence`
+- Branch: `feat/r1-assessment-lab-presentation`
+- Exact base SHA: `b6529e70ddbdcc26d46ce742eea793273138c635`
 - Last accepted implementation stage: Stage 2B pure R1 assessment-domain core.
 - Stage 2B PR: `#280`, merged.
 - Stage 2B merge commit: `220c870f89a5af7f98adb88578373dbc3a681a9c`.
-- Stage 3A is read-only design work only. No Stage 3 implementation is authorised.
 
 ## Active goal
 
-Prepare the Stage 3B technical contract for the smallest credible DEV-only, fixture-backed R1 assessment-lab presentation layer.
+DEV-only fixture-backed assessment-lab presentation.
 
 ## Read before any Stage 3 work
 
@@ -29,78 +30,144 @@ Prepare the Stage 3B technical contract for the smallest credible DEV-only, fixt
 - `docs/ai/R1_RECONSTRUCTION_CONTRACT_V1.md`
 - the merged Stage 1 DEV boundary and Stage 2B core files.
 
-## Stage 3A accepted direction
-
-### Confirmed contract
-
-- The lab remains available only through the existing DEV-only `#r1-assessment-lab` entry boundary.
-- Stage 3B is fixture-backed only and directly consumes the accepted pure Stage 2B evaluator.
-- No production routing, normal app navigation, provider, store, API, live-data, or persistence behavior may be added.
-- No score, rank, best-system wording, recommendation, strategy, Plan Fit, report, digest, export, download, material planning, route planning, or colonisation-staging control belongs in Stage 3B.
-- Fixed fixture data must remain read-only.
-- Results must render in this order:
-  1. assessment state;
-  2. structured conditions;
-  3. requirement trace;
-  4. frozen evidence and provenance;
-  5. carrier scenario comparison where `compare_both` is selected.
-- `compare_both` must present `no_carrier` before `carrier_available`.
-
-### Accepted Stage 3B lens decision
-
-- The UI may expose an explicit Role/Question lens picker.
-- The selected lens is passed to the evaluator and displayed as assessment context.
-- Lens selection is **context-only** in Stage 3B. It must not change fixture evaluation, requirement outcomes, conditions, or assessment state.
-- The UI must state this plainly and persistently. It must not imply that lens-specific analysis has been reconstructed.
-
-### Honest status language required
-
-The presentation must clearly state that it is:
-
-- DEV-only;
-- fixture-backed;
-- a reconstruction-contract surface;
-- not a recovery of the historic evaluator;
-- not production scoring or live recommendations.
-
-## Strongly supported Stage 3B boundary
-
-The technical contract should consider this smallest credible file set:
+## Allowed files
 
 - `docs/ai/CURRENT_STAGE.md`
 - `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
 - `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx`
-- `frontend-v2/src/lab/r1-assessment-lab/presentation.ts`
-- `frontend-v2/src/lab/r1-assessment-lab/presentation.test.ts`
 
-This is a proposed boundary, not coding authorisation. The technical-contract review must either accept it exactly or justify a narrower alternative.
+No other files are authorised. Do not modify `App.tsx`, `src/main.tsx`, Stage 1 tests, Stage 2B core files or tests, routes, navigation, providers, stores, APIs, build/configuration files, stylesheets, or package files.
+
+## Fixed controls and defaults
+
+Use only local React `useState` and synchronous direct `evaluateAssessment(...)` calls.
+
+Render exactly four labelled HTML `select` controls, in this order:
+
+1. `Fixture`
+   - default: `compact_sufficient_case`
+   - options, in order:
+     - `compact_sufficient_case`
+     - `incomplete_evidence_case`
+     - `contradictory_allocation_case`
+     - `fake_flexibility_case`
+     - `remote_materials_carrier_case`
+2. `Lens kind`
+   - default: `role`
+   - options, in order:
+     - `role`
+     - `question`
+3. `Lens value`
+   - when `Lens kind` is `role`:
+     - default: `expedition-lead`
+     - options, in order:
+       - `expedition-lead`
+       - `logistics-reviewer`
+   - when `Lens kind` is `question`:
+     - default: `baseline-assessment`
+     - options, in order:
+       - `baseline-assessment`
+       - `carrier-sensitivity-check`
+   - changing `Lens kind` resets `Lens value` to that kind’s default
+4. `Carrier mode`
+   - default: `no_carrier`
+   - options, in order:
+     - `no_carrier`
+     - `carrier_available`
+     - `compare_both`
+
+There are exactly five selectable fixture IDs. The six Stage 2B fixture/scenario assertion rows are not six fixtures.
+
+There is no form submission, Evaluate button, reset button, URL state, free-text input, JSON input, checkbox, radio group, textarea, timer, promise, async function, `useEffect`, dynamic runtime import, error boundary, or evaluator-error UI.
+
+## Exact disclosures
+
+Render these exact lines, visibly and persistently:
+
+- `R1 Lab — DEV-only fixture-backed reconstruction.`
+- `R1 Lab — historic evaluator recovery is not claimed.`
+- `R1 Lab — no production scoring or live system advice.`
+- `R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.`
+- `R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.`
+- `Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)`
+
+## Context-only lens rule
+
+The selected role/question lens must be passed to the Stage 2B evaluator and shown as selected context, but it must not change fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.
+
+## Result order
+
+Render results in this exact order:
+
+1. `Assessment state`
+2. `Structured conditions`
+3. `Requirement trace`
+4. `Frozen evidence and provenance`
+5. `Carrier scenario comparison` where `compare_both` is selected
+
+Inside `compare_both`, render:
+
+1. `no_carrier`
+2. `carrier_available`
 
 ## Required Stage 3B evidence to define before coding
 
-- existing Stage 1 entry-isolation, route, no-network, and source-boundary tests remain unchanged regression gates;
-- existing Stage 2B core tests remain an unchanged regression gate;
-- dedicated UI tests for fixed fixture selection, visible context-only lens notice, all three carrier modes, and `compare_both` order;
-- visible proof of all four assessment states;
-- visible `No structured conditions.` empty state;
-- deterministic visible frozen evidence/provenance;
-- interaction-time network/persistence silence after changing all controls;
-- no rendered forbidden terms or fields: `score`, `rank`, `best`, `plan_fit`;
-- typecheck and production build;
-- production JS/CSS/HTML scan for the existing seven lab-only identifiers **plus every new Stage 3-specific visible lab string**;
-- explicit diff/check evidence and clean worktree.
+- `R1AssessmentLabApp.test.tsx` proves the exact controls/defaults, disclosures, fixed-template line, all five selectable fixture IDs, all three carrier modes, and exclusive lens selection with reset-to-default behavior.
+- `R1AssessmentLabApp.test.tsx` proves these exact state-coverage combinations:
+  - `compact_sufficient_case` + `no_carrier` => `supported`
+  - `incomplete_evidence_case` + `no_carrier` => `not_assessable`
+  - `contradictory_allocation_case` + `no_carrier` => `not_assessable`
+  - `fake_flexibility_case` + `no_carrier` => `not_supported`
+  - `remote_materials_carrier_case` + `no_carrier` => `conditionally_supported`
+  - `remote_materials_carrier_case` + `carrier_available` => `supported`
+  - `remote_materials_carrier_case` + `compare_both` => `no_carrier` then `carrier_available`
+- `R1AssessmentLabApp.test.tsx` proves the mandatory context-only lens test:
+  - select `remote_materials_carrier_case` and `compare_both`
+  - capture rendered scenario result content for state, conditions, requirement trace, and frozen evidence/provenance
+  - change lens kind and lens value
+  - prove selected lens context changed
+  - prove all captured scenario-result content is unchanged and remains in the same order
+- `R1AssessmentLabApp.test.tsx` proves `No structured conditions.` renders for condition-free scenarios.
+- `R1AssessmentLabApp.test.tsx` proves requirement trace and frozen evidence/provenance render visibly.
+- `R1AssessmentLabApp.test.tsx` proves no network or persistence activity after each control change: fixture, lens kind, lens value, and carrier mode.
+- `R1AssessmentLabApp.test.tsx` proves the rendered UI, case-insensitively, contains no `score`, `rank`, `best`, `plan_fit`, `plan fit`, `recommend`, `strategy`, `report`, `export`, or `download`.
+- unchanged regression gates must pass:
+  - `AppEntryIsolation.test.tsx`
+  - `R1AssessmentLabRoute.test.tsx`
+  - `noNetwork.test.tsx`
+  - `sourceBoundary.test.ts`
+  - `evaluateAssessment.test.ts`
+- `typecheck` and production `build`
+- production deployable `JS/CSS/HTML` scan returns zero matches for:
+  - the existing seven Stage 1 lab-only identifiers
+  - the Stage 3-only strings and identifiers:
+    - `R1 Lab — DEV-only fixture-backed reconstruction.`
+    - `R1 Lab — historic evaluator recovery is not claimed.`
+    - `R1 Lab — no production scoring or live system advice.`
+    - `R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.`
+    - `R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.`
+    - `Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)`
+    - `compact_sufficient_case`
+    - `incomplete_evidence_case`
+    - `contradictory_allocation_case`
+    - `fake_flexibility_case`
+    - `remote_materials_carrier_case`
+    - `no_carrier`
+    - `carrier_available`
+    - `compare_both`
+- explicit `git status --short`, `git diff --stat`, `git diff --name-status`, `git diff --check`, and `git diff --cached --check` evidence with a final clean worktree.
 
 ## Explicit non-goals
 
-- changes to `App.tsx`, `src/main.tsx`, routes, normal navigation, production behavior, stores, APIs, or configuration;
-- changes to Stage 2B evaluator semantics, fixtures, or types;
-- editable fixture data, JSON inputs, overrides, free-form system search, or what-if modelling;
-- reports, digests, exports, markdown generation, hashes, or downloads;
-- strategy selection, Plan Fit, material recommendations, route planning, or colonisation staging;
-- public-facing UI.
+- `App.tsx`, `src/main.tsx`, route, normal navigation, provider, store, API, build/configuration, stylesheet, or package changes;
+- Stage 2B evaluator, type, fixture, or semantic changes;
+- CSS work, inline styles, state-specific class names, visual statuses, icons, badges, or winner styling;
+- editable fixture data, JSON inputs, overrides, free-form inputs, template picker, or error workflow;
+- network, persistence, reports, exports, downloads, hashes, markdown output, strategy, Plan Fit, scores, ranking, recommendations, material planning, route planning, colonisation staging, or public UI.
 
 ## Next safe action
 
-Obtain a revised **Stage 3B technical contract** that incorporates the accepted context-only lens decision, the precise UI copy, exact controls/defaults, allowed files, tests, final artifact-scan identifier list, and explicit non-goals. Do not create a Stage 3 branch or edit product code until the owner accepts that contract.
+Implement Stage 3B only in `R1AssessmentLabApp.tsx` and `R1AssessmentLabApp.test.tsx`, then gather the required evidence before requesting review of the DEV-only presentation slice.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-**Implementing — Stage 3B evidence gathered**
+**Implementing — Stage 3B correction required**
 
 ## Baseline
 
@@ -15,6 +15,7 @@
 - Stage 2B PR: `#280`, merged.
 - Stage 2B merge commit: `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - Stage 3B implementation commit: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
+- Current head before correction: `e8e4ffed601ec3b0d952ee9a9c089c2c6fde4a4a`
 
 ## Active goal
 
@@ -34,86 +35,34 @@ DEV-only fixture-backed assessment-lab presentation.
 ## Allowed files
 
 - `docs/ai/CURRENT_STAGE.md`
-- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
 - `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx`
 
-No other files are authorised. Do not modify `App.tsx`, `src/main.tsx`, Stage 1 tests, Stage 2B core files or tests, routes, navigation, providers, stores, APIs, build/configuration files, stylesheets, or package files.
+No other files are authorised. Do not modify `R1AssessmentLabApp.tsx`, `App.tsx`, `src/main.tsx`, Stage 1 tests, Stage 2B core files or tests, routes, navigation, providers, stores, APIs, build/configuration files, stylesheets, or package files.
 
-## Fixed controls and defaults
+## Correction requirements
 
-Use only local React `useState` and synchronous direct `evaluateAssessment(...)` calls.
+1. Replace the aggregate-only side-effect interaction check with explicit separate no-call proofs after each individual control change:
+   - fixture;
+   - lens kind;
+   - lens value;
+   - carrier mode.
 
-Render exactly four labelled HTML `select` controls, in this order:
+2. Strengthen the default compact-fixture rendering test to prove visible requirement trace and full frozen-evidence provenance in scoped assertions:
+   - requirement ID: `foundation_evidence`
+   - outcome: `met`
+   - matched evidence ID: `compact-foundation`
+   - evidence ID: `compact-foundation`
+   - fact key: `foundation-evidence`
+   - availability: `known`
+   - provenance fixture ID: `compact_sufficient_case`
+   - provenance fixture revision: `v1`
 
-1. `Fixture`
-   - default: `compact_sufficient_case`
-   - options, in order:
-     - `compact_sufficient_case`
-     - `incomplete_evidence_case`
-     - `contradictory_allocation_case`
-     - `fake_flexibility_case`
-     - `remote_materials_carrier_case`
-2. `Lens kind`
-   - default: `role`
-   - options, in order:
-     - `role`
-     - `question`
-3. `Lens value`
-   - when `Lens kind` is `role`:
-     - default: `expedition-lead`
-     - options, in order:
-       - `expedition-lead`
-       - `logistics-reviewer`
-   - when `Lens kind` is `question`:
-     - default: `baseline-assessment`
-     - options, in order:
-       - `baseline-assessment`
-       - `carrier-sensitivity-check`
-   - changing `Lens kind` resets `Lens value` to that kind’s default
-4. `Carrier mode`
-   - default: `no_carrier`
-   - options, in order:
-     - `no_carrier`
-     - `carrier_available`
-     - `compare_both`
+## Required evidence before acceptance
 
-There are exactly five selectable fixture IDs. The six Stage 2B fixture/scenario assertion rows are not six fixtures.
-
-There is no form submission, Evaluate button, reset button, URL state, free-text input, JSON input, checkbox, radio group, textarea, timer, promise, async function, `useEffect`, dynamic runtime import, error boundary, or evaluator-error UI.
-
-## Exact disclosures
-
-Render these exact lines, visibly and persistently:
-
-- `R1 Lab — DEV-only fixture-backed reconstruction.`
-- `R1 Lab — historic evaluator recovery is not claimed.`
-- `R1 Lab — no production scoring or live system advice.`
-- `R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.`
-- `R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.`
-- `Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)`
-
-## Context-only lens rule
-
-The selected role/question lens must be passed to the Stage 2B evaluator and shown as selected context, but it must not change fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.
-
-## Result order
-
-Render results in this exact order:
-
-1. `Assessment state`
-2. `Structured conditions`
-3. `Requirement trace`
-4. `Frozen evidence and provenance`
-5. `Carrier scenario comparison` where `compare_both` is selected
-
-Inside `compare_both`, render:
-
-1. `no_carrier`
-2. `carrier_available`
-
-## Required Stage 3B evidence to define before coding
-
-- `R1AssessmentLabApp.test.tsx` proves the exact controls/defaults, disclosures, fixed-template line, all five selectable fixture IDs, all three carrier modes, and exclusive lens selection with reset-to-default behavior.
+- `R1AssessmentLabApp.test.tsx` passes, including:
+  - separate immediate no-call proofs after each single control change
+  - scoped requirement-trace and frozen-evidence provenance assertions for the compact fixture
+  - the existing Stage 3B control/default/disclosure/state-coverage checks
 - `R1AssessmentLabApp.test.tsx` proves these exact state-coverage combinations:
   - `compact_sufficient_case` + `no_carrier` => `supported`
   - `incomplete_evidence_case` + `no_carrier` => `not_assessable`
@@ -158,47 +107,6 @@ Inside `compare_both`, render:
     - `compare_both`
 - explicit `git status --short`, `git diff --stat`, `git diff --name-status`, `git diff --check`, and `git diff --cached --check` evidence with a final clean worktree.
 
-## Actual evidence
-
-- Branch: `feat/r1-assessment-lab-presentation`
-- Current implementation commit: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
-- Stage 3B presentation test:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
-  - Result: `1 passed, 7 tests passed`
-- Stage 1 regression tests:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/AppEntryIsolation.test.tsx" "src/lab/r1-assessment-lab/R1AssessmentLabRoute.test.tsx" "src/lab/r1-assessment-lab/noNetwork.test.tsx" "src/lab/r1-assessment-lab/sourceBoundary.test.ts"`
-  - Result: `4 passed, 9 tests passed`
-- Stage 2B core regression test:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
-  - Result: `1 passed, 23 tests passed`
-- Typecheck:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" typecheck`
-  - Result: passed
-- Production build:
-  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" build`
-  - Result: passed
-- Production deployable `JS/CSS/HTML` scan:
-  - existing seven Stage 1 lab-only identifiers → no matches
-  - Stage 3-only strings and identifiers → no matches
-- Git checks executed before final docs update:
-  - `git status --short`
-  - `git diff --stat`
-  - `git diff --name-status`
-  - `git diff --check`
-  - `git diff --cached --check`
-
-## Raw outcome summary
-
-- Replaced the inert Stage 1 lab body with a closed local presentation surface using only local `useState` and synchronous direct `evaluateAssessment(...)` calls.
-- Added exactly four labelled `select` controls with the approved defaults and option order.
-- Preserved the Stage 1 boundary strings required by unchanged regression tests.
-- Rendered exact Stage 2B state labels neutrally, without winner framing, recommendations, or ranking language.
-- Added a dedicated UI test proving the mandatory context-only lens behavior and interaction-time network/persistence silence after each control change.
-
-## Remaining caveats
-
-- The production build still emits the pre-existing Coalsack asset warnings and chunk-size warning; Stage 3B did not change build policy or those asset paths.
-
 ## Explicit non-goals
 
 - `App.tsx`, `src/main.tsx`, route, normal navigation, provider, store, API, build/configuration, stylesheet, or package changes;
@@ -209,7 +117,7 @@ Inside `compare_both`, render:
 
 ## Next safe action
 
-Push the branch with the Stage 3B implementation and request review of the DEV-only presentation slice. Do not begin another stage until this one is reviewed.
+Make the test-only correction in `R1AssessmentLabApp.test.tsx`, gather the required evidence again, and open the required PR against `work/r1-canonical-body-evidence`.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-**Implementing — Stage 3B correction required**
+**Implementing — Stage 3B correction evidence gathered**
 
 ## Baseline
 
@@ -16,6 +16,7 @@
 - Stage 2B merge commit: `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - Stage 3B implementation commit: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
 - Current head before correction: `e8e4ffed601ec3b0d952ee9a9c089c2c6fde4a4a`
+- Stage 3B correction implementation commit: `2c10872a82046949bc91cb53481b1cee2390a853`
 
 ## Active goal
 
@@ -107,6 +108,48 @@ No other files are authorised. Do not modify `R1AssessmentLabApp.tsx`, `App.tsx`
     - `compare_both`
 - explicit `git status --short`, `git diff --stat`, `git diff --name-status`, `git diff --check`, and `git diff --cached --check` evidence with a final clean worktree.
 
+## Actual evidence
+
+- Branch: `feat/r1-assessment-lab-presentation`
+- Review PR: `#282`
+- Current implementation commit: `2c10872a82046949bc91cb53481b1cee2390a853`
+- Correction evidence commit: `pending final docs checkpoint`
+- Stage 3B presentation test:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
+  - Result: `1 passed, 7 tests passed`
+- Stage 1 regression tests:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/AppEntryIsolation.test.tsx" "src/lab/r1-assessment-lab/R1AssessmentLabRoute.test.tsx" "src/lab/r1-assessment-lab/noNetwork.test.tsx" "src/lab/r1-assessment-lab/sourceBoundary.test.ts"`
+  - Result: `4 passed, 9 tests passed`
+- Stage 2B core regression test:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
+  - Result: `1 passed, 23 tests passed`
+- Typecheck:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" typecheck`
+  - Result: passed
+- Production build:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" build`
+  - Result: passed
+- Production artifact scans:
+  - existing seven Stage 1 strings → no matches
+  - full Stage 3-only scan → no matches
+- Git checks executed before final docs update:
+  - `git status --short`
+  - `git diff --stat`
+  - `git diff --name-status`
+  - `git diff --check`
+  - `git diff --cached --check`
+- Final worktree state: pending final docs checkpoint
+
+## Raw outcome summary
+
+- Replaced the aggregate-only side-effect interaction proof with separate immediate no-call assertions after each individual control change.
+- Strengthened the default compact-fixture rendering test with scoped requirement-trace and frozen-evidence provenance assertions for `foundation_evidence` and `compact-foundation`.
+- Left `R1AssessmentLabApp.tsx`, Stage 1 tests, Stage 2B core files/tests, routes, stores, providers, APIs, configuration, and stylesheets unchanged.
+
+## Remaining caveats
+
+- The production build still emits the pre-existing Coalsack asset warnings and chunk-size warning; this correction did not change build policy or those asset paths.
+
 ## Explicit non-goals
 
 - `App.tsx`, `src/main.tsx`, route, normal navigation, provider, store, API, build/configuration, stylesheet, or package changes;
@@ -117,7 +160,7 @@ No other files are authorised. Do not modify `R1AssessmentLabApp.tsx`, `App.tsx`
 
 ## Next safe action
 
-Make the test-only correction in `R1AssessmentLabApp.test.tsx`, gather the required evidence again, and open the required PR against `work/r1-canonical-body-evidence`.
+Request final Stage 3B review on PR `#282`. Do not begin another stage.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -113,7 +113,7 @@ No other files are authorised. Do not modify `R1AssessmentLabApp.tsx`, `App.tsx`
 - Branch: `feat/r1-assessment-lab-presentation`
 - Review PR: `#282`
 - Current implementation commit: `2c10872a82046949bc91cb53481b1cee2390a853`
-- Correction evidence commit: `pending final docs checkpoint`
+- Correction evidence commit: `0a664579163b7b14b08167dcd68ceaf94ffee3a5`
 - Stage 3B presentation test:
   - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
   - Result: `1 passed, 7 tests passed`
@@ -138,7 +138,7 @@ No other files are authorised. Do not modify `R1AssessmentLabApp.tsx`, `App.tsx`
   - `git diff --name-status`
   - `git diff --check`
   - `git diff --cached --check`
-- Final worktree state: pending final docs checkpoint
+- Final worktree state: clean after final docs checkpoint
 
 ## Raw outcome summary
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-**Implementing — Stage 3B authorised**
+**Implementing — Stage 3B evidence gathered**
 
 ## Baseline
 
@@ -14,6 +14,7 @@
 - Last accepted implementation stage: Stage 2B pure R1 assessment-domain core.
 - Stage 2B PR: `#280`, merged.
 - Stage 2B merge commit: `220c870f89a5af7f98adb88578373dbc3a681a9c`.
+- Stage 3B implementation commit: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
 
 ## Active goal
 
@@ -157,6 +158,47 @@ Inside `compare_both`, render:
     - `compare_both`
 - explicit `git status --short`, `git diff --stat`, `git diff --name-status`, `git diff --check`, and `git diff --cached --check` evidence with a final clean worktree.
 
+## Actual evidence
+
+- Branch: `feat/r1-assessment-lab-presentation`
+- Current implementation commit: `fe28827d0703e9fe1ca4d510fbb434e39f64bcf0`
+- Stage 3B presentation test:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
+  - Result: `1 passed, 7 tests passed`
+- Stage 1 regression tests:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/AppEntryIsolation.test.tsx" "src/lab/r1-assessment-lab/R1AssessmentLabRoute.test.tsx" "src/lab/r1-assessment-lab/noNetwork.test.tsx" "src/lab/r1-assessment-lab/sourceBoundary.test.ts"`
+  - Result: `4 passed, 9 tests passed`
+- Stage 2B core regression test:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" vitest run "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
+  - Result: `1 passed, 23 tests passed`
+- Typecheck:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" typecheck`
+  - Result: passed
+- Production build:
+  - `yarn --cwd "/data/user/work/ed-finder/frontend-v2" build`
+  - Result: passed
+- Production deployable `JS/CSS/HTML` scan:
+  - existing seven Stage 1 lab-only identifiers → no matches
+  - Stage 3-only strings and identifiers → no matches
+- Git checks executed before final docs update:
+  - `git status --short`
+  - `git diff --stat`
+  - `git diff --name-status`
+  - `git diff --check`
+  - `git diff --cached --check`
+
+## Raw outcome summary
+
+- Replaced the inert Stage 1 lab body with a closed local presentation surface using only local `useState` and synchronous direct `evaluateAssessment(...)` calls.
+- Added exactly four labelled `select` controls with the approved defaults and option order.
+- Preserved the Stage 1 boundary strings required by unchanged regression tests.
+- Rendered exact Stage 2B state labels neutrally, without winner framing, recommendations, or ranking language.
+- Added a dedicated UI test proving the mandatory context-only lens behavior and interaction-time network/persistence silence after each control change.
+
+## Remaining caveats
+
+- The production build still emits the pre-existing Coalsack asset warnings and chunk-size warning; Stage 3B did not change build policy or those asset paths.
+
 ## Explicit non-goals
 
 - `App.tsx`, `src/main.tsx`, route, normal navigation, provider, store, API, build/configuration, stylesheet, or package changes;
@@ -167,7 +209,7 @@ Inside `compare_both`, render:
 
 ## Next safe action
 
-Implement Stage 3B only in `R1AssessmentLabApp.tsx` and `R1AssessmentLabApp.test.tsx`, then gather the required evidence before requesting review of the DEV-only presentation slice.
+Push the branch with the Stage 3B implementation and request review of the DEV-only presentation slice. Do not begin another stage until this one is reviewed.
 
 ## Recovery instruction
 

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
@@ -1,0 +1,214 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import R1AssessmentLabApp from '@/lab/r1-assessment-lab/R1AssessmentLabApp';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function getSelect(label: string) {
+  return screen.getByLabelText(label) as HTMLSelectElement;
+}
+
+function optionLabels(select: HTMLSelectElement) {
+  return Array.from(select.options).map((option) => option.textContent);
+}
+
+function scenarioState(mode: 'no_carrier' | 'carrier_available') {
+  return screen.getByTestId(`scenario-state-${mode}`).textContent;
+}
+
+describe('R1AssessmentLabApp', () => {
+  it('renders the exact four labelled selects, defaults, options, and persistent disclosures', () => {
+    render(<R1AssessmentLabApp />);
+
+    const selects = screen.getAllByRole('combobox');
+    expect(selects).toHaveLength(4);
+    expect(selects.map((select) => select.getAttribute('id'))).toEqual([
+      'r1-fixture-select',
+      'r1-lens-kind-select',
+      'r1-lens-value-select',
+      'r1-carrier-mode-select',
+    ]);
+
+    const fixture = getSelect('Fixture');
+    const lensKind = getSelect('Lens kind');
+    const lensValue = getSelect('Lens value');
+    const carrierMode = getSelect('Carrier mode');
+
+    expect(fixture.value).toBe('compact_sufficient_case');
+    expect(lensKind.value).toBe('role');
+    expect(lensValue.value).toBe('expedition-lead');
+    expect(carrierMode.value).toBe('no_carrier');
+
+    expect(optionLabels(fixture)).toEqual([
+      'compact_sufficient_case',
+      'incomplete_evidence_case',
+      'contradictory_allocation_case',
+      'fake_flexibility_case',
+      'remote_materials_carrier_case',
+    ]);
+    expect(optionLabels(lensKind)).toEqual(['role', 'question']);
+    expect(optionLabels(lensValue)).toEqual(['expedition-lead', 'logistics-reviewer']);
+    expect(optionLabels(carrierMode)).toEqual(['no_carrier', 'carrier_available', 'compare_both']);
+
+    expect(screen.getByText('R1 Assessment Laboratory')).toBeTruthy();
+    expect(screen.getByText('DEV only — reconstruction shell')).toBeTruthy();
+    expect(screen.getByText('R1 Lab — DEV-only fixture-backed reconstruction.')).toBeTruthy();
+    expect(screen.getByText('R1 Lab — historic evaluator recovery is not claimed.')).toBeTruthy();
+    expect(screen.getByText('R1 Lab — no production scoring or live system advice.')).toBeTruthy();
+    expect(screen.getByText('R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.')).toBeTruthy();
+    expect(screen.getByText('R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.')).toBeTruthy();
+    expect(screen.getByText('Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)')).toBeTruthy();
+
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('checkbox')).toBeNull();
+    expect(screen.queryByRole('radio')).toBeNull();
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+
+  it('keeps role and question modes exclusive and resets Lens value to the mode default', () => {
+    render(<R1AssessmentLabApp />);
+
+    const lensKind = getSelect('Lens kind');
+    const lensValue = getSelect('Lens value');
+
+    fireEvent.change(lensKind, { target: { value: 'question' } });
+    expect(lensKind.value).toBe('question');
+    expect(lensValue.value).toBe('baseline-assessment');
+    expect(optionLabels(lensValue)).toEqual(['baseline-assessment', 'carrier-sensitivity-check']);
+
+    fireEvent.change(lensValue, { target: { value: 'carrier-sensitivity-check' } });
+    expect(lensValue.value).toBe('carrier-sensitivity-check');
+
+    fireEvent.change(lensKind, { target: { value: 'role' } });
+    expect(lensKind.value).toBe('role');
+    expect(lensValue.value).toBe('expedition-lead');
+    expect(optionLabels(lensValue)).toEqual(['expedition-lead', 'logistics-reviewer']);
+  });
+
+  it('renders the exact state coverage combinations and compare_both ordering', () => {
+    const { container } = render(<R1AssessmentLabApp />);
+
+    const fixture = getSelect('Fixture');
+    const carrierMode = getSelect('Carrier mode');
+
+    expect(scenarioState('no_carrier')).toContain('supported');
+
+    fireEvent.change(fixture, { target: { value: 'incomplete_evidence_case' } });
+    fireEvent.change(carrierMode, { target: { value: 'no_carrier' } });
+    expect(scenarioState('no_carrier')).toContain('not_assessable');
+
+    fireEvent.change(fixture, { target: { value: 'contradictory_allocation_case' } });
+    expect(scenarioState('no_carrier')).toContain('not_assessable');
+
+    fireEvent.change(fixture, { target: { value: 'fake_flexibility_case' } });
+    expect(scenarioState('no_carrier')).toContain('not_supported');
+
+    fireEvent.change(fixture, { target: { value: 'remote_materials_carrier_case' } });
+    fireEvent.change(carrierMode, { target: { value: 'no_carrier' } });
+    expect(scenarioState('no_carrier')).toContain('conditionally_supported');
+
+    fireEvent.change(carrierMode, { target: { value: 'carrier_available' } });
+    expect(scenarioState('carrier_available')).toContain('supported');
+
+    fireEvent.change(carrierMode, { target: { value: 'compare_both' } });
+    const scenarioSections = Array.from(container.querySelectorAll('section[data-testid^="scenario-"]'))
+      .map((section) => section.getAttribute('data-testid'));
+    expect(screen.getByText('Carrier scenario comparison')).toBeTruthy();
+    expect(scenarioSections).toEqual(['scenario-no_carrier', 'scenario-carrier_available']);
+  });
+
+  it('renders No structured conditions. for condition-free scenarios and shows requirement trace and frozen evidence/provenance', () => {
+    render(<R1AssessmentLabApp />);
+    const scenario = screen.getByTestId('scenario-no_carrier');
+    const scoped = within(scenario);
+
+    expect(screen.getByText('No structured conditions.')).toBeTruthy();
+    expect(scoped.getByText('Requirement trace')).toBeTruthy();
+    expect(scoped.getByText('Frozen evidence and provenance')).toBeTruthy();
+    expect(scoped.getAllByText('compact-foundation').length).toBeGreaterThan(0);
+    expect(scoped.getAllByText('compact_sufficient_case').length).toBeGreaterThan(0);
+  });
+
+  it('keeps scenario result content unchanged when only lens context changes', () => {
+    render(<R1AssessmentLabApp />);
+
+    const fixture = getSelect('Fixture');
+    const carrierMode = getSelect('Carrier mode');
+    const lensKind = getSelect('Lens kind');
+    const lensValue = getSelect('Lens value');
+
+    fireEvent.change(fixture, { target: { value: 'remote_materials_carrier_case' } });
+    fireEvent.change(carrierMode, { target: { value: 'compare_both' } });
+
+    const beforeNoCarrier = screen.getByTestId('scenario-no_carrier').textContent;
+    const beforeCarrierAvailable = screen.getByTestId('scenario-carrier_available').textContent;
+    const beforeOrder = screen.getAllByTestId(/scenario-(no_carrier|carrier_available)/).map((element) => element.getAttribute('data-testid'));
+    expect(screen.getByTestId('selected-lens-context').textContent).toContain('role / expedition-lead');
+
+    fireEvent.change(lensKind, { target: { value: 'question' } });
+    fireEvent.change(lensValue, { target: { value: 'carrier-sensitivity-check' } });
+
+    expect(screen.getByTestId('selected-lens-context').textContent).toContain('question / carrier-sensitivity-check');
+    expect(screen.getByTestId('scenario-no_carrier').textContent).toBe(beforeNoCarrier);
+    expect(screen.getByTestId('scenario-carrier_available').textContent).toBe(beforeCarrierAvailable);
+    expect(screen.getAllByTestId(/scenario-(no_carrier|carrier_available)/).map((element) => element.getAttribute('data-testid')))
+      .toEqual(beforeOrder);
+  });
+
+  it('does not perform network or persistence activity after each control change', () => {
+    const fetchSpy = vi.fn();
+    const xhrOpenSpy = vi.fn();
+    const webSocketSpy = vi.fn();
+    const eventSourceSpy = vi.fn();
+    const sendBeaconSpy = vi.fn();
+    const localStorageSetSpy = vi.spyOn(Object.getPrototypeOf(window.localStorage), 'setItem');
+    const sessionStorageSetSpy = vi.spyOn(Object.getPrototypeOf(window.sessionStorage), 'setItem');
+    const indexedDbOpenSpy = vi.fn();
+
+    vi.stubGlobal('fetch', fetchSpy);
+    vi.stubGlobal('XMLHttpRequest', class {
+      open = xhrOpenSpy;
+      send = vi.fn();
+    });
+    vi.stubGlobal('WebSocket', webSocketSpy);
+    vi.stubGlobal('EventSource', eventSourceSpy);
+    Object.defineProperty(window.navigator, 'sendBeacon', {
+      configurable: true,
+      value: sendBeaconSpy,
+    });
+    Object.defineProperty(window, 'indexedDB', {
+      configurable: true,
+      value: { open: indexedDbOpenSpy },
+    });
+
+    render(<R1AssessmentLabApp />);
+
+    fireEvent.change(getSelect('Fixture'), { target: { value: 'remote_materials_carrier_case' } });
+    fireEvent.change(getSelect('Lens kind'), { target: { value: 'question' } });
+    fireEvent.change(getSelect('Lens value'), { target: { value: 'carrier-sensitivity-check' } });
+    fireEvent.change(getSelect('Carrier mode'), { target: { value: 'compare_both' } });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(xhrOpenSpy).not.toHaveBeenCalled();
+    expect(webSocketSpy).not.toHaveBeenCalled();
+    expect(eventSourceSpy).not.toHaveBeenCalled();
+    expect(sendBeaconSpy).not.toHaveBeenCalled();
+    expect(localStorageSetSpy).not.toHaveBeenCalled();
+    expect(sessionStorageSetSpy).not.toHaveBeenCalled();
+    expect(indexedDbOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders no forbidden language in the DOM', () => {
+    const { container } = render(<R1AssessmentLabApp />);
+    const text = container.textContent?.toLowerCase() ?? '';
+
+    for (const term of ['score', 'rank', 'best', 'plan_fit', 'plan fit', 'recommend', 'strategy', 'report', 'export', 'download']) {
+      expect(text.includes(term)).toBe(false);
+    }
+  });
+});

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
@@ -20,6 +20,66 @@ function scenarioState(mode: 'no_carrier' | 'carrier_available') {
   return screen.getByTestId(`scenario-state-${mode}`).textContent;
 }
 
+function setupSideEffectMocks() {
+  const fetchSpy = vi.fn();
+  const xhrOpenSpy = vi.fn();
+  const webSocketSpy = vi.fn();
+  const eventSourceSpy = vi.fn();
+  const sendBeaconSpy = vi.fn();
+  const localStorageSetSpy = vi.spyOn(Object.getPrototypeOf(window.localStorage), 'setItem');
+  const sessionStorageSetSpy = vi.spyOn(Object.getPrototypeOf(window.sessionStorage), 'setItem');
+  const indexedDbOpenSpy = vi.fn();
+
+  vi.stubGlobal('fetch', fetchSpy);
+  vi.stubGlobal('XMLHttpRequest', class {
+    open = xhrOpenSpy;
+    send = vi.fn();
+  });
+  vi.stubGlobal('WebSocket', webSocketSpy);
+  vi.stubGlobal('EventSource', eventSourceSpy);
+  Object.defineProperty(window.navigator, 'sendBeacon', {
+    configurable: true,
+    value: sendBeaconSpy,
+  });
+  Object.defineProperty(window, 'indexedDB', {
+    configurable: true,
+    value: { open: indexedDbOpenSpy },
+  });
+
+  return {
+    fetchSpy,
+    xhrOpenSpy,
+    webSocketSpy,
+    eventSourceSpy,
+    sendBeaconSpy,
+    localStorageSetSpy,
+    sessionStorageSetSpy,
+    indexedDbOpenSpy,
+  };
+}
+
+function resetSideEffectMocks(mocks: ReturnType<typeof setupSideEffectMocks>) {
+  mocks.fetchSpy.mockClear();
+  mocks.xhrOpenSpy.mockClear();
+  mocks.webSocketSpy.mockClear();
+  mocks.eventSourceSpy.mockClear();
+  mocks.sendBeaconSpy.mockClear();
+  mocks.localStorageSetSpy.mockClear();
+  mocks.sessionStorageSetSpy.mockClear();
+  mocks.indexedDbOpenSpy.mockClear();
+}
+
+function expectNoSideEffects(mocks: ReturnType<typeof setupSideEffectMocks>) {
+  expect(mocks.fetchSpy).not.toHaveBeenCalled();
+  expect(mocks.xhrOpenSpy).not.toHaveBeenCalled();
+  expect(mocks.webSocketSpy).not.toHaveBeenCalled();
+  expect(mocks.eventSourceSpy).not.toHaveBeenCalled();
+  expect(mocks.sendBeaconSpy).not.toHaveBeenCalled();
+  expect(mocks.localStorageSetSpy).not.toHaveBeenCalled();
+  expect(mocks.sessionStorageSetSpy).not.toHaveBeenCalled();
+  expect(mocks.indexedDbOpenSpy).not.toHaveBeenCalled();
+}
+
 describe('R1AssessmentLabApp', () => {
   it('renders the exact four labelled selects, defaults, options, and persistent disclosures', () => {
     render(<R1AssessmentLabApp />);
@@ -126,12 +186,29 @@ describe('R1AssessmentLabApp', () => {
     render(<R1AssessmentLabApp />);
     const scenario = screen.getByTestId('scenario-no_carrier');
     const scoped = within(scenario);
+    const tables = scoped.getAllByRole('table');
+    const requirementTraceTable = tables[0];
+    const frozenEvidenceTable = tables[1];
 
     expect(screen.getByText('No structured conditions.')).toBeTruthy();
     expect(scoped.getByText('Requirement trace')).toBeTruthy();
     expect(scoped.getByText('Frozen evidence and provenance')).toBeTruthy();
-    expect(scoped.getAllByText('compact-foundation').length).toBeGreaterThan(0);
-    expect(scoped.getAllByText('compact_sufficient_case').length).toBeGreaterThan(0);
+
+    const requirementRow = within(requirementTraceTable).getByText('foundation_evidence').closest('tr');
+    if (!requirementRow) throw new Error('foundation_evidence row not found');
+    const requirementRowScope = within(requirementRow);
+    expect(requirementRowScope.getByText('foundation_evidence')).toBeTruthy();
+    expect(requirementRowScope.getByText('met')).toBeTruthy();
+    expect(requirementRowScope.getByText('compact-foundation')).toBeTruthy();
+
+    const evidenceRow = within(frozenEvidenceTable).getByText('compact-foundation').closest('tr');
+    if (!evidenceRow) throw new Error('compact-foundation evidence row not found');
+    const evidenceRowScope = within(evidenceRow);
+    expect(evidenceRowScope.getByText('compact-foundation')).toBeTruthy();
+    expect(evidenceRowScope.getByText('foundation-evidence')).toBeTruthy();
+    expect(evidenceRowScope.getByText('known')).toBeTruthy();
+    expect(evidenceRowScope.getByText('compact_sufficient_case')).toBeTruthy();
+    expect(evidenceRowScope.getByText('v1')).toBeTruthy();
   });
 
   it('keeps scenario result content unchanged when only lens context changes', () => {
@@ -160,47 +237,26 @@ describe('R1AssessmentLabApp', () => {
       .toEqual(beforeOrder);
   });
 
-  it('does not perform network or persistence activity after each control change', () => {
-    const fetchSpy = vi.fn();
-    const xhrOpenSpy = vi.fn();
-    const webSocketSpy = vi.fn();
-    const eventSourceSpy = vi.fn();
-    const sendBeaconSpy = vi.fn();
-    const localStorageSetSpy = vi.spyOn(Object.getPrototypeOf(window.localStorage), 'setItem');
-    const sessionStorageSetSpy = vi.spyOn(Object.getPrototypeOf(window.sessionStorage), 'setItem');
-    const indexedDbOpenSpy = vi.fn();
-
-    vi.stubGlobal('fetch', fetchSpy);
-    vi.stubGlobal('XMLHttpRequest', class {
-      open = xhrOpenSpy;
-      send = vi.fn();
-    });
-    vi.stubGlobal('WebSocket', webSocketSpy);
-    vi.stubGlobal('EventSource', eventSourceSpy);
-    Object.defineProperty(window.navigator, 'sendBeacon', {
-      configurable: true,
-      value: sendBeaconSpy,
-    });
-    Object.defineProperty(window, 'indexedDB', {
-      configurable: true,
-      value: { open: indexedDbOpenSpy },
-    });
+  it('does not perform network or persistence activity after each separate control change', () => {
+    const mocks = setupSideEffectMocks();
 
     render(<R1AssessmentLabApp />);
 
+    resetSideEffectMocks(mocks);
     fireEvent.change(getSelect('Fixture'), { target: { value: 'remote_materials_carrier_case' } });
-    fireEvent.change(getSelect('Lens kind'), { target: { value: 'question' } });
-    fireEvent.change(getSelect('Lens value'), { target: { value: 'carrier-sensitivity-check' } });
-    fireEvent.change(getSelect('Carrier mode'), { target: { value: 'compare_both' } });
+    expectNoSideEffects(mocks);
 
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(xhrOpenSpy).not.toHaveBeenCalled();
-    expect(webSocketSpy).not.toHaveBeenCalled();
-    expect(eventSourceSpy).not.toHaveBeenCalled();
-    expect(sendBeaconSpy).not.toHaveBeenCalled();
-    expect(localStorageSetSpy).not.toHaveBeenCalled();
-    expect(sessionStorageSetSpy).not.toHaveBeenCalled();
-    expect(indexedDbOpenSpy).not.toHaveBeenCalled();
+    resetSideEffectMocks(mocks);
+    fireEvent.change(getSelect('Lens kind'), { target: { value: 'question' } });
+    expectNoSideEffects(mocks);
+
+    resetSideEffectMocks(mocks);
+    fireEvent.change(getSelect('Lens value'), { target: { value: 'carrier-sensitivity-check' } });
+    expectNoSideEffects(mocks);
+
+    resetSideEffectMocks(mocks);
+    fireEvent.change(getSelect('Carrier mode'), { target: { value: 'compare_both' } });
+    expectNoSideEffects(mocks);
   });
 
   it('renders no forbidden language in the DOM', () => {

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx
@@ -1,4 +1,157 @@
+import { useState } from 'react';
+
+import { R1_ASSESSMENT_FIXTURES, R1_ASSESSMENT_TEMPLATE } from '@/lab/r1-assessment-lab/core/fixtures';
+import { evaluateAssessment } from '@/lab/r1-assessment-lab/core/evaluateAssessment';
+import type {
+  AssessmentEvaluationResult,
+  AssessmentLens,
+  CarrierMode,
+  ScenarioAssessment,
+} from '@/lab/r1-assessment-lab/core/types';
+
+const FIXTURE_OPTIONS = [
+  'compact_sufficient_case',
+  'incomplete_evidence_case',
+  'contradictory_allocation_case',
+  'fake_flexibility_case',
+  'remote_materials_carrier_case',
+] as const;
+
+const LENS_KIND_OPTIONS = ['role', 'question'] as const;
+const ROLE_OPTIONS = ['expedition-lead', 'logistics-reviewer'] as const;
+const QUESTION_OPTIONS = ['baseline-assessment', 'carrier-sensitivity-check'] as const;
+const CARRIER_MODE_OPTIONS = ['no_carrier', 'carrier_available', 'compare_both'] as const;
+
+type FixtureOption = typeof FIXTURE_OPTIONS[number];
+type LensKindOption = typeof LENS_KIND_OPTIONS[number];
+type RoleOption = typeof ROLE_OPTIONS[number];
+type QuestionOption = typeof QUESTION_OPTIONS[number];
+
+function lensValueFor(kind: LensKindOption): RoleOption | QuestionOption {
+  return kind === 'role' ? 'expedition-lead' : 'baseline-assessment';
+}
+
+function buildLens(kind: LensKindOption, value: string): AssessmentLens {
+  if (kind === 'role') {
+    return { kind: 'role', roleId: value };
+  }
+  return { kind: 'question', questionId: value };
+}
+
+function renderConditions(scenario: ScenarioAssessment) {
+  if (scenario.conditions.length === 0) {
+    return <p>No structured conditions.</p>;
+  }
+
+  return (
+    <ul>
+      {scenario.conditions.map((condition) => (
+        <li key={condition.id}>
+          <div><code>{condition.id}</code></div>
+          <div>{condition.summary}</div>
+          <div>blocking: <code>{String(condition.blocking)}</code></div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function renderRequirementTrace(scenario: ScenarioAssessment) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">requirementId</th>
+          <th scope="col">outcome</th>
+          <th scope="col">matchedEvidenceIds</th>
+          <th scope="col">missingEvidenceIds</th>
+          <th scope="col">contradictoryEvidenceIds</th>
+          <th scope="col">carrierLogisticsAffected</th>
+        </tr>
+      </thead>
+      <tbody>
+        {scenario.requirementResults.map((requirement) => (
+          <tr key={requirement.requirementId}>
+            <td><code>{requirement.requirementId}</code></td>
+            <td><code>{requirement.outcome}</code></td>
+            <td><code>{requirement.matchedEvidenceIds.join(', ') || '[]'}</code></td>
+            <td><code>{requirement.missingEvidenceIds.join(', ') || '[]'}</code></td>
+            <td><code>{requirement.contradictoryEvidenceIds.join(', ') || '[]'}</code></td>
+            <td><code>{String(requirement.carrierLogisticsAffected)}</code></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function renderFrozenEvidence(scenario: ScenarioAssessment) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">id</th>
+          <th scope="col">factKey</th>
+          <th scope="col">availability</th>
+          <th scope="col">fixtureId</th>
+          <th scope="col">fixtureRevision</th>
+        </tr>
+      </thead>
+      <tbody>
+        {scenario.frozenEvidence.map((evidence) => (
+          <tr key={evidence.id}>
+            <td><code>{evidence.id}</code></td>
+            <td><code>{evidence.factKey}</code></td>
+            <td><code>{evidence.availability}</code></td>
+            <td><code>{evidence.provenance.fixtureId}</code></td>
+            <td><code>{evidence.provenance.fixtureRevision}</code></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ScenarioResultSection({ scenario }: { scenario: ScenarioAssessment }) {
+  return (
+    <section data-testid={`scenario-${scenario.carrierMode}`}>
+      <h3><code>{scenario.carrierMode}</code></h3>
+
+      <h4>Assessment state</h4>
+      <p data-testid={`scenario-state-${scenario.carrierMode}`}><code>{scenario.state}</code></p>
+
+      <h4>Structured conditions</h4>
+      {renderConditions(scenario)}
+
+      <h4>Requirement trace</h4>
+      {renderRequirementTrace(scenario)}
+
+      <h4>Frozen evidence and provenance</h4>
+      {renderFrozenEvidence(scenario)}
+    </section>
+  );
+}
+
 export default function R1AssessmentLabApp() {
+  const [fixtureId, setFixtureId] = useState<FixtureOption>('compact_sufficient_case');
+  const [lensKind, setLensKind] = useState<LensKindOption>('role');
+  const [lensValue, setLensValue] = useState<RoleOption | QuestionOption>('expedition-lead');
+  const [carrierMode, setCarrierMode] = useState<CarrierMode>('no_carrier');
+
+  const selectedLens = buildLens(lensKind, lensValue);
+  const result: AssessmentEvaluationResult = evaluateAssessment({
+    fixture: R1_ASSESSMENT_FIXTURES[fixtureId],
+    template: R1_ASSESSMENT_TEMPLATE,
+    lens: selectedLens,
+    carrierMode,
+  });
+
+  const selectedLensContext = selectedLens.kind === 'role'
+    ? `role / ${selectedLens.roleId}`
+    : `question / ${selectedLens.questionId}`;
+
+  const lensOptions = lensKind === 'role' ? ROLE_OPTIONS : QUESTION_OPTIONS;
+
   return (
     <main className="min-h-screen px-4 py-8 text-slate-100 sm:px-6">
       <div className="mx-auto max-w-3xl rounded-2xl border border-cyan-500/40 bg-slate-950/90 p-6 shadow-2xl shadow-cyan-950/30">
@@ -9,11 +162,83 @@ export default function R1AssessmentLabApp() {
           <h1 className="text-3xl font-semibold text-white">
             DEV only — reconstruction shell
           </h1>
-          <ul className="space-y-2 text-sm text-slate-200">
-            <li>No production scoring</li>
-            <li>No network or persistence</li>
-            <li>Assessment engine not yet reconstructed</li>
-          </ul>
+          <p>R1 Lab — DEV-only fixture-backed reconstruction.</p>
+          <p>R1 Lab — historic evaluator recovery is not claimed.</p>
+          <p>R1 Lab — no production scoring or live system advice.</p>
+          <p>R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.</p>
+          <p>R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.</p>
+          <p>Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)</p>
+
+          <div>
+            <label htmlFor="r1-fixture-select">Fixture</label>{' '}
+            <select
+              id="r1-fixture-select"
+              value={fixtureId}
+              onChange={(event) => setFixtureId(event.currentTarget.value as FixtureOption)}
+            >
+              {FIXTURE_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="r1-lens-kind-select">Lens kind</label>{' '}
+            <select
+              id="r1-lens-kind-select"
+              value={lensKind}
+              onChange={(event) => {
+                const nextKind = event.currentTarget.value as LensKindOption;
+                setLensKind(nextKind);
+                setLensValue(lensValueFor(nextKind));
+              }}
+            >
+              {LENS_KIND_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="r1-lens-value-select">Lens value</label>{' '}
+            <select
+              id="r1-lens-value-select"
+              value={lensValue}
+              onChange={(event) => setLensValue(event.currentTarget.value as RoleOption | QuestionOption)}
+            >
+              {lensOptions.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="r1-carrier-mode-select">Carrier mode</label>{' '}
+            <select
+              id="r1-carrier-mode-select"
+              value={carrierMode}
+              onChange={(event) => setCarrierMode(event.currentTarget.value as CarrierMode)}
+            >
+              {CARRIER_MODE_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+
+          <p data-testid="selected-lens-context">Selected lens context: {selectedLensContext}</p>
+
+          {carrierMode === 'compare_both' ? (
+            <section>
+              <h2>Carrier scenario comparison</h2>
+              {result.scenarioResults.map((scenario) => (
+                <ScenarioResultSection key={scenario.carrierMode} scenario={scenario} />
+              ))}
+            </section>
+          ) : (
+            result.scenarioResults.map((scenario) => (
+              <ScenarioResultSection key={scenario.carrierMode} scenario={scenario} />
+            ))
+          )}
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add the DEV-only fixture-backed R1 assessment-lab presentation surface
- add dedicated Stage 3B UI coverage
- harden the presentation test with separate control-change no-side-effect proofs and scoped requirement/evidence assertions

## Evidence
- Stage 3B UI tests passed
- unchanged Stage 1 regression gates passed
- unchanged Stage 2B core test passed
- typecheck passed
- production build passed
- production artifact scans returned zero matches for the Stage 1 and Stage 3 lab-only strings

## Scope
No App.tsx changes, no core semantic changes, no routes/providers/stores/APIs, no stylesheets, no persistence, no deployment.