### PR TITLE
docs: clarify Stage 4B carrier scenarios

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -9,8 +9,8 @@
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Current documentation branch: `docs/r1-stage4-plan-fit-contract`
-- Base SHA: `83f4e4bc9829c173979fce5aa0bda734174ca55a`
+- Current documentation branch: `docs/r1-stage4b-carrier-clarification`
+- Base SHA: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -9,8 +9,8 @@
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Current documentation branch: `docs/r1-stage4b-carrier-clarification`
-- Base SHA: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
+- Carrier-scenario clarification branch: `docs/r1-stage4b-carrier-clarification`
+- Carrier-scenario clarification base SHA: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,13 +4,15 @@
 
 ## Status
 
-**Stage 4B technical contract revised after independent review — awaiting final independent review and owner approval**
+**Stage 4B contract merged — carrier-scenario clarification awaiting independent review; implementation remains blocked**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
 - Current documentation branch: `docs/r1-stage4-plan-fit-contract`
 - Base SHA: `83f4e4bc9829c173979fce5aa0bda734174ca55a`
+- Stage 4B contract PR: `#284`, merged
+- Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
 - Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
 - Last accepted implementation stage: Stage 2B pure R1 assessment-domain core, merged by PR `#280` at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
@@ -19,9 +21,10 @@
 ## Active contract record
 
 - Contract file: `docs/ai/R1_STAGE4_PLAN_FIT_CONTRACT_V1.md`
-- This branch is documentation-only.
+- This follow-up corrects documentation only.
 - No Stage 4B implementation is authorised.
 - The first independent review required deterministic-output and carrier-boundary wording corrections in the contract text.
+- No Stage 4B implementation is authorised while this carrier-scenario clarification is under review.
 
 ## Proposed later Stage 4B implementation allowlist
 
@@ -85,7 +88,7 @@ Stage 4B does not add:
 
 ## Next safe action
 
-Obtain independent read-only review of `R1_STAGE4_PLAN_FIT_CONTRACT_V1.md`. Do not create a Stage 4B implementation branch or edit core code until the owner explicitly authorises implementation.
+Obtain an independent read-only review of the carrier-scenario clarification. Do not create a Stage 4B implementation branch or edit core code until this clarification is merged and the owner explicitly authorises implementation.
 
 ## Recovery instruction
 

--- a/docs/ai/R1_STAGE4_PLAN_FIT_CONTRACT_V1.md
+++ b/docs/ai/R1_STAGE4_PLAN_FIT_CONTRACT_V1.md
@@ -303,7 +303,8 @@ Require narrow guards for:
 - reject any scenario whose assessment state is not `not_assessable` but whose requirement results contain an `unknown` or `contradictory` outcome
 - per-scenario requirement results containing every accepted template requirement exactly once
 - no unknown, duplicate, or missing requirement IDs
-- requirement-result carrier modes matching their enclosing scenario
+- `RequirementAssessment` does not carry a carrier mode. Carrier identity is supplied only by its enclosing `ScenarioAssessment.carrierMode`. The Plan Fit evaluator must not require, infer, or invent a per-requirement carrier mode.
+- `carrierLogisticsAffected`, where present in the accepted Stage 2B type, must be boolean and must not be treated as a second carrier-mode field
 - selected strategy ID resolving exactly once in the fixed strategy registry
 
 The evaluator must not verify whether an assessment state was correctly derived from the full requirement outcomes. That is Stage 2B’s responsibility. The `unknown` / `contradictory` rule above is a narrow structural consistency guard only; it does not recompute Stage 2B assessment state.
@@ -313,6 +314,8 @@ The evaluator must not verify whether an assessment state was correctly derived 
 Plan Fit never applies, repairs, transforms, or independently calculates carrier effects.
 
 Any carrier difference originates solely from accepted Stage 2B per-scenario requirement outcomes.
+
+Plan Fit copies each accepted Stage 2B scenario assessment state unchanged into its matching Plan Fit scenario result. It does not calculate, suppress, or replace assessment-state changes caused upstream by accepted Stage 2B carrier evaluation.
 
 Carrier can affect only strategy dependencies that are both:
 
@@ -324,6 +327,13 @@ In `compare_both`, for each selected strategy requirement dependency, the evalua
 Where an outcome differs across scenarios, that requirement ID must be declared in the selected strategy’s `logisticsSensitiveRequirementIds`; otherwise reject the assessment result as incompatible with the selected strategy.
 
 Plan Fit’s only response to accepted carrier-specific outcomes is to map them through the fixed dependency-to-reason rules.
+
+In `compare_both`, a carrier-sensitive logistics outcome may produce both:
+
+- a different incoming `assessmentState`
+- a different Plan Fit dependency-reason set
+
+These are distinct effects. Plan Fit preserves the first and maps the second through the fixed dependency-to-reason rules.
 
 Carrier must never:
 
@@ -363,8 +373,15 @@ These are forward-reconstruction fixture combinations, not recovered historic st
 
 3. `remote_materials_carrier_case` + `remote_logistics_strategy` + `compare_both`
    - exact scenario order: `no_carrier` then `carrier_available`
-   - `no_carrier` retains the logistics reason
-   - `carrier_available` removes that permitted logistics reason
+   - `no_carrier`
+     - `assessmentState: conditionally_supported`
+     - `planFitState: provisional_plan_fit`
+     - includes non-blocking `dependency:remote_logistics`
+   - `carrier_available`
+     - `assessmentState: supported`
+     - `planFitState: provisional_plan_fit`
+     - has no `dependency:remote_logistics` reason
+   - these assessment states are accepted Stage 2B input preserved by Plan Fit, not recalculated by Plan Fit
    - no comparative recommendation language
 
 4. `fake_flexibility_case` + `baseline_local_strategy` + `no_carrier`
@@ -404,7 +421,14 @@ The later Stage 4B test suite must prove:
 - gate-first plus lexical ordering of all following dependency reasons
 - the exact reason-ID scheme is used
 - required fixture matrix passes
-- carrier changes only the permitted remote logistics reason
+- `compare_both` preserves accepted Stage 2B scenario states exactly:
+  - `no_carrier` remains `conditionally_supported`
+  - `carrier_available` remains `supported`
+- the only Plan Fit dependency-reason difference for the approved remote-logistics fixture is:
+  - `dependency:remote_logistics` exists in `no_carrier`
+  - `dependency:remote_logistics` is absent in `carrier_available`
+- the evaluator does not require or inspect a per-requirement carrier mode, because none exists in `RequirementAssessment`
+- the evaluator does not calculate carrier effects or assessment-state transitions; it preserves scenario states provided by Stage 2B and maps dependency outcomes only
 - carrier cannot repair missing evidence, contradiction, capacity, shared constraint, `not_assessable`, or `not_supported`
 - changing only lens changes only returned context lens
 - scenario order is exact


### PR DESCRIPTION
- docs-only correction to the merged Stage 4B contract;
- clarifies that scenario assessment states are carried from Stage 2B unchanged;
- removes an impossible per-requirement carrier-mode guard;
- no implementation, tests, configuration, or production change;
- implementation remains blocked pending review and explicit owner authorisation;
- no deployment.