### PR TITLE
Stage 4B: bounded Plan Fit pure core

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,27 +4,27 @@
 
 ## Status
 
-**Stage 4B contract merged — carrier-scenario clarification awaiting independent review; implementation remains blocked**
+**Stage 4B bounded pure-core implementation complete — awaiting independent review and owner acceptance**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Carrier-scenario clarification branch: `docs/r1-stage4b-carrier-clarification`
-- Carrier-scenario clarification base SHA: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
+- Implementation branch: `feat/r1-plan-fit-core`
+- Implementation base SHA: `5fa49ae2a8f538b2e3111524c27299290a082bf0`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
+- Owner authorised bounded Stage 4B implementation on `2026-07-02`
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
 - Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
 - Last accepted implementation stage: Stage 2B pure R1 assessment-domain core, merged by PR `#280` at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - No deployment occurred.
 
-## Active contract record
+## Active implementation record
 
 - Contract file: `docs/ai/R1_STAGE4_PLAN_FIT_CONTRACT_V1.md`
-- This follow-up corrects documentation only.
-- No Stage 4B implementation is authorised.
-- The first independent review required deterministic-output and carrier-boundary wording corrections in the contract text.
-- No Stage 4B implementation is authorised while this carrier-scenario clarification is under review.
+- Stage 4B implementation is limited to the five-file allowlist below.
+- No UI, production behavior, deployment, or Stage 1–3 modification is authorised or included.
+- The implementation remains bounded pure-core work subordinate to accepted Stage 2B assessment results.
 
 ## Proposed later Stage 4B implementation allowlist
 
@@ -82,13 +82,21 @@ Stage 4B does not add:
 
 ## Caveats
 
-- This branch contains only documentation updates.
-- No implementation, test, configuration, or production change is authorised by the Stage 4B contract alone.
-- Any later Stage 4B implementation must use the new focused plan-fit files rather than modifying accepted Stage 2B or Stage 3B files.
+- No deployment occurred.
+- Validation completed locally on the implementation branch:
+  - new focused Stage 4B Plan Fit tests
+  - existing Stage 2B evaluator tests
+  - existing Stage 3B assessment-lab UI tests
+  - full test suite
+  - typecheck
+  - lint
+  - production build
+  - production artifact scan extended for Stage 4 identifiers
+- The production build retained the pre-existing Coalsack asset-resolution warnings and chunk-size warning.
 
 ## Next safe action
 
-Obtain an independent read-only review of the carrier-scenario clarification. Do not create a Stage 4B implementation branch or edit core code until this clarification is merged and the owner explicitly authorises implementation.
+Obtain an independent read-only review of this implementation PR, followed by owner acceptance before merge.
 
 ## Recovery instruction
 

--- a/frontend-v2/src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts
+++ b/frontend-v2/src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it } from 'vitest';
+
+import { R1_ASSESSMENT_FIXTURES, R1_ASSESSMENT_TEMPLATE } from '@/lab/r1-assessment-lab/core/fixtures';
+import { evaluateAssessment } from '@/lab/r1-assessment-lab/core/evaluateAssessment';
+import { evaluatePlanFit } from '@/lab/r1-assessment-lab/core/evaluatePlanFit';
+import type {
+  PlanFitEvaluationResult,
+  PlanFitScenarioResult,
+} from '@/lab/r1-assessment-lab/core/planFitTypes';
+import { FIXED_STRATEGY_FIXTURES, validateStrategyFixtures } from '@/lab/r1-assessment-lab/core/strategyFixtures';
+import type {
+  AssessmentEvaluationInput,
+  AssessmentEvaluationResult,
+  CarrierMode,
+} from '@/lab/r1-assessment-lab/core/types';
+
+function buildAssessmentInput(
+  fixtureId: keyof typeof R1_ASSESSMENT_FIXTURES,
+  overrides: Partial<AssessmentEvaluationInput> = {},
+): AssessmentEvaluationInput {
+  return {
+    fixture: R1_ASSESSMENT_FIXTURES[fixtureId],
+    template: R1_ASSESSMENT_TEMPLATE,
+    lens: { kind: 'role', roleId: 'expedition-lead' },
+    carrierMode: 'no_carrier',
+    ...overrides,
+  };
+}
+
+function buildAcceptedAssessmentResult(
+  fixtureId: keyof typeof R1_ASSESSMENT_FIXTURES,
+  carrierMode: CarrierMode = 'no_carrier',
+  overrides: Partial<AssessmentEvaluationInput> = {},
+): AssessmentEvaluationResult {
+  return evaluateAssessment(buildAssessmentInput(fixtureId, { carrierMode, ...overrides }));
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function scenario(result: PlanFitEvaluationResult, carrierMode: 'no_carrier' | 'carrier_available'): PlanFitScenarioResult {
+  const match = result.scenarioResults.find((item) => item.carrierMode === carrierMode);
+  if (!match) {
+    throw new Error(`Scenario ${carrierMode} missing in test setup`);
+  }
+  return match;
+}
+
+function collectForbiddenKeys(value: unknown, found = new Set<string>()): Set<string> {
+  if (!value || typeof value !== 'object') return found;
+  if (Array.isArray(value)) {
+    for (const item of value) collectForbiddenKeys(item, found);
+    return found;
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    if (['score', 'rank', 'best', 'recommend', 'recommendation', 'preference', 'winner', 'desirability'].includes(key)) {
+      found.add(key);
+    }
+    collectForbiddenKeys(nested, found);
+  }
+  return found;
+}
+
+function assertDeepFrozen(value: unknown) {
+  if (!value || typeof value !== 'object') return;
+  expect(Object.isFrozen(value)).toBe(true);
+  if (Array.isArray(value)) {
+    for (const item of value) assertDeepFrozen(item);
+    return;
+  }
+  for (const nested of Object.values(value)) {
+    assertDeepFrozen(nested);
+  }
+}
+
+describe('strategyFixtures', () => {
+  it('contains exactly the two approved fixed strategy records with exact fields', () => {
+    expect(FIXED_STRATEGY_FIXTURES).toEqual([
+      {
+        fixtureKey: 'baseline_local_strategy',
+        strategyId: 'baseline_local_strategy',
+        strategyRevision: 'v1',
+        label: 'Baseline local strategy',
+        compatibility: {
+          programmeId: 'r1_assessment_programme',
+          templateId: 'core_assessment_template',
+          templateRevision: 'r1-contract-v1',
+        },
+        provenance: {
+          sourceKind: 'fixture',
+          fixtureId: 'baseline_local_strategy',
+          fixtureRevision: 'v1',
+        },
+        requiredAssessmentRequirementIds: [
+          'foundation_evidence',
+          'allocation_consistency',
+          'capacity_floor',
+        ],
+        logisticsSensitiveRequirementIds: [],
+      },
+      {
+        fixtureKey: 'remote_logistics_strategy',
+        strategyId: 'remote_logistics_strategy',
+        strategyRevision: 'v1',
+        label: 'Remote logistics strategy',
+        compatibility: {
+          programmeId: 'r1_assessment_programme',
+          templateId: 'core_assessment_template',
+          templateRevision: 'r1-contract-v1',
+        },
+        provenance: {
+          sourceKind: 'fixture',
+          fixtureId: 'remote_logistics_strategy',
+          fixtureRevision: 'v1',
+        },
+        requiredAssessmentRequirementIds: [
+          'foundation_evidence',
+          'allocation_consistency',
+          'capacity_floor',
+          'remote_logistics',
+        ],
+        logisticsSensitiveRequirementIds: [
+          'remote_logistics',
+        ],
+      },
+    ]);
+    assertDeepFrozen(FIXED_STRATEGY_FIXTURES);
+  });
+
+  it('rejects duplicate strategy ids', () => {
+    const fixtures = clone(FIXED_STRATEGY_FIXTURES);
+    fixtures[1].strategyId = fixtures[0].strategyId;
+    expect(() => validateStrategyFixtures(fixtures)).toThrow('Duplicate strategy id: baseline_local_strategy');
+  });
+
+  it('rejects duplicate fixture keys', () => {
+    const fixtures = clone(FIXED_STRATEGY_FIXTURES);
+    fixtures[1].fixtureKey = fixtures[0].fixtureKey;
+    fixtures[1].strategyId = 'remote_logistics_strategy_variant';
+    expect(() => validateStrategyFixtures(fixtures)).toThrow('Duplicate strategy fixture key: baseline_local_strategy');
+  });
+
+  it('rejects invalid compatibility tuples before output', () => {
+    const fixtures = clone(FIXED_STRATEGY_FIXTURES);
+    fixtures[0].compatibility.templateRevision = 'wrong-revision';
+    expect(() => validateStrategyFixtures(fixtures)).toThrow(
+      'Strategy baseline_local_strategy compatibility tuple does not match the accepted template.',
+    );
+  });
+
+  it('rejects unknown required requirement ids', () => {
+    const fixtures = clone(FIXED_STRATEGY_FIXTURES);
+    fixtures[0].requiredAssessmentRequirementIds.push('unknown_requirement');
+    expect(() => validateStrategyFixtures(fixtures)).toThrow(
+      'Strategy baseline_local_strategy references unknown required assessment requirement id: unknown_requirement',
+    );
+  });
+
+  it('rejects invalid logistics-sensitive declarations for capacity, non-logistics, carrier-insensitive, and shared requirements', () => {
+    for (const invalidRequirementId of ['capacity_floor', 'foundation_evidence', 'allocation_consistency']) {
+      const fixtures = clone(FIXED_STRATEGY_FIXTURES);
+      fixtures[0].logisticsSensitiveRequirementIds = [invalidRequirementId];
+      expect(() => validateStrategyFixtures(fixtures)).toThrow(
+        `Strategy baseline_local_strategy declares invalid logistics-sensitive requirement ${invalidRequirementId}.`,
+      );
+    }
+  });
+});
+
+describe('evaluatePlanFit', () => {
+  it('rejects a raw fixture-shaped object instead of an accepted assessment result', () => {
+    expect(() =>
+      evaluatePlanFit(R1_ASSESSMENT_FIXTURES.compact_sufficient_case as unknown as AssessmentEvaluationResult, 'baseline_local_strategy'),
+    ).toThrow('Plan Fit evaluation requires an AssessmentEvaluationResult input.');
+  });
+
+  it('rejects missing or unknown selected strategy ids', () => {
+    const assessmentResult = buildAcceptedAssessmentResult('compact_sufficient_case');
+
+    expect(() => evaluatePlanFit(assessmentResult, '')).toThrow('Plan Fit evaluation requires a non-empty selectedStrategyId.');
+    expect(() => evaluatePlanFit(assessmentResult, 'unknown_strategy')).toThrow('Unknown selected strategy id: unknown_strategy');
+  });
+
+  it('rejects malformed context, invalid lens, invalid carrier mode, invalid scenario ordering/count, duplicate scenarios, and malformed requirement structures', () => {
+    const assessmentResult = buildAcceptedAssessmentResult('compact_sufficient_case', 'compare_both');
+
+    const malformedProgramme = clone(assessmentResult);
+    malformedProgramme.context.programmeId = ' ';
+    expect(() => evaluatePlanFit(malformedProgramme, 'baseline_local_strategy')).toThrow(
+      'Plan Fit evaluation requires a non-empty programmeId.',
+    );
+
+    const malformedLens = clone(assessmentResult);
+    malformedLens.context.lens = { kind: 'role', roleId: 'expedition-lead', questionId: 'q1' } as never;
+    expect(() => evaluatePlanFit(malformedLens, 'baseline_local_strategy')).toThrow(
+      'Plan Fit role lens must not contain questionId.',
+    );
+
+    const malformedCarrierMode = clone(assessmentResult);
+    malformedCarrierMode.context.carrierMode = 'fleet_train' as CarrierMode;
+    expect(() => evaluatePlanFit(malformedCarrierMode, 'baseline_local_strategy')).toThrow(
+      'Unsupported Plan Fit carrier mode: fleet_train',
+    );
+
+    const malformedScenarioOrder = clone(assessmentResult);
+    malformedScenarioOrder.scenarioResults.reverse();
+    expect(() => evaluatePlanFit(malformedScenarioOrder, 'baseline_local_strategy')).toThrow(
+      'Plan Fit scenario order must match no_carrier, carrier_available.',
+    );
+
+    const duplicateScenario = clone(assessmentResult);
+    duplicateScenario.scenarioResults[1].carrierMode = 'no_carrier';
+    expect(() => evaluatePlanFit(duplicateScenario, 'baseline_local_strategy')).toThrow(
+      'Duplicate scenario carrier mode no_carrier in Plan Fit input.',
+    );
+
+    const missingRequirement = clone(assessmentResult);
+    missingRequirement.scenarioResults[0].requirementResults = missingRequirement.scenarioResults[0].requirementResults.filter(
+      (item) => item.requirementId !== 'capacity_floor',
+    );
+    expect(() => evaluatePlanFit(missingRequirement, 'baseline_local_strategy')).toThrow(
+      'Scenario no_carrier must contain every accepted template requirement exactly once.',
+    );
+
+    const duplicateRequirement = clone(assessmentResult);
+    duplicateRequirement.scenarioResults[0].requirementResults.push(clone(duplicateRequirement.scenarioResults[0].requirementResults[0]));
+    expect(() => evaluatePlanFit(duplicateRequirement, 'baseline_local_strategy')).toThrow(
+      /Duplicate requirement result id .* in scenario no_carrier\./,
+    );
+
+    const unknownRequirement = clone(assessmentResult);
+    unknownRequirement.scenarioResults[0].requirementResults[0].requirementId = 'unknown_requirement';
+    expect(() => evaluatePlanFit(unknownRequirement, 'baseline_local_strategy')).toThrow(
+      'Unknown requirement result id unknown_requirement in scenario no_carrier.',
+    );
+
+    const nonBooleanCarrierFlag = clone(assessmentResult);
+    nonBooleanCarrierFlag.scenarioResults[0].requirementResults[0].carrierLogisticsAffected = 'true' as never;
+    expect(() => evaluatePlanFit(nonBooleanCarrierFlag, 'baseline_local_strategy')).toThrow(
+      /Requirement .* in scenario no_carrier requires boolean carrierLogisticsAffected\./,
+    );
+  });
+
+  it('rejects non-not_assessable scenarios containing unknown or contradictory requirement outcomes', () => {
+    const supportedWithUnknown = clone(buildAcceptedAssessmentResult('compact_sufficient_case'));
+    supportedWithUnknown.scenarioResults[0].requirementResults[0].outcome = 'unknown';
+    expect(() => evaluatePlanFit(supportedWithUnknown, 'baseline_local_strategy')).toThrow(
+      'Scenario no_carrier is structurally inconsistent: non-not_assessable state cannot contain unknown or contradictory requirement outcomes.',
+    );
+
+    const supportedWithContradiction = clone(buildAcceptedAssessmentResult('compact_sufficient_case'));
+    supportedWithContradiction.scenarioResults[0].requirementResults[0].outcome = 'contradictory';
+    expect(() => evaluatePlanFit(supportedWithContradiction, 'baseline_local_strategy')).toThrow(
+      'Scenario no_carrier is structurally inconsistent: non-not_assessable state cannot contain unknown or contradictory requirement outcomes.',
+    );
+  });
+
+  it('returns supported compact baseline as provisional_plan_fit with no dependency reasons', () => {
+    const result = evaluatePlanFit(buildAcceptedAssessmentResult('compact_sufficient_case'), 'baseline_local_strategy');
+    expect(result.context).toEqual({
+      programmeId: 'r1_assessment_programme',
+      templateId: 'core_assessment_template',
+      templateRevision: 'r1-contract-v1',
+      lens: { kind: 'role', roleId: 'expedition-lead' },
+      originalCarrierMode: 'no_carrier',
+      selectedStrategyId: 'baseline_local_strategy',
+      selectedStrategyRevision: 'v1',
+    });
+    expect(result.scenarioResults).toHaveLength(1);
+    expect(result.scenarioResults[0]).toMatchObject({
+      carrierMode: 'no_carrier',
+      assessmentState: 'supported',
+      planFitState: 'provisional_plan_fit',
+      selectedStrategyId: 'baseline_local_strategy',
+      selectedStrategyRevision: 'v1',
+      selectedStrategyProvenance: {
+        sourceKind: 'fixture',
+        fixtureId: 'baseline_local_strategy',
+        fixtureRevision: 'v1',
+      },
+    });
+    expect(result.scenarioResults[0].reasons).toEqual([]);
+  });
+
+  it('returns not_assessable as no_plan_fit with exactly gate:not_assessable and no dependency reasons', () => {
+    const result = evaluatePlanFit(buildAcceptedAssessmentResult('incomplete_evidence_case'), 'baseline_local_strategy');
+    expect(result.scenarioResults[0].assessmentState).toBe('not_assessable');
+    expect(result.scenarioResults[0].planFitState).toBe('no_plan_fit');
+    expect(result.scenarioResults[0].reasons).toEqual([
+      {
+        id: 'gate:not_assessable',
+        kind: 'assessment_state_gate',
+        summary: 'Assessment state is not assessable.',
+        blocking: true,
+        relatedRequirementIds: [],
+        relatedEvidenceIds: [],
+      },
+    ]);
+  });
+
+  it('returns not_supported as blocked_plan_fit with gate first and all applicable selected dependency reasons after it', () => {
+    const result = evaluatePlanFit(buildAcceptedAssessmentResult('fake_flexibility_case'), 'baseline_local_strategy');
+    expect(result.scenarioResults[0].assessmentState).toBe('not_supported');
+    expect(result.scenarioResults[0].planFitState).toBe('blocked_plan_fit');
+    expect(result.scenarioResults[0].reasons).toEqual([
+      {
+        id: 'gate:not_supported',
+        kind: 'assessment_state_gate',
+        summary: 'Assessment state is not supported.',
+        blocking: true,
+        relatedRequirementIds: [],
+        relatedEvidenceIds: [],
+      },
+      {
+        id: 'dependency:capacity_floor',
+        kind: 'strategy_dependency',
+        summary: 'Selected strategy dependency capacity_floor is unmet.',
+        blocking: true,
+        relatedRequirementIds: ['capacity_floor'],
+        relatedEvidenceIds: ['flex-capacity'],
+      },
+    ]);
+  });
+
+  it('maps conditional logistics and non-logistics dependencies and unmet dependencies through the exact reason rules', () => {
+    const logisticsResult = evaluatePlanFit(
+      buildAcceptedAssessmentResult('remote_materials_carrier_case', 'no_carrier'),
+      'remote_logistics_strategy',
+    );
+    expect(logisticsResult.scenarioResults[0].reasons).toEqual([
+      {
+        id: 'dependency:remote_logistics',
+        kind: 'logistics_dependency',
+        summary: 'Selected strategy dependency remote_logistics remains conditionally satisfied.',
+        blocking: false,
+        relatedRequirementIds: ['remote_logistics'],
+        relatedEvidenceIds: ['remote-logistics-evidence'],
+      },
+    ]);
+
+    const nonLogisticsAssessment = clone(buildAcceptedAssessmentResult('compact_sufficient_case'));
+    nonLogisticsAssessment.scenarioResults[0].state = 'conditionally_supported';
+    nonLogisticsAssessment.scenarioResults[0].requirementResults.find((item) => item.requirementId === 'capacity_floor')!.outcome = 'conditional';
+    const nonLogisticsResult = evaluatePlanFit(nonLogisticsAssessment, 'baseline_local_strategy');
+    expect(nonLogisticsResult.scenarioResults[0].reasons).toEqual([
+      {
+        id: 'dependency:capacity_floor',
+        kind: 'strategy_dependency',
+        summary: 'Selected strategy dependency capacity_floor remains unresolved.',
+        blocking: false,
+        relatedRequirementIds: ['capacity_floor'],
+        relatedEvidenceIds: ['compact-capacity'],
+      },
+    ]);
+
+    const unmetResult = evaluatePlanFit(buildAcceptedAssessmentResult('fake_flexibility_case'), 'baseline_local_strategy');
+    expect(unmetResult.scenarioResults[0].reasons[1]).toEqual({
+      id: 'dependency:capacity_floor',
+      kind: 'strategy_dependency',
+      summary: 'Selected strategy dependency capacity_floor is unmet.',
+      blocking: true,
+      relatedRequirementIds: ['capacity_floor'],
+      relatedEvidenceIds: ['flex-capacity'],
+    });
+  });
+
+  it('preserves the exact remote compare_both order, scenario states, Plan Fit states, and permitted reason difference', () => {
+    const result = evaluatePlanFit(
+      buildAcceptedAssessmentResult('remote_materials_carrier_case', 'compare_both'),
+      'remote_logistics_strategy',
+    );
+
+    expect(result.scenarioResults.map((item) => item.carrierMode)).toEqual(['no_carrier', 'carrier_available']);
+    expect(result.scenarioResults.map((item) => item.assessmentState)).toEqual(['conditionally_supported', 'supported']);
+    expect(result.scenarioResults.map((item) => item.planFitState)).toEqual(['provisional_plan_fit', 'provisional_plan_fit']);
+    expect(scenario(result, 'no_carrier').reasons.map((reason) => reason.id)).toEqual(['dependency:remote_logistics']);
+    expect(scenario(result, 'carrier_available').reasons).toEqual([]);
+  });
+
+  it('returns both contradictory compare_both scenarios as no_plan_fit and carrier cannot repair contradiction', () => {
+    const result = evaluatePlanFit(
+      buildAcceptedAssessmentResult('contradictory_allocation_case', 'compare_both'),
+      'baseline_local_strategy',
+    );
+    expect(result.scenarioResults).toHaveLength(2);
+    expect(result.scenarioResults.map((item) => item.planFitState)).toEqual(['no_plan_fit', 'no_plan_fit']);
+    expect(result.scenarioResults.every((item) => item.reasons.length === 1 && item.reasons[0].id === 'gate:not_assessable')).toBe(true);
+  });
+
+  it('preserves not_supported across compare_both and carrier cannot turn it provisional', () => {
+    const result = evaluatePlanFit(
+      buildAcceptedAssessmentResult('fake_flexibility_case', 'compare_both'),
+      'baseline_local_strategy',
+    );
+    expect(result.scenarioResults.map((item) => item.assessmentState)).toEqual(['not_supported', 'not_supported']);
+    expect(result.scenarioResults.map((item) => item.planFitState)).toEqual(['blocked_plan_fit', 'blocked_plan_fit']);
+  });
+
+  it('rejects compare_both when a selected dependency changes outcome without logistics-sensitive declaration', () => {
+    const capacityVariance = clone(buildAcceptedAssessmentResult('compact_sufficient_case', 'compare_both'));
+    capacityVariance.scenarioResults[1].state = 'conditionally_supported';
+    capacityVariance.scenarioResults[1].requirementResults.find((item) => item.requirementId === 'capacity_floor')!.outcome = 'conditional';
+    expect(() => evaluatePlanFit(capacityVariance, 'baseline_local_strategy')).toThrow(
+      'Selected strategy dependency capacity_floor varies across compare_both without logistics-sensitive declaration.',
+    );
+
+    const sharedConstraintVariance = clone(buildAcceptedAssessmentResult('compact_sufficient_case', 'compare_both'));
+    sharedConstraintVariance.scenarioResults[1].state = 'conditionally_supported';
+    sharedConstraintVariance.scenarioResults[1].requirementResults.find((item) => item.requirementId === 'allocation_consistency')!.outcome = 'conditional';
+    expect(() => evaluatePlanFit(sharedConstraintVariance, 'baseline_local_strategy')).toThrow(
+      'Selected strategy dependency allocation_consistency varies across compare_both without logistics-sensitive declaration.',
+    );
+  });
+
+  it('changes only the copied output context lens when only the assessment lens changes', () => {
+    const roleAssessment = buildAcceptedAssessmentResult('remote_materials_carrier_case', 'compare_both');
+    const questionAssessment = clone(roleAssessment);
+    questionAssessment.context.lens = { kind: 'question', questionId: 'carrier-sensitivity-check' };
+
+    const roleResult = evaluatePlanFit(roleAssessment, 'remote_logistics_strategy');
+    const questionResult = evaluatePlanFit(questionAssessment, 'remote_logistics_strategy');
+
+    expect(roleResult.context.lens).toEqual({ kind: 'role', roleId: 'expedition-lead' });
+    expect(questionResult.context.lens).toEqual({ kind: 'question', questionId: 'carrier-sensitivity-check' });
+    expect(roleResult.scenarioResults).toEqual(questionResult.scenarioResults);
+  });
+
+  it('is deterministic, deeply immutable, and does not mutate inputs, fixed strategy fixtures, or earlier outputs', () => {
+    const assessmentResult = buildAcceptedAssessmentResult('remote_materials_carrier_case', 'compare_both');
+    const beforeInput = JSON.stringify(assessmentResult);
+    const beforeRegistry = JSON.stringify(FIXED_STRATEGY_FIXTURES);
+
+    const first = evaluatePlanFit(assessmentResult, 'remote_logistics_strategy');
+    const firstJson = JSON.stringify(first);
+    const second = evaluatePlanFit(assessmentResult, 'remote_logistics_strategy');
+    const secondJson = JSON.stringify(second);
+
+    expect(first).toEqual(second);
+    expect(firstJson).toBe(secondJson);
+    expect(JSON.stringify(assessmentResult)).toBe(beforeInput);
+    expect(JSON.stringify(FIXED_STRATEGY_FIXTURES)).toBe(beforeRegistry);
+    expect(JSON.stringify(first)).toBe(firstJson);
+
+    assertDeepFrozen(first);
+    assertDeepFrozen(second);
+    assertDeepFrozen(FIXED_STRATEGY_FIXTURES);
+  });
+
+  it('contains no forbidden output keys anywhere in the result shape', () => {
+    const result = evaluatePlanFit(buildAcceptedAssessmentResult('remote_materials_carrier_case', 'compare_both'), 'remote_logistics_strategy');
+    expect([...collectForbiddenKeys(result)]).toEqual([]);
+  });
+});

--- a/frontend-v2/src/lab/r1-assessment-lab/core/evaluatePlanFit.ts
+++ b/frontend-v2/src/lab/r1-assessment-lab/core/evaluatePlanFit.ts
@@ -1,0 +1,378 @@
+import { R1_ASSESSMENT_TEMPLATE } from '@/lab/r1-assessment-lab/core/fixtures';
+import type {
+  AssessmentEvaluationResult,
+  AssessmentLens,
+  AssessmentState,
+  CarrierMode,
+  CarrierScenarioMode,
+  RequirementAssessment,
+  RequirementOutcome,
+  ScenarioAssessment,
+} from '@/lab/r1-assessment-lab/core/types';
+import type {
+  FixedStrategyFixture,
+  PlanFitEvaluationResult,
+  PlanFitReason,
+  PlanFitReasonKind,
+  PlanFitScenarioResult,
+} from '@/lab/r1-assessment-lab/core/planFitTypes';
+import { FIXED_STRATEGY_FIXTURES } from '@/lab/r1-assessment-lab/core/strategyFixtures';
+
+const VALID_CARRIER_MODES: CarrierMode[] = ['no_carrier', 'carrier_available', 'compare_both'];
+const VALID_SCENARIO_ORDER: Record<CarrierMode, CarrierScenarioMode[]> = {
+  no_carrier: ['no_carrier'],
+  carrier_available: ['carrier_available'],
+  compare_both: ['no_carrier', 'carrier_available'],
+};
+const VALID_ASSESSMENT_STATES: AssessmentState[] = [
+  'not_assessable',
+  'not_supported',
+  'conditionally_supported',
+  'supported',
+];
+const VALID_REQUIREMENT_OUTCOMES: RequirementOutcome[] = [
+  'met',
+  'unmet',
+  'conditional',
+  'unknown',
+  'contradictory',
+];
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    const nestedValues = Array.isArray(value) ? value : Object.values(value);
+    for (const nested of nestedValues) {
+      deepFreeze(nested);
+    }
+  }
+  return value;
+}
+
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(message);
+  }
+}
+
+function assertValidLens(lens: AssessmentLens): asserts lens is AssessmentLens {
+  if (!lens || typeof lens !== 'object' || !('kind' in lens)) {
+    throw new Error('Plan Fit evaluation requires a valid assessment lens.');
+  }
+  if (lens.kind === 'role') {
+    if ('questionId' in lens) {
+      throw new Error('Plan Fit role lens must not contain questionId.');
+    }
+    if (typeof lens.roleId !== 'string' || lens.roleId.trim() === '') {
+      throw new Error('Plan Fit role lens requires a non-empty roleId.');
+    }
+    return;
+  }
+  if (lens.kind === 'question') {
+    if ('roleId' in lens) {
+      throw new Error('Plan Fit question lens must not contain roleId.');
+    }
+    if (typeof lens.questionId !== 'string' || lens.questionId.trim() === '') {
+      throw new Error('Plan Fit question lens requires a non-empty questionId.');
+    }
+    return;
+  }
+  throw new Error('Plan Fit lens must be a role lens or a question lens.');
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function cloneLens(lens: AssessmentLens): AssessmentLens {
+  return lens.kind === 'role'
+    ? { kind: 'role', roleId: lens.roleId }
+    : { kind: 'question', questionId: lens.questionId };
+}
+
+function buildReason(
+  id: string,
+  kind: PlanFitReasonKind,
+  summary: string,
+  blocking: boolean,
+  relatedRequirementIds: string[],
+  relatedEvidenceIds: string[],
+): PlanFitReason {
+  return {
+    id,
+    kind,
+    summary,
+    blocking,
+    relatedRequirementIds: uniqueSorted(relatedRequirementIds),
+    relatedEvidenceIds: uniqueSorted(relatedEvidenceIds),
+  };
+}
+
+function dependencyReasonFor(
+  strategy: FixedStrategyFixture,
+  requirement: RequirementAssessment,
+): PlanFitReason | null {
+  const evidenceIds = uniqueSorted([
+    ...requirement.matchedEvidenceIds,
+    ...requirement.missingEvidenceIds,
+    ...requirement.contradictoryEvidenceIds,
+  ]);
+  const reasonId = `dependency:${requirement.requirementId}`;
+
+  if (requirement.outcome === 'met') {
+    return null;
+  }
+
+  if (requirement.outcome === 'conditional') {
+    const isLogisticsSensitive = strategy.logisticsSensitiveRequirementIds.includes(requirement.requirementId);
+    return buildReason(
+      reasonId,
+      isLogisticsSensitive ? 'logistics_dependency' : 'strategy_dependency',
+      isLogisticsSensitive
+        ? `Selected strategy dependency ${requirement.requirementId} remains conditionally satisfied.`
+        : `Selected strategy dependency ${requirement.requirementId} remains unresolved.`,
+      false,
+      [requirement.requirementId],
+      evidenceIds,
+    );
+  }
+
+  if (requirement.outcome === 'unmet') {
+    return buildReason(
+      reasonId,
+      'strategy_dependency',
+      `Selected strategy dependency ${requirement.requirementId} is unmet.`,
+      true,
+      [requirement.requirementId],
+      evidenceIds,
+    );
+  }
+
+  throw new Error(
+    `Plan Fit received unsupported requirement outcome ${requirement.outcome} for ${requirement.requirementId}.`,
+  );
+}
+
+function validateScenarioRequirementResults(scenario: ScenarioAssessment) {
+  const expectedRequirementIds = R1_ASSESSMENT_TEMPLATE.requirements.map((requirement) => requirement.id).sort();
+  const seenRequirementIds = new Set<string>();
+
+  for (const requirement of scenario.requirementResults) {
+    if (seenRequirementIds.has(requirement.requirementId)) {
+      throw new Error(`Duplicate requirement result id ${requirement.requirementId} in scenario ${scenario.carrierMode}.`);
+    }
+    seenRequirementIds.add(requirement.requirementId);
+
+    if (!expectedRequirementIds.includes(requirement.requirementId)) {
+      throw new Error(`Unknown requirement result id ${requirement.requirementId} in scenario ${scenario.carrierMode}.`);
+    }
+    if (!VALID_REQUIREMENT_OUTCOMES.includes(requirement.outcome)) {
+      throw new Error(`Invalid requirement outcome ${String(requirement.outcome)} in scenario ${scenario.carrierMode}.`);
+    }
+    if (typeof requirement.carrierLogisticsAffected !== 'boolean') {
+      throw new Error(`Requirement ${requirement.requirementId} in scenario ${scenario.carrierMode} requires boolean carrierLogisticsAffected.`);
+    }
+  }
+
+  if (scenario.requirementResults.length !== expectedRequirementIds.length) {
+    throw new Error(`Scenario ${scenario.carrierMode} must contain every accepted template requirement exactly once.`);
+  }
+
+  const scenarioRequirementIds = [...seenRequirementIds].sort();
+  if (JSON.stringify(scenarioRequirementIds) !== JSON.stringify(expectedRequirementIds)) {
+    throw new Error(`Scenario ${scenario.carrierMode} must contain every accepted template requirement exactly once.`);
+  }
+
+  const hasUnknownOrContradictoryOutcome = scenario.requirementResults.some((requirement) =>
+    requirement.outcome === 'unknown' || requirement.outcome === 'contradictory',
+  );
+  if (scenario.state !== 'not_assessable' && hasUnknownOrContradictoryOutcome) {
+    throw new Error(
+      `Scenario ${scenario.carrierMode} is structurally inconsistent: non-not_assessable state cannot contain unknown or contradictory requirement outcomes.`,
+    );
+  }
+}
+
+function validateAssessmentResult(assessmentResult: AssessmentEvaluationResult) {
+  if (!assessmentResult || typeof assessmentResult !== 'object' || !('context' in assessmentResult) || !('scenarioResults' in assessmentResult)) {
+    throw new Error('Plan Fit evaluation requires an AssessmentEvaluationResult input.');
+  }
+
+  const { context, scenarioResults } = assessmentResult;
+  assertNonEmptyString(context.programmeId, 'Plan Fit evaluation requires a non-empty programmeId.');
+  assertNonEmptyString(context.templateId, 'Plan Fit evaluation requires a non-empty templateId.');
+  assertNonEmptyString(context.templateRevision, 'Plan Fit evaluation requires a non-empty templateRevision.');
+
+  if (
+    context.programmeId !== R1_ASSESSMENT_TEMPLATE.programmeId
+    || context.templateId !== R1_ASSESSMENT_TEMPLATE.templateId
+    || context.templateRevision !== R1_ASSESSMENT_TEMPLATE.revision
+  ) {
+    throw new Error('Plan Fit evaluation requires the accepted fixed template context tuple.');
+  }
+
+  assertValidLens(context.lens);
+
+  if (!VALID_CARRIER_MODES.includes(context.carrierMode)) {
+    throw new Error(`Unsupported Plan Fit carrier mode: ${String(context.carrierMode)}`);
+  }
+
+  const expectedScenarioOrder = VALID_SCENARIO_ORDER[context.carrierMode];
+  if (!Array.isArray(scenarioResults) || scenarioResults.length !== expectedScenarioOrder.length) {
+    throw new Error(`Plan Fit evaluation requires scenario count matching carrier mode ${context.carrierMode}.`);
+  }
+
+  const seenScenarioModes = new Set<string>();
+  scenarioResults.forEach((scenario, index) => {
+    if (seenScenarioModes.has(scenario.carrierMode)) {
+      throw new Error(`Duplicate scenario carrier mode ${scenario.carrierMode} in Plan Fit input.`);
+    }
+    seenScenarioModes.add(scenario.carrierMode);
+    if (scenario.carrierMode !== expectedScenarioOrder[index]) {
+      throw new Error(`Plan Fit scenario order must match ${expectedScenarioOrder.join(', ')}.`);
+    }
+    if (!VALID_ASSESSMENT_STATES.includes(scenario.state)) {
+      throw new Error(`Invalid assessment state ${String(scenario.state)} in scenario ${scenario.carrierMode}.`);
+    }
+    validateScenarioRequirementResults(scenario);
+  });
+}
+
+function resolveStrategy(selectedStrategyId: string): FixedStrategyFixture {
+  assertNonEmptyString(selectedStrategyId, 'Plan Fit evaluation requires a non-empty selectedStrategyId.');
+  const matches = FIXED_STRATEGY_FIXTURES.filter((strategy) => strategy.strategyId === selectedStrategyId);
+  if (matches.length !== 1) {
+    throw new Error(`Unknown selected strategy id: ${selectedStrategyId}`);
+  }
+  return matches[0];
+}
+
+function assertStrategyCompatibility(strategy: FixedStrategyFixture, assessmentResult: AssessmentEvaluationResult) {
+  if (
+    strategy.compatibility.programmeId !== assessmentResult.context.programmeId
+    || strategy.compatibility.templateId !== assessmentResult.context.templateId
+    || strategy.compatibility.templateRevision !== assessmentResult.context.templateRevision
+  ) {
+    throw new Error(`Selected strategy ${strategy.strategyId} is incompatible with the assessment context tuple.`);
+  }
+}
+
+function validateSelectedDependencyVariance(
+  strategy: FixedStrategyFixture,
+  scenarioResults: ScenarioAssessment[],
+) {
+  if (scenarioResults.length !== 2) return;
+
+  const [noCarrier, carrierAvailable] = scenarioResults;
+  const noCarrierMap = new Map(noCarrier.requirementResults.map((requirement) => [requirement.requirementId, requirement]));
+  const carrierAvailableMap = new Map(carrierAvailable.requirementResults.map((requirement) => [requirement.requirementId, requirement]));
+
+  for (const requirementId of strategy.requiredAssessmentRequirementIds) {
+    const noCarrierRequirement = noCarrierMap.get(requirementId);
+    const carrierAvailableRequirement = carrierAvailableMap.get(requirementId);
+    if (!noCarrierRequirement || !carrierAvailableRequirement) {
+      throw new Error(`Selected strategy dependency ${requirementId} is missing from compare_both scenarios.`);
+    }
+    if (
+      noCarrierRequirement.outcome !== carrierAvailableRequirement.outcome
+      && !strategy.logisticsSensitiveRequirementIds.includes(requirementId)
+    ) {
+      throw new Error(
+        `Selected strategy dependency ${requirementId} varies across compare_both without logistics-sensitive declaration.`,
+      );
+    }
+  }
+}
+
+function evaluateScenario(strategy: FixedStrategyFixture, scenario: ScenarioAssessment): PlanFitScenarioResult {
+  if (scenario.state === 'not_assessable') {
+    return {
+      carrierMode: scenario.carrierMode,
+      assessmentState: scenario.state,
+      planFitState: 'no_plan_fit',
+      reasons: [
+        buildReason(
+          'gate:not_assessable',
+          'assessment_state_gate',
+          'Assessment state is not assessable.',
+          true,
+          [],
+          [],
+        ),
+      ],
+      selectedStrategyId: strategy.strategyId,
+      selectedStrategyRevision: strategy.strategyRevision,
+      selectedStrategyProvenance: { ...strategy.provenance },
+    };
+  }
+
+  const requirementMap = new Map(scenario.requirementResults.map((requirement) => [requirement.requirementId, requirement]));
+  const dependencyReasons = strategy.requiredAssessmentRequirementIds
+    .map((requirementId) => {
+      const requirement = requirementMap.get(requirementId);
+      if (!requirement) {
+        throw new Error(`Selected strategy dependency ${requirementId} is missing from scenario ${scenario.carrierMode}.`);
+      }
+      return dependencyReasonFor(strategy, requirement);
+    })
+    .filter((value): value is PlanFitReason => value !== null)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  if (scenario.state === 'not_supported') {
+    return {
+      carrierMode: scenario.carrierMode,
+      assessmentState: scenario.state,
+      planFitState: 'blocked_plan_fit',
+      reasons: [
+        buildReason(
+          'gate:not_supported',
+          'assessment_state_gate',
+          'Assessment state is not supported.',
+          true,
+          [],
+          [],
+        ),
+        ...dependencyReasons,
+      ],
+      selectedStrategyId: strategy.strategyId,
+      selectedStrategyRevision: strategy.strategyRevision,
+      selectedStrategyProvenance: { ...strategy.provenance },
+    };
+  }
+
+  const hasBlockingDependency = dependencyReasons.some((reason) => reason.blocking);
+  return {
+    carrierMode: scenario.carrierMode,
+    assessmentState: scenario.state,
+    planFitState: hasBlockingDependency ? 'blocked_plan_fit' : 'provisional_plan_fit',
+    reasons: dependencyReasons,
+    selectedStrategyId: strategy.strategyId,
+    selectedStrategyRevision: strategy.strategyRevision,
+    selectedStrategyProvenance: { ...strategy.provenance },
+  };
+}
+
+export function evaluatePlanFit(
+  assessmentResult: AssessmentEvaluationResult,
+  selectedStrategyId: string,
+): PlanFitEvaluationResult {
+  validateAssessmentResult(assessmentResult);
+  const strategy = resolveStrategy(selectedStrategyId);
+  assertStrategyCompatibility(strategy, assessmentResult);
+  validateSelectedDependencyVariance(strategy, assessmentResult.scenarioResults);
+
+  const result: PlanFitEvaluationResult = {
+    context: {
+      programmeId: assessmentResult.context.programmeId,
+      templateId: assessmentResult.context.templateId,
+      templateRevision: assessmentResult.context.templateRevision,
+      lens: cloneLens(assessmentResult.context.lens),
+      originalCarrierMode: assessmentResult.context.carrierMode,
+      selectedStrategyId: strategy.strategyId,
+      selectedStrategyRevision: strategy.strategyRevision,
+    },
+    scenarioResults: assessmentResult.scenarioResults.map((scenario) => evaluateScenario(strategy, scenario)),
+  };
+
+  return deepFreeze(result);
+}

--- a/frontend-v2/src/lab/r1-assessment-lab/core/planFitTypes.ts
+++ b/frontend-v2/src/lab/r1-assessment-lab/core/planFitTypes.ts
@@ -1,0 +1,74 @@
+import type {
+  AssessmentEvaluationResult,
+  AssessmentLens,
+  AssessmentState,
+  CarrierMode,
+  CarrierScenarioMode,
+} from '@/lab/r1-assessment-lab/core/types';
+
+export type PlanFitState =
+  | 'no_plan_fit'
+  | 'blocked_plan_fit'
+  | 'provisional_plan_fit';
+
+export type PlanFitReasonKind =
+  | 'assessment_state_gate'
+  | 'strategy_dependency'
+  | 'logistics_dependency';
+
+export interface StrategyCompatibilityTuple {
+  programmeId: string;
+  templateId: string;
+  templateRevision: string;
+}
+
+export interface StrategyFixtureProvenance {
+  sourceKind: 'fixture';
+  fixtureId: string;
+  fixtureRevision: string;
+}
+
+export interface FixedStrategyFixture {
+  fixtureKey: string;
+  strategyId: string;
+  strategyRevision: string;
+  label: string;
+  compatibility: StrategyCompatibilityTuple;
+  provenance: StrategyFixtureProvenance;
+  requiredAssessmentRequirementIds: string[];
+  logisticsSensitiveRequirementIds: string[];
+}
+
+export interface PlanFitReason {
+  id: string;
+  kind: PlanFitReasonKind;
+  summary: string;
+  blocking: boolean;
+  relatedRequirementIds: string[];
+  relatedEvidenceIds: string[];
+}
+
+export interface PlanFitScenarioResult {
+  carrierMode: CarrierScenarioMode;
+  assessmentState: AssessmentState;
+  planFitState: PlanFitState;
+  reasons: PlanFitReason[];
+  selectedStrategyId: string;
+  selectedStrategyRevision: string;
+  selectedStrategyProvenance: StrategyFixtureProvenance;
+}
+
+export interface PlanFitEvaluationResult {
+  context: {
+    programmeId: string;
+    templateId: string;
+    templateRevision: string;
+    lens: AssessmentLens;
+    originalCarrierMode: CarrierMode;
+    selectedStrategyId: string;
+    selectedStrategyRevision: string;
+  };
+  scenarioResults: PlanFitScenarioResult[];
+}
+
+export type AcceptedAssessmentResult = AssessmentEvaluationResult;

--- a/frontend-v2/src/lab/r1-assessment-lab/core/strategyFixtures.ts
+++ b/frontend-v2/src/lab/r1-assessment-lab/core/strategyFixtures.ts
@@ -1,0 +1,173 @@
+import { R1_ASSESSMENT_TEMPLATE } from '@/lab/r1-assessment-lab/core/fixtures';
+import type { FixedStrategyFixture } from '@/lab/r1-assessment-lab/core/planFitTypes';
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    const nestedValues = Array.isArray(value) ? value : Object.values(value);
+    for (const nested of nestedValues) {
+      deepFreeze(nested);
+    }
+  }
+  return value;
+}
+
+const STRATEGY_FIXTURE_LIST: FixedStrategyFixture[] = [
+  {
+    fixtureKey: 'baseline_local_strategy',
+    strategyId: 'baseline_local_strategy',
+    strategyRevision: 'v1',
+    label: 'Baseline local strategy',
+    compatibility: {
+      programmeId: 'r1_assessment_programme',
+      templateId: 'core_assessment_template',
+      templateRevision: 'r1-contract-v1',
+    },
+    provenance: {
+      sourceKind: 'fixture',
+      fixtureId: 'baseline_local_strategy',
+      fixtureRevision: 'v1',
+    },
+    requiredAssessmentRequirementIds: [
+      'foundation_evidence',
+      'allocation_consistency',
+      'capacity_floor',
+    ],
+    logisticsSensitiveRequirementIds: [],
+  },
+  {
+    fixtureKey: 'remote_logistics_strategy',
+    strategyId: 'remote_logistics_strategy',
+    strategyRevision: 'v1',
+    label: 'Remote logistics strategy',
+    compatibility: {
+      programmeId: 'r1_assessment_programme',
+      templateId: 'core_assessment_template',
+      templateRevision: 'r1-contract-v1',
+    },
+    provenance: {
+      sourceKind: 'fixture',
+      fixtureId: 'remote_logistics_strategy',
+      fixtureRevision: 'v1',
+    },
+    requiredAssessmentRequirementIds: [
+      'foundation_evidence',
+      'allocation_consistency',
+      'capacity_floor',
+      'remote_logistics',
+    ],
+    logisticsSensitiveRequirementIds: [
+      'remote_logistics',
+    ],
+  },
+];
+
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(message);
+  }
+}
+
+function assertUniqueStrings(values: string[], message: string) {
+  if (new Set(values).size !== values.length) {
+    throw new Error(message);
+  }
+}
+
+export function validateStrategyFixtures(fixtures: FixedStrategyFixture[]): FixedStrategyFixture[] {
+  const seenFixtureKeys = new Set<string>();
+  const seenStrategyIds = new Set<string>();
+  const templateRequirementMap = new Map(R1_ASSESSMENT_TEMPLATE.requirements.map((requirement) => [requirement.id, requirement]));
+
+  for (const fixture of fixtures) {
+    assertNonEmptyString(fixture.fixtureKey, 'Strategy fixture key must be non-empty.');
+    assertNonEmptyString(fixture.strategyId, 'Strategy id must be non-empty.');
+    assertNonEmptyString(fixture.strategyRevision, `Strategy ${fixture.strategyId || fixture.fixtureKey} requires a non-empty revision.`);
+    assertNonEmptyString(fixture.label, `Strategy ${fixture.strategyId || fixture.fixtureKey} requires a non-empty label.`);
+    assertNonEmptyString(fixture.compatibility.programmeId, `Strategy ${fixture.strategyId} requires a non-empty compatibility programmeId.`);
+    assertNonEmptyString(fixture.compatibility.templateId, `Strategy ${fixture.strategyId} requires a non-empty compatibility templateId.`);
+    assertNonEmptyString(fixture.compatibility.templateRevision, `Strategy ${fixture.strategyId} requires a non-empty compatibility templateRevision.`);
+    assertNonEmptyString(fixture.provenance.sourceKind, `Strategy ${fixture.strategyId} requires a non-empty provenance sourceKind.`);
+    if (fixture.provenance.sourceKind !== 'fixture') {
+      throw new Error(`Strategy ${fixture.strategyId} provenance sourceKind must be fixture.`);
+    }
+    assertNonEmptyString(fixture.provenance.fixtureId, `Strategy ${fixture.strategyId} requires a non-empty provenance fixtureId.`);
+    assertNonEmptyString(fixture.provenance.fixtureRevision, `Strategy ${fixture.strategyId} requires a non-empty provenance fixtureRevision.`);
+
+    if (seenFixtureKeys.has(fixture.fixtureKey)) {
+      throw new Error(`Duplicate strategy fixture key: ${fixture.fixtureKey}`);
+    }
+    seenFixtureKeys.add(fixture.fixtureKey);
+
+    if (seenStrategyIds.has(fixture.strategyId)) {
+      throw new Error(`Duplicate strategy id: ${fixture.strategyId}`);
+    }
+    seenStrategyIds.add(fixture.strategyId);
+
+    if (
+      fixture.compatibility.programmeId !== R1_ASSESSMENT_TEMPLATE.programmeId
+      || fixture.compatibility.templateId !== R1_ASSESSMENT_TEMPLATE.templateId
+      || fixture.compatibility.templateRevision !== R1_ASSESSMENT_TEMPLATE.revision
+    ) {
+      throw new Error(`Strategy ${fixture.strategyId} compatibility tuple does not match the accepted template.`);
+    }
+
+    if (fixture.requiredAssessmentRequirementIds.length === 0) {
+      throw new Error(`Strategy ${fixture.strategyId} must declare at least one required assessment requirement id.`);
+    }
+
+    assertUniqueStrings(
+      fixture.requiredAssessmentRequirementIds,
+      `Strategy ${fixture.strategyId} has duplicate required assessment requirement ids.`,
+    );
+    assertUniqueStrings(
+      fixture.logisticsSensitiveRequirementIds,
+      `Strategy ${fixture.strategyId} has duplicate logistics-sensitive requirement ids.`,
+    );
+
+    for (const requirementId of fixture.requiredAssessmentRequirementIds) {
+      assertNonEmptyString(
+        requirementId,
+        `Strategy ${fixture.strategyId} has an empty required assessment requirement id.`,
+      );
+      if (!templateRequirementMap.has(requirementId)) {
+        throw new Error(`Strategy ${fixture.strategyId} references unknown required assessment requirement id: ${requirementId}`);
+      }
+    }
+
+    for (const requirementId of fixture.logisticsSensitiveRequirementIds) {
+      assertNonEmptyString(
+        requirementId,
+        `Strategy ${fixture.strategyId} has an empty logistics-sensitive requirement id.`,
+      );
+      if (!fixture.requiredAssessmentRequirementIds.includes(requirementId)) {
+        throw new Error(
+          `Strategy ${fixture.strategyId} declares logistics-sensitive requirement ${requirementId} outside required assessment requirement ids.`,
+        );
+      }
+      const templateRequirement = templateRequirementMap.get(requirementId);
+      if (!templateRequirement) {
+        throw new Error(`Strategy ${fixture.strategyId} references unknown logistics-sensitive requirement id: ${requirementId}`);
+      }
+      if (
+        templateRequirement.kind !== 'logistics'
+        || !templateRequirement.carrierSensitive
+        || templateRequirement.sharedConstraint
+      ) {
+        throw new Error(
+          `Strategy ${fixture.strategyId} declares invalid logistics-sensitive requirement ${requirementId}.`,
+        );
+      }
+    }
+  }
+
+  return fixtures.map((fixture) => deepFreeze({
+    ...fixture,
+    compatibility: { ...fixture.compatibility },
+    provenance: { ...fixture.provenance },
+    requiredAssessmentRequirementIds: [...fixture.requiredAssessmentRequirementIds],
+    logisticsSensitiveRequirementIds: [...fixture.logisticsSensitiveRequirementIds],
+  }));
+}
+
+export const FIXED_STRATEGY_FIXTURES = deepFreeze(validateStrategyFixtures(STRATEGY_FIXTURE_LIST));


### PR DESCRIPTION
implements only the owner-authorised Stage 4B pure-core contract;
adds fixed strategy fixtures, types, evaluator, and focused tests;
preserves accepted Stage 2B assessment states and carrier scenario outcomes;
contains no UI, routing, persistence, network, API, production, deployment, recommendation, scoring, ranking, or planning change;
lists exact validation results;
requires independent read-only review and owner acceptance before merge.

## Validation results
- `yarn test "src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts"` — passed
- `yarn test "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"` — passed
- `yarn test "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"` — passed
- `yarn test` — passed
- `yarn typecheck` — passed
- `yarn lint` — passed
- `yarn build` — passed with pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning
- Production deployable JS/CSS/HTML artifact scan — no matches for existing Stage 1 and Stage 3 DEV-only identifiers, and no matches for `baseline_local_strategy`, `remote_logistics_strategy`, `no_plan_fit`, `blocked_plan_fit`, or `provisional_plan_fit`
