### PR TITLE
docs: define Stage 4C Plan Fit lab presentation

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,71 +4,75 @@
 
 ## Status
 
-**Stage 4B bounded pure-core implementation complete — awaiting independent review and owner acceptance**
+**Stage 4C DEV-only Plan Fit presentation contract drafted — awaiting independent review and owner approval**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Implementation branch: `feat/r1-plan-fit-core`
-- Implementation base SHA: `5fa49ae2a8f538b2e3111524c27299290a082bf0`
+- Documentation branch: `docs/r1-stage4c-lab-presentation-contract`
+- Documentation base SHA: `0565a60428904c4fe234f500e05be9871adb5c6d`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
-- Owner authorised bounded Stage 4B implementation on `2026-07-02`
+- Stage 4B implementation PR: `#286`, merged
+- Stage 4B merge commit: `0565a60428904c4fe234f500e05be9871adb5c6d`
+- Stage 4B implementation head: `9f69061c3d625dc111864061166287407e6336c0`
+- Stage 4B was reviewed and owner-accepted before merge
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
 - Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
 - Last accepted implementation stage: Stage 2B pure R1 assessment-domain core, merged by PR `#280` at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - No deployment occurred.
 
-## Active implementation record
+## Active contract record
 
-- Contract file: `docs/ai/R1_STAGE4_PLAN_FIT_CONTRACT_V1.md`
-- Stage 4B implementation is limited to the five-file allowlist below.
-- No UI, production behavior, deployment, or Stage 1–3 modification is authorised or included.
-- The implementation remains bounded pure-core work subordinate to accepted Stage 2B assessment results.
+- Contract file: `docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`
+- Stage 4C is documentation-only at this point.
+- No Stage 4C implementation is authorised.
 
-## Proposed later Stage 4B implementation allowlist
+## Proposed later Stage 4C implementation allowlist
 
 - `docs/ai/CURRENT_STAGE.md`
-- `frontend-v2/src/lab/r1-assessment-lab/core/planFitTypes.ts`
-- `frontend-v2/src/lab/r1-assessment-lab/core/strategyFixtures.ts`
-- `frontend-v2/src/lab/r1-assessment-lab/core/evaluatePlanFit.ts`
-- `frontend-v2/src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts`
+- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
+- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx`
 
 ## Scope summary
 
-Stage 4B is defined only as a DEV-only, fixture-backed, deterministic, local, pure-core forward reconstruction for explicit strategy selection and provisional Plan Fit. The contract does not claim recovery of historic strategy or Plan Fit semantics and does not alter accepted Stage 2B assessment semantics.
+Stage 4C is defined only as a DEV-only, fixture-backed, deterministic, local, presentation-only forward reconstruction for rendering already accepted Assessment and Plan Fit output inside the existing R1 Assessment Laboratory. The contract does not claim recovery of historic UI or planning semantics and does not alter accepted Stage 2B or Stage 4B semantics.
 
 ## Exact non-goals
 
-Stage 4B does not add:
+Stage 4C does not add:
 
-- UI expansion
+- production behavior
 - `App.tsx` changes
-- routing or normal navigation
+- normal product navigation
+- routing
 - providers
 - stores
 - APIs
 - network
 - persistence
 - live system data
-- production behavior
 - deployment
 - editable plans
 - reports
 - exports
 - downloads
+- strategy creation
+- free-form strategy input
+- automatic strategy selection
+- strategy inference
 - scoring
 - ranking
-- best result
-- automatic strategy selection
+- “best” results
 - strategy recommendation
 - preference
 - winner selection
+- comparative advice
 - material planning
 - route planning
 - colonisation staging
-- lens-specific strategy semantics
-- any reinterpretation of accepted Stage 2B assessment semantics
+- changed Stage 2B assessment semantics
+- changed Stage 4B Plan Fit semantics
 
 ## Preserved merged invariants
 
@@ -76,27 +80,19 @@ Stage 4B does not add:
 - Five fixture IDs and three carrier modes are selectable; the six approved fixture/scenario state rows are test assertions, not six fixtures.
 - The fixed template is displayed read-only.
 - The selected Role/Question lens is passed to the evaluator and visibly displayed as context only. Changing it does not alter fixture outcomes, conditions, requirement results, frozen evidence/provenance, state, or ordering in this slice.
-- The app synchronously evaluates fixed local data only and has no UI for invalid evaluator input.
-- Results render state, structured conditions, requirement trace, and frozen evidence/provenance. `compare_both` preserves `no_carrier` then `carrier_available` order.
-- State values are rendered neutrally without score, ranking, winner, preference, strategy, Plan Fit, or recommendation behavior.
+- Accepted Stage 4B Plan Fit output remains bounded pure-core logic subordinate to accepted Stage 2B assessment results.
+- Stage 4C may only present returned Assessment and Plan Fit scenario output; it must not derive, rewrite, or recalculate them.
+- `compare_both` preserves `no_carrier` then `carrier_available` order.
 
 ## Caveats
 
 - No deployment occurred.
-- Validation completed locally on the implementation branch:
-  - new focused Stage 4B Plan Fit tests
-  - existing Stage 2B evaluator tests
-  - existing Stage 3B assessment-lab UI tests
-  - full test suite
-  - typecheck
-  - lint
-  - production build
-  - production artifact scan extended for Stage 4 identifiers
-- The production build retained the pre-existing Coalsack asset-resolution warnings and chunk-size warning.
+- Stage 4B is merged and accepted.
+- Stage 4C is documentation-only and introduces no implementation, validation run, or deployment.
 
 ## Next safe action
 
-Obtain an independent read-only review of this implementation PR, followed by owner acceptance before merge.
+Obtain an independent read-only review of the Stage 4C presentation contract. Do not create a Stage 4C implementation branch or edit laboratory UI code until the contract is merged and the owner explicitly authorises implementation.
 
 ## Recovery instruction
 

--- a/docs/ai/DECISIONS.md
+++ b/docs/ai/DECISIONS.md
@@ -105,3 +105,17 @@ Carrier remains limited to validated non-shared logistics dependencies. Lens rem
 
 **Evidence / reference**
 `docs/ai/R1_STAGE4_PLAN_FIT_CONTRACT_V1.md`; owner approval to draft the Stage 4B contract on 2026-07-01.
+
+## 2026-07-02 — Stage 4C permits DEV-only Plan Fit presentation
+
+**Decision**
+Stage 4C may present accepted Stage 4B Plan Fit output inside the existing DEV-only R1 Assessment Laboratory. Selected strategy is always explicit and local. Stage 4C must not infer strategy, alter Assessment or Plan Fit semantics, recommend a strategy, rank scenarios, score outcomes, or create product behavior.
+
+**Reason**
+Stage 4B established the accepted bounded pure-core Plan Fit output. A later Stage 4C slice may present that accepted output within the existing DEV-only lab without widening into production behavior or changing the underlying Stage 2B or Stage 4B semantics.
+
+**Invariant**
+Lens remains context-only. Carrier behavior remains entirely provided by accepted Stage 2B and Stage 4B outputs. The controlling reference is `docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`.
+
+**Evidence / reference**
+`docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`; owner approval to draft the Stage 4C presentation contract on 2026-07-02.

--- a/docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md
+++ b/docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md
@@ -1,0 +1,186 @@
+# R1 Stage 4C — DEV-only Plan Fit Laboratory Presentation Contract v1
+
+This is a forward-reconstruction presentation contract. It does not claim recovered historic UI or planning semantics.
+
+## 1. Status and purpose
+
+Stage 4C is:
+
+- DEV-only
+- fixture-backed
+- local
+- deterministic
+- presentation-only
+- limited to rendering accepted Stage 2B Assessment output alongside accepted Stage 4B Plan Fit output in the existing R1 Assessment Laboratory
+
+Stage 4C is not implementation-authorised merely because the contract exists.
+
+## 2. Explicit Stage 4C non-goals
+
+Stage 4C must not add:
+
+- production behavior
+- normal product navigation
+- routing
+- persistence
+- APIs
+- network
+- live system data
+- editable plans
+- reports
+- exports
+- downloads
+- strategy creation
+- free-form strategy input
+- automatic strategy selection
+- strategy inference
+- scores
+- ranking
+- “best” results
+- recommendation
+- preference
+- winner selection
+- comparative advice
+- material planning
+- route planning
+- colonisation staging
+- changed Stage 2B assessment semantics
+- changed Stage 4B Plan Fit semantics
+
+## 3. Presentation boundary
+
+The Stage 4C lab must:
+
+- call accepted `evaluateAssessment` using the existing closed local Fixture, Lens kind, Lens value, and Carrier mode controls
+- call accepted `evaluatePlanFit` using the resulting accepted assessment result plus one explicit selected strategy ID
+- render returned Plan Fit values without deriving, rewriting, sorting differently, or recalculating them
+- never call a state resolver or calculate carrier effects itself
+- never construct a Plan Fit result manually
+- keep lens context-only
+- retain `compare_both` scenario order exactly: `no_carrier`, then `carrier_available`
+
+## 4. Fifth closed selector
+
+Stage 4C may add exactly one new closed local selector:
+
+- label: `Strategy`
+- id: `r1-strategy-select`
+- default value: `baseline_local_strategy`
+- exact options:
+  - `baseline_local_strategy`
+  - `remote_logistics_strategy`
+
+The existing four selectors and their IDs, option values, defaults, semantics, and order must remain unchanged.
+
+Strategy selection is explicit local context only. It must not be inferred from fixture, assessment state, carrier mode, or lens.
+
+The UI must display plain language that strategy selection is not a recommendation, ranking, “best” result, or automatic choice.
+
+## 5. Required neutral Plan Fit presentation
+
+For every rendered Plan Fit scenario, display:
+
+- carrier mode
+- Assessment state
+- Plan Fit state
+- selected strategy ID
+- selected strategy revision
+- selected strategy fixture provenance
+- deterministic reasons
+
+For each reason, display:
+
+- reason ID
+- reason kind
+- neutral summary
+- blocking boolean
+- related requirement IDs
+- related evidence IDs
+
+The UI may group Assessment and Plan Fit output beneath the same scenario section, but it must visibly distinguish Assessment state from Plan Fit state.
+
+For `compare_both`, it must visibly preserve the two scenario sections in fixed order.
+
+The exact remote fixture case must visibly preserve:
+
+1. `no_carrier`
+   - Assessment state: `conditionally_supported`
+   - Plan Fit state: `provisional_plan_fit`
+   - non-blocking `dependency:remote_logistics`
+
+2. `carrier_available`
+   - Assessment state: `supported`
+   - Plan Fit state: `provisional_plan_fit`
+   - no `dependency:remote_logistics`
+
+The UI must not describe either scenario as preferred, better, recommended, viable, or best.
+
+## 6. Vocabulary restrictions
+
+The Stage 4C presentation must not render or introduce:
+
+- score
+- rank
+- best
+- recommend
+- recommendation
+- preference
+- winner
+- desirability
+- traffic-light language
+- comparative recommendation wording
+
+Strategy and Plan Fit are permitted as neutral domain labels solely within this DEV-only lab presentation.
+
+## 7. Future implementation boundary
+
+A later Stage 4C implementation PR may change only:
+
+- `docs/ai/CURRENT_STAGE.md`
+- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
+- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx`
+
+It must not modify:
+
+- any Stage 2B core file
+- any Stage 4B core file
+- `App.tsx`
+- `main.tsx`
+- routes
+- providers
+- stores
+- APIs
+- stylesheets
+- package or lock files
+- build or test configuration
+- production assets
+- deployment configuration
+
+## 8. Later implementation tests and evidence
+
+Require a later Stage 4C implementation to prove:
+
+- existing four controls remain intact
+- exactly one fifth Strategy selector exists
+- its options and default are exact
+- changing strategy changes only Plan Fit presentation, not Assessment results
+- changing only lens changes only displayed lens context and does not change Assessment or Plan Fit scenario output
+- remote `compare_both` output has exact scenario order and the exact accepted Stage 2B/Stage 4B state-and-reason pairing
+- no strategy is inferred
+- no invalid evaluator inputs are exposed through the UI
+- no forbidden output key or forbidden visible term is introduced
+- existing Stage 2B evaluator tests and Stage 4B tests remain unchanged regression gates
+- existing Stage 3B UI tests are updated only where the addition of the authorised fifth selector requires it
+- typecheck, lint, build, full tests, and production artifact scans pass
+- deployable `JS/CSS/HTML` artifacts contain none of the existing DEV-only R1 identifiers and none of:
+  - `baseline_local_strategy`
+  - `remote_logistics_strategy`
+  - `no_plan_fit`
+  - `blocked_plan_fit`
+  - `provisional_plan_fit`
+
+## 9. No implementation authorisation
+
+Stage 4C code cannot begin until this contract is independently reviewed and the owner separately accepts the reviewed contract and explicitly authorises the bounded Stage 4C implementation.
+
+No deployment is authorised.


### PR DESCRIPTION
- docs-only Stage 4C contract;
- records Stage 4B merge and acceptance;
- defines a DEV-only presentation of already accepted Plan Fit output;
- authorises no implementation;
- introduces no production, planning, recommendation, score, rank, or product behavior;
- requires independent review and explicit owner implementation authorisation;
- no deployment.