### PR TITLE
Stage 4C: DEV-only Plan Fit lab presentation

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,31 +4,32 @@
 
 ## Status
 
-**Stage 4C DEV-only Plan Fit presentation contract drafted — awaiting independent review and owner approval**
+**Stage 4C bounded DEV-only Plan Fit presentation implementation complete — awaiting independent review and owner acceptance**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Documentation branch: `docs/r1-stage4c-lab-presentation-contract`
-- Documentation base SHA: `0565a60428904c4fe234f500e05be9871adb5c6d`
+- Implementation branch: `feat/r1-stage4c-plan-fit-lab`
+- Implementation base SHA: `18464de5a204a109fe145eb4e64a8500b59eaee5`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 4B implementation PR: `#286`, merged
 - Stage 4B merge commit: `0565a60428904c4fe234f500e05be9871adb5c6d`
 - Stage 4B implementation head: `9f69061c3d625dc111864061166287407e6336c0`
 - Stage 4B was reviewed and owner-accepted before merge
+- Owner authorised bounded Stage 4C implementation on `2026-07-02`
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
 - Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
 - Last accepted implementation stage: Stage 2B pure R1 assessment-domain core, merged by PR `#280` at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - No deployment occurred.
 
-## Active contract record
+## Active implementation record
 
 - Contract file: `docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`
-- Stage 4C is documentation-only at this point.
-- No Stage 4C implementation is authorised.
+- Stage 4C implementation is limited to the three-file allowlist below.
+- No Stage 2B core file, Stage 4B core file, production behavior, or deployment change is authorised or included.
 
-## Proposed later Stage 4C implementation allowlist
+## Stage 4C implementation allowlist
 
 - `docs/ai/CURRENT_STAGE.md`
 - `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
@@ -36,7 +37,7 @@
 
 ## Scope summary
 
-Stage 4C is defined only as a DEV-only, fixture-backed, deterministic, local, presentation-only forward reconstruction for rendering already accepted Assessment and Plan Fit output inside the existing R1 Assessment Laboratory. The contract does not claim recovery of historic UI or planning semantics and does not alter accepted Stage 2B or Stage 4B semantics.
+Stage 4C is implemented only as a bounded DEV-only, fixture-backed, deterministic, local presentation slice for rendering already accepted Assessment and Plan Fit output inside the existing R1 Assessment Laboratory. It does not claim recovery of historic UI or planning semantics and does not alter accepted Stage 2B or Stage 4B semantics.
 
 ## Exact non-goals
 
@@ -88,11 +89,26 @@ Stage 4C does not add:
 
 - No deployment occurred.
 - Stage 4B is merged and accepted.
-- Stage 4C is documentation-only and introduces no implementation, validation run, or deployment.
+- Stage 4C introduces no production behavior, recommendation, ranking, scoring, strategy inference, or planning behavior.
+- Local validation completed on the implementation branch:
+  - `yarn test "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
+  - `yarn test "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
+  - `yarn test "src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts"`
+  - `yarn test`
+  - `yarn typecheck`
+  - `yarn lint`
+  - `yarn build`
+  - production deployable `JS/CSS/HTML` scan for existing DEV-only R1 identifiers plus:
+    - `baseline_local_strategy`
+    - `remote_logistics_strategy`
+    - `no_plan_fit`
+    - `blocked_plan_fit`
+    - `provisional_plan_fit`
+- The production build retained the pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
 
 ## Next safe action
 
-Obtain an independent read-only review of the Stage 4C presentation contract. Do not create a Stage 4C implementation branch or edit laboratory UI code until the contract is merged and the owner explicitly authorises implementation.
+Obtain an independent read-only review of this Stage 4C implementation PR, followed by owner acceptance before merge.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -104,6 +104,9 @@ Stage 4C does not add:
     - `no_plan_fit`
     - `blocked_plan_fit`
     - `provisional_plan_fit`
+    - `gate:not_assessable`
+    - `gate:not_supported`
+    - `dependency:`
 - The production build retained the pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
 
 ## Next safe action

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
@@ -20,6 +20,10 @@ function scenarioState(mode: 'no_carrier' | 'carrier_available') {
   return screen.getByTestId(`scenario-state-${mode}`).textContent;
 }
 
+function planFitState(mode: 'no_carrier' | 'carrier_available') {
+  return screen.getByTestId(`plan-fit-state-${mode}`).textContent;
+}
+
 function setupSideEffectMocks() {
   const fetchSpy = vi.fn();
   const xhrOpenSpy = vi.fn();
@@ -81,27 +85,30 @@ function expectNoSideEffects(mocks: ReturnType<typeof setupSideEffectMocks>) {
 }
 
 describe('R1AssessmentLabApp', () => {
-  it('renders the exact four labelled selects, defaults, options, and persistent disclosures', () => {
+  it('renders the exact five labelled selects, defaults, options, and persistent disclosures', () => {
     render(<R1AssessmentLabApp />);
 
     const selects = screen.getAllByRole('combobox');
-    expect(selects).toHaveLength(4);
+    expect(selects).toHaveLength(5);
     expect(selects.map((select) => select.getAttribute('id'))).toEqual([
       'r1-fixture-select',
       'r1-lens-kind-select',
       'r1-lens-value-select',
       'r1-carrier-mode-select',
+      'r1-strategy-select',
     ]);
 
     const fixture = getSelect('Fixture');
     const lensKind = getSelect('Lens kind');
     const lensValue = getSelect('Lens value');
     const carrierMode = getSelect('Carrier mode');
+    const strategy = getSelect('Strategy');
 
     expect(fixture.value).toBe('compact_sufficient_case');
     expect(lensKind.value).toBe('role');
     expect(lensValue.value).toBe('expedition-lead');
     expect(carrierMode.value).toBe('no_carrier');
+    expect(strategy.value).toBe('baseline_local_strategy');
 
     expect(optionLabels(fixture)).toEqual([
       'compact_sufficient_case',
@@ -113,6 +120,7 @@ describe('R1AssessmentLabApp', () => {
     expect(optionLabels(lensKind)).toEqual(['role', 'question']);
     expect(optionLabels(lensValue)).toEqual(['expedition-lead', 'logistics-reviewer']);
     expect(optionLabels(carrierMode)).toEqual(['no_carrier', 'carrier_available', 'compare_both']);
+    expect(optionLabels(strategy)).toEqual(['baseline_local_strategy', 'remote_logistics_strategy']);
 
     expect(screen.getByText('R1 Assessment Laboratory')).toBeTruthy();
     expect(screen.getByText('DEV only — reconstruction shell')).toBeTruthy();
@@ -122,6 +130,7 @@ describe('R1AssessmentLabApp', () => {
     expect(screen.getByText('R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.')).toBeTruthy();
     expect(screen.getByText('R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.')).toBeTruthy();
     expect(screen.getByText('Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)')).toBeTruthy();
+    expect(screen.getByText('Strategy is explicit local context only. It is chosen only from this selector and is not inferred from fixture, assessment state, carrier mode, or lens.')).toBeTruthy();
 
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(screen.queryByRole('button')).toBeNull();
@@ -150,7 +159,7 @@ describe('R1AssessmentLabApp', () => {
     expect(optionLabels(lensValue)).toEqual(['expedition-lead', 'logistics-reviewer']);
   });
 
-  it('renders the exact state coverage combinations and compare_both ordering', () => {
+  it('renders the exact assessment state coverage combinations and compare_both ordering', () => {
     const { container } = render(<R1AssessmentLabApp />);
 
     const fixture = getSelect('Fixture');
@@ -182,6 +191,39 @@ describe('R1AssessmentLabApp', () => {
     expect(scenarioSections).toEqual(['scenario-no_carrier', 'scenario-carrier_available']);
   });
 
+  it('renders the exact Strategy selector behavior and changes only Plan Fit presentation when strategy changes', () => {
+    render(<R1AssessmentLabApp />);
+
+    const fixture = getSelect('Fixture');
+    const carrierMode = getSelect('Carrier mode');
+    const strategy = getSelect('Strategy');
+
+    fireEvent.change(fixture, { target: { value: 'remote_materials_carrier_case' } });
+    fireEvent.change(carrierMode, { target: { value: 'compare_both' } });
+
+    const assessmentBefore = [
+      screen.getByTestId('scenario-no_carrier').querySelector('[data-testid="scenario-state-no_carrier"]')?.textContent,
+      screen.getByTestId('scenario-carrier_available').querySelector('[data-testid="scenario-state-carrier_available"]')?.textContent,
+    ];
+    const noCarrierPlanFitBefore = screen.getByTestId('scenario-no_carrier').textContent ?? '';
+    const carrierAvailableAssessmentStateBefore = scenarioState('carrier_available');
+    const carrierAvailablePlanFitStateBefore = planFitState('carrier_available');
+    expect(screen.getByTestId('selected-strategy-context').textContent).toContain('baseline_local_strategy');
+
+    fireEvent.change(strategy, { target: { value: 'remote_logistics_strategy' } });
+
+    expect(screen.getByTestId('selected-strategy-context').textContent).toContain('remote_logistics_strategy');
+    expect([
+      screen.getByTestId('scenario-no_carrier').querySelector('[data-testid="scenario-state-no_carrier"]')?.textContent,
+      screen.getByTestId('scenario-carrier_available').querySelector('[data-testid="scenario-state-carrier_available"]')?.textContent,
+    ]).toEqual(assessmentBefore);
+    expect(screen.getByTestId('scenario-no_carrier').textContent).not.toBe(noCarrierPlanFitBefore);
+    expect(screen.getByTestId('scenario-no_carrier').textContent).toContain('dependency:remote_logistics');
+    expect(scenarioState('carrier_available')).toBe(carrierAvailableAssessmentStateBefore);
+    expect(planFitState('carrier_available')).toBe(carrierAvailablePlanFitStateBefore);
+    expect(screen.getByTestId('scenario-carrier_available').textContent).not.toContain('dependency:remote_logistics');
+  });
+
   it('renders No structured conditions. for condition-free scenarios and shows requirement trace and frozen evidence/provenance', () => {
     render(<R1AssessmentLabApp />);
     const scenario = screen.getByTestId('scenario-no_carrier');
@@ -211,16 +253,18 @@ describe('R1AssessmentLabApp', () => {
     expect(evidenceRowScope.getByText('v1')).toBeTruthy();
   });
 
-  it('keeps scenario result content unchanged when only lens context changes', () => {
+  it('keeps assessment and Plan Fit scenario content unchanged when only lens context changes', () => {
     render(<R1AssessmentLabApp />);
 
     const fixture = getSelect('Fixture');
     const carrierMode = getSelect('Carrier mode');
+    const strategy = getSelect('Strategy');
     const lensKind = getSelect('Lens kind');
     const lensValue = getSelect('Lens value');
 
     fireEvent.change(fixture, { target: { value: 'remote_materials_carrier_case' } });
     fireEvent.change(carrierMode, { target: { value: 'compare_both' } });
+    fireEvent.change(strategy, { target: { value: 'remote_logistics_strategy' } });
 
     const beforeNoCarrier = screen.getByTestId('scenario-no_carrier').textContent;
     const beforeCarrierAvailable = screen.getByTestId('scenario-carrier_available').textContent;
@@ -235,6 +279,25 @@ describe('R1AssessmentLabApp', () => {
     expect(screen.getByTestId('scenario-carrier_available').textContent).toBe(beforeCarrierAvailable);
     expect(screen.getAllByTestId(/scenario-(no_carrier|carrier_available)/).map((element) => element.getAttribute('data-testid')))
       .toEqual(beforeOrder);
+  });
+
+  it('renders the exact remote compare_both Assessment and Plan Fit pairing for remote_logistics_strategy', () => {
+    render(<R1AssessmentLabApp />);
+
+    fireEvent.change(getSelect('Fixture'), { target: { value: 'remote_materials_carrier_case' } });
+    fireEvent.change(getSelect('Carrier mode'), { target: { value: 'compare_both' } });
+    fireEvent.change(getSelect('Strategy'), { target: { value: 'remote_logistics_strategy' } });
+
+    expect(screen.getAllByTestId(/scenario-(no_carrier|carrier_available)/).map((element) => element.getAttribute('data-testid')))
+      .toEqual(['scenario-no_carrier', 'scenario-carrier_available']);
+
+    expect(scenarioState('no_carrier')).toContain('conditionally_supported');
+    expect(planFitState('no_carrier')).toContain('provisional_plan_fit');
+    expect(screen.getByTestId('scenario-no_carrier').textContent).toContain('dependency:remote_logistics');
+
+    expect(scenarioState('carrier_available')).toContain('supported');
+    expect(planFitState('carrier_available')).toContain('provisional_plan_fit');
+    expect(screen.getByTestId('scenario-carrier_available').textContent).not.toContain('dependency:remote_logistics');
   });
 
   it('does not perform network or persistence activity after each separate control change', () => {
@@ -257,13 +320,17 @@ describe('R1AssessmentLabApp', () => {
     resetSideEffectMocks(mocks);
     fireEvent.change(getSelect('Carrier mode'), { target: { value: 'compare_both' } });
     expectNoSideEffects(mocks);
+
+    resetSideEffectMocks(mocks);
+    fireEvent.change(getSelect('Strategy'), { target: { value: 'remote_logistics_strategy' } });
+    expectNoSideEffects(mocks);
   });
 
   it('renders no forbidden language in the DOM', () => {
     const { container } = render(<R1AssessmentLabApp />);
     const text = container.textContent?.toLowerCase() ?? '';
 
-    for (const term of ['score', 'rank', 'best', 'plan_fit', 'plan fit', 'recommend', 'strategy', 'report', 'export', 'download']) {
+    for (const term of ['score', 'rank', 'best', 'recommend', 'preference', 'winner', 'desirability', 'report', 'export', 'download']) {
       expect(text.includes(term)).toBe(false);
     }
   });

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx
@@ -24,6 +24,14 @@ function planFitState(mode: 'no_carrier' | 'carrier_available') {
   return screen.getByTestId(`plan-fit-state-${mode}`).textContent;
 }
 
+function assessmentContent(mode: 'no_carrier' | 'carrier_available') {
+  return screen.getByTestId(`assessment-content-${mode}`).textContent;
+}
+
+function planFitReasons(mode: 'no_carrier' | 'carrier_available') {
+  return screen.getByTestId(`plan-fit-reasons-${mode}`);
+}
+
 function setupSideEffectMocks() {
   const fetchSpy = vi.fn();
   const xhrOpenSpy = vi.fn();
@@ -130,7 +138,7 @@ describe('R1AssessmentLabApp', () => {
     expect(screen.getByText('R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.')).toBeTruthy();
     expect(screen.getByText('R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.')).toBeTruthy();
     expect(screen.getByText('Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)')).toBeTruthy();
-    expect(screen.getByText('Strategy is explicit local context only. It is chosen only from this selector and is not inferred from fixture, assessment state, carrier mode, or lens.')).toBeTruthy();
+    expect(screen.getByText('Strategy is explicit local DEV-lab context only. It provides no selection guidance, comparison, or automatic choice.')).toBeTruthy();
 
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(screen.queryByRole('button')).toBeNull();
@@ -201,27 +209,21 @@ describe('R1AssessmentLabApp', () => {
     fireEvent.change(fixture, { target: { value: 'remote_materials_carrier_case' } });
     fireEvent.change(carrierMode, { target: { value: 'compare_both' } });
 
-    const assessmentBefore = [
-      screen.getByTestId('scenario-no_carrier').querySelector('[data-testid="scenario-state-no_carrier"]')?.textContent,
-      screen.getByTestId('scenario-carrier_available').querySelector('[data-testid="scenario-state-carrier_available"]')?.textContent,
-    ];
-    const noCarrierPlanFitBefore = screen.getByTestId('scenario-no_carrier').textContent ?? '';
-    const carrierAvailableAssessmentStateBefore = scenarioState('carrier_available');
-    const carrierAvailablePlanFitStateBefore = planFitState('carrier_available');
-    expect(screen.getByTestId('selected-strategy-context').textContent).toContain('baseline_local_strategy');
+    const assessmentNoCarrierBefore = assessmentContent('no_carrier');
+    const assessmentCarrierAvailableBefore = assessmentContent('carrier_available');
+    const noCarrierReasonsBefore = planFitReasons('no_carrier').textContent ?? '';
+    const carrierAvailableReasonsBefore = planFitReasons('carrier_available').textContent ?? '';
 
     fireEvent.change(strategy, { target: { value: 'remote_logistics_strategy' } });
 
-    expect(screen.getByTestId('selected-strategy-context').textContent).toContain('remote_logistics_strategy');
-    expect([
-      screen.getByTestId('scenario-no_carrier').querySelector('[data-testid="scenario-state-no_carrier"]')?.textContent,
-      screen.getByTestId('scenario-carrier_available').querySelector('[data-testid="scenario-state-carrier_available"]')?.textContent,
-    ]).toEqual(assessmentBefore);
-    expect(screen.getByTestId('scenario-no_carrier').textContent).not.toBe(noCarrierPlanFitBefore);
-    expect(screen.getByTestId('scenario-no_carrier').textContent).toContain('dependency:remote_logistics');
-    expect(scenarioState('carrier_available')).toBe(carrierAvailableAssessmentStateBefore);
-    expect(planFitState('carrier_available')).toBe(carrierAvailablePlanFitStateBefore);
-    expect(screen.getByTestId('scenario-carrier_available').textContent).not.toContain('dependency:remote_logistics');
+    expect(assessmentContent('no_carrier')).toBe(assessmentNoCarrierBefore);
+    expect(assessmentContent('carrier_available')).toBe(assessmentCarrierAvailableBefore);
+
+    expect(planFitReasons('no_carrier').textContent).not.toBe(noCarrierReasonsBefore);
+    expect(planFitReasons('no_carrier').textContent).toContain('dependency:remote_logistics');
+
+    expect(planFitReasons('carrier_available').textContent).toBe(carrierAvailableReasonsBefore);
+    expect(planFitReasons('carrier_available').textContent).not.toContain('dependency:remote_logistics');
   });
 
   it('renders No structured conditions. for condition-free scenarios and shows requirement trace and frozen evidence/provenance', () => {
@@ -279,6 +281,37 @@ describe('R1AssessmentLabApp', () => {
     expect(screen.getByTestId('scenario-carrier_available').textContent).toBe(beforeCarrierAvailable);
     expect(screen.getAllByTestId(/scenario-(no_carrier|carrier_available)/).map((element) => element.getAttribute('data-testid')))
       .toEqual(beforeOrder);
+  });
+
+  it('renders the remote no_carrier Plan Fit reason with all required fields and the required logistics fields', () => {
+    render(<R1AssessmentLabApp />);
+
+    fireEvent.change(getSelect('Fixture'), { target: { value: 'remote_materials_carrier_case' } });
+    fireEvent.change(getSelect('Carrier mode'), { target: { value: 'compare_both' } });
+    fireEvent.change(getSelect('Strategy'), { target: { value: 'remote_logistics_strategy' } });
+
+    const reasonsTable = planFitReasons('no_carrier');
+    const scoped = within(reasonsTable);
+
+    expect(scoped.getByText('reasonId')).toBeTruthy();
+    expect(scoped.getByText('reasonKind')).toBeTruthy();
+    expect(scoped.getByText('summary')).toBeTruthy();
+    expect(scoped.getByText('blocking')).toBeTruthy();
+    expect(scoped.getByText('relatedRequirementIds')).toBeTruthy();
+    expect(scoped.getByText('relatedEvidenceIds')).toBeTruthy();
+
+    const row = scoped.getByText('dependency:remote_logistics').closest('tr');
+    if (!row) throw new Error('dependency:remote_logistics reason row not found');
+    const rowScope = within(row);
+    expect(rowScope.getByText('dependency:remote_logistics')).toBeTruthy();
+    expect(rowScope.getByText('logistics_dependency')).toBeTruthy();
+    expect(rowScope.getByText('false')).toBeTruthy();
+    expect(rowScope.getByText('remote_logistics')).toBeTruthy();
+
+    const evidenceCell = rowScope.getAllByRole('cell')[5].textContent ?? '';
+    expect(evidenceCell).not.toBe('[]');
+
+    expect(planFitReasons('carrier_available').textContent).not.toContain('dependency:remote_logistics');
   });
 
   it('renders the exact remote compare_both Assessment and Plan Fit pairing for remote_logistics_strategy', () => {

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx
@@ -8,6 +8,7 @@ import type {
   AssessmentEvaluationResult,
   AssessmentLens,
   CarrierMode,
+  CarrierScenarioMode,
   ScenarioAssessment,
 } from '@/lab/r1-assessment-lab/core/types';
 
@@ -116,13 +117,13 @@ function renderFrozenEvidence(scenario: ScenarioAssessment) {
   );
 }
 
-function renderPlanFitReasons(planFitScenario: PlanFitScenarioResult) {
+function renderPlanFitReasons(carrierMode: CarrierScenarioMode, planFitScenario: PlanFitScenarioResult) {
   if (planFitScenario.reasons.length === 0) {
-    return <p>No Plan Fit reasons.</p>;
+    return <p data-testid={`plan-fit-reasons-${carrierMode}`}>No Plan Fit reasons.</p>;
   }
 
   return (
-    <table>
+    <table data-testid={`plan-fit-reasons-${carrierMode}`}>
       <thead>
         <tr>
           <th scope="col">reasonId</th>
@@ -156,17 +157,19 @@ function ScenarioResultSection(
     <section data-testid={`scenario-${scenario.carrierMode}`}>
       <h3><code>{scenario.carrierMode}</code></h3>
 
-      <h4>Assessment state</h4>
-      <p data-testid={`scenario-state-${scenario.carrierMode}`}><code>{scenario.state}</code></p>
+      <div data-testid={`assessment-content-${scenario.carrierMode}`}>
+        <h4>Assessment state</h4>
+        <p data-testid={`scenario-state-${scenario.carrierMode}`}><code>{scenario.state}</code></p>
 
-      <h4>Structured conditions</h4>
-      {renderConditions(scenario)}
+        <h4>Structured conditions</h4>
+        {renderConditions(scenario)}
 
-      <h4>Requirement trace</h4>
-      {renderRequirementTrace(scenario)}
+        <h4>Requirement trace</h4>
+        {renderRequirementTrace(scenario)}
 
-      <h4>Frozen evidence and provenance</h4>
-      {renderFrozenEvidence(scenario)}
+        <h4>Frozen evidence and provenance</h4>
+        {renderFrozenEvidence(scenario)}
+      </div>
 
       <h4>Plan Fit state</h4>
       <p data-testid={`plan-fit-state-${scenario.carrierMode}`}><code>{planFitScenario.planFitState}</code></p>
@@ -189,7 +192,7 @@ function ScenarioResultSection(
       </div>
 
       <h4>Plan Fit reasons</h4>
-      {renderPlanFitReasons(planFitScenario)}
+      {renderPlanFitReasons(scenario.carrierMode, planFitScenario)}
     </section>
   );
 }
@@ -215,8 +218,8 @@ export default function R1AssessmentLabApp() {
     : `question / ${selectedLens.questionId}`;
 
   const lensOptions = lensKind === 'role' ? ROLE_OPTIONS : QUESTION_OPTIONS;
-  const planFitScenarioByCarrierMode = new Map(
-    planFitResult.scenarioResults.map((scenario) => [scenario.carrierMode, scenario]),
+  const assessmentScenarioByCarrierMode = new Map(
+    assessmentResult.scenarioResults.map((scenario) => [scenario.carrierMode, scenario]),
   );
 
   return (
@@ -235,7 +238,7 @@ export default function R1AssessmentLabApp() {
           <p>R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.</p>
           <p>R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.</p>
           <p>Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)</p>
-          <p>Strategy is explicit local context only. It is chosen only from this selector and is not inferred from fixture, assessment state, carrier mode, or lens.</p>
+          <p>Strategy is explicit local DEV-lab context only. It provides no selection guidance, comparison, or automatic choice.</p>
 
           <div>
             <label htmlFor="r1-fixture-select">Fixture</label>{' '}
@@ -307,19 +310,18 @@ export default function R1AssessmentLabApp() {
           </div>
 
           <p data-testid="selected-lens-context">Selected lens context: {selectedLensContext}</p>
-          <p data-testid="selected-strategy-context">Selected strategy context: {selectedStrategyId}</p>
 
           {carrierMode === 'compare_both' ? (
             <section>
               <h2>Carrier scenario comparison</h2>
-              {assessmentResult.scenarioResults.map((scenario) => {
-                const planFitScenario = planFitScenarioByCarrierMode.get(scenario.carrierMode);
-                if (!planFitScenario) {
-                  throw new Error(`Missing Plan Fit scenario for carrier mode ${scenario.carrierMode}.`);
+              {planFitResult.scenarioResults.map((planFitScenario) => {
+                const scenario = assessmentScenarioByCarrierMode.get(planFitScenario.carrierMode);
+                if (!scenario) {
+                  throw new Error(`Missing Assessment scenario for carrier mode ${planFitScenario.carrierMode}.`);
                 }
                 return (
                   <ScenarioResultSection
-                    key={scenario.carrierMode}
+                    key={planFitScenario.carrierMode}
                     scenario={scenario}
                     planFitScenario={planFitScenario}
                   />
@@ -327,39 +329,20 @@ export default function R1AssessmentLabApp() {
               })}
             </section>
           ) : (
-            assessmentResult.scenarioResults.map((scenario) => {
-              const planFitScenario = planFitScenarioByCarrierMode.get(scenario.carrierMode);
-              if (!planFitScenario) {
-                throw new Error(`Missing Plan Fit scenario for carrier mode ${scenario.carrierMode}.`);
+            planFitResult.scenarioResults.map((planFitScenario) => {
+              const scenario = assessmentScenarioByCarrierMode.get(planFitScenario.carrierMode);
+              if (!scenario) {
+                throw new Error(`Missing Assessment scenario for carrier mode ${planFitScenario.carrierMode}.`);
               }
               return (
                 <ScenarioResultSection
-                  key={scenario.carrierMode}
+                  key={planFitScenario.carrierMode}
                   scenario={scenario}
                   planFitScenario={planFitScenario}
                 />
               );
             })
           )}
-
-          <section>
-            <h2>Plan Fit context</h2>
-            <div>programmeId: <code>{planFitResult.context.programmeId}</code></div>
-            <div>templateId: <code>{planFitResult.context.templateId}</code></div>
-            <div>templateRevision: <code>{planFitResult.context.templateRevision}</code></div>
-            <div>originalCarrierMode: <code>{planFitResult.context.originalCarrierMode}</code></div>
-            <div>selectedStrategyId: <code>{planFitResult.context.selectedStrategyId}</code></div>
-            <div>selectedStrategyRevision: <code>{planFitResult.context.selectedStrategyRevision}</code></div>
-            <div>
-              lens:
-              {' '}
-              <code>
-                {planFitResult.context.lens.kind === 'role'
-                  ? `role / ${planFitResult.context.lens.roleId}`
-                  : `question / ${planFitResult.context.lens.questionId}`}
-              </code>
-            </div>
-          </section>
         </div>
       </div>
     </main>

--- a/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx
+++ b/frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import { R1_ASSESSMENT_FIXTURES, R1_ASSESSMENT_TEMPLATE } from '@/lab/r1-assessment-lab/core/fixtures';
 import { evaluateAssessment } from '@/lab/r1-assessment-lab/core/evaluateAssessment';
+import { evaluatePlanFit } from '@/lab/r1-assessment-lab/core/evaluatePlanFit';
+import type { PlanFitScenarioResult } from '@/lab/r1-assessment-lab/core/planFitTypes';
 import type {
   AssessmentEvaluationResult,
   AssessmentLens,
@@ -21,11 +23,13 @@ const LENS_KIND_OPTIONS = ['role', 'question'] as const;
 const ROLE_OPTIONS = ['expedition-lead', 'logistics-reviewer'] as const;
 const QUESTION_OPTIONS = ['baseline-assessment', 'carrier-sensitivity-check'] as const;
 const CARRIER_MODE_OPTIONS = ['no_carrier', 'carrier_available', 'compare_both'] as const;
+const STRATEGY_OPTIONS = ['baseline_local_strategy', 'remote_logistics_strategy'] as const;
 
 type FixtureOption = typeof FIXTURE_OPTIONS[number];
 type LensKindOption = typeof LENS_KIND_OPTIONS[number];
 type RoleOption = typeof ROLE_OPTIONS[number];
 type QuestionOption = typeof QUESTION_OPTIONS[number];
+type StrategyOption = typeof STRATEGY_OPTIONS[number];
 
 function lensValueFor(kind: LensKindOption): RoleOption | QuestionOption {
   return kind === 'role' ? 'expedition-lead' : 'baseline-assessment';
@@ -112,7 +116,42 @@ function renderFrozenEvidence(scenario: ScenarioAssessment) {
   );
 }
 
-function ScenarioResultSection({ scenario }: { scenario: ScenarioAssessment }) {
+function renderPlanFitReasons(planFitScenario: PlanFitScenarioResult) {
+  if (planFitScenario.reasons.length === 0) {
+    return <p>No Plan Fit reasons.</p>;
+  }
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">reasonId</th>
+          <th scope="col">reasonKind</th>
+          <th scope="col">summary</th>
+          <th scope="col">blocking</th>
+          <th scope="col">relatedRequirementIds</th>
+          <th scope="col">relatedEvidenceIds</th>
+        </tr>
+      </thead>
+      <tbody>
+        {planFitScenario.reasons.map((reason) => (
+          <tr key={reason.id}>
+            <td><code>{reason.id}</code></td>
+            <td><code>{reason.kind}</code></td>
+            <td>{reason.summary}</td>
+            <td><code>{String(reason.blocking)}</code></td>
+            <td><code>{reason.relatedRequirementIds.join(', ') || '[]'}</code></td>
+            <td><code>{reason.relatedEvidenceIds.join(', ') || '[]'}</code></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ScenarioResultSection(
+  { scenario, planFitScenario }: { scenario: ScenarioAssessment; planFitScenario: PlanFitScenarioResult },
+) {
   return (
     <section data-testid={`scenario-${scenario.carrierMode}`}>
       <h3><code>{scenario.carrierMode}</code></h3>
@@ -128,6 +167,29 @@ function ScenarioResultSection({ scenario }: { scenario: ScenarioAssessment }) {
 
       <h4>Frozen evidence and provenance</h4>
       {renderFrozenEvidence(scenario)}
+
+      <h4>Plan Fit state</h4>
+      <p data-testid={`plan-fit-state-${scenario.carrierMode}`}><code>{planFitScenario.planFitState}</code></p>
+
+      <h4>Selected strategy</h4>
+      <div data-testid={`selected-strategy-${scenario.carrierMode}`}>
+        <div>strategyId: <code>{planFitScenario.selectedStrategyId}</code></div>
+        <div>strategyRevision: <code>{planFitScenario.selectedStrategyRevision}</code></div>
+        <div>
+          strategyProvenance:
+          {' '}
+          <code>
+            {planFitScenario.selectedStrategyProvenance.sourceKind}
+            {' / '}
+            {planFitScenario.selectedStrategyProvenance.fixtureId}
+            {' / '}
+            {planFitScenario.selectedStrategyProvenance.fixtureRevision}
+          </code>
+        </div>
+      </div>
+
+      <h4>Plan Fit reasons</h4>
+      {renderPlanFitReasons(planFitScenario)}
     </section>
   );
 }
@@ -137,20 +199,25 @@ export default function R1AssessmentLabApp() {
   const [lensKind, setLensKind] = useState<LensKindOption>('role');
   const [lensValue, setLensValue] = useState<RoleOption | QuestionOption>('expedition-lead');
   const [carrierMode, setCarrierMode] = useState<CarrierMode>('no_carrier');
+  const [selectedStrategyId, setSelectedStrategyId] = useState<StrategyOption>('baseline_local_strategy');
 
   const selectedLens = buildLens(lensKind, lensValue);
-  const result: AssessmentEvaluationResult = evaluateAssessment({
+  const assessmentResult: AssessmentEvaluationResult = evaluateAssessment({
     fixture: R1_ASSESSMENT_FIXTURES[fixtureId],
     template: R1_ASSESSMENT_TEMPLATE,
     lens: selectedLens,
     carrierMode,
   });
+  const planFitResult = evaluatePlanFit(assessmentResult, selectedStrategyId);
 
   const selectedLensContext = selectedLens.kind === 'role'
     ? `role / ${selectedLens.roleId}`
     : `question / ${selectedLens.questionId}`;
 
   const lensOptions = lensKind === 'role' ? ROLE_OPTIONS : QUESTION_OPTIONS;
+  const planFitScenarioByCarrierMode = new Map(
+    planFitResult.scenarioResults.map((scenario) => [scenario.carrierMode, scenario]),
+  );
 
   return (
     <main className="min-h-screen px-4 py-8 text-slate-100 sm:px-6">
@@ -168,6 +235,7 @@ export default function R1AssessmentLabApp() {
           <p>R1 Lab — Lens context only: changing it does not alter fixture outcomes, requirement outcomes, conditions, assessment state, or ordering in Stage 3B.</p>
           <p>R1 Lab — Lens labels are local presentation context, not rebuilt role or question semantics.</p>
           <p>Template: r1_assessment_programme / core_assessment_template / r1-contract-v1 (fixed for Stage 3B)</p>
+          <p>Strategy is explicit local context only. It is chosen only from this selector and is not inferred from fixture, assessment state, carrier mode, or lens.</p>
 
           <div>
             <label htmlFor="r1-fixture-select">Fixture</label>{' '}
@@ -225,20 +293,73 @@ export default function R1AssessmentLabApp() {
             </select>
           </div>
 
+          <div>
+            <label htmlFor="r1-strategy-select">Strategy</label>{' '}
+            <select
+              id="r1-strategy-select"
+              value={selectedStrategyId}
+              onChange={(event) => setSelectedStrategyId(event.currentTarget.value as StrategyOption)}
+            >
+              {STRATEGY_OPTIONS.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+          </div>
+
           <p data-testid="selected-lens-context">Selected lens context: {selectedLensContext}</p>
+          <p data-testid="selected-strategy-context">Selected strategy context: {selectedStrategyId}</p>
 
           {carrierMode === 'compare_both' ? (
             <section>
               <h2>Carrier scenario comparison</h2>
-              {result.scenarioResults.map((scenario) => (
-                <ScenarioResultSection key={scenario.carrierMode} scenario={scenario} />
-              ))}
+              {assessmentResult.scenarioResults.map((scenario) => {
+                const planFitScenario = planFitScenarioByCarrierMode.get(scenario.carrierMode);
+                if (!planFitScenario) {
+                  throw new Error(`Missing Plan Fit scenario for carrier mode ${scenario.carrierMode}.`);
+                }
+                return (
+                  <ScenarioResultSection
+                    key={scenario.carrierMode}
+                    scenario={scenario}
+                    planFitScenario={planFitScenario}
+                  />
+                );
+              })}
             </section>
           ) : (
-            result.scenarioResults.map((scenario) => (
-              <ScenarioResultSection key={scenario.carrierMode} scenario={scenario} />
-            ))
+            assessmentResult.scenarioResults.map((scenario) => {
+              const planFitScenario = planFitScenarioByCarrierMode.get(scenario.carrierMode);
+              if (!planFitScenario) {
+                throw new Error(`Missing Plan Fit scenario for carrier mode ${scenario.carrierMode}.`);
+              }
+              return (
+                <ScenarioResultSection
+                  key={scenario.carrierMode}
+                  scenario={scenario}
+                  planFitScenario={planFitScenario}
+                />
+              );
+            })
           )}
+
+          <section>
+            <h2>Plan Fit context</h2>
+            <div>programmeId: <code>{planFitResult.context.programmeId}</code></div>
+            <div>templateId: <code>{planFitResult.context.templateId}</code></div>
+            <div>templateRevision: <code>{planFitResult.context.templateRevision}</code></div>
+            <div>originalCarrierMode: <code>{planFitResult.context.originalCarrierMode}</code></div>
+            <div>selectedStrategyId: <code>{planFitResult.context.selectedStrategyId}</code></div>
+            <div>selectedStrategyRevision: <code>{planFitResult.context.selectedStrategyRevision}</code></div>
+            <div>
+              lens:
+              {' '}
+              <code>
+                {planFitResult.context.lens.kind === 'role'
+                  ? `role / ${planFitResult.context.lens.roleId}`
+                  : `question / ${planFitResult.context.lens.questionId}`}
+              </code>
+            </div>
+          </section>
         </div>
       </div>
     </main>


### PR DESCRIPTION
implements only the owner-authorised bounded Stage 4C DEV-only Plan Fit laboratory presentation;
keeps the existing four selectors intact and adds exactly one explicit closed Strategy selector;
renders accepted Stage 2B Assessment output alongside accepted Stage 4B Plan Fit output without changing core semantics;
contains no Stage 2B core change, no Stage 4B core change, no routing, no persistence, no network, no API, no production behavior, no deployment, no recommendation, no ranking, no scoring, and no planning behavior;
lists exact validation results;
requires independent read-only review and owner acceptance before merge.

## Validation results
- `yarn test "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"` — passed
- `yarn test "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"` — passed
- `yarn test "src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts"` — passed
- `yarn test` — passed, with retained pre-existing `act(...)` warnings from `src/features/my-work/MyWorkWorkspace.test.tsx`
- `yarn typecheck` — passed
- `yarn lint` — passed
- `yarn build` — passed with the pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning
- Production deployable JS/CSS/HTML artifact scan — no matches for the existing Stage 1 and Stage 3 DEV-only identifiers, and no matches for these Stage 4 identifiers:
  - `baseline_local_strategy`
  - `remote_logistics_strategy`
  - `no_plan_fit`
  - `blocked_plan_fit`
  - `provisional_plan_fit`
  - `gate:not_assessable`
  - `gate:not_supported`
  - `dependency:`
