### PR TITLE
docs: close Stage 4C acceptance record

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,32 +4,56 @@
 
 ## Status
 
-**Stage 4C bounded DEV-only Plan Fit presentation implementation complete — awaiting independent review and owner acceptance**
+**Stage 4C accepted and merged — no subsequent implementation stage is authorised.**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Implementation branch: `feat/r1-stage4c-plan-fit-lab`
-- Implementation base SHA: `18464de5a204a109fe145eb4e64a8500b59eaee5`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 4B implementation PR: `#286`, merged
-- Stage 4B merge commit: `0565a60428904c4fe234f500e05be9871adb5c6d`
-- Stage 4B implementation head: `9f69061c3d625dc111864061166287407e6336c0`
-- Stage 4B was reviewed and owner-accepted before merge
-- Owner authorised bounded Stage 4C implementation on `2026-07-02`
+- Stage 4B implementation merge commit: `0565a60428904c4fe234f500e05be9871adb5c6d`
+- Stage 4B reviewed implementation head: `9f69061c3d625dc111864061166287407e6336c0`
+- Stage 4B was independently reviewed and owner-accepted before merge.
+- Stage 4C contract PR: `#287`, merged
+- Stage 4C contract merge commit: `18464de5a204a109fe145eb4e64a8500b59eaee5`
+- Stage 4C implementation PR: `#288`, merged
+- Stage 4C implementation merge commit: `5017b713627600887cefc781066c3a6eacfdbcba`
+- Stage 4C accepted code commit: `4eabc24ba9b428c2902fa2221c15b7d5371d0433`
+- The Stage 4C implementation was independently reviewed and owner-accepted on `2026-07-02` before merge.
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
 - Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
-- Last accepted implementation stage: Stage 2B pure R1 assessment-domain core, merged by PR `#280` at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
+- Stage 2B pure R1 assessment-domain core: PR `#280`, merged at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - No deployment occurred.
 
-## Active implementation record
+## Acceptance checkpoint
+
+- Status: Accepted
+- Accepted code commit: `4eabc24ba9b428c2902fa2221c15b7d5371d0433`
+- Acceptance date: `2026-07-02`
+- Branch: `feat/r1-stage4c-plan-fit-lab`
+- Pull request: `#288`, merged at `5017b713627600887cefc781066c3a6eacfdbcba`
+- Acceptance checkpoint commit: pending exact SHA after this documentation-only checkpoint is created.
+- Evidence reviewed:
+  - Independent read-only Stage 4C implementation review at `4eabc24ba9b428c2902fa2221c15b7d5371d0433`, verdict: ready for owner acceptance.
+  - Reported focused UI test, unchanged Stage 2B and Stage 4B core tests, full test suite, typecheck, lint, and production build.
+  - Reported deployable `JS/CSS/HTML` artifact scan with no matches for existing DEV-only R1 identifiers or the Stage 4 identifiers recorded below.
+- Caveats:
+  - This acceptance checkpoint is a post-merge documentation repair because the required checkpoint was missed before PR `#288` merged. It does not reopen product-code review.
+  - The reported full suite retained pre-existing `act(...)` warnings from `src/features/my-work/MyWorkWorkspace.test.tsx`.
+  - The reported production build retained pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
+  - No deployment occurred.
+- Next safe action:
+  - Begin a separate documentation-only discovery and contract stage before any subsequent implementation. No new R1 laboratory scope, production wiring, or deployment is authorised.
+
+## Accepted Stage 4C record
 
 - Contract file: `docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`
-- Stage 4C implementation is limited to the three-file allowlist below.
-- No Stage 2B core file, Stage 4B core file, production behavior, or deployment change is authorised or included.
+- Stage 4C implemented only the accepted DEV-only, fixture-backed, deterministic, local presentation slice inside the existing R1 Assessment Laboratory.
+- Its code change was restricted to `R1AssessmentLabApp.tsx` and `R1AssessmentLabApp.test.tsx`; the stage record was the only documentation file changed.
+- No Stage 2B or Stage 4B core file, production behavior, routing, persistence, network, API, recommendation, scoring, ranking, planning behavior, deployment, or production asset change was included.
 
-## Stage 4C implementation allowlist
+## Stage 4C accepted implementation files
 
 - `docs/ai/CURRENT_STAGE.md`
 - `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
@@ -37,7 +61,7 @@
 
 ## Scope summary
 
-Stage 4C is implemented only as a bounded DEV-only, fixture-backed, deterministic, local presentation slice for rendering already accepted Assessment and Plan Fit output inside the existing R1 Assessment Laboratory. It does not claim recovery of historic UI or planning semantics and does not alter accepted Stage 2B or Stage 4B semantics.
+Stage 4C is a bounded DEV-only, fixture-backed, deterministic, local presentation slice that renders already accepted Assessment and Plan Fit output inside the existing R1 Assessment Laboratory. It does not claim recovery of historic UI or planning semantics and does not alter accepted Stage 2B or Stage 4B semantics.
 
 ## Exact non-goals
 
@@ -77,20 +101,21 @@ Stage 4C does not add:
 
 ## Preserved merged invariants
 
-- The lab exposes exactly four closed local select controls: Fixture, Lens kind, Lens value, and Carrier mode.
+- The lab exposes exactly five closed local select controls: Fixture, Lens kind, Lens value, Carrier mode, and Strategy.
+- The first four selector IDs, values, defaults, ordering, and semantics remain unchanged. Strategy is explicit local DEV-lab context only, with the fixed options `baseline_local_strategy` and `remote_logistics_strategy`; it is not inferred from fixture, assessment state, carrier mode, or lens.
 - Five fixture IDs and three carrier modes are selectable; the six approved fixture/scenario state rows are test assertions, not six fixtures.
 - The fixed template is displayed read-only.
-- The selected Role/Question lens is passed to the evaluator and visibly displayed as context only. Changing it does not alter fixture outcomes, conditions, requirement results, frozen evidence/provenance, state, or ordering in this slice.
+- The selected Role/Question lens is passed to the evaluator and visibly displayed as context only. Changing it does not alter fixture outcomes, conditions, requirement results, frozen evidence/provenance, state, Plan Fit output, or ordering in this slice.
 - Accepted Stage 4B Plan Fit output remains bounded pure-core logic subordinate to accepted Stage 2B assessment results.
-- Stage 4C may only present returned Assessment and Plan Fit scenario output; it must not derive, rewrite, or recalculate them.
+- Stage 4C presents returned Assessment and Plan Fit scenario output without deriving, rewriting, or recalculating it.
 - `compare_both` preserves `no_carrier` then `carrier_available` order.
 
 ## Caveats
 
 - No deployment occurred.
-- Stage 4B is merged and accepted.
+- Stage 4B and Stage 4C are merged and accepted.
 - Stage 4C introduces no production behavior, recommendation, ranking, scoring, strategy inference, or planning behavior.
-- Local validation completed on the implementation branch:
+- Local validation reported on the Stage 4C implementation branch:
   - `yarn test "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
   - `yarn test "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
   - `yarn test "src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts"`
@@ -107,11 +132,11 @@ Stage 4C does not add:
     - `gate:not_assessable`
     - `gate:not_supported`
     - `dependency:`
-- The production build retained the pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
+- The reported production build retained the pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
 
 ## Next safe action
 
-Obtain an independent read-only review of this Stage 4C implementation PR, followed by owner acceptance before merge.
+Begin a separate documentation-only discovery and contract stage before any subsequent implementation. Do not create a feature branch, edit application code, merge a new implementation, or deploy until the owner explicitly authorises that new stage.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -33,7 +33,7 @@
 - Acceptance date: `2026-07-02`
 - Branch: `feat/r1-stage4c-plan-fit-lab`
 - Pull request: `#288`, merged at `5017b713627600887cefc781066c3a6eacfdbcba`
-- Acceptance checkpoint commit: pending exact SHA after this documentation-only checkpoint is created.
+- Acceptance checkpoint commit: `2db42b27852f7cae19d0fa7754991cf530845b8c`
 - Evidence reviewed:
   - Independent read-only Stage 4C implementation review at `4eabc24ba9b428c2902fa2221c15b7d5371d0433`, verdict: ready for owner acceptance.
   - Reported focused UI test, unchanged Stage 2B and Stage 4B core tests, full test suite, typecheck, lint, and production build.


### PR DESCRIPTION
Documentation-only post-merge closeout repair for Stage 4C.

- records the independently reviewed and owner-accepted Stage 4C code commit `4eabc24ba9b428c2902fa2221c15b7d5371d0433`;
- records PR #288 merge commit `5017b713627600887cefc781066c3a6eacfdbcba`;
- adds the missed acceptance checkpoint required by `docs/ai/ACCEPTANCE_PROTOCOL.md`;
- corrects the Stage 4C record to reflect five closed selectors rather than the pre-Stage-4C four-selector invariant;
- changes only `docs/ai/CURRENT_STAGE.md`;
- contains no application code, configuration, deployment, or product behaviour change.

No implementation, deployment, or new feature scope is authorised by this closeout record.