### PR TITLE
docs: record Stage 5A control fixture discovery

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,11 +4,13 @@
 
 ## Status
 
-**Stage 4C accepted and merged — no subsequent implementation stage is authorised.**
+**Stage 5A docs-only R1 control-fixture discovery drafted — awaiting independent review and owner acceptance.**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
+- Stage 5A documentation branch: `docs/r1-stage5a-control-fixture-discovery`
+- Stage 5A documentation base SHA: `fe06439132f52c9ccae5c4652f10de838b5ec445`
 - Stage 4B contract PR: `#284`, merged
 - Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
 - Stage 4B implementation PR: `#286`, merged
@@ -20,31 +22,65 @@
 - Stage 4C implementation PR: `#288`, merged
 - Stage 4C implementation merge commit: `5017b713627600887cefc781066c3a6eacfdbcba`
 - Stage 4C accepted code commit: `4eabc24ba9b428c2902fa2221c15b7d5371d0433`
-- The Stage 4C implementation was independently reviewed and owner-accepted on `2026-07-02` before merge.
+- Stage 4C acceptance closeout PR: `#289`, merged
+- Stage 4C acceptance closeout merge commit: `fe06439132f52c9ccae5c4652f10de838b5ec445`
 - Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
 - Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
 - Stage 2B pure R1 assessment-domain core: PR `#280`, merged at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
 - No deployment occurred.
 
-## Acceptance checkpoint
+## Active Stage 5A discovery record
 
-- Status: Accepted
+- Discovery record: `docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`
+- Stage 5A is documentation-only.
+- It investigates the deferred names `wregoe_dual_dodec_control` and `plateau_30_vs_60_case` only to determine whether current repository evidence supports a precise later proof role.
+- Stage 5A does not assign either name new semantics, create a fixture, change a test, or authorise any implementation.
+- The documented finding is that neither name has a recoverable current fixture payload or deterministic proof role; both remain absent from the active registry pending a separate, explicit future contract.
+- No implementation is authorised by this discovery record.
+
+## Stage 5A allowed files
+
+- `docs/ai/CURRENT_STAGE.md`
+- `docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`
+
+`docs/ai/DECISIONS.md` remains unchanged until the owner accepts the independently reviewed Stage 5A conclusion.
+
+## Stage 5A non-goals
+
+Stage 5A does not add or change:
+
+- R1 fixture data;
+- R1 core types, Assessment semantics, or Plan Fit semantics;
+- R1 lab UI;
+- normal application behavior, routes, navigation, providers, stores, APIs, network, or persistence;
+- production assets, configuration, build behavior, deployment, exports, reports, scoring, ranking, recommendation, or planning;
+- claims of recovered historical semantics.
+
+## Stage 5A evidence boundary
+
+- `docs/ai/R1_RECONSTRUCTION_CONTRACT_V1.md` names both controls only as deferred controls requiring a later written contract with a specific proof role.
+- The active `R1_ASSESSMENT_FIXTURES` registry contains five fixtures only: `compact_sufficient_case`, `incomplete_evidence_case`, `contradictory_allocation_case`, `fake_flexibility_case`, and `remote_materials_carrier_case`.
+- Repository-wide source search found no current source, test, or document reference to either deferred name beyond the deferral note.
+- Fixture names alone are insufficient evidence from which to infer a Wregoe, Dodec, numerical-threshold, capacity, logistics, material, planning, ranking, or recommendation rule.
+
+## Stage 4C acceptance checkpoint
+
+- Status: Accepted and merged.
 - Accepted code commit: `4eabc24ba9b428c2902fa2221c15b7d5371d0433`
 - Acceptance date: `2026-07-02`
 - Branch: `feat/r1-stage4c-plan-fit-lab`
 - Pull request: `#288`, merged at `5017b713627600887cefc781066c3a6eacfdbcba`
-- Acceptance checkpoint commit: `2db42b27852f7cae19d0fa7754991cf530845b8c`
+- Documentation-only acceptance checkpoint commit: `2db42b27852f7cae19d0fa7754991cf530845b8c`
+- Documentation closeout record: PR `#289`, merged at `fe06439132f52c9ccae5c4652f10de838b5ec445`
 - Evidence reviewed:
   - Independent read-only Stage 4C implementation review at `4eabc24ba9b428c2902fa2221c15b7d5371d0433`, verdict: ready for owner acceptance.
   - Reported focused UI test, unchanged Stage 2B and Stage 4B core tests, full test suite, typecheck, lint, and production build.
   - Reported deployable `JS/CSS/HTML` artifact scan with no matches for existing DEV-only R1 identifiers or the Stage 4 identifiers recorded below.
 - Caveats:
-  - This acceptance checkpoint is a post-merge documentation repair because the required checkpoint was missed before PR `#288` merged. It does not reopen product-code review.
+  - The acceptance checkpoint was recorded in a post-merge documentation repair. It did not reopen product-code review.
   - The reported full suite retained pre-existing `act(...)` warnings from `src/features/my-work/MyWorkWorkspace.test.tsx`.
   - The reported production build retained pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
   - No deployment occurred.
-- Next safe action:
-  - Begin a separate documentation-only discovery and contract stage before any subsequent implementation. No new R1 laboratory scope, production wiring, or deployment is authorised.
 
 ## Accepted Stage 4C record
 
@@ -52,52 +88,6 @@
 - Stage 4C implemented only the accepted DEV-only, fixture-backed, deterministic, local presentation slice inside the existing R1 Assessment Laboratory.
 - Its code change was restricted to `R1AssessmentLabApp.tsx` and `R1AssessmentLabApp.test.tsx`; the stage record was the only documentation file changed.
 - No Stage 2B or Stage 4B core file, production behavior, routing, persistence, network, API, recommendation, scoring, ranking, planning behavior, deployment, or production asset change was included.
-
-## Stage 4C accepted implementation files
-
-- `docs/ai/CURRENT_STAGE.md`
-- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.tsx`
-- `frontend-v2/src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx`
-
-## Scope summary
-
-Stage 4C is a bounded DEV-only, fixture-backed, deterministic, local presentation slice that renders already accepted Assessment and Plan Fit output inside the existing R1 Assessment Laboratory. It does not claim recovery of historic UI or planning semantics and does not alter accepted Stage 2B or Stage 4B semantics.
-
-## Exact non-goals
-
-Stage 4C does not add:
-
-- production behavior
-- `App.tsx` changes
-- normal product navigation
-- routing
-- providers
-- stores
-- APIs
-- network
-- persistence
-- live system data
-- deployment
-- editable plans
-- reports
-- exports
-- downloads
-- strategy creation
-- free-form strategy input
-- automatic strategy selection
-- strategy inference
-- scoring
-- ranking
-- “best” results
-- strategy recommendation
-- preference
-- winner selection
-- comparative advice
-- material planning
-- route planning
-- colonisation staging
-- changed Stage 2B assessment semantics
-- changed Stage 4B Plan Fit semantics
 
 ## Preserved merged invariants
 
@@ -114,7 +104,7 @@ Stage 4C does not add:
 
 - No deployment occurred.
 - Stage 4B and Stage 4C are merged and accepted.
-- Stage 4C introduces no production behavior, recommendation, ranking, scoring, strategy inference, or planning behavior.
+- Stage 5A is a documentation-only discovery record and introduces no production behavior, recommendation, ranking, scoring, strategy inference, planning behavior, fixture change, test change, or code change.
 - Local validation reported on the Stage 4C implementation branch:
   - `yarn test "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
   - `yarn test "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
@@ -136,7 +126,7 @@ Stage 4C does not add:
 
 ## Next safe action
 
-Begin a separate documentation-only discovery and contract stage before any subsequent implementation. Do not create a feature branch, edit application code, merge a new implementation, or deploy until the owner explicitly authorises that new stage.
+Obtain an independent read-only review of the Stage 5A discovery record and this stage record. Do not create an implementation branch, edit R1 fixtures, tests, core, or UI, change the normal application, merge a new implementation, or deploy until the owner accepts the reviewed Stage 5A conclusion and separately authorises any later stage.
 
 ## Recovery instruction
 

--- a/docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md
+++ b/docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md
@@ -1,0 +1,117 @@
+# R1 Stage 5A — Control-Fixture Discovery Record v1
+
+**Status:** Drafted for independent review on 2026-07-02.
+
+This is a documentation-only discovery record. It does not claim to recover lost historical fixture semantics and it does not authorise any implementation.
+
+## 1. Purpose and boundary
+
+Stage 5A investigates two names explicitly reserved by the R1 reconstruction contract:
+
+- `wregoe_dual_dodec_control`
+- `plateau_30_vs_60_case`
+
+The only question in scope is whether the current repository contains enough deterministic, reviewable evidence to assign either name a precise proof role in a later DEV-only R1 stage.
+
+Stage 5A does not add or change:
+
+- application code;
+- R1 fixture data;
+- Stage 2B assessment semantics;
+- Stage 4B Plan Fit semantics;
+- the DEV lab UI;
+- normal routes, navigation, providers, stores, APIs, network, persistence, production assets, configuration, deployment, scoring, ranking, recommendation, planning, or exports.
+
+## 2. Sources inspected
+
+This discovery is based only on the current canonical repository at the Stage 4C closeout baseline.
+
+1. `docs/ai/R1_RECONSTRUCTION_CONTRACT_V1.md`
+   - It explicitly names both controls and says neither is part of Stage 2B unless a later written contract gives it a specific proof role.
+2. `frontend-v2/src/lab/r1-assessment-lab/core/fixtures.ts`
+   - The active fixture registry contains five fixture IDs only:
+     - `compact_sufficient_case`
+     - `incomplete_evidence_case`
+     - `contradictory_allocation_case`
+     - `fake_flexibility_case`
+     - `remote_materials_carrier_case`
+3. `frontend-v2/src/lab/r1-assessment-lab/core/types.ts`
+   - It defines the minimum current fixture shape: `fixtureId`, `fixtureRevision`, immutable fixture evidence with fixture provenance, and requirement evaluations.
+4. Repository-wide source search for both reserved names.
+   - No current source, test, or document reference beyond the Stage 2B reconstruction contract was found.
+
+## 3. Evidence finding
+
+Neither reserved name has a recoverable current fixture payload.
+
+For each name, the repository lacks all of the following:
+
+- a fixture revision;
+- evidence facts and fixture provenance;
+- requirement evaluation rows;
+- exact expected Assessment state or carrier-mode behavior;
+- structured conditions and evidence links;
+- a defined proof question;
+- a stated relation to an accepted invariant;
+- a test assertion;
+- an accepted Stage 4B Plan Fit interaction, if any.
+
+The names themselves are not sufficient evidence from which to infer those missing semantics.
+
+## 4. Per-control outcome
+
+### 4.1 `wregoe_dual_dodec_control`
+
+**Finding:** Not admitted to the active R1 fixture registry.
+
+**Reason:** The current repository contains only the name in a deferral note. It contains no deterministic payload, expected output, or proof role. The name must not be used to infer system-specific, station-specific, material, market, logistics, or planning semantics.
+
+**Stage 5A result:** No fixture, test, UI option, Assessment behavior, or Plan Fit behavior is authorised for this name.
+
+### 4.2 `plateau_30_vs_60_case`
+
+**Finding:** Not admitted to the active R1 fixture registry.
+
+**Reason:** The current repository contains only the name in a deferral note. It contains no deterministic payload, expected output, threshold definition, capacity interpretation, or proof role. The name must not be used to infer a numerical rule, comparison rule, threshold, ranking, recommendation, or planning outcome.
+
+**Stage 5A result:** No fixture, test, UI option, Assessment behavior, or Plan Fit behavior is authorised for this name.
+
+## 5. Non-inference rule
+
+A later R1 stage must not create semantics for either reserved name from:
+
+- the wording of the name;
+- lost-worktree recollection;
+- chat history alone;
+- assumptions about Wregoe, Dodecs, capacity, or colonisation mechanics;
+- an apparent numerical comparison;
+- an inferred best, preferred, recommended, or ranked result.
+
+A future fixture can be a forward reconstruction only after its proof role and payload are explicitly approved. It must never be presented as recovered historical behaviour unless source evidence exists and is recorded separately.
+
+## 6. Re-admission gate for any later fixture
+
+Before either reserved name may enter code, a separate written contract must define, for that one fixture:
+
+1. the exact fixture ID and fixture revision;
+2. a narrow proof question that is not a score, rank, recommendation, winner, or production feature;
+3. a complete deterministic `FixtureAssessmentScenario` payload compatible with the then-current accepted types;
+4. fixture-owned evidence facts, each with availability and fixture provenance;
+5. exactly one requirement-evaluation row for every requirement in the selected template, including evidence ID lists and base outcomes;
+6. exact expected Assessment result(s), carrier-mode behavior, conditions, ordering, and proof assertions;
+7. whether the fixture has any Stage 4B Plan Fit role; absence is the default unless explicitly specified;
+8. the exact test additions and their expected assertions;
+9. a narrow file allowlist and explicit exclusions;
+10. an independent read-only review and separate owner authorisation before implementation.
+
+No current Stage 5A finding supplies items 1–9 for either name.
+
+## 7. Stage 5A conclusion
+
+The current evidence is insufficient to assign a responsible proof role to either deferred control. Both remain intentionally absent from the active R1 fixture registry.
+
+This is a successful discovery result: it preserves the existing deterministic boundary by refusing to invent semantics. It does not block future forward reconstruction, but it does require a new, explicit, evidence-backed contract before either name can be introduced.
+
+## 8. Next safe action
+
+Obtain an independent read-only review of this discovery record and the corresponding `CURRENT_STAGE.md` update. Do not create an implementation branch, modify fixtures, tests, R1 core, the DEV lab UI, the normal app, or deployment configuration until the owner accepts the reviewed Stage 5A conclusion and separately authorises any later stage.


### PR DESCRIPTION
Documentation-only Stage 5A R1 control-fixture discovery.

- inspects the deferred names `wregoe_dual_dodec_control` and `plateau_30_vs_60_case`;
- records that neither has a current recoverable fixture payload, expected outcome, or deterministic proof role;
- keeps both names absent from the active R1 fixture registry rather than inventing semantics from their names;
- defines the explicit evidence and contract gate required before either could enter a later DEV-only forward-reconstruction stage;
- updates the authoritative stage record and adds `R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`;
- changes no code, fixture data, tests, UI, configuration, normal app behavior, production artifact, or deployment configuration.

This PR does not authorise an implementation. `DECISIONS.md` is deliberately unchanged until the discovery conclusion has independent review and owner acceptance.