### PR TITLE
docs: draft Stage 5B R1 evidence discipline

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,129 +4,91 @@
 
 ## Status
 
-**Stage 5A docs-only R1 control-fixture discovery drafted — awaiting independent review and owner acceptance.**
+**Stage 5B docs-only R1 evidence-discipline contract drafted — awaiting independent review and owner acceptance.**
 
 ## Baseline
 
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Stage 5A documentation branch: `docs/r1-stage5a-control-fixture-discovery`
-- Stage 5A documentation base SHA: `fe06439132f52c9ccae5c4652f10de838b5ec445`
-- Stage 4B contract PR: `#284`, merged
-- Stage 4B contract merge commit: `411ceb9232966bf27aa027d72aa5622c83ee0d03`
-- Stage 4B implementation PR: `#286`, merged
-- Stage 4B implementation merge commit: `0565a60428904c4fe234f500e05be9871adb5c6d`
-- Stage 4B reviewed implementation head: `9f69061c3d625dc111864061166287407e6336c0`
-- Stage 4B was independently reviewed and owner-accepted before merge.
-- Stage 4C contract PR: `#287`, merged
-- Stage 4C contract merge commit: `18464de5a204a109fe145eb4e64a8500b59eaee5`
-- Stage 4C implementation PR: `#288`, merged
-- Stage 4C implementation merge commit: `5017b713627600887cefc781066c3a6eacfdbcba`
+- Stage 5B documentation branch: `docs/r1-stage5b-evidence-discipline`
+- Stage 5B documentation base SHA: `dad3a99f4571428fcb517a13785be297f57e875a`
+- Stage 5A discovery PR: `#290`, merged
+- Stage 5A review head: `36371887bf09dad420c86b6c6ca6faffb7cfa0cd`
+- Stage 5A merge commit: `dad3a99f4571428fcb517a13785be297f57e875a`
+- Stage 5A was independently reviewed and owner-accepted before merge.
+- Stage 4C acceptance closeout PR: `#289`, merged at `fe06439132f52c9ccae5c4652f10de838b5ec445`
+- Stage 4C implementation PR: `#288`, merged at `5017b713627600887cefc781066c3a6eacfdbcba`
 - Stage 4C accepted code commit: `4eabc24ba9b428c2902fa2221c15b7d5371d0433`
-- Stage 4C acceptance closeout PR: `#289`, merged
-- Stage 4C acceptance closeout merge commit: `fe06439132f52c9ccae5c4652f10de838b5ec445`
-- Stage 3B PR: `#282` — `Stage 3B: DEV-only R1 assessment lab`, merged
-- Stage 3B merge commit: `98b4bacf1d799e7937b449210046659b3e96615b`
-- Stage 2B pure R1 assessment-domain core: PR `#280`, merged at `220c870f89a5af7f98adb88578373dbc3a681a9c`.
+- Stage 4B implementation PR: `#286`, merged at `0565a60428904c4fe234f500e05be9871adb5c6d`
+- Stage 4B contract PR: `#284`, merged at `411ceb9232966bf27aa027d72aa5622c83ee0d03`
+- Stage 3B PR: `#282`, merged at `98b4bacf1d799e7937b449210046659b3e96615b`
+- Stage 2B pure assessment core: PR `#280`, merged at `220c870f89a5af7f98adb88578373dbc3a681a9c`
 - No deployment occurred.
 
-## Active Stage 5A discovery record
+## Stage 5A accepted record
 
 - Discovery record: `docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`
-- Stage 5A is documentation-only.
-- It investigates the deferred names `wregoe_dual_dodec_control` and `plateau_30_vs_60_case` only to determine whether current repository evidence supports a precise later proof role.
-- Stage 5A does not assign either name new semantics, create a fixture, change a test, or authorise any implementation.
-- The documented finding is that neither name has a recoverable current fixture payload or deterministic proof role; both remain absent from the active registry pending a separate, explicit future contract.
-- No implementation is authorised by this discovery record.
+- Accepted conclusion: the canonical repository does not contain enough evidence to reconstruct semantics for `wregoe_dual_dodec_control` or `plateau_30_vs_60_case` as historic R1 controls.
+- Neither name is admitted to the active fixture registry, tests, Assessment semantics, Plan Fit semantics, UI, or normal product behavior.
+- This is a non-inference rule, not a claim that those controls never had historical meanings.
+- The durable accepted decision is appended in `docs/ai/DECISIONS.md`.
+- Any later forward reconstruction requires an explicit proof question, deterministic payload, traceable evidence, expected outputs, tests, independent review, and separate owner authorisation.
 
-## Stage 5A allowed files
+## Active Stage 5B contract
+
+- Contract file: `docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md`
+- Stage 5B adopts a proposed evidence-chain discipline for later R1 forward reconstruction:
+
+```text
+source record
+→ normalized evidence fact
+→ named programme requirement or constraint
+→ requirement outcome
+→ bounded Assessment or Plan Fit consequence
+```
+
+- The contract distinguishes repository evidence, external observed evidence, owner-provided forward-design intent, deterministic fixture representation, and derived evidence facts.
+- Owner-provided intent may authorise forward design but does not establish lost historical semantics or turn unknown game facts into known facts.
+- Missing, contradictory, stale, incomplete, or out-of-scope evidence must limit the conclusion; it cannot be silently treated as a positive.
+- No comparison may begin with total body count. A programme must first define finite, named requirements and constraints.
+- The illustrative `plateau_30_vs_60_case` principle is proposed only as a capacity-sufficiency rule: surplus bodies are neutral only where they change no named requirement or constraint. It is not a universal 30-body threshold, score, rank, recommendation, preference, or best-system rule.
+- A larger system may differ materially where extra bodies add a named required capability or resolve a named constraint.
+- The immediate deliverable is this documentation-only contract. No system evidence inventory, fixture, test, UI, code, live query, or implementation is authorised by Stage 5B.
+
+## Stage 5B allowed files
 
 - `docs/ai/CURRENT_STAGE.md`
-- `docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`
+- `docs/ai/DECISIONS.md`
+- `docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md`
 
-`docs/ai/DECISIONS.md` remains unchanged until the owner accepts the independently reviewed Stage 5A conclusion.
+## Stage 5B exact non-goals
 
-## Stage 5A non-goals
+Stage 5B does not add or change:
 
-Stage 5A does not add or change:
-
-- R1 fixture data;
-- R1 core types, Assessment semantics, or Plan Fit semantics;
-- R1 lab UI;
-- normal application behavior, routes, navigation, providers, stores, APIs, network, or persistence;
-- production assets, configuration, build behavior, deployment, exports, reports, scoring, ranking, recommendation, or planning;
-- claims of recovered historical semantics.
-
-## Stage 5A evidence boundary
-
-- `docs/ai/R1_RECONSTRUCTION_CONTRACT_V1.md` names both controls only as deferred controls requiring a later written contract with a specific proof role.
-- The active `R1_ASSESSMENT_FIXTURES` registry contains five fixtures only: `compact_sufficient_case`, `incomplete_evidence_case`, `contradictory_allocation_case`, `fake_flexibility_case`, and `remote_materials_carrier_case`.
-- Repository-wide source search found no current source, test, or document reference to either deferred name beyond the deferral note.
-- Fixture names alone are insufficient evidence from which to infer a Wregoe, Dodec, numerical-threshold, capacity, logistics, material, planning, ranking, or recommendation rule.
-
-## Stage 4C acceptance checkpoint
-
-- Status: Accepted and merged.
-- Accepted code commit: `4eabc24ba9b428c2902fa2221c15b7d5371d0433`
-- Acceptance date: `2026-07-02`
-- Branch: `feat/r1-stage4c-plan-fit-lab`
-- Pull request: `#288`, merged at `5017b713627600887cefc781066c3a6eacfdbcba`
-- Documentation-only acceptance checkpoint commit: `2db42b27852f7cae19d0fa7754991cf530845b8c`
-- Documentation closeout record: PR `#289`, merged at `fe06439132f52c9ccae5c4652f10de838b5ec445`
-- Evidence reviewed:
-  - Independent read-only Stage 4C implementation review at `4eabc24ba9b428c2902fa2221c15b7d5371d0433`, verdict: ready for owner acceptance.
-  - Reported focused UI test, unchanged Stage 2B and Stage 4B core tests, full test suite, typecheck, lint, and production build.
-  - Reported deployable `JS/CSS/HTML` artifact scan with no matches for existing DEV-only R1 identifiers or the Stage 4 identifiers recorded below.
-- Caveats:
-  - The acceptance checkpoint was recorded in a post-merge documentation repair. It did not reopen product-code review.
-  - The reported full suite retained pre-existing `act(...)` warnings from `src/features/my-work/MyWorkWorkspace.test.tsx`.
-  - The reported production build retained pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
-  - No deployment occurred.
-
-## Accepted Stage 4C record
-
-- Contract file: `docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`
-- Stage 4C implemented only the accepted DEV-only, fixture-backed, deterministic, local presentation slice inside the existing R1 Assessment Laboratory.
-- Its code change was restricted to `R1AssessmentLabApp.tsx` and `R1AssessmentLabApp.test.tsx`; the stage record was the only documentation file changed.
-- No Stage 2B or Stage 4B core file, production behavior, routing, persistence, network, API, recommendation, scoring, ranking, planning behavior, deployment, or production asset change was included.
+- R1 fixture data, types, templates, requirements, conditions, Assessment semantics, or Plan Fit semantics;
+- R1 core, tests, DEV-lab UI, routes, normal navigation, providers, stores, APIs, network behavior, persistence, configuration, build behavior, production assets, exports, reports, or deployment;
+- a universal threshold, score, rank, recommendation, preference, winner, best-system result, or automatic selection;
+- live runtime data dependence or a claim of recovered historical semantics;
+- an external system evidence inventory or a later implementation stage.
 
 ## Preserved merged invariants
 
+- The R1 laboratory remains DEV-only, fixture-backed, deterministic, and local.
 - The lab exposes exactly five closed local select controls: Fixture, Lens kind, Lens value, Carrier mode, and Strategy.
-- The first four selector IDs, values, defaults, ordering, and semantics remain unchanged. Strategy is explicit local DEV-lab context only, with the fixed options `baseline_local_strategy` and `remote_logistics_strategy`; it is not inferred from fixture, assessment state, carrier mode, or lens.
-- Five fixture IDs and three carrier modes are selectable; the six approved fixture/scenario state rows are test assertions, not six fixtures.
-- The fixed template is displayed read-only.
-- The selected Role/Question lens is passed to the evaluator and visibly displayed as context only. Changing it does not alter fixture outcomes, conditions, requirement results, frozen evidence/provenance, state, Plan Fit output, or ordering in this slice.
-- Accepted Stage 4B Plan Fit output remains bounded pure-core logic subordinate to accepted Stage 2B assessment results.
-- Stage 4C presents returned Assessment and Plan Fit scenario output without deriving, rewriting, or recalculating it.
-- `compare_both` preserves `no_carrier` then `carrier_available` order.
+- Lens remains explicit context only; it does not alter accepted fixture outcomes, conditions, evidence, state, Plan Fit output, or ordering.
+- Strategy remains explicit local DEV-lab context only, with fixed `baseline_local_strategy` and `remote_logistics_strategy` options; it is not inferred.
+- Carrier behavior remains bounded to accepted logistics-sensitive outcomes. `compare_both` preserves `no_carrier` then `carrier_available` order.
+- Stage 4B Plan Fit remains subordinate to accepted Stage 2B Assessment output.
+- No production behavior, scoring, ranking, recommendation, strategy inference, planning behavior, or deployment is introduced.
 
 ## Caveats
 
 - No deployment occurred.
-- Stage 4B and Stage 4C are merged and accepted.
-- Stage 5A is a documentation-only discovery record and introduces no production behavior, recommendation, ranking, scoring, strategy inference, planning behavior, fixture change, test change, or code change.
-- Local validation reported on the Stage 4C implementation branch:
-  - `yarn test "src/lab/r1-assessment-lab/R1AssessmentLabApp.test.tsx"`
-  - `yarn test "src/lab/r1-assessment-lab/core/evaluateAssessment.test.ts"`
-  - `yarn test "src/lab/r1-assessment-lab/core/evaluatePlanFit.test.ts"`
-  - `yarn test`
-  - `yarn typecheck`
-  - `yarn lint`
-  - `yarn build`
-  - production deployable `JS/CSS/HTML` scan for existing DEV-only R1 identifiers plus:
-    - `baseline_local_strategy`
-    - `remote_logistics_strategy`
-    - `no_plan_fit`
-    - `blocked_plan_fit`
-    - `provisional_plan_fit`
-    - `gate:not_assessable`
-    - `gate:not_supported`
-    - `dependency:`
-- The reported production build retained the pre-existing Coalsack asset-resolution warnings and the existing chunk-size warning.
+- Stage 5B is proposed documentation, not an accepted new semantic rule until independently reviewed and owner-accepted.
+- Earlier Stage 4C validation evidence remains historical implementation evidence only; no validation commands are required or implied for this documentation-only stage.
 
 ## Next safe action
 
-Obtain an independent read-only review of the Stage 5A discovery record and this stage record. Do not create an implementation branch, edit R1 fixtures, tests, core, or UI, change the normal application, merge a new implementation, or deploy until the owner accepts the reviewed Stage 5A conclusion and separately authorises any later stage.
+Obtain an independent read-only review of the Stage 5B evidence-discipline contract, the Stage 5A accepted decision entry, and this stage record. Do not collect external system evidence, create a fixture, edit R1 code/tests/UI, change the normal application, merge a new implementation, or deploy until the owner accepts the reviewed Stage 5B contract and separately authorises any later evidence-inventory stage.
 
 ## Recovery instruction
 

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -74,8 +74,10 @@ Stage 5B does not add or change:
 
 - The R1 laboratory remains DEV-only, fixture-backed, deterministic, and local.
 - The lab exposes exactly five closed local select controls: Fixture, Lens kind, Lens value, Carrier mode, and Strategy.
+- The first four selector IDs, values, defaults, ordering, and semantics remain unchanged. Strategy is explicit local DEV-lab context only, with fixed `baseline_local_strategy` and `remote_logistics_strategy` options; it is not inferred.
+- Five fixture IDs and three carrier modes are selectable; the six approved fixture/scenario state rows are test assertions, not six fixtures.
+- The fixed template is displayed read-only.
 - Lens remains explicit context only; it does not alter accepted fixture outcomes, conditions, evidence, state, Plan Fit output, or ordering.
-- Strategy remains explicit local DEV-lab context only, with fixed `baseline_local_strategy` and `remote_logistics_strategy` options; it is not inferred.
 - Carrier behavior remains bounded to accepted logistics-sensitive outcomes. `compare_both` preserves `no_carrier` then `carrier_available` order.
 - Stage 4B Plan Fit remains subordinate to accepted Stage 2B Assessment output.
 - No production behavior, scoring, ranking, recommendation, strategy inference, planning behavior, or deployment is introduced.

--- a/docs/ai/DECISIONS.md
+++ b/docs/ai/DECISIONS.md
@@ -119,3 +119,17 @@ Lens remains context-only. Carrier behavior remains entirely provided by accepte
 
 **Evidence / reference**
 `docs/ai/R1_STAGE4C_PLAN_FIT_LAB_PRESENTATION_CONTRACT_V1.md`; owner approval to draft the Stage 4C presentation contract on 2026-07-02.
+
+## 2026-07-02 — Stage 5A defers unsupported control-fixture semantics
+
+**Decision**
+`wregoe_dual_dodec_control` and `plateau_30_vs_60_case` remain absent from the active R1 fixture registry. Their names alone do not authorise fixture data, Assessment behavior, Plan Fit behavior, tests, UI controls, or an interpretation of lost historical R1 semantics.
+
+**Reason**
+The reconstruction contract named both controls only as deferred. Independent review confirmed that the current repository contains no recoverable fixture payload, expected outcome, condition definition, test assertion, or specific proof role for either name beyond that deferral.
+
+**Invariant**
+A later forward-reconstruction fixture for either name requires an explicit written contract defining its proof question, deterministic payload, evidence and provenance, requirement evaluations, expected outputs, tests, file boundary, independent review, and separate owner authorisation. No later work may infer semantics from the fixture name, lost-worktree recollection, chat history alone, unrelated Wregoe/Dodec uses elsewhere in the repository, or a numerical comparison.
+
+**Evidence / reference**
+`docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`; Stage 5A reviewed head `36371887bf09dad420c86b6c6ca6faffb7cfa0cd`; PR `#290`, merged at `dad3a99f4571428fcb517a13785be297f57e875a`; owner acceptance on 2026-07-02.

--- a/docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md
+++ b/docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md
@@ -1,0 +1,227 @@
+# R1 Stage 5B — Evidence Discipline Contract v1
+
+**Status:** Drafted for independent review on 2026-07-02.
+
+This is a documentation-only forward-design contract. It establishes the evidence standard for a possible later R1 capacity-sufficiency investigation. It does not claim to recover historical R1 behavior and it does not authorize any fixture, code, UI, production behavior, external lookup, or implementation.
+
+## 1. Governing rule
+
+No R1 assessment, Plan Fit result, comparison statement, or later forward-reconstruction conclusion may be stronger than the traceable evidence chain supporting it.
+
+A valid conclusion has this shape:
+
+```text
+source record
+→ normalized evidence fact
+→ named programme requirement or constraint
+→ requirement outcome
+→ bounded Assessment or Plan Fit consequence
+```
+
+Every arrow must be inspectable. A missing, contradictory, stale, out-of-scope, or unsupported arrow limits the conclusion accordingly.
+
+## 2. Scope
+
+This contract governs only the evidence discipline for a potential future capacity-sufficiency plateau control, provisionally associated with the deferred name `plateau_30_vs_60_case`.
+
+The owner-provided forward-design intent is:
+
+> Once a system meets every explicit requirement for a defined extraction/refining programme, additional bodies that do not satisfy an otherwise unmet requirement or resolve an otherwise present constraint are neutral. Raw total body count must not create a linear score, rank, recommendation, preference, or automatic conclusion.
+
+This is forward-design intent. It is not evidence of lost historical R1 semantics and must never be labelled as such.
+
+The values `30` and `60` are illustrative labels only. They are not universal thresholds, general Elite Dangerous facts, or requirements in themselves.
+
+## 3. Exact non-goals
+
+Stage 5B does not add or change:
+
+- any R1 fixture, requirement, condition, template, Assessment result, or Plan Fit result;
+- any R1 core, test, DEV-lab UI, route, navigation item, provider, store, API, persistence behavior, network request, or production asset;
+- a universal body-count threshold;
+- a score, rank, best-system result, recommendation, preference, winner, or automatic selection;
+- live-data dependence at runtime;
+- a claim that any historical R1 fixture meaning has been recovered;
+- an implementation stage, deployment, or system scouting result.
+
+## 4. Source classes and labelling
+
+Every evidence fact used in a later R1 contract must identify its source class and provenance. The permitted classes are:
+
+### 4.1 Repository evidence
+
+A fact recorded in the canonical repository.
+
+Required provenance:
+
+- repository path;
+- exact commit SHA or immutable ref;
+- relevant line, object, or record identifier;
+- retrieval date;
+- scope of what the source does and does not establish.
+
+Repository evidence may establish accepted project contracts, current fixture content, existing types, accepted test behavior, or durable decisions. It cannot establish lost behavior that is absent from the repository.
+
+### 4.2 External observed evidence
+
+A fact from a public, attributable source about a real system or game state.
+
+Required provenance:
+
+- source name and stable reference;
+- canonical system identifier;
+- retrieval date and time;
+- data field or display location used;
+- whether the fact is direct, inferred, incomplete, stale, or conflicting;
+- any material caveat about source coverage or update timing.
+
+External observed evidence may support a forward reconstruction input. It must not be used as a live runtime dependency for the DEV-only lab.
+
+### 4.3 Owner-provided forward-design intent
+
+A requirement, boundary, definition, or objective explicitly supplied by the owner.
+
+Required provenance:
+
+- date of owner statement;
+- concise statement of the accepted intent;
+- distinction between a design decision and an observed game fact;
+- the later contract or decision record that adopts it.
+
+Owner intent may authorise a future forward reconstruction. It does not establish historic R1 semantics or convert an unknown external fact into a known fact.
+
+### 4.4 Fixture representation
+
+A deterministic, local evidence representation admitted by a later written contract.
+
+Required provenance:
+
+- fixture ID and revision;
+- the precise source facts or owner-approved design inputs represented;
+- explicit transformation or normalization rules;
+- an exact mapping from source evidence IDs to fixture evidence IDs;
+- an explicit statement of what was intentionally omitted.
+
+A fixture is a bounded representation, not an independent source of truth.
+
+### 4.5 Derived evidence fact
+
+A transparent conclusion computed from one or more prior evidence facts.
+
+Required provenance:
+
+- derived fact ID;
+- ordered dependency IDs;
+- deterministic derivation rule;
+- resulting value;
+- scope and limitations;
+- explanation of why the derivation does not create a score, rank, preference, or recommendation.
+
+A derived fact must never hide a qualitative judgement behind a raw count or aggregate.
+
+## 5. Evidence status rules
+
+Each fact must be treated as one of:
+
+- **known:** directly established within the stated source scope;
+- **missing:** required evidence was not supplied or could not be verified;
+- **contradictory:** credible sources or records conflict;
+- **not applicable:** the named requirement does not apply in this programme context;
+- **derived:** transparently computed from identified known facts, with its derivation recorded.
+
+Rules:
+
+1. Missing evidence is not a positive fact.
+2. Contradictory evidence is not averaged, guessed away, or silently treated as sufficient.
+3. An incomplete or stale source must not be represented as complete current knowledge.
+4. A source outside the stated programme scope must not satisfy a requirement merely because it is favorable in another scope.
+5. A claim may be no broader than the least-supported evidence fact or derivation in its chain.
+
+## 6. Programme-first comparison rule
+
+No system comparison may begin with total body count.
+
+Before comparing candidate systems, the relevant programme/template must define a finite requirement table. For every requirement, the table must specify:
+
+- requirement ID and neutral label;
+- kind: eligibility, capacity, logistics, or constraint;
+- whether it is mandatory;
+- the exact capability or constraint being assessed;
+- the admissible evidence fields;
+- the success condition;
+- the treatment of missing or contradictory evidence;
+- whether carrier mode could affect it under the accepted R1 boundaries;
+- the exact reason extra bodies could or could not change it.
+
+Total body count may be recorded as context. It cannot be a proxy for capability, capacity, quality, or desirability unless a later contract explicitly defines a bounded requirement that uses a count and supplies its evidence basis.
+
+## 7. Capacity-sufficiency plateau rule
+
+A later control may test a plateau only after the programme requirements in Section 6 are explicit.
+
+For two candidate systems, a larger total body count is neutral only when all of the following are evidenced:
+
+1. The smaller candidate meets every mandatory programme requirement.
+2. The larger candidate also meets every mandatory programme requirement.
+3. Each additional body or group of bodies in the larger candidate does not:
+   - satisfy a requirement unmet by the smaller candidate;
+   - add a distinct required material or output coverage;
+   - add a qualifying body type, slot, capacity, or validated logistics capability relevant to a named requirement;
+   - resolve a shared or non-shared constraint present in the smaller candidate;
+   - change an accepted carrier-sensitive logistics outcome;
+   - introduce a separately defined required capability.
+4. The comparison does not hide any non-count distinction that changes a named requirement or constraint.
+
+When all four conditions hold, raw surplus body count must not by itself change the resulting requirement outcomes, Assessment state, conditions, Plan Fit state, or Plan Fit reasons.
+
+The converse is equally important: a larger system may differ materially when its extra bodies change a named requirement or constraint. This contract does not declare large systems neutral by default.
+
+## 8. Required evidence inventory before a later fixture contract
+
+Before any fixture implementation is proposed, a read-only evidence inventory must provide four categories of candidate evidence:
+
+1. **Below-sufficiency candidate:** at least one named mandatory requirement remains unmet or unknown.
+2. **Sufficient baseline candidate:** every named mandatory requirement is evidenced as met with a comparatively lower relevant-body count.
+3. **Neutral-surplus candidate:** materially more total bodies than the baseline, with evidence that the additional bodies alter no named requirement or constraint.
+4. **Additive-surplus candidate:** more bodies and evidence that the additional bodies do add a named capability or resolve a named constraint.
+
+For each candidate, the inventory must record:
+
+- total body count where known, clearly labelled as context;
+- counts of bodies relevant to each named requirement;
+- body types, slots, material/output coverage, and logistics facts used by each requirement;
+- source records and retrieval times;
+- direct versus inferred facts;
+- missing and contradictory information;
+- a per-extra-body or per-extra-group explanation of whether it changes any named requirement or constraint.
+
+The inventory may conclude that the available evidence is insufficient. That is a valid result and must not be resolved by assumption.
+
+## 9. Deterministic fixture admission rules
+
+A later fixture may be proposed only after the evidence inventory is reviewed and an owner-approved written contract supplies:
+
+1. an exact fixture ID and revision;
+2. one narrow proof question;
+3. the selected template and every requirement evaluation row;
+4. complete fixture-owned evidence facts with provenance;
+5. exact expected Assessment scenario results and ordered conditions;
+6. a statement of any permitted carrier effect;
+7. a statement of whether Plan Fit is relevant; absence is the default;
+8. exact tests proving the plateau and additive-surplus contrasts;
+9. a narrow file allowlist and explicit non-goals;
+10. an independent read-only review and separate owner authorisation before implementation.
+
+No fixture may be admitted merely because it has a familiar name, a compelling narrative, a larger number, or a plausible-looking data set.
+
+## 10. Presentation boundary
+
+Any later DEV-only presentation must render the evidence chain without turning it into an opaque total.
+
+It may show neutral, traceable information such as source scope, evidence IDs, requirement IDs, availability, conditions, and caveats. It must not introduce scoring, ranking, recommendation, best-system claims, traffic-light shorthand, or automatic selection.
+
+## 11. Stage 5B deliverable and next safe action
+
+The immediate Stage 5B deliverable is this reviewed evidence-discipline contract only.
+
+After owner acceptance, the next safe action would be a separately authorised, read-only evidence inventory under Section 8. That inventory would gather and assess evidence; it would not alter R1 code or create a fixture.


### PR DESCRIPTION
Documentation-only Stage 5B evidence-discipline contract.

- records the owner’s forward-design requirement that no R1 conclusion is stronger than its traceable evidence chain;
- defines source classes, provenance, status handling, derivation rules, and programme-first comparison requirements;
- defines a bounded capacity-sufficiency plateau discipline: surplus bodies are neutral only when they change no named requirement or constraint;
- states that `30` and `60` are illustrative labels, not universal thresholds;
- preserves the prohibition on scores, ranks, recommendations, preferences, automatic selection, and inferred historic semantics;
- records the already accepted Stage 5A non-inference decision in `DECISIONS.md`;
- changes docs only: `CURRENT_STAGE.md`, `DECISIONS.md`, and `R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md`.

This PR does not collect external system evidence, create a fixture, change R1 code/tests/UI, or authorise any implementation. Independent review and owner acceptance are required before a later read-only evidence inventory can be proposed.