### PR TITLE
docs: correct Stage 5 closeout status

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-**Stage 5A and Stage 5B are accepted and merged. Documentation-only acceptance-and-provenance closeout is drafted — awaiting independent review and owner merge authorisation.**
+**Stage 5A and Stage 5B are accepted and merged. The documentation-only acceptance-and-provenance closeout merged in PR `#292` at `1b7b36b4c411e50ad102adadd51339653476b68d`; no later external research, fixture, code, test, UI, implementation, or deployment work is authorised.**
 
 ## Baseline
 
@@ -93,7 +93,7 @@ source record
 
 ## Next safe action
 
-Obtain an independent read-only review of this documentation-only acceptance-and-provenance closeout. Do not collect external system evidence, create a fixture, edit R1 code/tests/UI, change the normal application, merge a later implementation, or deploy. Merge of this closeout itself remains a separate owner decision after review.
+Await separate owner authorisation for a later bounded stage. Do not collect external system evidence, create a fixture, edit R1 code/tests/UI, change the normal application, or deploy. Any later documentation or implementation pull request requires its own scoped review and owner merge authorisation.
 
 ## Recovery instruction
 

--- a/docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md
+++ b/docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md
@@ -1,6 +1,6 @@
 # R1 Stage 5A and Stage 5B — Acceptance and Provenance Closeout v1
 
-**Status:** Drafted for independent review on 2026-07-02.
+**Status:** Accepted and merged in PR `#292` at `1b7b36b4c411e50ad102adadd51339653476b68d` on 2026-07-02.
 
 This documentation-only closeout repairs missing durable acceptance records and records the provenance of the owner-provided forward-design input used by Stage 5B. It is the limited, durable amendment for Stage 5B acceptance metadata and owner-intent provenance. It does not alter R1 fixture data, Assessment semantics, Plan Fit semantics, tests, UI, normal application behavior, external research authority, implementation authority, or deployment behavior.
 
@@ -54,6 +54,6 @@ This closeout records those facts without reopening the reviewed Stage 5A discov
 
 ## 5. Next safe action
 
-No external system research, fixture, code, test, UI, implementation, merge beyond this closeout, or deployment is authorised by this record.
+No external system research, fixture, code, test, UI, implementation, or deployment is authorised by this record. This closeout was merged in PR `#292` at `1b7b36b4c411e50ad102adadd51339653476b68d`; any later pull request or merge requires separate owner authorisation.
 
 A later stage must first be separately authorised. The next plausible stage would be a documentation-only programme-definition contract that makes explicit that a capacity plateau is programme-relative: surplus may be neutral for extraction/refining while the same evidence can remain relevant to separate named programmes or constraints. That later stage must not be inferred as authorised by this closeout.


### PR DESCRIPTION
Superseded by merged PR #294, which applied the intended Stage 5 closeout status correction. No semantic Stage 5A/5B change is retained on this branch.