### PR TITLE
docs: correct Stage 5 closeout merge status

### DIFF
--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-**Stage 5A and Stage 5B are accepted and merged. Documentation-only acceptance-and-provenance closeout is drafted — awaiting independent review and owner merge authorisation.**
+**Stage 5A and Stage 5B are accepted and merged. The documentation-only acceptance-and-provenance closeout merged in PR `#292` at `1b7b36b4c411e50ad102adadd51339653476b68d`.**
 
 ## Baseline
 
@@ -93,7 +93,7 @@ source record
 
 ## Next safe action
 
-Obtain an independent read-only review of this documentation-only acceptance-and-provenance closeout. Do not collect external system evidence, create a fixture, edit R1 code/tests/UI, change the normal application, merge a later implementation, or deploy. Merge of this closeout itself remains a separate owner decision after review.
+No further work is authorised by this closeout. Do not collect external system evidence, create a fixture, edit R1 code/tests/UI, change the normal application, merge a later implementation, or deploy. Any later programme-definition or evidence-inventory stage requires separate owner authorisation.
 
 ## Recovery instruction
 

--- a/docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md
+++ b/docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md
@@ -1,6 +1,6 @@
 # R1 Stage 5A and Stage 5B — Acceptance and Provenance Closeout v1
 
-**Status:** Drafted for independent review on 2026-07-02.
+**Status:** Accepted and merged in PR `#292` at `1b7b36b4c411e50ad102adadd51339653476b68d` on 2026-07-02.
 
 This documentation-only closeout repairs missing durable acceptance records and records the provenance of the owner-provided forward-design input used by Stage 5B. It is the limited, durable amendment for Stage 5B acceptance metadata and owner-intent provenance. It does not alter R1 fixture data, Assessment semantics, Plan Fit semantics, tests, UI, normal application behavior, external research authority, implementation authority, or deployment behavior.
 
@@ -54,6 +54,6 @@ This closeout records those facts without reopening the reviewed Stage 5A discov
 
 ## 5. Next safe action
 
-No external system research, fixture, code, test, UI, implementation, merge beyond this closeout, or deployment is authorised by this record.
+This closeout is merged. No external system research, fixture, code, test, UI, implementation, later-stage merge, or deployment is authorised by this record.
 
 A later stage must first be separately authorised. The next plausible stage would be a documentation-only programme-definition contract that makes explicit that a capacity plateau is programme-relative: surplus may be neutral for extraction/refining while the same evidence can remain relevant to separate named programmes or constraints. That later stage must not be inferred as authorised by this closeout.


### PR DESCRIPTION
Narrow documentation-only post-merge status correction for the Stage 5A/5B acceptance-and-provenance closeout.

Changes exactly two files:
- `docs/ai/CURRENT_STAGE.md`
- `docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md`

It corrects stale wording that still described the closeout as drafted or awaiting review/owner merge authorisation, despite PR `#292` having merged at `1b7b36b4c411e50ad102adadd51339653476b68d`.

It preserves all Stage 5A and Stage 5B substantive rules and preserves the existing boundary that no external research, fixture, code, test, UI, implementation, or deployment work is authorised.

No changes to `DECISIONS.md`, code, fixtures, tests, UI, configuration, database access, research, or deployment.

Requires independent read-only review and separate owner acceptance before merge.