### PR TITLE
docs: establish system assessment continuity

### DIFF
--- a/docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md
+++ b/docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md
@@ -1,0 +1,192 @@
+# CPE System Assessment Roadmap v1
+
+**Status:** Drafted for independent review. Documentation-only programme roadmap.
+
+**Purpose:** Turn the accepted R1 Assessment Laboratory lineage into a durable, evidence-first future capability without burying it in generic planning work, duplicating CRE research truth, or prematurely creating a separate SRE repository.
+
+## 1. Target operating model
+
+```text
+CRE
+  Evidence, mechanics, provenance, observations, contradictions, uncertainty,
+  planner-safe knowledge releases, observed-state snapshots
+        ↓
+CPE / System Assessment Engine
+  Candidate-system assessment against an explicit programme, requirements,
+  Carrier scenario, and pinned CRE inputs
+        ↓
+CPE / Colony Plan Construction
+  Player-specific layouts, protected assets, sequence, alternatives,
+  trade-offs, validation gates
+        ↓
+ed-finder
+  Presentation, exploration, comparison display
+```
+
+## 2. Named CPE pillars
+
+### CPE / System Assessment Engine
+
+Evaluates a candidate system against an explicit colony programme. It owns:
+
+- programme templates and named requirements;
+- requirement evaluation;
+- assessment states and evidence/condition trace;
+- capacity-sufficiency and plateau controls;
+- Carrier scenarios;
+- Plan Fit for explicit strategies;
+- candidate-system comparison within compatible programme/scenario context;
+- comparison-ready, caveated outputs.
+
+It does **not** own raw research evidence, source provenance, mechanics, confidence/contradiction resolution, player-plan construction, or presentation.
+
+### CPE / Colony Plan Construction
+
+Turns an assessed system and player intent into candidate plans. It owns:
+
+- objectives, preferences, risk tolerance, protected assets, and prohibited actions;
+- candidate layouts, facility choices, sequencing, alternatives, and trade-offs;
+- expected effects and validation gates;
+- plan-specific outputs.
+
+It consumes System Assessment; it must not silently recreate its requirement logic or CRE research truth.
+
+## 3. R1 continuity rule
+
+The R1 Assessment Laboratory in `ed-finder` remains a **frozen DEV-only prototype and CPE control-suite lineage**.
+
+Future CPE work must:
+
+- preserve accepted R1 semantics;
+- reimplement them against equivalent controls;
+- keep the R1 lab unchanged as reference until the CPE controls pass;
+- never copy fixture payloads into CPE as real-world facts;
+- never infer semantics for deferred controls from their names, chat history, or unrelated repository references.
+
+## 4. Hard rules
+
+1. Assessment state is primary; Plan Fit is secondary and explicit-strategy-gated.
+2. Missing, contradictory, stale, incomplete, unsupported, or out-of-scope evidence must remain visible. It cannot silently become positive.
+3. Carrier effects are limited to accepted carrier-sensitive, non-shared logistics requirements.
+4. No universal score, rank, winner, recommendation, or automatic selection is introduced before requirement-level assessment and controls justify it.
+5. No candidate-system comparison begins with raw total body count.
+6. Extra bodies are neutral only when every mandatory requirement is met and they change no named requirement or constraint.
+7. `plateau_30_vs_60_case` and `wregoe_dual_dodec_control` remain out of code until a CRE-backed evidence inventory and later admission contract exist.
+8. CPE consumes pinned CRE publications. It must not recreate CRE evidence truth or access CRE private storage.
+9. No merge is complete until the continuity records are updated under the merge-closeout protocol.
+
+## 5. Programme roadmap
+
+| Phase | Status at this roadmap baseline | Deliverable | Gate before next phase |
+|---|---|---|---|
+| **Cleanup 0** — Stage/status hygiene | Drafted | Correct Stage 6C working point; record reviewed head and merge commit; resolve superseded bookkeeping when authorised | Independent review and owner merge authorisation |
+| **Cleanup 1** — R1 freeze and designation | Drafted | Declare R1 lab the frozen DEV-only prototype/control lineage | Recorded in current stage, ledger, and decisions |
+| **Cleanup 2** — Continuity Ledger | Drafted | One ownership/lifecycle/migration inventory | Independent review and owner merge authorisation |
+| **Cleanup 3** — System Assessment Roadmap | Drafted | This strategic programme record | Independent review and owner merge authorisation |
+| **Cleanup 4** — CPE documentation foundation | Drafted separately | Correct CPE README and establish its two pillars | Independent review and owner merge authorisation |
+| **Cleanup 5** — Merge closeout protocol | Drafted | Durable recovery rule for all future merges | Independent review and owner merge authorisation |
+| **A0** — Continuity audit | Owner-accepted | Read-only R1→CPE audit, with repository pins and lifecycle findings | Complete; informs cleanups |
+| **A1** — CPE documentation foundation | Not started | CPE top-level documentation, first-system-assessment scope, ownership clarity | Cleanup package merged |
+| **A2** — First CPE System Assessment contract | Not started | Documentation-only logical Assessment Request/Result contract with every field owned | A1 accepted; no implementation authority |
+| **A3** — Bounded assessment core | Not started | Narrow CPE implementation of accepted R1 assessment semantics against synthetic labelled controls | A2 accepted; separate implementation authorisation |
+| **A4** — Capacity-sufficiency evidence inventory | Not started | CRE-backed read-only inventory for below-sufficiency, compact-sufficient, neutral-surplus, additive-surplus cases | Separate authorisation; inventory may conclude insufficient evidence |
+| **A5** — Deferred control admission | Not started | Evidence-backed contract and tests for 30-v-60 and/or Wregoe control only after A4 | A4 reviewed; owner authorisation |
+| **A6** — Plan Fit and comparison | Not started | Mature CPE Plan Fit and comparable candidate-system outputs | Assessment core and controls accepted |
+| **B** — Colony Plan Construction | Not started | Candidate layouts, sequencing, alternatives, protected-asset and validation handling | System Assessment produces trusted results |
+| **C** — ed-finder graduation | Not started | Presentation of stable CPE outputs beyond DEV-only laboratory | CPE outputs and contracts stable |
+
+## 6. A0 findings that govern all later work
+
+The owner-accepted Programme A0 audit established:
+
+- all three repositories were reviewed at fixed pins;
+- accepted R1 prototype semantics are real and must be preserved;
+- the five current fixtures and two current strategies are fixture-only forward reconstruction material, not game truth;
+- `plateau_30_vs_60_case` and `wregoe_dual_dodec_control` have no admitted payload, expected result, test, UI, or active behaviour;
+- Stage 6B establishes the cross-repository ownership model;
+- CPE README ownership wording required correction;
+- Stage records require explicit, durable closeout to prevent stale recovery state.
+
+## 7. First CPE System Assessment contract shape
+
+This is a logical target only. It is not an executable schema or implementation authorisation.
+
+### Assessment Request
+
+- pinned CRE Knowledge Release;
+- pinned CRE Observed Colony-State Snapshot;
+- named programme/template/revision;
+- finite named requirements and constraints;
+- explicit Carrier scenario;
+- explicit assessment lens or question where applicable;
+- declared player constraints and scope limits;
+- treatment choice for unknown, contradictory, stale, or withheld CRE inputs.
+
+### Assessment Result
+
+- input pins and contract identity;
+- assessment state;
+- per-requirement outcomes;
+- evidence/provenance and caveat trace;
+- conditions, missing/contradictory/withheld limitations, and validation gates;
+- Carrier scenario comparison where applicable;
+- capacity-sufficiency finding;
+- Plan Fit state only when an explicit compatible strategy is supplied;
+- bounded comparison-ready result without pretending to be a universal score.
+
+The required order is:
+
+```text
+CRE evidence and named requirements
+        ↓
+Assessment state
+        ↓
+Plan Fit for explicit strategy
+        ↓
+Later comparison or rating display
+```
+
+## 8. Capacity-sufficiency and the 30-v-60 control
+
+The future control suite must prove four distinct cases:
+
+1. **Below sufficiency:** at least one mandatory requirement is unmet or unknown.
+2. **Compact sufficient baseline:** every mandatory requirement is met with fewer relevant bodies.
+3. **Neutral surplus:** more total bodies, but no additional body changes a named requirement or constraint.
+4. **Additive surplus:** extra bodies genuinely add required coverage, relevant capacity, qualifying body/slot capability, logistics improvement, or constraint resolution.
+
+Only the fourth case can improve an assessment because of the extra bodies. The 30/60 labels are illustrative; no global threshold is implied.
+
+## 9. Why there is no separate SRE repository
+
+A separate SRE repository is not justified now because it would:
+
+- duplicate CPE programme inputs or Plan Fit logic;
+- create a second source-of-truth boundary before the CPE contract exists;
+- force runtime/storage/package/API choices that Stage 6B explicitly leaves open;
+- risk copying R1 fixture material as if it were research truth;
+- multiply continuity and merge-closeout debt.
+
+The System Assessment Engine is a protected, first-class CPE domain. It may be extracted later only after stable contracts, independent consumers, control maturity, and a clear no-duplication case exist.
+
+## 10. Agent roles and review discipline
+
+| Role | Responsibility |
+|---|---|
+| Owner | Decides objectives, accepts audits, authorises implementation and merges. |
+| Independent auditor/reviewer | Read-only audit, contract review, control challenge, and scope verification. |
+| ChatGPT | Programme governance, cross-repository boundary guard, contract/continuity drafting, review coordination. |
+| Trae or focused implementation agent | One bounded implementation story on one branch after contract and owner authorisation. |
+
+Rules:
+
+- one writer per branch;
+- one bounded objective per PR;
+- an independent reviewer checks every non-trivial change;
+- no merge without exact-head owner authorisation;
+- no external evidence or live-game conclusion without explicit scope;
+- no CPE conclusion stronger than its weakest critical CRE dependency.
+
+## 11. Current next safe action
+
+Independently review the documentation-only cleanup package and the separate CPE documentation-foundation change. After explicit owner merge authorisation, begin **A1 CPE documentation foundation**. Do not start A2/A3/A4 work early.

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -1,146 +1,87 @@
 # Current Stage
 
-> **This is the authoritative working-point record.** Update it before an agent stops, before a chat is closed, and after any accepted decision or evidence run.
+> **This is the authoritative working-point record.** Update it before an agent stops, after every merged change, and after any accepted decision or evidence run.
 
 ## Status
 
-**Stage 5A and Stage 5B are accepted and merged. The Stage 6A read-only evidence-and-architecture audit contract merged in PR `#295`; the repository-only CRE audit report was independently reviewed, owner-accepted, and merged in PR `#297`; and the Stage 6B CRE-to-CPE logical ownership and boundary-governance contract was independently reviewed, owner-accepted, and merged in PR `#298` at `dad29b1760e8291f8c48db665ed4be5e193d51db`. The owner has authorised a documentation-only Stage 6C CRE-to-CPE field-contract-detail stage. Its documentation has been amended after independent architecture review and live GitHub review-thread corrections; it awaits fresh independent review, is not accepted or merged, and does not authorise implementation, scaffolding, integration, storage, database access, external research, or deployment.**
+**Stage 6C is accepted and merged in PR `#299`. Programme A0, the read-only continuity audit of the R1 Assessment Laboratory toward a future CPE / System Assessment Engine, has been owner-accepted. A documentation-only continuity cleanup is now drafted for independent review. It does not authorise implementation, CPE scaffolding, CRE changes, data collection, fixture changes, live-game work, architecture selection, or deployment.**
 
-## Baseline
+## Canonical baseline
 
+- Canonical repository: `brianstewart377-rgb/ed-finder`
 - Canonical base branch: `work/r1-canonical-body-evidence`
-- Canonical current baseline: `dad29b1760e8291f8c48db665ed4be5e193d51db` — Stage 6B CRE-to-CPE boundary contract merge
-- Stage 6A contract merge: PR `#295` at `7a4080363a23a0aefe9b68c795d621164b39c9e8`
-- Stage 6A accepted review head: `3f6891d8bc82faed4ac66b8aef60eacecbc26db6`
-- Stage 6A contract branch: `docs/r1-stage6a-audit-contract` (historical merged branch)
-- Stage 6A audit report: PR `#297`, merged at `c50723e307566e0c008acf29a84e6dfa88d6ef29`
-- Stage 6A accepted audit-review head: `0d80c488c41a92ad0a9d78fae9b6573a89ef4d30`
-- Stage 6A audit-report branch: `docs/r1-stage6a-cre-repo-audit-report` (historical merged branch)
-- Stage 6A audited CRE repository: `brianstewart377-rgb/colonisation-research-engine`, `main` at `add9a51350e7754dadc09cd9712cd43e96499e33`
-- Stage 6A observed CPE repository at audit retrieval on 2026-07-02: `brianstewart377-rgb/colony-planning-engine`, repository ID `1287613646`, public, default branch `main`, size `0`; no immutable commit/ref existed because the repository was empty at that time.
-- Stage 6B boundary contract: PR `#298`, merged at `dad29b1760e8291f8c48db665ed4be5e193d51db`
-- Stage 6B accepted review head: `80bc4dc3c97a7da56baf0b5f3e43120b21d37725`
-- Stage 6B contract branch: `docs/r1-stage6b-cre-cpe-boundary-contract` (historical merged branch)
-- Stage 6C field-contract branch: `docs/r1-stage6c-contract-detail`
-- Stage 6C contract base: `work/r1-canonical-body-evidence` at `dad29b1760e8291f8c48db665ed4be5e193d51db`
-- Stage 6C recovery rule: future review, acceptance, or merge work must retrieve the live PR `#299` head from pull-request metadata. No draft-document commit is a recovery pointer.
-- Stage 5A discovery PR: `#290`, merged at `dad3a99f4571428fcb517a13785be297f57e875a`
-- Stage 5A reviewed head: `36371887bf09dad420c86b6c6ca6faffb7cfa0cd`
-- Stage 5B evidence-discipline PR: `#291`, merged at `f1b1e5b42859a42b0e651ad957c01d5261bec754`
-- Stage 5B reviewed head: `b42d8cfa6d1ad453d6637ea7f24919d85950ec95`
+- Canonical current baseline: `038bdde4999c0ff6ea337abbe2653c08b61118da`
+- Baseline event: PR `#299` — `docs: draft Stage 6C CRE-CPE field contract detail`
+- Stage 6C accepted reviewed head: `f12d4af7b6a05388ba4ae6522c5fc3e15fe754db`
+- Stage 6C merge commit: `038bdde4999c0ff6ea337abbe2653c08b61118da`
 - No deployment occurred.
-- Recovery rule: for any open review, acceptance, or merge, fetch the live pull-request head from pull-request metadata; do not infer it from a content checkpoint or remembered commit.
 
-## Stage 6A accepted audit checkpoint
+## Accepted governance and ownership
 
-- **Status:** Accepted and merged in PR `#297`.
-- **Audit report:** `docs/ai/R1_STAGE6A_READ_ONLY_EVIDENCE_AND_ARCHITECTURE_AUDIT_REPORT_V1.md`
-- **Audit scope:** Read-only committed-file and repository-metadata inspection of CRE, plus the necessary Stage 6A governance documents in `ed-finder` and metadata confirmation that CPE was empty at audit retrieval.
-- **Database access:** None supplied, verified, or used.
-- **External research / live game work:** None performed.
-- **Material finding:** CRE is an evidence and research knowledge repository with planner-adjacent draft contracts. The current CRE summary index was stale against its export manifest and source-coverage register at the inspected CRE commit.
-- **Architecture status:** Stage 6A recorded options and a boundary discussion direction; it did not select a runtime, storage, transport, or implementation architecture.
+- Stage 5A and 5B remain accepted evidence-discipline records.
+- Stage 6A remains the repository-only CRE audit record.
+- Stage 6B remains the accepted CRE/CPE/ed-finder logical ownership boundary.
+- Stage 6C remains the accepted field-level documentation contract for the four logical boundary objects.
+- CRE owns research evidence, provenance, mechanics, observations, contradictions, confidence, planner-safe releases, and observed-state publications.
+- CPE is the future owner of player-specific planning.
+- Within CPE, the future **System Assessment Engine** owns programme-specific candidate-system assessment and comparison; **Colony Plan Construction** owns candidate layouts, sequencing, alternatives, and player-specific plan results.
+- ed-finder remains presentation and coordination only. The R1 Assessment Laboratory remains DEV-only, fixture-backed, deterministic, local, and separate from a future CPE runtime.
 
-## Stage 6B accepted boundary-contract checkpoint
+## Programme A0 accepted audit baseline
 
-- **Status:** Accepted and merged in PR `#298`.
-- **Contract:** `docs/ai/R1_STAGE6B_CRE_CPE_BOUNDARY_CONTRACT_V1.md`
-- **Purpose:** Establish the future logical CRE/CPE/ed-finder ownership boundary, four logical boundary objects, versioning/provenance/uncertainty rules, no-direct-private-storage rules, no-duplication rules, and migration preconditions.
-- **Boundary status:** Governance only. It does not create an executable schema, a shared package, an API, a shared database, a runtime, or an integration.
-- **No technical implementation:** No CPE scaffolding, code, tests, UI, schemas, APIs, shared storage, database access, external research, live-game work, deployment, product behaviour, or CRE material movement/copying/deletion is authorised by Stage 6B.
-- **No architecture selection:** Stage 6B does not choose a transport, runtime, storage, shared package, shared database, API, event system, or deployment model.
+The owner-accepted A0 audit reviewed these immutable repository pins:
 
-## Stage 6C field-contract-detail checkpoint
+| Repository | Branch | Pin |
+|---|---|---|
+| `ed-finder` | `work/r1-canonical-body-evidence` | `038bdde4999c0ff6ea337abbe2653c08b61118da` |
+| `colonisation-research-engine` | `main` | `add9a51350e7754dadc09cd9712cd43e96499e33` |
+| `colony-planning-engine` | `main` | `439624022b41b10492aed9269f9805403d0bb439` |
 
-- **Status:** Amended after independent architecture review and live GitHub review-thread corrections; awaiting fresh independent review and not merged.
-- **Contract:** `docs/ai/R1_STAGE6C_CRE_CPE_FIELD_CONTRACT_DETAIL_V1.md`
-- **Purpose:** Define logical field-level meaning for the four Stage 6B objects: CRE Knowledge Release, CRE Observed Colony-State Snapshot, CPE Planning Request, and CPE Plan Result.
-- **Scope:** Required, optional, conditionally required, and prohibited fields; ownership class; object identity; release pinning; timestamps; supersession; compatibility; observed/previewed/predicted/proposed/completed state; uncertainty/withholding; provenance/caveat propagation; non-executable examples; and documentation validation checklists.
-- **Architecture-review amendment scope:** Adds a non-strengthening rule for plan-level confidence and reconciles expected-effect terminology with the canonical Section 8 state taxonomy. It adds no implementation, field encoding, or architecture selection.
-- **Live-thread correction scope:** Permits request-only candidate provenance without invented CRE references; preserves every applicable withholding basis; defines field-level conditions for a permitted CRE input update versus a new Planning Request; separates a differently classified economy state into its own or referenced Snapshot item; treats declared programme requirement and capacity/coverage changes as material input changes; requires complete detail for conditional plan alternatives; provides safe withheld/excluded knowledge-entry stubs; defines downgraded entries as publishable only with explicit bounded limitations; adds limitation-only Snapshot stubs for Unknown, Missing, Withheld, or Out of scope items; requires Snapshot caveats to preserve every applicable Section 9 limitation; requires stale-evidence validation gates before irreversible action; and treats material Snapshot state or limitation changes as requiring a new Planning Request. It adds no implementation, field encoding, or architecture selection.
-- **Permitted durable files:** This contract and `docs/ai/CURRENT_STAGE.md` only.
-- **No technical implementation:** No CPE scaffolding, code, executable schemas, tests, UI, APIs, events, packages, shared storage, databases, credentials, external research, live-game work, deployment, product behaviour, or CRE material movement/copying/deletion is authorised.
-- **No architecture selection:** Stage 6C does not choose a physical encoding, runtime, transport, storage, shared-contract repository, shared package, API, event system, or deployment model.
-- **Next safe action:** Fetch live PR metadata, changed files, reviews, and all review threads; confirm the exact current head and no unresolved actionable thread; then obtain a fresh independent read-only review of the amended Stage 6C contract and this checkpoint. Obtain separate owner acceptance before merge.
+The audit established the following durable boundaries:
 
-## Closeout scope
+- Assessment state is primary; Plan Fit is secondary and explicit-strategy-gated.
+- Missing or contradictory evidence cannot be rescued by Carrier, strategy, or later logic.
+- Carrier variation is limited to carrier-sensitive, non-shared logistics requirements.
+- The R1 prototype has no universal score, rank, winner, recommendation, or inferred strategy.
+- `plateau_30_vs_60_case` and `wregoe_dual_dodec_control` remain deferred controls pending an evidence-backed future admission contract.
+- R1 semantics move to CPE by reimplementation against controls, not by copying fixture assumptions or treating fixture data as game truth.
 
-The Stage 5 closeout changes only:
+The full audit findings, lifecycle classifications, stale-record register, and cleanup recommendation are recorded in `docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md`.
 
-- `docs/ai/CURRENT_STAGE.md`
-- `docs/ai/DECISIONS.md`
-- `docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md`
+## Documentation-only continuity cleanup
 
-It records acceptance and provenance only. It does not alter R1 semantics, fixtures, tests, UI, normal application behavior, external research authority, implementation authority, or deployment behavior.
+This cleanup package contains only governance and recovery material:
 
-## Stage 5A acceptance checkpoint
+- corrected Stage 6C status and baseline information;
+- a durable System Assessment Continuity Ledger;
+- a CPE System Assessment Roadmap;
+- a Project Continuity and Merge Closeout Protocol;
+- accepted decisions establishing the CPE / System Assessment Engine naming and ownership;
+- a separate CPE README correction on its own documentation branch.
 
-- **Status:** Accepted and merged.
-- **Accepted code commit:** `36371887bf09dad420c86b6c6ca6faffb7cfa0cd`
-- **Acceptance date/time:** `2026-07-02`; owner acceptance occurred before PR `#290` merged at `2026-07-02T10:05:41Z`. The exact chat timestamp was not durably captured and is not fabricated here.
-- **Branch:** `docs/r1-stage5a-control-fixture-discovery`
-- **Pull request:** `#290`, merged at `dad3a99f4571428fcb517a13785be297f57e875a`
-- **Acceptance checkpoint commit:** `2d9b6fb65dfb246618a9133098b5eda53ea41182`
-- **Evidence reviewed:** Independent read-only Stage 5A discovery review found no required corrections and returned “Ready for owner acceptance.”
-- **Caveat:** The acceptance checkpoint was omitted at the time of merge and is recorded post-merge by this documentation-only closeout. It does not reopen the Stage 5A review.
-- **Next safe action:** A separate docs-only Stage 5B evidence-discipline contract, subject to independent review and owner acceptance. That contract was subsequently completed and merged.
+It must not alter R1 evaluator semantics, fixtures, tests, UI, normal application behaviour, CRE data, CPE implementation, scoring, ranking, recommendation, research, or deployment.
 
-## Stage 5B acceptance checkpoint
+## Deferred controls
 
-- **Status:** Accepted and merged.
-- **Accepted code commit:** `b42d8cfa6d1ad453d6637ea7f24919d85950ec95`
-- **Acceptance date/time:** `2026-07-02`; owner acceptance occurred before PR `#291` merged at `2026-07-02T10:55:34Z`. The exact chat timestamp was not durably captured and is not fabricated here.
-- **Branch:** `docs/r1-stage5b-evidence-discipline`
-- **Pull request:** `#291`, merged at `f1b1e5b42859a42b0e651ad957c01d5261bec754`
-- **Acceptance checkpoint commit:** `2d9b6fb65dfb246618a9133098b5eda53ea41182`
-- **Evidence reviewed:** An independent Stage 5B review found one recovery-record correction. The subsequent correction verification at `b42d8cfa6d1ad453d6637ea7f24919d85950ec95` found it complete and returned “Correction accepted; Stage 5B is ready for owner acceptance.”
-- **Caveat:** The acceptance checkpoint and owner-intent provenance were omitted from PR `#291` and are recorded post-merge by this documentation-only closeout. The accepted Stage 5B rules are unchanged.
-- **Next safe action:** No external evidence inventory, fixture, implementation, or deployment is authorised. Any later programme-definition or evidence-inventory stage requires separate owner authorisation.
-
-## Stage 5A accepted record
-
-- Discovery record: `docs/ai/R1_STAGE5A_CONTROL_FIXTURE_DISCOVERY_V1.md`
-- Accepted conclusion: the canonical repository does not contain enough evidence to reconstruct historic semantics for `wregoe_dual_dodec_control` or `plateau_30_vs_60_case`.
-- Neither name is admitted to the active fixture registry, tests, Assessment semantics, Plan Fit semantics, UI, or normal product behavior.
-- This is a non-inference rule, not a claim that those controls never had historical meanings.
-- The durable accepted decision is recorded in `docs/ai/DECISIONS.md`.
-
-## Stage 5B accepted record
-
-- Contract file: `docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md`
-- The authoritative accepted-status and owner-intent-provenance amendment is `docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md`.
-- Stage 5B adopts the evidence-chain discipline:
-
-```text
-source record
-→ normalized evidence fact
-→ named programme requirement or constraint
-→ requirement outcome
-→ bounded Assessment or Plan Fit consequence
-```
-
-- Owner-provided intent may authorise forward design but does not establish lost historical semantics or turn unknown game facts into known facts.
-- Missing, contradictory, stale, incomplete, unsupported, or out-of-scope evidence limits the conclusion; it cannot silently become a positive.
-- No comparison may begin with total body count. A programme must first define finite, named requirements and constraints.
-- The illustrative `plateau_30_vs_60_case` rule is capacity-sufficiency only: surplus bodies are neutral only where they change no named requirement or constraint. It is not a universal threshold, score, rank, recommendation, preference, or best-system rule.
-- The accepted contract does not authorise external system research, a fixture, test changes, UI changes, code changes, live queries, or implementation.
-
-## Preserved merged invariants
-
-- The R1 laboratory remains DEV-only, fixture-backed, deterministic, and local.
-- The lab exposes exactly five closed local select controls: Fixture, Lens kind, Lens value, Carrier mode, and Strategy.
-- The first four selector IDs, values, defaults, ordering, and semantics remain unchanged. Strategy is explicit local DEV-lab context only, with fixed `baseline_local_strategy` and `remote_logistics_strategy` options; it is not inferred.
-- Five fixture IDs and three carrier modes are selectable; the six approved fixture/scenario state rows are test assertions, not six fixtures.
-- The fixed template is displayed read-only.
-- Lens remains explicit context only; it does not alter accepted fixture outcomes, conditions, evidence, state, Plan Fit output, or ordering.
-- Carrier behavior remains bounded to accepted logistics-sensitive outcomes. `compare_both` preserves `no_carrier` then `carrier_available` order.
-- Stage 4B Plan Fit remains subordinate to accepted Stage 2B Assessment output.
-- No production behavior, scoring, ranking, recommendation, strategy inference, planning behavior, or deployment is introduced.
+- `plateau_30_vs_60_case` is an accepted capacity-sufficiency design rule, not an active fixture, threshold, score, rank, or system recommendation.
+- `wregoe_dual_dodec_control` is a deferred control name, not an active fixture or inferred statement of Wregoe/Dodec mechanics.
+- Neither enters code, tests, UI, Assessment behaviour, or Plan Fit without a separate evidence-backed contract, independent review, and owner authorisation.
 
 ## Next safe action
 
-Before any external re-review, fetch live PR `#299` metadata, changed files, submitted reviews, and all review threads; confirm the exact current head and that no actionable current review thread remains. Then obtain a fresh independent read-only review of the amended `docs/ai/R1_STAGE6C_CRE_CPE_FIELD_CONTRACT_DETAIL_V1.md` and this `CURRENT_STAGE.md` checkpoint. After that, perform one final live GitHub state check before presenting any owner-acceptance wording. Do not start CPE design or implementation, change CRE/ed-finder code or data, supply or query a database, collect external evidence, create a fixture, change R1 tests/UI, integrate repositories, select runtime/storage/transport, merge a later implementation, or deploy. This Stage 6C field-contract detail may merge only after independent review, a final clean live-thread check, and separate owner acceptance. Any later readiness, technical, migration, or implementation stage requires separate owner authorisation.
+Obtain an independent read-only review of the documentation-only continuity cleanup and the CPE documentation-foundation change. Verify the exact live heads, changed files, PR status, reviews, and review threads before any owner merge decision.
+
+Do not begin CPE implementation, change CRE source/data, add fixtures, collect external evidence, select runtime/storage/transport, integrate repositories, or deploy as part of this stage.
 
 ## Recovery instruction
 
-If context is lost, do not edit code. Read the files in `docs/ai`, run the read-only commands in `RECOVERY.md`, and report the result. Continue only after the owner approves the recovered state.
+If context is lost, start read-only. Read:
+
+1. this file;
+2. `docs/ai/PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md`;
+3. `docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md`;
+4. `docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md`;
+5. `docs/ai/DECISIONS.md`;
+6. the live PR metadata and Git status.
+
+Report the recovered branch, exact commit, active phase, pending review, and next safe action before making any write.

--- a/docs/ai/DECISIONS.md
+++ b/docs/ai/DECISIONS.md
@@ -147,3 +147,31 @@ Every later claim must retain a traceable chain from source record through evide
 
 **Evidence / reference**
 Owner-provided forward-design intent dated 2026-07-02, recorded as `owner_intent_capacity_sufficiency_plateau_2026-07-02` in `docs/ai/R1_STAGE5A_5B_ACCEPTANCE_CLOSEOUT_V1.md`; `docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md`; Stage 5B reviewed head `b42d8cfa6d1ad453d6637ea7f24919d85950ec95`; PR `#291`, merged at `f1b1e5b42859a42b0e651ad957c01d5261bec754`; owner acceptance on 2026-07-02.
+
+## 2026-07-03 — CPE / System Assessment Engine is the future assessment owner
+
+**Decision**
+Name and preserve **CPE / System Assessment Engine** as a first-class CPE pillar alongside **CPE / Colony Plan Construction**. The R1 Assessment Laboratory in `ed-finder` is the frozen DEV-only prototype and control-suite lineage for that future engine.
+
+**Reason**
+The R1 work evaluates candidate systems against an explicit programme, requirements, Carrier scenario, evidence status, and strategy context. That is player-specific planning and comparison work, not CRE research truth and not ed-finder presentation. A separate SRE repository would introduce a premature and duplicative source-of-truth boundary.
+
+**Invariant**
+CRE owns evidence, provenance, mechanics, observations, contradictions, confidence, planner-safe releases, and observed-state publications. CPE / System Assessment Engine owns programme-specific assessment, capacity-sufficiency, Carrier scenario evaluation, Plan Fit, and comparison-ready outputs. CPE / Colony Plan Construction owns player constraints, candidate plans, sequencing, alternatives, and validation steps. ed-finder presents but does not own research or planning truth. The R1 lab is reimplemented semantically in CPE only after an accepted contract and control migration; it is not copied as fixture truth.
+
+**Evidence / reference**
+Owner direction on 2026-07-03; `docs/ai/R1_STAGE6B_CRE_CPE_BOUNDARY_CONTRACT_V1.md`; `docs/ai/R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md`; Programme A0 continuity audit.
+
+## 2026-07-03 — Every merge must leave a durable recovery trail
+
+**Decision**
+Every merged change must leave the repository self-explanatory for a new chat or agent. `CURRENT_STAGE.md` is updated after every merge. The roadmap, continuity ledger, and decision register are updated when their respective subject matter changes.
+
+**Reason**
+Project knowledge was already vulnerable to chat slowdown, lost local worktree state, stale stage records, and overlapping closeout PRs. Recovery depends on durable repository records, not on a surviving conversation.
+
+**Invariant**
+A merge is not fully closed until its exact reviewed head, merge commit, scope, caveats, superseded items, and next safe action are recorded. New chats begin read-only from `CURRENT_STAGE.md`, the continuity protocol, roadmap, ledger, decisions, and live repository/PR state. No document may describe a merged stage as pending; status corrections must be treated as first-class maintenance.
+
+**Evidence / reference**
+Owner direction on 2026-07-03; `docs/ai/PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md`; Programme A0 finding F-13 and stale-record register.

--- a/docs/ai/PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md
+++ b/docs/ai/PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md
@@ -1,0 +1,104 @@
+# Project Continuity and Merge Closeout Protocol v1
+
+**Status:** Drafted for independent review.
+
+**Purpose:** Ensure that a new chat, reviewer, or implementation agent can recover the current project state from the repositories without relying on a long conversation, a remembered plan, or an uncommitted workspace.
+
+## 1. Governing rule
+
+> A merged change is not fully closed until its durable recovery records are updated.
+
+`CURRENT_STAGE.md` is mandatory after every merge. The roadmap, continuity ledger, and decision register are updated when their respective subject matter changes.
+
+## 2. Mandatory records
+
+| Record | Update requirement | Purpose |
+|---|---|---|
+| `docs/ai/CURRENT_STAGE.md` | **Every merge** | Exact working point, status, caveats, active phase, and next safe action. |
+| `docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md` | When a phase advances, blocks, changes dependency, or completes | Strategic programme state. |
+| `docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md` | When an artefact’s ownership, lifecycle label, control status, or migration treatment changes | R1/CPE/CRE continuity and anti-burial record. |
+| `docs/ai/DECISIONS.md` | When the owner accepts a durable rule or boundary that future work must obey | Append-only decision record. |
+| Relevant contract or acceptance record | When its own stage/status changes | Preserve exact contract/acceptance provenance. |
+
+## 3. Merge-closeout checklist
+
+For every merge:
+
+1. Verify the live merged PR state.
+2. Record the PR number, title, exact reviewed head SHA, merge commit SHA, merge method where known, and merge date/time.
+3. State in plain language what changed.
+4. State in plain language what did **not** change.
+5. Record caveats, unresolved questions, stale documents, superseded PRs, and any external dependency.
+6. Update `CURRENT_STAGE.md`.
+7. Update the roadmap only when programme phase status or dependency changed.
+8. Update the Continuity Ledger only when ownership, lifecycle classification, control admission, or migration treatment changed.
+9. Append to `DECISIONS.md` only when a durable owner decision changed future constraints.
+10. Set one explicit next safe action.
+11. Do not start that next action without separate scope/owner authorisation.
+
+## 4. Status vocabulary
+
+Use these labels consistently:
+
+- **Drafted** — exists on a branch or PR; not yet independently accepted.
+- **Reviewed** — independent review completed; owner acceptance may still be pending.
+- **Accepted, awaiting merge** — owner approved exact reviewed head; merge has not yet completed.
+- **Accepted and merged** — live branch contains the accepted merge.
+- **Deferred pending evidence** — no implementation or conclusion may be inferred yet.
+- **Blocked** — a named missing input, contradiction, review issue, or decision prevents progress.
+- **Historic reference only** — retained for provenance but cannot influence current decisions.
+- **Stale documentation debt** — can still mislead live work and must be scheduled for correction.
+
+No document may say a merged item is pending review or merge. No document may call a draft item accepted. When a factual status error is discovered, correct it through a narrow documentation-only change rather than letting it propagate.
+
+## 5. New-chat recovery protocol
+
+A new chat or agent begins read-only.
+
+1. Read `CURRENT_STAGE.md`.
+2. Read this protocol.
+3. Read the applicable roadmap and continuity ledger.
+4. Read `DECISIONS.md`.
+5. Inspect the live repository branch, exact commit, worktree/PR state, and current review threads.
+6. Report:
+   - repository and branch;
+   - exact commit;
+   - active phase;
+   - what is confirmed versus pending;
+   - open PR/review status;
+   - next safe action;
+   - any discrepancy between durable records and live GitHub state.
+7. Do not write, merge, push, close, deploy, reset, stash, or delete until the owner approves the recovered state.
+
+## 6. Cross-repository rule
+
+When work spans `ed-finder`, CRE, and CPE, record a separate immutable pin for each repository. A review must not silently follow moving `main` or a moving working branch.
+
+Each cross-repository handoff records:
+
+- repository URL;
+- branch;
+- full commit SHA;
+- whether the branch resolved to that SHA at review time;
+- which repository supplies research truth, planning assessment, plan construction, or presentation;
+- any uncertainty about PR/SHA linkage or merge method.
+
+## 7. Documentation boundaries
+
+This protocol does not authorise code, tests, fixture changes, data migration, external research, database access, architecture selection, deployment, or implementation. It governs continuity only.
+
+## 8. Review and merge rule
+
+Every substantial PR receives an independent read-only review before owner merge authorisation. The owner authorises a merge against an exact live head SHA. Before merging, re-fetch the live PR metadata, changed files, reviews, threads, and head SHA. If the head moved or an actionable thread exists, pause and re-review.
+
+## 9. Completion test
+
+A merge closeout is complete only when someone opening a new chat can answer, from the repository:
+
+```text
+What exists?
+Who owns it?
+What changed?
+What remains uncertain?
+What is allowed next?
+```

--- a/docs/ai/R1_STAGE6_STATUS_CLOSEOUT_V1.md
+++ b/docs/ai/R1_STAGE6_STATUS_CLOSEOUT_V1.md
@@ -1,0 +1,37 @@
+# R1 Stage 6 Status Closeout v1
+
+**Status:** Drafted for independent review. Documentation-only status correction.
+
+## Purpose
+
+The Stage 6B and Stage 6C contract bodies were drafted before their respective acceptance and merge events. Their draft-status wording is retained as historical contract context, but must not be read as current project status.
+
+This record is the current status authority for those two contracts together with `CURRENT_STAGE.md`.
+
+## Stage 6B
+
+- Contract: `docs/ai/R1_STAGE6B_CRE_CPE_BOUNDARY_CONTRACT_V1.md`
+- PR: `#298` — `docs: draft Stage 6B CRE-CPE boundary contract`
+- Accepted reviewed head: `80bc4dc3c97a7da56baf0b5f3e43120b21d37725`
+- Merge commit: `dad29b1760e8291f8c48db665ed4be5e193d51db`
+- Current status: **Accepted and merged.**
+
+Stage 6B establishes logical ownership and governance only. It does not authorise implementation, data movement, CPE scaffolding, APIs, databases, shared storage, runtime selection, external research, or deployment.
+
+## Stage 6C
+
+- Contract: `docs/ai/R1_STAGE6C_CRE_CPE_FIELD_CONTRACT_DETAIL_V1.md`
+- PR: `#299` — `docs: draft Stage 6C CRE-CPE field contract detail`
+- Accepted reviewed head: `f12d4af7b6a05388ba4ae6522c5fc3e15fe754db`
+- Merge commit: `038bdde4999c0ff6ea337abbe2653c08b61118da`
+- Current status: **Accepted and merged.**
+
+Stage 6C defines logical field-level meaning only. It does not authorise executable schemas, CPE implementation, database/API/storage work, integration, external research, live-game work, or deployment.
+
+## Interpretation rule
+
+When a historic contract header says `Drafted for independent review` but this closeout and `CURRENT_STAGE.md` say `Accepted and merged`, the latter records govern current status. The contract body remains authoritative for the accepted logical rules unless a later accepted decision explicitly supersedes a rule.
+
+## Next safe action
+
+Review the documentation-only continuity cleanup. Do not treat this closeout as authority to begin CPE implementation or modify CRE/R1 behaviour.

--- a/docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md
+++ b/docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md
@@ -102,7 +102,7 @@ A future CPE implementation may preserve the **behavioural control** of a fixtur
 | Stage 5 acceptance records and Stage 6A audit report | Retain for provenance | Historic reference only |
 | CPE README old ownership wording | Corrected in separate documentation PR | Stale documentation debt until merged |
 | Stage 6C current-stage unmerged wording | Corrected by this documentation cleanup | Stale documentation debt until merged |
-| PR #293 | Superseded by #294; close only with explicit owner authorisation | Stale documentation debt until closed |
+| PR #293 | Closed on 2026-07-03 as superseded by #294; retain only its closure provenance | Historic reference only |
 | CRE summary-index mismatch from Stage 6A | CRE-side follow-up; not changed here | Stale documentation debt |
 
 ## 8. Known collision and traceability cautions
@@ -115,16 +115,16 @@ The live station-type feature and related source references using `Dodec` are un
 
 PRs #297 and #298 are linked to their commits by the accepted project records because their commits do not embed the PR number in the commit subject. Future closeouts must explicitly record PR number, reviewed head, merge commit, and merge method to keep recovery auditable.
 
-### Confirmed Stage 2/3 foundation
+### Stage 2/3 lineage baseline
 
-Live GitHub metadata independently confirmed the early R1 lineage:
+At this documentation baseline, live GitHub PR metadata captured on 2026-07-03 verified that the early R1 PRs below were merged. Canonical git ancestry at the baseline corroborates the listed commit SHAs and matching subjects. Because PR-to-SHA association is not always recoverable from a commit subject alone, a later recovery must re-check live PR metadata rather than infer it solely from ancestry.
 
-| PR | Result | Merge commit |
-|---|---|---|
-| #280 — Stage 2B pure R1 assessment core | Merged | `220c870f89a5af7f98adb88578373dbc3a681a9c` |
-| #281 — Stage 3A lens context | Merged | `b6529e70ddbdcc26d46ce742eea793273138c635` |
-| #282 — Stage 3B DEV-only R1 assessment lab | Merged | `98b4bacf1d799e7937b449210046659b3e96615b` |
-| #283 — Stage 3B merge record correction | Merged | `83f4e4bc9829c173979fce5aa0bda734174ca55a` |
+| PR | Result | Merge commit | Durable corroboration |
+|---|---|---|---|
+| #280 — Stage 2B pure R1 assessment core | Merged | `220c870f89a5af7f98adb88578373dbc3a681a9c` | Canonical ancestry and matching subject |
+| #281 — Stage 3A lens context | Merged | `b6529e70ddbdcc26d46ce742eea793273138c635` | Canonical ancestry and matching subject |
+| #282 — Stage 3B DEV-only R1 assessment lab | Merged | `98b4bacf1d799e7937b449210046659b3e96615b` | Canonical ancestry and matching subject |
+| #283 — Stage 3B merge record correction | Merged | `83f4e4bc9829c173979fce5aa0bda734174ca55a` | Canonical ancestry and matching subject |
 
 ## 9. Minimum pre-code documentation package
 

--- a/docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md
+++ b/docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md
@@ -1,0 +1,144 @@
+# System Assessment Continuity Ledger v1
+
+**Status:** Drafted for independent review as a documentation-only continuity record.
+
+**Purpose:** Preserve the R1 Assessment Laboratory lineage while establishing the future home of programme-specific system assessment in **CPE / System Assessment Engine**. This ledger does not authorise implementation, migration, fixture changes, evidence collection, scoring, ranking, or architecture selection.
+
+## 1. Current truth in one page
+
+```text
+CRE
+  Research truth: evidence, mechanics, provenance, observations, contradictions,
+  confidence, planner-safe releases, observed-state publications
+        ↓ pinned release and snapshot
+CPE / System Assessment Engine
+  Programme-specific candidate-system assessment, capacity sufficiency,
+  Carrier scenarios, Plan Fit, comparison-ready outputs
+        ↓ assessment result
+CPE / Colony Plan Construction
+  Player constraints, protected assets, layouts, sequence, alternatives,
+  validation gates, plan outputs
+        ↓
+ed-finder
+  Presentation, exploration, comparison display, DEV-only R1 laboratory
+```
+
+The R1 Assessment Laboratory is **not discarded**. It remains the frozen DEV-only prototype and control-suite lineage until a future CPE implementation passes equivalent accepted controls.
+
+## 2. Lifecycle vocabulary and tie-break
+
+Every material item has one primary label:
+
+- **Accepted prototype semantic** — accepted R1 behaviour that a future CPE implementation must preserve.
+- **Accepted future design rule** — accepted forward constraint that is not yet executable behaviour.
+- **Pending evidence** — cannot be admitted without an evidence inventory or validation.
+- **Deferred control** — reserved named control without an admitted payload or proof role.
+- **Historic reference only** — retained only for provenance or comparison; cannot affect a live decision.
+- **Stale documentation debt** — can still mislead a live decision, handoff, review, or implementation action.
+- **Future CPE implementation target** — an accepted semantic destination, not currently implemented in CPE.
+
+**Tie-break:** use `Stale documentation debt` rather than `Historic reference only` whenever an item can still mislead live work.
+
+## 3. Accepted R1 semantics to preserve
+
+| Semantic | Primary label | Future treatment |
+|---|---|---|
+| Four assessment states: `not_assessable`, `not_supported`, `conditionally_supported`, `supported` | Accepted prototype semantic | Reimplement in CPE from an accepted contract and controls. |
+| Resolution order: unknown or contradictory evidence dominates; mandatory unmet follows; conditional outcomes follow; otherwise supported | Accepted prototype semantic | Preserve verbatim. |
+| Missing/contradictory evidence cannot be rescued by Carrier, strategy, or later logic | Accepted prototype semantic | Preserve verbatim. |
+| Exclusive role-or-question lens, context-only in the current prototype | Accepted prototype semantic | Preserve unless a later contract supplies real lens-specific evidence. |
+| Carrier can affect only carrier-sensitive, non-shared logistics requirements | Accepted prototype semantic | Preserve verbatim. |
+| Carrier comparison order is `no_carrier`, then `carrier_available` | Accepted prototype semantic | Preserve verbatim. |
+| Plan Fit is secondary and consumes accepted assessment output | Accepted prototype semantic | Preserve verbatim. |
+| Plan Fit states: `no_plan_fit`, `blocked_plan_fit`, `provisional_plan_fit`; no `supported_plan_fit` | Accepted prototype semantic | Preserve until a later explicit contract changes it. |
+| Explicit fixed strategies only; no inferred strategy, recommendation, ranking, or winner | Accepted prototype semantic | Preserve verbatim. |
+| Determinism, immutability, sorted trace/provenance, local fixture-backed DEV-only operation | Accepted prototype semantic | Preserve as migration controls. |
+| No universal score, rank, best-system result, or automatic selection | Accepted prototype semantic | Preserve until evidence-backed comparison design is separately accepted. |
+
+## 4. Fixture-only boundary
+
+The following are fixture-only forward reconstruction material, not game truth:
+
+- all evidence payloads, fact keys, values, conditions, and outcomes in the five R1 fixtures;
+- the four-requirement template and its mandatory/carrier/shared flags;
+- the two fixed strategy records;
+- any interpretation of a fixture result as a real Elite Dangerous mechanic or real candidate-system assessment.
+
+A future CPE implementation may preserve the **behavioural control** of a fixture without copying its evidence payload as research truth.
+
+## 5. Deferred controls
+
+| Item | Current status | Primary label | Admission gate |
+|---|---|---|---|
+| `plateau_30_vs_60_case` | Documentation-only capacity-sufficiency intent. No fixture, test, UI, payload, threshold, or expected result. | Pending evidence | CRE-backed evidence inventory; narrow proof question; complete requirement rows; expected output; independent review; owner authorisation. |
+| `wregoe_dual_dodec_control` | Documentation-only deferred control name. No fixture, test, UI, payload, or expected result. | Deferred control | Same gate as above. No inference from the name, memory, unrelated Wregoe/Dodec references, or numerical comparison. |
+
+`30` and `60` are illustrative labels only. Extra bodies are neutral only after every named mandatory requirement is met and the surplus changes no named requirement or constraint.
+
+## 6. Ownership map
+
+| Asset or responsibility | Current location | Future authority | Boundary treatment |
+|---|---|---|---|
+| Raw evidence, sources, observations, claims, mechanics, experiments, contradictions, unknowns, confidence, caveats | CRE | CRE | CPE consumes published planner-safe input; never rewrites it as fact. |
+| CRE knowledge releases and observed colony-state snapshots | CRE | CRE | Pinned CPE inputs. |
+| R1 assessment states, trace rules, Carrier constraints, Plan Fit semantics | `ed-finder` R1 lab | CPE / System Assessment Engine | Migrate semantically, never by fixture-copy. |
+| Capacity-sufficiency/plateau rule | Stage 5 documentation | CPE / System Assessment Engine | Remains future design until evidence-backed control admission. |
+| Candidate-system comparison inside a named programme and scenario | Not yet implemented | CPE / System Assessment Engine | Do not reduce to a universal score. |
+| Player objectives, protected assets, constraints, layouts, sequence, alternatives, validation | CRE drafts and future CPE | CPE / Colony Plan Construction | CPE owns plan-specific context and outputs. |
+| DEV lab UI, future comparison display, search/exploration presentation | `ed-finder` | ed-finder | Presentation only. |
+
+## 7. Keep / defer / migrate / historic-only register
+
+| Item | Required treatment | Primary label |
+|---|---|---|
+| `frontend-v2/src/lab/r1-assessment-lab/**` | Keep frozen as prototype/control lineage; migrate semantics later | Future CPE implementation target |
+| R1 evaluation and Plan Fit tests | Keep as mandatory migration controls | Accepted prototype semantic |
+| `R1_RECONSTRUCTION_CONTRACT_V1.md` | Keep as assessment reconstruction authority | Accepted prototype semantic |
+| `R1_STAGE4_PLAN_FIT_CONTRACT_V1.md` and Stage 4C presentation contract | Keep as Plan Fit authority | Accepted prototype semantic |
+| `R1_STAGE5B_EVIDENCE_DISCIPLINE_CONTRACT_V1.md` | Keep as capacity-sufficiency evidence discipline | Accepted future design rule |
+| `plateau_30_vs_60_case` | Defer | Pending evidence |
+| `wregoe_dual_dodec_control` | Defer | Deferred control |
+| Stage 6B and 6C contracts | Keep as cross-repository governance authority | Accepted future design rule |
+| Stage 5 acceptance records and Stage 6A audit report | Retain for provenance | Historic reference only |
+| CPE README old ownership wording | Corrected in separate documentation PR | Stale documentation debt until merged |
+| Stage 6C current-stage unmerged wording | Corrected by this documentation cleanup | Stale documentation debt until merged |
+| PR #293 | Superseded by #294; close only with explicit owner authorisation | Stale documentation debt until closed |
+| CRE summary-index mismatch from Stage 6A | CRE-side follow-up; not changed here | Stale documentation debt |
+
+## 8. Known collision and traceability cautions
+
+### `Dodec` collision
+
+The live station-type feature and related source references using `Dodec` are unrelated to `wregoe_dual_dodec_control`. No future work may infer deferred-control semantics by grepping the token alone.
+
+### PR traceability
+
+PRs #297 and #298 are linked to their commits by the accepted project records because their commits do not embed the PR number in the commit subject. Future closeouts must explicitly record PR number, reviewed head, merge commit, and merge method to keep recovery auditable.
+
+### Confirmed Stage 2/3 foundation
+
+Live GitHub metadata independently confirmed the early R1 lineage:
+
+| PR | Result | Merge commit |
+|---|---|---|
+| #280 — Stage 2B pure R1 assessment core | Merged | `220c870f89a5af7f98adb88578373dbc3a681a9c` |
+| #281 — Stage 3A lens context | Merged | `b6529e70ddbdcc26d46ce742eea793273138c635` |
+| #282 — Stage 3B DEV-only R1 assessment lab | Merged | `98b4bacf1d799e7937b449210046659b3e96615b` |
+| #283 — Stage 3B merge record correction | Merged | `83f4e4bc9829c173979fce5aa0bda734174ca55a` |
+
+## 9. Minimum pre-code documentation package
+
+Before any CPE code work, the project needs only:
+
+1. this Continuity Ledger;
+2. the CPE System Assessment Roadmap;
+3. the Project Continuity and Merge Closeout Protocol;
+4. an accurate `CURRENT_STAGE.md` working point;
+5. CPE README ownership correction;
+6. a later CPE documentation contract defining the first System Assessment request/result shapes.
+
+Explicitly excluded: new SRE repository, database, API, shared package, runtime/storage/transport decision, scoring formula, external evidence collection, R1 code change, CPE scaffolding, CRE source change, or deployment.
+
+## 10. Next safe action
+
+Review this ledger alongside `CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md`, `PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md`, and the separate CPE documentation PR. After independent review and separate owner merge authorisation, begin the CPE documentation foundation—not implementation.


### PR DESCRIPTION
## Purpose

Documentation-only continuity cleanup following the owner-accepted Programme A0 audit.

## Changes

- Corrects the current working point after Stage 6C / PR #299.
- Adds an explicit Stage 6 status closeout so historical draft headers cannot override merged status.
- Adds the System Assessment Continuity Ledger, including R1 lifecycle treatment, deferred controls, ownership map, and stale-record register.
- Adds the CPE System Assessment Roadmap.
- Adds the Project Continuity and Merge Closeout Protocol.
- Records the durable CPE / System Assessment Engine and merge-closeout decisions.

## Scope boundary

No R1 evaluator, fixture, test, UI, normal app, CRE data, CPE implementation, scoring, ranking, recommendation, external research, runtime/storage/API choice, or deployment change.

## Review focus

- Confirm the A0 correction for PRs #280–#283 is recorded accurately.
- Confirm deferred controls remain deferred.
- Confirm CPE ownership is stated without moving research truth out of CRE.
- Confirm continuity rules are practical and do not create a false implementation authorisation.

## Validation

Documentation-only. No executable behaviour changed. GitHub workflow runs are not attached to the final documentation commit.