### PR TITLE
docs: close continuity merge working point

### DIFF
--- a/docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md
+++ b/docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md
@@ -1,6 +1,6 @@
 # CPE System Assessment Roadmap v1
 
-**Status:** Drafted for independent review. Documentation-only programme roadmap.
+**Status:** Accepted and merged in ed-finder PR `#300` at `265738fe39513de3d6be32114485d4e19e6131f5`. This is a living documentation-only programme roadmap; update it when a phase advances, blocks, changes dependency, or completes.
 
 **Purpose:** Turn the accepted R1 Assessment Laboratory lineage into a durable, evidence-first future capability without burying it in generic planning work, duplicating CRE research truth, or prematurely creating a separate SRE repository.
 
@@ -77,23 +77,30 @@ Future CPE work must:
 
 ## 5. Programme roadmap
 
-| Phase | Status at this roadmap baseline | Deliverable | Gate before next phase |
+| Phase | Current status | Deliverable | Gate before next phase |
 |---|---|---|---|
-| **Cleanup 0** — Stage/status hygiene | Drafted | Correct Stage 6C working point; record reviewed head and merge commit; resolve superseded bookkeeping when authorised | Independent review and owner merge authorisation |
-| **Cleanup 1** — R1 freeze and designation | Drafted | Declare R1 lab the frozen DEV-only prototype/control lineage | Recorded in current stage, ledger, and decisions |
-| **Cleanup 2** — Continuity Ledger | Drafted | One ownership/lifecycle/migration inventory | Independent review and owner merge authorisation |
-| **Cleanup 3** — System Assessment Roadmap | Drafted | This strategic programme record | Independent review and owner merge authorisation |
-| **Cleanup 4** — CPE documentation foundation | Drafted separately | Correct CPE README and establish its two pillars | Independent review and owner merge authorisation |
-| **Cleanup 5** — Merge closeout protocol | Drafted | Durable recovery rule for all future merges | Independent review and owner merge authorisation |
-| **A0** — Continuity audit | Owner-accepted | Read-only R1→CPE audit, with repository pins and lifecycle findings | Complete; informs cleanups |
-| **A1** — CPE documentation foundation | Not started | CPE top-level documentation, first-system-assessment scope, ownership clarity | Cleanup package merged |
-| **A2** — First CPE System Assessment contract | Not started | Documentation-only logical Assessment Request/Result contract with every field owned | A1 accepted; no implementation authority |
+| **Cleanup 0** — Stage/status hygiene | Complete — ed-finder PR `#300` | Correct Stage 6C working point; record reviewed head and merge commit; resolve superseded bookkeeping | Completed and merged at `265738…` |
+| **Cleanup 1** — R1 freeze and designation | Complete — ed-finder PR `#300` | Declare R1 lab the frozen DEV-only prototype/control lineage | Recorded in current stage, ledger, and decisions |
+| **Cleanup 2** — Continuity Ledger | Complete — ed-finder PR `#300` | One ownership/lifecycle/migration inventory | Accepted and merged |
+| **Cleanup 3** — System Assessment Roadmap | Complete — ed-finder PR `#300` | This strategic programme record | Accepted and merged |
+| **Cleanup 4** — CPE documentation foundation | Complete — CPE PR `#1` | Correct CPE README and establish its two pillars | Merged at `9d5ff8…` |
+| **Cleanup 5** — Merge closeout protocol | Complete — ed-finder PR `#300` | Durable recovery rule for all future merges | Accepted and merged |
+| **A0** — Continuity audit | Complete — owner-accepted | Read-only R1→CPE audit, with repository pins and lifecycle findings | Informs all later work |
+| **A1** — CPE documentation foundation | Complete — minimum baseline | CPE top-level purpose, first System Assessment scope, and ownership clarity | CPE PR `#1` merged; no implementation authority created |
+| **D0** — Documentation Estate Audit and Spring-Clean Register | **Next authorised read-only audit** | Cross-repository inventory, lifecycle classification, canonical replacements, and safe cleanup batches | Independent review and owner acceptance; no physical cleanup during D0 |
+| **A2** — First CPE System Assessment contract | Not started | Documentation-only logical Assessment Request/Result contract with every field owned | D0 accepted and separate A2 owner authorisation |
 | **A3** — Bounded assessment core | Not started | Narrow CPE implementation of accepted R1 assessment semantics against synthetic labelled controls | A2 accepted; separate implementation authorisation |
 | **A4** — Capacity-sufficiency evidence inventory | Not started | CRE-backed read-only inventory for below-sufficiency, compact-sufficient, neutral-surplus, additive-surplus cases | Separate authorisation; inventory may conclude insufficient evidence |
 | **A5** — Deferred control admission | Not started | Evidence-backed contract and tests for 30-v-60 and/or Wregoe control only after A4 | A4 reviewed; owner authorisation |
 | **A6** — Plan Fit and comparison | Not started | Mature CPE Plan Fit and comparable candidate-system outputs | Assessment core and controls accepted |
 | **B** — Colony Plan Construction | Not started | Candidate layouts, sequencing, alternatives, protected-asset and validation handling | System Assessment produces trusted results |
 | **C** — ed-finder graduation | Not started | Presentation of stable CPE outputs beyond DEV-only laboratory | CPE outputs and contracts stable |
+
+### D0 scope boundary
+
+D0 inventories documents across `ed-finder`, CRE, and CPE against immutable pins. It classifies each item as canonical living, active contract, historic reference, generated/reference source, duplicate or superseded, stale or conflicting, deletion candidate, or unknown.
+
+D0 is evidence gathering only. It creates no archive, deletion, rename, relocation, versioning baseline, content rewrite, implementation, code, data, research, or deployment change. Its output is a Spring-Clean Register and proposed safe batches for separately authorised follow-up PRs.
 
 ## 6. A0 findings that govern all later work
 
@@ -104,8 +111,8 @@ The owner-accepted Programme A0 audit established:
 - the five current fixtures and two current strategies are fixture-only forward reconstruction material, not game truth;
 - `plateau_30_vs_60_case` and `wregoe_dual_dodec_control` have no admitted payload, expected result, test, UI, or active behaviour;
 - Stage 6B establishes the cross-repository ownership model;
-- CPE README ownership wording required correction;
-- Stage records require explicit, durable closeout to prevent stale recovery state.
+- the old CPE README ownership wording required correction, now completed in CPE PR `#1`;
+- stage records require explicit, durable closeout to prevent stale recovery state.
 
 ## 7. First CPE System Assessment contract shape
 
@@ -189,4 +196,4 @@ Rules:
 
 ## 11. Current next safe action
 
-Independently review the documentation-only cleanup package and the separate CPE documentation-foundation change. After explicit owner merge authorisation, begin **A1 CPE documentation foundation**. Do not start A2/A3/A4 work early.
+Conduct **D0 — Documentation Estate Audit and Spring-Clean Register** as a read-only cross-repository audit. Do not start physical cleanup, archive moves, deletions, a changelog/versioning baseline, or A2/A3/A4 work until D0 is independently reviewed and owner-accepted.

--- a/docs/ai/CURRENT_STAGE.md
+++ b/docs/ai/CURRENT_STAGE.md
@@ -4,17 +4,34 @@
 
 ## Status
 
-**Stage 6C is accepted and merged in PR `#299`. Programme A0, the read-only continuity audit of the R1 Assessment Laboratory toward a future CPE / System Assessment Engine, has been owner-accepted. A documentation-only continuity cleanup is now drafted for independent review. It does not authorise implementation, CPE scaffolding, CRE changes, data collection, fixture changes, live-game work, architecture selection, or deployment.**
+**The System Assessment continuity cleanup is accepted and merged in ed-finder PR `#300`. The initial CPE documentation foundation is accepted and merged in CPE PR `#1`. Cleanup 0–5 and Programme A0 are complete; the minimum A1 CPE documentation foundation is complete. The next safe action is D0: a read-only cross-repository Documentation Estate Audit and Spring-Clean Register. D0 does not authorise archive moves, deletions, versioning changes, CPE implementation, CRE data changes, external research, live-game work, architecture selection, or deployment.**
 
-## Canonical baseline
+## Current working points
 
-- Canonical repository: `brianstewart377-rgb/ed-finder`
-- Canonical base branch: `work/r1-canonical-body-evidence`
-- Canonical current baseline: `038bdde4999c0ff6ea337abbe2653c08b61118da`
-- Baseline event: PR `#299` — `docs: draft Stage 6C CRE-CPE field contract detail`
-- Stage 6C accepted reviewed head: `f12d4af7b6a05388ba4ae6522c5fc3e15fe754db`
-- Stage 6C merge commit: `038bdde4999c0ff6ea337abbe2653c08b61118da`
-- No deployment occurred.
+| Repository | Branch | Current verified commit | Current role |
+|---|---|---|---|
+| `brianstewart377-rgb/ed-finder` | `work/r1-canonical-body-evidence` | `265738fe39513de3d6be32114485d4e19e6131f5` | Cross-repository governance and future presentation |
+| `brianstewart377-rgb/colonisation-research-engine` | `main` | `add9a51350e7754dadc09cd9712cd43e96499e33` | Research evidence and planner-safe knowledge |
+| `brianstewart377-rgb/colony-planning-engine` | `main` | `9d5ff8cc3cdd6653081f5f490dfd4b5b40423197` | Future System Assessment and Colony Plan Construction |
+
+No deployment occurred.
+
+## Completed merge closeout
+
+| Repository | PR | Exact reviewed head | Merge commit | Merge method | Merged at | What changed | What did not change |
+|---|---|---|---|---|---|---|---|
+| `colony-planning-engine` | `#1` — `docs: establish CPE assessment ownership` | `08661c62d8741f17dc044f48607622f11b6ec903` | `9d5ff8cc3cdd6653081f5f490dfd4b5b40423197` | Merge commit | 2026-07-03 12:45:53 UTC | Corrected CPE README; established System Assessment Engine and Colony Plan Construction as CPE pillars; corrected CRE/CPE/ed-finder ownership language. | No CPE code, schema, tests, API, database, runtime, shared package, CRE change, R1 change, external research, or deployment. |
+| `ed-finder` | `#300` — `docs: establish system assessment continuity` | `d75ba145ad92f594608d377c7f675b927d3321ac` | `265738fe39513de3d6be32114485d4e19e6131f5` | Merge commit | 2026-07-03 12:46:02 UTC | Added the Stage 6 status closeout, System Assessment Continuity Ledger, CPE System Assessment Roadmap, merge-closeout protocol, and corrected recovery/status records. | No R1 evaluator, fixture, test, UI, normal app, CRE data, CPE implementation, scoring, ranking, recommendation, external research, runtime/storage/API choice, or deployment. |
+
+## Historical Programme A0 audit pins
+
+These are immutable audit pins, retained to make the accepted A0 review reproducible. They are not a claim that every repository has remained unchanged since that audit.
+
+| Repository | Branch at audit | Audit pin |
+|---|---|---|
+| `ed-finder` | `work/r1-canonical-body-evidence` | `038bdde4999c0ff6ea337abbe2653c08b61118da` |
+| `colonisation-research-engine` | `main` | `add9a51350e7754dadc09cd9712cd43e96499e33` |
+| `colony-planning-engine` | `main` | `439624022b41b10492aed9269f9805403d0bb439` |
 
 ## Accepted governance and ownership
 
@@ -23,21 +40,10 @@
 - Stage 6B remains the accepted CRE/CPE/ed-finder logical ownership boundary.
 - Stage 6C remains the accepted field-level documentation contract for the four logical boundary objects.
 - CRE owns research evidence, provenance, mechanics, observations, contradictions, confidence, planner-safe releases, and observed-state publications.
-- CPE is the future owner of player-specific planning.
 - Within CPE, the future **System Assessment Engine** owns programme-specific candidate-system assessment and comparison; **Colony Plan Construction** owns candidate layouts, sequencing, alternatives, and player-specific plan results.
 - ed-finder remains presentation and coordination only. The R1 Assessment Laboratory remains DEV-only, fixture-backed, deterministic, local, and separate from a future CPE runtime.
 
-## Programme A0 accepted audit baseline
-
-The owner-accepted A0 audit reviewed these immutable repository pins:
-
-| Repository | Branch | Pin |
-|---|---|---|
-| `ed-finder` | `work/r1-canonical-body-evidence` | `038bdde4999c0ff6ea337abbe2653c08b61118da` |
-| `colonisation-research-engine` | `main` | `add9a51350e7754dadc09cd9712cd43e96499e33` |
-| `colony-planning-engine` | `main` | `439624022b41b10492aed9269f9805403d0bb439` |
-
-The audit established the following durable boundaries:
+## R1 continuity boundaries
 
 - Assessment state is primary; Plan Fit is secondary and explicit-strategy-gated.
 - Missing or contradictory evidence cannot be rescued by Carrier, strategy, or later logic.
@@ -46,20 +52,24 @@ The audit established the following durable boundaries:
 - `plateau_30_vs_60_case` and `wregoe_dual_dodec_control` remain deferred controls pending an evidence-backed future admission contract.
 - R1 semantics move to CPE by reimplementation against controls, not by copying fixture assumptions or treating fixture data as game truth.
 
-The full audit findings, lifecycle classifications, stale-record register, and cleanup recommendation are recorded in `docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md`.
+The full lifecycle classifications, stale-record register, and migration treatment are recorded in `docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md`.
 
-## Documentation-only continuity cleanup
+## D0 — Documentation Estate Audit and Spring-Clean Register
 
-This cleanup package contains only governance and recovery material:
+D0 is a read-only audit across `ed-finder`, CRE, and CPE. It must inventory documentation and classify each item as:
 
-- corrected Stage 6C status and baseline information;
-- a durable System Assessment Continuity Ledger;
-- a CPE System Assessment Roadmap;
-- a Project Continuity and Merge Closeout Protocol;
-- accepted decisions establishing the CPE / System Assessment Engine naming and ownership;
-- a separate CPE README correction on its own documentation branch.
+- canonical living;
+- active contract;
+- historic reference;
+- generated/reference source;
+- duplicate or superseded;
+- stale or conflicting;
+- deletion candidate; or
+- unknown.
 
-It must not alter R1 evaluator semantics, fixtures, tests, UI, normal application behaviour, CRE data, CPE implementation, scoring, ranking, recommendation, research, or deployment.
+For each item, D0 records repository, branch/pin, owner, current role, canonical replacement where applicable, inbound references where known, evidence/reasoning, and recommended treatment: keep, update, archive, merge, or delete.
+
+D0 produces a Spring-Clean Register and a safe sequence of small cleanup PRs. It performs no archive move, deletion, product-version change, physical document restructure, code change, data change, or external research.
 
 ## Deferred controls
 
@@ -69,9 +79,9 @@ It must not alter R1 evaluator semantics, fixtures, tests, UI, normal applicatio
 
 ## Next safe action
 
-Obtain an independent read-only review of the documentation-only continuity cleanup and the CPE documentation-foundation change. Verify the exact live heads, changed files, PR status, reviews, and review threads before any owner merge decision.
+Conduct D0 as a read-only cross-repository Documentation Estate Audit and Spring-Clean Register against separately verified immutable pins for ed-finder, CRE, and CPE.
 
-Do not begin CPE implementation, change CRE source/data, add fixtures, collect external evidence, select runtime/storage/transport, integrate repositories, or deploy as part of this stage.
+Do not start physical documentation cleanup, archive moves, deletions, a changelog/versioning baseline, CPE implementation, CRE source/data changes, fixtures, external research, live-game work, runtime/storage/transport selection, integration, or deployment until D0 is independently reviewed and accepted.
 
 ## Recovery instruction
 
@@ -82,6 +92,6 @@ If context is lost, start read-only. Read:
 3. `docs/ai/CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md`;
 4. `docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md`;
 5. `docs/ai/DECISIONS.md`;
-6. the live PR metadata and Git status.
+6. the live repository/PR metadata and Git state.
 
-Report the recovered branch, exact commit, active phase, pending review, and next safe action before making any write.
+Report the recovered repositories, branches, exact commits, active phase, confirmed versus pending status, open PR/review state, and next safe action before making any write.

--- a/docs/ai/PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md
+++ b/docs/ai/PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md
@@ -1,6 +1,6 @@
 # Project Continuity and Merge Closeout Protocol v1
 
-**Status:** Drafted for independent review.
+**Status:** Accepted and merged in ed-finder PR `#300` at `265738fe39513de3d6be32114485d4e19e6131f5`.
 
 **Purpose:** Ensure that a new chat, reviewer, or implementation agent can recover the current project state from the repositories without relying on a long conversation, a remembered plan, or an uncommitted workspace.
 
@@ -9,6 +9,12 @@
 > A merged change is not fully closed until its durable recovery records are updated.
 
 `CURRENT_STAGE.md` is mandatory after every merge. The roadmap, continuity ledger, and decision register are updated when their respective subject matter changes.
+
+### Self-closeout rule
+
+A PR that itself updates `CURRENT_STAGE.md` cannot know its own merge SHA before it merges. It must record every completed predecessor merge it is closing, including exact reviewed heads and merge commits. Its own merge event remains recoverable from live GitHub PR metadata until a later ordinary working-point update references it.
+
+Do not create an endless chain of documentation-only PRs solely to record the merge SHA of the preceding closeout PR. The rule is satisfied when each closeout PR accurately records all prior unclosed merge events and its own exact head is guarded at merge time.
 
 ## 2. Mandatory records
 
@@ -35,6 +41,7 @@ For every merge:
 9. Append to `DECISIONS.md` only when a durable owner decision changed future constraints.
 10. Set one explicit next safe action.
 11. Do not start that next action without separate scope/owner authorisation.
+12. For a self-closeout PR, record its own approved head before merging and rely on GitHub PR metadata for its eventual merge SHA; do not open a recursive closeout solely for that event.
 
 ## 4. Status vocabulary
 

--- a/docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md
+++ b/docs/ai/SYSTEM_ASSESSMENT_CONTINUITY_LEDGER_V1.md
@@ -1,6 +1,6 @@
 # System Assessment Continuity Ledger v1
 
-**Status:** Drafted for independent review as a documentation-only continuity record.
+**Status:** Accepted and merged in ed-finder PR `#300` at `265738fe39513de3d6be32114485d4e19e6131f5`. This living continuity record is updated when an artefact’s ownership, lifecycle label, control status, or migration treatment changes.
 
 **Purpose:** Preserve the R1 Assessment Laboratory lineage while establishing the future home of programme-specific system assessment in **CPE / System Assessment Engine**. This ledger does not authorise implementation, migration, fixture changes, evidence collection, scoring, ranking, or architecture selection.
 
@@ -100,8 +100,8 @@ A future CPE implementation may preserve the **behavioural control** of a fixtur
 | `wregoe_dual_dodec_control` | Defer | Deferred control |
 | Stage 6B and 6C contracts | Keep as cross-repository governance authority | Accepted future design rule |
 | Stage 5 acceptance records and Stage 6A audit report | Retain for provenance | Historic reference only |
-| CPE README old ownership wording | Corrected in separate documentation PR | Stale documentation debt until merged |
-| Stage 6C current-stage unmerged wording | Corrected by this documentation cleanup | Stale documentation debt until merged |
+| Previous CPE README ownership wording | Resolved by CPE PR `#1`, merged at `9d5ff8cc3cdd6653081f5f490dfd4b5b40423197`; retain only as historical before-state | Historic reference only |
+| Stage 6C current-stage unmerged wording | Resolved by ed-finder PR `#300`, merged at `265738fe39513de3d6be32114485d4e19e6131f5`; retain only as historical before-state | Historic reference only |
 | PR #293 | Closed on 2026-07-03 as superseded by #294; retain only its closure provenance | Historic reference only |
 | CRE summary-index mismatch from Stage 6A | CRE-side follow-up; not changed here | Stale documentation debt |
 
@@ -141,4 +141,4 @@ Explicitly excluded: new SRE repository, database, API, shared package, runtime/
 
 ## 10. Next safe action
 
-Review this ledger alongside `CPE_SYSTEM_ASSESSMENT_ROADMAP_V1.md`, `PROJECT_CONTINUITY_AND_MERGE_CLOSEOUT_PROTOCOL_V1.md`, and the separate CPE documentation PR. After independent review and separate owner merge authorisation, begin the CPE documentation foundation—not implementation.
+Conduct D0 — the read-only cross-repository Documentation Estate Audit and Spring-Clean Register. Do not change this ledger’s classifications further until that audit supplies evidence for a lifecycle, replacement, archive, or deletion recommendation.


### PR DESCRIPTION
## Purpose

Documentation-only post-merge closeout for CPE PR #1 and ed-finder PR #300.

## Changes

- Records both completed merge events, exact reviewed heads, merge commits, merge method, times, scope, and non-scope in `CURRENT_STAGE.md`.
- Marks Cleanup 0–5, A0, and the minimum A1 CPE documentation foundation complete.
- Adds D0 — Documentation Estate Audit and Spring-Clean Register — as the next authorised read-only phase.
- Resolves merged-status lifecycle entries in the Continuity Ledger.
- Clarifies the merge-closeout protocol’s self-closeout handling to prevent recursive documentation-only closeout PRs.

## Scope boundary

No physical document cleanup, archive move, deletion, changelog/versioning baseline, CPE implementation, CRE data change, R1 change, external research, live-game work, runtime/storage/API decision, or deployment.

## Review focus

- Verify the merge facts for CPE PR #1 and ed-finder PR #300.
- Verify D0 remains read-only and does not quietly authorise the spring-clean itself.
- Verify the self-closeout rule strengthens continuity rather than weakening merge accountability.
- Confirm only the three living governance documents changed.