### PR TITLE
fix: improve local single-user app readiness

### DIFF
--- a/frontend-v2/scripts/dev-doctor.mjs
+++ b/frontend-v2/scripts/dev-doctor.mjs
@@ -9,6 +9,7 @@ const APP_ROOT = process.cwd();
 const REPO_ROOT = path.resolve(APP_ROOT, '..');
 const args = new Set(process.argv.slice(2));
 const strictMode = args.has('--strict');
+const DEFAULT_CANONICAL_COMPARE_REF = 'origin/work/r1-canonical-body-evidence';
 
 const warnings = [];
 const failures = [];
@@ -93,6 +94,21 @@ function resolveApiTarget() {
   return {
     target: 'http://127.0.0.1:8001',
     source: 'vite fallback default',
+  };
+}
+
+function resolveCompareRef() {
+  const override = process.env.DEV_DOCTOR_COMPARE_REF?.trim();
+  if (override) {
+    return {
+      ref: override,
+      source: 'process.env.DEV_DOCTOR_COMPARE_REF',
+    };
+  }
+
+  return {
+    ref: DEFAULT_CANONICAL_COMPARE_REF,
+    source: 'default canonical branch',
   };
 }
 
@@ -191,6 +207,8 @@ async function main() {
   const branch = runGit('rev-parse --abbrev-ref HEAD', true) || '(unknown)';
   const commit = runGit('rev-parse --short HEAD', true) || '(unknown)';
   printResult('[ok]', `branch=${branch} commit=${commit}`);
+  const { ref: compareRef, source: compareRefSource } = resolveCompareRef();
+  printResult('[ok]', `compare ref=${compareRef} (source: ${compareRefSource})`);
 
   const trackedChanges = runGit('status --porcelain --untracked-files=no', true) || '';
   if (trackedChanges) {
@@ -214,25 +232,31 @@ async function main() {
 
   const fetched = runGit('fetch --quiet origin', true);
   if (fetched !== null && branch !== '(unknown)') {
-    const aheadBehindRaw = runGit('rev-list --left-right --count HEAD...origin/main', true) || '';
-    if (aheadBehindRaw) {
+    const compareRefExists = runGit(`rev-parse --verify ${compareRef}`, true);
+    const aheadBehindRaw = compareRefExists
+      ? runGit(`rev-list --left-right --count HEAD...${compareRef}`, true) || ''
+      : '';
+    if (!compareRefExists) {
+      warnings.push(`Unable to verify comparison reference ${compareRef}.`);
+      printResult('[warn]', `unable to verify comparison reference ${compareRef}`);
+    } else if (aheadBehindRaw) {
       const [aheadText, behindText] = aheadBehindRaw.split(/\s+/);
       const ahead = Number(aheadText || '0');
       const behind = Number(behindText || '0');
       if (ahead > 0 && behind > 0) {
-        warnings.push('Branch diverged from origin/main.');
+        warnings.push(`Branch diverged from ${compareRef}.`);
         printResult('[warn]', `branch diverged (ahead ${ahead}, behind ${behind})`);
       } else if (behind > 0) {
-        warnings.push(`Local branch is behind origin/main by ${behind} commit(s).`);
-        printResult('[warn]', `behind origin/main by ${behind}`);
+        warnings.push(`Local branch is behind ${compareRef} by ${behind} commit(s).`);
+        printResult('[warn]', `behind ${compareRef} by ${behind}`);
       } else if (ahead > 0) {
-        warnings.push(`Local branch is ahead of origin/main by ${ahead} commit(s).`);
-        printResult('[warn]', `ahead of origin/main by ${ahead}`);
+        warnings.push(`Local branch is ahead of ${compareRef} by ${ahead} commit(s).`);
+        printResult('[warn]', `ahead of ${compareRef} by ${ahead}`);
       } else {
-        printResult('[ok]', 'in sync with origin/main');
+        printResult('[ok]', `in sync with ${compareRef}`);
       }
     } else {
-      printResult('[warn]', 'unable to compare against origin/main');
+      printResult('[warn]', `unable to compare against ${compareRef}`);
     }
   } else {
     printResult('[warn]', 'unable to fetch origin for sync check');
@@ -297,9 +321,10 @@ async function main() {
     }
   }
 
+  const syncBranch = compareRef.startsWith('origin/') ? compareRef.slice('origin/'.length) : compareRef;
   console.log('');
   console.log(
-    'If warnings appear, run: git pull --ff-only, verify .env.local, restart dev server, then rerun npm run dev:doctor:strict'
+    `If warnings appear, run: git pull --ff-only origin ${syncBranch}, verify .env.local, restart dev server, then rerun npm run dev:doctor:strict`
   );
 
   if (strictMode && (warnings.length > 0 || failures.length > 0)) {

--- a/frontend-v2/scripts/start-or-reuse.mjs
+++ b/frontend-v2/scripts/start-or-reuse.mjs
@@ -66,10 +66,16 @@ async function main() {
   }
 
   const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-  const viteBin = path.resolve(scriptDir, '../node_modules/vite/bin/vite.js');
+  const npmExecPath = process.env.npm_execpath;
+  if (!npmExecPath) {
+    console.error(
+      'npm execution context is unavailable. Run `npm install --no-package-lock` in frontend-v2, then rerun `npm run start`.'
+    );
+    process.exit(1);
+  }
 
   await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [viteBin, '--host', '0.0.0.0', '--port', '3000'], {
+    const child = spawn(process.execPath, [npmExecPath, 'run', 'dev', '--', '--host', '0.0.0.0', '--port', '3000'], {
       stdio: 'inherit',
       cwd: path.resolve(scriptDir, '..'),
     });

--- a/frontend-v2/vite.config.ts
+++ b/frontend-v2/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig, loadEnv, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -9,6 +9,97 @@ const rootDir = fileURLToPath(new URL('.', import.meta.url));
 const packageJsonPath = path.resolve(rootDir, 'package.json');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8')) as { version?: string };
 const appVersion = packageJson.version ?? '0.0.0';
+
+function createApiProxyPlugin(proxyTarget: string): Plugin {
+  const handler = async (req: any, res: any, next: () => void) => {
+    if (!req.url?.startsWith('/api')) {
+      next();
+      return;
+    }
+
+    try {
+      const upstreamUrl = new URL(req.url, proxyTarget);
+      const headers = new Headers();
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (!value) continue;
+        const lowerKey = key.toLowerCase();
+        if (lowerKey === 'host' || lowerKey === 'connection' || lowerKey === 'content-length') {
+          continue;
+        }
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            headers.append(key, item);
+          }
+        } else {
+          headers.set(key, String(value));
+        }
+      }
+
+      const bodyChunks: Buffer[] = [];
+      if (req.method && !['GET', 'HEAD'].includes(req.method.toUpperCase())) {
+        for await (const chunk of req) {
+          bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+      }
+
+      const response = await fetch(upstreamUrl, {
+        method: req.method,
+        headers,
+        body: bodyChunks.length > 0 ? Buffer.concat(bodyChunks) : undefined,
+        redirect: 'manual',
+      });
+
+      res.statusCode = response.status;
+      for (const [key, value] of response.headers.entries()) {
+        const lowerKey = key.toLowerCase();
+        if (lowerKey === 'content-length' || lowerKey === 'content-encoding' || lowerKey === 'transfer-encoding' || lowerKey === 'connection') {
+          continue;
+        }
+        res.setHeader(key, value);
+      }
+
+      const bytes = Buffer.from(await response.arrayBuffer());
+      res.setHeader('content-length', String(bytes.length));
+      res.end(bytes);
+    } catch (error) {
+      res.statusCode = 502;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          detail: `Local dev proxy could not reach ${proxyTarget}. Check VITE_DEV_API_TARGET and network access.`,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    }
+  };
+
+  return {
+    name: 'local-dev-api-proxy',
+    configureServer(server) {
+      server.middlewares.use(handler);
+    },
+    configurePreviewServer(server) {
+      server.middlewares.use(handler);
+    },
+  };
+}
+
+function resolveHmrConfig(loadedEnv: Record<string, string>, runtimeEnv: NodeJS.ProcessEnv) {
+  const protocol = loadedEnv.VITE_DEV_HMR_PROTOCOL || runtimeEnv.VITE_DEV_HMR_PROTOCOL;
+  const host = loadedEnv.VITE_DEV_HMR_HOST || runtimeEnv.VITE_DEV_HMR_HOST;
+  const clientPortRaw = loadedEnv.VITE_DEV_HMR_CLIENT_PORT || runtimeEnv.VITE_DEV_HMR_CLIENT_PORT;
+  const clientPort = clientPortRaw ? Number(clientPortRaw) : undefined;
+
+  if (!protocol && !host && clientPort === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(protocol ? { protocol } : {}),
+    ...(host ? { host } : {}),
+    ...(Number.isFinite(clientPort) ? { clientPort } : {}),
+  };
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Vite config for ed-finder v2 — Emergent preview / dev variant.
@@ -29,13 +120,14 @@ export default defineConfig(({ mode }) => {
   const publicBase = loadedEnv.VITE_PUBLIC_BASE
     || process.env.VITE_PUBLIC_BASE
     || '/';
+  const hmr = resolveHmrConfig(loadedEnv, process.env);
 
   return {
     base: publicBase,
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
     },
-    plugins: [react()],
+    plugins: [react(), createApiProxyPlugin(proxyTarget)],
     resolve: {
       preserveSymlinks: true,
       alias: {
@@ -47,16 +139,7 @@ export default defineConfig(({ mode }) => {
       port: 3000,
       strictPort: true,
       allowedHosts: true,
-      hmr: {
-        clientPort: 443,
-        protocol: 'wss',
-      },
-      proxy: {
-        '/api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-      },
+      ...(hmr ? { hmr } : {}),
     },
     // Preview server (used by Playwright E2E and `yarn preview`) proxies
     // /api the same way the dev server does. Without this, the production
@@ -64,12 +147,6 @@ export default defineConfig(({ mode }) => {
     preview: {
       host: '0.0.0.0',
       port: 4173,
-      proxy: {
-        '/api': {
-          target: proxyTarget,
-          changeOrigin: true,
-        },
-      },
     },
     build: {
       outDir: 'dist',


### PR DESCRIPTION
## Purpose

Make the real local app easier for its sole user/tester to run and use through the planner journey.

## Confirmed fixes

- `dev:doctor` compares against the canonical branch by default, prints its comparison ref, and gives the corresponding fast-forward pull command.
- `npm run start` launches through the npm execution context instead of a hard-coded Vite binary path.
- local development API requests can proxy to an explicit target, with a readable 502 payload when that target is unreachable.
- HMR now uses ordinary localhost defaults unless remote settings are explicitly supplied.

## Verified journey

Using `VITE_DEV_API_TARGET=https://ed-finder.app`, the author verified:

```text
Finder → System Detail → Start a plan → Create/open draft → Build Plan → Preview → Validation
```

Preview remains correctly gated until actual plan content is selected; that was not a dead end.

## Scope

Frontend development/readiness only:

- `frontend-v2/scripts/dev-doctor.mjs`
- `frontend-v2/scripts/start-or-reuse.mjs`
- `frontend-v2/vite.config.ts`

No hosted Review Lab, Docker, database, Redis, deployment, accounts, API router, schema, or Stage 26 implementation work.

## Validation reported

- `VITE_DEV_API_TARGET=https://ed-finder.app npm run start`
- browser core-journey check
- `npm run typecheck`
- `npm run build` (existing non-fatal asset/chunk warnings)
- `npm run test:planner`
- `npm run dev:doctor` (expected warning: no local API at `127.0.0.1:8001`)

## Review focus

One independent review only. Verify the exact base/head and the three-file scope, then concentrate on:

1. proxy correctness for query strings, non-JSON responses, redirects, errors, and any streaming/SSE route that the frontend actually relies on;
2. whether the custom middleware is necessary and correctly applies to both Vite dev and preview;
3. whether the start script works under the supported package-manager execution path;
4. no regression to the genuine local Finder → Detail → Planner → Preview → Validation route.

Do not treat this PR as deployment or hosted-review authority.