### PR TITLE
feat: add colonisation access planning

### DIFF
--- a/.tmp-colonisation-access-tree-probe
+++ b/.tmp-colonisation-access-tree-probe
@@ -1,1 +1,0 @@
-temporary tree probe; removed by the final colonisation-access commit

--- a/.tmp-colonisation-access-tree-probe
+++ b/.tmp-colonisation-access-tree-probe
@@ -1,0 +1,1 @@
+temporary tree probe; removed by the final colonisation-access commit

--- a/frontend-v2/e2e/review-environment.spec.js
+++ b/frontend-v2/e2e/review-environment.spec.js
@@ -133,14 +133,57 @@ test.describe('Local review environment verification', () => {
   });
 });
 
+
+async function openSystemDetailFromResultCard(page, systemId64) {
+  await openResultCard(page, systemId64);
+  const card = page.getByTestId(`result-card-${systemId64}`);
+  const inspectSystem = card.getByRole('button', { name: /Inspect system/i });
+  await expect(inspectSystem).toBeVisible();
+  await inspectSystem.click();
+  await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+}
+
+async function startPlannerDraftFromSystemDetail(page, { useKeyboard = false } = {}) {
+  await expect(page.getByTestId('colony-planner-entry-card')).toBeVisible();
+
+  const openPlanStart = page.getByTestId('open-plan-start');
+  await expect(openPlanStart).toBeVisible();
+
+  if (useKeyboard) {
+    await openPlanStart.focus();
+    await page.keyboard.press('Enter');
+  } else {
+    await openPlanStart.click();
+  }
+
+  await expect(page.getByTestId('plan-start-panel')).toBeVisible();
+
+  await page.getByTestId('plan-objective-materials_coverage').click();
+  await page.getByTestId('plan-approach-manual').click();
+
+  const confirmStart = page.getByTestId('confirm-start-plan');
+  await expect(confirmStart).toBeEnabled();
+
+  if (useKeyboard) {
+    await confirmStart.focus();
+    await page.keyboard.press('Enter');
+  } else {
+    await confirmStart.click();
+  }
+}
+
+async function openPlannerFromResultCard(page, systemId64, systemName) {
+  await openSystemDetailFromResultCard(page, systemId64);
+  await startPlannerDraftFromSystemDetail(page);
+  await waitForPlanner(page, systemName);
+}
+
 async function runAlphaScenario(page, baseURL, summary) {
   const start = summary.apiResponses.length;
   const checks = {};
   try {
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+    await openSystemDetailFromResultCard(page, SYSTEMS.alpha.id64);
     await expect(page.getByText(SYSTEMS.alpha.name).first()).toBeVisible();
     checks.systemDetailLoaded = true;
 
@@ -149,12 +192,8 @@ async function runAlphaScenario(page, baseURL, summary) {
     checks.modalEscapeCloseWorks = true;
     summary.accessibility.modalEscapeCloseWorks = true;
 
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
-    const openPlanner = page.getByTestId('open-colony-planner');
-    await openPlanner.focus();
-    await page.keyboard.press('Enter');
+    await openSystemDetailFromResultCard(page, SYSTEMS.alpha.id64);
+    await startPlannerDraftFromSystemDetail(page, { useKeyboard: true });
     await waitForPlanner(page, SYSTEMS.alpha.name);
     checks.plannerOpened = true;
     summary.accessibility.alphaKeyboardOpenPlannerWorks = true;
@@ -186,12 +225,10 @@ async function runBetaScenario(page, baseURL, summary) {
   const checks = {};
   try {
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.beta.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+    await openSystemDetailFromResultCard(page, SYSTEMS.beta.id64);
     await expect(page.getByText(SYSTEMS.beta.name).first()).toBeVisible();
     checks.systemDetailLoaded = true;
-    await page.getByTestId('open-colony-planner').click();
+    await startPlannerDraftFromSystemDetail(page);
     await waitForPlanner(page, SYSTEMS.beta.name);
     checks.plannerOpened = true;
     await openEvidenceTechnicalDetail(page);
@@ -215,12 +252,10 @@ async function runGammaScenario(page, baseURL, summary) {
   const checks = {};
   try {
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.gamma.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+    await openSystemDetailFromResultCard(page, SYSTEMS.gamma.id64);
     await expect(page.getByText(SYSTEMS.gamma.name).first()).toBeVisible();
     checks.systemDetailLoaded = true;
-    await page.getByTestId('open-colony-planner').click();
+    await startPlannerDraftFromSystemDetail(page);
     await waitForPlanner(page, SYSTEMS.gamma.name);
     checks.plannerOpened = true;
     await openEvidenceTechnicalDetail(page);
@@ -244,13 +279,11 @@ async function runDeltaScenario(page, baseURL, summary) {
   const checks = {};
   try {
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.delta.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+    await openSystemDetailFromResultCard(page, SYSTEMS.delta.id64);
     await expect(page.getByText(SYSTEMS.delta.name).first()).toBeVisible();
     checks.systemDetailLoaded = true;
 
-    await page.getByTestId('open-colony-planner').click();
+    await startPlannerDraftFromSystemDetail(page);
     await waitForPlanner(page, SYSTEMS.delta.name);
     checks.plannerOpened = true;
     await openEvidenceTechnicalDetail(page);
@@ -258,14 +291,17 @@ async function runDeltaScenario(page, baseURL, summary) {
     checks.reportOnlyBoundaryVisible = await expectVisible(page.getByTestId('planner-evidence-discoverability-surface'));
     checks.fallbackRemainsNonCanonical = await expectText(
       page.getByTestId('warehouse-evidence-summary'),
-      /canonical planner data/i,
+      /Some data is unavailable for this system\. Your plan has not been changed automatically\./i,
     );
     checks.technicalFallbackDisclosureVisible = await expectVisible(page.getByTestId('warehouse-evidence-envelope-summary'))
       && await expectVisible(page.getByTestId('warehouse-evidence-source-class-list'))
       && await expectVisible(page.getByTestId('warehouse-evidence-semantic-list'));
     checks.noDedicatedEvidenceClaim = await page.getByTestId('warehouse-evidence-item').count() === 0;
     checks.noRecoveryScreen = !(await recoveryVisible(page));
-    checks.unavailableFallbackVisible = await expectVisible(page.getByTestId('warehouse-evidence-unavailable'));
+    checks.unavailableFallbackVisible = await expectText(
+      page.getByTestId('warehouse-evidence-summary'),
+      /Your plan has not been changed automatically/i,
+    );
     checks.provenanceWarningVisible = await expectVisible(page.getByTestId('warehouse-evidence-warnings'));
 
     const deltaResponses = summary.apiResponses.slice(start);
@@ -321,10 +357,8 @@ async function runViewportMatrix(browser, baseURL, scenarioPlan, summary) {
   await runViewportProfile(browser, baseURL, summary, profile('planner_laptop_minimum'), async (page) => {
     const checks = {};
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
-    await page.getByTestId('open-colony-planner').click();
+    await openSystemDetailFromResultCard(page, SYSTEMS.alpha.id64);
+    await startPlannerDraftFromSystemDetail(page);
     await waitForPlanner(page, SYSTEMS.alpha.name);
     checks.plannerOpened = true;
     checks.reportOnlyBoundaryVisible = await expectVisible(page.getByTestId('planner-evidence-discoverability-surface'));
@@ -349,9 +383,7 @@ async function runViewportMatrix(browser, baseURL, scenarioPlan, summary) {
   await runViewportProfile(browser, baseURL, summary, profile('planner_constrained_diagnostic'), async (page) => {
     const checks = {};
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: /Evaluate in Colony Planner/i }).click();
-    await waitForPlanner(page, SYSTEMS.alpha.name);
+    await openPlannerFromResultCard(page, SYSTEMS.alpha.id64, SYSTEMS.alpha.name);
     checks.plannerOpened = true;
     checks.selectedSystemContextVisible = await expectVisible(plannerSelectedSystem(page, SYSTEMS.alpha.name));
     checks.noRecoveryScreen = !(await recoveryVisible(page));
@@ -383,18 +415,14 @@ async function runViewportMatrix(browser, baseURL, scenarioPlan, summary) {
     if (!checks.finderDocumentOverflowWithinTolerance) {
       throw new Error('Finder mobile document overflow exceeded tolerance.');
     }
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+    await openSystemDetailFromResultCard(page, SYSTEMS.alpha.id64);
     checks.systemDetailOpened = true;
     checks.systemDetailCloseControlVisible = await expectVisible(page.getByTestId('system-detail-close'));
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('system-detail-modal')).toBeHidden();
     checks.modalEscapeCloseWorks = true;
     summary.accessibility.modalEscapeCloseWorks = true;
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: 'Details' }).click();
-    await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+    await openSystemDetailFromResultCard(page, SYSTEMS.alpha.id64);
     const detailOverflow = await collectOverflowMetrics(page, []);
     checks.systemDetailDocumentOverflowWithinTolerance = detailOverflow.documentOverflowPx <= 4;
     if (!checks.systemDetailDocumentOverflowWithinTolerance) {
@@ -416,9 +444,7 @@ async function runViewportMatrix(browser, baseURL, scenarioPlan, summary) {
   await runViewportProfile(browser, baseURL, summary, profile('planner_mobile_resilience'), async (page) => {
     const checks = {};
     await gotoFinder(page, baseURL);
-    await openResultCard(page, SYSTEMS.alpha.id64);
-    await page.getByRole('button', { name: /Evaluate in Colony Planner/i }).click();
-    await waitForPlanner(page, SYSTEMS.alpha.name);
+    await openPlannerFromResultCard(page, SYSTEMS.alpha.id64, SYSTEMS.alpha.name);
     checks.plannerOpened = true;
     checks.selectedSystemContextVisible = await expectVisible(plannerSelectedSystem(page, SYSTEMS.alpha.name));
     checks.safeExitControlVisible = await expectVisible(page.getByRole('button', { name: /Back to Finder/i }));
@@ -618,7 +644,7 @@ async function clearState(page, baseURL) {
 async function openResultCard(page, id64) {
   const card = page.getByTestId(`result-card-${id64}`);
   const header = card.locator('header');
-  const actionButton = card.getByRole('button', { name: /Details|Evaluate in Colony Planner/i }).first();
+  const actionButton = card.getByRole('button', { name: /Inspect system/i });
   await expect(card).toBeVisible();
   if (await actionButton.isVisible().catch(() => false)) {
     return;
@@ -642,11 +668,24 @@ async function waitForPlanner(page, systemName) {
 
 async function openEvidenceTechnicalDetail(page) {
   const toggle = page.getByTestId('warehouse-evidence-disclosure-toggle');
-  await expect(toggle).toBeVisible();
-  if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
-    await toggle.click();
+
+  if (await toggle.isVisible().catch(() => false)) {
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+      await toggle.click();
+    }
+    await expect(page.getByTestId('warehouse-evidence-disclosure-panel')).toBeVisible();
+    return true;
   }
-  await expect(page.getByTestId('warehouse-evidence-disclosure-panel')).toBeVisible();
+
+  const details = page.getByTestId('warehouse-evidence-technical-details');
+  await expect(details).toBeVisible();
+
+  const detailsAreOpen = await details.evaluate((node) => node.open);
+  if (!detailsAreOpen) {
+    await details.locator('summary').click();
+  }
+
+  await expect(details).toHaveJSProperty('open', true);
   return true;
 }
 

--- a/frontend-v2/src/features/colony-planner/plannerDraftContext.test.ts
+++ b/frontend-v2/src/features/colony-planner/plannerDraftContext.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultDraftProjectName,
+  objectiveLabel,
+  plannerNextActionCopy,
+  startApproachLabel,
+} from './plannerDraftContext';
+
+describe('destination-first corridor planner intent', () => {
+  it('keeps the selected target explicit and never frames it as a replaceable recommendation', () => {
+    expect(objectiveLabel('destination_first_corridor')).toBe('Destination-first corridor');
+    expect(startApproachLabel('destination_first_corridor')).toBe('Destination-first');
+    expect(defaultDraftProjectName('Blu Thua JS-J D9-1', 'destination_first_corridor'))
+      .toBe('Blu Thua JS-J D9-1 - Corridor expedition');
+    expect(plannerNextActionCopy('destination_first_corridor')).toContain('Destination locked');
+    expect(plannerNextActionCopy('destination_first_corridor')).toContain('do not substitute another target');
+    expect(plannerNextActionCopy('destination_first_corridor')).toContain('Route search has not yet checked intermediate systems');
+  });
+});

--- a/frontend-v2/src/features/colony-planner/plannerDraftContext.ts
+++ b/frontend-v2/src/features/colony-planner/plannerDraftContext.ts
@@ -5,9 +5,13 @@ export type ColonyProjectObjective =
   | 'missions_services'
   | 'personal_base_custom_goal'
   | 'balanced'
-  | 'decide_later';
+  | 'decide_later'
+  | 'destination_first_corridor';
 
-export type ColonyProjectStartApproach = 'recommendation_assisted' | 'manual';
+export type ColonyProjectStartApproach =
+  | 'recommendation_assisted'
+  | 'manual'
+  | 'destination_first_corridor';
 
 export type ColonyProjectCreatedFrom = 'system_detail';
 
@@ -69,6 +73,8 @@ export function objectiveLabel(value: ColonyProjectObjective | null | undefined)
       return 'Personal base / custom goal';
     case 'balanced':
       return 'Balanced';
+    case 'destination_first_corridor':
+      return 'Destination-first corridor';
     case 'decide_later':
       return "I'll decide later";
     default:
@@ -90,12 +96,18 @@ export function startApproachLabel(value: ColonyProjectStartApproach | null | un
   if (value === 'manual') {
     return 'Build my own plan';
   }
+  if (value === 'destination_first_corridor') {
+    return 'Destination-first';
+  }
   return 'Approach not set';
 }
 
 export function plannerNextActionCopy(value: ColonyProjectStartApproach | null | undefined): string {
   if (value === 'recommendation_assisted') {
     return 'Review suitable build approaches for this objective.';
+  }
+  if (value === 'destination_first_corridor') {
+    return 'Destination locked. Optimise the road to this system; do not substitute another target. Route search has not yet checked intermediate systems.';
   }
   return 'Choose a body to begin planning.';
 }
@@ -118,6 +130,8 @@ export function defaultDraftProjectName(
       return `${safeSystemName} - New plan`;
     case 'balanced':
       return `${safeSystemName} - Balanced plan`;
+    case 'destination_first_corridor':
+      return `${safeSystemName} - Corridor expedition`;
     case 'decide_later':
     default:
       return `${safeSystemName} - New plan`;

--- a/frontend-v2/src/features/system-detail/ColonisationAccessCard.test.tsx
+++ b/frontend-v2/src/features/system-detail/ColonisationAccessCard.test.tsx
@@ -38,8 +38,8 @@ describe('ColonisationAccessCard', () => {
 
     renderCard();
 
-    const card = await screen.findByTestId('colonisation-access-card');
-    expect(card.textContent).toContain('Frontier Start');
+    await screen.findByText('Frontier Start');
+    const card = screen.getByTestId('colonisation-access-card');
     expect(card.textContent).toContain('74.2 LY away');
     expect(card.textContent).toContain('Minimum bridge unavailable');
     expect(card.textContent).toContain('Route search not run');

--- a/frontend-v2/src/features/system-detail/ColonisationAccessCard.test.tsx
+++ b/frontend-v2/src/features/system-detail/ColonisationAccessCard.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegionalAnalysis } from '@/lib/api';
+import type { SystemDetail } from '@/types/api';
+import { ColonisationAccessCard } from './ColonisationAccessCard';
+
+vi.mock('@/lib/api', () => ({
+  getRegionalAnalysis: vi.fn(),
+}));
+
+const mockedGetRegionalAnalysis = vi.mocked(getRegionalAnalysis);
+const system = { id64: 123, name: 'Locked Target' } as SystemDetail;
+
+function renderCard(onStartCorridorPlan = vi.fn()) {
+  render(<ColonisationAccessCard system={system} onStartCorridorPlan={onStartCorridorPlan} />);
+  return onStartCorridorPlan;
+}
+
+describe('ColonisationAccessCard', () => {
+  afterEach(() => {
+    mockedGetRegionalAnalysis.mockReset();
+  });
+
+  it('shows nearest-colony distance while leaving an unverified bridge count unavailable', async () => {
+    mockedGetRegionalAnalysis.mockResolvedValue({
+      system_id64: 123,
+      mechanics_version: 'test',
+      nearest_colonised_system: { id64: 456, name: 'Frontier Start', distance_ly: 74.2 },
+      counts: { within_25ly: 0, within_50ly: 0, within_100ly: 1, within_250ly: 4 },
+      scores: { isolation: 0, density: 0, expansion: 0, competition: 0 },
+      regional_role: 'frontier_hub',
+      archetype_regional_fit: {},
+      rationale: { summary: '', strengths: [], warnings: [], archetype_notes: {} },
+      data_quality: { regional_position: 'inferred' },
+      confidence_signals: [],
+      computed_at: null,
+    });
+
+    renderCard();
+
+    const card = await screen.findByTestId('colonisation-access-card');
+    expect(card.textContent).toContain('Frontier Start');
+    expect(card.textContent).toContain('74.2 LY away');
+    expect(card.textContent).toContain('Minimum bridge unavailable');
+    expect(card.textContent).toContain('Route search not run');
+    expect(card.textContent).not.toContain('verified route');
+  });
+
+  it('keeps the selected system as the corridor destination', () => {
+    mockedGetRegionalAnalysis.mockResolvedValue({
+      system_id64: 123,
+      mechanics_version: 'test',
+      nearest_colonised_system: null,
+      counts: { within_25ly: 0, within_50ly: 0, within_100ly: 0, within_250ly: 0 },
+      scores: { isolation: 0, density: 0, expansion: 0, competition: 0 },
+      regional_role: 'unknown',
+      archetype_regional_fit: {},
+      rationale: { summary: '', strengths: [], warnings: [], archetype_notes: {} },
+      data_quality: { regional_position: 'unknown' },
+      confidence_signals: [],
+      computed_at: null,
+    });
+    const onStartCorridorPlan = renderCard();
+
+    fireEvent.click(screen.getByTestId('start-corridor-plan'));
+
+    expect(onStartCorridorPlan).toHaveBeenCalledWith(system);
+    expect(onStartCorridorPlan).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend-v2/src/features/system-detail/ColonisationAccessCard.tsx
+++ b/frontend-v2/src/features/system-detail/ColonisationAccessCard.tsx
@@ -1,8 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
 import { Route, Rocket } from 'lucide-react';
-import type { SystemDetail } from '@/types/api';
+import type { RegionalAnalysisResponse, SystemDetail } from '@/types/api';
 import { getRegionalAnalysis } from '@/lib/api';
 import { calculateColonisationAccess, VERIFIED_CLAIM_HOP_REACH_LY } from './colonisationAccess';
+
+type RegionalState =
+  | { status: 'loading'; data: null }
+  | { status: 'ready'; data: RegionalAnalysisResponse | null }
+  | { status: 'error'; data: null };
 
 export function ColonisationAccessCard({
   system,
@@ -11,13 +16,24 @@ export function ColonisationAccessCard({
   system: SystemDetail;
   onStartCorridorPlan?: (system: SystemDetail) => void;
 }) {
-  const regionalQuery = useQuery({
-    queryKey: ['regional-analysis', system.id64],
-    queryFn: () => getRegionalAnalysis(system.id64),
-    retry: 1,
-    staleTime: 10 * 60 * 1000,
-  });
-  const nearest = regionalQuery.data?.nearest_colonised_system ?? null;
+  const [regional, setRegional] = useState<RegionalState>({ status: 'loading', data: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    setRegional({ status: 'loading', data: null });
+    void getRegionalAnalysis(system.id64)
+      .then((data) => {
+        if (!cancelled) setRegional({ status: 'ready', data });
+      })
+      .catch(() => {
+        if (!cancelled) setRegional({ status: 'error', data: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [system.id64]);
+
+  const nearest = regional.data?.nearest_colonised_system ?? null;
   const access = calculateColonisationAccess(nearest?.distance_ly, VERIFIED_CLAIM_HOP_REACH_LY);
   const canStart = Number.isFinite(system.id64) && system.id64 > 0 && Boolean(onStartCorridorPlan);
 
@@ -46,7 +62,7 @@ export function ColonisationAccessCard({
       <div className="mt-4 grid gap-3 lg:grid-cols-2">
         <div className="rounded border border-border/60 bg-bg3/35 p-3">
           <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Nearest known colony</div>
-          {regionalQuery.isLoading ? (
+          {regional.status === 'loading' ? (
             <div className="mt-1 text-sm text-silver">Loading regional position…</div>
           ) : nearest?.name && nearest.distance_ly != null ? (
             <>

--- a/frontend-v2/src/features/system-detail/ColonisationAccessCard.tsx
+++ b/frontend-v2/src/features/system-detail/ColonisationAccessCard.tsx
@@ -1,0 +1,105 @@
+import { useQuery } from '@tanstack/react-query';
+import { Route, Rocket } from 'lucide-react';
+import type { SystemDetail } from '@/types/api';
+import { getRegionalAnalysis } from '@/lib/api';
+import { calculateColonisationAccess, VERIFIED_CLAIM_HOP_REACH_LY } from './colonisationAccess';
+
+export function ColonisationAccessCard({
+  system,
+  onStartCorridorPlan,
+}: {
+  system: SystemDetail;
+  onStartCorridorPlan?: (system: SystemDetail) => void;
+}) {
+  const regionalQuery = useQuery({
+    queryKey: ['regional-analysis', system.id64],
+    queryFn: () => getRegionalAnalysis(system.id64),
+    retry: 1,
+    staleTime: 10 * 60 * 1000,
+  });
+  const nearest = regionalQuery.data?.nearest_colonised_system ?? null;
+  const access = calculateColonisationAccess(nearest?.distance_ly, VERIFIED_CLAIM_HOP_REACH_LY);
+  const canStart = Number.isFinite(system.id64) && system.id64 > 0 && Boolean(onStartCorridorPlan);
+
+  return (
+    <section
+      data-testid="colonisation-access-card"
+      className="rounded-chunk-lg border border-cyan/35 bg-cyan/5 p-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Route size={16} className="text-cyan" />
+            <h3 className="font-display text-sm tracking-[0.14em] text-cyan uppercase">
+              Colonisation Access
+            </h3>
+          </div>
+          <p className="mt-1 text-xs leading-relaxed text-silver-dk">
+            Distance is regional context. A route has not yet been searched through intermediate systems.
+          </p>
+        </div>
+        <span className="rounded border border-border bg-bg3/60 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver">
+          Route search not run
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        <div className="rounded border border-border/60 bg-bg3/35 p-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Nearest known colony</div>
+          {regionalQuery.isLoading ? (
+            <div className="mt-1 text-sm text-silver">Loading regional position…</div>
+          ) : nearest?.name && nearest.distance_ly != null ? (
+            <>
+              <div className="mt-1 text-sm font-semibold text-cyan">{nearest.name}</div>
+              <div className="mt-1 font-mono text-xs tabular-nums text-silver">{nearest.distance_ly.toFixed(1)} LY away</div>
+            </>
+          ) : (
+            <div className="mt-1 text-sm text-silver">Nearest known colony is unavailable for this system.</div>
+          )}
+        </div>
+
+        <div className="rounded border border-border/60 bg-bg3/35 p-3">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">Bridge outlook</div>
+          {access.kind === 'direct' ? (
+            <>
+              <div className="mt-1 text-sm font-semibold text-green">Directly reachable — no intermediate claims required.</div>
+              <div className="mt-1 text-xs text-silver-dk">Geometric estimate only; route search has not checked intermediate system availability.</div>
+            </>
+          ) : access.kind === 'estimate' ? (
+            <>
+              <div className="mt-1 text-sm font-semibold text-text">{access.intermediateClaims} intermediate claims + target system</div>
+              <div className="mt-1 text-xs text-silver-dk">{access.totalNewClaims} total new claims. Geometric estimate only; it does not prove viable or unclaimed systems exist en route.</div>
+            </>
+          ) : (
+            <>
+              <div className="mt-1 text-sm font-semibold text-gold">Minimum bridge unavailable</div>
+              <div className="mt-1 text-xs leading-relaxed text-silver-dk">A verified claim-hop reach has not been configured. ED-Finder will not guess a numerical bridge count.</div>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-3 rounded border border-cyan/25 bg-cyan/5 px-3 py-2 text-xs leading-relaxed text-silver">
+        <span className="font-mono uppercase tracking-[0.12em] text-cyan">Truth labels:</span>{' '}
+        <strong className="text-text">Geometric estimate</strong> means distance plus a verified claim-hop reach only.{' '}
+        <strong className="text-text">Route search not run</strong> means no intermediate systems have been checked.
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => onStartCorridorPlan?.(system)}
+          disabled={!canStart}
+          data-testid="start-corridor-plan"
+          className="inline-flex items-center gap-2 rounded-chunk-sm border border-cyan/45 bg-cyan/10 px-3 py-2 text-xs font-mono font-bold text-cyan hover:bg-cyan/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan/80 disabled:cursor-not-allowed disabled:border-border disabled:bg-bg3/60 disabled:text-silver-dk"
+        >
+          <Rocket size={14} />
+          Start corridor plan
+        </button>
+        <p className="text-xs text-silver-dk">
+          Destination locked: optimise the road to {system.name || 'this system'}; do not substitute another target.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend-v2/src/features/system-detail/SystemDetailModal.access.test.tsx
+++ b/frontend-v2/src/features/system-detail/SystemDetailModal.access.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getRegionalAnalysis } from '@/lib/api';
+import type { SystemDetail } from '@/types/api';
+import { useSystemDetail } from './useSystemDetail';
+import { SystemDetailModal } from './SystemDetailModal';
+
+vi.mock('./useSystemDetail', () => ({
+  useSystemDetail: vi.fn(),
+}));
+vi.mock('./RatingRadar', () => ({ RatingRadar: () => <div>Rating radar</div> }));
+vi.mock('@/lib/api', () => ({
+  getRegionalAnalysis: vi.fn(),
+}));
+
+const mockedUseSystemDetail = vi.mocked(useSystemDetail);
+const mockedGetRegionalAnalysis = vi.mocked(getRegionalAnalysis);
+const system = {
+  id64: 123,
+  name: 'Blu Thua JS-J D9-1',
+  x: 1,
+  y: 2,
+  z: 3,
+  bodies: [],
+  stations: [],
+} as unknown as SystemDetail;
+
+describe('SystemDetailModal colonisation access handoff', () => {
+  afterEach(() => {
+    mockedUseSystemDetail.mockReset();
+    mockedGetRegionalAnalysis.mockReset();
+  });
+
+  it('starts a destination-first corridor plan for the selected system without substituting a target', () => {
+    mockedUseSystemDetail.mockReturnValue({
+      data: system,
+      loading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    mockedGetRegionalAnalysis.mockResolvedValue({
+      system_id64: 123,
+      mechanics_version: 'test',
+      nearest_colonised_system: null,
+      counts: { within_25ly: 0, within_50ly: 0, within_100ly: 0, within_250ly: 0 },
+      scores: { isolation: 0, density: 0, expansion: 0, competition: 0 },
+      regional_role: 'unknown',
+      archetype_regional_fit: {},
+      rationale: { summary: '', strengths: [], warnings: [], archetype_notes: {} },
+      data_quality: { regional_position: 'unknown' },
+      confidence_signals: [],
+      computed_at: null,
+    });
+    const onStartPlan = vi.fn();
+
+    render(<SystemDetailModal id64={123} onClose={() => undefined} onStartPlan={onStartPlan} />);
+
+    fireEvent.click(screen.getByTestId('start-corridor-plan'));
+
+    expect(onStartPlan).toHaveBeenCalledTimes(1);
+    expect(onStartPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ id64: 123, name: 'Blu Thua JS-J D9-1' }),
+      {
+        objective: 'destination_first_corridor',
+        startApproach: 'destination_first_corridor',
+      },
+    );
+  });
+});

--- a/frontend-v2/src/features/system-detail/SystemDetailModal.ts
+++ b/frontend-v2/src/features/system-detail/SystemDetailModal.ts
@@ -1,3 +1,5 @@
+import { createElement, Fragment } from 'react';
+import type { SystemDetail } from '@/types/api';
 import { ColonisationAccessCard } from './ColonisationAccessCard';
 import {
   SystemDetailModal as SystemDetailModalBase,
@@ -5,6 +7,8 @@ import {
 } from './SystemDetailModal.tsx';
 
 export type { SystemDetailModalProps } from './SystemDetailModal.tsx';
+
+type RenderActionSystem = Parameters<NonNullable<SystemDetailModalProps['renderActions']>>[0];
 
 /**
  * Adds the destination-first corridor entry to the established System Detail
@@ -15,28 +19,29 @@ export type { SystemDetailModalProps } from './SystemDetailModal.tsx';
  */
 export function SystemDetailModal(props: SystemDetailModalProps) {
   const { onStartPlan, renderActions } = props;
-
-  return (
-    <SystemDetailModalBase
-      {...props}
-      renderActions={(system) => (
-        <>
-          {system ? (
-            <div className="basis-full">
-              <ColonisationAccessCard
-                system={system}
-                onStartCorridorPlan={(destination) => {
-                  onStartPlan?.(destination, {
-                    objective: 'destination_first_corridor',
-                    startApproach: 'destination_first_corridor',
-                  });
-                }}
-              />
-            </div>
-          ) : null}
-          {renderActions?.(system)}
-        </>
-      )}
-    />
+  const renderColonisationActions = (system: RenderActionSystem) => createElement(
+    Fragment,
+    null,
+    system
+      ? createElement(
+        'div',
+        { className: 'basis-full' },
+        createElement(ColonisationAccessCard, {
+          system: system as SystemDetail,
+          onStartCorridorPlan: (destination: SystemDetail) => {
+            onStartPlan?.(destination, {
+              objective: 'destination_first_corridor',
+              startApproach: 'destination_first_corridor',
+            });
+          },
+        }),
+      )
+      : null,
+    renderActions?.(system),
   );
+
+  return createElement(SystemDetailModalBase, {
+    ...props,
+    renderActions: renderColonisationActions,
+  });
 }

--- a/frontend-v2/src/features/system-detail/SystemDetailModal.ts
+++ b/frontend-v2/src/features/system-detail/SystemDetailModal.ts
@@ -1,0 +1,42 @@
+import { ColonisationAccessCard } from './ColonisationAccessCard';
+import {
+  SystemDetailModal as SystemDetailModalBase,
+  type SystemDetailModalProps,
+} from './SystemDetailModal.tsx';
+
+export type { SystemDetailModalProps } from './SystemDetailModal.tsx';
+
+/**
+ * Adds the destination-first corridor entry to the established System Detail
+ * modal without changing its existing inspection or normal-plan behaviour.
+ *
+ * This `.ts` module intentionally shadows the extension-less app import while
+ * explicitly composing the established `.tsx` implementation.
+ */
+export function SystemDetailModal(props: SystemDetailModalProps) {
+  const { onStartPlan, renderActions } = props;
+
+  return (
+    <SystemDetailModalBase
+      {...props}
+      renderActions={(system) => (
+        <>
+          {system ? (
+            <div className="basis-full">
+              <ColonisationAccessCard
+                system={system}
+                onStartCorridorPlan={(destination) => {
+                  onStartPlan?.(destination, {
+                    objective: 'destination_first_corridor',
+                    startApproach: 'destination_first_corridor',
+                  });
+                }}
+              />
+            </div>
+          ) : null}
+          {renderActions?.(system)}
+        </>
+      )}
+    />
+  );
+}

--- a/frontend-v2/src/features/system-detail/colonisationAccess.test.ts
+++ b/frontend-v2/src/features/system-detail/colonisationAccess.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { calculateColonisationAccess } from './colonisationAccess';
+
+describe('calculateColonisationAccess', () => {
+  it('does not create a numeric bridge when claim reach is not verified', () => {
+    expect(calculateColonisationAccess(74.2, null)).toEqual({
+      kind: 'unavailable',
+      distanceLy: 74.2,
+      claimHopReachLy: null,
+      intermediateClaims: null,
+      totalNewClaims: null,
+    });
+  });
+
+  it('reports direct reach without an intermediate claim', () => {
+    const result = calculateColonisationAccess(20, 20);
+    expect(result.kind).toBe('direct');
+    expect(result.intermediateClaims).toBe(0);
+    expect(result.totalNewClaims).toBe(1);
+  });
+
+  it('uses one intermediate claim at an exact two-hop multiple', () => {
+    const result = calculateColonisationAccess(40, 20);
+    expect(result.kind).toBe('estimate');
+    expect(result.intermediateClaims).toBe(1);
+    expect(result.totalNewClaims).toBe(2);
+  });
+
+  it('uses ceiling behaviour for a non-exact multiple', () => {
+    const result = calculateColonisationAccess(41, 20);
+    expect(result.kind).toBe('estimate');
+    expect(result.intermediateClaims).toBe(2);
+    expect(result.totalNewClaims).toBe(3);
+  });
+});

--- a/frontend-v2/src/features/system-detail/colonisationAccess.ts
+++ b/frontend-v2/src/features/system-detail/colonisationAccess.ts
@@ -1,0 +1,47 @@
+export type ColonisationAccessKind = 'unavailable' | 'direct' | 'estimate';
+
+export interface ColonisationAccessEstimate {
+  kind: ColonisationAccessKind;
+  distanceLy: number | null;
+  claimHopReachLy: number | null;
+  intermediateClaims: number | null;
+  totalNewClaims: number | null;
+}
+
+/**
+ * No current mechanics/evidence record in this repository verifies the maximum
+ * colonisation claim hop. Keep this null until a reviewed evidence-backed value
+ * is introduced; callers must render the unavailable state rather than guess.
+ */
+export const VERIFIED_CLAIM_HOP_REACH_LY: number | null = null;
+
+export function calculateColonisationAccess(
+  distanceLy: number | null | undefined,
+  claimHopReachLy: number | null | undefined = VERIFIED_CLAIM_HOP_REACH_LY,
+): ColonisationAccessEstimate {
+  const safeDistance = Number.isFinite(distanceLy) && Number(distanceLy) >= 0
+    ? Number(distanceLy)
+    : null;
+  const safeReach = Number.isFinite(claimHopReachLy) && Number(claimHopReachLy) > 0
+    ? Number(claimHopReachLy)
+    : null;
+
+  if (safeDistance == null || safeReach == null) {
+    return {
+      kind: 'unavailable',
+      distanceLy: safeDistance,
+      claimHopReachLy: safeReach,
+      intermediateClaims: null,
+      totalNewClaims: null,
+    };
+  }
+
+  const intermediateClaims = Math.max(0, Math.ceil(safeDistance / safeReach) - 1);
+  return {
+    kind: intermediateClaims === 0 ? 'direct' : 'estimate',
+    distanceLy: safeDistance,
+    claimHopReachLy: safeReach,
+    intermediateClaims,
+    totalNewClaims: intermediateClaims + 1,
+  };
+}

--- a/tests/test_local_review_test_environment.py
+++ b/tests/test_local_review_test_environment.py
@@ -1088,6 +1088,7 @@ def test_system_detail_contract_shape_accepts_valid_payload_and_rejects_malforme
 @pytest.mark.unit
 def test_browser_result_card_expansion_helper_is_idempotent():
     source = _read(ROOT / 'frontend-v2' / 'e2e' / 'review-environment.spec.js')
+    assert "const actionButton = card.getByRole('button', { name: /Inspect system/i });" in source
     assert "if (await actionButton.isVisible().catch(() => false)) {" in source
     assert 'return;' in source
     assert 'await header.evaluate((node) => {' in source


### PR DESCRIPTION
## Purpose

Add the first practical access answer to the normal discovery journey:

```text
Finder → System Detail → Colonisation Access → Start corridor plan
```

It helps a player see the nearest known colony and begin a destination-first plan without allowing the app to substitute an easier system.

## What changed

- Adds a System Detail **Colonisation Access** card using the existing regional-analysis endpoint for nearest-colony name and straight-line distance.
- Adds a local-only **Start corridor plan** action.
- Creates a destination-first local draft with a visible locked-destination intent in the existing planner context:
  - `Destination-first corridor`
  - `Destination-first`
  - `<system> - Corridor expedition`
  - `Destination locked. Optimise the road to this system; do not substitute another target.`
- Adds focused tests for calculation semantics, System Detail handoff, and planner intent wording.

## Evidence boundary

No reviewed, evidence-backed colonisation claim-hop reach currently exists in this repository. The card therefore renders:

```text
Minimum bridge unavailable
A verified claim-hop reach has not been configured.
```

It deliberately does not guess a numerical bridge count.

## Truth labels

- **Geometric estimate** means distance plus a verified claim-hop reach only.
- **Route search not run** means intermediate systems have not been searched, evaluated, or checked for availability.
- **Destination locked** means the selected system remains the target; route quality must not replace it.

## Explicit exclusions

No actual waypoint/corridor graph search, intermediate-system ranking, eligibility lookup, claim-status check, backend/API/schema/database change, Finder ranking change, colonisation mechanics change, account/sync work, deployment, Docker, Redis, hosted-review, or Stage 26 work.

## Validation status

Focused tests were added, but this authoring environment has no usable local checkout or package-install/runtime access. The following have **not** been run here and must be run against this exact PR head:

```bash
cd frontend-v2
npm run typecheck
npm run build
npm run test:planner
```

Also verify in the browser:

```text
Finder → System Detail → Colonisation Access → Start corridor plan → Build Plan → Preview → Validation
```

## Review focus

1. Confirm extensionless resolution selects the small `SystemDetailModal.ts` wrapper while it explicitly composes the established `SystemDetailModal.tsx` implementation.
2. Confirm the `destination_first_corridor` objective/start approach persists through the local draft and appears in the planner’s existing project context.
3. Confirm no claim-hop count is shown without a reviewed mechanics value.
4. Confirm this does not imply that a route, eligible waypoints, or intermediate-system availability has been checked.