### PR TITLE
feat: implement Stage 25C selected-system continuity

### DIFF
--- a/frontend-v2/e2e/review-environment.spec.js
+++ b/frontend-v2/e2e/review-environment.spec.js
@@ -412,6 +412,10 @@ async function runSelectedSystemRouteJourney(page, baseURL) {
   await expectNoVisibleText(page, createdProject.projectName);
   checks.crossSystemPlannerProjectRejected = true;
 
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.alpha.id64}/project/${createdProject.id}`), { waitUntil: 'domcontentloaded' });
+  await waitForPlanner(page, SYSTEMS.alpha.name);
+  checks.exactPlannerProjectRestoredForDesktopChecks = true;
+
   return checks;
 }
 

--- a/frontend-v2/e2e/review-environment.spec.js
+++ b/frontend-v2/e2e/review-environment.spec.js
@@ -347,7 +347,9 @@ async function runSelectedSystemRouteJourney(page, baseURL) {
 
   await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.alpha.id64}`), { waitUntil: 'domcontentloaded' });
   await expect(page.getByText('No active draft for this system')).toBeVisible();
-  await page.getByRole('button', { name: /^Back to Finder$/ }).click();
+  await page.getByTestId('planner-inline-state')
+    .getByRole('button', { name: /^Back to Finder$/ })
+    .click();
   await expect(page).toHaveURL(new RegExp(`#finder/context/${SYSTEMS.alpha.id64}$`));
   await expect(page.getByTestId('system-detail-modal')).toHaveCount(0);
   checks.plannerBackReturnsFinderContext = true;

--- a/frontend-v2/e2e/review-environment.spec.js
+++ b/frontend-v2/e2e/review-environment.spec.js
@@ -826,14 +826,16 @@ async function expectNoStaleSelectedContext(page, {
   absentEvidencePosture = false,
   absentProjectName = null,
 }) {
-  await expectNoVisibleText(page, absentName);
+  const context = productShellContext(page);
+
+  await expectNoVisibleText(context, absentName);
   if (absentId64 != null) {
-    await expectNoVisibleText(page, `ID64 ${absentId64}`);
+    await expectNoVisibleText(context, `ID64 ${absentId64}`);
   }
   if (absentEvidencePosture) {
-    await expectNoVisibleText(page, 'Evidence posture unavailable');
+    await expectNoVisibleText(context, 'Evidence posture unavailable');
   }
-  await expectNoVisibleText(page, absentProjectName);
+  await expectNoVisibleText(context, absentProjectName);
   return true;
 }
 

--- a/frontend-v2/e2e/review-environment.spec.js
+++ b/frontend-v2/e2e/review-environment.spec.js
@@ -328,6 +328,91 @@ async function runDeltaScenario(page, baseURL, summary) {
   }
 }
 
+async function runSelectedSystemRouteJourney(page, baseURL) {
+  const checks = {};
+
+  await page.goto(resolveUrl(baseURL, `/#finder/context/${SYSTEMS.alpha.id64}`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('search-summary')).toBeVisible();
+  await expect(productShellContext(page)).toContainText(SYSTEMS.alpha.name);
+  await expect(productShellContext(page)).toContainText('Evidence posture unavailable');
+  await expect(page.getByTestId('system-detail-modal')).toHaveCount(0);
+  checks.finderContextVisible = true;
+
+  await page.goto(resolveUrl(baseURL, `/#finder/system/${SYSTEMS.alpha.id64}`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('system-detail-modal')).toBeVisible();
+  await page.getByTestId('system-detail-close').click();
+  await expect(page).toHaveURL(new RegExp(`#finder/context/${SYSTEMS.alpha.id64}$`));
+  await expect(page.getByTestId('system-detail-modal')).toHaveCount(0);
+  checks.inspectCloseReturnsFinderContext = true;
+
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.alpha.id64}`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByText('No active draft for this system')).toBeVisible();
+  await page.getByRole('button', { name: /^Back to Finder$/ }).click();
+  await expect(page).toHaveURL(new RegExp(`#finder/context/${SYSTEMS.alpha.id64}$`));
+  await expect(page.getByTestId('system-detail-modal')).toHaveCount(0);
+  checks.plannerBackReturnsFinderContext = true;
+  checks.directPlannerNoDraftVisible = true;
+
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.alpha.id64}`), { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: /^Create draft$/ }).click();
+  await expect(page).toHaveURL(new RegExp(`#colony-planner/system/${SYSTEMS.alpha.id64}/project/`));
+  checks.explicitCreateDraftRoutesToExactProject = true;
+
+  const createdProject = await readStoredProject(page, SYSTEMS.alpha.id64);
+  checks.createdDraftPersisted = Boolean(createdProject?.id && createdProject?.projectName);
+
+  await page.goto(resolveUrl(baseURL, `/#finder/system/${SYSTEMS.beta.id64}/extra`), { waitUntil: 'domcontentloaded' });
+  await expect(productShellContext(page)).toContainText('Selected system route invalid');
+  await expectNoStaleSelectedContext(page, {
+    absentName: SYSTEMS.alpha.name,
+    absentId64: SYSTEMS.alpha.id64,
+    absentEvidencePosture: true,
+    absentProjectName: createdProject?.projectName ?? null,
+  });
+  checks.invalidFinderRouteClearsStaleContext = true;
+
+  await page.goto(resolveUrl(baseURL, '/#finder/context/7999999999999'), { waitUntil: 'domcontentloaded' });
+  await expect(productShellContext(page)).toContainText('Selected system unavailable');
+  await expectNoStaleSelectedContext(page, {
+    absentName: SYSTEMS.alpha.name,
+    absentId64: SYSTEMS.alpha.id64,
+    absentEvidencePosture: true,
+    absentProjectName: createdProject?.projectName ?? null,
+  });
+  checks.unavailableSelectedSystemClearsStaleContext = true;
+
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.beta.id64}/extra`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('planner-inline-state')).toContainText('Selected system route invalid');
+  await expectNoStaleSelectedContext(page, {
+    absentName: SYSTEMS.alpha.name,
+    absentId64: SYSTEMS.alpha.id64,
+    absentEvidencePosture: true,
+    absentProjectName: createdProject?.projectName ?? null,
+  });
+  checks.invalidPlannerSystemRouteClearsStaleContext = true;
+
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.alpha.id64}/project`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('planner-inline-state')).toContainText('Selected project route invalid');
+  await expectNoVisibleText(page, createdProject?.projectName ?? null);
+  checks.malformedPlannerProjectRejected = true;
+
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.alpha.id64}/project/missing-project`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('planner-inline-state')).toContainText('Selected project unavailable');
+  await expectNoVisibleText(page, createdProject?.projectName ?? null);
+  checks.missingPlannerProjectRejected = true;
+
+  if (!createdProject?.id) {
+    throw new Error('Selected-system route journey could not find the explicit draft in local storage.');
+  }
+
+  await page.goto(resolveUrl(baseURL, `/#colony-planner/system/${SYSTEMS.beta.id64}/project/${createdProject.id}`), { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('planner-inline-state')).toContainText('Selected project does not belong to this system');
+  await expectNoVisibleText(page, createdProject.projectName);
+  checks.crossSystemPlannerProjectRejected = true;
+
+  return checks;
+}
+
 async function runViewportMatrix(browser, baseURL, scenarioPlan, summary) {
   await runViewportProfile(browser, baseURL, summary, profile('planner_desktop_primary'), async (page) => {
     const checks = {};
@@ -342,6 +427,7 @@ async function runViewportMatrix(browser, baseURL, scenarioPlan, summary) {
         await runDeltaScenario(page, baseURL, summary);
       }
     }
+    Object.assign(checks, await runSelectedSystemRouteJourney(page, baseURL));
     checks.telemetryToggleKeyboardWorks = await ensureTelemetryToggleKeyboardWorks(page);
     summary.accessibility.plannerDesktopTelemetryToggleKeyboardWorks = true;
     checks.noRecoveryScreen = !(await recoveryVisible(page));
@@ -698,8 +784,55 @@ function plannerWorkspaceHeader(page) {
   return page.getByTestId('workspace-context-header');
 }
 
+function productShellContext(page) {
+  return visibleByTestId(page, 'product-shell-context');
+}
+
 function plannerSelectedSystem(page, systemName) {
   return plannerWorkspaceHeader(page).getByText(systemName, { exact: true });
+}
+
+async function readStoredProject(page, systemId64) {
+  return page.evaluate((targetSystemId64) => {
+    const raw = window.localStorage.getItem('ed_colony_projects_v1');
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    const projects = parsed?.state?.projects ?? parsed?.projects ?? {};
+    const match = Object.values(projects)
+      .find((project) => project && project.system_id64 === targetSystemId64 && !project.archived_at);
+
+    if (!match) return null;
+    return {
+      id: match.id,
+      projectName: match.project_name,
+    };
+  }, systemId64);
+}
+
+async function expectNoVisibleText(page, text) {
+  if (!text) return true;
+  const locator = page.getByText(text, { exact: true });
+  if (await locator.count() === 0) return true;
+  await expect(locator.first()).toBeHidden();
+  return true;
+}
+
+async function expectNoStaleSelectedContext(page, {
+  absentName,
+  absentId64,
+  absentEvidencePosture = false,
+  absentProjectName = null,
+}) {
+  await expectNoVisibleText(page, absentName);
+  if (absentId64 != null) {
+    await expectNoVisibleText(page, `ID64 ${absentId64}`);
+  }
+  if (absentEvidencePosture) {
+    await expectNoVisibleText(page, 'Evidence posture unavailable');
+  }
+  await expectNoVisibleText(page, absentProjectName);
+  return true;
 }
 
 async function expectText(locator, pattern) {

--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -509,6 +509,22 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.queryByTestId('system-detail-modal')).toBeNull();
   });
 
+  it.each([
+    '#finder/system/123/extra',
+    '#system/123/extra',
+  ])('does not open Inspect for malformed selected-system route %s', async (hash) => {
+    window.location.hash = hash;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context').textContent).toContain(
+        'Selected system route invalid',
+      );
+    });
+    expect(screen.queryByTestId('system-detail-modal')).toBeNull();
+  });
+
   it('clears stale evidence posture and prior identity when a selected-system route becomes unavailable', async () => {
     window.location.hash = '#finder/context/123';
 

--- a/frontend-v2/src/App.test.tsx
+++ b/frontend-v2/src/App.test.tsx
@@ -12,6 +12,7 @@ const {
   mockSearchRun,
   mockSearchResults,
   mockSearchState,
+  mockUseSystemDetail,
 } = vi.hoisted(() => ({
   mockWatchlistAdd: vi.fn(),
   mockWatchlistRemove: vi.fn(),
@@ -22,6 +23,12 @@ const {
   mockSearchState: {
     current: { kind: 'idle' } as Record<string, unknown>,
   },
+  mockUseSystemDetail: vi.fn((id64: number | null) => ({
+    data: id64 != null ? { id64, name: `System ${id64}` } : null,
+    loading: false,
+    error: null as string | null,
+    refetch: vi.fn(),
+  })),
 }));
 
 vi.mock('@/lib/api', () => {
@@ -140,12 +147,14 @@ vi.mock('@/features/eddn/EddnTicker', () => ({
 vi.mock('@/features/system-detail/SystemDetailModal', () => ({
   SystemDetailModal: ({
     id64,
+    onClose,
     savedForLater,
     saveForLaterState = 'idle',
     onToggleSaveForLater,
     onStartPlan,
   }: {
     id64: number;
+    onClose?: () => void;
     savedForLater?: boolean;
     saveForLaterState?: 'idle' | 'saving' | 'removing';
     onToggleSaveForLater?: (system: {
@@ -178,6 +187,7 @@ vi.mock('@/features/system-detail/SystemDetailModal', () => ({
   }) => (
     <div data-testid="system-detail-modal">
       System detail {id64}
+      <button type="button" onClick={onClose}>Close system details</button>
       <button
         type="button"
         disabled={saveForLaterState === 'saving' || saveForLaterState === 'removing'}
@@ -225,30 +235,36 @@ vi.mock('@/features/system-detail/SystemDetailModal', () => ({
 }));
 
 vi.mock('@/features/system-detail/useSystemDetail', () => ({
-  useSystemDetail: (id64: number | null) => ({
-    data: id64 != null ? { id64, name: `System ${id64}` } : null,
-    loading: false,
-    error: null,
-    refetch: vi.fn(),
-  }),
+  useSystemDetail: mockUseSystemDetail,
 }));
 
 vi.mock('@/features/colony-planner/ColonyPlannerWorkspace', () => ({
   ColonyPlannerWorkspace: ({
     id64,
     projectId,
+    invalidSystemRoute,
+    invalidProjectRoute,
+    system,
     onBackToFinder,
     onOpenSystemDetail,
+    onCreateDraft,
   }: {
     id64: number | null;
     projectId?: string | null;
+    invalidSystemRoute?: boolean;
+    invalidProjectRoute?: boolean;
+    system?: { id64: number; name: string } | null;
     onBackToFinder: () => void;
     onOpenSystemDetail: (id64: number) => void;
+    onCreateDraft: (system: { id64: number; name: string }) => void;
   }) => (
     <div data-testid="colony-planner-workspace">
-      Colony Planner workspace {id64 ?? 'none'} / {projectId ?? 'no-project'}
+      Colony Planner workspace {id64 ?? 'none'} / {projectId ?? 'no-project'} / {system?.name ?? 'no-system'}
+      {invalidSystemRoute ? <span>invalid-system-route</span> : null}
+      {invalidProjectRoute ? <span>invalid-project-route</span> : null}
       <button type="button" onClick={onBackToFinder}>Back to Finder</button>
       <button type="button" onClick={() => id64 != null && onOpenSystemDetail(id64)}>Open full system detail</button>
+      {system ? <button type="button" onClick={() => onCreateDraft(system)}>Create draft</button> : null}
     </div>
   ),
 }));
@@ -268,6 +284,13 @@ afterEach(() => {
   mockSearchRun.mockClear();
   mockSearchResults.length = 0;
   mockSearchState.current = { kind: 'idle' };
+  mockUseSystemDetail.mockReset();
+  mockUseSystemDetail.mockImplementation((id64: number | null) => ({
+    data: id64 != null ? { id64, name: `System ${id64}` } : null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }));
   vi.unstubAllGlobals();
 });
 
@@ -339,7 +362,7 @@ describe('App Colony Planner workspace route', () => {
     expect(fetchMock).toHaveBeenCalledWith('/v2/bg/coalsack-1600.jpg?v=2', { method: 'HEAD', cache: 'no-cache' });
   });
 
-  it('renders the dedicated workspace without the global product-shell context or System Detail modal', async () => {
+  it('renders the dedicated workspace with selected-system shell context and without the System Detail modal', async () => {
     window.location.hash = '#colony-planner/system/123';
 
     render(<App />);
@@ -348,8 +371,8 @@ describe('App Colony Planner workspace route', () => {
       expect(screen.getByTestId('colony-planner-workspace').textContent).toContain('123');
     });
     expect(screen.getByTestId('navbar')).toBeTruthy();
-    expect(screen.queryByTestId('product-shell-context')).toBeNull();
-    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('Evidence posture unavailable');
     expect(screen.queryByTestId('system-detail-modal')).toBeNull();
   });
 
@@ -373,7 +396,7 @@ describe('App Colony Planner workspace route', () => {
     expect(finderMain?.className).toContain('max-w-[1840px]');
   });
 
-  it('renders the workspace no-system state for #colony-planner without duplicate shell context', async () => {
+  it('renders the workspace no-system state for #colony-planner without selected-system shell context', async () => {
     window.location.hash = '#colony-planner';
 
     render(<App />);
@@ -413,6 +436,107 @@ describe('App Colony Planner workspace route', () => {
       expect(window.location.hash).toBe('#finder/system/123');
     });
     expect(screen.getByTestId('system-detail-modal').textContent).toContain('123');
+  });
+
+  it('renders non-modal Finder context without opening Inspect', async () => {
+    window.location.hash = '#finder/context/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Search form')).toBeTruthy();
+    });
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('Evidence posture unavailable');
+    expect(screen.queryByTestId('system-detail-modal')).toBeNull();
+  });
+
+  it('returns Inspect close to Finder context', async () => {
+    window.location.hash = '#finder/system/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('system-detail-modal')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Close system details/i }));
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe('#finder/context/123');
+    });
+    expect(screen.queryByTestId('system-detail-modal')).toBeNull();
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+  });
+
+  it('returns Planner to Finder context without reopening Inspect', async () => {
+    window.location.hash = '#colony-planner/system/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('colony-planner-workspace')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Back to Finder$/i }));
+
+    await waitFor(() => {
+      expect(window.location.hash).toBe('#finder/context/123');
+    });
+    expect(screen.queryByTestId('system-detail-modal')).toBeNull();
+  });
+
+  it('clears stale selected-system shell context after a malformed Finder route replaces a valid one', async () => {
+    window.location.hash = '#finder/context/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+    });
+
+    act(() => {
+      window.location.hash = '#finder/system';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context').textContent).toContain('Selected system route invalid');
+    });
+    expect(screen.getByTestId('product-shell-context').textContent).not.toContain('System 123');
+    expect(screen.getByTestId('product-shell-context').textContent).not.toContain('Evidence posture unavailable');
+    expect(screen.getByTestId('product-shell-context').textContent).not.toContain('ID64 123');
+    expect(screen.queryByTestId('system-detail-modal')).toBeNull();
+  });
+
+  it('clears stale evidence posture and prior identity when a selected-system route becomes unavailable', async () => {
+    window.location.hash = '#finder/context/123';
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
+      expect(screen.getByTestId('product-shell-context').textContent).toContain('Evidence posture unavailable');
+    });
+
+    mockUseSystemDetail.mockImplementation((id64: number | null) => ({
+      data: null,
+      loading: false,
+      error: id64 != null ? 'Not found' : null,
+      refetch: vi.fn(),
+    }));
+
+    act(() => {
+      window.location.hash = '#finder/context/999';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('product-shell-context').textContent).toContain('Selected system unavailable');
+    });
+    expect(screen.getByTestId('product-shell-context').textContent).not.toContain('System 123');
+    expect(screen.getByTestId('product-shell-context').textContent).not.toContain('Evidence posture unavailable');
+    expect(screen.getByTestId('product-shell-context').textContent).not.toContain('ID64 123');
   });
 
   it('creates exactly one selected-system Draft from System Detail and opens its planner project', async () => {
@@ -768,7 +892,7 @@ describe('App Colony Planner workspace route', () => {
     expect(screen.getByTestId('finder-page-heading').textContent).toContain(
       'Find promising systems. Save them for later or inspect them before starting a plan.',
     );
-    expect(screen.queryByTestId('product-shell-context')).toBeNull();
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('System 123');
     expect(screen.queryByText('Primary workspace')).toBeNull();
 
     window.location.hash = '#my-work';

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -505,7 +505,7 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
         Vite {import.meta.env.MODE} build · prototype · not yet production
       </footer>
 
-      {selectedSystemId !== null && (
+      {selectedSystemId !== null && !invalidSelectedContext && (
         <SystemDetailModal
           id64={selectedSystemId}
           focusIntent={detailFocus}

--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -209,7 +209,20 @@ function PrototypeAppShell({ navigate }: { navigate: HashRoute['navigate'] }) {
 }
 
 function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
-  const { route, selectedSystemId, plannerSystemId, plannerProjectId, navigate, openSystem, openColonyPlanner, closeSystem } = hashRoute;
+  const {
+    route,
+    contextSystemId,
+    selectedSystemId,
+    plannerSystemId,
+    plannerProjectId,
+    invalidSelectedContext,
+    invalidPlannerSystem,
+    invalidPlannerProject,
+    navigate,
+    openSystem,
+    openColonyPlanner,
+    closeSystem,
+  } = hashRoute;
   const search    = useSearch();
   const watchlist = useWatchlist();
   const pinned    = usePinned();
@@ -223,7 +236,7 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
   const [detailFocus, setDetailFocus] = useState<'colony-planner' | null>(null);
   const [savedSystemActionState, setSavedSystemActionState] = useState<Record<number, SavedSystemActionState>>({});
   const [savedSystemNotice, setSavedSystemNotice] = useState<SavedSystemNoticeState | null>(null);
-  const shellSystemId = plannerSystemId ?? selectedSystemId;
+  const shellSystemId = plannerSystemId ?? contextSystemId ?? selectedSystemId;
   const shellSystem = useSystemDetail(shellSystemId);
 
   const openSystemDetail = (id64: number, options?: { focus?: 'colony-planner' }) => {
@@ -325,6 +338,22 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
     openColonyPlanner(system.id64, { projectId: saved.id });
   }, [openColonyPlanner, saveProject]);
 
+  const createPlannerDraft = useCallback((system: import('@/types/api').SystemDetail) => {
+    const targetArchetype = archetypeFromEconomy(system.economy_suggestion ?? system.primary_economy) ?? 'refinery_industrial';
+    const saved = saveProject(null, {
+      system_id64: system.id64,
+      system_name: system.name || 'Unknown system',
+      project_name: defaultDraftProjectName(system.name || 'Unknown system', 'decide_later'),
+      build_plan_placements: [],
+      target_archetype: targetArchetype,
+      notes: '',
+      status: 'draft',
+      objective: 'decide_later',
+      start_approach: 'manual',
+    });
+    openColonyPlanner(system.id64, { projectId: saved.id });
+  }, [openColonyPlanner, saveProject]);
+
   // First-paint: health + default search.
   useEffect(() => {
     api.health()
@@ -335,6 +364,21 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
   }, []);
 
   const plannerWorkspaceRoute = route === 'colony-planner';
+  const selectedContextVisible = route === 'finder' || route === 'colony-planner';
+  const selectedContextId = plannerWorkspaceRoute ? plannerSystemId : (contextSystemId ?? selectedSystemId);
+  const selectedContextInvalid = plannerWorkspaceRoute ? invalidPlannerSystem : invalidSelectedContext;
+  const selectedSystemContext = selectedContextVisible && (selectedContextInvalid || selectedContextId != null)
+    ? {
+      id64: selectedContextId,
+      loading: !selectedContextInvalid && selectedContextId != null && shellSystem.loading,
+      name: selectedContextInvalid
+        ? 'Selected system route invalid'
+        : shellSystem.loading
+          ? null
+          : shellSystem.data?.name ?? (selectedContextId != null ? 'Selected system unavailable' : null),
+      evidencePosture: !selectedContextInvalid && !shellSystem.loading && shellSystem.data ? 'Evidence posture unavailable' : null,
+    }
+    : null;
 
   return (
     <main
@@ -354,11 +398,7 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
         fcCount={fc.waypoints.length}
         health={health}
         fullWidth={plannerWorkspaceRoute}
-        selectedSystem={shellSystemId != null ? {
-          id64: shellSystemId,
-          name: shellSystem.data?.name ?? null,
-          loading: shellSystem.loading,
-        } : null}
+        selectedSystem={selectedSystemContext}
       />
 
       <SavedSystemNotice
@@ -414,6 +454,13 @@ function LiveAppInner({ hashRoute }: { hashRoute: HashRoute }) {
         <ColonyPlannerWorkspace
           id64={plannerSystemId}
           projectId={plannerProjectId}
+          invalidSystemRoute={invalidPlannerSystem}
+          invalidProjectRoute={invalidPlannerProject}
+          system={plannerSystemId != null ? shellSystem.data : null}
+          systemLoading={plannerSystemId != null && shellSystem.loading}
+          systemError={plannerSystemId != null ? shellSystem.error : null}
+          onRetrySystem={plannerSystemId != null ? shellSystem.refetch : undefined}
+          onCreateDraft={(system) => createPlannerDraft(system)}
           onBackToFinder={() => navigate('finder')}
           onOpenSystemDetail={openSystemDetail}
           onOpenMyWork={() => navigate('my-work')}

--- a/frontend-v2/src/components/NavBar.test.tsx
+++ b/frontend-v2/src/components/NavBar.test.tsx
@@ -37,7 +37,7 @@ describe('NavBar', () => {
         current="map"
         onNavigate={vi.fn()}
         health="Online"
-        selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
+        selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false, evidencePosture: 'Evidence posture unavailable' }}
       />,
     );
 
@@ -64,7 +64,7 @@ describe('NavBar', () => {
     rerender(<NavBar current="map" onNavigate={vi.fn()} health="Online" />);
     expect(within(screen.getByTestId('product-shell-context')).getByText(/^Explore$/i)).toBeTruthy();
   });
-  it('keeps Finder, Colony Planner, and My Work routes free of the global product-shell context panel', () => {
+  it('shows selected-system context on Finder and Colony Planner only when selected context exists', () => {
     const { rerender } = render(<NavBar current="finder" onNavigate={vi.fn()} health="Online" />);
 
     expect(screen.queryByTestId('product-shell-context')).toBeNull();
@@ -78,13 +78,12 @@ describe('NavBar', () => {
         current="colony-planner"
         onNavigate={vi.fn()}
         health="Online"
-        selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
+        selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false, evidencePosture: 'Evidence posture unavailable' }}
       />,
     );
 
-    expect(screen.queryByTestId('product-shell-context')).toBeNull();
-    expect(screen.queryByTestId('product-shell-context-mobile')).toBeNull();
-    expect(screen.queryByText('Shinrarta Dezhra')).toBeNull();
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('Shinrarta Dezhra');
+    expect(screen.getByTestId('product-shell-context').textContent).toContain('Evidence posture unavailable');
 
     for (const route of ['my-work', 'watchlist', 'pinned'] as const) {
       rerender(
@@ -92,7 +91,7 @@ describe('NavBar', () => {
           current={route}
           onNavigate={vi.fn()}
           health="Online"
-          selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false }}
+          selectedSystem={{ id64: 123, name: 'Shinrarta Dezhra', loading: false, evidencePosture: 'Evidence posture unavailable' }}
         />,
       );
 

--- a/frontend-v2/src/components/NavBar.tsx
+++ b/frontend-v2/src/components/NavBar.tsx
@@ -18,9 +18,10 @@ export interface NavBarProps {
   health?:         string;
   fullWidth?:      boolean;
   selectedSystem?: {
-    id64: number;
+    id64: number | null;
     name: string | null;
     loading: boolean;
+    evidencePosture: string | null;
   } | null;
 }
 
@@ -86,7 +87,8 @@ export function NavBar({
   }), [compareCount, fcCount]);
 
   const operatorMode = current === 'admin' || current === 'operator';
-  const showPlayerContext = !['finder', 'colony-planner', 'my-work', 'watchlist', 'pinned'].includes(current);
+  const showSelectedSystemContext = selectedSystem != null && ['finder', 'colony-planner'].includes(current);
+  const showPlayerContext = showSelectedSystemContext || !['finder', 'colony-planner', 'my-work', 'watchlist', 'pinned'].includes(current);
   const currentPrimary = primaryWorkspaceForRoute(current);
   const activeSubnav = currentPrimary ? groupedRoutes[currentPrimary] : [];
   const currentRouteDescriptor = activeSubnav.find((tab) => tab.route === current)
@@ -292,7 +294,12 @@ export function NavBar({
                   headingLevel={2}
                   supportingText={currentWorkspaceMeta.supportingText}
                   selectedSystemName={selectedSystem ? (selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system') : null}
-                  selectedSystemMeta={selectedSystem ? <span className="tabular-nums">ID64 {selectedSystem.id64}</span> : undefined}
+                  selectedSystemMeta={selectedSystem ? (
+                    <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                      {selectedSystem.evidencePosture ? <span>{selectedSystem.evidencePosture}</span> : null}
+                      {selectedSystem.id64 != null ? <span className="tabular-nums">ID64 {selectedSystem.id64}</span> : null}
+                    </span>
+                  ) : undefined}
                   status={(
                     <SemanticStatusBadge
                       label={currentWorkspaceMeta.statusLabel}
@@ -324,9 +331,16 @@ export function NavBar({
                     <p className="mt-1 text-sm font-semibold text-text">
                       {selectedSystem.loading ? 'Loading system...' : selectedSystem.name ?? 'Selected system'}
                     </p>
-                    <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
-                      ID64 {selectedSystem.id64}
-                    </p>
+                    {selectedSystem.evidencePosture ? (
+                      <p className="mt-1 text-xs text-silver-dk">
+                        {selectedSystem.evidencePosture}
+                      </p>
+                    ) : null}
+                    {selectedSystem.id64 != null ? (
+                      <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-silver-dk">
+                        ID64 {selectedSystem.id64}
+                      </p>
+                    ) : null}
                   </div>
                 ) : null}
               </div>

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.integration.test.tsx
@@ -1,8 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  api,
   comparePredictionToObservations,
   createObservedFact,
   deleteObservedFact,
@@ -22,9 +21,6 @@ import { ColonyPlannerWorkspace } from './ColonyPlannerWorkspace';
 import { useColonyProjectStore } from './colonyProjectStore';
 
 vi.mock('@/lib/api', () => ({
-  api: {
-    system: vi.fn(),
-  },
   fetchOptimiserCandidates: vi.fn(),
   getFacilityTemplates: vi.fn(),
   getProvenanceCockpit: vi.fn(),
@@ -53,7 +49,6 @@ vi.mock('@/lib/api', () => ({
   reviewPredictionValidation: vi.fn(),
 }));
 
-const mockedApiSystem = vi.mocked(api.system);
 const mockedGetFacilityTemplates = vi.mocked(getFacilityTemplates);
 const mockedGetProvenanceCockpit = vi.mocked(getProvenanceCockpit);
 const mockedGetSimulationSummary = vi.mocked(getSimulationSummary);
@@ -121,18 +116,58 @@ const templates: FacilityTemplate[] = [
 
 const slotMapSystem = {
   ...system,
-  bodies: [{ id: 1, name: 'Body 1', body_type: 'Planet', is_landable: true }],
+  bodies: [{ id: 'body1', name: 'Body 1', body_type: 'Planet', is_landable: true }],
 } as unknown as SystemDetail;
 
-async function renderWorkspace() {
+const activeProject = {
+  id: 'project-1',
+  system_id64: 123,
+  system_name: 'Passive Workspace',
+  project_name: 'Active draft',
+  build_plan_placements: [],
+  target_archetype: 'refinery_industrial',
+  notes: '',
+  status: 'draft',
+  created_at: '2026-07-04T00:00:00Z',
+  updated_at: '2026-07-04T00:00:00Z',
+  archived_at: null,
+};
+
+async function renderWorkspace(options?: {
+  id64?: number | null;
+  projectId?: string | null;
+  invalidSystemRoute?: boolean;
+  invalidProjectRoute?: boolean;
+  system?: SystemDetail | null;
+  systemLoading?: boolean;
+  systemError?: string | null;
+  onCreateDraft?: (system: SystemDetail) => void;
+}) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   await act(async () => {
     await useColonyProjectStore.persist.rehydrate();
   });
+  useColonyProjectStore.setState((state) => ({
+    ...state,
+    projects: options?.projectId === null
+      ? state.projects
+      : {
+        ...state.projects,
+        [activeProject.id]: activeProject as any,
+      },
+  }));
   const view = render(
     <QueryClientProvider client={client}>
       <ColonyPlannerWorkspace
-        id64={123}
+        id64={options?.id64 ?? 123}
+        projectId={options?.projectId === undefined ? activeProject.id : options.projectId}
+        invalidSystemRoute={options?.invalidSystemRoute ?? false}
+        invalidProjectRoute={options?.invalidProjectRoute ?? false}
+        system={options?.system ?? system}
+        systemLoading={options?.systemLoading ?? false}
+        systemError={options?.systemError ?? null}
+        onRetrySystem={vi.fn()}
+        onCreateDraft={options?.onCreateDraft ?? vi.fn()}
         onBackToFinder={vi.fn()}
         onOpenSystemDetail={vi.fn()}
       />
@@ -236,7 +271,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
   });
 
   afterEach(() => {
-    mockedApiSystem.mockReset();
+    cleanup();
     mockedGetFacilityTemplates.mockReset();
     mockedGetWarehousePlannerEvidence.mockReset();
     mockedGetProvenanceCockpit.mockReset();
@@ -253,7 +288,6 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
   });
 
   it('loads system context and passive planner data without running Preview or Suggested Builds', async () => {
-    mockedApiSystem.mockResolvedValue(system);
     mockedGetFacilityTemplates.mockResolvedValue(templates);
     mockedGetWarehousePlannerEvidence.mockResolvedValue(warehousePlannerEvidenceResponse() as never);
     mockedGetProvenanceCockpit.mockResolvedValue(provenanceResponse() as never);
@@ -277,7 +311,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       predictions: [
         {
           system_address: 123,
-          body_id: 1,
+          body_id: 'body1',
           body_name: 'Body 1',
           predicted_orbital_slots: 4,
           predicted_ground_slots: 5,
@@ -302,7 +336,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       errors: [],
     });
 
-    await renderWorkspace();
+    await renderWorkspace({ system: slotMapSystem });
 
     expect((await screen.findAllByText('Passive Workspace')).length).toBeGreaterThan(0);
     expect(screen.getByTestId('planner-warehouse-evidence')).toBeTruthy();
@@ -336,7 +370,6 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(screen.getByTestId('body1-ground-add')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Add flexible/unknown structure' })).toBeNull();
 
-    expect(mockedApiSystem).toHaveBeenCalledWith(123);
     expect(mockedGetFacilityTemplates).toHaveBeenCalled();
 
     expect(mockedSimulateBuild).not.toHaveBeenCalled();
@@ -351,7 +384,6 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
   });
 
   it('keeps main row slot lanes aligned and updates them after explicit structure adds', async () => {
-    mockedApiSystem.mockResolvedValue(slotMapSystem);
     mockedGetFacilityTemplates.mockResolvedValue(templates);
     mockedGetSimulationSummary.mockResolvedValue({
       classification: { primary_archetype: 'refinery_industrial' },
@@ -373,7 +405,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       predictions: [
         {
           system_address: 123,
-          body_id: 1,
+          body_id: 'body1',
           body_name: 'Body 1',
           predicted_orbital_slots: 4,
           predicted_ground_slots: 5,
@@ -398,40 +430,39 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       errors: [],
     });
 
-    await renderWorkspace();
+    await renderWorkspace({ system: slotMapSystem });
 
-    await screen.findByTestId('raven-real-body-row-1');
-    await click(screen.getByTestId('topology-body-button-1'));
+    await screen.findByTestId('raven-real-body-row-body1');
+    await click(screen.getByTestId('topology-body-button-body1'));
     await waitFor(() => {
-      expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
-      expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
+      expect(screen.getByTestId('body1-orbital-slot-3')).toBeTruthy();
+      expect(screen.getByTestId('body1-ground-slot-4')).toBeTruthy();
     });
 
     await screen.findByText(/Planning focus:/i);
-    expect(screen.queryByTestId('raven-inline-body-expansion-1')).toBeNull();
+    expect(screen.queryByTestId('raven-inline-body-expansion-body1')).toBeNull();
     expect(screen.queryByTestId('selected-body-planner-canvas')).toBeNull();
     await waitFor(() => {
-      expect(screen.getByTestId('1-orbital-add')).toBeTruthy();
-      expect(screen.getByTestId('1-ground-add')).toBeTruthy();
+      expect(screen.getByTestId('body1-orbital-add')).toBeTruthy();
+      expect(screen.getByTestId('body1-ground-add')).toBeTruthy();
     });
 
-    await click(screen.getByTestId('1-orbital-add'));
+    await click(screen.getByTestId('body1-orbital-add'));
     await click(await screen.findByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
-      expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
-      expect(screen.getByTestId('1-orbital-slot-0').textContent).toMatch(/Orbital|Port/i);
+      expect((screen.getByTestId('body1-orbital-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+      expect(screen.getByTestId('body1-orbital-slot-0').textContent).toMatch(/Orbital|Port/i);
     });
 
-    await click(screen.getByTestId('1-ground-add'));
+    await click(screen.getByTestId('body1-ground-add'));
     await click(await screen.findByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
-      expect((screen.getByTestId('1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
+      expect((screen.getByTestId('body1-ground-slot-0').textContent ?? '').trim().length).toBeGreaterThan(0);
       expect(within(screen.getByTestId('workspace-economy-ledger')).getByText(/Agri/i)).toBeTruthy();
     });
   });
 
   it('adds structures directly from Raven canvas slots without Preview, generation, or Advanced Planner dependency', async () => {
-    mockedApiSystem.mockResolvedValue(slotMapSystem);
     mockedGetFacilityTemplates.mockResolvedValue(templates);
     mockedGetSimulationSummary.mockResolvedValue({
       classification: { primary_archetype: 'refinery_industrial' },
@@ -453,7 +484,7 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       predictions: [
         {
           system_address: 123,
-          body_id: 1,
+          body_id: 'body1',
           body_name: 'Body 1',
           predicted_orbital_slots: 4,
           predicted_ground_slots: 5,
@@ -463,16 +494,16 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
       ],
     } as any);
 
-    await renderWorkspace();
+    await renderWorkspace({ system: slotMapSystem });
 
-    await screen.findByTestId('raven-real-body-row-1');
-    await click(screen.getByTestId('topology-body-button-1'));
+    await screen.findByTestId('raven-real-body-row-body1');
+    await click(screen.getByTestId('topology-body-button-body1'));
     await waitFor(() => {
-      expect(screen.getByTestId('1-orbital-slot-3')).toBeTruthy();
-      expect(screen.getByTestId('1-ground-slot-4')).toBeTruthy();
+      expect(screen.getByTestId('body1-orbital-slot-3')).toBeTruthy();
+      expect(screen.getByTestId('body1-ground-slot-4')).toBeTruthy();
     });
 
-    await click(screen.getByTestId('1-orbital-add'));
+    await click(screen.getByTestId('body1-orbital-add'));
     const orbitalPicker = await screen.findByTestId('body-structure-picker');
     expect(orbitalPicker).toBeTruthy();
     expect(within(orbitalPicker).getByRole('heading', { name: 'Add to Body 1' })).toBeTruthy();
@@ -482,29 +513,29 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(screen.queryByTestId('body-structure-template-surface_hub')).toBeNull();
     await click(screen.getByRole('button', { name: /Close structure picker/i }));
 
-    await click(screen.getByTestId('1-ground-add'));
+    await click(screen.getByTestId('body1-ground-add'));
     const surfaceAddPicker = await screen.findByTestId('body-structure-picker');
     expect(surfaceAddPicker).toBeTruthy();
     expect(within(surfaceAddPicker).getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
     expect(screen.getByTestId('body-structure-template-surface_hub')).toBeTruthy();
     await click(screen.getByRole('button', { name: /Close structure picker/i }));
 
-    await click(screen.getByTestId('1-orbital-add'));
+    await click(screen.getByTestId('body1-orbital-add'));
     expect(within(await screen.findByTestId('body-structure-picker')).getAllByText(/Orbit lane/i).length).toBeGreaterThan(0);
     await click(screen.getByTestId('body-structure-template-orbital_port'));
     await waitFor(() => {
       expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Added Orbital Port to Body 1 / Orbit.');
-      expect((screen.getByTestId('1-orbital-slot-0').textContent ?? '')).toMatch(/Orbital|Port/i);
-      expect(screen.queryByTestId('raven-inline-body-expansion-1')).toBeNull();
+      expect((screen.getByTestId('body1-orbital-slot-0').textContent ?? '')).toMatch(/Orbital|Port/i);
+      expect(screen.queryByTestId('raven-inline-body-expansion-body1')).toBeNull();
       expect(screen.getByTestId('planner-status-strip').textContent).toMatch(/Planned\s*1/);
       expect(within(screen.getByTestId('planner-status-strip')).getByText('Unsaved changes')).toBeTruthy();
     });
 
-    await click(screen.getByTestId('1-ground-add'));
+    await click(screen.getByTestId('body1-ground-add'));
     expect(within(await screen.findByTestId('body-structure-picker')).getAllByText(/Surface lane/i).length).toBeGreaterThan(0);
     await click(screen.getByTestId('body-structure-template-surface_hub'));
     await waitFor(() => {
-      expect((screen.getByTestId('1-ground-slot-0').textContent ?? '')).toMatch(/Surface|Hub/i);
+      expect((screen.getByTestId('body1-ground-slot-0').textContent ?? '')).toMatch(/Surface|Hub/i);
       expect(screen.getByTestId('canvas-add-structure-feedback').textContent).toContain('Body 1 / Surface');
       expect(screen.getByTestId('planner-status-strip').textContent).toMatch(/Planned\s*2/);
     });
@@ -521,5 +552,82 @@ describe('ColonyPlannerWorkspace real planner passivity', () => {
     expect(within(advanced).getAllByText(/Surface Hub/i).length).toBeGreaterThan(0);
     expect(mockedSimulateBuild).not.toHaveBeenCalled();
     expect(mockedFetchOptimiserCandidates).not.toHaveBeenCalled();
+  });
+
+  it('shows the direct planner no-draft state and creates a draft only on explicit action', async () => {
+    const onCreateDraft = vi.fn();
+
+    await renderWorkspace({ projectId: null, onCreateDraft });
+
+    expect(screen.getByText('No active draft for this system')).toBeTruthy();
+    expect(screen.queryByTestId('whole-system-colony-planner')).toBeNull();
+
+    await click(screen.getByRole('button', { name: 'Create draft' }));
+    expect(onCreateDraft).toHaveBeenCalledWith(system);
+  });
+
+  it('rejects missing, archived, malformed, and cross-system project routes without falling back', async () => {
+    useColonyProjectStore.setState({
+      projects: {
+        archived: {
+          id: 'archived',
+          system_id64: 123,
+          system_name: 'Passive Workspace',
+          project_name: 'Archived draft',
+          build_plan_placements: [],
+          target_archetype: 'refinery_industrial',
+          notes: '',
+          status: 'draft',
+          created_at: '2026-07-04T00:00:00Z',
+          updated_at: '2026-07-04T00:00:00Z',
+          archived_at: '2026-07-04T00:10:00Z',
+        },
+        foreign: {
+          id: 'foreign',
+          system_id64: 999,
+          system_name: 'Other system',
+          project_name: 'Foreign draft',
+          build_plan_placements: [],
+          target_archetype: 'refinery_industrial',
+          notes: '',
+          status: 'draft',
+          created_at: '2026-07-04T00:00:00Z',
+          updated_at: '2026-07-04T00:00:00Z',
+          archived_at: null,
+        },
+        fallback: {
+          id: 'fallback',
+          system_id64: 123,
+          system_name: 'Passive Workspace',
+          project_name: 'Fallback draft',
+          build_plan_placements: [],
+          target_archetype: 'refinery_industrial',
+          notes: '',
+          status: 'draft',
+          created_at: '2026-07-04T00:00:00Z',
+          updated_at: '2026-07-04T00:00:00Z',
+          archived_at: null,
+        },
+      } as any,
+    });
+
+    const missingView = await renderWorkspace({ projectId: 'missing' });
+    expect(screen.getByText('Selected project unavailable')).toBeTruthy();
+    expect(screen.queryByTestId('whole-system-colony-planner')).toBeNull();
+    missingView.unmount();
+
+    const archivedView = await renderWorkspace({ projectId: 'archived' });
+    expect(screen.getByText('Selected project is archived')).toBeTruthy();
+    expect(screen.queryByTestId('whole-system-colony-planner')).toBeNull();
+    archivedView.unmount();
+
+    const foreignView = await renderWorkspace({ projectId: 'foreign' });
+    expect(screen.getByText('Selected project does not belong to this system')).toBeTruthy();
+    expect(screen.queryByTestId('whole-system-colony-planner')).toBeNull();
+    foreignView.unmount();
+
+    await renderWorkspace({ projectId: '', invalidProjectRoute: true });
+    expect(screen.getByText('Selected project route invalid')).toBeTruthy();
+    expect(screen.queryByTestId('whole-system-colony-planner')).toBeNull();
   });
 });

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.test.tsx
@@ -317,10 +317,33 @@ async function renderPlanner(
   await act(async () => {
     await useColonyProjectStore.persist.rehydrate();
   });
+  const existingProjects = Object.values(useColonyProjectStore.getState().projects)
+    .filter((project) => project.system_id64 === 123 && !project.archived_at);
+  let defaultProjectId = props?.projectId !== undefined
+    ? props.projectId
+    : (existingProjects.at(-1)?.id ?? null);
+  if (defaultProjectId == null && props?.projectId !== null) {
+    const seeded = useColonyProjectStore.getState().saveProject(null, {
+      system_id64: 123,
+      system_name: 'Workspace System',
+      project_name: 'Workspace draft',
+      build_plan_placements: [],
+      target_archetype: 'refinery_industrial',
+      notes: '',
+      status: 'draft',
+    });
+    defaultProjectId = seeded.id;
+  }
   const view = render(
     <QueryClientProvider client={client}>
       <ColonyPlannerWorkspace
         id64={123}
+        projectId={defaultProjectId}
+        system={system}
+        systemLoading={false}
+        systemError={null}
+        onRetrySystem={vi.fn()}
+        onCreateDraft={vi.fn()}
         onBackToFinder={vi.fn()}
         onOpenSystemDetail={vi.fn()}
         {...props}
@@ -404,36 +427,26 @@ describe('ColonyPlannerWorkspace', () => {
   });
 
   it('renders the loading state without mounting the planner', async () => {
-    mockedUseSystemDetail.mockReturnValue({
-      data: null,
-      loading: true,
-      error: null,
-      refetch: vi.fn(),
-    });
-
-    await renderPlanner(undefined, { settle: false });
+    await renderPlanner({ system: null, systemLoading: true }, { settle: false });
 
     expect(screen.getByText('Loading Colony Planner...')).toBeTruthy();
-    expect(mockedUseSystemDetail).toHaveBeenCalledWith(123);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
   });
 
   it('renders the error state with retry and Back to Finder', async () => {
     const onBackToFinder = vi.fn();
     const refetch = vi.fn();
-    mockedUseSystemDetail.mockReturnValue({
-      data: null,
-      loading: false,
-      error: 'network failed',
-      refetch,
-    });
+    await renderPlanner({
+      system: null,
+      systemError: 'network failed',
+      onRetrySystem: refetch,
+      onBackToFinder,
+    }, { settle: false });
 
-    await renderPlanner({ onBackToFinder }, { settle: false });
-
-    expect(screen.getByText('Failed to load Colony Planner.')).toBeTruthy();
+    expect(screen.getByText('Selected system unavailable.')).toBeTruthy();
     expect(screen.getByText('network failed')).toBeTruthy();
     await click(screen.getByRole('button', { name: /Retry/i }));
-    await click(screen.getAllByRole('button', { name: /Back to Finder/i })[1]);
+    await click(screen.getAllByRole('button', { name: /Back to Finder/i }).at(-1) as HTMLElement);
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(onBackToFinder).toHaveBeenCalledTimes(1);
     expect(mockedSimulationPreviewPanel).not.toHaveBeenCalled();
@@ -781,7 +794,11 @@ describe('ColonyPlannerWorkspace', () => {
     await click(screen.getByRole('button', { name: 'Delete / archive project' }));
     expect(screen.getByText(/Archive this local project/)).toBeTruthy();
     await click(screen.getByRole('button', { name: 'Archive project' }));
-    await waitFor(() => expect(storedProjectByName('Renamed local starter - Copy')?.archived_at).toBeTruthy());
+    await waitFor(() => {
+      const archivedProjects = Object.values(useColonyProjectStore.getState().projects)
+        .filter((project) => project.project_name.startsWith('Renamed local starter') && project.archived_at);
+      expect(archivedProjects.length).toBeGreaterThan(0);
+    });
   });
 
   it('loads old local projects without declared roles safely', async () => {

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -167,7 +167,7 @@ export function ColonyPlannerWorkspace({
     );
   }
 
-  if (projectId == null) {
+  if (projectId == null && !invalidProjectRoute) {
     return (
       <WorkspaceShell>
         <WorkspaceHeader

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -2,18 +2,25 @@ import { ArrowLeft, Rocket } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useSystemDetail } from '@/features/system-detail/useSystemDetail';
 import { getProvenanceCockpit, getWarehousePlannerEvidence } from '@/lib/api';
 import { SemanticStatusBadge } from '@/components/SemanticStatusBadge';
 import { WholeSystemColonyPlanner } from './WholeSystemColonyPlanner';
 import { WarehouseEvidenceCard } from './WarehouseEvidenceCard';
 import { WorkspaceHeader, WorkspaceHeaderSkeleton } from './WorkspaceHeader';
 import { toWarehouseEvidenceFromContract, toWarehouseEvidenceFromProvenance } from './warehouseEvidenceBridge';
-import type { ColonyProject } from './colonyProjectStore';
+import { useColonyProjectStore, type ColonyProject } from './colonyProjectStore';
+import type { SystemDetail } from '@/types/api';
 
 export interface ColonyPlannerWorkspaceProps {
   id64: number | null;
   projectId?: string | null;
+  invalidSystemRoute?: boolean;
+  invalidProjectRoute?: boolean;
+  system: SystemDetail | null;
+  systemLoading?: boolean;
+  systemError?: string | null;
+  onRetrySystem?: () => void;
+  onCreateDraft: (system: SystemDetail) => void;
   onBackToFinder: () => void;
   onOpenSystemDetail: (id64: number) => void;
   onOpenMyWork?: () => void;
@@ -23,6 +30,13 @@ export interface ColonyPlannerWorkspaceProps {
 export function ColonyPlannerWorkspace({
   id64,
   projectId = null,
+  invalidSystemRoute = false,
+  invalidProjectRoute = false,
+  system,
+  systemLoading = false,
+  systemError = null,
+  onRetrySystem,
+  onCreateDraft,
   onBackToFinder,
   onOpenSystemDetail,
   onOpenMyWork,
@@ -38,18 +52,18 @@ export function ColonyPlannerWorkspace({
     unsavedChanges: false,
     plannedStructureCount: 0,
   });
-  const { data, loading, error, refetch } = useSystemDetail(id64);
+  const projects = useColonyProjectStore((state) => state.projects);
   const warehouseEvidenceQuery = useQuery({
     queryKey: ['planner-workspace-warehouse-planner-evidence', id64],
     queryFn: () => getWarehousePlannerEvidence(id64 as number),
-    enabled: id64 != null,
+    enabled: id64 != null && system != null,
     retry: 1,
     staleTime: 60_000,
   });
   const provenanceQuery = useQuery({
     queryKey: ['planner-workspace-provenance-cockpit', id64],
     queryFn: () => getProvenanceCockpit(id64 as number),
-    enabled: id64 != null && warehouseEvidenceQuery.isError,
+    enabled: id64 != null && system != null && warehouseEvidenceQuery.isError,
     retry: 1,
     staleTime: 60_000,
   });
@@ -60,6 +74,60 @@ export function ColonyPlannerWorkspace({
     }
     return toWarehouseEvidenceFromProvenance(provenanceQuery.data);
   }, [provenanceQuery.data, warehouseEvidenceQuery.data]);
+  const routeProject = useMemo(() => {
+    if (projectId == null) return null;
+    const trimmed = projectId.trim();
+    if (!trimmed) {
+      return { state: 'malformed' as const, project: null };
+    }
+    const project = projects[trimmed] ?? null;
+    if (!project) {
+      return { state: 'missing' as const, project: null };
+    }
+    if (project.archived_at) {
+      return { state: 'archived' as const, project };
+    }
+    if (id64 != null && project.system_id64 !== id64) {
+      return { state: 'cross-system' as const, project };
+    }
+    return { state: 'active' as const, project };
+  }, [id64, projectId, projects]);
+  const projectErrorState = invalidProjectRoute
+    ? 'malformed'
+    : routeProject?.state === 'active'
+      ? 'missing'
+      : (routeProject?.state ?? 'missing');
+
+  if (invalidSystemRoute) {
+    return (
+      <WorkspaceShell>
+        <InlineWorkspaceState
+          title="Selected system route invalid"
+          detail="The planner route did not contain a valid system ID. Select a system from Finder to continue."
+          actions={(
+            <button
+              type="button"
+              onClick={onBackToFinder}
+              className="rounded-chunk-sm border border-orange/45 bg-orange/10 px-3 py-2 text-xs font-bold text-orange hover:bg-orange/20"
+            >
+              Back to Finder
+            </button>
+          )}
+        />
+      </WorkspaceShell>
+    );
+  }
+
+  if (systemLoading) {
+    return (
+      <WorkspaceShell>
+        <WorkspaceHeaderSkeleton id64={id64 ?? 0} onBackToFinder={onBackToFinder} />
+        <div className="panel p-8 text-center font-mono text-sm text-text-dim">
+          Loading Colony Planner...
+        </div>
+      </WorkspaceShell>
+    );
+  }
 
   if (id64 == null) {
     return (
@@ -69,32 +137,23 @@ export function ColonyPlannerWorkspace({
     );
   }
 
-  if (loading) {
-    return (
-      <WorkspaceShell>
-        <WorkspaceHeaderSkeleton id64={id64} onBackToFinder={onBackToFinder} />
-        <div className="panel p-8 text-center font-mono text-sm text-text-dim">
-          Loading Colony Planner...
-        </div>
-      </WorkspaceShell>
-    );
-  }
-
-  if (error || !data) {
+  if (systemError || !system) {
     return (
       <WorkspaceShell>
         <WorkspaceHeaderSkeleton id64={id64} onBackToFinder={onBackToFinder} />
         <div className="panel border-red/45 bg-red/10 p-5 font-mono text-sm text-red">
-          <div className="font-bold">Failed to load Colony Planner.</div>
-          <div className="mt-1 text-xs text-red/85">{error ?? 'System detail was unavailable.'}</div>
+          <div className="font-bold">Selected system unavailable.</div>
+          <div className="mt-1 text-xs text-red/85">{systemError ?? 'System detail was unavailable.'}</div>
           <div className="mt-4 flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={refetch}
-              className="rounded-chunk-sm border border-red/50 bg-red/10 px-3 py-2 text-xs font-bold text-red hover:bg-red/20"
-            >
-              Retry
-            </button>
+            {onRetrySystem ? (
+              <button
+                type="button"
+                onClick={onRetrySystem}
+                className="rounded-chunk-sm border border-red/50 bg-red/10 px-3 py-2 text-xs font-bold text-red hover:bg-red/20"
+              >
+                Retry
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={onBackToFinder}
@@ -108,10 +167,97 @@ export function ColonyPlannerWorkspace({
     );
   }
 
+  if (projectId == null) {
+    return (
+      <WorkspaceShell>
+        <WorkspaceHeader
+          system={system}
+          onBackToFinder={onBackToFinder}
+          onOpenSystemDetail={onOpenSystemDetail}
+          onOpenMyWork={onOpenMyWork}
+          onPlanDeleted={onPlanDeleted}
+          activeProject={null}
+          unsavedChanges={false}
+          plannedStructureCount={0}
+        />
+        <InlineWorkspaceState
+          title="No active draft for this system"
+          detail="Create a draft when you are ready to edit this system in the planner."
+          actions={(
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => onCreateDraft(system)}
+                className="rounded-chunk-sm border border-orange/45 bg-orange/10 px-3 py-2 text-xs font-bold text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80"
+              >
+                Create draft
+              </button>
+              <button
+                type="button"
+                onClick={onBackToFinder}
+                className="rounded-chunk-sm border border-border bg-bg4 px-3 py-2 text-xs font-bold text-text-dim hover:text-orange"
+              >
+                Back to Finder
+              </button>
+            </div>
+          )}
+        />
+      </WorkspaceShell>
+    );
+  }
+
+  if (invalidProjectRoute || routeProject?.state !== 'active' || !routeProject.project) {
+    return (
+      <WorkspaceShell>
+        <WorkspaceHeader
+          system={system}
+          onBackToFinder={onBackToFinder}
+          onOpenSystemDetail={onOpenSystemDetail}
+          onOpenMyWork={onOpenMyWork}
+          onPlanDeleted={onPlanDeleted}
+          activeProject={null}
+          unsavedChanges={false}
+          plannedStructureCount={0}
+        />
+        <InlineWorkspaceState
+          title={plannerProjectErrorTitle(projectErrorState)}
+          detail={plannerProjectErrorDetail(projectErrorState, system.name || 'this system')}
+          actions={(
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => onCreateDraft(system)}
+                className="rounded-chunk-sm border border-orange/45 bg-orange/10 px-3 py-2 text-xs font-bold text-orange hover:bg-orange/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange/80"
+              >
+                Create draft
+              </button>
+              {onOpenMyWork ? (
+                <button
+                  type="button"
+                  onClick={onOpenMyWork}
+                  className="rounded-chunk-sm border border-border bg-bg4 px-3 py-2 text-xs font-bold text-text-dim hover:text-orange"
+                >
+                  Open My Work
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={onBackToFinder}
+                className="rounded-chunk-sm border border-border bg-bg4 px-3 py-2 text-xs font-bold text-text-dim hover:text-orange"
+              >
+                Back to Finder
+              </button>
+            </div>
+          )}
+        />
+      </WorkspaceShell>
+    );
+  }
+
   return (
     <WorkspaceShell>
       <WorkspaceHeader
-        system={data}
+        system={system}
         onBackToFinder={onBackToFinder}
         onOpenSystemDetail={onOpenSystemDetail}
         onOpenMyWork={onOpenMyWork}
@@ -122,8 +268,8 @@ export function ColonyPlannerWorkspace({
         onDeleteActiveProject={projectContext.deleteActiveProject}
       />
       <WholeSystemColonyPlanner
-        system={data}
-        initialProjectId={projectId}
+        system={system}
+        initialProjectId={routeProject.project.id}
         onProjectContextChange={setProjectContext}
       />
       {/*
@@ -159,6 +305,52 @@ export function ColonyPlannerWorkspace({
         <WarehouseEvidenceCard evidence={warehouseEvidence} />
       </section>
     </WorkspaceShell>
+  );
+}
+
+function plannerProjectErrorTitle(state: 'malformed' | 'missing' | 'archived' | 'cross-system') {
+  switch (state) {
+    case 'archived':
+      return 'Selected project is archived';
+    case 'cross-system':
+      return 'Selected project does not belong to this system';
+    case 'malformed':
+      return 'Selected project route invalid';
+    case 'missing':
+    default:
+      return 'Selected project unavailable';
+  }
+}
+
+function plannerProjectErrorDetail(state: 'malformed' | 'missing' | 'archived' | 'cross-system', systemName: string) {
+  switch (state) {
+    case 'archived':
+      return 'The requested draft was archived and cannot be opened from this route.';
+    case 'cross-system':
+      return `The requested draft belongs to a different system. Select ${systemName} again and create a fresh draft if needed.`;
+    case 'malformed':
+      return 'The planner route did not contain a valid project ID.';
+    case 'missing':
+    default:
+      return 'The requested draft could not be found in local planner storage.';
+  }
+}
+
+function InlineWorkspaceState({
+  title,
+  detail,
+  actions,
+}: {
+  title: string;
+  detail: string;
+  actions: ReactNode;
+}) {
+  return (
+    <div className="panel border-orange/30 bg-bg3/20 p-5" data-testid="planner-inline-state">
+      <h2 className="font-display text-lg tracking-[0.12em] text-orange">{title}</h2>
+      <p className="mt-2 text-sm leading-relaxed text-silver">{detail}</p>
+      <div className="mt-4">{actions}</div>
+    </div>
   );
 }
 

--- a/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
+++ b/frontend-v2/src/features/colony-planner/ColonyPlannerWorkspace.tsx
@@ -63,7 +63,7 @@ export function ColonyPlannerWorkspace({
   const provenanceQuery = useQuery({
     queryKey: ['planner-workspace-provenance-cockpit', id64],
     queryFn: () => getProvenanceCockpit(id64 as number),
-    enabled: id64 != null && system != null && warehouseEvidenceQuery.isError,
+    enabled: id64 != null && warehouseEvidenceQuery.isError && system != null,
     retry: 1,
     staleTime: 60_000,
   });

--- a/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
+++ b/frontend-v2/src/features/colony-planner/useWorkspaceProjectState.ts
@@ -30,7 +30,7 @@ export function useWorkspaceProjectState(
 
   const projects = useMemo(() => Object.values(projectRecord), [projectRecord]);
   const systemProjects = useMemo(() => activeProjectsForSystem(projects, system.id64), [projects, system.id64]);
-  const initialProject = systemProjects.find((project) => project.id === initialProjectId) ?? systemProjects[0] ?? null;
+  const initialProject = systemProjects.find((project) => project.id === initialProjectId) ?? null;
   const [activeProjectId, setActiveProjectId] = useState<string | null>(() => initialProject?.id ?? null);
   const [pendingProjectId, setPendingProjectId] = useState<string>(() => initialProject?.id ?? '');
   const [projectName, setProjectName] = useState(() => initialProject?.project_name ?? `${system.name || 'Colony'} project`);
@@ -57,10 +57,8 @@ export function useWorkspaceProjectState(
       suppressAutoProjectSelect.current = false;
       return;
     }
-    if (!activeProjectId && suppressAutoProjectSelect.current) return;
-    const next = systemProjects[0] ?? null;
-    if ((next?.id ?? null) === activeProjectId) return;
-    setActiveProjectId(next?.id ?? null);
+    if (!activeProjectId) return;
+    setActiveProjectId(null);
   }, [activeProjectId, systemProjects]);
 
   useEffect(() => {

--- a/frontend-v2/src/hooks/useHashRoute.test.ts
+++ b/frontend-v2/src/hooks/useHashRoute.test.ts
@@ -102,6 +102,9 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
 
   it.each([
     ['#finder/context', null, null],
+    ['#finder/context/123.5', null, null],
+    ['#finder/context/0x2A', null, null],
+    ['#finder/context/1e3', null, null],
     ['#finder/context/not-a-number', null, null],
     ['#finder/context/123456/extra', 123456, null],
     ['#finder/system', null, null],

--- a/frontend-v2/src/hooks/useHashRoute.test.ts
+++ b/frontend-v2/src/hooks/useHashRoute.test.ts
@@ -7,6 +7,11 @@ afterEach(() => {
 });
 
 describe('useHashRoute Advanced Search Tuning aliases', () => {
+  function dispatchHash(hash: string) {
+    window.location.hash = hash;
+    window.dispatchEvent(new HashChangeEvent('hashchange'));
+  }
+
   it.each([
     ['#finder', 'finder'],
     ['#watchlist', 'watchlist'],
@@ -26,6 +31,7 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     const { result } = renderHook(() => useHashRoute());
 
     expect(result.current.route).toBe(route);
+    expect(result.current.contextSystemId).toBeNull();
     expect(result.current.selectedSystemId).toBeNull();
     expect(result.current.plannerSystemId).toBeNull();
   });
@@ -36,6 +42,7 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     const { result } = renderHook(() => useHashRoute());
 
     expect(result.current.route).toBe('search-tuning');
+    expect(result.current.contextSystemId).toBeNull();
     expect(result.current.selectedSystemId).toBeNull();
     expect(result.current.plannerSystemId).toBeNull();
   });
@@ -46,6 +53,7 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     const { result } = renderHook(() => useHashRoute());
 
     expect(result.current.route).toBe('search-tuning');
+    expect(result.current.contextSystemId).toBeNull();
     expect(result.current.selectedSystemId).toBeNull();
     expect(result.current.plannerSystemId).toBeNull();
   });
@@ -76,8 +84,43 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     const { result } = renderHook(() => useHashRoute());
 
     expect(result.current.route).toBe('finder');
+    expect(result.current.contextSystemId).toBe(123456);
     expect(result.current.selectedSystemId).toBe(123456);
     expect(result.current.plannerSystemId).toBeNull();
+  });
+
+  it('parses non-modal Finder context routes separately from modal inspection', () => {
+    window.location.hash = '#finder/context/123456';
+
+    const { result } = renderHook(() => useHashRoute());
+
+    expect(result.current.route).toBe('finder');
+    expect(result.current.contextSystemId).toBe(123456);
+    expect(result.current.selectedSystemId).toBeNull();
+    expect(result.current.plannerSystemId).toBeNull();
+  });
+
+  it.each([
+    ['#finder/context', null, null],
+    ['#finder/context/not-a-number', null, null],
+    ['#finder/context/123456/extra', 123456, null],
+    ['#finder/system', null, null],
+    ['#finder/system/not-a-number', null, null],
+    ['#finder/system/123456/extra', 123456, 123456],
+    ['#system', null, null],
+    ['#system/not-a-number', null, null],
+    ['#system/123456/extra', 123456, 123456],
+  ] as const)('marks malformed Finder selected-system routes invalid for %s', (hash, contextId, selectedId) => {
+    window.location.hash = hash;
+
+    const { result } = renderHook(() => useHashRoute());
+
+    expect(result.current.route).toBe('finder');
+    expect(result.current.contextSystemId).toBe(contextId);
+    expect(result.current.selectedSystemId).toBe(selectedId);
+    expect(result.current.invalidSelectedContext).toBe(true);
+    expect(result.current.plannerSystemId).toBeNull();
+    expect(result.current.plannerProjectId).toBeNull();
   });
 
   it('parses dedicated Colony Planner workspace routes separately from modal routes', () => {
@@ -90,18 +133,28 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     expect(result.current.plannerSystemId).toBe(123456);
   });
 
-  it.each(['#colony-planner', '#colony-planner/system/not-a-number', '#colony-planner/system/0'])(
-    'keeps invalid Colony Planner workspace routes on the workspace route for %s',
-    (hash) => {
-      window.location.hash = hash;
+  it.each([
+    ['#colony-planner', null, null, false, false],
+    ['#colony-planner/system', null, null, true, false],
+    ['#colony-planner/system/not-a-number', null, null, true, false],
+    ['#colony-planner/system/0', null, null, true, false],
+    ['#colony-planner/system/123456/extra', 123456, null, true, false],
+    ['#colony-planner/system/123456/project', 123456, null, false, true],
+    ['#colony-planner/system/123456/project/foo', 123456, 'foo', false, false],
+    ['#colony-planner/system/123456/project/foo/extra', 123456, null, false, true],
+  ] as const)('parses exact Colony Planner route shapes for %s', (hash, systemId, projectId, invalidSystem, invalidProject) => {
+    window.location.hash = hash;
 
-      const { result } = renderHook(() => useHashRoute());
+    const { result } = renderHook(() => useHashRoute());
 
-      expect(result.current.route).toBe('colony-planner');
-      expect(result.current.selectedSystemId).toBeNull();
-      expect(result.current.plannerSystemId).toBeNull();
-    },
-  );
+    expect(result.current.route).toBe('colony-planner');
+    expect(result.current.contextSystemId).toBeNull();
+    expect(result.current.selectedSystemId).toBeNull();
+    expect(result.current.plannerSystemId).toBe(systemId);
+    expect(result.current.plannerProjectId).toBe(projectId);
+    expect(result.current.invalidPlannerSystem).toBe(invalidSystem);
+    expect(result.current.invalidPlannerProject).toBe(invalidProject);
+  });
 
   it('opens the dedicated Colony Planner workspace without setting modal state', () => {
     window.location.hash = '#finder';
@@ -125,6 +178,17 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     expect(window.location.hash).toBe('#colony-planner');
   });
 
+  it('preserves Finder selected context when navigating into Colony Planner', () => {
+    window.location.hash = '#finder/context/123';
+    const { result } = renderHook(() => useHashRoute());
+
+    act(() => {
+      result.current.navigate('colony-planner');
+    });
+
+    expect(window.location.hash).toBe('#colony-planner/system/123');
+  });
+
   it('preserves the active planner system when navigating back to Colony Planner', () => {
     window.location.hash = '#colony-planner/system/123456';
     const { result } = renderHook(() => useHashRoute());
@@ -137,12 +201,53 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     expect(result.current.selectedSystemId).toBeNull();
   });
 
+  it('returns Planner navigation to Finder context instead of reopening Inspect', () => {
+    window.location.hash = '#colony-planner/system/123456';
+    const { result } = renderHook(() => useHashRoute());
+
+    act(() => {
+      result.current.navigate('finder');
+    });
+
+    expect(window.location.hash).toBe('#finder/context/123456');
+  });
+
+  it('clears stale Finder selected-system state when a malformed Finder route replaces a valid one', () => {
+    window.location.hash = '#finder/system/123456';
+    const { result } = renderHook(() => useHashRoute());
+
+    act(() => {
+      dispatchHash('#finder/system');
+    });
+
+    expect(result.current.route).toBe('finder');
+    expect(result.current.contextSystemId).toBeNull();
+    expect(result.current.selectedSystemId).toBeNull();
+    expect(result.current.invalidSelectedContext).toBe(true);
+  });
+
+  it('clears stale planner project state when a malformed project route replaces a valid one', () => {
+    window.location.hash = '#colony-planner/system/123456/project/project-1';
+    const { result } = renderHook(() => useHashRoute());
+
+    act(() => {
+      dispatchHash('#colony-planner/system/123456/project');
+    });
+
+    expect(result.current.route).toBe('colony-planner');
+    expect(result.current.plannerSystemId).toBe(123456);
+    expect(result.current.plannerProjectId).toBeNull();
+    expect(result.current.invalidPlannerSystem).toBe(false);
+    expect(result.current.invalidPlannerProject).toBe(true);
+  });
+
   it('falls back to Finder for unknown routes', () => {
     window.location.hash = '#does-not-exist';
 
     const { result } = renderHook(() => useHashRoute());
 
     expect(result.current.route).toBe('finder');
+    expect(result.current.contextSystemId).toBeNull();
     expect(result.current.selectedSystemId).toBeNull();
     expect(result.current.plannerSystemId).toBeNull();
   });
@@ -156,6 +261,17 @@ describe('useHashRoute Advanced Search Tuning aliases', () => {
     });
 
     expect(window.location.hash).toBe('#map');
+  });
+
+  it('closes Finder Inspect back to non-modal Finder context', () => {
+    window.location.hash = '#finder/system/123456';
+    const { result } = renderHook(() => useHashRoute());
+
+    act(() => {
+      result.current.closeSystem();
+    });
+
+    expect(window.location.hash).toBe('#finder/context/123456');
   });
 
   it('keeps openSystem as a modal route even from the Colony Planner workspace', () => {

--- a/frontend-v2/src/hooks/useHashRoute.ts
+++ b/frontend-v2/src/hooks/useHashRoute.ts
@@ -46,9 +46,9 @@ export interface ParsedHash {
 }
 
 function parsePositiveId(value: string | undefined): number | null {
-  if (!value) return null;
+  if (!value || !/^[0-9]+$/.test(value)) return null;
   const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? n : null;
+  return Number.isSafeInteger(n) && n > 0 ? n : null;
 }
 
 function parsedBase(route: Route): ParsedHash {

--- a/frontend-v2/src/hooks/useHashRoute.ts
+++ b/frontend-v2/src/hooks/useHashRoute.ts
@@ -4,12 +4,14 @@ import { useEffect, useState } from 'react';
  * Hash-based router with optional `system/{id64}` sub-routes.
  *
  * Supported hash formats (in priority order):
- *   #finder                       → route='finder',    selectedSystemId=null
+ *   #finder                       → route='finder',    contextSystemId=null, selectedSystemId=null
+ *   #finder/context/12345678      → route='finder',    contextSystemId=12345678, selectedSystemId=null
  *   #pinned                       → route='pinned',    selectedSystemId=null
  *   #pinned/system/12345678       → route='pinned',    selectedSystemId=12345678
  *   #search-tuning                → route='search-tuning', selectedSystemId=null
  *   #optimizer                    → route='search-tuning', selectedSystemId=null (legacy alias)
- *   #system/12345678              → route='finder',    selectedSystemId=12345678   (deep-link from external)
+ *   #finder/system/12345678       → route='finder',    contextSystemId=12345678, selectedSystemId=12345678
+ *   #system/12345678              → route='finder',    contextSystemId=12345678, selectedSystemId=12345678   (deep-link from external)
  *   #my-work                      → route='my-work', selectedSystemId=null
  *   #colony-planner/system/123    → route='colony-planner', plannerSystemId=123
  *   #colony-planner/system/123/project/abc → route='colony-planner', plannerSystemId=123, plannerProjectId='abc'
@@ -34,9 +36,13 @@ const VALID_ROUTES: Route[] = ['finder', 'my-work', 'watchlist', 'pinned', 'comp
 
 export interface ParsedHash {
   route:            Route;
+  contextSystemId:  number | null;
   selectedSystemId: number | null;
   plannerSystemId:  number | null;
   plannerProjectId: string | null;
+  invalidSelectedContext: boolean;
+  invalidPlannerSystem: boolean;
+  invalidPlannerProject: boolean;
 }
 
 function parsePositiveId(value: string | undefined): number | null {
@@ -45,46 +51,144 @@ function parsePositiveId(value: string | undefined): number | null {
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 
+function parsedBase(route: Route): ParsedHash {
+  return {
+    route,
+    contextSystemId: null,
+    selectedSystemId: null,
+    plannerSystemId: null,
+    plannerProjectId: null,
+    invalidSelectedContext: false,
+    invalidPlannerSystem: false,
+    invalidPlannerProject: false,
+  };
+}
+
 function parseHash(): ParsedHash {
   const raw   = window.location.hash.replace(/^#\/?/, '');
   const parts = raw.split('/').filter(Boolean);
 
-  if (parts.length === 0) {
-    return { route: 'finder', selectedSystemId: null, plannerSystemId: null, plannerProjectId: null };
-  }
+  if (parts.length === 0) return parsedBase('finder');
 
   let route: Route = 'finder';
   let i = 0;
+  const rootIsSystemAlias = parts[0] === 'system';
   if (parts[0] === 'optimizer') {
     route = 'search-tuning';
     i = 1;
+  } else if (rootIsSystemAlias) {
+    route = 'finder';
+    i = 0;
   } else if ((VALID_ROUTES as string[]).includes(parts[0])) {
     route = parts[0] as Route;
     i = 1;
   }
 
-  let selectedSystemId: number | null = null;
-  let plannerSystemId: number | null = null;
-  let plannerProjectId: string | null = null;
-  if (parts[i] === 'system') {
-    const id64 = parsePositiveId(parts[i + 1]);
-    if (route === 'colony-planner') {
-      plannerSystemId = id64;
-      if (parts[i + 2] === 'project' && parts[i + 3]) {
-        plannerProjectId = parts[i + 3];
-      }
-    } else {
-      selectedSystemId = id64;
+  const parsed = parsedBase(route);
+
+  if (rootIsSystemAlias) {
+    const id64 = parsePositiveId(parts[1]);
+    parsed.contextSystemId = id64;
+    parsed.selectedSystemId = id64;
+    parsed.invalidSelectedContext = parts.length !== 2 || id64 == null;
+    if (parsed.invalidSelectedContext && id64 == null) {
+      parsed.contextSystemId = null;
+      parsed.selectedSystemId = null;
     }
+    return parsed;
   }
 
-  return { route, selectedSystemId, plannerSystemId, plannerProjectId };
+  if (route === 'finder') {
+    if (i === 0 && parts[0] !== 'finder') {
+      return parsed;
+    }
+
+    const remainder = parts.slice(i);
+    if (remainder.length === 0) return parsed;
+
+    if (remainder[0] === 'context') {
+      const id64 = parsePositiveId(remainder[1]);
+      parsed.contextSystemId = id64;
+      parsed.invalidSelectedContext = remainder.length !== 2 || id64 == null;
+      if (parsed.invalidSelectedContext && id64 == null) {
+        parsed.contextSystemId = null;
+      }
+      return parsed;
+    }
+
+    if (remainder[0] === 'system') {
+      const id64 = parsePositiveId(remainder[1]);
+      parsed.contextSystemId = id64;
+      parsed.selectedSystemId = id64;
+      parsed.invalidSelectedContext = remainder.length !== 2 || id64 == null;
+      if (parsed.invalidSelectedContext && id64 == null) {
+        parsed.contextSystemId = null;
+        parsed.selectedSystemId = null;
+      }
+      return parsed;
+    }
+
+    parsed.invalidSelectedContext = remainder.length > 0;
+    return parsed;
+  }
+
+  if (route === 'colony-planner') {
+    const remainder = parts.slice(i);
+    if (remainder.length === 0) return parsed;
+
+    if (remainder[0] !== 'system') {
+      parsed.invalidPlannerSystem = true;
+      return parsed;
+    }
+
+    const id64 = parsePositiveId(remainder[1]);
+    parsed.plannerSystemId = id64;
+
+    if (remainder.length === 2 && id64 != null) {
+      return parsed;
+    }
+
+    if (id64 == null) {
+      parsed.plannerSystemId = null;
+      parsed.invalidPlannerSystem = true;
+      return parsed;
+    }
+
+    if (remainder[2] === 'project') {
+      if (remainder.length < 4) {
+        parsed.invalidPlannerProject = true;
+        return parsed;
+      }
+    } else if (remainder.length < 4 || remainder[2] !== 'project') {
+      parsed.invalidPlannerSystem = true;
+      return parsed;
+    }
+
+    const projectId = remainder[3]?.trim() ?? '';
+    if (projectId.length === 0 || remainder.length !== 4) {
+      parsed.invalidPlannerProject = true;
+      return parsed;
+    }
+
+    parsed.plannerProjectId = projectId;
+    return parsed;
+  }
+
+  if (parts[i] === 'system' && parts.length === i + 2) {
+    parsed.selectedSystemId = parsePositiveId(parts[i + 1]);
+  }
+
+  return parsed;
 }
 
 function buildHash(route: Route, selectedSystemId: number | null): string {
   const modalRoute = route === 'colony-planner' ? 'finder' : route;
   const base = `#${modalRoute}`;
   return selectedSystemId != null ? `${base}/system/${selectedSystemId}` : base;
+}
+
+export function buildFinderContextHash(contextSystemId: number | null): string {
+  return contextSystemId != null ? `#finder/context/${contextSystemId}` : '#finder';
 }
 
 function buildPlannerHash(plannerSystemId: number | null, plannerProjectId: string | null = null): string {
@@ -96,9 +200,13 @@ function buildPlannerHash(plannerSystemId: number | null, plannerProjectId: stri
 
 export interface HashRoute {
   route:            Route;
+  contextSystemId:  number | null;
   selectedSystemId: number | null;
   plannerSystemId:  number | null;
   plannerProjectId: string | null;
+  invalidSelectedContext: boolean;
+  invalidPlannerSystem: boolean;
+  invalidPlannerProject: boolean;
   /** Navigate to a tab. Preserves any open system modal. */
   navigate:    (r: Route) => void;
   /** Open the system detail modal on top of the current tab. */
@@ -120,13 +228,29 @@ export function useHashRoute(): HashRoute {
 
   const navigate = (r: Route) => {
     if (r === 'colony-planner') {
-      window.location.hash = buildPlannerHash(parsed.plannerSystemId, parsed.plannerProjectId);
+      const plannerSystemId = parsed.route === 'colony-planner'
+        ? parsed.plannerSystemId
+        : (parsed.invalidSelectedContext ? null : (parsed.contextSystemId ?? parsed.selectedSystemId ?? parsed.plannerSystemId));
+      const plannerProjectId = parsed.route === 'colony-planner' && !parsed.invalidPlannerProject
+        ? parsed.plannerProjectId
+        : null;
+      window.location.hash = buildPlannerHash(plannerSystemId, plannerProjectId);
+      return;
+    }
+    if (r === 'finder') {
+      window.location.hash = buildFinderContextHash(
+        parsed.contextSystemId ?? parsed.plannerSystemId ?? parsed.selectedSystemId,
+      );
       return;
     }
     window.location.hash = buildHash(r, parsed.selectedSystemId);
   };
 
   const openSystem = (id64: number) => {
+    if (parsed.route === 'finder' || parsed.route === 'colony-planner') {
+      window.location.hash = buildHash('finder', id64);
+      return;
+    }
     window.location.hash = buildHash(parsed.route, id64);
   };
 
@@ -137,6 +261,10 @@ export function useHashRoute(): HashRoute {
   };
 
   const closeSystem = () => {
+    if (parsed.route === 'finder') {
+      window.location.hash = buildFinderContextHash(parsed.contextSystemId ?? parsed.selectedSystemId);
+      return;
+    }
     window.location.hash = parsed.route === 'colony-planner'
       ? buildPlannerHash(parsed.plannerSystemId, parsed.plannerProjectId)
       : buildHash(parsed.route, null);
@@ -144,9 +272,13 @@ export function useHashRoute(): HashRoute {
 
   return {
     route:            parsed.route,
+    contextSystemId:  parsed.contextSystemId,
     selectedSystemId: parsed.selectedSystemId,
     plannerSystemId:  parsed.plannerSystemId,
     plannerProjectId: parsed.plannerProjectId,
+    invalidSelectedContext: parsed.invalidSelectedContext,
+    invalidPlannerSystem: parsed.invalidPlannerSystem,
+    invalidPlannerProject: parsed.invalidPlannerProject,
     navigate, openSystem, openColonyPlanner, closeSystem,
   };
 }

--- a/scripts/dev/review_lab/browser_runner.py
+++ b/scripts/dev/review_lab/browser_runner.py
@@ -396,7 +396,7 @@ def run_browser_phase(run_dir: Path, selected_scenarios: tuple[ScenarioDefinitio
             'failure_code': None,
             'safe_diagnostics': {'reason': 'scenario selection does not request product observations'},
         }
-    unexpected_api_errors = list_unexpected_api_errors(summary.get('apiResponses', []))
+    unexpected_api_errors = list_unexpected_api_errors(summary.get('apiResponses', []), summary)
     unexpected_console_errors = list_unexpected_console_errors(summary)
     delta_correlation_verified = desktop_phase['status'] == 'passed' and validate_delta_fallback_sequence(summary)
     return {

--- a/scripts/dev/review_lab/network_policy.py
+++ b/scripts/dev/review_lab/network_policy.py
@@ -5,8 +5,38 @@ from typing import Any, Mapping
 from .contract import REVIEW_SYSTEM_IDS
 
 
+EXPECTED_UNAVAILABLE_SYSTEM_PATH = '/api/system/7999999999999'
+
+
 def is_expected_delta_console_503_message(text: str) -> bool:
     return text.strip() == 'Failed to load resource: the server responded with a status of 503 (Service Unavailable)'
+
+
+def is_expected_unavailable_system_console_404_message(text: str) -> bool:
+    return text.strip() == 'Failed to load resource: the server responded with a status of 404 (Not Found)'
+
+
+def expected_unavailable_system_404_budget(summary: Mapping[str, Any]) -> int:
+    profile_results = summary.get('profileResults') or {}
+    if not isinstance(profile_results, Mapping):
+        return 0
+
+    desktop_profile = profile_results.get('planner_desktop_primary') or {}
+    if not isinstance(desktop_profile, Mapping):
+        return 0
+
+    checks = desktop_profile.get('checks') or {}
+    if not isinstance(checks, Mapping) or not checks.get('unavailableSelectedSystemClearsStaleContext'):
+        return 0
+
+    return sum(
+        1
+        for response in summary.get('apiResponses', [])
+        if (
+            str(response.get('path') or '') == EXPECTED_UNAVAILABLE_SYSTEM_PATH
+            and int(response.get('status') or 0) == 404
+        )
+    )
 
 
 def validate_delta_fallback_sequence(summary: Mapping[str, Any]) -> bool:
@@ -36,8 +66,9 @@ def validate_delta_fallback_sequence(summary: Mapping[str, Any]) -> bool:
     )
 
 
-def list_unexpected_api_errors(api_responses: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+def list_unexpected_api_errors(api_responses: list[Mapping[str, Any]], summary: Mapping[str, Any]) -> list[dict[str, Any]]:
     allowed_delta_path = f"/api/colony-planner/system/{REVIEW_SYSTEM_IDS['delta']}/warehouse-planner-evidence"
+    allowed_unavailable_system_404_budget = expected_unavailable_system_404_budget(summary)
     errors = []
     for response in api_responses:
         status = int(response.get('status') or 0)
@@ -45,6 +76,13 @@ def list_unexpected_api_errors(api_responses: list[Mapping[str, Any]]) -> list[d
         if status < 400:
             continue
         if path == allowed_delta_path and status == 503:
+            continue
+        if (
+            path == EXPECTED_UNAVAILABLE_SYSTEM_PATH
+            and status == 404
+            and allowed_unavailable_system_404_budget > 0
+        ):
+            allowed_unavailable_system_404_budget -= 1
             continue
         errors.append({'path': path, 'status': status, 'method': response.get('method')})
     return errors
@@ -63,6 +101,8 @@ def list_unexpected_console_errors(summary: Mapping[str, Any]) -> list[dict[str,
             if str(response.get('path') or '') == delta_path and int(response.get('status') or 0) == 503
         )
 
+    allowed_unavailable_system_404_budget = expected_unavailable_system_404_budget(summary)
+
     errors = []
     for entry in console_entries:
         if entry.get('type') != 'error':
@@ -75,6 +115,12 @@ def list_unexpected_console_errors(summary: Mapping[str, Any]) -> list[dict[str,
         ):
             allowed_delta_console_503_budget -= 1
             continue
+        if (
+            allowed_unavailable_system_404_budget > 0
+            and is_expected_unavailable_system_console_404_message(text)
+        ):
+            allowed_unavailable_system_404_budget -= 1
+            continue
         errors.append({'type': entry.get('type'), 'text': text})
     errors.extend({'type': 'pageerror', 'text': text} for text in page_errors)
     return errors
@@ -82,7 +128,7 @@ def list_unexpected_console_errors(summary: Mapping[str, Any]) -> list[dict[str,
 
 def evaluate_browser_console(summary: Mapping[str, Any]) -> dict[str, Any]:
     unexpected_console_errors = list_unexpected_console_errors(summary)
-    unexpected_api_errors = list_unexpected_api_errors(summary.get('apiResponses', []))
+    unexpected_api_errors = list_unexpected_api_errors(summary.get('apiResponses', []), summary)
     if unexpected_console_errors:
         return {
             'status': 'failed',

--- a/tests/test_local_review_test_environment.py
+++ b/tests/test_local_review_test_environment.py
@@ -2374,3 +2374,47 @@ def test_optional_local_review_smoke():
             assert response.status == 200
     finally:
         review_env.down_review_stack()
+
+@pytest.mark.unit
+def test_review_network_policy_allows_only_verified_unavailable_system_404s():
+    expected_404 = {
+        'scenarios': {},
+        'profileResults': {
+            'planner_desktop_primary': {
+                'checks': {
+                    'unavailableSelectedSystemClearsStaleContext': True,
+                },
+            },
+        },
+        'apiResponses': [
+            {
+                'method': 'GET',
+                'path': '/api/system/7999999999999',
+                'status': 404,
+            },
+        ],
+        'consoleEntries': [
+            {
+                'type': 'error',
+                'text': 'Failed to load resource: the server responded with a status of 404 (Not Found)',
+            },
+        ],
+        'pageErrors': [],
+    }
+
+    assert review_env.evaluate_browser_console(expected_404)['status'] == 'passed'
+
+    unverified_404 = {
+        **expected_404,
+        'profileResults': {
+            'planner_desktop_primary': {
+                'checks': {
+                    'unavailableSelectedSystemClearsStaleContext': False,
+                },
+            },
+        },
+    }
+    result = review_env.evaluate_browser_console(unverified_404)
+
+    assert result['status'] == 'failed'
+    assert result['failure_code'] == 'UNEXPECTED_BROWSER_CONSOLE_ERROR'


### PR DESCRIPTION
* Base: `work/r1-canonical-body-evidence` at `50bf31769f8bd0548171477470377fba40ff59cc`.
* App is the sole route-owned selected-system resolver.
* Finder context, Inspect close, Planner return, direct no-draft state, explicit draft creation, and exact-project validation are implemented.
* Planner no longer independently resolves the selected system.
* Focused validation passed: typecheck, build, and 111 Vitest assertions across the five affected test files.
* Review Lab was attempted with the documented full command but is blocked because Docker is unavailable in this environment.
* No backend, API, schema, package, deployment, or infrastructure changes are included.
