### PR TITLE
Add code-quality findings register

### DIFF
--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -1,0 +1,132 @@
+# Code Quality Findings Register
+
+Standing register for code-quality findings from audits and reviews.
+Discipline mirrors docs/operations/known-issues.md: every finding carries
+an ID, date raised, source, severity (Confirmed / Strongly supported /
+Hypothesis / Unknown / Disproved), locations, close-when criteria, and
+status. Findings close only with evidence (commit SHA plus verification
+output), never by fiat. Nothing is deleted: closed findings move to
+Resolved with date and closing commit. New audits append.
+
+## Open
+
+### CQ-001 — 16 silently dead test functions (name shadowing)
+- Raised 2026-07-16 · full-codebase audit @ 0a768a2 · Confirmed
+- tests/test_optimiser.py lines 655–835: helper `ranked_candidate` plus 16
+  tests shadowed by identically named rewrites at 876–1039 (later-definition
+  wins; first block never collected). Previously surfaced in the informal
+  review; never remediated.
+- Close when: dead block deleted; pytest --collect-only name list unchanged;
+  ruff --select F811 clean on the file; F811 gated in CI (see CQ-005).
+
+### CQ-002 — 8 orphaned frontend components (1,390 dead lines)
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed (zero references incl. tests)
+- colony-planner/SelectedBodyPlannerCanvas.tsx (640),
+  system-detail/BuildabilityPanel.tsx (228),
+  system-detail/SlotPredictionPanel.tsx (223), news/EliteNewsBanner.tsx (106),
+  preview/ChipPreview.tsx (84), system-detail/RecommendedBuildsPanel.tsx (76),
+  colony-planner/SystemSlotMapPanel.tsx (27), colony-planner/WorkspaceGrid.tsx (6).
+  Hypothesis on cause: superseded by the Stage 25D cockpit fold.
+- Close when: each file deleted (or re-wired with stated reason); knip or
+  equivalent unused-export check added to frontend CI.
+
+### CQ-003 — orphaned one-shot script targeting retired column
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed
+- scripts/repair_ratings_score_breakdown_null.py (391 lines), referenced by
+  nothing; targets retired score_breakdown.
+- Close when: moved to scripts/operator/archive/ with historical declaration
+  per the operator-script contract.
+
+### CQ-004 — zip() without strict= (11 sites, 2 on hot paths)
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed
+- Hot: apps/api/src/routers/simulation.py:179 (live slot-prediction endpoint;
+  length mismatch silently truncates predictions — carried over unfixed from
+  the earlier informal review); apps/importer/src/build_clusters.py:359.
+  Others: canonical_evidence_promotion.py:288, enrichment_warehouse_sql.py:768,
+  source_run_compatibility.py:307, station_type_canonical_pilot.py:835,
+  scripts/dev/review_lab/process_registry.py:69 and :83, two stage-19 operator
+  scripts, tests/test_stage17n2d_backfill_framework.py:289.
+- Close when: strict=True at all 11 sites (if any site's lengths may
+  legitimately differ, stop and escalate — never downgrade to strict=False
+  silently); regression tests on both hot paths; B905 gated in CI.
+
+### CQ-005 — CI runs no lint; ruff fails at 302 errors
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed
+- Makefile:84 defines `ruff check apps tests`; .github/workflows/ci.yml never
+  invokes it. 302 errors at both ruff 0.6.9 and 0.15.21 (87 E701, 77 F401,
+  62 E402, 38 F541, 16 F811, 13 F841, 4 E401, 4 E702, 1 F821). Root cause of
+  CQ-001 surviving the earlier review.
+- Close when: [tool.ruff] config committed (per-file-ignores for deliberate
+  sys.path-bootstrap E402; explicit decision recorded on E701/E702 style);
+  F-class errors at zero; ruff wired into ci.yml and green.
+
+### CQ-006 — undefined name `Any` (NameError if executed)
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed
+- tests/test_local_review_test_environment.py:1587.
+- Close when: import fixed AND the line demonstrably executes under pytest,
+  or the dead path is removed.
+
+### CQ-007 — cluster-search endpoint outside both type contracts
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed (both halves)
+- frontend/src/features/cluster-search/useClusterSearch.ts:134 raw fetch
+  bypasses lib/api.ts jsonFetch; apps/api/src/routers/search.py:228 declares
+  no response_model on POST /api/search/cluster. Introduced with
+  7224f87/fc96364.
+- Close when: response_model declared in models.py and used on the route;
+  yarn types:gen drift-free; api.ts helper added; hook migrated to it;
+  openapi-types CI job green.
+
+### CQ-008 — computed-then-dropped locals (10 sites)
+- Raised 2026-07-16 · audit @ 0a768a2
+- Strongly supported residue, delete: build_ratings.py:1217 secondary_eco and
+  :1246 top_pair_meta (score_breakdown retirement residue; no ratings-side
+  secondary/pair column exists); local_search.py:115 display_score plus its
+  stale comment (legacy-score retirement residue; response dict carries
+  archetype/buildability/purity scores only).
+- Investigate first, Hypothesis: simulation/link_modifiers.py:58 `modifiers`
+  parsed from modifier_economies and unused in the function — verify modifier
+  economies are applied elsewhere in the simulation before deleting; if not,
+  promote to its own feature-gap finding.
+- Mechanical deletes: cp_simulator.py:268 cp_headroom, service_graph.py:113
+  resolved_by_graph_key, build_archetype_scores.py:568, build_grid.py:557,
+  build_topology.py:1032, enrichment_staging_db_loader.py:542.
+- Close when: every site deleted with rationale in the commit, or promoted to
+  its own finding here.
+
+### CQ-009 — unused import / variable (vulture, high confidence)
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed
+- simulation/buildability.py:34 unused import choose_location;
+  simulation/topology_simulator.py:123 unused traits_row.
+- Close when: removed; recurrence covered by the CQ-005 gate.
+
+### CQ-010 — CLAUDE.md stale on frontend/src/_redesign/
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed (directory no longer exists)
+- Close when: CLAUDE.md frontend section updated; fold into the pending
+  roadmap/docs drift update.
+
+### CQ-011 — nightly_update.sh:66 cd without failure guard (SC2164)
+- Raised 2026-07-16 · audit @ 0a768a2 · Confirmed, cosmetic (line 51 existence
+  check mitigates; script deliberately runs set -uo pipefail without -e)
+- Close when: `cd "$COMPOSE" || fatal "..."`; shellcheck -S warning clean.
+
+### CQ-012 — oversized files (accepted split opportunities)
+- Raised 2026-07-16 · audit @ 0a768a2 · improvement, not defect
+- PlannerCanvasPreview.tsx 1,417 (continue plannerCanvasUtils extraction);
+  MyWorkWorkspace.tsx 1,098 (extract ExpansionPlansSection while seam is
+  fresh); NavBar.tsx 722 (feature logic out of nav);
+  evidence_store/store.py 1,547; eddn_listener.py 1,445 (transport vs
+  per-schema handlers); local_search.py 1,314 (candidate for edfinder_api/
+  packaging). nightly_update.sh: collapse six VACUUM ANALYZE stanzas to a loop.
+- Close when: each split lands, or is declined with rationale recorded here.
+
+### CQ-013 — dependency refresh lane (deferred until CQ-005 closes)
+- Raised 2026-07-16 · audit @ 0a768a2 · improvement, not defect
+- pydantic 2.9.2 → 2.11.x (requires models.py audit + types:gen drift check
+  per the documented 2.10+ Optional[dict] hazard); fastapi 0.115, asyncpg
+  0.29 → 0.30, redis-py 5.0.8 → 6.x ride along.
+- Close when: refresh PR lands with openapi-types job green, or deferred with
+  rationale recorded here.
+
+## Resolved
+
+(none yet)


### PR DESCRIPTION
Adds docs/development/code-quality-findings.md — a standing register of 13 code-quality findings from the 2026-07-16 audit at 0a768a2.

Findings: CQ-001 dead test functions (name shadowing), CQ-002 orphaned frontend components (1,390 dead lines), CQ-003 orphaned script (retired column), CQ-004 zip() without strict= (11 sites), CQ-005 CI runs no lint (302 ruff errors), CQ-006 undefined name, CQ-007 cluster-search outside type contracts, CQ-008 computed-then-dropped locals (10 sites), CQ-009 unused imports, CQ-010 stale CLAUDE.md, CQ-011 cd guard, CQ-012 oversized files, CQ-013 dependency refresh.

Register mirrors docs/operations/known-issues.md discipline: every finding carries ID, date, source, severity, locations, close-when criteria, and status. Nothing deleted — closed findings move to Resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)