### PR TITLE
CQ-015: escape ILIKE % in data invariants check

### DIFF
--- a/shared_contracts/data_invariant_contracts.py
+++ b/shared_contracts/data_invariant_contracts.py
@@ -118,8 +118,8 @@ classified AS (
                     AND (
                         br.source_body_id = 0
                         OR br.body_id = 0
-                        OR br.body_name ILIKE '% belt%'
-                        OR br.ring_name ILIKE '% belt%'
+                        OR br.body_name ILIKE '%% belt%%'
+                        OR br.ring_name ILIKE '%% belt%%'
                     )
                    THEN 'belt_source_evidence'
                WHEN same_system_body.id IS NOT NULL


### PR DESCRIPTION
## Problem

The `ring_association_status_drift` check in `shared_contracts/data_invariant_contracts.py` contains two unescaped `%` wildcards in ILIKE patterns (lines 121-122):

```sql
br.body_name ILIKE '% belt%'
br.ring_name ILIKE '% belt%'
```

psycopg2 interprets bare `%` as a format placeholder. When `fetch_count()` calls `cur.execute(sql, ())` with an empty params tuple, psycopg2 tries to consume `% b` as a format specifier, finds nothing in the tuple, and raises `IndexError: tuple index out of range`.

This crashes the `openapi-types` CI job on every PR since `cac355b`.

## Fix

Escape `%` → `%%` on exactly the two ILIKE lines. The production admin endpoint (`apps/api/src/routers/admin.py`) uses asyncpg (`fetchval()`) which uses `$1`-style placeholders, so it is unaffected.

## Diff stat

```
shared_contracts/data_invariant_contracts.py | 4 ++--
1 file changed, 2 insertions(+), 2 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)