### PR TITLE
CQ-027: put repo root on PYTHONPATH so API boots in CI (shared_contracts import)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,7 @@ jobs:
           CORS_ORIGINS: http://test
           ADMIN_TOKEN:  test-admin-token
           LOG_LEVEL:    WARNING
+          PYTHONPATH:   ${{ github.workspace }}
         working-directory: apps/api/src
         run: |
           nohup python -m uvicorn edfinder_api.main:app --host 127.0.0.1 --port 8000 > /tmp/uvicorn.log 2>&1 &
@@ -538,6 +539,7 @@ jobs:
           CORS_ORIGINS: http://localhost:4173
           ADMIN_TOKEN:  test-admin-token
           LOG_LEVEL:    WARNING
+          PYTHONPATH:   ${{ github.workspace }}
         working-directory: apps/api/src
         run: |
           nohup python -m uvicorn edfinder_api.main:app --host 127.0.0.1 --port 8002 > /tmp/uvicorn.log 2>&1 &


### PR DESCRIPTION
The Boot API step failed with ModuleNotFoundError: shared_contracts because CI launches uvicorn from apps/api/src without the repo root on sys.path. Prod (apps/api/Dockerfile) co-locates both packages in /app. This adds PYTHONPATH=github.workspace to both boot steps, matching prod's import topology. Verified locally: API fails without it, boots with it.