### PR TITLE
Fix backend integration CI regressions

### DIFF
--- a/.github/workflows/container-image-parity.yml
+++ b/.github/workflows/container-image-parity.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Prepare Compose environment
+        run: cp env.example .env
+
       - name: Run static container parity contracts
         run: python -m pytest tests/test_container_image_parity.py -q
 

--- a/apps/api/src/ratings_breakdown.py
+++ b/apps/api/src/ratings_breakdown.py
@@ -40,6 +40,11 @@ _COMPLEMENTARY_PAIRS: tuple[tuple[str, str], ...] = (
 )
 
 
+def _value_or_zero(value: Any) -> Any:
+    """Return zero for absent rating values while preserving numeric types."""
+    return 0 if value is None else value
+
+
 def _rank_economies(economies: Mapping[str, Any]) -> tuple[str | None, str | None, dict]:
     """Mirrors build_ratings.py rate_system() lines ~1181-1220 and ~1246-1252."""
     if not economies:
@@ -128,21 +133,21 @@ def reconstruct_score_breakdown(
     classification entirely and reconstruct purely from `rating_row`.
     """
     economies = {
-        'Agriculture': rating_row['score_agriculture'],
-        'Refinery':    rating_row['score_refinery'],
-        'Industrial':  rating_row['score_industrial'],
-        'HighTech':    rating_row['score_hightech'],
-        'Military':    rating_row['score_military'],
-        'Tourism':     rating_row['score_tourism'],
-        'Extraction':  rating_row['score_extraction'],
+        'Agriculture': _value_or_zero(rating_row.get('score_agriculture')),
+        'Refinery':    _value_or_zero(rating_row.get('score_refinery')),
+        'Industrial':  _value_or_zero(rating_row.get('score_industrial')),
+        'HighTech':    _value_or_zero(rating_row.get('score_hightech')),
+        'Military':    _value_or_zero(rating_row.get('score_military')),
+        'Tourism':     _value_or_zero(rating_row.get('score_tourism')),
+        'Extraction':  _value_or_zero(rating_row.get('score_extraction')),
     }
 
     dimensions = {
-        'slots':        rating_row['slots'],
-        'strategic':    rating_row['body_quality'],
-        'safety':       rating_row['orbital_safety'],
-        'terraforming': rating_row['terraforming_potential'],
-        'diversity':    rating_row['body_diversity'],
+        'slots':        _value_or_zero(rating_row.get('slots')),
+        'strategic':    _value_or_zero(rating_row.get('body_quality')),
+        'safety':       _value_or_zero(rating_row.get('orbital_safety')),
+        'terraforming': _value_or_zero(rating_row.get('terraforming_potential')),
+        'diversity':    _value_or_zero(rating_row.get('body_diversity')),
     }
 
     if rating_row.get('rocky_count'):
@@ -155,17 +160,17 @@ def reconstruct_score_breakdown(
         'rocky_geo':     rocky['rocky_geo'],
         'rocky_bio':     rocky['rocky_bio'],
         'rocky_rings':   rocky['rocky_rings'],
-        'rocky_ice':     rating_row['rocky_ice_count'],
-        'icy':           rating_row['icy_count'],
-        'hmc':           rating_row['hmc_count'],
-        'gas_giant':     rating_row['gas_giant_count'],
-        'elw':           rating_row['elw_count'],
-        'ww':            rating_row['ww_count'],
-        'ammonia':       rating_row['ammonia_count'],
-        'landable':      rating_row['landable_count'],
-        'terraformable': rating_row['terraformable_count'],
-        'bio':           rating_row['bio_signal_total'],
-        'geo':           rating_row['geo_signal_total'],
+        'rocky_ice':     _value_or_zero(rating_row.get('rocky_ice_count')),
+        'icy':           _value_or_zero(rating_row.get('icy_count')),
+        'hmc':           _value_or_zero(rating_row.get('hmc_count')),
+        'gas_giant':     _value_or_zero(rating_row.get('gas_giant_count')),
+        'elw':           _value_or_zero(rating_row.get('elw_count')),
+        'ww':            _value_or_zero(rating_row.get('ww_count')),
+        'ammonia':       _value_or_zero(rating_row.get('ammonia_count')),
+        'landable':      _value_or_zero(rating_row.get('landable_count')),
+        'terraformable': _value_or_zero(rating_row.get('terraformable_count')),
+        'bio':           _value_or_zero(rating_row.get('bio_signal_total')),
+        'geo':           _value_or_zero(rating_row.get('geo_signal_total')),
     }
 
     primary_eco, secondary_eco, top_pair = _rank_economies(economies)

--- a/apps/api/src/routers/systems.py
+++ b/apps/api/src/routers/systems.py
@@ -1,13 +1,13 @@
 """System / body / batch detail endpoints."""
 import json
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import asyncpg
 import redis.asyncio as aioredis
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from edfinder_api.body_sorting import natural_body_sort_key_string, sort_bodies_by_hierarchy
-from edfinder_api.config import settings, log
+from edfinder_api.config import settings
 from edfinder_api.deps import get_pool, get_redis, cache_get, cache_set
 from edfinder_api.helpers import sys_row_to_dict
 from edfinder_api.models import SystemDetailResponse
@@ -43,7 +43,8 @@ async def get_system(
 ):
     cache_key = f'sys:{SYSTEM_CACHE_VERSION}:{id64}'
     cached = await cache_get(cache_key, redis)
-    if cached: return cached
+    if cached:
+        return cached
 
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
@@ -64,9 +65,9 @@ async def get_system(
                 r.rocky_count, r.rocky_ice_count, r.icy_count, r.hmc_count,
                 r.terraforming_potential, r.body_diversity,
                 r.confidence, r.rationale, r.rating_version,
-                body_fresh.body_data_updated_at,
+                body_fresh.body_data_updated_at::text AS body_data_updated_at,
                 body_fresh.body_data_sources,
-                COALESCE(s.eddn_updated_at, s.updated_at) AS status_updated_at,
+                COALESCE(s.eddn_updated_at, s.updated_at)::text AS status_updated_at,
                 CASE
                     WHEN s.eddn_updated_at IS NOT NULL THEN 'eddn'
                     WHEN s.updated_at IS NOT NULL THEN 'canonical'
@@ -352,7 +353,8 @@ async def get_body(
 ):
     cache_key = f'body:{BODY_CACHE_VERSION}:{body_id}'
     cached = await cache_get(cache_key, redis)
-    if cached: return cached
+    if cached:
+        return cached
 
     async with pool.acquire() as conn:
         row = await conn.fetchrow('SELECT * FROM bodies WHERE id = $1', body_id)
@@ -400,9 +402,9 @@ async def batch_systems(
                     r.rocky_count, r.rocky_ice_count, r.icy_count, r.hmc_count,
                     r.confidence, r.rationale,
                     r.elw_count, r.ww_count, r.ammonia_count,
-                    r.gas_giant_count, r.landable_count,
+                    r.gas_giant_count, r.landable_count, r.terraformable_count,
                     r.bio_signal_total, r.geo_signal_total,
-                    r.neutron_count, r.black_hole_count
+                    r.neutron_count, r.black_hole_count, r.white_dwarf_count
                 FROM systems s
                 LEFT JOIN ratings r ON r.system_id64 = s.id64
                 WHERE s.id64 = ANY($1::bigint[])

--- a/scripts/apply_migrations.sh
+++ b/scripts/apply_migrations.sh
@@ -120,10 +120,11 @@ PY
 run_sql_stdin() {
   local at_mode="${1:-0}"
   if [[ -n "${DATABASE_URL:-}" ]]; then
-    local args=("$DATABASE_URL" -v ON_ERROR_STOP=1)
+    local args=(-v ON_ERROR_STOP=1)
     if [[ "$at_mode" == "1" ]]; then
       args+=(-At)
     fi
+    args+=("$DATABASE_URL")
     PGOPTIONS="$PGOPTIONS_VALUE" psql "${args[@]}"
   else
     local extra_flags="-v ON_ERROR_STOP=1"
@@ -143,7 +144,7 @@ run_sql_query() {
 apply_sql_file() {
   local file="$1"
   if [[ -n "${DATABASE_URL:-}" ]]; then
-    PGOPTIONS="$PGOPTIONS_VALUE" psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file" >/dev/null
+    PGOPTIONS="$PGOPTIONS_VALUE" psql -v ON_ERROR_STOP=1 -f "$file" "$DATABASE_URL" >/dev/null
   else
     cat "$file" | run_sql_stdin 0 >/dev/null
   fi

--- a/scripts/baseline_migration_ledger.sh
+++ b/scripts/baseline_migration_ledger.sh
@@ -79,10 +79,11 @@ PY
 run_sql_stdin() {
   local at_mode="${1:-0}"
   if [[ -n "${DATABASE_URL:-}" ]]; then
-    local args=("$DATABASE_URL" -v ON_ERROR_STOP=1)
+    local args=(-v ON_ERROR_STOP=1)
     if [[ "$at_mode" == "1" ]]; then
       args+=(-At)
     fi
+    args+=("$DATABASE_URL")
     PGOPTIONS="$PGOPTIONS_VALUE" psql "${args[@]}"
   else
     local extra_flags="-v ON_ERROR_STOP=1"

--- a/scripts/seed_check.sh
+++ b/scripts/seed_check.sh
@@ -35,7 +35,7 @@ echo
 DATABASE_URL="$DB_URL" bash "$(dirname "$0")/apply_migrations.sh" --include-manual
 
 echo "  ✓ seed_preview.sql"
-psql "$DB_URL" -v ON_ERROR_STOP=1 -q -f "$SQL_DIR/seed_preview.sql" >/dev/null
+psql -v ON_ERROR_STOP=1 -q -f "$SQL_DIR/seed_preview.sql" "$DB_URL" >/dev/null
 
 # ── Post-conditions ────────────────────────────────────────────────────
 echo
@@ -44,7 +44,7 @@ echo "▶ seed_check: invariants"
 assert_count() {
     local label="$1"; local sql="$2"; local min="$3"
     local n
-    n=$(psql "$DB_URL" -At -c "$sql")
+    n=$(psql -At -c "$sql" "$DB_URL")
     if [ "$n" -lt "$min" ]; then
         echo "  ✗ $label: got $n, expected ≥ $min"
         echo "    SQL: $sql"
@@ -62,11 +62,11 @@ assert_count "galaxy_regions"   "SELECT COUNT(*) FROM galaxy_regions"        42
 # Cross-table invariant: every system must have a rating row.
 # The previous seed_preview.sql 'INSERT has more expressions' bug
 # left ratings empty while systems were populated; this catches that.
-orphans=$(psql "$DB_URL" -At -c "
+orphans=$(psql -At -c "
     SELECT COUNT(*) FROM systems s
     LEFT JOIN ratings r ON r.system_id64 = s.id64
     WHERE r.system_id64 IS NULL
-")
+  " "$DB_URL")
 if [ "$orphans" -gt 0 ]; then
     echo "  ✗ unrated systems: $orphans (must be 0 — seed_preview's"
     echo "    ratings INSERT silently failed; check sql/seed_preview.sql)"
@@ -77,9 +77,9 @@ echo "  ✓ every system has a rating row"
 # Materialised views (added in sql/009) must be REFRESH-able. Empty MVs
 # are OK with the small seed, but a syntax/permission failure here would
 # only surface on first /api/map/* call in prod, which is too late.
-psql "$DB_URL" -v ON_ERROR_STOP=1 -q -c "SELECT refresh_map_mviews();" >/dev/null
+psql -v ON_ERROR_STOP=1 -q -c "SELECT refresh_map_mviews();" "$DB_URL" >/dev/null
 echo "  ✓ refresh_map_mviews() succeeds"
-psql "$DB_URL" -v ON_ERROR_STOP=1 -q -c "REFRESH MATERIALIZED VIEW mv_archetype_rankings;" >/dev/null
+psql -v ON_ERROR_STOP=1 -q -c "REFRESH MATERIALIZED VIEW mv_archetype_rankings;" "$DB_URL" >/dev/null
 echo "  ✓ mv_archetype_rankings refreshed"
 
 echo

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,7 @@ _ROOT = _HERE.parent.parent     # tests/integration/conftest.py → repo root
 sys.path.insert(0, str(_ROOT / 'apps' / 'api' / 'src'))
 sys.path.insert(0, str(_ROOT / 'apps' / 'importer' / 'src'))
 
-from tests.helpers import db_isolation
+from tests.helpers import db_isolation  # noqa: E402
 
 # --- env defaults that must be set BEFORE importing the api ----------
 if 'DATABASE_URL' in os.environ:
@@ -49,11 +49,11 @@ os.environ.setdefault('ADMIN_TOKEN', 'test-admin-token')
 os.environ.setdefault('LOG_LEVEL', 'WARNING')
 os.environ.setdefault('EXPOSE_ERROR_DETAIL', 'true')
 
-import pytest
-import pytest_asyncio
-import asyncpg
-import redis.asyncio as aioredis
-from httpx import ASGITransport, AsyncClient
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+import asyncpg  # noqa: E402
+import redis.asyncio as aioredis  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
 
 
 # Function-scoped fixture: each test gets its own pool/redis lifecycle.
@@ -95,9 +95,8 @@ async def redis_client(app):
 async def clean_db():
     """Wipe per-test mutable rows + Redis cache before every test.
 
-    * PostgreSQL: TRUNCATE the small per-test mutable tables (watchlist,
-      system_notes, profile_sync, watchlist_changelog, api_cache).
-      Systems / bodies / ratings come from the seed and stay put.
+    * PostgreSQL: TRUNCATE per-test mutable user/evidence tables. Systems,
+      bodies, ratings, and source-run seed data stay put.
     * Redis (test DB 15): FLUSHDB. Without this, the API's per-endpoint
       caches (map.regions / heatmap / timeline / status / search:v2:…)
       bleed between tests — earlier-run state poisons the next test's
@@ -123,7 +122,9 @@ async def clean_db():
         async with pool.acquire() as conn:
             await conn.execute(
                 'TRUNCATE TABLE watchlist, system_notes, profile_sync, '
-                'watchlist_changelog, api_cache CASCADE'
+                'watchlist_changelog, api_cache, evidence_records, '
+                'derived_features, rule_decisions, rule_proposals, '
+                'observed_facts CASCADE'
             )
     finally:
         await pool.close()

--- a/tests/integration/test_evidence_observation_operator_auth.py
+++ b/tests/integration/test_evidence_observation_operator_auth.py
@@ -44,7 +44,20 @@ async def test_evidence_mutations_require_admin_token(client):
 
 async def test_evidence_mutations_accept_admin_token(client, pool):
     async with pool.acquire() as conn:
-        system_id64 = await conn.fetchval('SELECT id64 FROM systems LIMIT 1')
+        system_id64 = await conn.fetchval(
+            """
+            SELECT s.id64
+            FROM systems s
+            WHERE EXISTS (
+                SELECT 1 FROM bodies b WHERE b.system_id64 = s.id64
+            ) OR EXISTS (
+                SELECT 1 FROM stations st WHERE st.system_id64 = s.id64
+            )
+            ORDER BY s.id64
+            LIMIT 1
+            """
+        )
+    assert system_id64 is not None
 
     headers = {'X-Admin-Token': ADMIN_TOKEN}
     feature_name = f'cov_gap_auth_{system_id64}_{uuid4().hex[:8]}'

--- a/tests/test_container_image_parity.py
+++ b/tests/test_container_image_parity.py
@@ -88,6 +88,7 @@ def test_env_and_compose_expose_optional_readonly_database_dsn():
     assert 'COPY scripts/checks/data_invariants.py' in maintenance_dockerfile
     assert 'COPY shared_contracts/data_invariant_contracts.py' in maintenance_dockerfile
     assert "EDFINDER_RUN_CONTAINER_PARITY: 'yes'" in workflow
+    assert 'cp env.example .env' in workflow
     assert "'apps/api/requirements.txt'" in workflow
     assert "'apps/eddn/requirements.txt'" in workflow
     assert "'apps/importer/requirements.txt'" in workflow

--- a/tests/test_data_trust_runtime.py
+++ b/tests/test_data_trust_runtime.py
@@ -64,7 +64,7 @@ def test_body_contract_repair_and_reconcile_restore_clean_invariants():
               id64, name, x, y, z, population,
               has_body_data, body_count, rating_dirty, cluster_dirty
             )
-            VALUES (4201, 'Runtime Body Drift', 1, 2, 3, NULL, TRUE, 3, FALSE, FALSE);
+            VALUES (4201, 'Runtime Body Drift', 1, 2, 3, NULL, TRUE, 0, FALSE, FALSE);
 
             INSERT INTO ratings (system_id64, score, rating_version)
             VALUES (4201, 77, '3.4');
@@ -261,6 +261,9 @@ def test_station_body_link_repair_restores_clean_invariants():
             INSERT INTO stations (id, system_id64, name, station_type)
             VALUES (7201, 5201, 'Runtime Port', 'Coriolis');
 
+            -- Seed legacy drift past migration 034's write-time repair guard.
+            SET LOCAL session_replication_role = replica;
+
             INSERT INTO station_body_links (
               station_id,
               market_id,
@@ -393,6 +396,12 @@ def test_data_trust_health_snapshot_reports_runtime_drift_buckets():
               (7102, 6102, 'Snapshot Unflagged Positive 1', 'Planet'),
               (7104, 6104, 'Snapshot Eligible 1', 'Planet');
 
+            -- Recreate legacy systems/body drift after the body trigger repairs it.
+            UPDATE systems
+               SET has_body_data = FALSE,
+                   body_count = 2
+             WHERE id64 = 6102;
+
             INSERT INTO ratings (system_id64, score, rating_version)
             VALUES
               (6101, 11, '3.4'),
@@ -425,6 +434,9 @@ def test_data_trust_health_snapshot_reports_runtime_drift_buckets():
 
             INSERT INTO stations (id, system_id64, name, station_type)
             VALUES (8104, 6104, 'Snapshot Port', 'Coriolis');
+
+            -- The snapshot must observe impossible legacy drift that new writes reject.
+            SET LOCAL session_replication_role = replica;
 
             INSERT INTO station_body_links (
               station_id,

--- a/tests/test_migration_script_contracts.py
+++ b/tests/test_migration_script_contracts.py
@@ -27,7 +27,7 @@ def test_apply_migrations_uses_manifest_ledger_and_checksum_guards():
     assert 'checksum_sha256 TEXT NOT NULL' in script
     assert 'if [[ "$mode" == "manual" && "$INCLUDE_MANUAL" -ne 1 ]]; then' in script
     assert 'die "Checksum mismatch for already-recorded migration $filename"' in script
-    assert 'PGOPTIONS="$PGOPTIONS_VALUE" psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"' in script
+    assert 'PGOPTIONS="$PGOPTIONS_VALUE" psql -v ON_ERROR_STOP=1 -f "$file" "$DATABASE_URL"' in script
     assert 'if [[ -n "${DATABASE_URL:-}" ]]; then' in script
     assert 'need_cmd psql' in script
     assert 'else\n  need_cmd docker\nfi' in script
@@ -37,7 +37,7 @@ def test_seed_check_stays_on_manifested_apply_path_and_asserts_seed_invariants()
     script = _read(SEED_CHECK)
 
     assert 'DATABASE_URL="$DB_URL" bash "$(dirname "$0")/apply_migrations.sh" --include-manual' in script
-    assert 'psql "$DB_URL" -v ON_ERROR_STOP=1 -q -f "$SQL_DIR/seed_preview.sql"' in script
+    assert 'psql -v ON_ERROR_STOP=1 -q -f "$SQL_DIR/seed_preview.sql" "$DB_URL"' in script
     assert 'LEFT JOIN ratings r ON r.system_id64 = s.id64' in script
     assert 'SELECT refresh_map_mviews();' in script
     assert 'REFRESH MATERIALIZED VIEW mv_archetype_rankings;' in script

--- a/tests/test_ratings_breakdown.py
+++ b/tests/test_ratings_breakdown.py
@@ -28,8 +28,8 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(ROOT, 'apps', 'api', 'src'))
 sys.path.insert(0, os.path.join(ROOT, 'apps', 'importer', 'src'))
 
-from build_ratings import rate_system, classify_bodies
-from ratings_breakdown import reconstruct_score_breakdown
+from build_ratings import rate_system, classify_bodies  # noqa: E402
+from ratings_breakdown import reconstruct_score_breakdown  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -201,4 +201,32 @@ def test_has_standout_false_when_no_trigger_present():
     bodies = _rocky_mix_bodies()
     row = rate_system(1003, bodies, 'G')
     result = reconstruct_score_breakdown(row, bodies)
+    assert result['has_standout'] is False
+
+
+def test_reconstruction_normalizes_missing_and_null_rating_values():
+    row = {
+        'score_agriculture': None,
+        'score_refinery': 12,
+        'score_industrial': None,
+        'score_hightech': None,
+        'score_military': None,
+        'score_tourism': None,
+        'score_extraction': None,
+        'rocky_count': None,
+    }
+
+    result = reconstruct_score_breakdown(row)
+
+    assert result['economies']['Agriculture'] == 0
+    assert result['economies']['Refinery'] == 12
+    assert result['primary_economy'] == 'Refinery'
+    assert result['dimensions'] == {
+        'slots': 0,
+        'strategic': 0,
+        'safety': 0,
+        'terraforming': 0,
+        'diversity': 0,
+    }
+    assert set(result['bodies'].values()) == {0}
     assert result['has_standout'] is False


### PR DESCRIPTION
## What changed
- make score-breakdown reconstruction tolerate unrated/partial rows and align the batch ratings query
- serialize detail timestamps to the declared wire type
- restore deterministic evidence and data-trust integration fixtures
- make migration and seed scripts compatible with native Windows `psql` option parsing

## Root cause
The integration job combined nullable legacy rating rows, a drifted batch SELECT, fixtures auto-healed by newer database triggers, and mutable evidence tables that were not reset between tests. Native Windows `psql` also stops parsing options after the database URL, unlike the Linux CI client.

## Validation
- strict project-state gate
- backend unit: 1446 passed, 15 skipped
- backend integration parity: 76 passed
- ratings/migration contracts: 10 passed
- native PostgreSQL 16 seed check and data invariants: PASS
- Ruff changed-file check: PASS
- shell syntax checks: PASS