### PR TITLE
Add Ruff defect-class gate to backend CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Python syntax check (py_compile, all .py under apps/)
         run: python -m compileall -q apps
 
+      - name: Run Ruff lint gate
+        run: python -m ruff check apps tests
+
       - name: Run backend unit test suite (no DB required)
         run: python -m pytest -m "unit or not (integration or db or operator or e2e or slow)" -q
 

--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -1533,7 +1533,8 @@ def import_systems_delta(conn, dump_path: Path, resume_offset: int = 0) -> int:
 # Download helpers
 # ---------------------------------------------------------------------------
 def _download_with_aria2(url: str, dest: Path) -> bool:
-    import shutil, subprocess
+    import shutil
+    import subprocess
     if not shutil.which('aria2c'):
         return False
     log.info("  Using aria2c (16 parallel connections) ...")
@@ -1548,7 +1549,8 @@ def _download_with_aria2(url: str, dest: Path) -> bool:
 
 
 def _download_with_wget(url: str, dest: Path) -> bool:
-    import shutil, subprocess
+    import shutil
+    import subprocess
     if not shutil.which('wget'):
         return False
     log.info("  Using wget (resumable) ...")
@@ -1556,7 +1558,8 @@ def _download_with_wget(url: str, dest: Path) -> bool:
 
 
 def _download_with_curl(url: str, dest: Path) -> bool:
-    import shutil, subprocess
+    import shutil
+    import subprocess
     if not shutil.which('curl'):
         return False
     log.info("  Using curl (resumable) ...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.0.1"
 description = "Elite Dangerous colonisation planner — searches 186M star systems by economy, body types, and distance."
 requires-python = ">=3.12"
 
-# This file is intentionally a thin metadata-only manifest. Real runtime
+# This file is intentionally a thin project/tooling manifest. Real runtime
 # deps live in per-app requirements.txt files so each Docker image only
 # pulls what it needs (audit fix §Refactor 4 + §M15):
 #
@@ -17,6 +17,27 @@ requires-python = ">=3.12"
 #   pip install -r apps/api/requirements.txt \
 #               -r apps/eddn/requirements.txt \
 #               -r apps/importer/requirements.txt
+
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+# E701/E702 are accepted legacy one-line style, not defect-class findings.
+ignore = ["E701", "E702"]
+
+[tool.ruff.lint.per-file-ignores]
+"apps/importer/src/build_regional_analysis.py" = ["E402"]
+"tests/test_body_hierarchy_sort.py" = ["E402"]
+"tests/test_elite_news_parser.py" = ["E402"]
+"tests/test_facility_catalogue.py" = ["E402"]
+"tests/test_observations.py" = ["E402"]
+"tests/test_ring_data_model.py" = ["E402"]
+"tests/test_simulation_contracts.py" = ["E402"]
+"tests/test_smoke.py" = ["E402"]
+"tests/test_stage17n2c_data_trust.py" = ["E402"]
+"tests/test_stage6c_comparison.py" = ["E402"]
+"tests/test_stage6e_review.py" = ["E402"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/requirements-ci.txt
+++ b/tests/requirements-ci.txt
@@ -10,3 +10,4 @@ pytest==8.3.4
 pytest-asyncio==0.24.0
 httpx==0.28.1
 pyzmq==26.2.0
+ruff==0.15.22

--- a/tests/test_ci_dependency_contract.py
+++ b/tests/test_ci_dependency_contract.py
@@ -16,6 +16,19 @@ def test_ci_requirements_cover_httpx_used_by_pytest_collection():
     assert 'from httpx import ASGITransport, AsyncClient' in integration_conftest
 
 
+def test_ci_pins_and_runs_the_repo_ruff_contract():
+    requirements = _read('tests', 'requirements-ci.txt')
+    pyproject = _read('pyproject.toml')
+    workflow = _read('.github', 'workflows', 'ci.yml')
+
+    assert 'ruff==0.15.22' in requirements
+    assert '[tool.ruff.lint]' in pyproject
+    assert 'select = ["E4", "E7", "E9", "F"]' in pyproject
+    assert 'ignore = ["E701", "E702"]' in pyproject
+    assert '[tool.ruff.lint.per-file-ignores]' in pyproject
+    assert 'python -m ruff check apps tests' in workflow
+
+
 def test_confirmed_target_or_skip_is_pytest8_safe_for_module_level_smokes():
     helper = _read('tests', 'helpers', 'db_isolation.py')
 

--- a/tests/test_ratings_rationale.py
+++ b/tests/test_ratings_rationale.py
@@ -14,7 +14,8 @@ Invariant under test:
 """
 from __future__ import annotations
 
-import sys, pathlib
+import sys
+import pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'apps' / 'importer' / 'src'))
 
 import pytest


### PR DESCRIPTION
Closes the implementation side of CQ-005 by pinning Ruff 0.15.22, committing the repository lint contract, and running it inside the existing required backend job.

Policy:
- F-class and E4/E9 defects are gated
- deliberate bootstrap E402s are ignored per exact file
- E701/E702 legacy one-line style is explicitly accepted to avoid an unrelated 89-site reformat
- four E401 imports are normalized

Verification:
- python -m ruff check apps tests: clean
- CI dependency contract: 3 passed
- backend unit selection: 1447 passed, 15 skipped, 124 deselected