### PR TITLE
Run required parity check on every pull request

### DIFF
--- a/.github/workflows/container-image-parity.yml
+++ b/.github/workflows/container-image-parity.yml
@@ -2,22 +2,6 @@ name: Container image parity
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/container-image-parity.yml'
-      - 'apps/api/Dockerfile'
-      - 'apps/eddn/Dockerfile'
-      - 'apps/importer/Dockerfile'
-      - 'apps/api/requirements.txt'
-      - 'apps/eddn/requirements.txt'
-      - 'apps/importer/requirements.txt'
-      - 'apps/api/src/**'
-      - 'apps/eddn/src/**'
-      - 'apps/importer/src/**'
-      - 'docker-compose.yml'
-      - 'docker-compose.review.yml'
-      - 'env.example'
-      - 'shared_contracts/**'
-      - 'tests/test_container_image_parity.py'
   push:
     branches: [main]
     paths:

--- a/tests/test_container_image_parity.py
+++ b/tests/test_container_image_parity.py
@@ -17,6 +17,15 @@ def _read(*parts: str) -> str:
     return ROOT.joinpath(*parts).read_text(encoding='utf-8')
 
 
+def test_required_parity_check_runs_for_every_pull_request():
+    workflow = _read('.github', 'workflows', 'container-image-parity.yml')
+    pull_request_block = workflow.split('  pull_request:', 1)[1].split('  push:', 1)[0]
+    push_block = workflow.split('  push:', 1)[1].split('  schedule:', 1)[0]
+
+    assert 'paths:' not in pull_request_block
+    assert 'paths:' in push_block
+
+
 def _docker_binary() -> str:
     docker = shutil.which('docker.exe') or shutil.which('docker')
     if docker is None:


### PR DESCRIPTION
Removes the pull-request path filter from the required Container image parity workflow so docs-only PRs receive the Built image parity context and can merge without an admin override. Pushes to main retain their existing path filter.

Adds a regression contract distinguishing the pull_request and push trigger behavior.

Verification:
- Ruff: clean
- static parity tests: 2 passed, 1 skipped
- full built-image parity smoke: 3 passed