### PR TITLE
Harden zip pairings and gate Ruff B905

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
         run: python -m compileall -q apps
 
       - name: Run Ruff lint gate
-        run: python -m ruff check apps tests
+        run: |
+          python -m ruff check apps tests
+          python -m ruff check apps tests scripts --select B905
 
       - name: Run backend unit test suite (no DB required)
         run: python -m pytest -m "unit or not (integration or db or operator or e2e or slow)" -q

--- a/apps/api/src/routers/simulation.py
+++ b/apps/api/src/routers/simulation.py
@@ -173,7 +173,10 @@ async def get_slot_predictions(
         'estimated_ground_slots': prediction.get('predicted_ground_slots_total'),
         'slot_confidence': round(float(slot_confidence), 3) if slot_confidence is not None else None,
         'slot_confidence_label': confidence_label(slot_confidence),
-        'predictions': [_slot_prediction_to_api(p, fact) for p, fact in zip(prediction['body_predictions'], scan_facts)],
+        'predictions': [
+            _slot_prediction_to_api(p, fact)
+            for p, fact in zip(prediction['body_predictions'], scan_facts, strict=True)
+        ],
         'note': None if prediction.get('prediction_status') != 'unknown' else (
             f'{INSUFFICIENT_DATA_REASON}. Verify in Architect Mode.'
         ),

--- a/apps/importer/src/build_clusters.py
+++ b/apps/importer/src/build_clusters.py
@@ -194,6 +194,12 @@ INSERT_TEMPLATE = """(%s,
 # ---------------------------------------------------------------------------
 # Coverage score (Python side — mirrors the SQL function)
 # ---------------------------------------------------------------------------
+def _row_to_dict(description, row) -> dict:
+    """Map a positional DB row to its cursor column names."""
+    columns = [column[0] for column in description]
+    return dict(zip(columns, row, strict=True))
+
+
 def compute_coverage_score(rd: dict) -> float:
     """
     Compute a weighted coverage score (0-100) for an anchor system.
@@ -355,8 +361,7 @@ def worker_fn(worker_id: int, macro_queue: Queue, done_counter, db_url: str,
             if not row:
                 continue
 
-            cols = [d[0] for d in cur.description]
-            rd = dict(zip(cols, row))
+            rd = _row_to_dict(cur.description, row)
 
             coverage  = compute_coverage_score(rd)
             diversity = sum(1 for eco in ('agriculture', 'refinery', 'industrial',

--- a/apps/importer/src/canonical_evidence_promotion.py
+++ b/apps/importer/src/canonical_evidence_promotion.py
@@ -284,5 +284,5 @@ def _fetchone_mapping(cur: Any) -> dict[str, Any] | None:
     description = getattr(cur, 'description', None)
     if description:
         keys = [col[0] for col in description]
-        return dict(zip(keys, row))
+        return dict(zip(keys, row, strict=True))
     return None

--- a/apps/importer/src/enrichment_warehouse_sql.py
+++ b/apps/importer/src/enrichment_warehouse_sql.py
@@ -763,7 +763,7 @@ def _cursor_row_to_dict(cur: Any, row: Any) -> dict[str, Any]:
         raise TypeError(
             'DB cursor row length does not match cursor.description for staged report/preflight helpers'
         )
-    return dict(zip(column_names, row))
+    return dict(zip(column_names, row, strict=True))
 
 
 def _is_positional_row(row: Any) -> bool:

--- a/apps/importer/src/source_run_compatibility.py
+++ b/apps/importer/src/source_run_compatibility.py
@@ -304,7 +304,7 @@ def _row_to_dict(row: Any, cursor: Any | None = None) -> dict[str, Any] | None:
             raise TypeError(
                 'compatibility helper cursor row length does not match cursor.description'
             )
-        return dict(zip(column_names, row))
+        return dict(zip(column_names, row, strict=True))
     raise TypeError('compatibility helper cursor rows must be mapping-like')
 
 

--- a/apps/importer/src/station_type_canonical_pilot.py
+++ b/apps/importer/src/station_type_canonical_pilot.py
@@ -832,7 +832,7 @@ def _fetchone_mapping(cur: Any) -> dict[str, Any] | None:
     description = getattr(cur, 'description', None)
     if description:
         keys = [col[0] for col in description]
-        return dict(zip(keys, row))
+        return dict(zip(keys, row, strict=True))
     return None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.12"
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F"]
+select = ["B905", "E4", "E7", "E9", "F"]
 # E701/E702 are accepted legacy one-line style, not defect-class findings.
 ignore = ["E701", "E702"]
 

--- a/scripts/dev/review_lab/process_registry.py
+++ b/scripts/dev/review_lab/process_registry.py
@@ -66,7 +66,7 @@ class ReviewProcessRegistry:
         return process
 
     def stop_all(self, *, grace_seconds: int = 5) -> None:
-        for process, record in reversed(list(zip(self._processes, self._records))):
+        for process, record in reversed(list(zip(self._processes, self._records, strict=True))):
             if process.poll() is not None:
                 record.running = False
                 continue
@@ -80,7 +80,7 @@ class ReviewProcessRegistry:
             if all(process.poll() is not None for process in self._processes):
                 break
             time.sleep(0.2)
-        for process, record in reversed(list(zip(self._processes, self._records))):
+        for process, record in reversed(list(zip(self._processes, self._records, strict=True))):
             if process.poll() is None:
                 try:
                     _kill_process_group(process, record.pgid)

--- a/scripts/operator/stage19anr_warehouse_derived_staging_rehearsal.py
+++ b/scripts/operator/stage19anr_warehouse_derived_staging_rehearsal.py
@@ -846,7 +846,7 @@ def _row_to_dict(row: Any, cursor: Any | None = None) -> dict[str, Any] | None:
         if not description:
             raise TypeError('cursor.description is required for positional rows')
         columns = [str(column[0]) for column in description]
-        return dict(zip(columns, row))
+        return dict(zip(columns, row, strict=True))
     raise TypeError('cursor rows must be mapping-like or positional')
 
 

--- a/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
+++ b/scripts/operator/stage19ar_edsm_25_row_staging_pilot.py
@@ -1106,7 +1106,7 @@ def _row_to_dict(row: Any, cursor: Any | None = None) -> dict[str, Any] | None:
         if not description:
             raise TypeError('cursor.description is required for positional rows')
         columns = [str(column[0]) for column in description]
-        return dict(zip(columns, row))
+        return dict(zip(columns, row, strict=True))
     raise TypeError('cursor rows must be mapping-like or positional')
 
 

--- a/tests/test_build_clusters.py
+++ b/tests/test_build_clusters.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / 'apps' / 'importer' / 'src' / 'build_clusters.py'
+
+
+def _load_build_clusters(monkeypatch, tmp_path):
+    monkeypatch.setenv('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+    monkeypatch.setenv('LOG_FILE', str(tmp_path / 'build_clusters.log'))
+    monkeypatch.syspath_prepend(str(SCRIPT_PATH.parent))
+    spec = importlib.util.spec_from_file_location('build_clusters_under_test', SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_row_to_dict_rejects_cursor_shape_mismatch(monkeypatch, tmp_path):
+    build_clusters = _load_build_clusters(monkeypatch, tmp_path)
+    description = [('system_id64',), ('score',)]
+
+    assert build_clusters._row_to_dict(description, (42, 87)) == {
+        'system_id64': 42,
+        'score': 87,
+    }
+    with pytest.raises(ValueError, match=r'zip\(\) argument 2 is shorter'):
+        build_clusters._row_to_dict(description, (42,))

--- a/tests/test_ci_dependency_contract.py
+++ b/tests/test_ci_dependency_contract.py
@@ -23,10 +23,11 @@ def test_ci_pins_and_runs_the_repo_ruff_contract():
 
     assert 'ruff==0.15.22' in requirements
     assert '[tool.ruff.lint]' in pyproject
-    assert 'select = ["E4", "E7", "E9", "F"]' in pyproject
+    assert 'select = ["B905", "E4", "E7", "E9", "F"]' in pyproject
     assert 'ignore = ["E701", "E702"]' in pyproject
     assert '[tool.ruff.lint.per-file-ignores]' in pyproject
     assert 'python -m ruff check apps tests' in workflow
+    assert 'python -m ruff check apps tests scripts --select B905' in workflow
 
 
 def test_confirmed_target_or_skip_is_pytest8_safe_for_module_level_smokes():

--- a/tests/test_slot_prediction_endpoint.py
+++ b/tests/test_slot_prediction_endpoint.py
@@ -108,6 +108,30 @@ async def test_slot_prediction_endpoint_uses_canonical_predictor(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slot_prediction_endpoint_rejects_prediction_count_mismatch(monkeypatch):
+    def fake_predict_system_slots(_facts):
+        return {
+            'predicted_orbital_slots_total': 0,
+            'predicted_ground_slots_total': 0,
+            'slot_confidence': 0.96,
+            'body_predictions': [],
+            'prediction_status': 'predicted',
+            'prediction_version': 'validated-slot-v1',
+            'validation_note': 'test fixture',
+            'required_input_missing': [],
+        }
+
+    monkeypatch.setattr(simulation_router, 'predict_system_slots', fake_predict_system_slots)
+
+    with pytest.raises(ValueError, match=r'zip\(\) argument 2 is longer'):
+        await simulation_router.get_slot_predictions(
+            id64=123,
+            pool=MockPool(),
+            redis=None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_slot_prediction_endpoint_reports_unknown_without_fallback(monkeypatch):
     def fake_predict_system_slots(_facts):
         return {

--- a/tests/test_stage17n2d_backfill_framework.py
+++ b/tests/test_stage17n2d_backfill_framework.py
@@ -286,7 +286,7 @@ class RingRepairConnection:
         if 'repair_eddn_ring_identity:update_repair_batch' in sql_lower:
             ids, local_body_ids = params
             self.repair_update_batches.append(list(ids))
-            local_by_id = dict(zip(ids, local_body_ids))
+            local_by_id = dict(zip(ids, local_body_ids, strict=True))
             updated = []
             for row in self.body_rings:
                 if row['id'] not in local_by_id:


### PR DESCRIPTION
Closes CQ-004 by applying strict=True to all 11 audited zip pairings, adding regression coverage for the simulation endpoint and build-clusters cursor mapping, and gating B905 across apps, tests, and scripts.\n\nLocal verification:\n- Ruff apps/tests: passed\n- Ruff B905 apps/tests/scripts: passed\n- Backend unit: 1450 passed, 15 skipped, 124 deselected\n- Affected operator/importer suite: 168 passed\n- Focused contracts/regressions: 7 passed