### PR TITLE
Docs: record CI restoration in roadmap and changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,31 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-18 — CI restoration, branch protection, and strict zip hardening
+
+**CI restored and enforced** — Recovered the full GitHub Actions board across
+backend unit and integration tests, canonical safety, script contracts, nginx,
+OpenAPI drift, frontend build, Playwright E2E, and built-image parity. `main` is
+now branch-protected by all nine exact check contexts, with strict status-check
+matching and an admin override retained for emergencies.
+
+**Failure causes fixed** — Repaired the backend dual-import split, Windows CRLF
+shell-script failures, seeded database invariant gaps, API boot import path,
+OpenAPI type drift, evidence-promotion fixture gap, and the systems batch/detail
+endpoint defects exposed as red checks were cleared.
+
+**Lint and pairing contracts tightened** — Pinned Ruff and added the repository
+E4/E7/E9/F gate, then enabled B905 across `apps`, `tests`, and `scripts`. All 11
+audited `zip()` pairings now use `strict=True`, with mismatch regressions on the
+live slot-prediction endpoint and cluster-builder cursor mapping.
+
+**Docs-only PRs no longer deadlock** — Required `Built image parity` now runs on
+every pull request while retaining source-path filtering for `main` pushes.
+Documentation-only PR #339 exercised the protected merge path without an admin
+bypass.
+
+---
+
 ## 2026-05-03 — Backend fix: auto-rebuild indexes transaction error
 
 ### backend/import_spansh.py

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -327,7 +327,12 @@ competing roadmap source.
   certified artifact instead of rebuilding JS dependencies on the server.
   Current state: local broad pytest is green; carry that honesty into seeded CI
   and keep the local preflight and integration stack stable.
-  - CI restored to fully green and branch-protected 2026-07-17 (see CQ-019..034 in code-quality-findings.md); the "red masks red" signal-loss that let this drift is now structurally prevented.
+  - CI restored to fully green and branch-protected across all nine required
+    checks on 2026-07-17; follow-up hardening on 2026-07-18 added the Ruff
+    E4/E7/E9/F+B905 gate, strict pairing regressions, and a parity trigger that
+    also protects docs-only PRs (see CQ-004, CQ-005, and CQ-019..034 in
+    code-quality-findings.md). The "red masks red" signal-loss that let this
+    drift is now structurally prevented.
 - 5. Run one bounded residue/hygiene pass on hidden routes, preview-only
   surfaces, stale operator one-shots, and naming drift.
 - 6. Re-evaluate accounts/auth only after steps 1-5 are complete.


### PR DESCRIPTION
Records the completed CI restoration, nine-check branch protection, Ruff/B905 strict-zip hardening, and docs-only parity-trigger fix in CHANGES.md and the canonical ROADMAP. Documentation only.