### PR TITLE
Restore immutable migration 001 checksum

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,13 @@ every pull request while retaining source-path filtering for `main` pushes.
 Documentation-only PR #339 exercised the protected merge path without an admin
 bypass.
 
+**Migration history integrity repaired** — The production deploy guard caught
+that `001_schema.sql` had been edited after its ledger baseline when the cluster
+summary widening landed. Restored migration 001 byte-for-byte to its recorded
+checksum; migration 040 remains the additive owner of the widening. A CI
+contract now pins the production-baselined checksum and the migration-040
+ownership boundary.
+
 ---
 
 ## 2026-05-03 — Backend fix: auto-rebuild indexes transaction error

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -315,6 +315,10 @@ competing roadmap source.
 - 2. Current remaining work: execute the reviewed baseline helper on any
   already-existing pre-ledger databases that still need recorded cutover state
   beyond the now-recorded local `edfinder` cutover.
+- 2. Deploy-integrity follow-up: production's checksum guard caught a
+  post-baseline edit to `001_schema.sql`; the historical file is restored to
+  its recorded checksum, migration 040 retains the additive schema change, and
+  CI now pins that ownership boundary.
 - 3. Add backup/restore automation plus a tested restore runbook.
 - 3. Add backup/restore automation plus a tested restore runbook.
   Current state: automation and runbook are committed, and a recorded local

--- a/sql/001_schema.sql
+++ b/sql/001_schema.sql
@@ -558,31 +558,31 @@ CREATE TABLE IF NOT EXISTS macro_grid (
 CREATE TABLE IF NOT EXISTS cluster_summary (
     system_id64         BIGINT          PRIMARY KEY REFERENCES systems(id64) ON DELETE CASCADE,
 
-    agriculture_count   INTEGER         NOT NULL DEFAULT 0,
-    agriculture_best    INTEGER         DEFAULT NULL,
+    agriculture_count   SMALLINT        NOT NULL DEFAULT 0,
+    agriculture_best    SMALLINT        DEFAULT NULL,
     agriculture_top_id  BIGINT          DEFAULT NULL,
 
-    refinery_count      INTEGER         NOT NULL DEFAULT 0,
-    refinery_best       INTEGER         DEFAULT NULL,
+    refinery_count      SMALLINT        NOT NULL DEFAULT 0,
+    refinery_best       SMALLINT        DEFAULT NULL,
     refinery_top_id     BIGINT          DEFAULT NULL,
 
-    industrial_count    INTEGER         NOT NULL DEFAULT 0,
-    industrial_best     INTEGER         DEFAULT NULL,
+    industrial_count    SMALLINT        NOT NULL DEFAULT 0,
+    industrial_best     SMALLINT        DEFAULT NULL,
     industrial_top_id   BIGINT          DEFAULT NULL,
 
-    hightech_count      INTEGER         NOT NULL DEFAULT 0,
-    hightech_best       INTEGER         DEFAULT NULL,
+    hightech_count      SMALLINT        NOT NULL DEFAULT 0,
+    hightech_best       SMALLINT        DEFAULT NULL,
     hightech_top_id     BIGINT          DEFAULT NULL,
 
-    military_count      INTEGER         NOT NULL DEFAULT 0,
-    military_best       INTEGER         DEFAULT NULL,
+    military_count      SMALLINT        NOT NULL DEFAULT 0,
+    military_best       SMALLINT        DEFAULT NULL,
     military_top_id     BIGINT          DEFAULT NULL,
 
-    tourism_count       INTEGER         NOT NULL DEFAULT 0,
-    tourism_best        INTEGER         DEFAULT NULL,
+    tourism_count       SMALLINT        NOT NULL DEFAULT 0,
+    tourism_best        SMALLINT        DEFAULT NULL,
     tourism_top_id      BIGINT          DEFAULT NULL,
 
-    total_viable        INTEGER         NOT NULL DEFAULT 0,
+    total_viable        SMALLINT        NOT NULL DEFAULT 0,
     coverage_score      REAL            DEFAULT NULL,
     economy_diversity   SMALLINT        NOT NULL DEFAULT 0,
     search_radius       SMALLINT        NOT NULL DEFAULT 500,

--- a/tests/test_migration_script_contracts.py
+++ b/tests/test_migration_script_contracts.py
@@ -1,3 +1,4 @@
+import hashlib
 from pathlib import Path
 
 
@@ -7,6 +8,9 @@ BASELINE_MIGRATIONS = ROOT / 'scripts' / 'baseline_migration_ledger.sh'
 SEED_CHECK = ROOT / 'scripts' / 'seed_check.sh'
 LOCAL_CI_PARITY = ROOT / 'scripts' / 'checks' / 'local-ci-parity.sh'
 CI_WORKFLOW = ROOT / '.github' / 'workflows' / 'ci.yml'
+BASELINE_SCHEMA = ROOT / 'sql' / '001_schema.sql'
+CLUSTER_WIDENING = ROOT / 'sql' / '040_cluster_summary_widen_counts.sql'
+MIGRATION_MANIFEST = ROOT / 'sql' / 'migration-manifest.txt'
 
 
 def _read(path: Path) -> str:
@@ -31,6 +35,33 @@ def test_apply_migrations_uses_manifest_ledger_and_checksum_guards():
     assert 'if [[ -n "${DATABASE_URL:-}" ]]; then' in script
     assert 'need_cmd psql' in script
     assert 'else\n  need_cmd docker\nfi' in script
+
+
+def test_production_baselined_schema_migration_remains_immutable():
+    expected_checksum = '190df25ad2f7ea0f657788e9446581bd6193560aac93dbf846ff20d75f4aa653'
+    baseline_bytes = BASELINE_SCHEMA.read_bytes().replace(b'\r\n', b'\n')
+    actual_checksum = hashlib.sha256(baseline_bytes).hexdigest()
+    widening = _read(CLUSTER_WIDENING)
+    manifest = _read(MIGRATION_MANIFEST)
+
+    assert actual_checksum == expected_checksum
+    assert '040_cluster_summary_widen_counts.sql' in manifest
+    for column in (
+        'agriculture_count',
+        'agriculture_best',
+        'refinery_count',
+        'refinery_best',
+        'industrial_count',
+        'industrial_best',
+        'hightech_count',
+        'hightech_best',
+        'military_count',
+        'military_best',
+        'tourism_count',
+        'tourism_best',
+        'total_viable',
+    ):
+        assert f'ALTER COLUMN {column}' in widening
 
 
 def test_seed_check_stays_on_manifested_apply_path_and_asserts_seed_invariants():


### PR DESCRIPTION
Unblocks the guarded production deploy by restoring sql/001_schema.sql to the SHA-256 recorded in production's migration ledger. The cluster-summary widening remains correctly owned by additive migration 040. Adds a cross-platform checksum/ownership regression to the required script-contract job and records the deploy-safety finding in ROADMAP and CHANGES.\n\nVerification:\n- Production ledger audit: 38 recorded, 0 missing, exactly 1 mismatch (001)\n- Restored normalized SHA-256: 190df25ad2f7ea0f657788e9446581bd6193560aac93dbf846ff20d75f4aa653\n- Focused migration/CI contracts: 16 passed\n- Ruff apps/tests and B905 apps/tests/scripts: passed\n- Backend unit: 1451 passed, 15 skipped, 124 deselected