### PR TITLE
Fix dirty-rating retry tail and production invariant policy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,23 @@ checksum; migration 040 remains the additive owner of the widening. A CI
 contract now pins the production-baselined checksum and the migration-040
 ownership boundary.
 
+**Production invariant tail closed** - Reconciled 144,942 truthful no-body
+dirty systems in bounded production batches, deleting 31,417 stale ratings;
+repaired 2,766 ring association statuses and the final stale body-count row.
+Durable repair and invariant receipts now show zero persisted body, no-body,
+ring, station-link, and evidence-lifecycle drift.
+
+**Dirty-rating retry storm fixed** - The scheduled dirty-ratings worker had
+treated every truthful no-body system as a retryable rating error every 30
+minutes. The guarded cron now performs bounded no-body reconciliation first,
+then counts and rates only body-backed systems. Summary-free cleanup mode keeps
+the steady-state pass cheap on the 188M-system production catalogue.
+
+**Freshness policy made explicit** - Deploy and weekly invariant receipts keep
+reporting colonisation age buckets but explicitly allow the >14-day tail. EDDN
+refreshes status on observations; an unchanged positive status aging past 14
+days is freshness telemetry, not by itself a persisted-integrity failure.
+
 ---
 
 ## 2026-05-03 — Backend fix: auto-rebuild indexes transaction error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,14 @@ Do not remove.
 ### run_importer entrypoint
 The `importer` image sets `ENTRYPOINT ["python3"]`. `docker compose run <service> <cmd>` appends the given command on top of the entrypoint rather than replacing it, so `run_importer()` in `scripts/nightly_update.sh` must invoke it as `docker compose run --rm --entrypoint python3 importer <script> <args>` — never pass a redundant literal `python3` as part of `<cmd>`, or every invocation fails trying to execute a file named `python3`. `scripts/run_dirty_ratings_if_needed.sh` already uses the correct `--entrypoint python3` pattern; match it.
 
+### Dirty ratings maintenance
+`scripts/run_dirty_ratings_if_needed.sh` owns both sides of the deferred queue
+under one `flock`: it first runs bounded `reconcile_no_body_ratings.py` cleanup,
+then counts and rates only `rating_dirty = TRUE AND has_body_data = TRUE` rows.
+Do not remove the no-body cleanup or broaden the ratings stream back to all
+dirty systems; truthful no-body rows otherwise become permanent retry errors
+and stale ratings survive indefinitely.
+
 ### Nightly job caps
 `build_archetype_scores.py`'s new-system mode has a hidden `limit or 10_000_000` fallback that silently caps at 10M rows if `--limit` isn't passed explicitly — always pass `--limit`. `scripts/nightly_update.sh` caps new-system archetype scoring and regional-analysis backfills at 5,000,000 rows/night to avoid unattended multi-day runs; lower this once each backlog clears (e.g. to `--limit 500000` for steady-state maintenance).
 

--- a/apps/importer/src/build_ratings.py
+++ b/apps/importer/src/build_ratings.py
@@ -1738,6 +1738,7 @@ def main():
                 SELECT id64, main_star_type
                 FROM   systems
                 WHERE  rating_dirty = TRUE
+                  AND  has_body_data = TRUE
                 ORDER BY id64
             """)
         elif args.rebuild:

--- a/apps/maintenance/scripts/crontab
+++ b/apps/maintenance/scripts/crontab
@@ -17,4 +17,4 @@
 10 2 * * *   /usr/local/bin/run_backup.sh nightly
 15 3 * * *   /usr/local/bin/run_maintenance.sh nightly
  0 4 * * 0   /usr/local/bin/run_maintenance.sh weekly
-45 4 * * 0   /usr/local/bin/run_data_invariants_receipted.sh --target-rating-version 3.4 --production-safe --receipt-file /data/receipts/data-invariants/weekly-latest.json --durable-receipt-dir /data/receipts/data-invariants/weekly-history >> /data/logs/data-invariants.log 2>&1
+45 4 * * 0   /usr/local/bin/run_data_invariants_receipted.sh --target-rating-version 3.4 --production-safe --allow-stale-colonisation-status --receipt-file /data/receipts/data-invariants/weekly-latest.json --durable-receipt-dir /data/receipts/data-invariants/weekly-history >> /data/logs/data-invariants.log 2>&1

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,16 +22,17 @@ document that should answer "what next?".
   Score**, API rerank helpers stay under **archetypes**, and the current DB
   implementation still runs on the **Ratings v3.4** scorer/tables. The full
   production rebaseline main pass has completed and the steady-state
-  dirty-ratings cron has been restored. The remaining ratings integrity issue
-  is a tiny post-rerate body-data contract tail
-  (`systems.has_body_data` / `systems.body_count` versus actual `bodies`
-  rows), not an active mixed-generation rerate backlog. The larger no-body and
-  ring-drift repair buckets have already been drained on production into a
-  small live-churn retry band plus `3` persistent body-contract rows.
-- Data-trust follow-up posture: the next persisted-integrity hardening lane is
-  `station_body_links` drift; Finder populated/uninhabited filter semantics now
-  match end-to-end, but canonical population storage still needs a later
-  unknown-vs-zero migration.
+  dirty-ratings cron has been restored. The 2026-07-18 production closeout
+  drained 144,942 truthful no-body dirty rows, deleted 31,417 stale ratings,
+  repaired 2,766 ring-status rows, and corrected the final body-count row. The
+  production-safe integrity buckets now read zero; steady-state maintenance
+  reconciles no-body rows before body-backed rerating so the backlog cannot
+  recur as a retry storm.
+- Data-trust follow-up posture: persisted body, ring, station-link, and evidence
+  lifecycle invariants are clean. Colonisation age buckets remain visible
+  observational telemetry and no longer block deploys merely because a
+  positive EDDN status has not been re-observed within 14 days. Canonical
+  population storage still needs a later unknown-vs-zero migration.
 - Local test-environment posture: real-service readiness now proves live local
   Postgres access without fake fallbacks, while historical Stage 19 checkpoint
   assertions skip explicitly when the approved historical baseline rows are not
@@ -135,9 +136,9 @@ Stage 25 has exactly one primary objective:
    continuing codebase and documentation cleanup.
 5. Advance the evidence-store and ingestion lane safely, with reviewable
    operator/admin surfaces rather than implicit write automation.
-6. Close out the ratings rebaseline properly so the live app does not quietly
-   carry body-contract drift or unrated ingest edge cases behind the current
-   Development Score / archetype-led product language.
+6. Preserve the closed ratings/data-integrity baseline through bounded
+   no-body reconciliation, body-backed rerating, and durable production
+   receipts.
 7. Keep the now-green local test environment honest: preserve the repo-venv
    runner, preflight path, explicit real-service skips, and broad pytest
    coverage so local "green" continues to mean something.
@@ -157,15 +158,15 @@ competing roadmap source.
 
 ### Do Now
 
-- Finish the last tiny production body-data contract tail
-  (`flagged_but_zero_count = 3`) without reopening expensive wide scans on the
-  live 120 GB database.
+- Preserve the zeroed production body, ring, no-body rating, station-link, and
+  evidence-lifecycle invariant buckets established by the 2026-07-18 repair
+  receipts.
 - Keep receipting `scripts/run_data_invariants_receipted.sh --production-safe`
   on production so the post-rerate end-state is evidenced, not assumed, and
   persist the dated durable receipts under the production receipts path plus
   committed review artifacts.
-- Preserve the now-clean ring and station-link lanes while the remaining
-  no-body dirty rows wobble inside a bounded live-churn retry band.
+- Monitor the now-bounded no-body cleanup and body-backed rerating cadence;
+  colonisation age remains reported separately as source freshness telemetry.
 - Keep Stage 25 shell/context work closed and stable while the audit-response
   foundation follow-through finishes.
 

--- a/docs/operations/stage17n2c-data-trust-runbook.md
+++ b/docs/operations/stage17n2c-data-trust-runbook.md
@@ -129,8 +129,12 @@ Stage 17N.2d-R keeps EDDN ingestion and rating recalculation separate:
 
 - EDDN marks affected rows with `systems.rating_dirty = TRUE`.
 - Host cron periodically runs `scripts/run_dirty_ratings_if_needed.sh`.
+- Under the same `flock`, the script first reconciles up to 50,000 truthful
+  no-body rows in 5,000-row transactions. That deletes stale ratings and clears
+  dirty flags without paying for broad summary scans.
 - The script runs `build_ratings.py --dirty` only when the dirty queue is at or
-  above `DIRTY_RATING_THRESHOLD`.
+  above `DIRTY_RATING_THRESHOLD`; both the threshold count and rating stream
+  are restricted to `has_body_data = TRUE` systems.
 - The script uses `flock` on `/tmp/ed-finder-dirty-ratings.lock` by default, so
   two scheduled invocations of this script cannot overlap.
 
@@ -171,7 +175,18 @@ DIRTY_RATING_THRESHOLD=999999999 bash scripts/run_dirty_ratings_if_needed.sh
 Validation SQL:
 
 ```sql
-SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE;
+SELECT COUNT(*)
+FROM systems
+WHERE rating_dirty = TRUE
+  AND has_body_data = TRUE;
+
+SELECT COUNT(*)
+FROM systems s
+WHERE s.rating_dirty = TRUE
+  AND COALESCE(s.has_body_data, FALSE) = FALSE
+  AND NOT EXISTS (
+      SELECT 1 FROM bodies b WHERE b.system_id64 = s.id64
+  );
 
 SELECT rating_version, COUNT(*)
 FROM ratings
@@ -190,7 +205,7 @@ Log checks:
 
 ```bash
 tail -100 /data/logs/dirty-ratings.log
-grep -E "start time=|dirty_count=|below threshold|dirty ratings rebuild command|exit_status=|another dirty ratings maintenance run" /data/logs/dirty-ratings.log | tail -100
+grep -E "start time=|body_backed_dirty_count=|truthful no-body cleanup|below threshold|dirty ratings rebuild command|exit_status=|another dirty ratings maintenance run" /data/logs/dirty-ratings.log | tail -100
 ```
 
 The script does not clear Redis caches automatically. Cache clears remain a
@@ -212,7 +227,10 @@ Wrapper:
 Post-deploy path:
 
 - `scripts/deploy_main.sh` now runs the wrapper by default in
-  `--production-safe` mode unless `--skip-invariants` is supplied.
+  `--production-safe` mode unless `--skip-invariants` is supplied. It passes
+  `--allow-stale-colonisation-status` explicitly because the EDDN-backed age
+  buckets are observational freshness telemetry, not proof that an unchanged
+  positive status is false. The buckets remain printed and receipted.
 - The deploy hook writes a transient receipt to
   `/tmp/ed-finder-data-invariants-post-deploy.json` and also copies a dated
   durable receipt into `/data/receipts/data-invariants/post-deploy/` so the
@@ -223,7 +241,7 @@ The weekly steady-state schedule now runs from the maintenance sidecar's
 committed crontab, not an out-of-band host cron:
 
 ```cron
-45 4 * * 0 /usr/local/bin/run_data_invariants_receipted.sh --target-rating-version 3.4 --production-safe --receipt-file /data/receipts/data-invariants/weekly-latest.json --durable-receipt-dir /data/receipts/data-invariants/weekly-history >> /data/logs/data-invariants.log 2>&1
+45 4 * * 0 /usr/local/bin/run_data_invariants_receipted.sh --target-rating-version 3.4 --production-safe --allow-stale-colonisation-status --receipt-file /data/receipts/data-invariants/weekly-latest.json --durable-receipt-dir /data/receipts/data-invariants/weekly-history >> /data/logs/data-invariants.log 2>&1
 ```
 
 The maintenance service prefers `DATA_INVARIANTS_DATABASE_URL` and should point

--- a/scripts/deploy_main.sh
+++ b/scripts/deploy_main.sh
@@ -242,6 +242,7 @@ if [[ "$SKIP_INVARIANTS" -eq 0 ]]; then
   bash scripts/run_data_invariants_receipted.sh \
     --target-rating-version 3.4 \
     --production-safe \
+    --allow-stale-colonisation-status \
     --receipt-file /tmp/ed-finder-data-invariants-post-deploy.json \
     --durable-receipt-dir /data/receipts/data-invariants/post-deploy
   ok "post-deploy data invariants passed"

--- a/scripts/reconcile_no_body_ratings.py
+++ b/scripts/reconcile_no_body_ratings.py
@@ -124,6 +124,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Emit machine-readable JSON.",
     )
+    parser.add_argument(
+        "--skip-summary",
+        action="store_true",
+        help=(
+            "Skip the full before/after summary scans. Intended for bounded "
+            "steady-state cleanup runs. Requires --apply."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -168,6 +176,10 @@ def fetch_summary(conn) -> dict[str, int]:
         cur.execute(SUMMARY_SQL)
         row = dict(cur.fetchone() or {})
     return {key: int(row.get(key) or 0) for key in SUMMARY_KEYS}
+
+
+def empty_summary() -> dict[str, None]:
+    return dict.fromkeys(SUMMARY_KEYS)
 
 
 def fetch_batch(conn, batch_size: int) -> list[dict[str, object]]:
@@ -238,15 +250,19 @@ def apply_batches(
 
 def run(conn, args: argparse.Namespace) -> dict[str, object]:
     configure_session(conn)
-    before = fetch_summary(conn)
+    if args.skip_summary and not args.apply:
+        raise ValueError("--skip-summary requires --apply")
+
+    summary_skipped = bool(args.skip_summary)
+    before = empty_summary() if summary_skipped else fetch_summary(conn)
     reconciled = 0
     deleted_ratings = 0
     cleared_dirty = 0
     batches = 0
 
     if args.apply:
-        target_total = before["total_candidates"]
-        if args.limit is not None:
+        target_total = None if summary_skipped else before["total_candidates"]
+        if args.limit is not None and target_total is not None:
             target_total = min(target_total, args.limit)
         reconciled, deleted_ratings, cleared_dirty, batches = apply_batches(
             conn,
@@ -254,7 +270,7 @@ def run(conn, args: argparse.Namespace) -> dict[str, object]:
             limit=args.limit,
             target_total=target_total,
         )
-        after = fetch_summary(conn)
+        after = empty_summary() if summary_skipped else fetch_summary(conn)
     else:
         conn.rollback()
         after = before
@@ -265,6 +281,7 @@ def run(conn, args: argparse.Namespace) -> dict[str, object]:
         "apply": bool(args.apply),
         "batch_size": args.batch_size,
         "limit": args.limit,
+        "summary_skipped": summary_skipped,
         "reconciled": reconciled,
         "deleted_ratings": deleted_ratings,
         "cleared_dirty": cleared_dirty,
@@ -280,12 +297,14 @@ def render_text_report(report: dict[str, object]) -> str:
             "reconcile_no_body_ratings "
             f"mode={report['mode']} "
             f"batch_size={report['batch_size']} "
-            f"limit={report['limit']}"
+            f"limit={report['limit']} "
+            f"summary_skipped={report['summary_skipped']}"
         ),
         "summary:",
     ]
     for key in SUMMARY_KEYS:
-        lines.append(f"  {key}: {report.get(key, 0)}")
+        value = report.get(key)
+        lines.append(f"  {key}: {'skipped' if value is None else value}")
     lines.extend(
         [
             f"reconciled: {report['reconciled']}",
@@ -297,7 +316,8 @@ def render_text_report(report: dict[str, object]) -> str:
     if report["apply"]:
         lines.append("after:")
         for key in SUMMARY_KEYS:
-            lines.append(f"  {key}: {report['after'].get(key, 0)}")
+            value = report['after'].get(key)
+            lines.append(f"  {key}: {'skipped' if value is None else value}")
     return "\n".join(lines)
 
 
@@ -305,6 +325,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     if not args.dsn:
         print("DATABASE_URL or --dsn is required", file=sys.stderr)
+        return 2
+    if args.skip_summary and not args.apply:
+        print("--skip-summary requires --apply", file=sys.stderr)
         return 2
 
     import psycopg2

--- a/scripts/run_data_invariants_receipted.sh
+++ b/scripts/run_data_invariants_receipted.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TARGET_RATING_VERSION="${TARGET_RATING_VERSION:-3.4}"
 PRODUCTION_SAFE=0
+ALLOW_STALE_COLONISATION_STATUS=0
 RECEIPT_FILE="${RECEIPT_FILE:-}"
 DURABLE_RECEIPT_DIR="${DURABLE_RECEIPT_DIR:-}"
 DATABASE_URL_OVERRIDE="${DATA_INVARIANTS_DATABASE_URL:-}"
@@ -37,6 +38,7 @@ while [[ $# -gt 0 ]]; do
     --compose-file) COMPOSE_FILE_OVERRIDE="$2"; shift 2 ;;
     --project-name) COMPOSE_PROJECT_NAME_OVERRIDE="$2"; shift 2 ;;
     --production-safe) PRODUCTION_SAFE=1; shift ;;
+    --allow-stale-colonisation-status) ALLOW_STALE_COLONISATION_STATUS=1; shift ;;
     -h|--help)
       usage
       exit 0
@@ -82,6 +84,9 @@ resolve_host_database_url() {
 command_args=(scripts/checks/data_invariants.py --target-rating-version "$TARGET_RATING_VERSION")
 if [[ "$PRODUCTION_SAFE" -eq 1 ]]; then
   command_args+=(--production-safe)
+fi
+if [[ "$ALLOW_STALE_COLONISATION_STATUS" -eq 1 ]]; then
+  command_args+=(--allow-stale-colonisation-status)
 fi
 
 mode="host_database_url"
@@ -130,7 +135,8 @@ receipt_json="$(cat <<EOF
   "exit_code": $exit_code,
   "mode": "$mode",
   "target_rating_version": "$TARGET_RATING_VERSION",
-  "production_safe": $([[ "$PRODUCTION_SAFE" -eq 1 ]] && echo true || echo false)
+  "production_safe": $([[ "$PRODUCTION_SAFE" -eq 1 ]] && echo true || echo false),
+  "allow_stale_colonisation_status": $([[ "$ALLOW_STALE_COLONISATION_STATUS" -eq 1 ]] && echo true || echo false)
 }
 EOF
 )"

--- a/scripts/run_dirty_ratings_if_needed.sh
+++ b/scripts/run_dirty_ratings_if_needed.sh
@@ -7,6 +7,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIRTY_RATING_THRESHOLD="${DIRTY_RATING_THRESHOLD:-250}"
 DIRTY_RATING_WORKERS="${DIRTY_RATING_WORKERS:-2}"
 DIRTY_RATING_CHUNK="${DIRTY_RATING_CHUNK:-1000}"
+DIRTY_NO_BODY_BATCH="${DIRTY_NO_BODY_BATCH:-5000}"
+DIRTY_NO_BODY_LIMIT="${DIRTY_NO_BODY_LIMIT:-50000}"
 DIRTY_RATING_LOCK_FILE="${DIRTY_RATING_LOCK_FILE:-/tmp/ed-finder-dirty-ratings.lock}"
 
 log() {
@@ -40,6 +42,8 @@ command -v flock >/dev/null 2>&1 || die "flock is not available"
 require_non_negative_int "DIRTY_RATING_THRESHOLD" "$DIRTY_RATING_THRESHOLD"
 require_positive_int "DIRTY_RATING_WORKERS" "$DIRTY_RATING_WORKERS"
 require_positive_int "DIRTY_RATING_CHUNK" "$DIRTY_RATING_CHUNK"
+require_positive_int "DIRTY_NO_BODY_BATCH" "$DIRTY_NO_BODY_BATCH"
+require_positive_int "DIRTY_NO_BODY_LIMIT" "$DIRTY_NO_BODY_LIMIT"
 
 cd "$REPO_ROOT"
 [[ -f docker-compose.yml ]] || die "docker-compose.yml not found in $REPO_ROOT"
@@ -54,13 +58,35 @@ fi
 
 started_epoch="$(date +%s)"
 started_iso="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-log "start time=$started_iso threshold=$DIRTY_RATING_THRESHOLD workers=$DIRTY_RATING_WORKERS chunk=$DIRTY_RATING_CHUNK lock=$DIRTY_RATING_LOCK_FILE"
+log "start time=$started_iso threshold=$DIRTY_RATING_THRESHOLD workers=$DIRTY_RATING_WORKERS chunk=$DIRTY_RATING_CHUNK no_body_batch=$DIRTY_NO_BODY_BATCH no_body_limit=$DIRTY_NO_BODY_LIMIT lock=$DIRTY_RATING_LOCK_FILE"
+
+cleanup_cmd=(
+    docker compose --profile import run --rm
+    --entrypoint python3
+    importer
+    /opt/ed-finder/scripts/reconcile_no_body_ratings.py
+    --apply
+    --batch-size "$DIRTY_NO_BODY_BATCH"
+    --limit "$DIRTY_NO_BODY_LIMIT"
+    --skip-summary
+    --json
+)
+log "truthful no-body cleanup command: $(format_command "${cleanup_cmd[@]}")"
+set +e
+"${cleanup_cmd[@]}"
+status=$?
+set -e
+if [[ "$status" -ne 0 ]]; then
+    duration=$(( "$(date +%s)" - started_epoch ))
+    log "truthful no-body cleanup failed exit_status=$status duration_seconds=$duration"
+    exit "$status"
+fi
 
 count_cmd=(
     docker compose exec -T postgres
     psql -U edfinder -d edfinder -Atq -v ON_ERROR_STOP=1
     -c "SET statement_timeout = '30s'"
-    -c "SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE;"
+    -c "SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE AND has_body_data = TRUE;"
 )
 log "dirty count command: $(format_command "${count_cmd[@]}")"
 
@@ -74,7 +100,7 @@ else
 fi
 
 [[ "$dirty_count" =~ ^[0-9]+$ ]] || die "dirty count query returned non-numeric output: '$dirty_count'"
-log "dirty_count=$dirty_count"
+log "body_backed_dirty_count=$dirty_count"
 
 if (( dirty_count < DIRTY_RATING_THRESHOLD )); then
     duration=$(( "$(date +%s)" - started_epoch ))

--- a/tests/test_backup_restore_ops.py
+++ b/tests/test_backup_restore_ops.py
@@ -25,6 +25,7 @@ def test_backup_automation_is_wired_through_maintenance_sidecar():
     assert '- /data/receipts:/data/receipts' in compose
     assert '/usr/local/bin/run_backup.sh nightly' in crontab
     assert '/usr/local/bin/run_data_invariants_receipted.sh --target-rating-version 3.4' in crontab
+    assert '--production-safe --allow-stale-colonisation-status' in crontab
     assert 'apk add --no-cache dcron tini bash python3 py3-psycopg2 rclone' in dockerfile
     assert 'COPY apps/maintenance/scripts/run_backup.sh                /usr/local/bin/run_backup.sh' in dockerfile
     assert 'COPY scripts/run_data_invariants_receipted.sh              /usr/local/bin/run_data_invariants_receipted.sh' in dockerfile
@@ -110,13 +111,16 @@ def test_data_invariants_ops_path_is_wired_for_post_deploy_and_weekly_maintenanc
     assert 'bash scripts/run_data_invariants_receipted.sh \\' in deploy
     assert '/tmp/ed-finder-data-invariants-post-deploy.json' in deploy
     assert '--durable-receipt-dir /data/receipts/data-invariants/post-deploy' in deploy
+    assert '--allow-stale-colonisation-status' in deploy
     assert 'TARGET_RATING_VERSION="${TARGET_RATING_VERSION:-3.4}"' in wrapper
     assert 'DURABLE_RECEIPT_DIR="${DURABLE_RECEIPT_DIR:-}"' in wrapper
     assert 'DATABASE_URL_OVERRIDE="${DATA_INVARIANTS_DATABASE_URL:-}"' in wrapper
     assert '--database-url) DATABASE_URL_OVERRIDE="$2"; shift 2 ;;' in wrapper
     assert '--durable-receipt-dir) DURABLE_RECEIPT_DIR="$2"; shift 2 ;;' in wrapper
     assert '--production-safe' in wrapper
+    assert '--allow-stale-colonisation-status) ALLOW_STALE_COLONISATION_STATUS=1; shift ;;' in wrapper
     assert '"status": "$status"' in wrapper
+    assert '"allow_stale_colonisation_status":' in wrapper
     assert 'data-invariants-${durable_stamp}.json' in wrapper
     assert 'latest.json' in wrapper
     assert '45 4 * * 0 /usr/local/bin/run_data_invariants_receipted.sh' in runbook

--- a/tests/test_body_data_contracts.py
+++ b/tests/test_body_data_contracts.py
@@ -76,5 +76,7 @@ def test_reconcile_no_body_ratings_script_clears_dirty_and_deletes_stale_rows():
     assert "DELETE FROM ratings" in source
     assert "SET rating_dirty = FALSE" in source
     assert "Apply the reconciliation. Omit for dry-run summary only." in source
+    assert '"--skip-summary"' in source
+    assert "--skip-summary requires --apply" in source
     assert "candidates_with_rating" in source
     assert "candidates_without_rating" in source

--- a/tests/test_data_trust_runtime.py
+++ b/tests/test_data_trust_runtime.py
@@ -105,6 +105,7 @@ def test_body_contract_repair_and_reconcile_restore_clean_invariants():
             '--apply',
             '--batch-size',
             '100',
+            '--skip-summary',
             '--json',
         )
         assert reconcile.returncode == 0, reconcile.stderr
@@ -112,7 +113,9 @@ def test_body_contract_repair_and_reconcile_restore_clean_invariants():
         assert reconcile_report['reconciled'] == 1
         assert reconcile_report['deleted_ratings'] == 1
         assert reconcile_report['cleared_dirty'] == 1
-        assert reconcile_report['after']['total_candidates'] == 0
+        assert reconcile_report['summary_skipped'] is True
+        assert reconcile_report['before']['total_candidates'] is None
+        assert reconcile_report['after']['total_candidates'] is None
 
         after = _run_python(
             DATA_INVARIANTS,
@@ -148,6 +151,17 @@ def test_body_contract_repair_and_reconcile_restore_clean_invariants():
 
 def test_body_contract_skip_summary_requires_apply():
     result = _run_python(REPAIR_BODY_CONTRACT, '--dsn', 'postgresql://example.invalid/db', '--skip-summary')
+    assert result.returncode != 0
+    assert '--skip-summary requires --apply' in result.stderr
+
+
+def test_no_body_reconcile_skip_summary_requires_apply():
+    result = _run_python(
+        RECONCILE_NO_BODY_RATINGS,
+        '--dsn',
+        'postgresql://example.invalid/db',
+        '--skip-summary',
+    )
     assert result.returncode != 0
     assert '--skip-summary requires --apply' in result.stderr
 

--- a/tests/test_stage17n2c_data_trust.py
+++ b/tests/test_stage17n2c_data_trust.py
@@ -553,6 +553,7 @@ def test_dirty_mode_selects_only_rating_dirty_systems():
     source = inspect.getsource(build_ratings.main)
 
     assert 'WHERE  rating_dirty = TRUE' in source
+    assert 'AND  has_body_data = TRUE' in source
     assert 'Query: dirty systems only' in source
 
 
@@ -562,8 +563,12 @@ def test_dirty_ratings_maintenance_script_is_host_cron_safe():
     assert 'DIRTY_RATING_THRESHOLD="${DIRTY_RATING_THRESHOLD:-250}"' in source
     assert 'DIRTY_RATING_WORKERS="${DIRTY_RATING_WORKERS:-2}"' in source
     assert 'DIRTY_RATING_CHUNK="${DIRTY_RATING_CHUNK:-1000}"' in source
+    assert 'DIRTY_NO_BODY_BATCH="${DIRTY_NO_BODY_BATCH:-5000}"' in source
+    assert 'DIRTY_NO_BODY_LIMIT="${DIRTY_NO_BODY_LIMIT:-50000}"' in source
     assert 'flock -n 9' in source
-    assert 'SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE;' in source
+    assert '/opt/ed-finder/scripts/reconcile_no_body_ratings.py' in source
+    assert '--skip-summary' in source
+    assert 'SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE AND has_body_data = TRUE;' in source
     assert 'docker compose --profile import run --rm' in source
     assert '/app/build_ratings.py' in source
     assert '--dirty' in source
@@ -603,8 +608,9 @@ def test_dirty_ratings_runbook_documents_host_cron_installation():
         'DIRTY_RATING_WORKERS=2 DIRTY_RATING_CHUNK=1000 '
         'bash scripts/run_dirty_ratings_if_needed.sh >> /data/logs/dirty-ratings.log 2>&1'
     ) in runbook
-    assert 'SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE;' in runbook
-    assert 'grep -E "start time=|dirty_count=|below threshold|' in runbook
+    assert 'WHERE rating_dirty = TRUE\n  AND has_body_data = TRUE;' in runbook
+    assert 'COALESCE(s.has_body_data, FALSE) = FALSE' in runbook
+    assert 'grep -E "start time=|body_backed_dirty_count=|truthful no-body cleanup|' in runbook
     assert 'does not clear Redis caches automatically' in runbook
 
 


### PR DESCRIPTION
## What changed

- reconcile truthful no-body dirty systems before scheduled rating work, in bounded batches under the existing host-cron lock
- restrict dirty rating counts and rating streams to body-backed systems
- add a guarded `--skip-summary` cleanup mode for production-scale steady-state runs
- keep colonisation freshness buckets visible while explicitly allowing the observational >14-day tail in deploy and weekly receipts
- update CLAUDE.md, ROADMAP, CHANGES, the operations runbook, and affected contracts

## Root cause

The scheduled `build_ratings.py --dirty` path selected all dirty systems. Truthful no-body systems were treated as retryable errors, so 144,940 rows were retried every 30 minutes and stale ratings were never deleted. The same deploy also treated event-driven colonisation observation age as a hard persisted-integrity failure.

## Production repair evidence

- reconciled 144,942 no-body rows in bounded 5,000-row transactions
- deleted 31,417 stale ratings
- repaired 2,766 ring association statuses
- corrected the final stale body-count row
- post-repair production-safe invariant buckets are zero for body, no-body dirty, ring, station-link, and evidence lifecycle checks; only the reported colonisation age tail remains
- durable receipts: `/data/receipts/data-repairs/20260718T103332Z`

## Local verification

- strict project-state resolver: passed
- backend unit selection: 1,451 passed, 15 skipped, 125 deselected
- script contracts: 34 passed, 1 skipped
- focused contracts: 60 passed
- disposable Postgres runtime repair/invariant test: passed
- Ruff full gate and B905 gate: passed
- shell syntax and compile checks: passed
