### PR TITLE
Docs: authorize Stage 26 next-generation map foundation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,25 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-19 - Stage 26A next-generation map authorization
+
+**Desktop map replacement contract opened** - Authorized a staged replacement
+of the current low-value map frontend while preserving Map as a secondary
+Explore surface and Colony Cockpit as the sole planning workspace. The current
+renderer is no longer an architectural baseline, but remains live until a
+deliberate gated cutover.
+
+**Galaxy regions and feature integration made non-negotiable** - Required all
+42 named in-game galaxy regions, arbitrary two-, three-, and multi-system
+highlights, complete cluster membership and edge context, overlap
+disambiguation, selected-system continuity, and explicit Finder, Compare,
+saved/evidence, and planner hand-offs. Mobile and touch map work are excluded.
+
+**Research before renderer selection** - Defined a paid artifact-backed
+Research Control run with complete TypeScript/JSON deliverables, followed by an
+equal deck.gl OrbitView, deck.gl OrthographicView, and Three.js/R3F desktop
+bake-off. Stage 26A changes no runtime route and selects no renderer.
+
 ## 2026-07-18 — CI restoration, branch protection, and strict zip hardening
 
 **H2 trust and hygiene hardening** — Expanded the required Ruff surface to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-ED-Finder: an Elite Dangerous colonisation planner, currently at **Stage 25** (Stages 25A–25H complete). Product journey: **Explore → Inspect → Plan → Simulate/Sequence → Review Evidence → Export/Share**. The **Colony Cockpit** (Plan workspace) is the canonical live planning surface; the galaxy Map is a secondary Explore surface only, not a planning workspace.
+ED-Finder: an Elite Dangerous colonisation planner, currently at **Stage 26A** (Stages 25A-25H complete; Stage 26A is the active map authorization contract). Product journey: **Explore → Inspect → Plan → Simulate/Sequence → Review Evidence → Export/Share**. The **Colony Cockpit** (Plan workspace) is the canonical live planning surface; the galaxy Map is a secondary Explore surface only, not a planning workspace. Stage 26 authorizes a measured desktop replacement of the low-value map frontend without changing that ownership.
 
 `ed-finder` is one of **three repos** in this workspace, and it is the app-only one:
 - `ed-finder` (this repo) — runnable product app, frontend, API, local dev stack. Nothing here should invent new colonisation mechanics truth.
@@ -33,7 +33,11 @@ For mechanics-affecting work specifically, also read `docs/reference/colonisatio
 - No hidden scoring/CP/economy/service/optimiser changes.
 - No canonical database write lane unless a stage explicitly authorizes it.
 - No scheduler/service/timer activation for import automation by default.
-- No map redesign or planner–map fusion.
+- Map redesign is authorized only through
+  `docs/colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md`:
+  Stage 26A is docs-only, Stage 26B is isolated artifact-backed research and a
+  three-renderer bake-off, and no production renderer or cutover is authorized
+  before those gates. Planner-map fusion remains prohibited.
 - No visual cloning, asset copying, or code copying from external planner references (RavenColonial).
 - Accounts/OAuth/collaboration/plan-sync, journal-import canonical promotion, and score-weighted colonisation-corridor routing are all explicitly **deferred** pending the foundation work below — don't start them opportunistically.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder is the main documentation entry point for the repo.
 ## Start Here
 
 - [`ROADMAP.md`](./ROADMAP.md) for the single authoritative roadmap and current priorities.
+- [`colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md`](./colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md) for the active desktop map authorization and bake-off contract.
 - [`colonisation-redesign/README.md`](./colonisation-redesign/README.md) for active planner, evidence, enrichment, and historical stage-control docs.
 - [`development/`](./development/) for local workflow, test environment, handoff, and implementation-contract docs.
 - [`operations/`](./operations/) for deployment, hosting, SSH, and operator runbooks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,9 +5,10 @@ document that should answer "what next?".
 
 ## Current State
 
-- Programme: Stage 25 product scope is complete on the active integration line;
-  promotion and foundation follow-through remain active.
-- Status: Stage 25A through Stage 25H are complete.
+- Programme: Stage 25 product scope is complete; Stage 26 opens the bounded
+  next-generation map replacement lane without reopening planner scope.
+- Status: Stage 25A through Stage 25H are complete. Stage 26A is the active
+  documentation and authorization checkpoint.
 - Local engineering posture: the repo-local Python 3.12 `.venv` path is now
   the canonical local test runner, Docker-backed disposable Postgres/Redis on
   `127.0.0.1:55432` / `127.0.0.1:6379` are validated by preflight, and the
@@ -17,7 +18,8 @@ document that should answer "what next?".
 - Primary planning surface: Colony Planner remains the canonical live planning
   workspace.
 - Map posture: Map remains a secondary Explore surface, not the primary
-  planning workspace.
+  planning workspace. Stage 26 authorizes a measured desktop replacement of
+  its low-value frontend implementation while preserving that product role.
 - Scoring posture: player-facing UI continues to speak in **Development
   Score**, API rerank helpers stay under **archetypes**, and the current DB
   implementation still runs on the **Ratings v3.4** scorer/tables. The full
@@ -129,9 +131,9 @@ Stage 25 has exactly one primary objective:
 
 ## What We Are Doing Now
 
-1. Keep the landed Stage 25C shell/context baseline stable while Stage 25D
-   folds the strongest planner and simulation surfaces into one canonical Plan
-   workspace.
+1. Execute Stage 26A as a documentation-only authorization, then use
+   artifact-backed research and an equal three-renderer bake-off before any
+   production map implementation or renderer choice.
 2. Preserve a visible selected-system context and explicit Plan hand-off across
    Explore, Inspect, Plan, and Review / Export flows.
 3. Improve evidence, provenance, and review surfaces without turning
@@ -228,6 +230,23 @@ competing roadmap source.
 - Stage 25 product work is complete and promoted. Preserve its shell/context
   baseline while documentation triage, scoring cleanup, and CRE contract work
   proceed.
+
+### Stage 26A
+
+- Active: authorize and pin the next-generation desktop map contract in
+  [`stage-26a-next-generation-map-foundation-contract.md`](./colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md).
+- The replacement must render all 42 named in-game galaxy regions correctly,
+  support arbitrary multi-system and cluster overlays, preserve selected-system
+  context, and keep the Colony Cockpit as the sole planning workspace.
+- The current frontend map renderer is not an architectural baseline. It stays
+  live until deliberate cutover; independently verified backend/API assets may
+  be reused.
+- Stage 26A selects no renderer and changes no runtime route. Its only follow-on
+  authorization is Stage 26B: a paid artifact-backed Research Control run and
+  an isolated, equally measured deck.gl OrbitView, deck.gl OrthographicView,
+  and Three.js/R3F bake-off.
+- Desktop viewports 1280x720 and 1440x900 are required. Mobile and touch map
+  work are explicitly out of scope.
 
 ### Stage 25C
 
@@ -329,16 +348,18 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Preserve production data-integrity receipts and the bounded rerating cadence.
-2. Complete dependency-aware documentation triage and historical archiving.
-3. Finish the archetype-scoring pivot and retire legacy score storage safely.
-4. Reconcile CRE confidence/source-authority contracts before runtime integration.
-5. Maintain all ten protected CI checks, reproducible release artifacts, local
+1. Complete Stage 26A, then run the artifact-backed map research and measured
+   renderer bake-off without selecting a renderer in advance.
+2. Preserve production data-integrity receipts and the bounded rerating cadence.
+3. Complete dependency-aware documentation triage and historical archiving.
+4. Finish the archetype-scoring pivot and retire legacy score storage safely.
+5. Reconcile CRE confidence/source-authority contracts before runtime integration.
+6. Maintain all ten protected CI checks, reproducible release artifacts, local
    parity, and the green isolated Review Lab browser workflow.
-6. Preserve the reviewed database-operator secret channels, finite migration
+7. Preserve the reviewed database-operator secret channels, finite migration
    timeout policy, and explicit exceptional-run opt-in.
-7. Continue planner trust, evidence clarity, and operator reviewability.
-8. Keep product-shell and selected-system continuity stable while foundations
+8. Continue planner trust, evidence clarity, and operator reviewability.
+9. Keep product-shell and selected-system continuity stable while foundations
    evolve.
 
 ## Boundaries
@@ -349,7 +370,11 @@ competing roadmap source.
 - No hidden scoring, CP, economy, service, or optimiser changes.
 - No canonical database write lane unless a future stage explicitly authorizes it.
 - No scheduler, service, or timer activation for import automation by default.
-- No map redesign or planner-map fusion unless later evidence justifies it.
+- Map redesign is authorized only through the Stage 26 sequence. Stage 26A is
+  documentation-only; Stage 26B is isolated research and measurement. No
+  production renderer choice or route cutover occurs before its recorded gates.
+- No planner-map fusion. Map may hand selected context into Plan but must not
+  mutate Build Plan, execute Preview, or become a planning workspace.
 - No visual cloning, asset copying, or derivative workflow shortcuts from
   external planner references.
 
@@ -374,6 +399,10 @@ competing roadmap source.
 
 Read these when a task needs more detail than this roadmap provides:
 
+- [`colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md`](./colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md):
+  active authorization, non-negotiable region and feature-integration contract,
+  artifact requirements, renderer bake-off, and staged cutover sequence for the
+  next-generation desktop map.
 - `docs/colonisation-redesign/stage-24a-readonly-evidence-adoption-contract.md`:
   Stage 24A contract checkpoint and evidence-surface ownership baseline.
 - `docs/colonisation-redesign/stage-24b-planner-evidence-discoverability.md`:

--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -4,19 +4,28 @@ This folder contains the active contracts, closeout records, architecture notes,
 and historical implementation docs for ED-Finder's colonisation, planner,
 evidence, and enrichment work.
 
-## Active Stage 25 Control
+## Active Stage 26 Control
+
+The prior **Active Stage 25 Control** is complete and remains the settled
+product-shell and selected-system context baseline for this new lane.
 
 - [`../ROADMAP.md`](../ROADMAP.md) is the single authoritative roadmap and the
   default answer to "what next?".
+- [`stage-26a-next-generation-map-foundation-contract.md`](./stage-26a-next-generation-map-foundation-contract.md)
+  is the active authorization and implementation-boundary contract for the
+  next-generation desktop map lane.
 - [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md)
-  is the active implementation contract for the current Stage 25 slice.
+  remains the settled shell and selected-system context baseline.
 
 ## Read This First
 
 Use this order before changing planner, evidence, or enrichment behaviour:
 
 1. [`../ROADMAP.md`](../ROADMAP.md)
-2. [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md)
+2. [`stage-26a-next-generation-map-foundation-contract.md`](./stage-26a-next-generation-map-foundation-contract.md)
+   for map work, or
+   [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md)
+   for shell and planner-context work
 3. [`stage-25b-evidence-language-visual-primitives.md`](./stage-25b-evidence-language-visual-primitives.md)
    and [`stage-25a-current-state-map-product-visual-baseline.md`](./stage-25a-current-state-map-product-visual-baseline.md)
 4. [`stage-17p-current-state-forward-plan.md`](./stage-17p-current-state-forward-plan.md)
@@ -31,7 +40,8 @@ If an older document's recommended next step conflicts with
 | Document | Why it matters |
 |---|---|
 | [`../ROADMAP.md`](../ROADMAP.md) | Single source for current priorities, boundaries, and next work. |
-| [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) | Active implementation contract for the current slice. |
+| [`stage-26a-next-generation-map-foundation-contract.md`](./stage-26a-next-generation-map-foundation-contract.md) | Active map authorization, research artifacts, renderer bake-off, integration boundary, and staged cutover contract. |
+| [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md) | Settled shell and selected-system context baseline. |
 | [`stage-25b-evidence-language-visual-primitives.md`](./stage-25b-evidence-language-visual-primitives.md) | Current evidence-language and visual-system baseline. |
 | [`stage-25a-current-state-map-product-visual-baseline.md`](./stage-25a-current-state-map-product-visual-baseline.md) | Current-state audit and map posture baseline. |
 | [`stage-17p-current-state-forward-plan.md`](./stage-17p-current-state-forward-plan.md) | Planner truth, source authority, and hard product boundaries. |

--- a/docs/colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md
+++ b/docs/colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md
@@ -1,0 +1,180 @@
+# Stage 26A Next-Generation Map Foundation Contract
+
+## Status
+
+Stage 26A is the active authorization and contract checkpoint for replacing the
+current galaxy-map frontend.
+
+This checkpoint is documentation only. It authorizes an artifact-backed
+research run and an isolated renderer bake-off. It does not select a renderer,
+change a production route, add a database write lane, or authorize planner-map
+fusion.
+
+## Product Decision
+
+ED-Finder needs a useful desktop galaxy map rather than another incremental
+repair of the current canvas implementation.
+
+The replacement remains a secondary `Explore` surface. The Colony Cockpit
+remains the canonical planning workspace. Map interactions may select, compare,
+and hand systems into existing workflows, but they must not mutate a Build Plan,
+run Preview, promote evidence, or invent mechanics truth.
+
+The current frontend map implementation is not an architectural baseline for
+the replacement. It may remain live until cutover, but its renderer,
+orchestration, camera model, and interaction model must not constrain the new
+design. Verified backend data, API contracts, query ownership, error handling,
+and other independently useful assets may be reused after review.
+
+## Non-Negotiable Requirements
+
+1. Render all 42 named in-game galaxy regions with correct names, recognizable
+   boundaries, and correct galactic placement. Region index 0 remains an
+   unmapped sentinel and is not a forty-third named region.
+2. Use one continuous camera with a top-down default and optional tilt/rotation.
+   A mode change must not abruptly replace the scene or lose user context.
+3. Accept a typed scene descriptor and return typed interaction events. Feature
+   code must not reach into renderer internals.
+4. Highlight arbitrary sets of systems, including two-system comparisons and
+   three-or-more-system cluster results, even when a highlighted system is
+   absent from an aggregated background level of detail.
+5. Represent cluster anchors, member IDs, member roles, edges, radius or hull,
+   and labels. Selecting an anchor must not discard its member context.
+6. Preserve bidirectional selected-system context between Map, Finder, System
+   Detail, Compare, saved/evidence views, and explicit planner hand-off.
+7. Disambiguate overlapping selectable systems. Never choose an arbitrary
+   system silently.
+8. Auto-fit a new scene at most once. Manual camera movement must survive later
+   data, selection, and layer updates until the scene revision changes.
+9. Give every bounded data response explicit `count`, `truncated`, and
+   continuation or aggregate-remainder semantics. A bare `LIMIT` is invalid.
+10. Provide a bounded contextual keyboard-accessible companion view for the
+    selected systems, active overlays, search results, and overlap candidates.
+11. Treat GPU timing as unknown unless measured with a GPU timer extension or a
+    captured system trace. JavaScript callback duration is not GPU duration.
+12. Target desktop browsers only. Required viewports are 1280x720 and 1440x900.
+    Mobile, touch gestures, and phone-width map layouts are out of scope.
+
+## Scene Boundary
+
+The artifact-backed research run must produce a compilable TypeScript boundary
+equivalent in responsibility to:
+
+- `MapSceneDescriptor`: revision, one-time fit intent, camera intent and state,
+  origin/return state, systems, clusters, highlights, routes, annotations, and
+  layer visibility;
+- `MapSystemEntry`: id64, name, coordinates, region, source, score where
+  relevant, and primary/secondary/context role;
+- `MapClusterDescriptor`: anchor, members, member roles, edges, radius/hull,
+  economy context, and labels;
+- `MapInteractionResult`: selection, deselection, overlap choice, navigation,
+  camera change, and layer change events;
+- `MapRendererAdapter`: renderer-independent mount, update, resize, context-loss
+  recovery, measurement, and disposal behavior.
+
+Names may change during the research run, but these responsibilities and their
+separation may not disappear.
+
+## Required Integration Scenarios
+
+The shared bake-off harness must execute the same scenarios against every
+renderer candidate:
+
+1. Three-system cluster with anchor, two members, edges, radius/hull, labels,
+   and preserved group context after selection.
+2. Two-system comparison fitted together and individually selectable.
+3. Finder results with selection reflected both in the map and the originating
+   result surface.
+4. Highlighted system rendered above the background LOD even when aggregation
+   omitted it.
+5. Explicit planner navigation followed by exact map return-state restoration,
+   without map-side plan mutation.
+6. Evidence and saved-system overlays visible simultaneously with distinct,
+   text-supported semantics.
+7. One-time auto-fit followed by manual camera movement that survives
+   selection, loading, and layer changes.
+
+## Region Data And Legal Gate
+
+The V5 research report identifies `klightspeed/EliteDangerousRegionMap` commit
+`6c1191a58e1e593966f44f16235ab39d1ad24d84` as a useful implementation and
+verification reference. Its MIT license covers its code, not Frontier's region
+names or galaxy geography.
+
+No new third-party region data may be committed by this checkpoint. Before
+shipping region geometry, the implementation stage must:
+
+- inventory the region data already present in ED-Finder;
+- verify all 42 names, IDs, lookup orientation, scale, origin, and boundaries;
+- record provenance and redistribution reasoning;
+- derive label points from region interiors, using stored centroids only as an
+  explicit fallback; and
+- prove region alignment with automated fixtures plus desktop visual review.
+
+Raven Colonial screenshots are usability warnings only. No layout, styling,
+assets, or interaction design may be copied or closely imitated.
+
+## Research-Control Run
+
+Stage 26B begins with a paid, artifact-backed Research Control run against the
+exact merged ED-Finder commit containing this contract. It must use DeepSeek Pro
+with a broad specialist fan-out and retain complete, validated artifacts rather
+than prose appendices.
+
+Required retained artifacts are:
+
+1. `map-scene-contract.ts`, validated by the strict in-memory TypeScript gate;
+2. `map-renderer-adapter.ts`, validated by the same gate;
+3. `map-bakeoff-scenarios.ts`, containing deterministic fixtures for all seven
+   integration scenarios and validated by the same gate;
+4. `map-region-verification.json`, validated as JSON and covering the 42 named
+   regions plus the unmapped sentinel; and
+5. `map-research-closure.md`, linking each requirement to primary evidence,
+   retained artifacts, disagreements, and unresolved legal or measurement work.
+
+The run must use repository search/read evidence pinned to the registered
+commit. Generated code remains non-executable during generic research.
+
+## Renderer Bake-Off
+
+No renderer is selected by Stage 26A. Stage 26B must compare these three
+candidates through one shared Vite/React desktop harness:
+
+- deck.gl `OrbitView` with its orthographic top-down posture and continuous
+  tilt path;
+- deck.gl `OrthographicView` as the deliberately top-down control candidate;
+- Three.js with React Three Fiber and an explicit camera-transition design.
+
+Every candidate receives the same deterministic 100,000- and 500,000-system
+datasets, region layer, controls, scenarios, instrumentation, and Playwright
+journey. A candidate cannot be skipped because another looks promising.
+
+The recorded decision must cover frame-time percentiles, initial load,
+click-selection latency, memory, compressed bundle contribution, context-loss
+recovery, region correctness, overlap handling, keyboard workflow, and all seven
+integration scenarios. Unknown measurements remain unknown; they are not
+converted into passes.
+
+## Delivery Sequence
+
+- **Stage 26A:** authorize and pin this contract. Documentation only.
+- **Stage 26B:** run artifact-backed research and the isolated three-renderer
+  bake-off; select a renderer only from recorded evidence.
+- **Stage 26C:** implement the region-first replacement foundation behind an
+  isolated development entry, with no production route cutover.
+- **Stage 26D:** wire Finder, Cluster Search, Compare, saved/evidence overlays,
+  selected-system context, and explicit planner hand-off through the typed scene
+  boundary.
+- **Stage 26E:** complete parity, accessibility, performance, context-loss,
+  visual, and browser gates; cut over deliberately and then remove superseded
+  frontend map code.
+
+## Stage 26A Exit Criteria
+
+Stage 26A is complete when this contract, the canonical roadmap, `CLAUDE.md`,
+the documentation index, and the change log are merged with all protected checks
+green.
+
+Completion of Stage 26A authorizes Stage 26B only. It does not authorize a
+production renderer, production map cutover, backend schema change, canonical
+write path, or planner-map fusion.


### PR DESCRIPTION
## Summary
- authorize Stage 26A as the documentation-only next-generation map foundation checkpoint
- require all 42 named in-game galaxy regions, typed multi-system/cluster overlays, selected-system continuity, and desktop-only delivery
- define the artifact-backed Research Control run, equal three-renderer bake-off, staged implementation, and deliberate cutover gates

## Why
The current map remains a secondary Explore surface but its frontend implementation is not useful enough to serve as the architecture for future features. The roadmap previously prohibited map redesign entirely, so implementation could not begin honestly without a bounded replacement contract.

## Boundaries
- documentation only; no runtime route or renderer change
- no renderer selected
- no planner-map fusion or map-side plan mutation
- no new third-party region data committed
- the existing map remains live until a measured replacement clears cutover gates
- mobile and touch map work remain out of scope

## Verification
- strict repository state gate passed
- focused documentation/hygiene contracts: 33 passed
- complete unit gate: 1471 passed, 15 skipped, 125 deselected
- staged diff contains only CHANGES.md, CLAUDE.md, and docs paths