### PR TITLE
Fix Windows Make and frontend bundle portability (CQ-044)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,8 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 through user-scoped `winget` and removed the Makefile's shell-specific inline
 environment assignments. Windows virtualenv paths now use separators accepted
 by both `cmd.exe` and Bash, while integration-test defaults are exported by Make
-itself.
+itself without expanding dollar signs in credentials; unset and explicitly
+empty values both receive the disposable local-test defaults.
 
 **Drive-letter release packaging fixed** - Frontend bundle creation now
 normalizes Windows drive-letter paths through the available MSYS path adapter

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,11 @@ environment assignments. Windows virtualenv paths now use separators accepted
 by both `cmd.exe` and Bash, while integration-test defaults are exported by Make
 itself.
 
-**Drive-letter release packaging fixed** - Frontend bundle creation now forces
-GNU tar to treat `C:` paths as local and normalizes the escaped checksum prefix
-emitted for Windows filenames. Direct Windows regressions cover native Make
-command generation plus archive creation and checksum verification.
+**Drive-letter release packaging fixed** - Frontend bundle creation now
+normalizes Windows drive-letter paths through the available MSYS path adapter
+before invoking tar and checksum tools, without requiring GNU-only tar flags or
+rewriting checksum mode markers. Direct Windows regressions cover native Make
+command generation, archive creation, and `sha256sum -c` verification.
 
 ## 2026-07-19 - Stage 26A next-generation map authorization
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,19 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-19 - Windows GNU Make and bundle portability
+
+**Documented Make targets now run from PowerShell** - Installed GNU Make 4.4.1
+through user-scoped `winget` and removed the Makefile's shell-specific inline
+environment assignments. Windows virtualenv paths now use separators accepted
+by both `cmd.exe` and Bash, while integration-test defaults are exported by Make
+itself.
+
+**Drive-letter release packaging fixed** - Frontend bundle creation now forces
+GNU tar to treat `C:` paths as local and normalizes the escaped checksum prefix
+emitted for Windows filenames. Direct Windows regressions cover native Make
+command generation plus archive creation and checksum verification.
+
 ## 2026-07-19 - Stage 26A next-generation map authorization
 
 **Desktop map replacement contract opened** - Authorized a staged replacement

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,9 @@ itself.
 **Drive-letter release packaging fixed** - Frontend bundle creation now
 normalizes Windows drive-letter paths through the available MSYS path adapter
 before invoking tar and checksum tools, without requiring GNU-only tar flags or
-rewriting checksum mode markers. Direct Windows regressions cover native Make
-command generation, archive creation, and `sha256sum -c` verification.
+rewriting checksum mode markers. Direct regressions cover native Windows Make
+command generation, archive creation, and checksum verification through either
+the GNU `sha256sum` or portable `shasum` path used by the release script.
 
 ## 2026-07-19 - Stage 26A next-generation map authorization
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@ through user-scoped `winget` and removed the Makefile's shell-specific inline
 environment assignments. Windows virtualenv paths now use separators accepted
 by both `cmd.exe` and Bash, while integration-test defaults are exported by Make
 itself without expanding dollar signs in credentials; unset and explicitly
-empty values both receive the disposable local-test defaults.
+empty environment or Make command-line values all receive the disposable
+local-test defaults.
 
 **Drive-letter release packaging fixed** - Frontend bundle creation now
 normalizes Windows drive-letter paths through the available MSYS path adapter

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ data-invariants:  ## Run read-only data integrity checks against DATABASE_URL
 	$(PYTHON) scripts/checks/data_invariants.py
 
 # ── Backend ──────────────────────────────────────────────────────────────────
-test: export DATABASE_URL ?= postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder
-test: export REDIS_URL ?= redis://localhost:6379/15
-test: export CORS_ORIGINS ?= http://test
-test: export ADMIN_TOKEN ?= test-admin-token
-test: export LOG_LEVEL ?= WARNING
-test: export EXPOSE_ERROR_DETAIL ?= true
+test: export DATABASE_URL := $(if $(strip $(value DATABASE_URL)),$(value DATABASE_URL),postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder)
+test: export REDIS_URL := $(if $(strip $(value REDIS_URL)),$(value REDIS_URL),redis://localhost:6379/15)
+test: export CORS_ORIGINS := $(if $(strip $(value CORS_ORIGINS)),$(value CORS_ORIGINS),http://test)
+test: export ADMIN_TOKEN := $(if $(strip $(value ADMIN_TOKEN)),$(value ADMIN_TOKEN),test-admin-token)
+test: export LOG_LEVEL := $(if $(strip $(value LOG_LEVEL)),$(value LOG_LEVEL),WARNING)
+test: export EXPOSE_ERROR_DETAIL := $(if $(strip $(value EXPOSE_ERROR_DETAIL)),$(value EXPOSE_ERROR_DETAIL),true)
 test:  ## Run backend unit + integration tests
 	$(PYTHON) -m unittest discover -s tests -p test_smoke.py
 	$(PYTHON) -m pytest tests/integration/ -q

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ data-invariants:  ## Run read-only data integrity checks against DATABASE_URL
 	$(PYTHON) scripts/checks/data_invariants.py
 
 # ── Backend ──────────────────────────────────────────────────────────────────
-test: export DATABASE_URL := $(or $(DATABASE_URL),postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder)
-test: export REDIS_URL := $(or $(REDIS_URL),redis://localhost:6379/15)
-test: export CORS_ORIGINS := $(or $(CORS_ORIGINS),http://test)
-test: export ADMIN_TOKEN := $(or $(ADMIN_TOKEN),test-admin-token)
-test: export LOG_LEVEL := $(or $(LOG_LEVEL),WARNING)
-test: export EXPOSE_ERROR_DETAIL := true
+test: export DATABASE_URL ?= postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder
+test: export REDIS_URL ?= redis://localhost:6379/15
+test: export CORS_ORIGINS ?= http://test
+test: export ADMIN_TOKEN ?= test-admin-token
+test: export LOG_LEVEL ?= WARNING
+test: export EXPOSE_ERROR_DETAIL ?= true
 test:  ## Run backend unit + integration tests
 	$(PYTHON) -m unittest discover -s tests -p test_smoke.py
 	$(PYTHON) -m pytest tests/integration/ -q

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 .PHONY: help lint typecheck test seed-check data-invariants api-smoke state-check state-check-docs test-env-check test-unit test-operator test-db test-db-isolation test-integration test-ci-local clean
 
 ifeq ($(OS),Windows_NT)
-VENV_PYTHON := .venv\Scripts\python.exe
+VENV_PYTHON := .venv/Scripts/python.exe
 else
 VENV_PYTHON := .venv/bin/python
 endif
@@ -16,6 +16,8 @@ PYTHON ?= python
 else
 PYTHON ?= $(VENV_PYTHON)
 endif
+
+export PYTHONDONTWRITEBYTECODE := 1
 
 help:  ## Show this help
 	@awk 'BEGIN{FS=":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -28,44 +30,44 @@ data-invariants:  ## Run read-only data integrity checks against DATABASE_URL
 	$(PYTHON) scripts/checks/data_invariants.py
 
 # ── Backend ──────────────────────────────────────────────────────────────────
+test: export DATABASE_URL := $(or $(DATABASE_URL),postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder)
+test: export REDIS_URL := $(or $(REDIS_URL),redis://localhost:6379/15)
+test: export CORS_ORIGINS := $(or $(CORS_ORIGINS),http://test)
+test: export ADMIN_TOKEN := $(or $(ADMIN_TOKEN),test-admin-token)
+test: export LOG_LEVEL := $(or $(LOG_LEVEL),WARNING)
+test: export EXPOSE_ERROR_DETAIL := true
 test:  ## Run backend unit + integration tests
 	$(PYTHON) -m unittest discover -s tests -p test_smoke.py
-	DATABASE_URL=$${DATABASE_URL:-postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder} \
-	REDIS_URL=$${REDIS_URL:-redis://localhost:6379/15} \
-	CORS_ORIGINS=$${CORS_ORIGINS:-http://test} \
-	ADMIN_TOKEN=$${ADMIN_TOKEN:-test-admin-token} \
-	LOG_LEVEL=$${LOG_LEVEL:-WARNING} \
-	EXPOSE_ERROR_DETAIL=true \
 	$(PYTHON) -m pytest tests/integration/ -q
 
 test-env-check:  ## Run the local test-environment preflight without writes
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/test_env_preflight.py
+	$(PYTHON) -B scripts/dev/test_env_preflight.py
 
 state-check:  ## Resolve Stage 19/test-env state authority before operational work
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/resolve_project_state.py --strict
+	$(PYTHON) -B scripts/dev/resolve_project_state.py --strict
 
 state-check-docs:  ## Resolve Stage 19/test-env state authority for docs-only work
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B scripts/dev/resolve_project_state.py --strict --allow-docs-only
+	$(PYTHON) -B scripts/dev/resolve_project_state.py --strict --allow-docs-only
 
 test-unit:  ## Run tests that do not require external services
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m "unit or not (integration or db or operator or e2e or slow)"
+	$(PYTHON) -B -m pytest -m "unit or not (integration or db or operator or e2e or slow)"
 
 test-operator:  ## Run Stage 19 operator safety tests
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py -m operator
+	$(PYTHON) -B -m pytest tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py -m operator
 
 test-db:  ## Run DB-marked tests, including explicit skips for absent real services
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m db -rs
+	$(PYTHON) -B -m pytest -m db -rs
 
 test-db-isolation:  ## Run DB isolation guardrails and real Postgres readiness checks
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_db_isolation_guardrails.py tests/test_stage19_real_postgres_readiness.py -p no:cacheprovider -rs
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m py_compile tests/helpers/db_isolation.py
+	$(PYTHON) -B -m pytest tests/test_db_isolation_guardrails.py tests/test_stage19_real_postgres_readiness.py -p no:cacheprovider -rs
+	$(PYTHON) -B -m py_compile tests/helpers/db_isolation.py
 
 test-integration:  ## Run integration-marked tests
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest -m integration -rs
+	$(PYTHON) -B -m pytest -m integration -rs
 
 test-ci-local: test-env-check test-db-isolation  ## Run focused local CI checks for the test environment stack
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m pytest tests/test_test_env_preflight.py tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py -rs
-	PYTHONDONTWRITEBYTECODE=1 $(PYTHON) -B -m py_compile scripts/dev/test_env_preflight.py scripts/operator/stage19ar_edsm_25_row_staging_pilot.py scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py tests/helpers/db_isolation.py
+	$(PYTHON) -B -m pytest tests/test_test_env_preflight.py tests/test_stage19ar_operator_script.py tests/test_stage19ap_operator_visibility.py -rs
+	$(PYTHON) -B -m py_compile scripts/dev/test_env_preflight.py scripts/operator/stage19ar_edsm_25_row_staging_pilot.py scripts/operator/stage19as_au_edsm_100_row_controlled_expansion.py tests/helpers/db_isolation.py
 	git diff --check
 
 api-smoke:  ## Curl the Phase-2 happy paths against a running API

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ data-invariants:  ## Run read-only data integrity checks against DATABASE_URL
 	$(PYTHON) scripts/checks/data_invariants.py
 
 # ── Backend ──────────────────────────────────────────────────────────────────
-test: export DATABASE_URL := $(if $(strip $(value DATABASE_URL)),$(value DATABASE_URL),postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder)
-test: export REDIS_URL := $(if $(strip $(value REDIS_URL)),$(value REDIS_URL),redis://localhost:6379/15)
-test: export CORS_ORIGINS := $(if $(strip $(value CORS_ORIGINS)),$(value CORS_ORIGINS),http://test)
-test: export ADMIN_TOKEN := $(if $(strip $(value ADMIN_TOKEN)),$(value ADMIN_TOKEN),test-admin-token)
-test: export LOG_LEVEL := $(if $(strip $(value LOG_LEVEL)),$(value LOG_LEVEL),WARNING)
-test: export EXPOSE_ERROR_DETAIL := $(if $(strip $(value EXPOSE_ERROR_DETAIL)),$(value EXPOSE_ERROR_DETAIL),true)
+test: override export DATABASE_URL := $(if $(strip $(value DATABASE_URL)),$(value DATABASE_URL),postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder)
+test: override export REDIS_URL := $(if $(strip $(value REDIS_URL)),$(value REDIS_URL),redis://localhost:6379/15)
+test: override export CORS_ORIGINS := $(if $(strip $(value CORS_ORIGINS)),$(value CORS_ORIGINS),http://test)
+test: override export ADMIN_TOKEN := $(if $(strip $(value ADMIN_TOKEN)),$(value ADMIN_TOKEN),test-admin-token)
+test: override export LOG_LEVEL := $(if $(strip $(value LOG_LEVEL)),$(value LOG_LEVEL),WARNING)
+test: override export EXPOSE_ERROR_DETAIL := $(if $(strip $(value EXPOSE_ERROR_DETAIL)),$(value EXPOSE_ERROR_DETAIL),true)
 test:  ## Run backend unit + integration tests
 	$(PYTHON) -m unittest discover -s tests -p test_smoke.py
 	$(PYTHON) -m pytest tests/integration/ -q

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -109,6 +109,24 @@ Resolved with date and closing commit. New audits append.
 
 ## Resolved
 
+### CQ-044 - Windows Make and frontend packaging paths were not portable - RESOLVED 2026-07-19
+- Raised 2026-07-19 during installation and first use of GNU Make 4.4.1 on the
+  documented Windows development path. Confirmed developer-workflow and release
+  reproducibility defect: `make test-unit` sent POSIX inline environment syntax
+  to `cmd.exe`, and forcing Git Bash instead consumed backslashes in the Windows
+  virtualenv path.
+- The resulting full test run exposed a second Windows path defect in
+  `package_frontend_bundle.sh`: GNU tar interpreted `C:` as a remote host, then
+  `sha256sum` escaped a drive-letter filename by prefixing the digest with `\`.
+- Fixed in `981a6c9`: Make now exports `PYTHONDONTWRITEBYTECODE` itself, uses a
+  cross-shell virtualenv path, and exports integration defaults as target-local
+  variables. Bundle packaging uses tar's explicit local-path mode and writes a
+  normalized digest.
+- Closed with 10 focused Make/reproducibility tests, Ruff, Bash syntax checking,
+  a passing native `make state-check`, a clean Windows drive-path archive and
+  checksum rehearsal, and native `make test-unit` at 1476 passed, 13 skipped,
+  and 125 deselected.
+
 ### CQ-041 — sync_password.sh exposed credentials in process arguments — RESOLVED 2026-07-18
 - Raised 2026-07-18 · forensic audit @ a447222 · Confirmed · high operational
   risk. The same unsafe password URI and SQL interpolation had also drifted into

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -128,9 +128,13 @@ Resolved with date and closing commit. New audits append.
 - An exact-head review found that the archive regression itself still required
   GNU `sha256sum` even though the release script supports BSD/macOS `shasum`.
   The regression now mirrors the production verifier selection.
+- A second exact-head review found that Make's raw-value-preserving defaults
+  treated explicitly empty test variables as intentional values. The final
+  defaults use Make's unexpanded `value` function, preserving literal dollar
+  signs while restoring the previous empty-means-missing behavior.
 - Closed with focused Make/reproducibility tests, Ruff, Bash syntax checking, a
   passing native `make state-check`, a clean Windows drive-path archive and
-  checksum rehearsal, and native `make test-unit` at 1477 passed, 13 skipped,
+  checksum rehearsal, and native `make test-unit` at 1483 passed, 13 skipped,
   and 125 deselected.
 
 ### CQ-041 — sync_password.sh exposed credentials in process arguments — RESOLVED 2026-07-18

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -132,9 +132,12 @@ Resolved with date and closing commit. New audits append.
   treated explicitly empty test variables as intentional values. The final
   defaults use Make's unexpanded `value` function, preserving literal dollar
   signs while restoring the previous empty-means-missing behavior.
+- A third exact-head review found that an empty Make command-line assignment
+  could still outrank the target default. Target-specific `override export`
+  semantics now apply the same contract to environment and command-line input.
 - Closed with focused Make/reproducibility tests, Ruff, Bash syntax checking, a
   passing native `make state-check`, a clean Windows drive-path archive and
-  checksum rehearsal, and native `make test-unit` at 1483 passed, 13 skipped,
+  checksum rehearsal, and native `make test-unit` at 1490 passed, 13 skipped,
   and 125 deselected.
 
 ### CQ-041 — sync_password.sh exposed credentials in process arguments — RESOLVED 2026-07-18

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -122,10 +122,14 @@ Resolved with date and closing commit. New audits append.
   cross-shell virtualenv path, and exports integration defaults as target-local
   variables. Bundle packaging uses tar's explicit local-path mode and writes a
   normalized digest.
-- Closed with 10 focused Make/reproducibility tests, Ruff, Bash syntax checking,
+- Review Lab on `286fcce` found four portability edge cases in that first fix:
+  dollar signs in caller-supplied environment values, checksum mode-marker
+  preservation, BSD tar compatibility, and valid global-Python fallback when a
+  Windows repo venv is absent. Fixed in `78faa28` with direct regressions.
+- Closed with 11 focused Make/reproducibility tests, Ruff, Bash syntax checking,
   a passing native `make state-check`, a clean Windows drive-path archive and
-  checksum rehearsal, and native `make test-unit` at 1476 passed, 13 skipped,
-  and 125 deselected.
+  `sha256sum -c` rehearsal, and native `make test-unit` at 1477 passed,
+  13 skipped, and 125 deselected.
 
 ### CQ-041 — sync_password.sh exposed credentials in process arguments — RESOLVED 2026-07-18
 - Raised 2026-07-18 · forensic audit @ a447222 · Confirmed · high operational

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -118,18 +118,20 @@ Resolved with date and closing commit. New audits append.
 - The resulting full test run exposed a second Windows path defect in
   `package_frontend_bundle.sh`: GNU tar interpreted `C:` as a remote host, then
   `sha256sum` escaped a drive-letter filename by prefixing the digest with `\`.
-- Fixed in `981a6c9`: Make now exports `PYTHONDONTWRITEBYTECODE` itself, uses a
-  cross-shell virtualenv path, and exports integration defaults as target-local
-  variables. Bundle packaging uses tar's explicit local-path mode and writes a
-  normalized digest.
+- The first fix in `981a6c9` moved environment defaults into Make, selected a
+  cross-shell virtualenv path, and attempted to make drive-letter archive paths
+  explicit to tar and the checksum writer.
 - Review Lab on `286fcce` found four portability edge cases in that first fix:
   dollar signs in caller-supplied environment values, checksum mode-marker
   preservation, BSD tar compatibility, and valid global-Python fallback when a
   Windows repo venv is absent. Fixed in `78faa28` with direct regressions.
-- Closed with 11 focused Make/reproducibility tests, Ruff, Bash syntax checking,
-  a passing native `make state-check`, a clean Windows drive-path archive and
-  `sha256sum -c` rehearsal, and native `make test-unit` at 1477 passed,
-  13 skipped, and 125 deselected.
+- An exact-head review found that the archive regression itself still required
+  GNU `sha256sum` even though the release script supports BSD/macOS `shasum`.
+  The regression now mirrors the production verifier selection.
+- Closed with focused Make/reproducibility tests, Ruff, Bash syntax checking, a
+  passing native `make state-check`, a clean Windows drive-path archive and
+  checksum rehearsal, and native `make test-unit` at 1477 passed, 13 skipped,
+  and 125 deselected.
 
 ### CQ-041 — sync_password.sh exposed credentials in process arguments — RESOLVED 2026-07-18
 - Raised 2026-07-18 · forensic audit @ a447222 · Confirmed · high operational

--- a/docs/development/windows-dev-environment.md
+++ b/docs/development/windows-dev-environment.md
@@ -40,6 +40,7 @@ What each one does:
 Recommended local tools:
 
 - Git for Windows, including `bash.exe`
+- GNU Make 4.4+ for the repository convenience targets
 - Python `3.12+`
 - Node.js with Yarn support (`yarn` or `corepack yarn`)
 - Docker Desktop
@@ -47,6 +48,21 @@ Recommended local tools:
 
 `doctor.ps1` will still run without every optional tool, but it will tell you
 what is missing.
+
+Install GNU Make without an elevated shell:
+
+```powershell
+winget install --id ezwinports.make --exact --scope user --source winget --accept-source-agreements --accept-package-agreements
+```
+
+Restart the terminal after installation so the updated user `PATH` is visible.
+The Makefile now supports Windows-native GNU Make for its Python verification
+targets:
+
+```powershell
+make state-check
+make test-unit
+```
 
 ## Bootstrap Flow
 
@@ -140,6 +156,8 @@ cache issues in OneDrive-synced workspaces.
 ## Troubleshooting
 
 - `bash not found`: install Git for Windows or set `EDFINDER_BASH`.
+- `make not found`: install `ezwinports.make` with the user-scoped `winget`
+  command above, then restart the terminal.
 - `Virtualenv not found`: run `bootstrap-windows.ps1`.
 - `POSTGRES_PASSWORD is missing in .env`: bootstrap again or edit `.env`.
 - `pg_isready_missing`: install PostgreSQL client tools if you want full DB

--- a/scripts/package_frontend_bundle.sh
+++ b/scripts/package_frontend_bundle.sh
@@ -13,6 +13,13 @@ ARCHIVE_PATH=""
 say() { printf '\n[INFO] %s\n' "$*"; }
 ok()  { printf '[OK]   %s\n' "$*"; }
 die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+shell_path() {
+  if [[ "$1" =~ ^[A-Za-z]:[\\/] ]] && command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -32,32 +39,34 @@ done
 
 command -v tar >/dev/null 2>&1 || die "tar not found"
 
-[[ -d "$FRONTEND_DIR/dist" ]] || die "frontend build output missing: $FRONTEND_DIR/dist"
-[[ -f "$FRONTEND_DIR/yarn.lock" ]] || die "frontend lockfile missing: $FRONTEND_DIR/yarn.lock"
+FRONTEND_IO_DIR="$(shell_path "$FRONTEND_DIR")"
+OUTPUT_IO_DIR="$(shell_path "$OUTPUT_DIR")"
 
-mkdir -p "$OUTPUT_DIR"
+[[ -d "$FRONTEND_IO_DIR/dist" ]] || die "frontend build output missing: $FRONTEND_DIR/dist"
+[[ -f "$FRONTEND_IO_DIR/yarn.lock" ]] || die "frontend lockfile missing: $FRONTEND_DIR/yarn.lock"
+
+mkdir -p "$OUTPUT_IO_DIR"
 
 if [[ -z "$ARCHIVE_PATH" ]]; then
   ARCHIVE_PATH="$OUTPUT_DIR/frontend-dist-${COMMIT_SHA}.tar.gz"
 fi
 
 CHECKSUM_PATH="${ARCHIVE_PATH}.sha256"
+ARCHIVE_IO_PATH="$(shell_path "$ARCHIVE_PATH")"
+CHECKSUM_IO_PATH="$(shell_path "$CHECKSUM_PATH")"
 
 say "Create frontend bundle"
-tar --force-local -C "$FRONTEND_DIR" -czf "$ARCHIVE_PATH" dist
+tar -C "$FRONTEND_IO_DIR" -czf "$ARCHIVE_IO_PATH" dist
 ok "archive written: $ARCHIVE_PATH"
 
 say "Write bundle checksum"
 if command -v sha256sum >/dev/null 2>&1; then
-  CHECKSUM_OUTPUT="$(sha256sum "$ARCHIVE_PATH")"
+  sha256sum "$ARCHIVE_IO_PATH" > "$CHECKSUM_IO_PATH"
 elif command -v shasum >/dev/null 2>&1; then
-  CHECKSUM_OUTPUT="$(shasum -a 256 "$ARCHIVE_PATH")"
+  shasum -a 256 "$ARCHIVE_IO_PATH" > "$CHECKSUM_IO_PATH"
 else
   die "missing sha256sum/shasum"
 fi
-CHECKSUM="${CHECKSUM_OUTPUT%% *}"
-CHECKSUM="${CHECKSUM#\\}"
-printf '%s  %s\n' "$CHECKSUM" "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
 ok "checksum written: $CHECKSUM_PATH"
 
 printf '%s\n' "$ARCHIVE_PATH"

--- a/scripts/package_frontend_bundle.sh
+++ b/scripts/package_frontend_bundle.sh
@@ -44,17 +44,20 @@ fi
 CHECKSUM_PATH="${ARCHIVE_PATH}.sha256"
 
 say "Create frontend bundle"
-tar -C "$FRONTEND_DIR" -czf "$ARCHIVE_PATH" dist
+tar --force-local -C "$FRONTEND_DIR" -czf "$ARCHIVE_PATH" dist
 ok "archive written: $ARCHIVE_PATH"
 
 say "Write bundle checksum"
 if command -v sha256sum >/dev/null 2>&1; then
-  sha256sum "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
+  CHECKSUM_OUTPUT="$(sha256sum "$ARCHIVE_PATH")"
 elif command -v shasum >/dev/null 2>&1; then
-  shasum -a 256 "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
+  CHECKSUM_OUTPUT="$(shasum -a 256 "$ARCHIVE_PATH")"
 else
   die "missing sha256sum/shasum"
 fi
+CHECKSUM="${CHECKSUM_OUTPUT%% *}"
+CHECKSUM="${CHECKSUM#\\}"
+printf '%s  %s\n' "$CHECKSUM" "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
 ok "checksum written: $CHECKSUM_PATH"
 
 printf '%s\n' "$ARCHIVE_PATH"

--- a/tests/test_ci_build_reproducibility_contracts.py
+++ b/tests/test_ci_build_reproducibility_contracts.py
@@ -110,6 +110,16 @@ def test_package_frontend_bundle_script_builds_archive_and_checksum_from_real_di
         actual_checksum = hashlib.sha256(archive_path.read_bytes()).hexdigest()
         assert checksum_line == actual_checksum
 
+        check_result = subprocess.run(
+            [bash, '-lc', 'sha256sum -c "$1"', 'bash', str(checksum_path)],
+            cwd=ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert check_result.returncode == 0, check_result.stderr or check_result.stdout
+
 
 def test_deploy_and_release_paths_support_prebuilt_frontend_artifacts():
     deploy = _read('scripts', 'deploy_main.sh')
@@ -125,7 +135,8 @@ def test_deploy_and_release_paths_support_prebuilt_frontend_artifacts():
     assert 'frontend-dist-$head.tar.gz' in release
     assert 'frontend/dist' in package
     assert 'frontend/yarn.lock' in package or '$FRONTEND_DIR/yarn.lock' in package
-    assert 'tar --force-local' in package
+    assert 'cygpath -u' in package
+    assert 'tar --force-local' not in package
     assert '.sha256' in package
 
 

--- a/tests/test_ci_build_reproducibility_contracts.py
+++ b/tests/test_ci_build_reproducibility_contracts.py
@@ -111,7 +111,17 @@ def test_package_frontend_bundle_script_builds_archive_and_checksum_from_real_di
         assert checksum_line == actual_checksum
 
         check_result = subprocess.run(
-            [bash, '-lc', 'sha256sum -c "$1"', 'bash', str(checksum_path)],
+            [
+                bash,
+                '-lc',
+                'if command -v sha256sum >/dev/null 2>&1; then '
+                'sha256sum -c "$1"; '
+                'elif command -v shasum >/dev/null 2>&1; then '
+                'shasum -a 256 -c "$1"; '
+                'else exit 127; fi',
+                'bash',
+                str(checksum_path),
+            ],
             cwd=ROOT,
             env=env,
             capture_output=True,

--- a/tests/test_ci_build_reproducibility_contracts.py
+++ b/tests/test_ci_build_reproducibility_contracts.py
@@ -125,6 +125,7 @@ def test_deploy_and_release_paths_support_prebuilt_frontend_artifacts():
     assert 'frontend-dist-$head.tar.gz' in release
     assert 'frontend/dist' in package
     assert 'frontend/yarn.lock' in package or '$FRONTEND_DIR/yarn.lock' in package
+    assert 'tar --force-local' in package
     assert '.sha256' in package
 
 

--- a/tests/test_makefile_python_contract.py
+++ b/tests/test_makefile_python_contract.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -38,13 +39,40 @@ def test_makefile_exports_python_policy_without_shell_specific_assignment():
 def test_makefile_test_target_exports_cross_platform_integration_defaults():
     makefile = ROOT.joinpath('Makefile').read_text(encoding='utf-8')
 
-    assert 'test: export DATABASE_URL :=' in makefile
-    assert 'test: export REDIS_URL :=' in makefile
-    assert 'test: export CORS_ORIGINS :=' in makefile
-    assert 'test: export ADMIN_TOKEN :=' in makefile
-    assert 'test: export LOG_LEVEL :=' in makefile
-    assert 'test: export EXPOSE_ERROR_DETAIL := true' in makefile
+    assert 'test: export DATABASE_URL ?=' in makefile
+    assert 'test: export REDIS_URL ?=' in makefile
+    assert 'test: export CORS_ORIGINS ?=' in makefile
+    assert 'test: export ADMIN_TOKEN ?=' in makefile
+    assert 'test: export LOG_LEVEL ?=' in makefile
+    assert 'test: export EXPOSE_ERROR_DETAIL ?= true' in makefile
     assert '\tDATABASE_URL=' not in makefile
+
+
+def test_makefile_preserves_dollar_signs_in_environment_overrides(tmp_path):
+    make = shutil.which('make')
+    if make is None:
+        pytest.skip('GNU Make is not installed')
+
+    database_url = 'postgresql://u:pa$ss@localhost/db'
+    probe = tmp_path / 'Makefile'
+    probe.write_text(
+        f'include {ROOT.joinpath("Makefile").as_posix()}\n'
+        'test:\n'
+        f'\t@"{Path(sys.executable).as_posix()}" -c '
+        '"import os; print(os.environ[\'DATABASE_URL\'])"\n',
+        encoding='utf-8',
+    )
+    result = subprocess.run(
+        [make, '--no-print-directory', '-f', str(probe), 'test'],
+        cwd=ROOT,
+        env={**os.environ, 'DATABASE_URL': database_url},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == database_url
 
 
 @pytest.mark.skipif(os.name != 'nt', reason='Windows-native GNU Make contract')
@@ -62,5 +90,6 @@ def test_windows_make_dry_run_uses_cmd_safe_python_command():
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
-    assert '.venv/Scripts/python.exe -B -m pytest' in result.stdout
+    expected_python = '.venv/Scripts/python.exe' if ROOT.joinpath('.venv', 'Scripts', 'python.exe').exists() else 'python'
+    assert f'{expected_python} -B -m pytest' in result.stdout
     assert 'PYTHONDONTWRITEBYTECODE=1' not in result.stdout

--- a/tests/test_makefile_python_contract.py
+++ b/tests/test_makefile_python_contract.py
@@ -1,4 +1,9 @@
+import os
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -8,7 +13,7 @@ def test_makefile_prefers_repo_venv_python_before_global_python():
     makefile = ROOT.joinpath('Makefile').read_text(encoding='utf-8')
 
     assert 'ifeq ($(OS),Windows_NT)' in makefile
-    assert 'VENV_PYTHON := .venv\\Scripts\\python.exe' in makefile
+    assert 'VENV_PYTHON := .venv/Scripts/python.exe' in makefile
     assert 'VENV_PYTHON := .venv/bin/python' in makefile
     assert 'PYTHON ?= $(VENV_PYTHON)' in makefile
     assert 'PYTHON ?= python' in makefile
@@ -21,3 +26,41 @@ def test_makefile_test_target_uses_configured_python_variable_everywhere():
     assert '\t$(PYTHON) -m pytest tests/integration/ -q' in makefile
     assert '\tpython -m unittest discover -s tests -p test_smoke.py' not in makefile
     assert '\tpython -m pytest tests/integration/ -q' not in makefile
+
+
+def test_makefile_exports_python_policy_without_shell_specific_assignment():
+    makefile = ROOT.joinpath('Makefile').read_text(encoding='utf-8')
+
+    assert 'export PYTHONDONTWRITEBYTECODE := 1' in makefile
+    assert '\tPYTHONDONTWRITEBYTECODE=1 ' not in makefile
+
+
+def test_makefile_test_target_exports_cross_platform_integration_defaults():
+    makefile = ROOT.joinpath('Makefile').read_text(encoding='utf-8')
+
+    assert 'test: export DATABASE_URL :=' in makefile
+    assert 'test: export REDIS_URL :=' in makefile
+    assert 'test: export CORS_ORIGINS :=' in makefile
+    assert 'test: export ADMIN_TOKEN :=' in makefile
+    assert 'test: export LOG_LEVEL :=' in makefile
+    assert 'test: export EXPOSE_ERROR_DETAIL := true' in makefile
+    assert '\tDATABASE_URL=' not in makefile
+
+
+@pytest.mark.skipif(os.name != 'nt', reason='Windows-native GNU Make contract')
+def test_windows_make_dry_run_uses_cmd_safe_python_command():
+    make = shutil.which('make')
+    if make is None:
+        pytest.skip('GNU Make is not installed')
+
+    result = subprocess.run(
+        [make, '--dry-run', 'test-unit'],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert '.venv/Scripts/python.exe -B -m pytest' in result.stdout
+    assert 'PYTHONDONTWRITEBYTECODE=1' not in result.stdout

--- a/tests/test_makefile_python_contract.py
+++ b/tests/test_makefile_python_contract.py
@@ -39,12 +39,15 @@ def test_makefile_exports_python_policy_without_shell_specific_assignment():
 def test_makefile_test_target_exports_cross_platform_integration_defaults():
     makefile = ROOT.joinpath('Makefile').read_text(encoding='utf-8')
 
-    assert 'test: export DATABASE_URL ?=' in makefile
-    assert 'test: export REDIS_URL ?=' in makefile
-    assert 'test: export CORS_ORIGINS ?=' in makefile
-    assert 'test: export ADMIN_TOKEN ?=' in makefile
-    assert 'test: export LOG_LEVEL ?=' in makefile
-    assert 'test: export EXPOSE_ERROR_DETAIL ?= true' in makefile
+    for variable in (
+        'DATABASE_URL',
+        'REDIS_URL',
+        'CORS_ORIGINS',
+        'ADMIN_TOKEN',
+        'LOG_LEVEL',
+        'EXPOSE_ERROR_DETAIL',
+    ):
+        assert f'test: export {variable} := $(if $(strip $(value {variable}))' in makefile
     assert '\tDATABASE_URL=' not in makefile
 
 
@@ -73,6 +76,43 @@ def test_makefile_preserves_dollar_signs_in_environment_overrides(tmp_path):
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert result.stdout.strip() == database_url
+
+
+@pytest.mark.parametrize(
+    ('variable', 'expected'),
+    (
+        ('DATABASE_URL', 'postgresql://edfinder:edfinder@127.0.0.1:55432/edfinder'),
+        ('REDIS_URL', 'redis://localhost:6379/15'),
+        ('CORS_ORIGINS', 'http://test'),
+        ('ADMIN_TOKEN', 'test-admin-token'),
+        ('LOG_LEVEL', 'WARNING'),
+        ('EXPOSE_ERROR_DETAIL', 'true'),
+    ),
+)
+def test_makefile_treats_empty_integration_environment_values_as_missing(tmp_path, variable, expected):
+    make = shutil.which('make')
+    if make is None:
+        pytest.skip('GNU Make is not installed')
+
+    probe = tmp_path / 'Makefile'
+    probe.write_text(
+        f'include {ROOT.joinpath("Makefile").as_posix()}\n'
+        'test:\n'
+        f'\t@"{Path(sys.executable).as_posix()}" -c '
+        f'"import os; print(os.environ[\'{variable}\'])"\n',
+        encoding='utf-8',
+    )
+    result = subprocess.run(
+        [make, '--no-print-directory', '-f', str(probe), 'test'],
+        cwd=ROOT,
+        env={**os.environ, variable: ''},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == expected
 
 
 @pytest.mark.skipif(os.name != 'nt', reason='Windows-native GNU Make contract')

--- a/tests/test_makefile_python_contract.py
+++ b/tests/test_makefile_python_contract.py
@@ -47,11 +47,12 @@ def test_makefile_test_target_exports_cross_platform_integration_defaults():
         'LOG_LEVEL',
         'EXPOSE_ERROR_DETAIL',
     ):
-        assert f'test: export {variable} := $(if $(strip $(value {variable}))' in makefile
+        assert f'test: override export {variable} := $(if $(strip $(value {variable}))' in makefile
     assert '\tDATABASE_URL=' not in makefile
 
 
-def test_makefile_preserves_dollar_signs_in_environment_overrides(tmp_path):
+@pytest.mark.parametrize('source', ('environment', 'command-line'))
+def test_makefile_preserves_dollar_signs_in_integration_overrides(tmp_path, source):
     make = shutil.which('make')
     if make is None:
         pytest.skip('GNU Make is not installed')
@@ -65,10 +66,18 @@ def test_makefile_preserves_dollar_signs_in_environment_overrides(tmp_path):
         '"import os; print(os.environ[\'DATABASE_URL\'])"\n',
         encoding='utf-8',
     )
+    command = [make, '--no-print-directory', '-f', str(probe)]
+    env = {**os.environ}
+    if source == 'environment':
+        env['DATABASE_URL'] = database_url
+    else:
+        command.append(f'DATABASE_URL={database_url}')
+    command.append('test')
+
     result = subprocess.run(
-        [make, '--no-print-directory', '-f', str(probe), 'test'],
+        command,
         cwd=ROOT,
-        env={**os.environ, 'DATABASE_URL': database_url},
+        env=env,
         capture_output=True,
         text=True,
         check=False,
@@ -89,7 +98,8 @@ def test_makefile_preserves_dollar_signs_in_environment_overrides(tmp_path):
         ('EXPOSE_ERROR_DETAIL', 'true'),
     ),
 )
-def test_makefile_treats_empty_integration_environment_values_as_missing(tmp_path, variable, expected):
+@pytest.mark.parametrize('source', ('environment', 'command-line'))
+def test_makefile_treats_empty_integration_values_as_missing(tmp_path, variable, expected, source):
     make = shutil.which('make')
     if make is None:
         pytest.skip('GNU Make is not installed')
@@ -102,10 +112,18 @@ def test_makefile_treats_empty_integration_environment_values_as_missing(tmp_pat
         f'"import os; print(os.environ[\'{variable}\'])"\n',
         encoding='utf-8',
     )
+    command = [make, '--no-print-directory', '-f', str(probe)]
+    env = {**os.environ}
+    if source == 'environment':
+        env[variable] = ''
+    else:
+        command.append(f'{variable}=')
+    command.append('test')
+
     result = subprocess.run(
-        [make, '--no-print-directory', '-f', str(probe), 'test'],
+        command,
         cwd=ROOT,
-        env={**os.environ, variable: ''},
+        env=env,
         capture_output=True,
         text=True,
         check=False,


### PR DESCRIPTION
## Summary
- make documented Python verification targets work under Windows-native GNU Make and cmd.exe
- preserve caller overrides while exporting integration defaults through Make rather than POSIX shell syntax
- make frontend bundle archives and checksums safe for Windows drive-letter paths
- record CQ-044 and the verified user-scoped winget installation path

## Root cause
The Makefile embedded POSIX environment assignments and a backslash virtualenv path. Native Windows Make passed those recipes to cmd.exe, which rejected the assignment; forcing Git Bash consumed the path separators. Once the complete unit suite ran through Bash, GNU tar treated C: as a remote host and sha256sum escaped the drive-letter filename by prefixing the digest.

## Verification
- GNU Make 4.4.1 installed via user-scoped winget
- focused Make/reproducibility suite: 10 passed
- native make state-check: passed
- native make test-unit: 1476 passed, 13 skipped, 125 deselected
- Windows drive-letter archive and checksum runtime regression: passed
- Ruff: passed
- Bash syntax check: passed
- git diff --check: passed