### PR TITLE
Fix Windows release packaging argument forwarding (CQ-045)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,19 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-19 - Windows release packaging invocation
+
+**Artifact packaging now receives its complete argument list** - The canonical
+PowerShell release wrapper now invokes the Git Bash adapter directly, preserving
+the `--output` flag and Windows archive path as one `ScriptArgs` array. The old
+nested `powershell.exe -File` call split that array across parameters and stopped
+an otherwise-green release before upload or production changes.
+
+**Failure is pinned and rehearsed** - Added a release-path contract that rejects
+the nested invocation and requires direct array forwarding. The repaired wrapper
+completed its validation-and-packaging phase from a clean `main` clone, producing
+the frontend archive and checksum before deploy was deliberately skipped.
+
 ## 2026-07-19 - Windows GNU Make and bundle portability
 
 **Documented Make targets now run from PowerShell** - Installed GNU Make 4.4.1

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -185,8 +185,9 @@ competing roadmap source.
 - Reconcile the CRE and ed-finder confidence vocabularies before consuming CRE
   source-authority or release artifacts at runtime.
 - Keep CI/build reproducibility honest: preserve all ten protected checks, the
-  expanded Ruff/Knip gates, the pinned lockfile, built-image parity, and the
-  isolated Review Lab browser journey.
+  expanded Ruff/Knip gates, the pinned lockfile, built-image parity, the
+  artifact-backed Windows release wrapper, and the isolated Review Lab browser
+  journey.
 - Preserve the repaired local verification path: the Docker-backed preflight,
   map MV latency guard, archetypes JSON-response normalization, and explicit
   Stage 19 baseline/checkpoint skip semantics are now part of the expected

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -109,6 +109,20 @@ Resolved with date and closing commit. New audits append.
 
 ## Resolved
 
+### CQ-045 - Windows release wrapper split frontend packaging arguments - RESOLVED 2026-07-19
+- Raised 2026-07-19 during the canonical production release of merge commit
+  `cd5c753`. Confirmed operational defect: `release-main-to-prod.ps1` launched
+  `run-bash.ps1` through nested Windows PowerShell `-File` argument binding, so
+  the `string[]` archive arguments spilled into `-Command` and `-Script` at once.
+- The release failed closed before artifact upload or any production change;
+  typecheck, build, and frontend tests had already passed.
+- Fixed in `2f58d74`: the release wrapper invokes the Git Bash adapter directly
+  and passes `@('--output', $frontendArchiveLocal)` as a real PowerShell array.
+- Closed with a release-path regression contract, PowerShell syntax parsing,
+  five focused reproducibility tests, native `make test-unit` at 1490 passed,
+  13 skipped, and 125 deselected, plus a clean-clone packaging rehearsal that
+  produced both the frontend archive and checksum with deploy disabled.
+
 ### CQ-044 - Windows Make and frontend packaging paths were not portable - RESOLVED 2026-07-19
 - Raised 2026-07-19 during installation and first use of GNU Make 4.4.1 on the
   documented Windows development path. Confirmed developer-workflow and release

--- a/docs/operations/ssh-deploy-from-windows.md
+++ b/docs/operations/ssh-deploy-from-windows.md
@@ -100,6 +100,8 @@ That script now assumes the current root-served SPA:
 - probes `/` as the live app entrypoint
 - validates `/index.html`
 - uses `yarn` for frontend install/build/test steps
+- packages the validated frontend through the Git Bash adapter with the exact
+  Windows archive path, then uploads that prebuilt artifact for deployment
 
 ## 6. Operational Notes
 

--- a/scripts/release-main-to-prod.ps1
+++ b/scripts/release-main-to-prod.ps1
@@ -160,9 +160,9 @@ if (-not $SkipFrontendArtifact) {
     throw "Git Bash wrapper not found: $runBash"
   }
   Write-Host "[release] Packaging frontend artifact: $frontendArchiveLocal"
-  & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $runBash `
+  & $runBash `
     -Script 'scripts/package_frontend_bundle.sh' `
-    -ScriptArgs '--output', $frontendArchiveLocal
+    -ScriptArgs @('--output', $frontendArchiveLocal)
   if ($LASTEXITCODE -ne 0) { throw 'frontend artifact packaging failed' }
 }
 

--- a/tests/test_ci_build_reproducibility_contracts.py
+++ b/tests/test_ci_build_reproducibility_contracts.py
@@ -140,6 +140,9 @@ def test_deploy_and_release_paths_support_prebuilt_frontend_artifacts():
     assert 'tar -xzf "$FRONTEND_ARCHIVE"' in deploy
     assert 'yarn install --frozen-lockfile --no-progress --non-interactive' in deploy
     assert 'scripts/package_frontend_bundle.sh' in release
+    assert '& $runBash `' in release
+    assert "-ScriptArgs @('--output', $frontendArchiveLocal)" in release
+    assert '& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $runBash' not in release
     assert 'scp' in release
     assert '--frontend-archive' in release
     assert 'frontend-dist-$head.tar.gz' in release


### PR DESCRIPTION
Fixes the canonical Windows release wrapper so the frontend packaging flag and archive path are passed to the Git Bash adapter as one PowerShell array. Adds a regression contract and records the failed-closed release rehearsal in CQ-045, CHANGES, ROADMAP, and the Windows deploy runbook.