### PR TITLE
Fix release SCP target construction (CQ-046)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,17 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-19 - Windows release SCP target handling
+
+**SSH aliases no longer become accidental local sources** - The release wrapper
+now models SCP flags separately from the remote destination. Alias-based deploys
+produce `scp [options] <archive> alias:/tmp/...`; direct host deploys add only
+the `-P` port option before the same source/destination pair.
+
+**Upload failure remains fail-closed** - The defect was exposed only after local
+typecheck, build, frontend tests, and artifact packaging succeeded. SCP rejected
+the malformed command before upload, so no production files or services changed.
+
 ## 2026-07-19 - Windows release packaging invocation
 
 **Artifact packaging now receives its complete argument list** - The canonical

--- a/docs/development/code-quality-findings.md
+++ b/docs/development/code-quality-findings.md
@@ -109,6 +109,23 @@ Resolved with date and closing commit. New audits append.
 
 ## Resolved
 
+### CQ-046 - Windows release wrapper treated SSH alias as an SCP source - RESOLVED 2026-07-19
+- Raised 2026-07-19 during the production release retry for `649e9c1`.
+  Confirmed operational defect: `Resolve-SshTarget` mixed SCP options with the
+  remote host, then the upload builder appended that mixed array before the
+  local archive. OpenSSH therefore tried to stat a local file named after the
+  `ed-finder-prod` alias.
+- The release failed closed before artifact upload, remote command execution, or
+  any production service change. Local typecheck, build, frontend tests,
+  archive creation, and checksum creation had passed.
+- Fixed in `71abc8e`: resolved targets now expose `ScpOptions` and `Destination`
+  separately. Alias mode has no extra SCP flags; direct-host mode contributes
+  only `-P <port>`; both append exactly one local source and one remote target.
+- Closed with PowerShell syntax parsing, five focused reproducibility tests,
+  Ruff, and native `make test-unit` at 1490 passed, 13 skipped, and 125
+  deselected. The release-path contract rejects the former mixed `ScpArgs`
+  representation and pins the destination order.
+
 ### CQ-045 - Windows release wrapper split frontend packaging arguments - RESOLVED 2026-07-19
 - Raised 2026-07-19 during the canonical production release of merge commit
   `cd5c753`. Confirmed operational defect: `release-main-to-prod.ps1` launched

--- a/docs/operations/ssh-deploy-from-windows.md
+++ b/docs/operations/ssh-deploy-from-windows.md
@@ -106,6 +106,9 @@ That script now assumes the current root-served SPA:
 ## 6. Operational Notes
 
 - The SSH alias is better than hardcoding the production IP into commands.
+- The wrapper treats an SSH alias as the remote SCP destination, while direct
+  host mode adds `-P <port>` separately; neither form adds the host as a local
+  upload source.
 - `scripts/deploy_main.sh` remains the canonical server-side deploy entrypoint.
 - The PowerShell wrappers should call the server script, not reimplement the
   deployment logic locally.

--- a/scripts/release-main-to-prod.ps1
+++ b/scripts/release-main-to-prod.ps1
@@ -57,7 +57,8 @@ function Resolve-SshTarget {
     return @{
       Display = $DeployTarget
       SshArgs = @($DeployTarget)
-      ScpArgs = @($DeployTarget)
+      ScpOptions = @()
+      Destination = $DeployTarget
       CanProbeTcp = $false
     }
   }
@@ -69,7 +70,8 @@ function Resolve-SshTarget {
   return @{
     Display = "$DeployUser@$DeployHost`:$DeployPort"
     SshArgs = @('-p', "$DeployPort", "$DeployUser@$DeployHost")
-    ScpArgs = @('-P', "$DeployPort", "$DeployUser@$DeployHost")
+    ScpOptions = @('-P', "$DeployPort")
+    Destination = "$DeployUser@$DeployHost"
     CanProbeTcp = $true
   }
 }
@@ -201,9 +203,9 @@ setx EDFINDER_DEPLOY_PORT 22
     if ($SshOptions.Trim()) {
       $scpArgs += $SshOptions.Trim().Split(' ')
     }
-    $scpArgs += $resolvedTarget.ScpArgs
+    $scpArgs += $resolvedTarget.ScpOptions
     $scpArgs += $frontendArchiveLocal
-    $scpArgs += "$(($resolvedTarget.SshArgs | Select-Object -Last 1))`:$remoteFrontendArchive"
+    $scpArgs += "$($resolvedTarget.Destination)`:$remoteFrontendArchive"
     & scp @scpArgs
     if ($LASTEXITCODE -ne 0) {
       throw "Failed to upload frontend artifact to $($resolvedTarget.Display)"

--- a/tests/test_ci_build_reproducibility_contracts.py
+++ b/tests/test_ci_build_reproducibility_contracts.py
@@ -143,6 +143,11 @@ def test_deploy_and_release_paths_support_prebuilt_frontend_artifacts():
     assert '& $runBash `' in release
     assert "-ScriptArgs @('--output', $frontendArchiveLocal)" in release
     assert '& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $runBash' not in release
+    assert 'ScpOptions = @()' in release
+    assert 'Destination = $DeployTarget' in release
+    assert '$scpArgs += $resolvedTarget.ScpOptions' in release
+    assert '$scpArgs += $resolvedTarget.ScpArgs' not in release
+    assert '$scpArgs += "$($resolvedTarget.Destination)`:$remoteFrontendArchive"' in release
     assert 'scp' in release
     assert '--frontend-archive' in release
     assert 'frontend-dist-$head.tar.gz' in release


### PR DESCRIPTION
Separates SCP options from the remote destination so SSH aliases and direct hosts produce one local archive source and one remote target. Adds a regression contract and records the failed-closed release attempt in CQ-046, CHANGES, and the Windows deploy runbook.