### PR TITLE
Implement Stage 26D typed feature hand-offs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,22 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-22 - Stage 26D typed feature hand-offs
+
+**Existing feature state now crosses one typed map boundary** - Added reusable
+adapters for Finder, Compare, device-local and server-backed saved systems,
+evidence summaries, System Detail, Cluster Search, and read-only Planner
+returns. The boundary preserves camera and layer state, retains selected-system
+and cluster context, and reports systems that cannot render because their real
+feature response has no coordinates.
+
+**Map interactions now resolve to explicit host commands** - Selection and all
+feature navigation requests are translated without renderer-owned routing.
+Planner navigation requires a selected system and emits a hand-off only; it
+cannot create or mutate a Build Plan. The isolated workbench and both required
+desktop browser journeys exercise every return path while the production map
+route remains unchanged.
+
 ## 2026-07-22 - Stage 26C region-first R3F foundation
 
 **The selected renderer now has an isolated production-candidate foundation** -

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,10 @@ This folder is the main documentation entry point for the repo.
 ## Start Here
 
 - [`ROADMAP.md`](./ROADMAP.md) for the single authoritative roadmap and current priorities.
-- [`colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md`](./colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md) for the desktop map authorization and active Stage 26B bake-off contract; its accepted research bundle is under `../artifacts/map-foundation/stage-26b/`.
+- [`colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md`](./colonisation-redesign/stage-26a-next-generation-map-foundation-contract.md) for the desktop map authorization and delivery sequence; its accepted research bundle is under `../artifacts/map-foundation/stage-26b/`.
 - [`colonisation-redesign/stage-26b-renderer-bakeoff-decision.md`](./colonisation-redesign/stage-26b-renderer-bakeoff-decision.md) for the completed equal-renderer evidence and Stage 26C R3F foundation choice.
 - [`colonisation-redesign/stage-26c-region-first-foundation-contract.md`](./colonisation-redesign/stage-26c-region-first-foundation-contract.md) for the isolated R3F implementation boundary, evidence, and Stage 26D hand-off.
+- [`colonisation-redesign/stage-26d-feature-handoff-contract.md`](./colonisation-redesign/stage-26d-feature-handoff-contract.md) for the completed typed feature integration and Stage 26E cutover boundary.
 - [`colonisation-redesign/README.md`](./colonisation-redesign/README.md) for active planner, evidence, enrichment, and historical stage-control docs.
 - [`development/`](./development/) for local workflow, test environment, handoff, and implementation-contract docs.
 - [`operations/`](./operations/) for deployment, hosting, SSH, and operator runbooks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,9 +7,10 @@ document that should answer "what next?".
 
 - Programme: Stage 25 product scope is complete; Stage 26 opens the bounded
   next-generation map replacement lane without reopening planner scope.
-- Status: Stage 25A through Stage 25H and Stage 26A through Stage 26C are
-  complete. The isolated Three.js/R3F foundation is bounded and verified at the
-  required desktop viewports; no production route or cutover is authorized.
+- Status: Stage 25A through Stage 25H and Stage 26A through Stage 26D are
+  complete. The isolated Three.js/R3F foundation and typed feature hand-offs
+  are bounded and verified at the required desktop viewports; no production
+  route or cutover is authorized.
 - Local engineering posture: the repo-local Python 3.12 `.venv` path is now
   the canonical local test runner, Docker-backed disposable Postgres/Redis on
   `127.0.0.1:55432` / `127.0.0.1:6379` are validated by preflight, and the
@@ -276,9 +277,23 @@ competing roadmap source.
   while retaining every guaranteed system and reporting the aggregate
   remainder. Both required desktop Playwright journeys pass camera, keyboard,
   overlap, planner-separation, and post-context-restoration interaction checks.
-- The production map route remains unchanged. Stage 26D owns feature hand-off
-  wiring; Stage 26E retains production performance, accessibility, browser,
-  visual-regression, legal, and cutover gates.
+- The production map route remained unchanged. Stage 26D completed feature
+  hand-off wiring; Stage 26E retains production performance, accessibility,
+  browser, visual-regression, legal, and cutover gates.
+
+### Stage 26D
+
+- Complete: Finder, Compare, both saved-system persistence shapes, evidence,
+  System Detail, Cluster Search, and read-only Planner state now normalize
+  through reusable typed feature-to-scene adapters behind the isolated entry.
+- Evidence and cluster members without real coordinates are explicitly omitted
+  and reported; no position is invented. Camera, origin, layers,
+  selected-system identity, and cluster group context survive round trips.
+- Renderer interactions resolve to explicit host commands. Planner navigation
+  requires a selected system and cannot create or mutate a Build Plan.
+- Focused unit tests and both required Chromium journeys exercise every
+  hand-off. The production map route remains unchanged; Stage 26E owns parity,
+  final gates, deliberate cutover, and superseded-map removal.
 
 ### Stage 25C
 
@@ -380,8 +395,8 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Execute Stage 26D feature hand-offs through the typed Stage 26C scene and
-   interaction boundary without changing the production map route.
+1. Execute Stage 26E parity and final performance, GPU, accessibility, browser,
+   visual-regression, and legal gates; cut over only after explicit review.
 2. Preserve production data-integrity receipts and the bounded rerating cadence.
 3. Complete dependency-aware documentation triage and historical archiving.
 4. Finish the archetype-scoring pivot and retire legacy score storage safely.

--- a/docs/colonisation-redesign/README.md
+++ b/docs/colonisation-redesign/README.md
@@ -20,7 +20,10 @@ product-shell and selected-system context baseline for this new lane.
   Three.js/R3F selection for the isolated Stage 26C foundation.
 - [`stage-26c-region-first-foundation-contract.md`](./stage-26c-region-first-foundation-contract.md)
   records the isolated R3F foundation, bounded visibility contract, local
-  evidence, and the feature-integration work deferred to Stage 26D.
+  evidence, and the feature-integration work completed in Stage 26D.
+- [`stage-26d-feature-handoff-contract.md`](./stage-26d-feature-handoff-contract.md)
+  records the typed Finder, Compare, saved/evidence, System Detail, Cluster
+  Search, and read-only Planner hand-offs retained behind the isolated entry.
 - [`stage-25c-product-shell-shared-context-contract.md`](./stage-25c-product-shell-shared-context-contract.md)
   remains the settled shell and selected-system context baseline.
 

--- a/docs/colonisation-redesign/stage-26d-feature-handoff-contract.md
+++ b/docs/colonisation-redesign/stage-26d-feature-handoff-contract.md
@@ -1,0 +1,86 @@
+# Stage 26D Typed Feature Hand-off Contract
+
+## Status And Authorization
+
+Stage 26D connects ED-Finder's existing Finder, Compare, saved-system, evidence,
+System Detail, Cluster Search, and Planner data shapes to the Stage 26C typed
+scene and interaction boundary. The integration remains behind the isolated
+map-foundation entry. It does not replace the production map route, mutate a
+Build Plan, change backend schemas, or authorize cutover.
+
+## Inbound Boundary
+
+`applyFeatureHandoff` accepts the existing frontend feature types and returns a
+new `MapSceneState`, accepted system IDs, and explicitly omitted system IDs.
+The adapter preserves camera, origin, and layer state through the retained
+`MapReturnWorkflow` reducer.
+
+The supported inputs are:
+
+- Finder `SystemResult` rows with bounded-response metadata and optional
+  selected-system context;
+- Compare `SystemResult` snapshots and the explicit left/right pair;
+- device-local `PinnedEntry` and server-backed `WatchlistEntry` saved-system
+  snapshots without conflating their persistence models;
+- evidence summaries paired with a coordinate-bearing system snapshot;
+- the existing `SystemDetail` response;
+- `ClusterResult` plus an explicit coordinate-bearing lookup for slot members;
+  and
+- read-only Planner highlights, layers, clusters, systems, and opaque workflow
+  context.
+
+All coordinate-bearing production shapes normalize to renderer-independent
+`SystemRecord` values. Y is retained by the source feature but is intentionally
+not part of the current galactic X/Z scene contract.
+
+## Missing Coordinate Rule
+
+Evidence summaries and cluster slot matches identify systems but do not carry
+renderable member coordinates. Stage 26D never invents coordinates. Their
+callers must provide an existing coordinate-bearing system snapshot. Missing or
+invalid coordinates are returned in `omittedSystemIds` and mark the hand-off's
+bounded response as truncated.
+
+The Cluster Search anchor may use its existing `anchor_coords`; every other
+member requires the explicit lookup. The rendered cluster contains only
+resolved members and retains its anchor/member roles, edges, radius, label, and
+group context.
+
+## Outbound Boundary
+
+`resolveMapInteraction` translates renderer events into host commands for Map,
+Finder, System Detail, Compare, saved systems, evidence, Cluster Search, and
+Planner. Selection updates the selected-system context and carries the cluster
+anchor ID when present. Camera and layer events update scene state without a
+navigation command.
+
+Planner navigation resolves only to `openPlanner(systemId64)` when a system is
+already selected. Otherwise it returns `plannerSelectionRequired`. Neither the
+renderer nor the adapter creates, loads, or changes a plan.
+
+## Isolated Workbench Evidence
+
+The Stage 26C workbench now identifies itself as Stage 26D and exposes a
+keyboard-operable feature-return selector. It exercises all seven inbound
+feature families against the real adapter and reports the retained return
+workflow, the last outbound host command, and coordinate omissions.
+
+The two required Chromium journeys at 1280x720 and 1440x900 verify that:
+
+- Finder, Compare, saved systems, evidence, System Detail, Cluster Search, and
+  Planner each cross the typed return boundary;
+- camera bearing, pitch, centre, and zoom survive every feature round trip;
+- the fixture has no unreported coordinate omissions; and
+- a selected-system Planner request becomes `openPlanner` while producing no
+  plan mutation.
+
+Focused unit coverage verifies each production input shape, evidence and
+cluster omission behavior, selected-system and cluster-anchor context, every
+outbound route command, and the planner selection guard.
+
+## Deferred Gates
+
+The live `#map` route still uses the existing map implementation. Stage 26E
+owns deliberate route cutover, production parity, final accessibility,
+performance and GPU evidence, browser and visual-regression coverage, legal
+closure, and removal of superseded map code.

--- a/frontend/map-foundation/e2e/foundation.spec.ts
+++ b/frontend/map-foundation/e2e/foundation.spec.ts
@@ -54,10 +54,19 @@ for (const viewport of viewports) {
     expect(cameraAfter.bearingDeg).not.toBe(0);
     expect(cameraAfter.pitchDeg).not.toBe(0);
 
+    const handoffSelect = page.getByLabel('Return from feature');
+    for (const workflow of ['compare', 'savedSystems', 'evidenceMap', 'systemDetail', 'clusterSearch', 'planner', 'finder'] as const) {
+      await handoffSelect.selectOption(workflow);
+      await expect(page.getByTestId('return-workflow')).toHaveText(workflow);
+      expect((await page.evaluate(() => window.__stage26cFoundation!.snapshot())).camera).toEqual(cameraAfter);
+    }
+    expect((await page.evaluate(() => window.__stage26cFoundation!.snapshot())).omittedHandoffSystemIds).toEqual([]);
+
     await page.getByRole('button', { name: 'Hide regions' }).click();
     await expect(page.locator('.map-foundation-labels span')).toHaveCount(0);
     await page.getByRole('button', { name: 'Request Plan hand-off' }).click();
     await expect(page.getByTestId('last-interaction')).toHaveText('navigateToPlanner');
+    await expect(page.getByTestId('last-host-command')).toHaveText('openPlanner');
     await expect(page.getByText('No plan mutation occurred.')).toBeVisible();
     expect(consoleErrors).toEqual([]);
   });

--- a/frontend/map-foundation/workbench.tsx
+++ b/frontend/map-foundation/workbench.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DatasetSize } from '../../artifacts/map-foundation/stage-26b/map-bakeoff-scenarios';
+import type { ClusterResult } from '../src/features/cluster-search/useClusterSearch';
 import {
   initOverlapCycling,
   reduceScene,
@@ -8,6 +9,8 @@ import {
 } from '../../artifacts/map-foundation/stage-26b/map-scene-contract';
 import { R3FMapFoundation } from '../src/features/map-foundation/R3FMapFoundation';
 import { createFoundationDemoScene } from '../src/features/map-foundation/demo-scene';
+import { applyFeatureHandoff, resolveMapInteraction } from '../src/features/map-foundation/feature-handoffs';
+import type { EvidenceSystemSummaryResponse, SystemDetail, SystemResult } from '../src/types/api';
 import type {
   FoundationSnapshot,
   RegionLayerData,
@@ -25,6 +28,23 @@ const EMPTY_VISIBILITY: VisibilityMetadata = {
   truncated: false,
   guaranteedCount: 0,
 };
+type HandoffScenario = 'finder' | 'compare' | 'savedSystems' | 'evidenceMap' | 'systemDetail' | 'clusterSearch' | 'planner';
+
+function systemResult(system: MapSceneState['systems'][number]): SystemResult {
+  return {
+    id64: system.id64, name: system.name, coords: { x: system.coords.x, y: 0, z: system.coords.z },
+    population: system.population, primaryEconomy: system.primaryEconomy,
+    overall_development_potential: system.developmentScore,
+  };
+}
+
+function evidenceSummary(systemId64: number): EvidenceSystemSummaryResponse {
+  return {
+    schema_version: 'evidence_store/v1', system_id64: systemId64,
+    observed_fact_count: 1, imported_record_count: 0, derived_feature_count: 0, open_rule_proposal_count: 0,
+    focus_areas: [], records: [], derived_features: [], open_rule_proposals: [],
+  };
+}
 
 export function MapFoundationWorkbench() {
   const [datasetSize, setDatasetSize] = useState<DatasetSize>(500_000);
@@ -35,8 +55,12 @@ export function MapFoundationWorkbench() {
   const [overlapCandidateIds, setOverlapCandidateIds] = useState<number[]>([]);
   const [contextState, setContextState] = useState<FoundationSnapshot['contextState']>('ready');
   const [lastInteraction, setLastInteraction] = useState<MapInteractionEvent | null>(null);
+  const [lastHostCommand, setLastHostCommand] = useState('none');
+  const [omittedHandoffSystemIds, setOmittedHandoffSystemIds] = useState<number[]>([]);
   const [visibility, setVisibility] = useState<VisibilityMetadata>(EMPTY_VISIBILITY);
   const viewportRef = useRef<HTMLDivElement>(null);
+  const sceneRef = useRef(scene);
+  sceneRef.current = scene;
   const contextStateRef = useRef(contextState);
   contextStateRef.current = contextState;
 
@@ -59,6 +83,7 @@ export function MapFoundationWorkbench() {
 
   const onInteraction = useCallback((event: MapInteractionEvent) => {
     setLastInteraction(event);
+    setLastHostCommand(resolveMapInteraction(sceneRef.current, event).command.type);
     if (contextStateRef.current === 'restored' && (
       event.type === 'selectSystem' || event.type === 'overlapChoiceRequired'
     )) {
@@ -100,6 +125,80 @@ export function MapFoundationWorkbench() {
     }
   }, []);
 
+  const applyScenario = (scenario: HandoffScenario) => {
+    setScene((current) => {
+      const [anchor, memberA, memberB, compareLeft, compareRight] = current.systems;
+      if (!anchor || !memberA || !memberB || !compareLeft || !compareRight) return current;
+      const systems = [anchor, memberA, memberB, compareLeft, compareRight].map(systemResult);
+      let result;
+      switch (scenario) {
+        case 'finder':
+          result = applyFeatureHandoff(current, {
+            type: 'finder', systems, selectedSystemId64: anchor.id64,
+            metadata: { count: systems.length, truncated: false, continuationToken: null },
+          });
+          break;
+        case 'compare':
+          result = applyFeatureHandoff(current, {
+            type: 'compare', systems: [systems[3]!, systems[4]!],
+            leftId64: compareLeft.id64, rightId64: compareRight.id64,
+          });
+          break;
+        case 'savedSystems':
+          result = applyFeatureHandoff(current, { type: 'savedSystems', systems: [
+            { id64: anchor.id64, name: anchor.name, x: anchor.coords.x, y: 0, z: anchor.coords.z,
+              population: anchor.population, is_colonised: false, economy: anchor.primaryEconomy,
+              pinned_at: '2026-07-22T00:00:00Z' },
+            { system_id64: memberA.id64, name: memberA.name, x: memberA.coords.x, y: 0, z: memberA.coords.z,
+              population: memberA.population, is_colonised: false, added_at: '2026-07-22T00:00:00Z' },
+          ] });
+          break;
+        case 'evidenceMap':
+          result = applyFeatureHandoff(current, { type: 'evidenceMap', entries: [
+            { system: systems[1]!, summary: evidenceSummary(memberA.id64) },
+            { system: systems[2]!, summary: evidenceSummary(memberB.id64) },
+          ] });
+          break;
+        case 'systemDetail': {
+          const system: SystemDetail = {
+            id64: anchor.id64, name: anchor.name, x: anchor.coords.x, y: 0, z: anchor.coords.z,
+            population: anchor.population, primary_economy: anchor.primaryEconomy,
+          };
+          result = applyFeatureHandoff(current, { type: 'systemDetail', system });
+          break;
+        }
+        case 'clusterSearch': {
+          const cluster: ClusterResult = {
+            anchor_id64: anchor.id64, anchor_name: anchor.name,
+            anchor_coords: { x: anchor.coords.x, y: 0, z: anchor.coords.z }, galaxy_region: 'Inner Orion Spur',
+            coverage_score: 80, economy_diversity: 2, total_viable: 3,
+            agriculture_count: 0, agriculture_best: 0, refinery_count: 1, refinery_best: 80,
+            industrial_count: 1, industrial_best: 70, hightech_count: 0, hightech_best: 0,
+            military_count: 0, military_best: 0, tourism_count: 0, tourism_best: 0,
+            distance_ly: 0, cluster_radius_ly: 1_800,
+            slots: [{ slot_index: 0, label: 'Members', economies: ['Industrial'], matches: [
+              { system_id64: memberA.id64, system_name: memberA.name, scores: {}, distance_from_anchor_ly: 10 },
+              { system_id64: memberB.id64, system_name: memberB.name, scores: {}, distance_from_anchor_ly: 20 },
+            ] }],
+          };
+          result = applyFeatureHandoff(current, {
+            type: 'clusterSearch', cluster,
+            systemsById: new Map(systems.map((system) => [system.id64, system])),
+          });
+          break;
+        }
+        case 'planner':
+          result = applyFeatureHandoff(current, {
+            type: 'planner', systems, highlights: current.highlights, layers: current.layers,
+            clusters: current.clusters, workflowPayload: { mode: 'map', readOnly: true },
+          });
+          break;
+      }
+      setOmittedHandoffSystemIds(result.omittedSystemIds);
+      return result.scene;
+    });
+  };
+
   const highlightIds = useMemo(() => highlightedSystemIds(scene.highlights), [scene.highlights]);
   const systemsById = useMemo(() => new Map(scene.systems.map((system) => [system.id64, system])), [scene.systems]);
   const regionVisible = scene.layers.find((layer) => layer.type === 'regions')?.visible ?? false;
@@ -117,7 +216,10 @@ export function MapFoundationWorkbench() {
     overlapCandidateIds,
     contextState,
     lastInteraction,
-  }), [contextState, datasetSize, highlightIds.size, lastInteraction, overlapCandidateIds, ready, regions, scene, visibility]);
+    returnWorkflowType: scene.returnWorkflow?.type ?? null,
+    lastHostCommand,
+    omittedHandoffSystemIds,
+  }), [contextState, datasetSize, highlightIds.size, lastHostCommand, lastInteraction, omittedHandoffSystemIds, overlapCandidateIds, ready, regions, scene, visibility]);
 
   useEffect(() => {
     window.__stage26cFoundation = {
@@ -145,8 +247,8 @@ export function MapFoundationWorkbench() {
   return <main className="foundation-shell">
     <header className="foundation-header">
       <div>
-        <p className="eyebrow">Development-only · Stage 26C</p>
-        <h1>Region-first R3F foundation</h1>
+        <p className="eyebrow">Development-only · Stage 26D</p>
+        <h1>Typed feature hand-offs</h1>
       </div>
       <label>Dataset
         <select value={datasetSize} onChange={(event) => {
@@ -173,6 +275,17 @@ export function MapFoundationWorkbench() {
         onInteraction({ type: 'layerChanged', layers });
       }}>{regionVisible ? 'Hide' : 'Show'} regions</button>
       <button type="button" onClick={() => onInteraction({ type: 'navigateToPlanner' })}>Request Plan hand-off</button>
+      <label>Return from
+        <select aria-label="Return from feature" defaultValue="finder" onChange={(event) => applyScenario(event.target.value as HandoffScenario)}>
+          <option value="finder">Finder</option>
+          <option value="compare">Compare</option>
+          <option value="savedSystems">Saved Systems</option>
+          <option value="evidenceMap">Evidence Map</option>
+          <option value="systemDetail">System Detail</option>
+          <option value="clusterSearch">Cluster Search</option>
+          <option value="planner">Planner</option>
+        </select>
+      </label>
     </header>
 
     <section className="foundation-status" aria-live="polite">
@@ -218,6 +331,9 @@ export function MapFoundationWorkbench() {
         <section className="event-log">
           <h3>Last typed interaction</h3>
           <code data-testid="last-interaction">{lastInteraction?.type ?? 'none'}</code>
+          <p>Host command: <code data-testid="last-host-command">{lastHostCommand}</code></p>
+          <p>Return workflow: <code data-testid="return-workflow">{scene.returnWorkflow?.type ?? 'none'}</code></p>
+          <p>{omittedHandoffSystemIds.length} coordinate omissions</p>
           {lastInteraction?.type === 'navigateToPlanner' && <p>No plan mutation occurred.</p>}
         </section>
       </aside>

--- a/frontend/src/features/map-foundation/feature-handoffs.test.ts
+++ b/frontend/src/features/map-foundation/feature-handoffs.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import type { ClusterResult } from '@/features/cluster-search/useClusterSearch';
+import type { WatchlistEntry } from '@/lib/api';
+import type { PinnedEntry } from '@/store/pinnedStore';
+import type { EvidenceSystemSummaryResponse, SystemDetail, SystemResult } from '@/types/api';
+import { createFoundationDemoScene } from './demo-scene';
+import { applyFeatureHandoff, resolveMapInteraction, toSystemRecord } from './feature-handoffs';
+
+const result = (id64: number, x = id64, z = -id64): SystemResult => ({
+  id64,
+  name: `System ${id64}`,
+  coords: { x, y: 0, z },
+  population: 1_000,
+  primaryEconomy: 'Industrial',
+  overall_development_potential: 77,
+});
+
+const detail = (id64: number): SystemDetail => ({
+  id64,
+  name: `Detail ${id64}`,
+  x: id64,
+  y: 0,
+  z: -id64,
+  population: 2_000,
+  primary_economy: 'Refinery',
+});
+
+const evidence = (systemId64: number): EvidenceSystemSummaryResponse => ({
+  schema_version: 'evidence_store/v1',
+  system_id64: systemId64,
+  observed_fact_count: 1,
+  imported_record_count: 0,
+  derived_feature_count: 0,
+  open_rule_proposal_count: 0,
+  focus_areas: [],
+  records: [],
+  derived_features: [],
+  open_rule_proposals: [],
+});
+
+describe('Stage 26D inbound feature hand-offs', () => {
+  it('maps Finder results without resetting camera or layers and keeps bounded metadata', () => {
+    const scene = createFoundationDemoScene(100_000);
+    scene.camera = { center: { x: 123, z: 456 }, zoom: 9, pitchDeg: 20, bearingDeg: 30 };
+    const layers = scene.layers;
+    const handoff = applyFeatureHandoff(scene, {
+      type: 'finder',
+      systems: [result(11), result(12)],
+      selectedSystemId64: 12,
+      metadata: { count: 900, truncated: true, continuationToken: 'next-page' },
+    });
+
+    expect(handoff.scene.camera).toEqual(scene.camera);
+    expect(handoff.scene.layers).toEqual(layers);
+    expect(handoff.scene.selectedSystemId64).toBe(12);
+    expect(handoff.scene.boundedResponse).toEqual({ count: 900, truncated: true, continuationToken: 'next-page' });
+    expect(handoff.acceptedSystemIds).toEqual([11, 12]);
+  });
+
+  it('maps Compare and both real saved-system persistence shapes', () => {
+    let scene = createFoundationDemoScene(100_000);
+    scene = applyFeatureHandoff(scene, {
+      type: 'compare', systems: [result(21), result(22)], leftId64: 21, rightId64: 22,
+    }).scene;
+    expect(scene.highlights).toEqual([{ type: 'compare', leftId64: 21, rightId64: 22 }]);
+
+    const pinned: PinnedEntry = {
+      id64: 23, name: 'Pinned', x: 23, y: 0, z: -23, population: null,
+      is_colonised: false, economy: 'Tourism', pinned_at: '2026-07-22T00:00:00Z',
+    };
+    const watched: WatchlistEntry = {
+      system_id64: 24, name: 'Watched', x: 24, y: 0, z: -24, population: null,
+      is_colonised: false, added_at: '2026-07-22T00:00:00Z', economy_suggestion: 'High Tech',
+    };
+    const saved = applyFeatureHandoff(scene, { type: 'savedSystems', systems: [pinned, watched] });
+    expect(saved.acceptedSystemIds).toEqual([23, 24]);
+    expect(saved.scene.highlights.at(-1)).toMatchObject({ type: 'cluster', cluster: { memberIds: [23, 24], label: 'Saved Systems' } });
+  });
+
+  it('requires coordinate-bearing evidence context and reports missing coordinates', () => {
+    const noCoords = { ...result(31), coords: null };
+    const mapped = applyFeatureHandoff(createFoundationDemoScene(100_000), {
+      type: 'evidenceMap',
+      entries: [
+        { summary: evidence(30), system: result(30) },
+        { summary: evidence(31), system: noCoords },
+        { summary: evidence(32), system: result(99) },
+      ],
+    });
+    expect(mapped.acceptedSystemIds).toEqual([30]);
+    expect(mapped.omittedSystemIds).toEqual([31, 32]);
+    expect(mapped.scene.boundedResponse.truncated).toBe(true);
+    expect(mapped.scene.highlights.at(-1)).toMatchObject({ type: 'cluster', cluster: { memberIds: [30], label: 'Evidence Systems' } });
+  });
+
+  it('maps System Detail into selected context', () => {
+    const scene = createFoundationDemoScene(100_000);
+    const guaranteedBefore = [...scene.guaranteedSystemIds];
+    const mapped = applyFeatureHandoff(scene, { type: 'systemDetail', system: detail(40) });
+    expect(mapped.scene.selectedSystemId64).toBe(40);
+    expect(mapped.scene.guaranteedSystemIds).toContain(40);
+    expect(mapped.scene.systems.find((system) => system.id64 === 40)).toMatchObject({ primaryEconomy: 'Refinery' });
+    expect(scene.guaranteedSystemIds).toEqual(guaranteedBefore);
+  });
+
+  it('maps only coordinate-resolved cluster members and retains group context', () => {
+    const cluster: ClusterResult = {
+      anchor_id64: 50, anchor_name: 'Cluster Anchor', anchor_coords: { x: 50, y: 0, z: -50 },
+      galaxy_region: 'Inner Orion Spur', coverage_score: 80, economy_diversity: 2, total_viable: 3,
+      agriculture_count: 0, agriculture_best: 0, refinery_count: 1, refinery_best: 80,
+      industrial_count: 1, industrial_best: 70, hightech_count: 0, hightech_best: 0,
+      military_count: 0, military_best: 0, tourism_count: 0, tourism_best: 0,
+      distance_ly: 10, cluster_radius_ly: 25,
+      slots: [{ slot_index: 0, label: 'Industry', economies: ['Industrial'], matches: [
+        { system_id64: 51, system_name: 'Resolved', scores: {}, distance_from_anchor_ly: 5 },
+        { system_id64: 52, system_name: 'Missing', scores: {}, distance_from_anchor_ly: 9 },
+      ] }],
+    };
+    const mapped = applyFeatureHandoff(createFoundationDemoScene(100_000), {
+      type: 'clusterSearch', cluster, systemsById: new Map([[51, result(51)]]),
+    });
+    expect(mapped.acceptedSystemIds).toEqual([51, 50]);
+    expect(mapped.omittedSystemIds).toEqual([52]);
+    expect(mapped.scene.clusters.at(-1)).toMatchObject({
+      anchorId64: 50,
+      memberIds: [50, 51],
+      groupContext: { name: 'Cluster Anchor' },
+    });
+  });
+
+  it('round-trips planner overlays without mutating a plan payload', () => {
+    const scene = createFoundationDemoScene(100_000);
+    const payload = { projectId: 'draft-1', mode: 'map' };
+    const mapped = applyFeatureHandoff(scene, {
+      type: 'planner',
+      systems: [result(60)],
+      highlights: scene.highlights,
+      layers: scene.layers,
+      clusters: scene.clusters,
+      workflowPayload: payload,
+    });
+    expect(mapped.scene.returnWorkflow).toMatchObject({ type: 'planner', workflowPayload: payload });
+    expect(payload).toEqual({ projectId: 'draft-1', mode: 'map' });
+    expect(mapped.scene.camera).toEqual(scene.camera);
+  });
+
+  it('normalizes every coordinate-bearing production shape', () => {
+    expect(toSystemRecord(result(70))).toMatchObject({ id64: 70, primaryEconomy: 'Industrial' });
+    expect(toSystemRecord(detail(71))).toMatchObject({ id64: 71, primaryEconomy: 'Refinery' });
+  });
+});
+
+describe('Stage 26D outbound interaction routing', () => {
+  it('updates selected-system context with cluster anchor identity', () => {
+    const scene = createFoundationDemoScene(100_000);
+    const resolved = resolveMapInteraction(scene, { type: 'selectSystem', systemId64: 81, clusterAnchorId64: 80 });
+    expect(resolved.scene.selectedSystemId64).toBe(81);
+    expect(resolved.command).toEqual({ type: 'selectSystem', systemId64: 81, clusterAnchorId64: 80 });
+  });
+
+  it('routes every feature request through host commands', () => {
+    const scene = { ...createFoundationDemoScene(100_000), selectedSystemId64: 91 };
+    expect(resolveMapInteraction(scene, { type: 'navigateToFinder' }).command.type).toBe('openFinder');
+    expect(resolveMapInteraction(scene, { type: 'navigateToSystemDetail', systemId64: 91 }).command.type).toBe('openSystemDetail');
+    expect(resolveMapInteraction(scene, { type: 'navigateToCompare', leftId64: 91, rightId64: 92 }).command.type).toBe('openCompare');
+    expect(resolveMapInteraction(scene, { type: 'navigateToSavedSystems' }).command.type).toBe('openSavedSystems');
+    expect(resolveMapInteraction(scene, { type: 'navigateToEvidenceMap' }).command.type).toBe('openEvidenceMap');
+    expect(resolveMapInteraction(scene, { type: 'navigateToClusterSearch', clusterId: 'cluster-91' }).command.type).toBe('openClusterSearch');
+    expect(resolveMapInteraction(scene, { type: 'navigateToPlanner' }).command).toEqual({ type: 'openPlanner', systemId64: 91 });
+  });
+
+  it('requires an explicit selected system before planner navigation', () => {
+    const scene = { ...createFoundationDemoScene(100_000), selectedSystemId64: null };
+    const resolved = resolveMapInteraction(scene, { type: 'navigateToPlanner' });
+    expect(resolved.command).toEqual({ type: 'plannerSelectionRequired' });
+    expect(resolved.scene).toBe(scene);
+  });
+});

--- a/frontend/src/features/map-foundation/feature-handoffs.ts
+++ b/frontend/src/features/map-foundation/feature-handoffs.ts
@@ -1,0 +1,284 @@
+import type { ClusterResult } from '@/features/cluster-search/useClusterSearch';
+import type { WatchlistEntry } from '@/lib/api';
+import type { PinnedEntry } from '@/store/pinnedStore';
+import type { EvidenceSystemSummaryResponse, SystemDetail, SystemResult } from '@/types/api';
+import {
+  reduceReturnWorkflow,
+  type BoundedResponseMetadata,
+  type ClusterRepresentation,
+  type HighlightSet,
+  type MapInteractionEvent,
+  type MapLayerState,
+  type MapReturnWorkflow,
+  type MapSceneState,
+  type SystemRecord,
+} from '../../../../artifacts/map-foundation/stage-26b/map-scene-contract';
+
+export type CoordinateBearingSystem = SystemResult | SystemDetail | PinnedEntry | WatchlistEntry;
+
+export type EvidenceMapEntry = {
+  summary: EvidenceSystemSummaryResponse;
+  system: CoordinateBearingSystem;
+};
+
+export type FeatureHandoff =
+  | { type: 'finder'; systems: SystemResult[]; selectedSystemId64?: number | null; metadata?: Partial<BoundedResponseMetadata> }
+  | { type: 'compare'; systems: SystemResult[]; leftId64: number; rightId64: number }
+  | { type: 'savedSystems'; systems: Array<PinnedEntry | WatchlistEntry> }
+  | { type: 'evidenceMap'; entries: EvidenceMapEntry[] }
+  | { type: 'systemDetail'; system: SystemDetail }
+  | { type: 'clusterSearch'; cluster: ClusterResult; systemsById: ReadonlyMap<number, CoordinateBearingSystem> }
+  | {
+      type: 'planner';
+      systems?: CoordinateBearingSystem[];
+      highlights: HighlightSet[];
+      layers: MapLayerState;
+      clusters: ClusterRepresentation[];
+      workflowPayload: Record<string, unknown>;
+    };
+
+export type FeatureHandoffResult = {
+  scene: MapSceneState;
+  acceptedSystemIds: number[];
+  omittedSystemIds: number[];
+};
+
+export type MapHostCommand =
+  | { type: 'none' }
+  | { type: 'selectSystem'; systemId64: number; clusterAnchorId64: number | null }
+  | { type: 'clearSelectedSystem' }
+  | { type: 'openMap' }
+  | { type: 'openFinder' }
+  | { type: 'openSystemDetail'; systemId64: number }
+  | { type: 'openCompare'; leftId64: number; rightId64: number }
+  | { type: 'openSavedSystems' }
+  | { type: 'openEvidenceMap' }
+  | { type: 'openClusterSearch'; clusterId: string }
+  | { type: 'openPlanner'; systemId64: number }
+  | { type: 'plannerSelectionRequired' };
+
+export type MapInteractionResolution = {
+  scene: MapSceneState;
+  command: MapHostCommand;
+};
+
+function finite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function identity(system: CoordinateBearingSystem): { id64: number; name: string } {
+  const value = system as { id64?: unknown; system_id64?: unknown; name?: unknown };
+  return {
+    id64: finite(value.system_id64) ? value.system_id64 : finite(value.id64) ? value.id64 : Number.NaN,
+    name: typeof value.name === 'string' ? value.name : '',
+  };
+}
+
+export function toSystemRecord(system: CoordinateBearingSystem): SystemRecord | null {
+  const { id64, name } = identity(system);
+  const value = system as {
+    coords?: { x?: unknown; z?: unknown } | null;
+    x?: unknown;
+    z?: unknown;
+    overall_development_potential?: unknown;
+    archetype_score?: unknown;
+    score?: unknown;
+    primaryEconomy?: unknown;
+    primary_economy?: unknown;
+    economy?: unknown;
+    economy_suggestion?: unknown;
+    population?: unknown;
+  };
+  const coords = value.coords ?? value;
+  if (!Number.isFinite(id64) || id64 <= 0 || !finite(coords.x) || !finite(coords.z)) return null;
+  const scoreCandidates = [value.overall_development_potential, value.archetype_score, value.score];
+  const economyCandidates = [value.primaryEconomy, value.primary_economy, value.economy, value.economy_suggestion];
+  const developmentScore = scoreCandidates.find(finite) ?? null;
+  const primaryEconomy = economyCandidates.find((candidate): candidate is string => typeof candidate === 'string') ?? null;
+
+  return {
+    id64,
+    name: name || `System ${id64}`,
+    coords: { x: coords.x, z: coords.z },
+    developmentScore,
+    primaryEconomy,
+    population: finite(value.population) ? value.population : null,
+  };
+}
+
+function collectSystems(systems: CoordinateBearingSystem[]): {
+  records: SystemRecord[];
+  acceptedSystemIds: number[];
+  omittedSystemIds: number[];
+} {
+  const records = new Map<number, SystemRecord>();
+  const omitted = new Set<number>();
+  for (const system of systems) {
+    const { id64 } = identity(system);
+    const record = toSystemRecord(system);
+    if (record) records.set(record.id64, record);
+    else if (Number.isFinite(id64) && id64 > 0) omitted.add(id64);
+  }
+  return {
+    records: [...records.values()],
+    acceptedSystemIds: [...records.keys()],
+    omittedSystemIds: [...omitted].filter((id64) => !records.has(id64)),
+  };
+}
+
+function mergeSystems(current: SystemRecord[], additions: SystemRecord[]): SystemRecord[] {
+  const byId = new Map(current.map((system) => [system.id64, system]));
+  additions.forEach((system) => byId.set(system.id64, system));
+  return [...byId.values()];
+}
+
+function clusterMembers(cluster: ClusterResult): number[] {
+  const ids = new Set<number>([cluster.anchor_id64]);
+  cluster.slots?.forEach((slot) => slot.matches.forEach((match) => ids.add(match.system_id64)));
+  return [...ids];
+}
+
+function toClusterRepresentation(cluster: ClusterResult, acceptedIds: Set<number>): ClusterRepresentation {
+  const memberIds = clusterMembers(cluster).filter((id64) => acceptedIds.has(id64));
+  const anchorId64 = acceptedIds.has(cluster.anchor_id64) ? cluster.anchor_id64 : memberIds[0] ?? cluster.anchor_id64;
+  return {
+    anchorId64,
+    memberIds,
+    memberRoles: Object.fromEntries(memberIds.map((id64) => [id64, [id64 === anchorId64 ? 'anchor' : 'member']])),
+    edges: memberIds.filter((id64) => id64 !== anchorId64).map((id64) => ({ fromId64: anchorId64, toId64: id64 })),
+    radiusLy: cluster.cluster_radius_ly,
+    hull: null,
+    label: cluster.anchor_name,
+    groupContext: {
+      name: cluster.anchor_name,
+      description: `${cluster.total_viable} viable systems · ${cluster.economy_diversity} economy groups`,
+    },
+  };
+}
+
+export function applyFeatureHandoff(scene: MapSceneState, handoff: FeatureHandoff): FeatureHandoffResult {
+  let sources: CoordinateBearingSystem[];
+  if (handoff.type === 'evidenceMap') {
+    sources = handoff.entries
+      .filter((entry) => identity(entry.system).id64 === entry.summary.system_id64)
+      .map((entry) => entry.system);
+  }
+  else if (handoff.type === 'clusterSearch') {
+    sources = clusterMembers(handoff.cluster)
+      .map((id64) => handoff.systemsById.get(id64))
+      .filter((system): system is CoordinateBearingSystem => system !== undefined);
+    if (handoff.cluster.anchor_coords && !handoff.systemsById.has(handoff.cluster.anchor_id64)) {
+      sources.push({
+        id64: handoff.cluster.anchor_id64,
+        name: handoff.cluster.anchor_name,
+        coords: handoff.cluster.anchor_coords,
+      } as SystemResult);
+    }
+  } else if (handoff.type === 'planner') sources = handoff.systems ?? [];
+  else if (handoff.type === 'systemDetail') sources = [handoff.system];
+  else sources = handoff.systems;
+
+  const collected = collectSystems(sources);
+  const expectedIds = handoff.type === 'clusterSearch'
+    ? clusterMembers(handoff.cluster)
+    : handoff.type === 'evidenceMap'
+      ? handoff.entries.map((entry) => entry.summary.system_id64)
+      : [];
+  const missingIds = expectedIds.filter((id64) => !collected.acceptedSystemIds.includes(id64));
+  const omittedSystemIds = [...new Set([...collected.omittedSystemIds, ...missingIds])];
+  const withSystems: MapSceneState = {
+    ...scene,
+    sceneRevision: scene.sceneRevision + 1,
+    systems: mergeSystems(scene.systems, collected.records),
+    highlights: [...scene.highlights],
+    clusters: [...scene.clusters],
+    layers: [...scene.layers],
+    guaranteedSystemIds: [...scene.guaranteedSystemIds],
+    boundedResponse: {
+      count: handoff.type === 'finder'
+        ? handoff.metadata?.count ?? handoff.systems.length
+        : collected.records.length,
+      truncated: handoff.type === 'finder' ? handoff.metadata?.truncated ?? false : omittedSystemIds.length > 0,
+      continuationToken: handoff.type === 'finder' ? handoff.metadata?.continuationToken ?? null : null,
+    },
+  };
+  const camera = scene.camera;
+  const origin = scene.origin;
+  let workflow: MapReturnWorkflow;
+
+  switch (handoff.type) {
+    case 'finder':
+      workflow = { type: 'finder', camera, origin };
+      break;
+    case 'compare':
+      workflow = { type: 'compare', leftId64: handoff.leftId64, rightId64: handoff.rightId64, camera, origin };
+      break;
+    case 'savedSystems':
+      workflow = { type: 'savedSystems', highlightedIds: collected.acceptedSystemIds, camera, origin };
+      break;
+    case 'evidenceMap':
+      workflow = { type: 'evidenceMap', highlightedIds: collected.acceptedSystemIds, camera, origin };
+      break;
+    case 'systemDetail':
+      workflow = { type: 'systemDetail', systemId64: handoff.system.id64, camera, origin };
+      break;
+    case 'clusterSearch':
+      workflow = {
+        type: 'clusterSearch',
+        cluster: toClusterRepresentation(handoff.cluster, new Set(collected.acceptedSystemIds)),
+        camera,
+        origin,
+      };
+      break;
+    case 'planner':
+      workflow = {
+        type: 'planner', camera, origin, highlights: handoff.highlights, layers: handoff.layers,
+        clusters: handoff.clusters, workflowDiscriminator: 'planner', workflowPayload: handoff.workflowPayload,
+      };
+      break;
+  }
+
+  const next = reduceReturnWorkflow(withSystems, workflow);
+  if (handoff.type === 'finder' && handoff.selectedSystemId64) {
+    next.selectedSystemId64 = handoff.selectedSystemId64;
+    next.guaranteedSystemIds = [...new Set([...next.guaranteedSystemIds, handoff.selectedSystemId64])];
+  }
+  return {
+    scene: next,
+    acceptedSystemIds: collected.acceptedSystemIds,
+    omittedSystemIds,
+  };
+}
+
+export function resolveMapInteraction(scene: MapSceneState, event: MapInteractionEvent): MapInteractionResolution {
+  switch (event.type) {
+    case 'selectSystem':
+    case 'overlapChoice':
+      return {
+        scene: { ...scene, selectedSystemId64: event.systemId64 },
+        command: { type: 'selectSystem', systemId64: event.systemId64, clusterAnchorId64: event.clusterAnchorId64 },
+      };
+    case 'deselectSystem':
+      return { scene: { ...scene, selectedSystemId64: null }, command: { type: 'clearSelectedSystem' } };
+    case 'cameraChanged':
+      return { scene: { ...scene, camera: event.camera, cameraIntent: 'user' }, command: { type: 'none' } };
+    case 'layerChanged':
+      return { scene: { ...scene, layers: event.layers }, command: { type: 'none' } };
+    case 'navigateToMap': return { scene, command: { type: 'openMap' } };
+    case 'navigateToFinder': return { scene, command: { type: 'openFinder' } };
+    case 'navigateToSystemDetail': return { scene, command: { type: 'openSystemDetail', systemId64: event.systemId64 } };
+    case 'navigateToCompare': return { scene, command: { type: 'openCompare', leftId64: event.leftId64, rightId64: event.rightId64 } };
+    case 'navigateToSavedSystems': return { scene, command: { type: 'openSavedSystems' } };
+    case 'navigateToEvidenceMap': return { scene, command: { type: 'openEvidenceMap' } };
+    case 'navigateToClusterSearch': return { scene, command: { type: 'openClusterSearch', clusterId: event.clusterId } };
+    case 'navigateToPlanner':
+      return {
+        scene,
+        command: scene.selectedSystemId64
+          ? { type: 'openPlanner', systemId64: scene.selectedSystemId64 }
+          : { type: 'plannerSelectionRequired' },
+      };
+    default:
+      return { scene, command: { type: 'none' } };
+  }
+}

--- a/frontend/src/features/map-foundation/types.ts
+++ b/frontend/src/features/map-foundation/types.ts
@@ -3,6 +3,7 @@ import type {
   ClusterRepresentation,
   GalaxyCoord,
   MapInteractionEvent,
+  MapReturnWorkflow,
   MapSceneState,
   SystemRecord,
 } from '../../../../artifacts/map-foundation/stage-26b/map-scene-contract';
@@ -52,6 +53,9 @@ export type FoundationSnapshot = {
   overlapCandidateIds: number[];
   contextState: 'ready' | 'lost' | 'restored' | 'usable';
   lastInteraction: MapInteractionEvent | null;
+  returnWorkflowType: MapReturnWorkflow['type'] | null;
+  lastHostCommand: string;
+  omittedHandoffSystemIds: number[];
 };
 
 export type FoundationRendererProps = {


### PR DESCRIPTION
## What changed

- added reusable typed inbound adapters for Finder, Compare, saved systems, evidence, System Detail, Cluster Search, and Planner
- added outbound interaction resolution into explicit host commands with selected-system and planner guards
- exercised all hand-offs in the isolated R3F workbench at both required desktop viewports
- documented Stage 26D completion and advanced the roadmap to Stage 26E

## Why

Stage 26C established the renderer-independent scene and interaction boundary. Stage 26D connects the existing frontend feature shapes to that boundary before any production route cutover.

## Impact and boundaries

The production `#map` route is unchanged. Evidence and cluster members without real coordinates are reported as omissions instead of receiving invented positions. Planner hand-off remains read-only and cannot create or mutate a Build Plan.

## Validation

- `yarn map-foundation:typecheck`
- `yarn map-foundation:lint`
- `yarn map-foundation:test` (17 passed)
- `yarn map-foundation:build`
- `yarn map-foundation:e2e` (2 passed)
- `yarn build:typecheck`
- `git diff --check`