### PR TITLE
Bound Stage 26E heatmap transport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,21 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-22 - Stage 26E bounded heatmap transport
+
+**Raw heatmap responses now have a deterministic ceiling** - The API returns at
+most 50,000 cells, selects density-first with coordinate tie-breakers, and
+fetches one sentinel row to emit explicit `max_cells` and `truncated` metadata.
+The cache key includes the requested cap, and the fallback aggregation follows
+the same ordering and limit.
+
+**Transport memory is measured separately from renderer buffers** - A
+maximum-width 50,000-cell compact JSON fixture measures 4,550,111 bytes against
+an 8 MiB budget. The frontend carries server truncation through the typed
+foundation without inventing omitted positions. Live-route heap, GPU timing,
+and region-geometry attribution remain blocking; the production map route is
+unchanged.
+
 ## 2026-07-22 - Stage 26E isolated production parity and memory bounds
 
 **The isolated candidate now carries the remaining live map shapes** - Added

--- a/apps/api/src/routers/map.py
+++ b/apps/api/src/routers/map.py
@@ -12,6 +12,8 @@ from edfinder_api.search_economies import canonical_economy_key, ratings_score_c
 
 router = APIRouter(tags=['map'])
 
+MAX_MAP_HEATMAP_CELLS = 50_000
+
 
 
 
@@ -159,6 +161,12 @@ async def map_heatmap(
     request: Request,
     voxel_size:  int = Query(200,  ge=50,  le=2000, description='Voxel cell size in LY'),
     min_systems: int = Query(5,    ge=1,   le=100,  description='Minimum systems per voxel'),
+    max_cells:   int = Query(
+        MAX_MAP_HEATMAP_CELLS,
+        ge=100,
+        le=MAX_MAP_HEATMAP_CELLS,
+        description='Maximum heatmap cells returned',
+    ),
     economy:     Optional[str] = Query(None, description='Filter to a specific economy score'),
     pool: asyncpg.Pool = Depends(get_pool),
     redis: Optional[aioredis.Redis] = Depends(get_redis),
@@ -179,7 +187,7 @@ async def map_heatmap(
             raise HTTPException(status_code=422, detail=f'Invalid economy: {economy}')
         eco_col = ratings_score_column(eco_key)
 
-    cache_key = f'map:heatmap:v1:{voxel_size}:{min_systems}:{eco_col or "overall"}'
+    cache_key = f'map:heatmap:v2:{voxel_size}:{min_systems}:{max_cells}:{eco_col or "overall"}'
     cached = await cache_get(cache_key, redis)
     if cached is not None:
         return JSONResponse(content=cached)
@@ -212,7 +220,9 @@ async def map_heatmap(
                        {_eco_col} AS max_score
                 FROM   {_mv}
                 WHERE  n >= $1 AND {_filter_col} IS NOT NULL
-            """, min_systems)
+                ORDER BY n DESC, cx, cy, cz
+                LIMIT $2
+            """, min_systems, max_cells + 1)
         except asyncpg.exceptions.UndefinedTableError:
             log.warning('%s missing; falling back to live GROUP BY', _mv)
             # Defence-in-depth: cap heatmap scan at 8 s.
@@ -231,14 +241,21 @@ async def map_heatmap(
                     WHERE  r.{score_col} IS NOT NULL
                     GROUP BY cx, cy, cz
                     HAVING COUNT(*) >= $2
-                """, voxel_size, min_systems, timeout=15)
+                    ORDER BY n DESC, cx, cy, cz
+                    LIMIT $3
+                """, voxel_size, min_systems, max_cells + 1, timeout=15)
+
+    truncated = len(rows) > max_cells
+    bounded_rows = rows[:max_cells]
 
     result = {
         'voxel_size': voxel_size,
         'voxel_bucket': _bucket,        # actual MV resolution used
         'economy':    economy,
-        'cells':      [dict(r) for r in rows],
-        'count':      len(rows),
+        'cells':      [dict(r) for r in bounded_rows],
+        'count':      len(bounded_rows),
+        'max_cells':  max_cells,
+        'truncated':  truncated,
     }
     await cache_set(cache_key, result, settings.ttl_cluster, redis)
     return result

--- a/artifacts/map-foundation/stage-26e/README.md
+++ b/artifacts/map-foundation/stage-26e/README.md
@@ -8,13 +8,15 @@ claiming production cutover readiness.
   steady-state readings from the deterministic 500,000-system development
   fixture after the Stage 26D hand-off journey.
 - `production-memory-budget.json` records the bounded normalized overlay
-  buffers, their deterministic worst-case byte count, and the raw-response and
-  live-route measurements that remain open.
+  buffers, their deterministic worst-case byte count, the closed raw-response
+  bound, and the live-route measurements that remain open.
+- `heatmap-response-envelope.json` records the server-side 50,000-cell ceiling,
+  stable density-first ordering, truncation contract, and compact JSON budget.
 - The visual golden is retained beside its Playwright test under
   `frontend/map-foundation/e2e/visual.spec.ts-snapshots/`.
 
 The GPU timer extension was unavailable, so GPU time remains unknown rather
 than being inferred from JavaScript frame callbacks. The isolated candidate now
-carries the live feature shapes, but production cutover remains blocked by raw
-heatmap/live-route memory evidence (including highly variable isolated heap
-snapshots), GPU evidence, and region-data provenance and attribution review.
+carries the live feature shapes, but production cutover remains blocked by
+live-route memory evidence (including highly variable isolated heap snapshots),
+GPU evidence, and region-data provenance and attribution review.

--- a/artifacts/map-foundation/stage-26e/cutover-gates.json
+++ b/artifacts/map-foundation/stage-26e/cutover-gates.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "stage": "26E",
   "status": "in_progress_cutover_not_authorized",
-  "baseline_sha": "359a17fca9d9a622b198de9d40d10c42224b2a50",
+  "baseline_sha": "2b61c1696cf7d8253d1b4ffd3fe58b529292f8a7",
   "recorded_on": "2026-07-22",
   "gates": {
     "typed_feature_handoffs": {
@@ -51,7 +51,7 @@
       "gpu_probe_ms": null
     },
     "memory": {
-      "status": "partial_normalized_buffers_bounded_raw_response_and_live_heap_open",
+      "status": "partial_transport_and_normalized_buffers_bounded_live_heap_open",
       "chromium_used_js_heap_bytes": {
         "1280x720": 662000000,
         "1440x900": 386000000
@@ -62,13 +62,21 @@
       },
       "normalized_overlay_buffer_budget_bytes": 8388608,
       "worst_case_normalized_overlay_buffer_bytes": 4272000,
+      "raw_heatmap_response": {
+        "status": "pass",
+        "max_cells": 50000,
+        "compact_json_budget_bytes": 8388608,
+        "measured_worst_case_fixture_bytes": 4550111,
+        "stable_selection_order": "n DESC, cx, cy, cz",
+        "truncation_metadata": ["max_cells", "truncated"]
+      },
       "normalized_limits": {
         "finder_systems": 500,
         "heatmap_cells": 50000,
         "aggregate_hulls": 2000,
         "timeline_points": 1200
       },
-      "remaining": "The raw heatmap response is unbounded before frontend normalization, repeat isolated heap readings are highly variable, and no live production-route heap budget has been measured."
+      "remaining": "Repeat isolated heap readings are highly variable, and no live production-route heap budget has been measured."
     },
     "production_feature_parity": {
       "status": "pass_for_isolated_candidate",

--- a/artifacts/map-foundation/stage-26e/heatmap-response-envelope.json
+++ b/artifacts/map-foundation/stage-26e/heatmap-response-envelope.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "stage": "26E",
+  "recorded_on": "2026-07-22",
+  "status": "pass",
+  "server_max_cells": 50000,
+  "query_sentinel_rows": 50001,
+  "selection_order": ["n DESC", "cx", "cy", "cz"],
+  "compact_json_budget_bytes": 8388608,
+  "measured_worst_case_fixture_bytes": 4550111,
+  "truncation_metadata": ["max_cells", "truncated"],
+  "scope": "Deterministic maximum-width numeric fixture for the bounded heatmap response. Live-route JavaScript heap remains a separate gate."
+}

--- a/artifacts/map-foundation/stage-26e/production-memory-budget.json
+++ b/artifacts/map-foundation/stage-26e/production-memory-budget.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "stage": "26E",
   "recorded_on": "2026-07-22",
-  "status": "partial_normalized_buffers_bounded_raw_response_and_live_heap_open",
+  "status": "partial_transport_and_normalized_buffers_bounded_live_heap_open",
   "normalized_limits": {
     "finder_systems": 500,
     "heatmap_cells": 50000,
@@ -10,6 +10,12 @@
     "timeline_points": 1200
   },
   "normalized_overlay_buffer_budget_bytes": 8388608,
+  "raw_heatmap_response": {
+    "max_cells": 50000,
+    "compact_json_budget_bytes": 8388608,
+    "measured_worst_case_fixture_bytes": 4550111,
+    "status": "pass"
+  },
   "worst_case_normalized_overlay_buffers": {
     "heatmap_positions_and_colors_bytes": 1200000,
     "aggregate_hull_line_positions_and_colors_bytes": 3072000,
@@ -25,7 +31,6 @@
     "1440x900": [188000000, 386000000]
   },
   "open_requirements": [
-    "cap the raw heatmap response before or during transport; the current API response has no cell-count bound",
     "measure the candidate inside the production route with live Finder and map-layer responses",
     "set and pass an end-to-end production-route JavaScript heap budget"
   ]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -303,8 +303,9 @@ competing roadmap source.
 - The 500,000-system steady-state Chromium p95 measured about 16.7-16.8 ms at
   the required viewports. The WebGL GPU timer extension was unavailable, so GPU
   time remains unknown. Normalized overlay buffers now pass a deterministic
-  8 MiB budget, but the raw heatmap response and live-route heap budget remain
-  open before cutover.
+  8 MiB budget. The heatmap API now has a stable 50,000-cell ceiling and its
+  worst-case fixture passes a separate 8 MiB raw-response budget; the live-route
+  heap budget remains open before cutover.
 - The isolated candidate now carries live heatmap cells, aggregate cluster
   hulls, timeline state, view presets, and typed ready/empty/error composition.
   Live-route wiring remains deliberately deferred until the blocking gates
@@ -415,7 +416,7 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Continue Stage 26E raw-response and live-route memory work; obtain
+1. Continue Stage 26E disabled live-route composition and heap-budget work; obtain
    region-geometry/attribution review and real GPU evidence before any
    deliberate cutover.
 2. Preserve production data-integrity receipts and the bounded rerating cadence.

--- a/docs/colonisation-redesign/stage-26e-cutover-readiness.md
+++ b/docs/colonisation-redesign/stage-26e-cutover-readiness.md
@@ -26,6 +26,10 @@ The machine-readable source of truth is
 - Sixty-frame steady-state samples after the 500,000-system hand-off journey
   measured approximately 16.7 ms and 16.8 ms p95 at the two required
   viewports, below the provisional 50 ms gate.
+- The heatmap API now returns at most 50,000 density-first cells, fetches one
+  sentinel row to report truncation, and emits explicit `max_cells` and
+  `truncated` metadata. A maximum-width compact JSON fixture measured 4,550,111
+  bytes against an 8 MiB raw-response budget.
 
 These are local Windows/Playwright readings. They do not imply a broad hardware
 performance guarantee.
@@ -43,16 +47,17 @@ duration is not substituted.
 
 The candidate now limits the current 500-system Finder envelope, 50,000
 normalized heatmap cells, 2,000 aggregate hulls, and 1,200 timeline points. At
-those maxima, the heatmap and score-coloured hull typed buffers total 4,272,000 bytes and pass
-an 8 MiB normalized-overlay budget. Repeated isolated 500,000-system journeys
+those maxima, the heatmap and score-coloured hull typed buffers total 4,272,000
+bytes and pass an 8 MiB normalized-overlay budget. Repeated isolated
+500,000-system journeys
 reported roughly 167-662 MB at 1280x720 and 188-386 MB at 1440x900, demonstrating
 that these development-fixture heap snapshots are not stable enough to serve as
 a production budget.
 
-This is partial closure only. The current heatmap API has no returned-cell cap,
-so its raw JSON can exceed the normalized frontend limit before adaptation. A
-live production-route heap budget has also not been measured. Both remain
-blocking memory work.
+This closes the raw heatmap transport bound. It is still partial memory closure:
+the candidate has not been composed into the live production route, so an
+end-to-end route heap budget has not been measured. The repeated isolated heap
+variability makes that live measurement mandatory rather than inferable.
 
 ### Production feature parity
 
@@ -91,9 +96,10 @@ then, the production route cannot cut over.
 
 ## Next Authorized Work
 
-Stage 26E may continue by bounding the raw heatmap response and measuring a
-live-route JavaScript heap budget. It may also rerun GPU timing on an environment
-exposing the required extension or with a captured system trace, and close the
-remaining region-geometry and attribution questions. Route cutover and
+Stage 26E may continue by composing the candidate behind a disabled production
+flag and measuring a live-route JavaScript heap budget. It may also rerun GPU
+timing on an environment exposing the required extension or with a captured
+system trace, and close the remaining region-geometry and attribution
+questions. Route cutover and
 superseded-map deletion remain unauthorized until every blocking gate is
 recorded as closed.

--- a/frontend/map-foundation/workbench.tsx
+++ b/frontend/map-foundation/workbench.tsx
@@ -42,6 +42,8 @@ const PRODUCTION_HEATMAP_FIXTURE: MapHeatmapResponse = {
   voxel_bucket: 1_000,
   economy: null,
   count: 16,
+  max_cells: 50_000,
+  truncated: false,
   cells: Array.from({ length: 16 }, (_, index) => ({
     cx: (index % 4 - 1.5) * 8_000,
     cy: 0,

--- a/frontend/src/features/map-foundation/production-parity.test.ts
+++ b/frontend/src/features/map-foundation/production-parity.test.ts
@@ -19,6 +19,8 @@ function heatmap(cellCount: number): MapHeatmapResponse {
     voxel_bucket: 200,
     economy: null,
     count: cellCount,
+    max_cells: PRODUCTION_PARITY_LIMITS.heatmapCells,
+    truncated: false,
     cells: Array.from({ length: cellCount }, (_, index) => ({
       cx: index * 200,
       cy: 0,
@@ -59,6 +61,7 @@ describe('Stage 26E production parity composition', () => {
 
     expect(composition.overlays.heatmap?.cellCount).toBe(PRODUCTION_PARITY_LIMITS.heatmapCells);
     expect(composition.overlays.heatmap?.omittedCellCount).toBe(10);
+    expect(composition.overlays.heatmap?.sourceTruncated).toBe(false);
     expect(composition.overlays.aggregateHulls?.hullCount).toBe(PRODUCTION_PARITY_LIMITS.aggregateHulls);
     expect(composition.overlays.aggregateHulls?.omittedHullCount).toBe(10);
     expect(composition.timeline).toEqual({
@@ -72,10 +75,11 @@ describe('Stage 26E production parity composition', () => {
   it('rejects invalid coordinates without inventing positions', () => {
     const invalidHeatmap = heatmap(2);
     invalidHeatmap.cells[0]!.cx = Number.NaN;
+    invalidHeatmap.truncated = true;
     const invalidHulls = hulls(2);
     invalidHulls[0]!.x = null;
 
-    expect(adaptHeatmap(invalidHeatmap)?.cellCount).toBe(1);
+    expect(adaptHeatmap(invalidHeatmap)).toMatchObject({ cellCount: 1, sourceTruncated: true });
     expect(adaptAggregateHulls(invalidHulls)?.hullCount).toBe(1);
   });
 

--- a/frontend/src/features/map-foundation/production-parity.ts
+++ b/frontend/src/features/map-foundation/production-parity.ts
@@ -79,6 +79,7 @@ export function adaptHeatmap(
     voxelSize: response.voxel_size,
     cellCount: retainedCount,
     omittedCellCount: Math.max(0, validCount - limit),
+    sourceTruncated: response.truncated,
   };
 }
 

--- a/frontend/src/features/map-foundation/types.ts
+++ b/frontend/src/features/map-foundation/types.ts
@@ -33,6 +33,7 @@ export type ProductionHeatmapGeometry = {
   voxelSize: number;
   cellCount: number;
   omittedCellCount: number;
+  sourceTruncated: boolean;
 };
 
 export type ProductionAggregateHullGeometry = {

--- a/frontend/src/features/map/GalacticMap.test.tsx
+++ b/frontend/src/features/map/GalacticMap.test.tsx
@@ -171,6 +171,8 @@ describe('GalacticMap', () => {
         { cx: 200, cy: 0, cz: 200, n: 8, avg_score: 40, max_score: 60 },
       ],
       count: 2,
+      max_cells: 50_000,
+      truncated: false,
     };
     render(
       <GalacticMap

--- a/frontend/src/features/map/MapTab.test.tsx
+++ b/frontend/src/features/map/MapTab.test.tsx
@@ -381,7 +381,7 @@ describe('MapTab', () => {
     expect(screen.getByText('Heatmap failed')).toBeTruthy();
   });
 
-  it('updates badge when heatmap is loaded', () => {
+  it('updates the badge and reports a capped heatmap response', () => {
     vi.mocked(useMapLayers).mockReturnValue({
       regions:  { data: undefined, isLoading: false, isError: false, error: null },
       clusters: { data: undefined, isLoading: false, isError: false, error: null },
@@ -392,6 +392,8 @@ describe('MapTab', () => {
           economy: null,
           cells: [{ cx: 0, cy: 0, cz: 0, n: 12, avg_score: 70, max_score: 90 }],
           count: 1,
+          max_cells: 50_000,
+          truncated: true,
         },
         isLoading: false,
         isError: false,
@@ -407,6 +409,7 @@ describe('MapTab', () => {
 
     fireEvent.click(screen.getByTestId('map-heatmap-toggle'));
     expect(screen.getByText('Finder results + Heatmap')).toBeTruthy();
+    expect(screen.getByTestId('map-heatmap-truncated').textContent).toContain('50,000 densest cells');
   });
 
   it('does not fetch clusters by default', () => {

--- a/frontend/src/features/map/MapTab.tsx
+++ b/frontend/src/features/map/MapTab.tsx
@@ -263,6 +263,8 @@ export function MapTab({
             regionsError={layers.regions.isError}
             heatmapLoading={layers.heatmap.isLoading}
             heatmapError={layers.heatmap.isError}
+            heatmapTruncated={layers.heatmap.data?.truncated ?? false}
+            heatmapMaxCells={layers.heatmap.data?.max_cells ?? null}
             clustersLoading={layers.clusters.isLoading}
             clustersError={layers.clusters.isError}
             timelineLoading={layers.timeline.isLoading}

--- a/frontend/src/features/map/mapTabPanels.tsx
+++ b/frontend/src/features/map/mapTabPanels.tsx
@@ -143,6 +143,8 @@ export function MapLayerStatusRow({
   regionsError,
   heatmapLoading,
   heatmapError,
+  heatmapTruncated,
+  heatmapMaxCells,
   clustersLoading,
   clustersError,
   timelineLoading,
@@ -158,6 +160,8 @@ export function MapLayerStatusRow({
   regionsError: boolean;
   heatmapLoading: boolean;
   heatmapError: boolean;
+  heatmapTruncated: boolean;
+  heatmapMaxCells: number | null;
   clustersLoading: boolean;
   clustersError: boolean;
   timelineLoading: boolean;
@@ -183,6 +187,11 @@ export function MapLayerStatusRow({
       {showRegions && regionsError && <StatusText tone="error">Regions failed</StatusText>}
       {showHeatmap && heatmapLoading && <StatusText tone="loading">Loading heatmap…</StatusText>}
       {showHeatmap && heatmapError && <StatusText tone="error">Heatmap failed</StatusText>}
+      {showHeatmap && !heatmapLoading && !heatmapError && heatmapTruncated && (
+        <span data-testid="map-heatmap-truncated" className="font-mono text-[10px] text-gold">
+          Heatmap capped at {heatmapMaxCells?.toLocaleString() ?? 'server limit'} densest cells
+        </span>
+      )}
       {showClusters && clustersLoading && <StatusText tone="loading">Loading clusters…</StatusText>}
       {showClusters && clustersError && <StatusText tone="error">Clusters failed</StatusText>}
       {showTimeline && timelineLoading && <StatusText tone="loading">Loading timeline…</StatusText>}

--- a/frontend/src/features/map/useMapLayers.test.tsx
+++ b/frontend/src/features/map/useMapLayers.test.tsx
@@ -67,11 +67,13 @@ describe('useMapLayers', () => {
       economy: null,
       cells: [{ cx: 0, cy: 0, cz: 0, n: 10, avg_score: 75, max_score: 90 }],
       count: 1,
+      max_cells: 50_000,
+      truncated: false,
     });
 
     const { result } = renderHook(
       () => useMapLayers({
-        heatmap: { enabled: true, voxel_size: 200, min_systems: 5, economy: 'Refinery' },
+        heatmap: { enabled: true, voxel_size: 200, min_systems: 5, max_cells: 500, economy: 'Refinery' },
       }),
       { wrapper },
     );
@@ -83,6 +85,7 @@ describe('useMapLayers', () => {
     expect(api.mapHeatmap).toHaveBeenCalledWith({
       voxel_size: 200,
       min_systems: 5,
+      max_cells: 500,
       economy: 'Refinery',
     });
   });

--- a/frontend/src/features/map/useMapLayers.ts
+++ b/frontend/src/features/map/useMapLayers.ts
@@ -16,7 +16,7 @@ export interface MapLayerOptions {
 export interface UseMapLayersOptions {
   regions?:    MapLayerOptions;
   clusters?:    MapLayerOptions & { min_count?: number; max_hulls?: number };
-  heatmap?:    MapLayerOptions & { voxel_size?: number; min_systems?: number; economy?: string | null };
+  heatmap?:    MapLayerOptions & { voxel_size?: number; min_systems?: number; max_cells?: number; economy?: string | null };
   timeline?:   MapLayerOptions & { bucket?: 'day' | 'week' | 'month' | 'quarter' | 'year' };
   /** Stale time shared across all layer queries (default 5 minutes). */
   staleTimeMs?: number;
@@ -66,10 +66,11 @@ export function useMapLayers(opts: UseMapLayersOptions = {}): UseMapLayersResult
   });
 
   const heatmapQuery = useQuery<MapHeatmapResponse, Error>({
-    queryKey: ['map', 'heatmap', opts.heatmap?.voxel_size, opts.heatmap?.min_systems, opts.heatmap?.economy],
+    queryKey: ['map', 'heatmap', opts.heatmap?.voxel_size, opts.heatmap?.min_systems, opts.heatmap?.max_cells, opts.heatmap?.economy],
     queryFn:  () => api.mapHeatmap({
       voxel_size: opts.heatmap?.voxel_size,
       min_systems: opts.heatmap?.min_systems,
+      max_cells: opts.heatmap?.max_cells,
       economy: opts.heatmap?.economy,
     }),
     enabled: opts.heatmap?.enabled ?? false,

--- a/frontend/src/lib/api.map.test.ts
+++ b/frontend/src/lib/api.map.test.ts
@@ -76,14 +76,16 @@ describe('map API helpers', () => {
           economy: null,
           cells: [{ cx: 0, cy: 0, cz: 0, n: 10, avg_score: 75, max_score: 90 }],
           count: 1,
+          max_cells: 50_000,
+          truncated: false,
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
     );
 
-    await api.mapHeatmap({ voxel_size: 200, min_systems: 5, economy: 'Refinery' });
+    await api.mapHeatmap({ voxel_size: 200, min_systems: 5, max_cells: 500, economy: 'Refinery' });
     expect(fetchSpy).toHaveBeenCalledWith(
-      '/api/map/heatmap?voxel_size=200&min_systems=5&economy=Refinery',
+      '/api/map/heatmap?voxel_size=200&min_systems=5&max_cells=500&economy=Refinery',
       expect.anything(),
     );
   });
@@ -97,6 +99,8 @@ describe('map API helpers', () => {
           economy: null,
           cells: [],
           count: 0,
+          max_cells: 50_000,
+          truncated: false,
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),
@@ -180,6 +184,8 @@ describe('map API helpers', () => {
           economy: null,
           cells: [],
           count: 0,
+          max_cells: 50_000,
+          truncated: false,
         }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       ),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -250,6 +250,8 @@ export interface MapHeatmapResponse {
   economy: string | null;
   cells: MapHeatmapCell[];
   count: number;
+  max_cells: number;
+  truncated: boolean;
 }
 
 export interface MapTimelinePoint {
@@ -630,10 +632,11 @@ export const api = {
     return jsonFetch(`/map/clusters/hulls${qs ? `?${qs}` : ''}`);
   },
 
-  mapHeatmap(opts?: { voxel_size?: number; min_systems?: number; economy?: string | null }): Promise<MapHeatmapResponse> {
+  mapHeatmap(opts?: { voxel_size?: number; min_systems?: number; max_cells?: number; economy?: string | null }): Promise<MapHeatmapResponse> {
     const params = new URLSearchParams();
     if (opts?.voxel_size !== undefined) params.set('voxel_size', String(opts.voxel_size));
     if (opts?.min_systems !== undefined) params.set('min_systems', String(opts.min_systems));
+    if (opts?.max_cells !== undefined) params.set('max_cells', String(opts.max_cells));
     if (opts?.economy != null) params.set('economy', opts.economy);
     const qs = params.toString();
     return jsonFetch(`/map/heatmap${qs ? `?${qs}` : ''}`);

--- a/frontend/src/types/api.gen.ts
+++ b/frontend/src/types/api.gen.ts
@@ -6870,6 +6870,8 @@ export interface operations {
                 voxel_size?: number;
                 /** @description Minimum systems per voxel */
                 min_systems?: number;
+                /** @description Maximum heatmap cells returned */
+                max_cells?: number;
                 /** @description Filter to a specific economy score */
                 economy?: string | null;
             };

--- a/tests/integration/test_phase5_map_materialised_views.py
+++ b/tests/integration/test_phase5_map_materialised_views.py
@@ -39,6 +39,8 @@ async def test_heatmap_endpoint_reads_from_mv(client, pool):
     body = r.json()
     assert body['voxel_bucket'] == 200, body
     assert body['count'] >= 1, body  # we seeded 40 systems
+    assert body['max_cells'] == 50_000, body
+    assert body['truncated'] is False, body
 
     # 750 LY bucket → 1000 LY MV (the closest pre-aggregated bucket up).
     r2 = await client.get('/api/map/heatmap?voxel_size=750&min_systems=1')

--- a/tests/test_map_heatmap_unit.py
+++ b/tests/test_map_heatmap_unit.py
@@ -1,6 +1,7 @@
 """Focused no-DB coverage for map heatmap economy SQL selection."""
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import sys
@@ -16,12 +17,17 @@ sys.path.insert(0, str(_REPO_ROOT / 'apps' / 'api' / 'src'))
 
 
 class _FakeConn:
-    def __init__(self) -> None:
+    def __init__(self, rows: list[dict] | None = None) -> None:
         self.queries: list[str] = []
+        self.arguments: list[tuple] = []
+        self.rows = rows if rows is not None else [
+            {'cx': 0, 'cy': 0, 'cz': 0, 'n': 1, 'avg_score': 10, 'max_score': 20}
+        ]
 
     async def fetch(self, query: str, *args, **kwargs) -> list[dict]:
         self.queries.append(query)
-        return [{'cx': 0, 'cy': 0, 'cz': 0, 'n': 1, 'avg_score': 10, 'max_score': 20}]
+        self.arguments.append(args)
+        return self.rows
 
 
 class _AcquireContext:
@@ -36,8 +42,8 @@ class _AcquireContext:
 
 
 class _FakePool:
-    def __init__(self) -> None:
-        self.conn = _FakeConn()
+    def __init__(self, rows: list[dict] | None = None) -> None:
+        self.conn = _FakeConn(rows)
 
     def acquire(self) -> _AcquireContext:
         return _AcquireContext(self.conn)
@@ -64,6 +70,7 @@ async def test_map_heatmap_uses_canonical_economy_mv_column(economy, expected_co
         request=None,
         voxel_size=200,
         min_systems=1,
+        max_cells=50_000,
         economy=economy,
         pool=pool,
         redis=None,
@@ -73,7 +80,11 @@ async def test_map_heatmap_uses_canonical_economy_mv_column(economy, expected_co
     assert expected_column in query
     assert f'{expected_column} AS max_score' in query
     assert f'AND {expected_column} IS NOT NULL' in query
+    assert 'ORDER BY n DESC, cx, cy, cz' in query
+    assert 'LIMIT $2' in query
+    assert pool.conn.arguments == [(1, 50_001)]
     assert result['economy'] == economy
+    assert result['truncated'] is False
 
 
 async def test_map_heatmap_rejects_invalid_economy():
@@ -83,6 +94,7 @@ async def test_map_heatmap_rejects_invalid_economy():
             request=None,
             voxel_size=200,
             min_systems=1,
+            max_cells=50_000,
             economy='NotAnEconomy',
             pool=pool,
             redis=None,
@@ -91,3 +103,56 @@ async def test_map_heatmap_rejects_invalid_economy():
     assert exc_info.value.status_code == 422
     assert exc_info.value.detail == 'Invalid economy: NotAnEconomy'
     assert pool.conn.queries == []
+
+
+async def test_map_heatmap_caps_deterministically_and_reports_truncation():
+    rows = [
+        {'cx': index, 'cy': 0, 'cz': -index, 'n': 200 - index, 'avg_score': 50, 'max_score': 80}
+        for index in range(101)
+    ]
+    pool = _FakePool(rows)
+    result = await _map_heatmap_handler()(
+        request=None,
+        voxel_size=200,
+        min_systems=1,
+        max_cells=100,
+        economy=None,
+        pool=pool,
+        redis=None,
+    )
+
+    assert result['count'] == 100
+    assert result['max_cells'] == 100
+    assert result['truncated'] is True
+    assert len(result['cells']) == 100
+    assert result['cells'][0]['cx'] == 0
+    assert result['cells'][-1]['cx'] == 99
+    assert pool.conn.arguments == [(1, 101)]
+
+
+async def test_map_heatmap_maximum_compact_json_stays_within_raw_response_budget():
+    rows = [
+        {
+            'cx': 99_999_999,
+            'cy': -99_999_999,
+            'cz': 99_999_999,
+            'n': 999_999_999,
+            'avg_score': 100,
+            'max_score': 100,
+        }
+        for _ in range(50_001)
+    ]
+    result = await _map_heatmap_handler()(
+        request=None,
+        voxel_size=200,
+        min_systems=1,
+        max_cells=50_000,
+        economy=None,
+        pool=_FakePool(rows),
+        redis=None,
+    )
+
+    payload_bytes = len(json.dumps(result, separators=(',', ':')).encode('utf-8'))
+    assert result['truncated'] is True
+    assert result['count'] == 50_000
+    assert payload_bytes <= 8 * 1_048_576


### PR DESCRIPTION
## What changed

- cap `/api/map/heatmap` at 50,000 cells and fetch one sentinel row to report truncation
- select capped cells deterministically by density and coordinate tie-breakers, with the requested cap included in the cache key
- expose `max_cells` and `truncated` through the API client, query hook, typed foundation adapter, and live-map status notice
- record a 4,550,111-byte maximum-width compact JSON fixture against an 8 MiB transport budget
- update the Stage 26E gate ledger, roadmap, evidence, generated OpenAPI types, and change log

The R3F production cutover remains unauthorized. This closes only the raw heatmap transport bound; live-route heap, GPU timing, and region-geometry attribution remain open.

## Validation

- backend unit contract: 7 passed
- broad backend unit gate: 1,475 passed, 30 skipped, 125 deselected
- full Ruff gate
- `yarn typecheck`
- `yarn test:map` (84 passed)
- `yarn map-foundation:test` (21 passed)
- `yarn build:typecheck`
- `yarn knip --files`
- `yarn map-foundation:build`
- `yarn map-foundation:e2e` (2 passed)
- OpenAPI types regenerated and JSON/diff/state gates passed

The DB materialized-view integration file skipped locally because the disposable DB fixture was unavailable; protected CI owns that real-service run.