### PR TITLE
Close Stage 26E hardware GPU timing gate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,21 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-22 - Stage 26E hardware GPU timing gate
+
+**GPU duration is now measured on the real candidate render** - Added a
+development-only `?gpu-test=1` diagnostic that runs 30
+`EXT_disjoint_timer_query_webgl2` queries around
+`WebGLRenderer.render(scene, camera)` for the visible 500,000-system scene. A
+hardware-backed Chromium session returned 30/30 valid queries with no disjoint
+samples at both required viewports: 1.358 ms p95 at 1280x720 and 1.747 ms p95
+at 1440x900.
+
+**The remaining cutover blocker is unchanged in scope** - The GPU evidence gate
+is closed, but the production candidate stays default-off and region geometry
+stays withheld. Region-geometry coverage and required attribution still need
+owner or qualified legal review before deliberate cutover.
+
 ## 2026-07-22 - Stage 26E default-off production route and heap budget
 
 **The R3F candidate now has a production-route composition without a cutover** -
@@ -20,9 +35,9 @@ measured seven steady `JSHeapUsedSize` samples at both required viewports after
 composing 500 Finder systems, 50,000 heatmap cells, 2,000 hulls, and 100
 timeline points from live API payloads. Maxima were 26,392,356 and 28,724,676
 bytes against a predeclared 268,435,456-byte budget. Axe reported zero
-detectable WCAG 2/2.1 A/AA violations at both composed-route viewports. GPU
-timing and region-data review still block cutover; the production flag remains
-off.
+detectable WCAG 2/2.1 A/AA violations at both composed-route viewports. The
+separate hardware-backed timing run now closes GPU evidence; region-data review
+still blocks cutover and the production flag remains off.
 
 **The owner-approved Frontier disclaimer is now site-wide** - The application
 footer carries the supplied non-commercial, non-endorsement, and no-employee-

--- a/artifacts/map-foundation/stage-26e/README.md
+++ b/artifacts/map-foundation/stage-26e/README.md
@@ -7,6 +7,10 @@ claiming production cutover readiness.
 - `performance-1280x720.json` and `performance-1440x900.json` are Chromium
   steady-state readings from the deterministic 500,000-system development
   fixture after the Stage 26D hand-off journey.
+- `hardware-gpu-timing.json` records 30 actual-render WebGL2 timer-query
+  samples at each required viewport on a hardware-backed Chromium session.
+  Both runs returned 30 valid samples with no disjoint results; p95 GPU time
+  was 1.358 ms at 1280x720 and 1.747 ms at 1440x900.
 - `production-memory-budget.json` records the bounded normalized overlay
   buffers, their deterministic worst-case byte count, the closed raw-response
   bound, and the closed live-route heap budget.
@@ -26,8 +30,9 @@ claiming production cutover readiness.
 - The visual golden is retained beside its Playwright test under
   `frontend/map-foundation/e2e/visual.spec.ts-snapshots/`.
 
-The GPU timer extension was unavailable, so GPU time remains unknown rather
-than being inferred from JavaScript frame callbacks. The candidate is composed
-behind an exact default-off production flag, and region geometry is withheld.
-Production cutover remains blocked by GPU evidence and region-data provenance
-coverage and attribution review.
+The earlier automated Chromium environment did not expose the timer extension.
+The hardware-backed rerun now closes that evidence gap using real
+`WebGLRenderer.render(scene, camera)` timer queries rather than JavaScript frame
+callbacks. The candidate is composed behind an exact default-off production
+flag, and production region geometry is withheld. Production cutover remains
+blocked by region-data coverage and attribution review.

--- a/artifacts/map-foundation/stage-26e/cutover-gates.json
+++ b/artifacts/map-foundation/stage-26e/cutover-gates.json
@@ -47,10 +47,17 @@
       "budget_ms": 50
     },
     "gpu_timing": {
-      "status": "unknown_blocking_final_performance_claim",
+      "status": "pass_hardware_timer_queries_actual_candidate_frames",
       "extension": "EXT_disjoint_timer_query_webgl2",
-      "extension_available": false,
-      "gpu_probe_ms": null
+      "extension_available": true,
+      "hardware_accelerated": true,
+      "samples_per_viewport": 30,
+      "discarded_disjoint_samples": 0,
+      "p95_ms": {
+        "1280x720": 1.357708,
+        "1440x900": 1.746875
+      },
+      "evidence": "artifacts/map-foundation/stage-26e/hardware-gpu-timing.json"
     },
     "memory": {
       "status": "pass_transport_normalized_buffers_and_live_route_heap_bounded",
@@ -154,7 +161,6 @@
     "production_route_cutover": {
       "status": "not_authorized",
       "blocking_gates": [
-        "gpu_timing",
         "region_redistribution_legal"
       ],
       "remaining_route_step": "deliberate live-route composition and regression run after blocking gates close"

--- a/artifacts/map-foundation/stage-26e/hardware-gpu-timing.json
+++ b/artifacts/map-foundation/stage-26e/hardware-gpu-timing.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": 1,
+  "stage": "26E",
+  "recorded_on": "2026-07-22",
+  "surface": "development-only isolated map-foundation harness",
+  "url": "http://127.0.0.1:4175/map-foundation/index.html?gpu-test=1",
+  "scene": {
+    "dataset_systems": 500000,
+    "rendered_background_systems": 25000,
+    "guaranteed_systems": 5,
+    "region_labels": 42,
+    "heatmap_cells": 16,
+    "aggregate_hulls": 3
+  },
+  "method": {
+    "api": "EXT_disjoint_timer_query_webgl2",
+    "operation": "timer query wrapped around WebGLRenderer.render(scene, camera)",
+    "samples_per_viewport": 30,
+    "warmup": "one preceding 30-sample run before the retained measurements",
+    "javascript_frame_time_used_as_gpu_time": false
+  },
+  "environment": {
+    "browser": "hardware-backed Chromium in the Codex in-app browser",
+    "renderer": "ANGLE (Intel, Intel(R) UHD Graphics (0x0000A78B) Direct3D11 vs_5_0 ps_5_0, D3D11)",
+    "hardware_accelerated": true,
+    "timer_extension_available": true
+  },
+  "measurements": [
+    {
+      "viewport": { "width": 1280, "height": 720 },
+      "requested_sample_count": 30,
+      "valid_sample_count": 30,
+      "discarded_disjoint_samples": 0,
+      "median_ms": 1.351354,
+      "p95_ms": 1.357708,
+      "max_ms": 1.357864
+    },
+    {
+      "viewport": { "width": 1440, "height": 900 },
+      "requested_sample_count": 30,
+      "valid_sample_count": 30,
+      "discarded_disjoint_samples": 0,
+      "median_ms": 1.287135,
+      "p95_ms": 1.746875,
+      "max_ms": 1.751249
+    }
+  ],
+  "provisional_frame_budget_ms": 50,
+  "status": "pass_gpu_timing_evidence_gate",
+  "limitations": [
+    "This is one Windows integrated-GPU environment, not a broad hardware guarantee.",
+    "The measurement closes the unknown-GPU-time evidence gap; it does not authorize production route cutover.",
+    "The production candidate remains default-off and production region geometry remains withheld pending rights review."
+  ]
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,8 +10,8 @@ document that should answer "what next?".
 - Status: Stage 25A through Stage 25H and Stage 26A through Stage 26D are
   complete. Stage 26E is in progress: browser, accessibility, visual,
   steady-state frame, default-off production parity, and live-route memory
-  gates are recorded, while GPU timing and region-data legal review still
-  block cutover.
+  gates are recorded, hardware GPU timing is now closed, and region-data legal
+  review is the remaining cutover blocker.
 - Local engineering posture: the repo-local Python 3.12 `.venv` path is now
   the canonical local test runner, Docker-backed disposable Postgres/Redis on
   `127.0.0.1:55432` / `127.0.0.1:6379` are validated by preflight, and the
@@ -302,9 +302,10 @@ competing roadmap source.
   journey at both required desktop viewports. Axe reports zero detectable WCAG
   2/2.1 A/AA violations, and the 1440x900 golden passes repeat comparison.
 - The 500,000-system steady-state Chromium p95 measured about 16.7-16.8 ms at
-  the required viewports. The WebGL GPU timer extension was unavailable, so GPU
-  time remains unknown. Normalized overlay buffers now pass a deterministic
-  8 MiB budget. The heatmap API now has a stable 50,000-cell ceiling and its
+  the required viewports. A hardware-backed Chromium rerun produced 30/30 valid
+  actual-render GPU timer queries at both viewports, with 1.358 ms and 1.747 ms
+  p95 and no disjoint samples. Normalized overlay buffers now pass a
+  deterministic 8 MiB budget. The heatmap API now has a stable 50,000-cell ceiling and its
   worst-case fixture passes a separate 8 MiB raw-response budget. A default-off
   `#map` composition with live payloads measured 26,392,356 and 28,724,676-byte
   Chromium heap maxima at the required viewports against a 256 MiB budget and
@@ -423,8 +424,8 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Continue Stage 26E by obtaining region-geometry/attribution review and real
-   GPU evidence before any deliberate route-flag activation or cutover.
+1. Continue Stage 26E by obtaining region-geometry coverage and attribution
+   review before any deliberate route-flag activation or cutover.
 2. Preserve production data-integrity receipts and the bounded rerating cadence.
 3. Complete dependency-aware documentation triage and historical archiving.
 4. Finish the archetype-scoring pivot and retire legacy score storage safely.

--- a/docs/colonisation-redesign/stage-26e-cutover-readiness.md
+++ b/docs/colonisation-redesign/stage-26e-cutover-readiness.md
@@ -63,8 +63,9 @@ a production budget.
 The raw transport, normalized overlay buffers, and default-off live-route heap
 are now all bounded. The live-route evidence supersedes the variable isolated
 fixture snapshots for the memory gate because it measures the actual route
-composition and live production-shaped payloads. It does not close GPU timing
-or authorize route cutover.
+composition and live production-shaped payloads. It does not by itself close
+GPU timing or authorize route cutover; the separate hardware-backed measurement
+below closes the GPU evidence gate.
 
 ## Closed Production Feature Parity
 
@@ -85,10 +86,22 @@ after the remaining blocking gates close.
 
 ### GPU timing
 
-Stage 26E now attempts a real WebGL2 `EXT_disjoint_timer_query_webgl2` query.
-The extension was unavailable in the measured Chromium environment, so GPU
-time remains explicitly unknown. JavaScript callback or request-animation-frame
-duration is not substituted.
+The initial automated Chromium environment did not expose
+`EXT_disjoint_timer_query_webgl2`. A hardware-backed Chromium rerun now wraps
+the real `WebGLRenderer.render(scene, camera)` call for the visible 500,000-
+system candidate scene. At 1280x720, 30/30 valid queries produced 1.358 ms p95;
+at 1440x900, 30/30 produced 1.747 ms p95. No samples were discarded as
+disjoint. The browser reported hardware-accelerated ANGLE/Direct3D 11 rather
+than a software rasterizer.
+
+This closes the unknown-GPU-time evidence gate without substituting JavaScript
+callback or request-animation-frame duration. The retained receipt is
+[`hardware-gpu-timing.json`](../../artifacts/map-foundation/stage-26e/hardware-gpu-timing.json).
+For a repeat measurement in normal Chrome, run `yarn map-foundation:dev` from
+`frontend/`, open
+`http://127.0.0.1:4175/map-foundation/index.html?gpu-test=1`, wait for `ready`,
+and select **Run GPU timing**. The diagnostic is development-only and does not
+change production route selection.
 
 ## Region Data And Legal Gate
 
@@ -137,8 +150,6 @@ route cannot cut over.
 
 ## Next Authorized Work
 
-Stage 26E may continue by rerunning GPU timing on an environment exposing the
-required extension or with a captured system trace, and by closing the
-remaining region-geometry and attribution questions. Route cutover and
-superseded-map deletion remain unauthorized until every blocking gate is
-recorded as closed.
+Stage 26E may continue by closing the remaining region-geometry coverage and
+attribution questions. Route cutover and superseded-map deletion remain
+unauthorized until that blocking gate is recorded as closed.

--- a/frontend/map-foundation/e2e/foundation.spec.ts
+++ b/frontend/map-foundation/e2e/foundation.spec.ts
@@ -96,6 +96,12 @@ for (const viewport of viewports) {
     expect(performance.frameP95Ms).toBeLessThan(50);
     expect(performance.frameMaxMs).toBeLessThan(100);
     if (performance.gpuTimerSupported) expect(performance.gpuProbeMs).not.toBeNull();
+    const gpuTiming = await page.evaluate(() => window.__stage26cFoundation!.measureGpuTiming(3));
+    expect(gpuTiming.requestedSampleCount).toBe(3);
+    if (gpuTiming.timerSupported) {
+      expect(gpuTiming.validSampleCount).toBeGreaterThan(0);
+      expect(gpuTiming.p95Ms).not.toBeNull();
+    }
     await test.info().attach('stage-26e-performance', {
       body: JSON.stringify(performance, null, 2),
       contentType: 'application/json',

--- a/frontend/map-foundation/style.css
+++ b/frontend/map-foundation/style.css
@@ -78,3 +78,12 @@ button:hover, button:focus-visible { border-color: #72c7ef; outline: none; }
 .foundation-companion button[aria-pressed="true"] { border-color: #ffb454; color: #ffcf91; }
 .foundation-companion ul { margin: 0; padding-left: 1.2rem; }
 .event-log code { color: #7dd9a7; }
+.gpu-diagnostics pre {
+  overflow-wrap: anywhere;
+  padding: 0.55rem;
+  color: #b8d7e8;
+  background: #05090e;
+  border: 1px solid #203847;
+  font-size: 0.65rem;
+  white-space: pre-wrap;
+}

--- a/frontend/map-foundation/workbench.tsx
+++ b/frontend/map-foundation/workbench.tsx
@@ -10,7 +10,11 @@ import {
 import { R3FMapFoundation } from '../src/features/map-foundation/R3FMapFoundation';
 import { createFoundationDemoScene } from '../src/features/map-foundation/demo-scene';
 import { applyFeatureHandoff, resolveMapInteraction } from '../src/features/map-foundation/feature-handoffs';
-import { measureFoundationPerformance } from '../src/features/map-foundation/performance';
+import {
+  measureFoundationPerformance,
+  type FoundationGpuTimer,
+  type FoundationGpuTimingMeasurement,
+} from '../src/features/map-foundation/performance';
 import {
   applyViewPreset,
   composeProductionParity,
@@ -105,7 +109,11 @@ export function MapFoundationWorkbench() {
   const [omittedHandoffSystemIds, setOmittedHandoffSystemIds] = useState<number[]>([]);
   const [visibility, setVisibility] = useState<VisibilityMetadata>(EMPTY_VISIBILITY);
   const [viewPreset, setViewPreset] = useState<MapViewPreset>('results');
+  const [gpuTiming, setGpuTiming] = useState<FoundationGpuTimingMeasurement | null>(null);
+  const [gpuTimingRunning, setGpuTimingRunning] = useState(false);
   const viewportRef = useRef<HTMLDivElement>(null);
+  const gpuTimerRef = useRef<FoundationGpuTimer | null>(null);
+  const gpuDiagnosticsEnabled = new URLSearchParams(window.location.search).get('gpu-test') === '1';
   const sceneRef = useRef(scene);
   sceneRef.current = scene;
   const contextStateRef = useRef(contextState);
@@ -281,6 +289,23 @@ export function MapFoundationWorkbench() {
     estimatedOverlayBufferBytes: productionParity.estimatedOverlayBufferBytes,
   }), [contextState, datasetSize, highlightIds.size, lastHostCommand, lastInteraction, omittedHandoffSystemIds, overlapCandidateIds, productionParity, ready, regions, scene, viewPreset, visibility]);
 
+  const onGpuTimerReady = useCallback((timer: FoundationGpuTimer | null) => {
+    gpuTimerRef.current = timer;
+  }, []);
+
+  const runGpuTiming = useCallback(async (sampleCount = 30) => {
+    const timer = gpuTimerRef.current;
+    if (!timer) throw new Error('Map foundation GPU timer is unavailable');
+    setGpuTimingRunning(true);
+    try {
+      const measurement = await timer(sampleCount);
+      setGpuTiming(measurement);
+      return measurement;
+    } finally {
+      setGpuTimingRunning(false);
+    }
+  }, []);
+
   useEffect(() => {
     window.__stage26cFoundation = {
       snapshot,
@@ -300,9 +325,10 @@ export function MapFoundationWorkbench() {
         setScene((current) => ({ ...current, camera: { ...current.camera } }));
         return measurement;
       },
+      measureGpuTiming: runGpuTiming,
     };
     return () => { delete window.__stage26cFoundation; };
-  }, [snapshot]);
+  }, [runGpuTiming, snapshot]);
 
   const chooseOverlap = (systemId64: number) => onInteraction({
     type: 'overlapChoice',
@@ -314,7 +340,7 @@ export function MapFoundationWorkbench() {
   return <main className="foundation-shell">
     <header className="foundation-header">
       <div>
-        <p className="eyebrow">Development-only · Stage 26D</p>
+        <p className="eyebrow">Development-only · Stage 26E</p>
         <h1>Typed feature hand-offs</h1>
       </div>
       <label>Dataset
@@ -383,11 +409,27 @@ export function MapFoundationWorkbench() {
       <div className="foundation-viewport" ref={viewportRef}>
         <R3FMapFoundation scene={scene} regions={regionVisible ? regions : EMPTY_REGIONS}
           productionOverlays={productionParity.overlays} viewport={viewport}
-          onReady={() => setReady(true)} onInteraction={onInteraction} onVisibilityChange={setVisibility} />
+          onReady={() => setReady(true)} onInteraction={onInteraction} onVisibilityChange={setVisibility}
+          onGpuTimerReady={onGpuTimerReady} />
       </div>
       <aside className="foundation-companion" aria-label="Map keyboard companion">
         <h2>Context companion</h2>
         <p>Tab to any system and press Enter. Shift-drag rotates/tilts; drag pans; wheel zooms.</p>
+        {gpuDiagnosticsEnabled && <section className="gpu-diagnostics" aria-labelledby="gpu-diagnostics-heading">
+          <h3 id="gpu-diagnostics-heading">Hardware GPU timing</h3>
+          <p>Runs 30 WebGL timer queries around real renders of the visible 500k candidate scene.</p>
+          <button type="button" disabled={gpuTimingRunning || !ready} onClick={() => { void runGpuTiming(); }}>
+            {gpuTimingRunning ? 'Measuring GPU…' : 'Run GPU timing'}
+          </button>
+          {gpuTiming && <>
+            <p role="status" data-testid="gpu-timing-summary">
+              {gpuTiming.timerSupported
+                ? `${gpuTiming.validSampleCount}/${gpuTiming.requestedSampleCount} valid · p95 ${gpuTiming.p95Ms?.toFixed(3) ?? 'unknown'} ms`
+                : 'Timer extension unavailable; use a Chrome system trace.'}
+            </p>
+            <pre data-testid="gpu-timing-json">{JSON.stringify(gpuTiming, null, 2)}</pre>
+          </>}
+        </section>}
         {overlapCandidateIds.length > 0 && <section data-testid="overlap-choices">
           <h3>Choose overlapping system</h3>
           {overlapCandidateIds.map((id) => <button type="button" key={id} onClick={() => chooseOverlap(id)}>

--- a/frontend/src/features/map-foundation/R3FMapFoundation.tsx
+++ b/frontend/src/features/map-foundation/R3FMapFoundation.tsx
@@ -8,6 +8,7 @@ import type {
 } from '../../../../artifacts/map-foundation/stage-26b/map-scene-contract';
 import { toThreeJSR3F } from '../../../../artifacts/map-foundation/stage-26b/map-renderer-adapter';
 import type { FoundationRendererProps, ProjectedLabel } from './types';
+import { measureRendererGpuTiming } from './performance';
 import {
   buildClusterGeometry,
   clusterAnchorIdForSystem,
@@ -44,6 +45,16 @@ function CameraProjection({ cameraState }: { cameraState: CameraState }) {
     orthographic.updateProjectionMatrix();
     invalidate();
   }, [camera, cameraState, invalidate, size]);
+  return null;
+}
+
+function GpuTimingBridge({ onReady }: { onReady: FoundationRendererProps['onGpuTimerReady'] }) {
+  const { camera, gl, scene } = useThree();
+  useEffect(() => {
+    if (!onReady) return undefined;
+    onReady((sampleCount) => measureRendererGpuTiming(gl, scene, camera, sampleCount));
+    return () => onReady(null);
+  }, [camera, gl, onReady, scene]);
   return null;
 }
 
@@ -229,6 +240,7 @@ export function R3FMapFoundation(props: FoundationRendererProps) {
         props.onReady?.();
       }}>
       <color attach="background" args={['#05090e']} />
+      <GpuTimingBridge onReady={props.onGpuTimerReady} />
       <SceneContents {...props} visible={visible} />
     </Canvas>
     <div className="map-foundation-labels" aria-hidden="true">

--- a/frontend/src/features/map-foundation/performance.ts
+++ b/frontend/src/features/map-foundation/performance.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 export type FoundationPerformanceMeasurement = {
   frameSampleCount: number;
   frameP95Ms: number;
@@ -6,6 +8,23 @@ export type FoundationPerformanceMeasurement = {
   gpuProbeMs: number | null;
   jsHeapBytes: number | null;
 };
+
+export type FoundationGpuTimingMeasurement = {
+  method: 'EXT_disjoint_timer_query_webgl2';
+  timerSupported: boolean;
+  requestedSampleCount: number;
+  validSampleCount: number;
+  discardedDisjointSamples: number;
+  medianMs: number | null;
+  p95Ms: number | null;
+  maxMs: number | null;
+  renderer: string | null;
+  hardwareAccelerated: boolean | null;
+};
+
+export type FoundationGpuTimer = (
+  sampleCount?: number,
+) => Promise<FoundationGpuTimingMeasurement>;
 
 type TimerQueryExtension = {
   TIME_ELAPSED_EXT: number;
@@ -16,6 +35,89 @@ function percentile(values: number[], fraction: number): number {
   if (values.length === 0) return 0;
   const ordered = [...values].sort((left, right) => left - right);
   return ordered[Math.min(ordered.length - 1, Math.floor(ordered.length * fraction))] ?? 0;
+}
+
+function rendererLooksHardwareAccelerated(renderer: string | null): boolean | null {
+  if (!renderer) return null;
+  return !/(swiftshader|llvmpipe|software rasterizer)/i.test(renderer);
+}
+
+async function readTimerQuery(
+  gl: WebGL2RenderingContext,
+  extension: TimerQueryExtension,
+  query: WebGLQuery,
+): Promise<{ milliseconds: number | null; disjoint: boolean }> {
+  gl.flush();
+  for (let attempt = 0; attempt < 180; attempt += 1) {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    const available = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE) as boolean;
+    const disjoint = gl.getParameter(extension.GPU_DISJOINT_EXT) as boolean;
+    if (available) {
+      const nanoseconds = gl.getQueryParameter(query, gl.QUERY_RESULT) as number;
+      return {
+        milliseconds: !disjoint && Number.isFinite(nanoseconds) ? nanoseconds / 1_000_000 : null,
+        disjoint,
+      };
+    }
+  }
+  return { milliseconds: null, disjoint: false };
+}
+
+export async function measureRendererGpuTiming(
+  renderer: THREE.WebGLRenderer,
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  requestedSampleCount = 30,
+): Promise<FoundationGpuTimingMeasurement> {
+  const gl = renderer.getContext() as WebGL2RenderingContext;
+  const extension = gl.getExtension('EXT_disjoint_timer_query_webgl2') as TimerQueryExtension | null;
+  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+  const rendererName = debugInfo
+    ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) as string
+    : gl.getParameter(gl.RENDERER) as string | null;
+  const base = {
+    method: 'EXT_disjoint_timer_query_webgl2' as const,
+    requestedSampleCount,
+    renderer: rendererName,
+    hardwareAccelerated: rendererLooksHardwareAccelerated(rendererName),
+  };
+  if (!extension) {
+    return {
+      ...base,
+      timerSupported: false,
+      validSampleCount: 0,
+      discardedDisjointSamples: 0,
+      medianMs: null,
+      p95Ms: null,
+      maxMs: null,
+    };
+  }
+
+  const samples: number[] = [];
+  let discardedDisjointSamples = 0;
+  for (let index = 0; index < requestedSampleCount; index += 1) {
+    const query = gl.createQuery();
+    if (!query) break;
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    gl.beginQuery(extension.TIME_ELAPSED_EXT, query);
+    renderer.render(scene, camera);
+    gl.endQuery(extension.TIME_ELAPSED_EXT);
+    const result = await readTimerQuery(gl, extension, query);
+    gl.deleteQuery(query);
+    if (result.disjoint) discardedDisjointSamples += 1;
+    if (result.milliseconds != null) samples.push(result.milliseconds);
+    if (result.milliseconds == null && !result.disjoint) break;
+  }
+
+  return {
+    ...base,
+    timerSupported: true,
+    validSampleCount: samples.length,
+    discardedDisjointSamples,
+    medianMs: samples.length > 0 ? percentile(samples, 0.5) : null,
+    p95Ms: samples.length > 0 ? percentile(samples, 0.95) : null,
+    maxMs: samples.length > 0 ? Math.max(...samples) : null,
+  };
 }
 
 async function sampleFrames(sampleCount: number): Promise<number[]> {

--- a/frontend/src/features/map-foundation/types.ts
+++ b/frontend/src/features/map-foundation/types.ts
@@ -7,7 +7,10 @@ import type {
   MapSceneState,
   SystemRecord,
 } from '../../../../artifacts/map-foundation/stage-26b/map-scene-contract';
-import type { FoundationPerformanceMeasurement } from './performance';
+import type {
+  FoundationGpuTimer,
+  FoundationPerformanceMeasurement,
+} from './performance';
 
 export type RegionLabel = {
   id: number;
@@ -95,6 +98,7 @@ export type FoundationRendererProps = {
   onInteraction: (event: MapInteractionEvent) => void;
   onVisibilityChange?: (metadata: VisibilityMetadata) => void;
   onReady?: () => void;
+  onGpuTimerReady?: (timer: FoundationGpuTimer | null) => void;
 };
 
 export type ClusterGeometry = {
@@ -113,6 +117,7 @@ declare global {
     snapshot: () => FoundationSnapshot;
     loseContext: () => boolean;
     measurePerformance: () => Promise<FoundationPerformanceMeasurement>;
+    measureGpuTiming: FoundationGpuTimer;
     };
   }
 }


### PR DESCRIPTION
## What changed

- add a development-only `?gpu-test=1` control that runs WebGL2 timer queries around the real R3F `WebGLRenderer.render(scene, camera)` call
- record 30/30 valid hardware-backed samples at 1280x720 and 1440x900, with no disjoint samples
- close the GPU evidence gate in the Stage 26E ledger and progress documentation
- keep the production candidate default-off and region geometry withheld

## Why

The automated Playwright environment did not expose `EXT_disjoint_timer_query_webgl2`, so GPU duration remained unknown. The new diagnostic can be run in normal hardware-backed Chrome and reports copyable structured evidence without substituting JavaScript frame timing.

## Validation

- `yarn map-foundation:typecheck`
- `yarn map-foundation:lint`
- `yarn map-foundation:test` (26 passed)
- `yarn map-foundation:build`
- `yarn map-foundation:e2e` (1440x900 passed; 1280x720 hit the existing 30-second preset-switch timeout, then passed on isolated rerun)
- JSON evidence parse validation
- manual hardware-backed Chromium runs at both required viewports

## Remaining gate

Production cutover is still not authorized. Region-geometry coverage and required attribution remain the sole blocking gate.