### PR TITLE
Add bounded Stage 26E production regions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,31 @@ lives at ed-finder.app (Hetzner/Docker). See `README.md` for deployment.
 
 ---
 
+## 2026-07-22 - Stage 26E production region delivery and cutover regression
+
+**The default-off production candidate now carries authoritative regions** -
+The exact `VITE_STAGE26E_PRODUCTION_MAP=enabled` build emits a bounded static
+`stage26e/authoritative-regions.json` asset generated from the pinned 2,048-row
+RLE source. The client accepts exactly 42 unique region labels, caps continuous
+boundaries at 25,000, validates every finite endpoint, and rejects responses
+larger than 4 MiB. The measured asset is 2,312,898 bytes with 22,595 boundaries
+and 542,280 typed position bytes. Normal unflagged builds omit the asset.
+
+**The final default-off regression is green** - The live candidate passes both
+required viewports with 500 Finder systems, 50,000 heatmap cells, 2,000 hulls,
+100 timeline points, and the full region layer visible. Retained Chromium heap
+maxima were 30,353,992 and 27,463,288 bytes against 268,435,456 bytes, with zero
+detectable Axe violations. Thirty-one focused tests, both retained Chromium
+journeys, all six Chromium/Firefox/WebKit viewport cells, the dedicated Axe
+journey, the visual golden, TypeScript, lint, and normal/flagged builds pass.
+
+**The next step is activation, not more foundation work** - All recorded
+blocking gates are closed. The candidate remains default-off in this change;
+the next bounded change may activate it in the production build, deploy and
+smoke-check the public `#map`, and retain the established renderer as an
+immediate flag-based rollback. Superseded-map removal remains later and
+explicit.
+
 ## 2026-07-22 - Stage 26E continuous region boundaries and owner review
 
 **Region dividers now read as boundaries instead of dashes** - Replaced the

--- a/artifacts/map-foundation/stage-26e/README.md
+++ b/artifacts/map-foundation/stage-26e/README.md
@@ -17,9 +17,14 @@ claiming production cutover readiness.
   bound, and the closed live-route heap budget.
 - `live-route-memory.json` records the exact default-off `#map` candidate at
   both required viewports with 500 live Finder systems, 50,000 heatmap cells,
-  2,000 aggregate hulls, and 100 timeline points. Chromium CDP heap maxima were
-  26,392,356 and 28,724,676 bytes against a 256 MiB budget; Axe reported zero
-  detectable WCAG 2/2.1 A/AA violations on both composed-route viewports.
+  2,000 aggregate hulls, 100 timeline points, 42 region labels, and 22,595
+  continuous region boundaries. Chromium CDP heap maxima were 30,353,992 and
+  27,463,288 bytes against a 256 MiB budget; Axe reported zero detectable WCAG
+  2/2.1 A/AA violations on both composed-route viewports.
+- `production-region-geometry.json` records the build-only delivery contract:
+  a 2,312,898-byte static asset against a 4 MiB response budget, exact label
+  and boundary limits, client validation, and confirmed omission from the
+  normal unflagged production build.
 - `heatmap-response-envelope.json` records the server-side 50,000-cell ceiling,
   stable density-first ordering, truncation contract, and compact JSON budget.
 - `region-source-review.json` records the exact local/upstream RLE comparison
@@ -33,7 +38,7 @@ claiming production cutover readiness.
 The earlier automated Chromium environment did not expose the timer extension.
 The hardware-backed rerun closes that evidence gap using real
 `WebGLRenderer.render(scene, camera)` timer queries rather than JavaScript frame
-callbacks. Region-data provenance, attribution, and the owner-review gate are
-now closed. The candidate remains behind an exact default-off production flag;
-bounded region delivery and the full cutover regression are the remaining
-route work.
+callbacks. Region-data provenance, attribution, owner review, bounded delivery,
+and the full default-off regression are now closed. The candidate remains
+behind an exact default-off production flag; explicit activation, deployment,
+and public smoke/rollback verification are the remaining route work.

--- a/artifacts/map-foundation/stage-26e/cutover-gates.json
+++ b/artifacts/map-foundation/stage-26e/cutover-gates.json
@@ -91,17 +91,20 @@
         "status": "pass",
         "route": "#map",
         "activation": "measurement build only; normal production flag remains unset",
-        "data_source": "live ED-Finder API payloads fulfilled unchanged into the measured route",
+        "data_source": "live ED-Finder API payloads plus the bounded build-emitted authoritative region asset, fulfilled unchanged into the measured route",
         "budget_bytes": 268435456,
         "chromium_cdp_js_heap_used_size_max_bytes": {
-          "1280x720": 26392356,
-          "1440x900": 28724676
+          "1280x720": 30353992,
+          "1440x900": 27463288
         },
         "finder_systems": 500,
         "heatmap_cells": 50000,
         "aggregate_hulls": 2000,
         "timeline_points": 100,
-        "region_geometry_exposed": false,
+        "region_geometry_exposed": true,
+        "region_labels": 42,
+        "region_boundary_segments": 22595,
+        "region_position_bytes": 542280,
         "evidence": "artifacts/map-foundation/stage-26e/live-route-memory.json"
       },
       "remaining": null
@@ -119,10 +122,13 @@
         "live aggregate cluster hulls",
         "timeline summary and bucket state",
         "Results, Galaxy, and Reference view presets",
+        "bounded authoritative region labels and continuous boundaries",
         "typed production error and empty-state composition"
       ],
       "normalized_overlay_buffer_test": "pass at 4272000 bytes against an 8388608-byte budget",
-      "live_route_wiring": "pass behind exact VITE_STAGE26E_PRODUCTION_MAP=enabled flag; normal production value remains unset"
+      "region_asset": "pass at 2312898 bytes, 42 labels, and 22595 boundaries against a 4194304-byte response budget",
+      "live_route_wiring": "pass behind exact VITE_STAGE26E_PRODUCTION_MAP=enabled flag with the region asset emitted only in flagged builds; normal production value remains unset and omits the asset",
+      "full_regression": "31 focused unit tests, two retained Chromium journeys, six Chromium/Firefox/WebKit viewport cells, Axe, visual golden, and two live-route viewport measurements pass"
     },
     "region_redistribution_legal": {
       "status": "pass_owner_reviewed_frontier_noncommercial_media_guidance_and_mit_provenance",
@@ -159,9 +165,9 @@
       "required_decisions": []
     },
     "production_route_cutover": {
-      "status": "ready_for_deliberate_cutover_regression",
+      "status": "ready_for_deliberate_activation_decision",
       "blocking_gates": [],
-      "remaining_route_step": "serve and wire bounded region geometry into the default-off production candidate, run the full regression matrix, then make a deliberate activation decision"
+      "remaining_route_step": "make the explicit production flag activation and deployment decision, smoke-check the public route, and retain the established renderer as an immediate flag-based rollback"
     }
   }
 }

--- a/artifacts/map-foundation/stage-26e/live-route-memory.json
+++ b/artifacts/map-foundation/stage-26e/live-route-memory.json
@@ -5,10 +5,10 @@
   "route": "#map",
   "renderer": "r3f",
   "activation": "measurement build only; normal production flag remains unset",
-  "data_source": "live ED-Finder API payloads fetched through the Vite preview proxy and fulfilled unchanged into the measured route",
+  "data_source": "live ED-Finder API payloads plus the bounded build-emitted authoritative region asset, fulfilled unchanged into the measured route",
   "collection_method": "Chromium CDP Performance.getMetrics JSHeapUsedSize after a one-second idle; garbage collection not forced",
   "accessibility_standard": "WCAG 2 A/AA and WCAG 2.1 A/AA detectable rules",
-  "region_geometry_exposed": false,
+  "region_geometry_exposed": true,
   "budget_bytes": 268435456,
   "measurements": [
     {
@@ -17,6 +17,7 @@
         "height": 720
       },
       "finderResponseStatus": 200,
+      "regionGeometryResponseStatus": 200,
       "heatmapResponseStatus": 200,
       "clusterResponseStatus": 200,
       "timelineResponseStatus": 200,
@@ -26,16 +27,16 @@
         "budgetBytes": 268435456,
         "sampleCount": 7,
         "samplesBytes": [
-          17604348,
-          17604348,
-          17604348,
-          17604348,
-          17604348,
-          17604348,
-          17604348
+          9994104,
+          9994104,
+          9994104,
+          9994104,
+          9994104,
+          9994104,
+          9994104
         ],
-        "minBytes": 17604348,
-        "maxBytes": 17604348,
+        "minBytes": 9994104,
+        "maxBytes": 9994104,
         "spreadBytes": 0,
         "withinBudget": true
       },
@@ -44,16 +45,16 @@
         "budgetBytes": 268435456,
         "sampleCount": 7,
         "samplesBytes": [
-          26392356,
-          26392356,
-          26392356,
-          26392356,
-          26392356,
-          26392356,
-          26392356
+          30353992,
+          30353992,
+          30353992,
+          30353992,
+          30353992,
+          30353992,
+          30353992
         ],
-        "minBytes": 26392356,
-        "maxBytes": 26392356,
+        "minBytes": 30353992,
+        "maxBytes": 30353992,
         "spreadBytes": 0,
         "withinBudget": true
       },
@@ -69,11 +70,16 @@
         "timelinePointCount": 100,
         "estimatedOverlayBufferBytes": 4272000,
         "overlayBufferWithinBudget": true,
-        "regionGeometryExposed": false,
+        "regionGeometryExposed": true,
+        "regionGeometryVisible": true,
+        "regionLabelCount": 42,
+        "regionBoundaryCount": 22595,
+        "regionPositionBytes": 542280,
         "heapBudgetBytes": 268435456
       },
       "requestedApiPaths": [
         "/api/local/search",
+        "/stage26e/authoritative-regions.json",
         "/api/map/heatmap?max_cells=50000",
         "/api/map/clusters/hulls?max_hulls=2000",
         "/api/map/timeline?bucket=month"
@@ -85,6 +91,7 @@
         "height": 900
       },
       "finderResponseStatus": 200,
+      "regionGeometryResponseStatus": 200,
       "heatmapResponseStatus": 200,
       "clusterResponseStatus": 200,
       "timelineResponseStatus": 200,
@@ -94,16 +101,16 @@
         "budgetBytes": 268435456,
         "sampleCount": 7,
         "samplesBytes": [
-          17549428,
-          17549428,
-          17549428,
-          17549428,
-          17549428,
-          17549428,
-          17549428
+          27463288,
+          27463288,
+          27463288,
+          27463288,
+          27463288,
+          27463288,
+          27463288
         ],
-        "minBytes": 17549428,
-        "maxBytes": 17549428,
+        "minBytes": 27463288,
+        "maxBytes": 27463288,
         "spreadBytes": 0,
         "withinBudget": true
       },
@@ -112,16 +119,16 @@
         "budgetBytes": 268435456,
         "sampleCount": 7,
         "samplesBytes": [
-          28724676,
-          28724676,
-          28724676,
-          28724676,
-          28724676,
-          28724676,
-          28724676
+          19762112,
+          19762112,
+          19762112,
+          19762112,
+          19762112,
+          19762112,
+          19762112
         ],
-        "minBytes": 28724676,
-        "maxBytes": 28724676,
+        "minBytes": 19762112,
+        "maxBytes": 19762112,
         "spreadBytes": 0,
         "withinBudget": true
       },
@@ -137,11 +144,16 @@
         "timelinePointCount": 100,
         "estimatedOverlayBufferBytes": 4272000,
         "overlayBufferWithinBudget": true,
-        "regionGeometryExposed": false,
+        "regionGeometryExposed": true,
+        "regionGeometryVisible": true,
+        "regionLabelCount": 42,
+        "regionBoundaryCount": 22595,
+        "regionPositionBytes": 542280,
         "heapBudgetBytes": 268435456
       },
       "requestedApiPaths": [
         "/api/local/search",
+        "/stage26e/authoritative-regions.json",
         "/api/map/heatmap?max_cells=50000",
         "/api/map/clusters/hulls?max_hulls=2000",
         "/api/map/timeline?bucket=month"

--- a/artifacts/map-foundation/stage-26e/production-memory-budget.json
+++ b/artifacts/map-foundation/stage-26e/production-memory-budget.json
@@ -38,13 +38,16 @@
     "heatmap_cells": 50000,
     "aggregate_hulls": 2000,
     "timeline_points": 100,
+    "region_labels": 42,
+    "region_boundary_segments": 22595,
+    "region_position_bytes": 542280,
     "budget_bytes": 268435456,
     "chromium_cdp_js_heap_used_size_max_bytes": {
-      "1280x720": 26392356,
-      "1440x900": 28724676
+      "1280x720": 30353992,
+      "1440x900": 27463288
     },
     "collection_method": "Performance.getMetrics after a one-second idle; garbage collection not forced",
-    "region_geometry_exposed": false
+    "region_geometry_exposed": true
   },
   "open_requirements": []
 }

--- a/artifacts/map-foundation/stage-26e/production-region-geometry.json
+++ b/artifacts/map-foundation/stage-26e/production-region-geometry.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "stage": "26E",
+  "recorded_on": "2026-07-22",
+  "status": "pass",
+  "source": {
+    "path": "apps/importer/src/data/region_map.json",
+    "format": "2048-row run-length encoded authoritative region grid",
+    "bytes": 234820
+  },
+  "delivery": {
+    "path": "stage26e/authoritative-regions.json",
+    "mechanism": "Vite build-emitted static asset",
+    "activation": "emitted only when VITE_STAGE26E_PRODUCTION_MAP=enabled",
+    "normal_build_asset_present": false,
+    "response_bytes": 2312898,
+    "response_budget_bytes": 4194304,
+    "within_response_budget": true
+  },
+  "geometry": {
+    "region_labels": 42,
+    "unique_region_ids": 42,
+    "boundary_segments": 22595,
+    "boundary_segment_limit": 25000,
+    "position_bytes": 542280
+  },
+  "client_guards": [
+    "HTTP success required",
+    "response byte budget enforced before JSON parsing",
+    "exactly 42 unique finite labels required",
+    "boundary count capped at 25000",
+    "all boundary endpoints must be finite three-number coordinates"
+  ],
+  "live_route_evidence": "artifacts/map-foundation/stage-26e/live-route-memory.json"
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,8 @@ document that should answer "what next?".
   steady-state frame, default-off production parity, and live-route memory
   gates are recorded; hardware GPU timing and the owner-reviewed region-data
   gate are closed. Bounded region delivery and the full default-off regression
-  remain before a deliberate cutover decision.
+  now pass; explicit production activation and smoke/rollback verification are
+  the remaining steps before the new map becomes the app default.
 - Local engineering posture: the repo-local Python 3.12 `.venv` path is now
   the canonical local test runner, Docker-backed disposable Postgres/Redis on
   `127.0.0.1:55432` / `127.0.0.1:6379` are validated by preflight, and the
@@ -309,11 +310,13 @@ competing roadmap source.
   18.982 ms and 27.243 ms p95 and no disjoint samples. Normalized overlay buffers pass a
   deterministic 8 MiB budget. The heatmap API now has a stable 50,000-cell ceiling and its
   worst-case fixture passes a separate 8 MiB raw-response budget. A default-off
-  `#map` composition with live payloads measured 26,392,356 and 28,724,676-byte
-  Chromium heap maxima at the required viewports against a 256 MiB budget and
-  passed Axe at both viewports with zero detectable violations.
-- The isolated candidate now carries live heatmap cells, aggregate cluster
-  hulls, timeline state, view presets, and typed ready/empty/error composition.
+  `#map` composition with live payloads plus 42 region labels and 22,595
+  continuous boundaries measured 30,353,992 and 27,463,288-byte Chromium heap
+  maxima at the required viewports against a 256 MiB budget and passed Axe at
+  both viewports with zero detectable violations.
+- The candidate now carries live heatmap cells, aggregate cluster hulls,
+  timeline state, view presets, 42 authoritative region labels, 22,595
+  continuous boundaries, and typed ready/empty/error composition.
   The live route composition now exists only behind the exact
   `VITE_STAGE26E_PRODUCTION_MAP=enabled` measurement flag; normal production
   builds leave it unset and keep the established renderer.
@@ -324,8 +327,10 @@ competing roadmap source.
   official long-form attribution is site-wide. This closes the internal gate
   as an owner governance decision, not independent legal advice. Donations are
   outside the current implementation and are not relied on by the review. The
-  live map route remains unchanged until bounded region delivery and the final
-  regression pass. See
+  flagged candidate emits a guarded 2,312,898-byte static region asset; normal
+  builds omit it. The retained interaction, three-browser, accessibility,
+  visual, and live-route regressions all pass. The live map route remains
+  unchanged only until the explicit activation/deployment step. See
   [`stage-26e-cutover-readiness.md`](./colonisation-redesign/stage-26e-cutover-readiness.md).
 - ED Astro's 134-file, roughly 335.58 GiB published catalogue is inventoried
   without opening a bulk-ingest lane. Nebula coordinates and combined POIs are
@@ -434,9 +439,9 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Continue Stage 26E by serving bounded region geometry to the default-off
-   production candidate and running the full regression matrix before any
-   deliberate route-flag activation or cutover.
+1. Continue Stage 26E with the deliberate production route-flag activation,
+   deploy and smoke-check the new app map, and retain the established renderer
+   as an immediate flag-based rollback until the candidate has a stable period.
 2. Preserve production data-integrity receipts and the bounded rerating cadence.
 3. Complete dependency-aware documentation triage and historical archiving.
 4. Finish the archetype-scoring pivot and retire legacy score storage safely.

--- a/docs/colonisation-redesign/stage-26e-cutover-readiness.md
+++ b/docs/colonisation-redesign/stage-26e-cutover-readiness.md
@@ -6,9 +6,11 @@ Stage 26E is in progress. The isolated production-candidate foundation now has
 measured desktop-browser, viewport, accessibility, visual-regression, and
 steady-state frame evidence. Its isolated boundary now carries the remaining
 production feature shapes, continuous authoritative region boundaries, and a
-closed owner-reviewed region-data gate. The live `#map` route is unchanged
-while bounded region delivery and the final default-off regression remain.
-This document is a progress checkpoint, not a completion or shipping claim.
+closed owner-reviewed region-data gate. The same bounded region layer is now
+wired into the default-off production `#map` candidate and the full regression
+passes. Normal production still selects the established map until an explicit
+activation/deployment decision. This document is a progress checkpoint, not a
+shipping claim.
 
 The machine-readable source of truth is
 [`cutover-gates.json`](../../artifacts/map-foundation/stage-26e/cutover-gates.json).
@@ -35,10 +37,20 @@ The machine-readable source of truth is
   `VITE_STAGE26E_PRODUCTION_MAP=enabled` measurement flag. Normal builds leave
   the value unset and continue to select the established map.
 - With 500 live Finder systems, 50,000 heatmap cells, 2,000 aggregate hulls,
-  and 100 timeline points, Chromium CDP reported composed-route heap maxima of
-  26,392,356 bytes at 1280x720 and 28,724,676 bytes at 1440x900. Both pass the
-  predeclared 256 MiB live-route budget. Region geometry was not requested or
-  exposed.
+  100 timeline points, 42 region labels, and 22,595 continuous boundary
+  segments, Chromium CDP reported composed-route heap maxima of 30,353,992
+  bytes at 1280x720 and 27,463,288 bytes at 1440x900. Both pass the predeclared
+  256 MiB live-route budget. The build-emitted region response is 2,312,898
+  bytes against a separate 4 MiB guard, and its typed positions occupy 542,280
+  bytes.
+- The retained interaction journey passes at both viewports; the compatibility
+  matrix passes all six Chromium/Firefox/WebKit viewport cells; the dedicated
+  Axe journey and 1440x900 visual golden also pass. The exact live-route
+  candidate passes both viewports with zero detectable Axe violations.
+- A normal `yarn build:typecheck` omits
+  `stage26e/authoritative-regions.json`; the asset is emitted only by the exact
+  flagged candidate build. This preserves the established renderer and a
+  build-time rollback boundary until activation.
 
 These are local Windows/Playwright readings. They do not imply a broad hardware
 performance guarantee.
@@ -74,14 +86,15 @@ The isolated typed boundary now supports Finder systems, selected-system
 context, compare and exact cluster highlights, overlap choice, camera return
 state, explicit Planner hand-off, live heatmap response shapes, aggregate
 cluster hulls, timeline summary/bucket state, Results/Galaxy/Reference presets,
-and typed ready/empty/error composition. Invalid overlay coordinates are
-omitted rather than invented, and the large-result preset calculation is
-iterative rather than spreading an unbounded result array onto the call stack.
+bounded authoritative region labels and continuous boundaries, and typed
+ready/empty/error composition. Invalid overlay coordinates are omitted rather
+than invented, and the large-result preset calculation is iterative rather
+than spreading an unbounded result array onto the call stack.
 
-This closes the feature-parity adapter and disabled live-route composition
-gates. The established renderer remains selected in normal production builds;
-deliberate flag activation and superseded-map removal remain final route steps
-after the remaining blocking gates close.
+This closes the feature-parity adapter, bounded region delivery, and disabled
+live-route regression gates. The established renderer remains selected in
+normal production builds; deliberate flag activation/deployment is now the
+next route step, while superseded-map removal remains later and explicit.
 
 ## Closed GPU Evidence
 
@@ -159,10 +172,11 @@ not treated as formal permission.
 
 ## Next Authorized Work
 
-Stage 26E may now serve and wire bounded region geometry into the default-off
-production candidate, repeat the full regression matrix, and then make a
-deliberate activation decision. The established route remains selected until
-that work passes; superseded-map deletion remains a later, explicit step.
+Stage 26E is ready for the deliberate activation decision. The next bounded
+change may set `VITE_STAGE26E_PRODUCTION_MAP=enabled` in the production build,
+deploy the candidate as the app's real `#map`, smoke-check the public route,
+and retain the established renderer as an immediate flag-based rollback.
+Superseded-map deletion remains a later, explicit step after a stable period.
 
 The supplied Raven Colonial reference identifies a useful post-cutover visual
 follow-up: an explicit 2D/3D control, a restrained oblique tabletop preset,

--- a/frontend/src/features/map-foundation/ProductionMapTab.test.tsx
+++ b/frontend/src/features/map-foundation/ProductionMapTab.test.tsx
@@ -2,18 +2,23 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProductionMapTab } from './ProductionMapTab';
 import { useMapLayers } from '@/features/map/useMapLayers';
+import { useAuthoritativeRegionLayer } from './production-regions';
 import type { SystemResult } from '@/types/api';
 
 vi.mock('@/features/map/useMapLayers');
+vi.mock('./production-regions');
 vi.mock('./R3FMapFoundation', () => ({
-  R3FMapFoundation: ({ scene, productionOverlays, onInteraction }: {
+  R3FMapFoundation: ({ scene, regions, productionOverlays, onInteraction }: {
     scene: { systems: Array<{ id64: number }> };
+    regions: { labels: unknown[]; boundaries: unknown[] };
     productionOverlays: { heatmap: { cellCount: number } | null; aggregateHulls: { hullCount: number } | null };
     onInteraction: (event: { type: 'selectSystem'; systemId64: number; clusterAnchorId64: null }) => void;
   }) => (
     <div
       data-testid="r3f-production-renderer"
       data-system-count={scene.systems.length}
+      data-region-label-count={regions.labels.length}
+      data-region-boundary-count={regions.boundaries.length}
       data-heatmap-count={productionOverlays.heatmap?.cellCount ?? 0}
       data-hull-count={productionOverlays.aggregateHulls?.hullCount ?? 0}
     >
@@ -71,6 +76,20 @@ const layers = {
   isError: false,
 } as ReturnType<typeof useMapLayers>;
 
+const regionLayer = {
+  data: {
+    labels: Array.from({ length: 42 }, (_, index) => ({
+      id: index + 1,
+      name: `Region ${index + 1}`,
+      position: [index, index, 0] as [number, number, number],
+    })),
+    boundaries: [{ source: [0, 0, 0] as [number, number, number], target: [1, 1, 0] as [number, number, number] }],
+  },
+  isLoading: false,
+  isError: false,
+  error: null,
+} as ReturnType<typeof useAuthoritativeRegionLayer>;
+
 function system(index: number): SystemResult {
   return {
     id64: index + 1,
@@ -83,6 +102,7 @@ function system(index: number): SystemResult {
 
 beforeEach(() => {
   vi.mocked(useMapLayers).mockReturnValue(layers);
+  vi.mocked(useAuthoritativeRegionLayer).mockReturnValue(regionLayer);
 });
 
 afterEach(() => {
@@ -90,14 +110,15 @@ afterEach(() => {
 });
 
 describe('Stage 26E production route composition', () => {
-  it('bounds Finder systems, withholds region geometry, and composes enabled live overlays', () => {
+  it('bounds Finder systems and composes authoritative regions plus enabled live overlays', () => {
     render(<ProductionMapTab systems={Array.from({ length: 510 }, (_, index) => system(index))} reference={{ name: 'Sol', x: 0, z: 0 }} />);
 
     expect(screen.getByTestId('stage26e-route-flag-state').textContent).toContain('Explicit route flag enabled');
-    expect(screen.getByText('Regions withheld')).toBeTruthy();
-    expect((screen.getByText('Regions withheld').querySelector('input') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByTestId('stage26e-map-regions-toggle') as HTMLInputElement).checked).toBe(true);
     const renderer = screen.getByTestId('r3f-production-renderer');
     expect(renderer.getAttribute('data-system-count')).toBe('500');
+    expect(renderer.getAttribute('data-region-label-count')).toBe('42');
+    expect(renderer.getAttribute('data-region-boundary-count')).toBe('1');
     expect(renderer.getAttribute('data-heatmap-count')).toBe('0');
     expect(renderer.getAttribute('data-hull-count')).toBe('0');
 
@@ -116,9 +137,17 @@ describe('Stage 26E production route composition', () => {
       heatmapCellCount: 1,
       aggregateHullCount: 1,
       timelinePointCount: 1,
-      regionGeometryExposed: false,
+      regionGeometryExposed: true,
+      regionGeometryVisible: true,
+      regionLabelCount: 42,
+      regionBoundaryCount: 1,
+      regionPositionBytes: 24,
       overlayBufferWithinBudget: true,
     });
+
+    fireEvent.click(screen.getByTestId('stage26e-map-regions-toggle'));
+    expect(renderer.getAttribute('data-region-label-count')).toBe('0');
+    expect(window.__stage26eProductionMap?.snapshot().regionGeometryVisible).toBe(false);
   });
 
   it('preserves selection and inspect hand-off on the candidate route', () => {

--- a/frontend/src/features/map-foundation/ProductionMapTab.tsx
+++ b/frontend/src/features/map-foundation/ProductionMapTab.tsx
@@ -27,6 +27,7 @@ import {
   PRODUCTION_PARITY_LIMITS,
   type MapViewPreset,
 } from './production-parity';
+import { useAuthoritativeRegionLayer } from './production-regions';
 import { R3FMapFoundation } from './R3FMapFoundation';
 import type { RegionLayerData, ViewportSize } from './types';
 import './ProductionMapTab.css';
@@ -49,7 +50,7 @@ function emptyProductionScene(reference: { x: number; z: number }): MapSceneStat
     routes: [],
     annotations: [],
     layers: [
-      { type: 'regions', visible: false },
+      { type: 'regions', visible: true },
       { type: 'heatmap', visible: false },
       { type: 'timeline', visible: false, bucket: 'month' },
       { type: 'routes', visible: false },
@@ -80,6 +81,7 @@ export function ProductionMapTab({
   const [viewport, setViewport] = useState(DEFAULT_VIEWPORT);
   const [scene, setScene] = useState<MapSceneState>(() => emptyProductionScene(referenceCoords));
   const [viewPreset, setViewPreset] = useState<MapViewPreset>('results');
+  const [showRegions, setShowRegions] = useState(true);
   const [showHeatmap, setShowHeatmap] = useState(false);
   const [showClusters, setShowClusters] = useState(false);
   const [showTimeline, setShowTimeline] = useState(false);
@@ -119,12 +121,12 @@ export function ProductionMapTab({
   }, []);
 
   const layers = useMapLayers({
-    regions: { enabled: false },
     heatmap: { enabled: showHeatmap, max_cells: PRODUCTION_PARITY_LIMITS.heatmapCells },
     clusters: { enabled: showClusters, max_hulls: PRODUCTION_PARITY_LIMITS.aggregateHulls },
     timeline: { enabled: showTimeline, bucket: timelineBucket },
   });
-  const layerError = [layers.heatmap, layers.clusters, layers.timeline]
+  const regionLayer = useAuthoritativeRegionLayer();
+  const layerError = [regionLayer, layers.heatmap, layers.clusters, layers.timeline]
     .find((layer) => layer.isError)?.error?.message ?? null;
   const composition = useMemo(() => composeProductionParity({
     systemCount: scene.systems.length,
@@ -177,12 +179,14 @@ export function ProductionMapTab({
   const currentViewMode = VIEW_MODES.find((mode) => mode.id === viewPreset) ?? VIEW_MODES[0];
   const activeLayerSummary = [
     'Finder dots',
+    showRegions ? 'Regions' : null,
     showHeatmap ? 'Heatmap' : null,
     showClusters ? 'Clusters' : null,
     showTimeline ? `Timeline (${timelineBucket})` : null,
   ].filter(Boolean).join(' + ');
   const sourceLabel = [
     `Finder results (${scene.systems.length})`,
+    regionLayer.data ? `Authoritative regions (${regionLayer.data.labels.length})` : null,
     showHeatmap && layers.heatmap.data ? 'Heatmap' : null,
     showClusters && layers.clusters.data ? 'Clusters' : null,
     showTimeline && layers.timeline.data ? 'Timeline' : null,
@@ -201,12 +205,16 @@ export function ProductionMapTab({
       timelinePointCount: composition.timeline?.pointCount ?? 0,
       estimatedOverlayBufferBytes: composition.estimatedOverlayBufferBytes,
       overlayBufferWithinBudget: composition.withinOverlayBufferBudget,
-      regionGeometryExposed: false,
+      regionGeometryExposed: regionLayer.data != null,
+      regionGeometryVisible: showRegions && regionLayer.data != null,
+      regionLabelCount: regionLayer.data?.labels.length ?? 0,
+      regionBoundaryCount: regionLayer.data?.boundaries.length ?? 0,
+      regionPositionBytes: (regionLayer.data?.boundaries.length ?? 0) * 6 * Float32Array.BYTES_PER_ELEMENT,
       heapBudgetBytes: LIVE_ROUTE_HEAP_BUDGET_BYTES,
     });
     window.__stage26eProductionMap = { snapshot, measureHeap: measureLiveRouteHeap };
     return () => { delete window.__stage26eProductionMap; };
-  }, [composition, scene.boundedResponse.truncated, scene.systems.length]);
+  }, [composition, regionLayer.data, scene.boundedResponse.truncated, scene.systems.length, showRegions]);
 
   return (
     <section data-testid="stage26e-production-map" aria-label="Stage 26E production map candidate" className="space-y-4">
@@ -221,7 +229,7 @@ export function ProductionMapTab({
         </div>
         <h2 className="font-display text-base tracking-[0.12em] text-text">Production-route R3F composition</h2>
         <p className="max-w-4xl text-sm leading-relaxed text-silver">
-          This candidate consumes the current Finder result set and live aggregate map responses. Region geometry remains withheld pending coverage and attribution review.
+          This candidate consumes the current Finder result set, bounded authoritative region geometry, and live aggregate map responses. Normal production still selects the established renderer unless the exact Stage 26E flag is enabled.
         </p>
         <div className="flex flex-wrap gap-2">
           <button type="button" data-testid="map-return-to-finder" onClick={onReturnToFinder} className="btn-metal text-[11px] font-mono">
@@ -257,9 +265,7 @@ export function ProductionMapTab({
             </button>
           ))}
         </div>
-        <label className="flex items-center gap-2 font-mono text-[10px] text-silver-dk">
-          <input type="checkbox" checked={false} disabled /> Regions withheld
-        </label>
+        <LayerToggle testId="stage26e-map-regions-toggle" label="Regions" checked={showRegions} onChange={setShowRegions} />
         <LayerToggle testId="stage26e-map-heatmap-toggle" label="Heatmap" checked={showHeatmap} onChange={setShowHeatmap} />
         <LayerToggle testId="stage26e-map-clusters-toggle" label="Clusters" checked={showClusters} onChange={setShowClusters} />
         <LayerToggle testId="stage26e-map-timeline-toggle" label="Timeline" checked={showTimeline} onChange={setShowTimeline} />
@@ -282,13 +288,13 @@ export function ProductionMapTab({
       />
       <MapLayerStatusRow
         sourceLabel={sourceLabel}
-        showRegions={false}
+        showRegions={showRegions}
         showHeatmap={showHeatmap}
         showClusters={showClusters}
         showTimeline={showTimeline}
         timelineBucket={timelineBucket}
-        regionsLoading={false}
-        regionsError={false}
+        regionsLoading={regionLayer.isLoading}
+        regionsError={regionLayer.isError}
         heatmapLoading={layers.heatmap.isLoading}
         heatmapError={layers.heatmap.isError}
         heatmapTruncated={layers.heatmap.data?.truncated ?? false}
@@ -321,7 +327,7 @@ export function ProductionMapTab({
             <div ref={viewportRef} data-testid="stage26e-production-map-viewport" className="stage26e-production-map-viewport">
               <R3FMapFoundation
                 scene={scene}
-                regions={EMPTY_REGIONS}
+                regions={showRegions ? regionLayer.data ?? EMPTY_REGIONS : EMPTY_REGIONS}
                 productionOverlays={composition.overlays}
                 viewport={viewport}
                 maxBackgroundPoints={PRODUCTION_PARITY_LIMITS.finderSystems}

--- a/frontend/src/features/map-foundation/live-route-memory.ts
+++ b/frontend/src/features/map-foundation/live-route-memory.ts
@@ -23,7 +23,11 @@ export type LiveRouteMapSnapshot = {
   timelinePointCount: number;
   estimatedOverlayBufferBytes: number;
   overlayBufferWithinBudget: boolean;
-  regionGeometryExposed: false;
+  regionGeometryExposed: boolean;
+  regionGeometryVisible: boolean;
+  regionLabelCount: number;
+  regionBoundaryCount: number;
+  regionPositionBytes: number;
   heapBudgetBytes: number;
 };
 

--- a/frontend/src/features/map-foundation/production-regions.test.ts
+++ b/frontend/src/features/map-foundation/production-regions.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTHORITATIVE_REGION_BOUNDARY_LIMIT,
+  fetchAuthoritativeRegionLayer,
+  validateAuthoritativeRegionLayer,
+} from './production-regions';
+
+function layer() {
+  return {
+    labels: Array.from({ length: 42 }, (_, index) => ({
+      id: index + 1,
+      name: `Region ${index + 1}`,
+      position: [index, index + 1, 0],
+    })),
+    boundaries: [{ source: [0, 0, 0], target: [1, 1, 0] }],
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('production authoritative region layer', () => {
+  it('fetches and validates the bounded build asset', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify(layer()), { status: 200 }));
+
+    const result = await fetchAuthoritativeRegionLayer();
+
+    expect(result.labels).toHaveLength(42);
+    expect(result.boundaries).toHaveLength(1);
+    expect(fetch).toHaveBeenCalledWith('/stage26e/authoritative-regions.json', { cache: 'no-cache' });
+  });
+
+  it('rejects duplicate labels and excessive boundary arrays', () => {
+    const duplicateLabels = layer();
+    duplicateLabels.labels[1]!.id = duplicateLabels.labels[0]!.id;
+    expect(() => validateAuthoritativeRegionLayer(duplicateLabels)).toThrow('label ids must be unique');
+
+    const excessive = layer();
+    excessive.boundaries = Array.from(
+      { length: AUTHORITATIVE_REGION_BOUNDARY_LIMIT + 1 },
+      () => ({ source: [0, 0, 0], target: [1, 1, 0] }),
+    );
+    expect(() => validateAuthoritativeRegionLayer(excessive)).toThrow('exceeds 25000 boundaries');
+  });
+
+  it('rejects a response above the four-MiB transport budget', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(' '.repeat(4 * 1_048_576 + 1), { status: 200 }));
+
+    await expect(fetchAuthoritativeRegionLayer()).rejects.toThrow('exceeds its response budget');
+  });
+});

--- a/frontend/src/features/map-foundation/production-regions.ts
+++ b/frontend/src/features/map-foundation/production-regions.ts
@@ -1,0 +1,61 @@
+import { useQuery } from '@tanstack/react-query';
+import type { RegionLayerData } from './types';
+
+export const AUTHORITATIVE_REGION_LAYER_PATH = 'stage26e/authoritative-regions.json';
+export const AUTHORITATIVE_REGION_LABEL_COUNT = 42;
+export const AUTHORITATIVE_REGION_BOUNDARY_LIMIT = 25_000;
+export const AUTHORITATIVE_REGION_RESPONSE_BUDGET_BYTES = 4 * 1_048_576;
+
+function isPoint(value: unknown): value is [number, number, number] {
+  return Array.isArray(value)
+    && value.length === 3
+    && value.every((coordinate) => typeof coordinate === 'number' && Number.isFinite(coordinate));
+}
+
+export function validateAuthoritativeRegionLayer(value: unknown): RegionLayerData {
+  if (!value || typeof value !== 'object') throw new Error('Authoritative region layer must be an object');
+  const candidate = value as Partial<RegionLayerData>;
+  if (!Array.isArray(candidate.labels) || candidate.labels.length !== AUTHORITATIVE_REGION_LABEL_COUNT) {
+    throw new Error(`Authoritative region layer must contain ${AUTHORITATIVE_REGION_LABEL_COUNT} labels`);
+  }
+  if (!Array.isArray(candidate.boundaries) || candidate.boundaries.length > AUTHORITATIVE_REGION_BOUNDARY_LIMIT) {
+    throw new Error(`Authoritative region layer exceeds ${AUTHORITATIVE_REGION_BOUNDARY_LIMIT} boundaries`);
+  }
+  const labelIds = new Set<number>();
+  candidate.labels.forEach((label) => {
+    if (!label || typeof label.id !== 'number' || !Number.isInteger(label.id)
+      || typeof label.name !== 'string' || label.name.length === 0 || !isPoint(label.position)) {
+      throw new Error('Authoritative region layer contains an invalid label');
+    }
+    labelIds.add(label.id);
+  });
+  if (labelIds.size !== AUTHORITATIVE_REGION_LABEL_COUNT) {
+    throw new Error('Authoritative region layer label ids must be unique');
+  }
+  candidate.boundaries.forEach((boundary) => {
+    if (!boundary || !isPoint(boundary.source) || !isPoint(boundary.target)) {
+      throw new Error('Authoritative region layer contains an invalid boundary');
+    }
+  });
+  return candidate as RegionLayerData;
+}
+
+export async function fetchAuthoritativeRegionLayer(): Promise<RegionLayerData> {
+  const response = await fetch(`${import.meta.env.BASE_URL}${AUTHORITATIVE_REGION_LAYER_PATH}`, { cache: 'no-cache' });
+  if (!response.ok) throw new Error(`Authoritative region layer request failed: ${response.status}`);
+  const body = await response.text();
+  if (new TextEncoder().encode(body).byteLength > AUTHORITATIVE_REGION_RESPONSE_BUDGET_BYTES) {
+    throw new Error('Authoritative region layer exceeds its response budget');
+  }
+  return validateAuthoritativeRegionLayer(JSON.parse(body) as unknown);
+}
+
+export function useAuthoritativeRegionLayer(enabled = true) {
+  return useQuery<RegionLayerData, Error>({
+    queryKey: ['stage26e', 'authoritative-regions'],
+    queryFn: fetchAuthoritativeRegionLayer,
+    enabled,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  });
+}

--- a/frontend/stage26e-route/e2e/live-route-memory.spec.ts
+++ b/frontend/stage26e-route/e2e/live-route-memory.spec.ts
@@ -11,6 +11,7 @@ const VIEWPORTS = [
 type RouteMeasurement = {
   viewport: { width: number; height: number };
   finderResponseStatus: number;
+  regionGeometryResponseStatus: number;
   heatmapResponseStatus: number;
   clusterResponseStatus: number;
   timelineResponseStatus: number;
@@ -60,7 +61,8 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
   const requestedApiPaths: string[] = [];
   page.on('request', (request) => {
     const url = new URL(request.url());
-    if (url.pathname === '/api/local/search' || url.pathname.startsWith('/api/map/')) {
+    if (url.pathname === '/api/local/search' || url.pathname.startsWith('/api/map/')
+      || url.pathname === '/stage26e/authoritative-regions.json') {
       requestedApiPaths.push(`${url.pathname}${url.search}`);
     }
   });
@@ -83,12 +85,24 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
       await expect(page.getByTestId('search-summary')).toBeVisible();
     });
 
-    await test.step('mount the flagged production route candidate', async () => {
+    let regionGeometryResponseStatus = 0;
+    await test.step('mount the flagged production route candidate with bounded region geometry', async () => {
+      const regionResponsePromise = page.waitForResponse((response) => (
+        new URL(response.url()).pathname === '/stage26e/authoritative-regions.json'
+      ));
       await page.getByTestId('nav-map').click();
+      const regionResponse = await regionResponsePromise;
+      regionGeometryResponseStatus = regionResponse.status();
+      const regionBody = await regionResponse.json() as { labels?: unknown[]; boundaries?: unknown[] };
+      expect(regionGeometryResponseStatus).toBe(200);
+      expect(regionBody.labels).toHaveLength(42);
+      expect(regionBody.boundaries).toHaveLength(22_595);
       await expect(page.getByTestId('stage26e-production-map')).toBeVisible();
       await expect(page.getByTestId('stage26e-production-map-viewport')).toBeVisible();
       await expect.poll(async () => page.evaluate(() => window.__stage26eProductionMap?.snapshot().finderSystemCount ?? 0))
         .toBe(500);
+      await expect.poll(async () => page.evaluate(() => window.__stage26eProductionMap?.snapshot().regionBoundaryCount ?? 0))
+        .toBe(22_595);
     });
 
     let beforeOverlays!: Awaited<ReturnType<typeof measureHeap>>;
@@ -186,32 +200,28 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
     });
     await test.step('sample and assert the composed live-route heap', async () => {
       afterOverlays = await measureHeap(context, page);
-      const estimatedOverlayBufferBytes = heatmapCellCount * 24 + aggregateHullCount * 1_536;
-      snapshot = {
-        renderer: 'r3f',
-        routeFlagEnabled: true,
-        surfaceKind: 'ready',
-        finderSystemCount,
-        finderResponseTruncated: false,
-        heatmapCellCount,
-        heatmapSourceTruncated,
-        aggregateHullCount,
-        timelinePointCount,
-        estimatedOverlayBufferBytes,
-        overlayBufferWithinBudget: estimatedOverlayBufferBytes <= 8 * 1_048_576,
-        regionGeometryExposed: false,
-        heapBudgetBytes: LIVE_ROUTE_HEAP_BUDGET_BYTES,
-      };
+      snapshot = await page.evaluate(() => window.__stage26eProductionMap!.snapshot());
       expect(afterOverlays.supported).toBe(true);
       expect(afterOverlays.withinBudget).toBe(true);
       expect(snapshot.overlayBufferWithinBudget).toBe(true);
-      expect(snapshot.regionGeometryExposed).toBe(false);
+      expect(snapshot.finderSystemCount).toBe(finderSystemCount);
+      expect(snapshot.heatmapCellCount).toBe(heatmapCellCount);
+      expect(snapshot.heatmapSourceTruncated).toBe(heatmapSourceTruncated);
+      expect(snapshot.aggregateHullCount).toBe(aggregateHullCount);
+      expect(snapshot.timelinePointCount).toBe(timelinePointCount);
+      expect(snapshot.regionGeometryExposed).toBe(true);
+      expect(snapshot.regionGeometryVisible).toBe(true);
+      expect(snapshot.regionLabelCount).toBe(42);
+      expect(snapshot.regionBoundaryCount).toBe(22_595);
+      expect(snapshot.regionPositionBytes).toBe(542_280);
       expect(requestedApiPaths.some((apiPath) => apiPath.startsWith('/api/map/regions'))).toBe(false);
+      expect(requestedApiPaths).toContain('/stage26e/authoritative-regions.json');
     });
 
     return {
       viewport,
       finderResponseStatus,
+      regionGeometryResponseStatus,
       heatmapResponseStatus,
       clusterResponseStatus,
       timelineResponseStatus,
@@ -248,10 +258,10 @@ test.afterAll(async () => {
     route: '#map',
     renderer: 'r3f',
     activation: 'measurement build only; normal production flag remains unset',
-    data_source: 'live ED-Finder API payloads fetched through the Vite preview proxy and fulfilled unchanged into the measured route',
+    data_source: 'live ED-Finder API payloads plus the bounded build-emitted authoritative region asset, fulfilled unchanged into the measured route',
     collection_method: 'Chromium CDP Performance.getMetrics JSHeapUsedSize after a one-second idle; garbage collection not forced',
     accessibility_standard: 'WCAG 2 A/AA and WCAG 2.1 A/AA detectable rules',
-    region_geometry_exposed: false,
+    region_geometry_exposed: true,
     budget_bytes: measurements[0]?.afterOverlays.budgetBytes ?? null,
     measurements,
     status: measurements.length === VIEWPORTS.length

--- a/frontend/vite.authoritative-regions.ts
+++ b/frontend/vite.authoritative-regions.ts
@@ -15,7 +15,11 @@ export function buildAuthoritativeRegionLayer(sourcePath = defaultSourcePath): s
   return JSON.stringify(buildAuthoritativeRegionLayerFromBlob(blob));
 }
 
-export function authoritativeRegionLayerPlugin(route: string, name: string): Plugin {
+export function authoritativeRegionLayerPlugin(
+  route: string,
+  name: string,
+  assetFileName?: string,
+): Plugin {
   const body = buildAuthoritativeRegionLayer();
   return {
     name,
@@ -26,6 +30,10 @@ export function authoritativeRegionLayerPlugin(route: string, name: string): Plu
         response.setHeader('Cache-Control', 'no-store');
         response.end(body);
       });
+    },
+    generateBundle() {
+      if (!assetFileName) return;
+      this.emitFile({ type: 'asset', fileName: assetFileName, source: body });
     },
   };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { authoritativeRegionLayerPlugin } from './vite.authoritative-regions';
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url));
 const packageJsonPath = path.resolve(rootDir, 'package.json');
@@ -31,6 +32,10 @@ export default defineConfig(({ mode }) => {
   const cacheDir = loadedEnv.VITE_CACHE_DIR
     || process.env.VITE_CACHE_DIR
     || 'node_modules/.vite';
+  const stage26eProductionMapEnabled = (
+    loadedEnv.VITE_STAGE26E_PRODUCTION_MAP
+    || process.env.VITE_STAGE26E_PRODUCTION_MAP
+  ) === 'enabled';
 
   return {
     base: publicBase,
@@ -38,7 +43,14 @@ export default defineConfig(({ mode }) => {
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
     },
-    plugins: [react()],
+    plugins: [
+      react(),
+      ...(stage26eProductionMapEnabled ? [authoritativeRegionLayerPlugin(
+        '/stage26e/authoritative-regions.json',
+        'stage26e-authoritative-region-layer',
+        'stage26e/authoritative-regions.json',
+      )] : []),
+    ],
     resolve: {
       preserveSymlinks: true,
       alias: {


### PR DESCRIPTION
## What changed

- emit the authoritative 42-region layer only in exact flagged Stage 26E builds
- fetch and validate the 2.31 MB static asset with a 4 MiB response guard and 25,000-boundary cap
- expose the region layer and toggle in the default-off production `#map` candidate
- extend live-route evidence to assert 42 labels, 22,595 boundaries, accessibility, and retained heap
- update the Stage 26E gate ledger, roadmap, change log, and evidence receipts

## Why

Authoritative region delivery was the last missing feature-parity item before an explicit production activation decision. Keeping the asset build-gated preserves the established map and immediate rollback path in normal builds.

## Validation

- 31 focused Vitest tests
- map-foundation TypeScript and lint
- normal `build:typecheck` (asset omitted)
- flagged Stage 26E build (2,312,898-byte asset)
- live-route E2E at 1280x720 and 1440x900 with 500 Finder systems and all overlays
- retained Chromium interaction journeys: 2/2
- Chromium/Firefox/WebKit viewport matrix: 6/6
- dedicated Axe journey: pass
- 1440x900 visual golden: pass

The user-owned untracked `docs/development/design-system-brief.md` is intentionally excluded.