### PR TITLE
Record Stage 26E production cutover

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,14 @@ disabled form must not contain it.
 Playwright smoke now navigates through the real Map tab, requires a successful
 region-asset response, and asserts the activated Stage 26E surface and visible
 Regions toggle. All seven ordinary app smoke tests pass against the default
-production bundle. This entry records activation implementation and local
-verification; public deployment and its smoke receipt follow after merge.
+production bundle.
+
+**Production cutover is complete** - PR #365 deployed commit `3b53477` to
+ed-finder.app. Public root, index, legacy `/v2/`, API health, data invariants,
+and the 2,312,898-byte region asset pass. The visible public Map tab reports
+`Stage 26E production map active`, Regions is enabled, and the map exposes all
+42 authoritative region labels. The established renderer remains available
+through the explicit disabled rollback build during the observation period.
 
 ## 2026-07-22 - Stage 26E production region delivery and cutover regression
 

--- a/artifacts/map-foundation/stage-26e/README.md
+++ b/artifacts/map-foundation/stage-26e/README.md
@@ -1,7 +1,7 @@
 # Stage 26E Cutover-Readiness Evidence
 
-This directory records the measured Stage 26E engineering progress without
-claiming production cutover readiness.
+This directory records the measured Stage 26E engineering progress and the
+completed production cutover receipt.
 
 - `cutover-gates.json` is the machine-readable gate ledger.
 - `performance-1280x720.json` and `performance-1440x900.json` are Chromium
@@ -15,7 +15,7 @@ claiming production cutover readiness.
 - `production-memory-budget.json` records the bounded normalized overlay
   buffers, their deterministic worst-case byte count, the closed raw-response
   bound, and the closed live-route heap budget.
-- `live-route-memory.json` records the exact default-off `#map` candidate at
+- `live-route-memory.json` records the exact pre-activation `#map` candidate at
   both required viewports with 500 live Finder systems, 50,000 heatmap cells,
   2,000 aggregate hulls, 100 timeline points, 42 region labels, and 22,595
   continuous region boundaries. Chromium CDP heap maxima were 30,353,992 and
@@ -25,6 +25,9 @@ claiming production cutover readiness.
   a 2,312,898-byte static asset against a 4 MiB response budget, exact label
   and boundary limits, client validation, default production emission, and
   confirmed omission from the explicit disabled rollback build.
+- `production-activation.json` records the deployed commit, public health and
+  compatibility probes, exact region-asset response, visible `#map` browser
+  smoke, and retained rollback target.
 - `heatmap-response-envelope.json` records the server-side 50,000-cell ceiling,
   stable density-first ordering, truncation contract, and compact JSON budget.
 - `region-source-review.json` records the exact local/upstream RLE comparison
@@ -42,4 +45,6 @@ callbacks. Region-data provenance, attribution, owner review, bounded delivery,
 and the full pre-activation regression are now closed. The production Vite
 configuration now selects the Stage 26E map by default and retains
 `VITE_STAGE26E_PRODUCTION_MAP=disabled` as the established-renderer rollback.
-Merge, deployment, and public smoke/rollback verification remain.
+Commit `3b53477` is deployed, the public route and region asset pass, and Stage
+26E is now in an observation period while normal map development continues on
+the app route.

--- a/artifacts/map-foundation/stage-26e/cutover-gates.json
+++ b/artifacts/map-foundation/stage-26e/cutover-gates.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "stage": "26E",
-  "status": "activation_implemented_public_deploy_pending",
+  "status": "activated_observation_period",
   "baseline_sha": "3352938b42c2dc5d4954b9577a1a734b553df582",
-  "recorded_on": "2026-07-22",
+  "recorded_on": "2026-07-23",
   "gates": {
     "typed_feature_handoffs": {
       "status": "pass",
@@ -24,7 +24,7 @@
       "tests_passed": 6
     },
     "accessibility": {
-      "status": "pass_for_isolated_foundation_and_default_off_live_route",
+      "status": "pass_for_isolated_foundation_and_activated_live_route",
       "automated_standard": "WCAG 2 A/AA and WCAG 2.1 A/AA detectable rules",
       "axe_violations": 0,
       "keyboard_journey": "pass",
@@ -90,7 +90,7 @@
       "live_production_route": {
         "status": "pass",
         "route": "#map",
-        "activation": "measurement build only; normal production flag remains unset",
+        "activation": "production default deployed in 3b534772c6c4fb2fafacdfafd7f98a35d7b4baba",
         "data_source": "live ED-Finder API payloads plus the bounded build-emitted authoritative region asset, fulfilled unchanged into the measured route",
         "budget_bytes": 268435456,
         "chromium_cdp_js_heap_used_size_max_bytes": {
@@ -110,7 +110,7 @@
       "remaining": null
     },
     "production_feature_parity": {
-      "status": "pass_for_default_off_live_route_candidate",
+      "status": "pass_for_activated_live_route",
       "supported": [
         "Finder coordinate-bearing systems",
         "selected-system context",
@@ -165,11 +165,15 @@
       "required_decisions": []
     },
     "production_route_cutover": {
-      "status": "activation_implemented_public_deploy_pending",
+      "status": "pass_activated_observation_period",
       "blocking_gates": [],
       "production_default": "Stage 26E R3F map",
       "rollback_override": "VITE_STAGE26E_PRODUCTION_MAP=disabled",
-      "remaining_route_step": "merge and deploy the activation build, smoke-check the public route and region asset, and retain the established renderer as an immediate flag-based rollback during the stability period"
+      "deployed_commit": "3b534772c6c4fb2fafacdfafd7f98a35d7b4baba",
+      "pull_request": 365,
+      "public_smoke": "pass for root, index.html, v2 compatibility, authoritative region asset, and visible #map activation state",
+      "evidence": "artifacts/map-foundation/stage-26e/production-activation.json",
+      "remaining_route_step": "observe the live map, continue normal map development on the app route, and retain the established renderer as an immediate flag-based rollback until a later explicit removal decision"
     }
   }
 }

--- a/artifacts/map-foundation/stage-26e/production-activation.json
+++ b/artifacts/map-foundation/stage-26e/production-activation.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "stage": "26E",
+  "status": "pass",
+  "deployed_commit": "3b534772c6c4fb2fafacdfafd7f98a35d7b4baba",
+  "pull_request": 365,
+  "public_url": "https://ed-finder.app",
+  "checked_at_utc": "2026-07-23T07:32:33.8826105Z",
+  "release": {
+    "public_health": "ok",
+    "database": "connected",
+    "app_http_status": 200,
+    "data_invariants": "pass",
+    "rollback_target_commit": "2d9e9c6",
+    "rollback_target_file": "/tmp/ed-finder-pre-deploy-commit.txt"
+  },
+  "http_smoke": {
+    "/": 200,
+    "/index.html": 200,
+    "/v2/": 200,
+    "/stage26e/authoritative-regions.json": 200
+  },
+  "region_asset": {
+    "response_bytes": 2312898,
+    "labels": 42,
+    "boundaries": 22595,
+    "content_type": "application/json"
+  },
+  "browser_smoke": {
+    "route": "#map",
+    "surface": "Stage 26E production map active",
+    "regions_checked": true,
+    "authoritative_region_labels_visible": 42,
+    "result": "pass"
+  },
+  "non_blocking_observation": "The existing service-worker registration warning remains visible because /sw.js resolves to the app HTML shell. It did not affect the map cutover and is retained as post-cutover hygiene."
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,13 +8,14 @@ document that should answer "what next?".
 - Programme: Stage 25 product scope is complete; Stage 26 opens the bounded
   next-generation map replacement lane without reopening planner scope.
 - Status: Stage 25A through Stage 25H and Stage 26A through Stage 26D are
-  complete. Stage 26E is in progress: browser, accessibility, visual,
+  complete. Stage 26E production cutover is complete and in observation:
+  browser, accessibility, visual,
   steady-state frame, pre-activation production parity, and live-route memory
   gates are recorded; hardware GPU timing and the owner-reviewed region-data
   gate are closed. Bounded region delivery and the full regression pass, and
-  the production build now selects the Stage 26E map by default. Merge,
-  deployment, and public smoke/rollback verification remain before claiming the
-  new map is live.
+  commit `3b53477` now serves the Stage 26E map as the public app map. Root,
+  index, legacy `/v2/`, region-asset, and visible `#map` smoke checks pass; the
+  explicit disabled build remains the immediate rollback.
 - Local engineering posture: the repo-local Python 3.12 `.venv` path is now
   the canonical local test runner, Docker-backed disposable Postgres/Redis on
   `127.0.0.1:55432` / `127.0.0.1:6379` are validated by preflight, and the
@@ -245,9 +246,9 @@ competing roadmap source.
 - The replacement must render all 42 named in-game galaxy regions correctly,
   support arbitrary multi-system and cluster overlays, preserve selected-system
   context, and keep the Colony Cockpit as the sole planning workspace.
-- The current frontend map renderer is not an architectural baseline. It stays
-  live until deliberate cutover; independently verified backend/API assets may
-  be reused.
+- The then-current frontend map renderer was not an architectural baseline and
+  was retained only until the deliberate Stage 26E cutover; independently
+  verified backend/API assets remained reusable.
 - Stage 26A selects no renderer and changes no runtime route. Its only follow-on
   authorization is Stage 26B: a paid artifact-backed Research Control run and
   an isolated, equally measured deck.gl OrbitView, deck.gl OrthographicView,
@@ -301,7 +302,7 @@ competing roadmap source.
 
 ### Stage 26E
 
-- In progress: Chromium, Firefox, and WebKit pass the isolated typed-foundation
+- Cutover complete, observation in progress: Chromium, Firefox, and WebKit pass the isolated typed-foundation
   journey at both required desktop viewports. Axe reports zero detectable WCAG
   2/2.1 A/AA violations, and the 1440x900 golden passes repeat comparison.
 - The 500,000-system steady-state Chromium p95 measured about 16.7-16.8 ms at
@@ -310,8 +311,8 @@ competing roadmap source.
   produced 30/30 valid actual-render GPU timer queries at both viewports, with
   18.982 ms and 27.243 ms p95 and no disjoint samples. Normalized overlay buffers pass a
   deterministic 8 MiB budget. The heatmap API now has a stable 50,000-cell ceiling and its
-  worst-case fixture passes a separate 8 MiB raw-response budget. A default-off
-  `#map` composition with live payloads plus 42 region labels and 22,595
+  worst-case fixture passes a separate 8 MiB raw-response budget. The
+  pre-activation `#map` composition with live payloads plus 42 region labels and 22,595
   continuous boundaries measured 30,353,992 and 27,463,288-byte Chromium heap
   maxima at the required viewports against a 256 MiB budget and passed Axe at
   both viewports with zero detectable violations.
@@ -331,8 +332,8 @@ competing roadmap source.
   default production build emits a guarded 2,312,898-byte static region asset;
   the explicit rollback build omits it. The retained interaction,
   three-browser, accessibility, visual, live-route, and ordinary app smoke
-  regressions all pass. The public map remains unchanged until merge and
-  deployment. See
+  regressions all pass. PR #365 deployed commit `3b53477`; public root,
+  compatibility, region-asset, health, and visible Map-tab checks pass. See
   [`stage-26e-cutover-readiness.md`](./colonisation-redesign/stage-26e-cutover-readiness.md).
 - ED Astro's 134-file, roughly 335.58 GiB published catalogue is inventoried
   without opening a bulk-ingest lane. Nebula coordinates and combined POIs are
@@ -441,9 +442,9 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Merge the Stage 26E production-default activation, deploy and smoke-check
-   the new public app map, and retain the explicit disabled build as an
-   immediate rollback until the candidate has a stable period.
+1. Observe and continue developing the live Stage 26E app map, address bounded
+   visual and interaction follow-ups on the real route, and retain the explicit
+   disabled build as an immediate rollback until a later removal decision.
 2. Preserve production data-integrity receipts and the bounded rerating cadence.
 3. Complete dependency-aware documentation triage and historical archiving.
 4. Finish the archetype-scoring pivot and retire legacy score storage safely.

--- a/docs/colonisation-redesign/stage-26e-cutover-readiness.md
+++ b/docs/colonisation-redesign/stage-26e-cutover-readiness.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Stage 26E is in progress. The isolated production-candidate foundation now has
+Stage 26E is deployed and in its observation period. The isolated
+production-candidate foundation has
 measured desktop-browser, viewport, accessibility, visual-regression, and
 steady-state frame evidence. Its isolated boundary now carries the remaining
 production feature shapes, continuous authoritative region boundaries, and a
@@ -10,11 +11,30 @@ closed owner-reviewed region-data gate. The same bounded region layer is wired
 into the production `#map` candidate and the full regression passes. The Vite
 production configuration now selects the Stage 26E map by default, while an
 explicit disabled override preserves the established renderer as rollback.
-Merge, deployment, and public smoke-checking remain; this document does not yet
-claim the public site has changed.
+Commit `3b53477` now serves this map on the public `#map` route. Public root,
+compatibility, region-asset, and visible-browser checks pass.
 
 The machine-readable source of truth is
 [`cutover-gates.json`](../../artifacts/map-foundation/stage-26e/cutover-gates.json).
+
+## Production Activation Receipt
+
+- PR #365 merged and deployed commit
+  `3b534772c6c4fb2fafacdfafd7f98a35d7b4baba`.
+- Public `/`, `/index.html`, and legacy `/v2/` probes returned HTTP 200.
+- `/stage26e/authoritative-regions.json` returned HTTP 200 with exactly
+  2,312,898 bytes, 42 labels, and 22,595 boundaries.
+- The in-app browser opened the public Map navigation item and observed
+  `Stage 26E production map active`, the checked Regions control, and 42
+  authoritative regions.
+- Public API health and post-deploy data invariants passed. The deploy saved
+  `2d9e9c6` in `/tmp/ed-finder-pre-deploy-commit.txt`; the explicit disabled
+  build remains the renderer rollback.
+- The existing `/sw.js` HTML-shell registration warning remains non-blocking
+  post-cutover hygiene and did not affect the map route.
+
+The machine-readable receipt is
+[`production-activation.json`](../../artifacts/map-foundation/stage-26e/production-activation.json).
 
 ## Closed Engineering Evidence
 
@@ -23,7 +43,7 @@ The machine-readable source of truth is
 - The existing overlap, context-restoration, camera, all-feature hand-off, and
   read-only Planner journey remains green in Chromium at both viewports.
 - Axe reports zero detectable WCAG 2/2.1 A/AA violations on the isolated
-  foundation and on the default-off composed live route at both viewports; the
+  foundation and on the pre-activation composed live route at both viewports; the
   companion selection and hand-off controls remain keyboard operable and named.
 - A repeatable 1440x900 Chromium golden image passes with a maximum one-percent
   pixel-difference budget and has been manually inspected.
@@ -78,7 +98,7 @@ reported roughly 167-662 MB at 1280x720 and 188-386 MB at 1440x900, demonstratin
 that these development-fixture heap snapshots are not stable enough to serve as
 a production budget.
 
-The raw transport, normalized overlay buffers, and default-off live-route heap
+The raw transport, normalized overlay buffers, and pre-activation live-route heap
 are now all bounded. The live-route evidence supersedes the variable isolated
 fixture snapshots for the memory gate because it measures the actual route
 composition and live production-shaped payloads. It does not by itself close
@@ -97,10 +117,9 @@ than invented, and the large-result preset calculation is iterative rather
 than spreading an unbounded result array onto the call stack.
 
 This closes the feature-parity adapter, bounded region delivery, pre-activation
-regression, and build-activation gates. Merge, production deployment, and a
-public browser smoke-check are now the next route steps. The established
-renderer remains available through the explicit disabled rollback build;
-superseded-map removal remains later and explicit.
+regression, build activation, production deployment, and public browser smoke
+gates. The established renderer remains available through the explicit
+disabled rollback build; superseded-map removal remains later and explicit.
 
 ## Closed GPU Evidence
 
@@ -178,11 +197,10 @@ not treated as formal permission.
 
 ## Next Authorized Work
 
-Stage 26E activation is implemented locally. The next bounded steps are to
-merge this configuration, deploy the ordinary production build, verify the
-public root and `#map` route plus the region asset, and retain
+Stage 26E is the live app map. Continue bounded visual and interaction work on
+the real `#map` route, monitor the observation period, and retain
 `VITE_STAGE26E_PRODUCTION_MAP=disabled` as the immediate rebuild rollback.
-Superseded-map deletion remains a later, explicit step after a stable period.
+Superseded-map deletion remains a later, explicit decision after stability.
 
 The supplied Raven Colonial reference identifies a useful post-cutover visual
 follow-up: an explicit 2D/3D control, a restrained oblique tabletop preset,


### PR DESCRIPTION
## Summary
- record the deployed Stage 26E commit and public activation receipt
- move the cutover gate ledger and roadmap into the observation period
- document public root, `/v2/`, authoritative region asset, visible Map-tab, health, invariant, and rollback checks

## Production evidence
- deployed commit: `3b534772c6c4fb2fafacdfafd7f98a35d7b4baba`
- `/`, `/index.html`, `/v2/`: HTTP 200
- authoritative regions: HTTP 200; 2,312,898 bytes; 42 labels; 22,595 boundaries
- public Map tab: `Stage 26E production map active`; Regions checked
- API health and post-deploy data invariants: pass
- rollback marker: `/tmp/ed-finder-pre-deploy-commit.txt` -> `2d9e9c6`

Docs/evidence only; no runtime change.