### PR TITLE
Record Stage 26E polish deployment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,12 @@ inspected 1440x900 golden records the new boundary treatment. The production
 map chunk is 948,580 bytes, an 18,320-byte raw increase from the activated
 baseline, while the 2,312,898-byte authoritative region asset is unchanged.
 
+**Production promotion is complete** - PR #367 deployed commit `c0eef72`.
+Public root, index, legacy `/v2/`, API health, and the exact region asset pass.
+The live browser reports 42 authoritative regions, keeps Regions enabled, and
+survives the explicit 2D -> 3D -> 2D journey. Production-safe data invariants
+pass and the release saved `3b53477` as its rollback target.
+
 ## 2026-07-22 - Stage 26E production map activation
 
 **The Stage 26E map is now the production-build default** - Vite supplies the

--- a/artifacts/map-foundation/stage-26e/post-cutover-visual-polish.json
+++ b/artifacts/map-foundation/stage-26e/post-cutover-visual-polish.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "stage": "26E",
-  "status": "implementation_verified_deploy_pending",
-  "checked_at_utc": "2026-07-23T08:37:44Z",
+  "status": "pass",
+  "checked_at_utc": "2026-07-23T08:53:05Z",
   "scope": {
     "route": "#map",
     "region_geometry_changed": false,
@@ -50,7 +50,26 @@
     "retained_isolated_interaction": "local slow-Windows automation exceeded its journey deadline at varying later actions; protected CI remains the publication gate"
   },
   "production": {
-    "deployment": "pending",
-    "public_browser_smoke": "pending"
+    "deployment": {
+      "pull_request": 367,
+      "commit": "c0eef7270ebabd93463580e1f9288919748a804d",
+      "health": "pass",
+      "data_invariants": "pass",
+      "rollback_target_commit": "3b53477"
+    },
+    "http_smoke": {
+      "/": 200,
+      "/index.html": 200,
+      "/v2/": 200,
+      "/stage26e/authoritative-regions.json": 200,
+      "/api/health": 200
+    },
+    "public_browser_smoke": {
+      "stage26e_active": true,
+      "regions_checked": true,
+      "authoritative_regions": 42,
+      "projection_2d_to_3d_to_2d": "pass",
+      "map_remained_visible": true
+    }
   }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -348,8 +348,9 @@ competing roadmap source.
   screen-space anti-aliased halo/core treatment. Region labels now share a
   restrained warm hierarchy, and the live control rail exposes explicit flat
   2D and oblique tabletop 3D presets through the existing camera state. The
-  1440x900 golden and Axe gate pass; production publication remains the final
-  step for this slice.
+  1440x900 golden and Axe gate pass. PR #367 deployed commit `c0eef72`; public
+  root, compatibility, health, exact region-asset, and 2D -> 3D -> 2D browser
+  checks pass.
 
 ### Stage 25C
 
@@ -451,10 +452,10 @@ competing roadmap source.
 
 ## Active Priorities
 
-1. Publish and observe the first Stage 26E post-cutover boundary/projection
-   polish, then continue bounded orientation and interaction follow-ups on the
-   real route while retaining the explicit disabled build as immediate
-   rollback until a later removal decision.
+1. Observe the deployed Stage 26E post-cutover boundary/projection polish, then
+   continue bounded orientation and interaction follow-ups on the real route
+   while retaining the explicit disabled build as immediate rollback until a
+   later removal decision.
 2. Preserve production data-integrity receipts and the bounded rerating cadence.
 3. Complete dependency-aware documentation triage and historical archiving.
 4. Finish the archetype-scoring pivot and retire legacy score storage safely.

--- a/docs/colonisation-redesign/stage-26e-cutover-readiness.md
+++ b/docs/colonisation-redesign/stage-26e-cutover-readiness.md
@@ -53,6 +53,12 @@ projection directions. The ordinary production-app smoke switches 2D -> 3D ->
 chunk is 948,580 bytes, up 18,320 raw bytes from the activation baseline; the
 separate authoritative region response remains exactly 2,312,898 bytes.
 
+PR #367 deployed commit `c0eef7270ebabd93463580e1f9288919748a804d`.
+Public root, index, legacy `/v2/`, health, and exact region-asset probes pass.
+The live browser reports 42 authoritative regions, Regions enabled, and a
+successful 2D -> 3D -> 2D journey with the map remaining visible. The canonical
+release passed production-safe data invariants and saved `3b53477` as rollback.
+
 The implementation receipt is
 [`post-cutover-visual-polish.json`](../../artifacts/map-foundation/stage-26e/post-cutover-visual-polish.json).
 
@@ -217,9 +223,8 @@ not treated as formal permission.
 
 ## Next Authorized Work
 
-Stage 26E is the live app map. Publish and observe the verified first
-post-cutover slice, then continue bounded visual and interaction work on the
-real `#map` route and retain
+Stage 26E is the live app map. Observe the deployed first post-cutover slice,
+then continue bounded visual and interaction work on the real `#map` route and retain
 `VITE_STAGE26E_PRODUCTION_MAP=disabled` as the immediate rebuild rollback.
 Superseded-map deletion remains a later, explicit decision after stability.
 


### PR DESCRIPTION
## What changed

- mark the post-cutover visual-polish receipt as passed and record PR #367 / deployed commit `c0eef72`
- record public HTTP, browser projection, health, invariant, and rollback evidence
- update the changelog, roadmap, and cutover-readiness document from deploy-pending to observation

## Validation

- production release completed through the canonical script
- full release typecheck, build, frontend tests, health, and production-safe data invariants passed
- public `/`, `/index.html`, `/v2/`, `/api/health`, and exact 2,312,898-byte region asset returned 200
- public browser confirmed Stage 26E active, Regions checked, 42 authoritative regions, and 2D → 3D → 2D with the map remaining visible
- receipt JSON parses successfully and `git diff --check` passes