### PR TITLE
Fix production-scale cluster and map maintenance

### DIFF
--- a/apps/importer/src/build_clusters.py
+++ b/apps/importer/src/build_clusters.py
@@ -62,6 +62,7 @@ LOG_FILE       = os.getenv('LOG_FILE', '/tmp/build_clusters.log')
 DEFAULT_RADIUS = 500    # LY — the standard colonisation bubble radius
 DEFAULT_SCORE  = 65     # Minimum score for a system to be considered viable
 TOP_N_ANCHORS  = 50     # Top N anchors to compute per macro-cell
+DEFAULT_CELL_TIMEOUT = 1800  # 30 min — proven at 187M-system scale
 
 os.makedirs(os.path.dirname(os.path.abspath(LOG_FILE)), exist_ok=True)
 logging.basicConfig(
@@ -262,7 +263,8 @@ def _connect_with_retry(worker_id: int, db_url: str, cell_timeout: int = 120,
 # ---------------------------------------------------------------------------
 def worker_fn(worker_id: int, macro_queue: Queue, done_counter, db_url: str,
               radius: float, min_score: int, dirty_only: bool,
-              cell_timeout: int = 300, top_n: int = TOP_N_ANCHORS):
+              cell_timeout: int = DEFAULT_CELL_TIMEOUT,
+              top_n: int = TOP_N_ANCHORS):
     """
     Pull macro-cells from the queue and process each one.
 
@@ -445,8 +447,8 @@ def main():
                         help=f'Top N anchors to compute per macro-cell (default: {TOP_N_ANCHORS})')
     parser.add_argument('--dirty-only',   action='store_true',
                         help='Only rebuild clusters for dirty anchors')
-    parser.add_argument('--cell-timeout', type=int,   default=300,
-                        help='Max seconds per anchor query (default: 300)')
+    parser.add_argument('--cell-timeout', type=int,   default=DEFAULT_CELL_TIMEOUT,
+                        help=f'Max seconds per anchor query (default: {DEFAULT_CELL_TIMEOUT})')
     args = parser.parse_args()
 
     script_start = time.time()
@@ -567,23 +569,23 @@ def main():
         VALUES ('clusters_built', 'true', NOW())
         ON CONFLICT (key) DO UPDATE SET value = 'true', updated_at = NOW()
     """)
-    log.info("Clearing orphaned cluster_dirty flags "
-             "(systems with no macro_grid_id or no body data) ...")
-    cur2.execute(
-        "UPDATE systems SET cluster_dirty = FALSE "
-        "WHERE cluster_dirty = TRUE "
-        "  AND (macro_grid_id IS NULL OR has_body_data = FALSE)"
-    )
-    orphans_cleared = cur2.rowcount
-    conn2.commit()
-    log.info(f"Cleared {orphans_cleared} orphaned cluster_dirty flags.")
 
     if not args.dirty_only:
         log.info("Clearing cluster_dirty flags after full rebuild ...")
+        full_cleanup_started = time.monotonic()
         cur2.execute(
-            "UPDATE systems SET cluster_dirty = FALSE WHERE has_body_data = TRUE"
+            "UPDATE systems SET cluster_dirty = FALSE "
+            "WHERE has_body_data = TRUE "
+            "AND macro_grid_id IS NOT NULL "
+            "AND cluster_dirty = TRUE"
         )
-        log.info("cluster_dirty flags cleared.")
+        full_cleanup_cleared = cur2.rowcount
+        full_cleanup_elapsed = time.monotonic() - full_cleanup_started
+        log.info(
+            "Cleared %s cluster_dirty flags after full rebuild in %s.",
+            fmt_num(full_cleanup_cleared),
+            fmt_duration(full_cleanup_elapsed),
+        )
 
     # Quick stats
     cur2.execute("SELECT COUNT(*), AVG(coverage_score)::int, MAX(coverage_score) FROM cluster_summary")

--- a/apps/importer/src/build_regional_analysis.py
+++ b/apps/importer/src/build_regional_analysis.py
@@ -169,7 +169,12 @@ def main() -> None:
 def _load_targets(cur: Any, args: argparse.Namespace) -> list[dict[str, Any]]:
     where = ''
     if args.dirty:
-        where = 'WHERE rating_dirty = TRUE OR cluster_dirty = TRUE'
+        where = (
+            'WHERE rating_dirty = TRUE '
+            'OR (cluster_dirty = TRUE '
+            'AND has_body_data = TRUE '
+            'AND macro_grid_id IS NOT NULL)'
+        )
     elif not args.all:
         where = 'WHERE NOT EXISTS (SELECT 1 FROM system_regional_analysis r WHERE r.system_id64 = systems.id64)'
     limit = f' LIMIT {int(args.limit)}' if args.limit else ''

--- a/apps/maintenance/scripts/run_maintenance.sh
+++ b/apps/maintenance/scripts/run_maintenance.sh
@@ -145,7 +145,8 @@ SQL
 )"
         # Refresh map materialised views — concurrently when supported,
         # falls back to plain refresh on first build.
-        run_step "refresh_map_mviews()"  "SELECT * FROM refresh_map_mviews(FALSE);"
+        run_step "refresh_map_mviews()"  \
+            "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(FALSE);"
         echo "===== Nightly maintenance complete ====="
         ;;
     weekly)

--- a/config/grafana/dashboards/ed-finder.json
+++ b/config/grafana/dashboards/ed-finder.json
@@ -76,7 +76,7 @@
       "gridPos": { "x": 0, "y": 20, "w": 12, "h": 8 },
       "targets": [
         { "expr": "ed_finder_rating_dirty_count", "legendFormat": "rating dirty" },
-        { "expr": "ed_finder_cluster_dirty_count", "legendFormat": "cluster dirty" }
+        { "expr": "ed_finder_cluster_dirty_count", "legendFormat": "eligible cluster dirty" }
       ]
     },
     {

--- a/config/postgres_exporter_queries.yaml
+++ b/config/postgres_exporter_queries.yaml
@@ -4,7 +4,11 @@ ed_finder_dirty_counts:
   query: |
     SELECT
       COUNT(*) FILTER (WHERE rating_dirty)  AS rating_dirty,
-      COUNT(*) FILTER (WHERE cluster_dirty) AS cluster_dirty
+      COUNT(*) FILTER (
+        WHERE cluster_dirty
+          AND has_body_data
+          AND macro_grid_id IS NOT NULL
+      ) AS cluster_dirty
     FROM systems
   metrics:
     - rating_dirty:
@@ -12,7 +16,7 @@ ed_finder_dirty_counts:
         description: "Number of systems with rating_dirty = true"
     - cluster_dirty:
         usage: GAUGE
-        description: "Number of systems with cluster_dirty = true"
+        description: "Number of eligible systems with cluster_dirty = true"
 
 ed_finder_import_progress:
   query: |

--- a/scripts/nightly_update.sh
+++ b/scripts/nightly_update.sh
@@ -334,6 +334,7 @@ log "--- Step 4: Rebuild clusters ---"
 # Strategy:
 # - Sunday (DOW=7): Full rebuild (ensures everything is in sync)
 # - Other days:     Incremental rebuild (dirty anchors only)
+ELIGIBLE_CLUSTER_DIRTY_SQL="cluster_dirty = TRUE AND has_body_data = TRUE AND macro_grid_id IS NOT NULL"
 
 if [[ "$DOW" == "7" ]]; then
     log "Weekly full cluster rebuild (Sunday) ..."
@@ -342,8 +343,8 @@ if [[ "$DOW" == "7" ]]; then
     #     && success "Full cluster rebuild complete" \
     #     || warn "Full cluster rebuild had errors (check ${LOG_DIR}/build_clusters_full.log)"
 else
-    DIRTY_CLUSTERS=$(pg_count "SELECT COUNT(*) FROM systems WHERE cluster_dirty = TRUE")
-    log "Dirty cluster anchors: $DIRTY_CLUSTERS"
+    DIRTY_CLUSTERS=$(pg_count "SELECT COUNT(*) FROM systems WHERE ${ELIGIBLE_CLUSTER_DIRTY_SQL}")
+    log "Eligible dirty cluster anchors: $DIRTY_CLUSTERS"
 
     if (( DIRTY_CLUSTERS > 0 )); then
         log "Running build_clusters.py --dirty-only ..."
@@ -352,11 +353,11 @@ else
             || warn "Cluster rebuild had errors (check ${LOG_DIR}/build_clusters.log)"
 
         # Post-rebuild verification
-        STILL_DIRTY_C=$(pg_count "SELECT COUNT(*) FROM systems WHERE cluster_dirty = TRUE")
+        STILL_DIRTY_C=$(pg_count "SELECT COUNT(*) FROM systems WHERE ${ELIGIBLE_CLUSTER_DIRTY_SQL}")
         if (( STILL_DIRTY_C > 0 )); then
-            warn "Cluster rebuild incomplete: $STILL_DIRTY_C systems still have cluster_dirty=TRUE"
+            warn "Cluster rebuild incomplete: $STILL_DIRTY_C eligible systems remain dirty"
         else
-            success "All cluster_dirty flags cleared"
+            success "All eligible cluster_dirty flags cleared"
         fi
     fi
 fi
@@ -404,7 +405,7 @@ done
 DISK_USED=$(df -h /data | awk 'NR==2{print $3 "/" $2 " (" $5 ")"}')
 PG_SIZE=$(pg_count "SELECT pg_size_pretty(pg_database_size('edfinder'))")
 SYS_COUNT=$(pg_count "SELECT TO_CHAR(COUNT(*), '999,999,999') FROM systems")
-REMAINING_DIRTY=$(pg_count "SELECT COUNT(*) FROM systems WHERE rating_dirty OR cluster_dirty")
+REMAINING_DIRTY=$(pg_count "SELECT COUNT(*) FROM systems WHERE rating_dirty OR (${ELIGIBLE_CLUSTER_DIRTY_SQL})")
 
 log "Systems: $SYS_COUNT | Disk: $DISK_USED | PostgreSQL DB: $PG_SIZE | Remaining dirty: $REMAINING_DIRTY"
 

--- a/tests/test_admin_runtime_contracts.py
+++ b/tests/test_admin_runtime_contracts.py
@@ -47,6 +47,7 @@ def test_maintenance_script_schedules_freshness_sweep_and_retention_pruning():
     assert "record_status = 'active'" in script
     assert "freshness_status = 'expired'" in script
     assert "record_status = 'quarantined'" not in script
+    assert "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(FALSE);" in script
 
 
 def test_maintenance_script_has_valid_bash_syntax():

--- a/tests/test_build_clusters.py
+++ b/tests/test_build_clusters.py
@@ -27,3 +27,34 @@ def test_row_to_dict_rejects_cursor_shape_mismatch(monkeypatch, tmp_path):
     }
     with pytest.raises(ValueError, match=r'zip\(\) argument 2 is shorter'):
         build_clusters._row_to_dict(description, (42,))
+
+
+def test_full_rebuild_only_clears_genuinely_dirty_eligible_systems():
+    script = SCRIPT_PATH.read_text(encoding='utf-8')
+
+    assert (
+        '"WHERE has_body_data = TRUE "'
+        in script
+    )
+    assert '"AND macro_grid_id IS NOT NULL "' in script
+    assert '"AND cluster_dirty = TRUE"' in script
+    assert (
+        '"UPDATE systems SET cluster_dirty = FALSE WHERE has_body_data = TRUE"'
+        not in script
+    )
+
+
+def test_full_rebuild_does_not_clear_latent_ineligible_dirty_flags():
+    script = SCRIPT_PATH.read_text(encoding='utf-8')
+
+    assert 'Clearing orphaned cluster_dirty flags' not in script
+    assert 'macro_grid_id IS NULL OR has_body_data = FALSE' not in script
+
+
+def test_cell_timeout_default_matches_proven_production_scale_value(
+    monkeypatch,
+    tmp_path,
+):
+    build_clusters = _load_build_clusters(monkeypatch, tmp_path)
+
+    assert build_clusters.DEFAULT_CELL_TIMEOUT == 1800

--- a/tests/test_cluster_dirty_eligibility.py
+++ b/tests/test_cluster_dirty_eligibility.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REGIONAL_ANALYSIS_PATH = ROOT / 'apps' / 'importer' / 'src' / 'build_regional_analysis.py'
+NIGHTLY_UPDATE_PATH = ROOT / 'scripts' / 'nightly_update.sh'
+EXPORTER_QUERIES_PATH = ROOT / 'config' / 'postgres_exporter_queries.yaml'
+
+
+def test_regional_analysis_scopes_cluster_dirty_to_eligible_systems():
+    source = REGIONAL_ANALYSIS_PATH.read_text(encoding='utf-8')
+
+    assert "'OR (cluster_dirty = TRUE '" in source
+    assert "'AND has_body_data = TRUE '" in source
+    assert "'AND macro_grid_id IS NOT NULL)'" in source
+    assert 'WHERE rating_dirty = TRUE OR cluster_dirty = TRUE' not in source
+
+
+def test_nightly_cluster_dirty_counts_share_the_eligibility_scope():
+    source = NIGHTLY_UPDATE_PATH.read_text(encoding='utf-8')
+
+    assert (
+        'ELIGIBLE_CLUSTER_DIRTY_SQL="cluster_dirty = TRUE '
+        'AND has_body_data = TRUE AND macro_grid_id IS NOT NULL"'
+        in source
+    )
+    assert source.count('${ELIGIBLE_CLUSTER_DIRTY_SQL}') == 3
+    assert 'WHERE cluster_dirty = TRUE")' not in source
+    assert 'WHERE rating_dirty OR cluster_dirty")' not in source
+
+
+def test_exported_cluster_dirty_metric_only_counts_eligible_systems():
+    source = EXPORTER_QUERIES_PATH.read_text(encoding='utf-8')
+
+    assert 'WHERE cluster_dirty' in source
+    assert 'AND has_body_data' in source
+    assert 'AND macro_grid_id IS NOT NULL' in source
+    assert 'Number of eligible systems with cluster_dirty = true' in source


### PR DESCRIPTION
## Summary

- give the map materialized-view refresh a 60-minute statement timeout, safely above the observed 28m03.940 full local refresh
- raise the cluster worker's default per-cell timeout from 300 seconds to the production-scale-proven 1,800 seconds
- remove the unbounded orphan dirty-flag rewrite and restrict the post-full-rebuild safety cleanup to dirty, cluster-eligible systems
- make regional analysis, nightly reporting, PostgreSQL exporter metrics, and the Grafana legend agree on the same cluster eligibility scope
- add regression coverage for the timeout, cleanup, and eligibility contracts

## What was wrong

Three independent limits combined to keep the production map pipeline stale or impractical:

1. The nightly map materialized-view refresh inherited a 15-second role-level `statement_timeout`, so it died on `mv_map_regions`, the first view.
2. A full `build_clusters.py` run inherited a 300-second cell timeout, which failed at 5m03.612 on the initial production-scale viable-macro-cell query.
3. Full rebuild cleanup included an orphan cleanup that attempted to rewrite roughly 114 million ineligible systems. On the healthy local production copy it had already run for 9h17 before cancellation and projected to roughly 11.3 hours. Those ineligible dirty flags are latent state and do not need to be physically cleared.

The regional-analysis dirty check also treated those ineligible flags as actionable, leaving it with a perpetual 114-million-row match set.

## Changes

- `run_maintenance.sh`: execute `refresh_map_mviews(FALSE)` with `SET statement_timeout = '60min'`.
- `build_clusters.py`:
  - default `--cell-timeout` is now 1,800 seconds;
  - the 114-million-row orphan cleanup is removed entirely;
  - the post-full-rebuild safety cleanup now requires `has_body_data = TRUE`, `macro_grid_id IS NOT NULL`, and `cluster_dirty = TRUE`;
  - log the safety cleanup's affected rows and elapsed time.
- `build_regional_analysis.py`: cluster-dirty targets use the same eligibility predicate.
- Nightly counts, PostgreSQL exporter metrics, and the Grafana label now report eligible cluster-dirty systems rather than latent ineligible state.

## Production-scale local evidence

All database work below used the retained local restore; production was not modified.

- systems: **187,819,898**
- 300-second cell timeout: failed after **5m03.612**
- 1,800-second cell timeout: full rebuild succeeded
- full fixed rebuild wall time: **3h34m28.5s**
- scoped cleanup: **15,958,493 rows in ~1h11m06.6s**
- old orphan cleanup: **9h17 elapsed before cancellation**, projected **~11.3h**
- regional-analysis dirty matches: **114,381,262 → 75**
- post-rebuild eligible cluster-dirty rows: **0**
- retained latent ineligible dirty rows: **114,381,187**
- resulting `cluster_summary` rows: **179,170**
- first full non-concurrent map-view refresh: **28m03.940**, motivating the 60-minute timeout

## Local validation

- Python compile: passed
- Ruff standard and B905 checks: passed
- backend test suite: **1,498 passed, 15 skipped, 126 deselected**
- Docker Compose validation: passed
- Bash syntax: passed
- YAML/JSON parsing: passed
- strict project-state resolver: passed
- frontend typecheck and Knip: passed
- frontend tests: **676 passed**
- production frontend build and map contract: passed

## Deployment gate

This PR is Part 1 only. It does not modify production. The full production cluster rebuild, concurrent map-view refresh, result verification, next-nightly confirmation, and retained local-resource cleanup remain explicitly gated on owner approval after review and merge.