### PR TITLE
Use concurrent map view refresh in maintenance

### DIFF
--- a/apps/maintenance/scripts/run_maintenance.sh
+++ b/apps/maintenance/scripts/run_maintenance.sh
@@ -143,10 +143,10 @@ updated AS (
 SELECT COUNT(*)::int AS stale_by_age FROM updated;
 SQL
 )"
-        # Refresh map materialised views — concurrently when supported,
-        # falls back to plain refresh on first build.
+        # Refresh populated map materialised views concurrently so readers
+        # remain available throughout the maintenance run.
         run_step "refresh_map_mviews()"  \
-            "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(FALSE);"
+            "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(TRUE);"
         echo "===== Nightly maintenance complete ====="
         ;;
     weekly)

--- a/tests/test_admin_runtime_contracts.py
+++ b/tests/test_admin_runtime_contracts.py
@@ -47,7 +47,7 @@ def test_maintenance_script_schedules_freshness_sweep_and_retention_pruning():
     assert "record_status = 'active'" in script
     assert "freshness_status = 'expired'" in script
     assert "record_status = 'quarantined'" not in script
-    assert "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(FALSE);" in script
+    assert "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(TRUE);" in script
 
 
 def test_maintenance_script_has_valid_bash_syntax():


### PR DESCRIPTION
## Summary

- run `refresh_map_mviews(TRUE)` from the nightly maintenance script so populated map materialized views refresh concurrently
- replace the stale comment describing fallback behavior that the call did not implement
- update the maintenance contract test to require concurrent mode

## Why

PR #373 raised the inherited statement timeout and repaired the production-scale cluster maintenance path, but the real nightly maintenance entry point still passed `FALSE` explicitly to `refresh_map_mviews`, forcing non-concurrent refreshes. The views are already populated and have the required unique indexes, so concurrent mode is the correct production path and keeps map reads available while maintenance runs.

## End-to-end local proof

This exact change was built into the production maintenance image and run against the retained production-scale local restore through the real entry point:

`/usr/local/bin/run_maintenance.sh nightly`

Observed results:

- complete maintenance wall time: **10m31.6s**
- `refresh_map_mviews()` step: **621s / 10m21s**
- script logged successful refreshes for all five views and exited 0
- while the refresh backend was active in `pg_stat_activity` with `refresh_map_mviews(TRUE)`, a second connection read `mv_map_regions` in **156.8ms** under a 5-second timeout
- that probe occurred about 58 seconds into the first view's **81.229s** refresh window, demonstrating the live read did not wait for completion

Post-refresh rows:

- `mv_map_regions`: **42**
- `mv_map_heatmap_200ly`: **1,543,584**
- `mv_map_heatmap_500ly`: **136,128**
- `mv_map_heatmap_1000ly`: **21,993**
- `mv_map_timeline_month`: **102**

## Local validation

- Python compile: passed
- Ruff standard and B905 checks: passed
- backend unit suite: **1,498 passed, 15 skipped, 126 deselected**
- Docker Compose validation: passed
- Bash syntax: passed
- frontend typecheck and Knip: passed
- frontend CI suite: **676 passed**
- production frontend build and map contract: passed

## Deployment gate

This PR is Part 1 only. Production deployment, the full production cluster rebuild, production maintenance refresh, row-count verification, scheduled-nightly proof, and retained-resource cleanup remain gated on review, merge, and a separate explicit owner go-ahead.