### PR TITLE
Fix importer full-cleanup statement timeout

### DIFF
--- a/apps/importer/src/build_clusters.py
+++ b/apps/importer/src/build_clusters.py
@@ -63,6 +63,7 @@ DEFAULT_RADIUS = 500    # LY — the standard colonisation bubble radius
 DEFAULT_SCORE  = 65     # Minimum score for a system to be considered viable
 TOP_N_ANCHORS  = 50     # Top N anchors to compute per macro-cell
 DEFAULT_CELL_TIMEOUT = 1800  # 30 min — proven at 187M-system scale
+FULL_CLEANUP_STATEMENT_TIMEOUT = '4h'  # >2x the observed 1h41m production cleanup
 
 os.makedirs(os.path.dirname(os.path.abspath(LOG_FILE)), exist_ok=True)
 logging.basicConfig(
@@ -256,6 +257,20 @@ def _connect_with_retry(worker_id: int, db_url: str, cell_timeout: int = 120,
             print(f"[W{worker_id}] DB connect attempt {attempt} failed: {e} — retrying in {wait}s", flush=True)
             time.sleep(wait)
     raise RuntimeError(f"[W{worker_id}] Could not connect to DB after {max_attempts} attempts")
+
+
+def _clear_full_rebuild_dirty_flags(cur) -> int:
+    """Clear eligible dirty flags with a timeout sized for production scale."""
+    cur.execute(
+        f"SET statement_timeout = '{FULL_CLEANUP_STATEMENT_TIMEOUT}'"
+    )
+    cur.execute(
+        "UPDATE systems SET cluster_dirty = FALSE "
+        "WHERE has_body_data = TRUE "
+        "AND macro_grid_id IS NOT NULL "
+        "AND cluster_dirty = TRUE"
+    )
+    return cur.rowcount
 
 
 # ---------------------------------------------------------------------------
@@ -573,13 +588,7 @@ def main():
     if not args.dirty_only:
         log.info("Clearing cluster_dirty flags after full rebuild ...")
         full_cleanup_started = time.monotonic()
-        cur2.execute(
-            "UPDATE systems SET cluster_dirty = FALSE "
-            "WHERE has_body_data = TRUE "
-            "AND macro_grid_id IS NOT NULL "
-            "AND cluster_dirty = TRUE"
-        )
-        full_cleanup_cleared = cur2.rowcount
+        full_cleanup_cleared = _clear_full_rebuild_dirty_flags(cur2)
         full_cleanup_elapsed = time.monotonic() - full_cleanup_started
         log.info(
             "Cleared %s cluster_dirty flags after full rebuild in %s.",

--- a/tests/test_build_clusters.py
+++ b/tests/test_build_clusters.py
@@ -1,4 +1,5 @@
 import importlib.util
+import inspect
 from pathlib import Path
 
 import pytest
@@ -58,3 +59,45 @@ def test_cell_timeout_default_matches_proven_production_scale_value(
     build_clusters = _load_build_clusters(monkeypatch, tmp_path)
 
     assert build_clusters.DEFAULT_CELL_TIMEOUT == 1800
+
+
+def test_full_rebuild_cleanup_sets_production_scale_timeout_before_update(
+    monkeypatch,
+    tmp_path,
+):
+    build_clusters = _load_build_clusters(monkeypatch, tmp_path)
+
+    class RecordingCursor:
+        rowcount = 17
+
+        def __init__(self):
+            self.statements = []
+
+        def execute(self, statement):
+            self.statements.append(' '.join(statement.split()))
+
+    cursor = RecordingCursor()
+
+    cleared = build_clusters._clear_full_rebuild_dirty_flags(cursor)
+
+    assert build_clusters.FULL_CLEANUP_STATEMENT_TIMEOUT == '4h'
+    assert cursor.statements == [
+        "SET statement_timeout = '4h'",
+        (
+            'UPDATE systems SET cluster_dirty = FALSE '
+            'WHERE has_body_data = TRUE '
+            'AND macro_grid_id IS NOT NULL '
+            'AND cluster_dirty = TRUE'
+        ),
+    ]
+    assert cleared == 17
+
+
+def test_full_rebuild_finalization_uses_timeout_aware_cleanup_helper(
+    monkeypatch,
+    tmp_path,
+):
+    build_clusters = _load_build_clusters(monkeypatch, tmp_path)
+    main_source = inspect.getsource(build_clusters.main)
+
+    assert '_clear_full_rebuild_dirty_flags(cur2)' in main_source


### PR DESCRIPTION
## What changed

- add an explicit `4h` PostgreSQL `statement_timeout` immediately before the eligibility-scoped full-rebuild cleanup in `build_clusters.py`
- keep the timeout and cleanup on the same `conn2`/`cur2` connection
- add focused coverage for timeout ordering, cleanup scope, affected-row reporting, and the real `main()` finalization call path

## Root cause

The worker and initial discovery connections set their own timeout, but the fresh `conn2` opened for finalization inherited production's role-level `15s` timeout. The canonical production full rebuild therefore completed all 3,437 macro cells and then failed at the scoped cleanup with `psycopg2.errors.QueryCanceled`.

The later 1h41m28s successful cleanup was a separate operational recovery transaction using `SET LOCAL statement_timeout = 0`; it did not prove the canonical importer connection was safe.

## Timeout choice

`4h` is finite and approximately 2.36 times the observed 1h41m28s production cleanup runtime, leaving substantial headroom while preserving an upper bound.

## Proof

A disposable local PostgreSQL instance was configured with a role default of `15s`. A fresh `conn2`-equivalent connection reported `15s`; after the new helper ran, the same connection reported `4h`, cleared the eligible row, and preserved the ineligible row.

Local focused validation:

- `python -m pytest tests/test_build_clusters.py -q` — 6 passed
- Ruff — passed
- Python compilation — passed
- `git diff --check` — passed

The stripped local environment lacks unrelated full-stack dependencies, so this PR is intentionally left to run the repository's complete protected CI matrix in GitHub Actions.