### PR TITLE
Add a manual production deploy-drift signal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ If it fails, **stop** — do not edit, commit, push, run DB writes, or report an
 
 ### Plan-change discipline
 - If a plan changes mid-execution (e.g. switching from approach A to approach B), stop and confirm the change before committing. Do not silently substitute one fix for another the user approved.
-- Every commit pushed to origin/main must be followed through to production deploy in the same message, unless the user explicitly says to hold.
+- A merge to `origin/main` does not authorize a production deploy. Follow the explicit owner-approved release sequence under **Frontend deployment**.
 - After any deploy, verify the deployed HEAD matches origin/main and report the receipt (commit hash + production `git log`).
 - DeepSeek must NEVER edit production files directly. All changes go through the local repo, commit, push, deploy flow — even for one-line production hotfixes.
 - Every bug fix ships with a contract/regression test if one could have caught the bug. Fix-only commits without hardening are incomplete — the test is part of the fix, not a follow-up.
@@ -196,6 +196,27 @@ Split across multiple workflow files now, not just one `ci.yml`:
 Stage 19 warehouse/enrichment operator scripts live here, split into active (top level + `actions/`) and `archive/`. `require_hetzner_operator_env.sh` gates production-touching operator scripts. **Stage 19 (data warehouse/enrichment) is currently paused** for test-environment hardening, not actively worked — don't resume Stage 19 operator actions without checking `docs/ROADMAP.md`'s current status first; the state-resolution gate above will hard-stop most of them anyway outside the right branch/context.
 
 ## Frontend deployment
+
+### Deliberate release sequence
+
+Production promotion is manual and explicit:
+
+1. The PR merges to `main`.
+2. The reviewer or owner checks the **local preview**, from `frontend/`, with
+   `VITE_STAGE26E_PRODUCTION_MAP=enabled` and `yarn dev`, and confirms the
+   change looks right.
+3. The owner explicitly requests a production deploy. A merge by itself is not
+   deploy authorization.
+4. Run `scripts/release-main-to-prod.ps1`, which delegates to the canonical
+   server-side `scripts/deploy_main.sh`.
+5. Only after that wrapper succeeds, check `https://ed-finder.app` and verify
+   the change on the real live site.
+
+Failure mode: checking the live site for a change that is merged but not yet
+deployed looks identical to a broken fix. First run
+`scripts/check-production-drift.ps1`; it compares the SHA reported by live
+`/api/health` with `origin/main`, prints how many commits production is behind,
+and exits non-zero on drift. This is visibility only: it never deploys.
 
 After any frontend code change is pushed to origin/main, the production deploy sequence is:
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,19 @@ docker compose up -d eddn
 
 ### Deploy `main`
 
+Promotion is deliberate and manual: merge, verify the flag-enabled local
+preview, obtain explicit owner approval, run the release wrapper, and only then
+verify the live site. Before assuming a merged change is broken, check whether
+production is simply behind:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-production-drift.ps1
+```
+
+The check fetches `origin/main`, compares it with the `build_sha` reported by
+the public `/api/health` endpoint, prints the exact number of commits behind,
+and exits non-zero on drift. It reports status only and never deploys.
+
 Use the production deploy wrapper for normal code/schema releases. It pulls
 `main`, applies the known safe additive SQL migrations, builds the frontend,
 rebuilds/restarts app containers, reloads nginx, and runs health checks.

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     rate_limit_search:  str  = '30/minute'
     rate_limit_default: str  = '120/minute'
     app_version:        str  = '3.0.1-hetzner'
+    build_sha:          str  = 'unknown'
     admin_token:        Optional[str] = None
     # Optional read-only station enrichment status artifact. This should point
     # at JSON produced by `scripts/station_enrichment_status.py --json` on a

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -396,6 +396,7 @@ class HealthResponse(BaseModel):
     status:   str
     database: str
     version:  str
+    build_sha: str
 
 
 class AutocompleteHit(BaseModel):

--- a/apps/api/src/routers/meta.py
+++ b/apps/api/src/routers/meta.py
@@ -62,6 +62,7 @@ async def health(pool: asyncpg.Pool = Depends(get_pool)):
             status='ok',
             database='connected',
             version=settings.app_version,
+            build_sha=settings.build_sha,
         )
     except asyncio.TimeoutError:
         raise HTTPException(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
       TTL_SEARCH:           3600
       TTL_SYSTEM:           86400
       TTL_CLUSTER:          86400
+      BUILD_SHA:            ${EDFINDER_BUILD_SHA:-unknown}
       COMPOSE_PROJECT_DIR:  /opt/ed-finder   # used by admin/rebuild-clusters endpoint
       # Security — admin endpoints disabled unless a token is set in .env.
       ADMIN_TOKEN:          ${ADMIN_TOKEN:-}

--- a/frontend/src/types/api.gen.ts
+++ b/frontend/src/types/api.gen.ts
@@ -2783,6 +2783,8 @@ export interface components {
             database: string;
             /** Version */
             version: string;
+            /** Build Sha */
+            build_sha: string;
         };
         /** JournalImportClientManifest */
         JournalImportClientManifest: {

--- a/scripts/check-production-drift.ps1
+++ b/scripts/check-production-drift.ps1
@@ -1,0 +1,60 @@
+param(
+  [string]$RepoPath = '',
+  [string]$PublicUrl = 'https://ed-finder.app'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoPath) {
+  $RepoPath = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+}
+
+Push-Location $RepoPath
+try {
+  git fetch --prune origin
+  if ($LASTEXITCODE -ne 0) {
+    throw 'Could not fetch origin.'
+  }
+
+  $mainSha = (git rev-parse origin/main).Trim()
+  $healthUrl = "$($PublicUrl.TrimEnd('/'))/api/health"
+  $health = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 20
+  $liveSha = [string]$health.build_sha
+
+  if ($liveSha -notmatch '^[0-9a-f]{40}$') {
+    Write-Host @"
+DEPLOY DRIFT UNKNOWN: $healthUrl did not report a full build_sha.
+Live value: '$liveSha'
+Deploy the build-SHA instrumentation once, then rerun this check.
+"@ -ForegroundColor Red
+    exit 2
+  }
+
+  if ($liveSha -eq $mainSha) {
+    Write-Host "DEPLOY CURRENT: production matches origin/main at $mainSha" -ForegroundColor Green
+    exit 0
+  }
+
+  git merge-base --is-ancestor $liveSha origin/main
+  if ($LASTEXITCODE -eq 0) {
+    $behind = (git rev-list --count "$liveSha..origin/main").Trim()
+    Write-Host @"
+DEPLOY DRIFT: production is $behind commit(s) behind origin/main.
+Production:  $liveSha
+origin/main: $mainSha
+If the owner has approved promotion, run scripts/release-main-to-prod.ps1.
+"@ -ForegroundColor Red
+    exit 1
+  }
+
+  Write-Host @"
+DEPLOY DIVERGENCE: production is not an ancestor of origin/main.
+Production:  $liveSha
+origin/main: $mainSha
+Inspect the production checkout before deploying.
+"@ -ForegroundColor Red
+  exit 3
+}
+finally {
+  Pop-Location
+}

--- a/scripts/deploy_main.sh
+++ b/scripts/deploy_main.sh
@@ -159,6 +159,9 @@ else
 fi
 
 say "Rebuild/restart application containers"
+export EDFINDER_BUILD_SHA
+EDFINDER_BUILD_SHA="$(git rev-parse HEAD)"
+ok "deployment build SHA: $EDFINDER_BUILD_SHA"
 docker compose up -d --build api eddn maintenance
 ok "application containers updated"
 

--- a/scripts/release-main-to-prod.ps1
+++ b/scripts/release-main-to-prod.ps1
@@ -266,6 +266,10 @@ $health = Invoke-RestMethod -Uri $healthUrl -TimeoutSec 20
 if ($health.status -ne 'ok') {
   throw "Public health check did not return status=ok from $healthUrl"
 }
+if ($health.build_sha -ne (git rev-parse HEAD).Trim()) {
+  throw "Public health build_sha does not match local HEAD. live=$($health.build_sha) local=$((git rev-parse HEAD).Trim())"
+}
+Write-Host "[release] Public build SHA matches local HEAD: $($health.build_sha)"
 
 $baseUrl = $PublicUrl.TrimEnd('/')
 $probePath = if ($AppProbePath.StartsWith('/')) { $AppProbePath } else { "/$AppProbePath" }

--- a/tests/integration/test_infrastructure.py
+++ b/tests/integration/test_infrastructure.py
@@ -10,6 +10,7 @@ async def test_health(client):
     assert r.status_code == 200
     body = r.json()
     assert body['status'] == 'ok'
+    assert body['build_sha']
 
 
 async def test_db_reachable(pool):

--- a/tests/integration/test_phase6_api_coverage.py
+++ b/tests/integration/test_phase6_api_coverage.py
@@ -82,6 +82,7 @@ async def test_health_endpoint(client):
     assert body['status'] == 'ok'
     assert body['database'] == 'connected'
     assert 'version' in body
+    assert 'build_sha' in body
 
 
 async def test_status_endpoint(client):

--- a/tests/test_deploy_drift_contract.py
+++ b/tests/test_deploy_drift_contract.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(*parts: str) -> str:
+    return ROOT.joinpath(*parts).read_text(encoding='utf-8')
+
+
+def test_health_exposes_the_deployed_commit_sha():
+    config = _read('apps', 'api', 'src', 'config.py')
+    model = _read('apps', 'api', 'src', 'models.py')
+    route = _read('apps', 'api', 'src', 'routers', 'meta.py')
+    compose = _read('docker-compose.yml')
+    deploy = _read('scripts', 'deploy_main.sh')
+
+    assert "build_sha:          str  = 'unknown'" in config
+    assert 'build_sha: str' in model
+    assert 'build_sha=settings.build_sha' in route
+    assert 'BUILD_SHA:            ${EDFINDER_BUILD_SHA:-unknown}' in compose
+    assert 'EDFINDER_BUILD_SHA="$(git rev-parse HEAD)"' in deploy
+
+
+def test_manual_drift_check_is_loud_and_never_deploys():
+    check = _read('scripts', 'check-production-drift.ps1')
+
+    assert 'git fetch --prune origin' in check
+    assert 'git rev-parse origin/main' in check
+    assert 'git rev-list --count "$liveSha..origin/main"' in check
+    assert 'DEPLOY DRIFT:' in check
+    assert 'scripts/release-main-to-prod.ps1' in check
+    assert '& scripts/release-main-to-prod.ps1' not in check
+
+
+def test_release_wrapper_requires_the_live_sha_to_match():
+    release = _read('scripts', 'release-main-to-prod.ps1')
+
+    assert "$health.build_sha -ne (git rev-parse HEAD).Trim()" in release
+    assert 'Public build SHA matches local HEAD' in release


### PR DESCRIPTION
## What changed

- documents the deliberate five-step release sequence: merge, flag-enabled local preview, explicit owner deploy request, release wrapper, then live-site verification
- names today's failure mode: a merged-but-not-deployed change looks identical to a broken fix when checked on production
- exposes the deployed commit as `build_sha` from `/api/health`
- injects the SHA through the canonical `deploy_main.sh` path
- adds `scripts/check-production-drift.ps1`, which fetches `origin/main`, reports current/behind/unknown/divergent state, prints the exact number of commits behind, and never deploys
- makes the release wrapper verify that the public `build_sha` matches the released HEAD

## Why

Production promotion is intentionally manual and requires explicit owner approval, but the merge-to-deploy handoff had no visible drift signal. That allowed a not-yet-deployed change to be mistaken for a failed fix.

## Validation

- `python -m pytest tests/test_deploy_drift_contract.py tests/test_ci_build_reproducibility_contracts.py -q` — 7 passed, 1 skipped
- `bash -n scripts/deploy_main.sh` through Git for Windows Bash
- `docker compose config` verified SHA propagation into `BUILD_SHA`
- live pre-instrumentation check returned the expected loud `DEPLOY DRIFT UNKNOWN` with exit code 2
- `python -m compileall -q apps/api/src`
- `git diff --check`

No automatic deployment workflow was added. Deploy remains a deliberate manual action.