### PR TITLE
Conditionally invalidate renderer resize telemetry

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -244,6 +244,139 @@ test.describe('ED Finder — smoke', () => {
     await expectCanvasToBeSynced(page);
     expect(graphicsWarnings).toEqual([]);
   });
+
+  test('invalidates renderer sync telemetry while a resize is pending', async ({ page }) => {
+    await page.getByTestId('nav-map').click();
+    await page.getByTestId('map-view-galaxy').click();
+
+    const renderer = page.locator('.map-foundation-renderer');
+    await expect(renderer).toHaveAttribute('data-galaxy-point-count', '18000');
+    const canvas = renderer.locator('canvas');
+    await expect.poll(
+      () => canvas.evaluate((element) => element.dataset.drawingBufferSynced),
+    ).toBe('true');
+
+    await canvas.evaluate((element) => {
+      const instrumented = element as HTMLCanvasElement & {
+        resizeTelemetryObserver?: MutationObserver;
+        resizeTelemetrySequence?: string[];
+      };
+      instrumented.resizeTelemetrySequence = [
+        element.dataset.drawingBufferSynced ?? 'missing',
+      ];
+      instrumented.resizeTelemetryObserver = new MutationObserver(() => {
+        instrumented.resizeTelemetrySequence?.push(
+          element.dataset.drawingBufferSynced ?? 'missing',
+        );
+      });
+      instrumented.resizeTelemetryObserver.observe(element, {
+        attributes: true,
+        attributeFilter: ['data-drawing-buffer-synced'],
+      });
+    });
+
+    await page.setViewportSize({ width: 1111, height: 733 });
+    await expect.poll(async () => {
+      const sequence = await canvas.evaluate((element) => (
+        (element as HTMLCanvasElement & { resizeTelemetrySequence?: string[] })
+          .resizeTelemetrySequence ?? []
+      ));
+      const invalidatedAt = sequence.indexOf('false');
+      return invalidatedAt >= 0
+        && sequence.slice(invalidatedAt + 1).includes('true');
+    }).toBe(true);
+
+    const sequence = await canvas.evaluate((element) => (
+      (element as HTMLCanvasElement & { resizeTelemetrySequence?: string[] })
+        .resizeTelemetrySequence ?? []
+    ));
+    const invalidatedAt = sequence.indexOf('false');
+    const revalidatedAt = sequence.indexOf('true', invalidatedAt + 1);
+    expect(invalidatedAt).toBeGreaterThanOrEqual(0);
+    expect(revalidatedAt).toBeGreaterThan(invalidatedAt);
+  });
+
+  test('keeps renderer sync telemetry verified for a same-size ResizeObserver fire', async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      const NativeResizeObserver = window.ResizeObserver;
+      if (!NativeResizeObserver) return;
+      const callbacks = new WeakMap<ResizeObserver, ResizeObserverCallback>();
+      const testWindow = window as typeof window & {
+        triggerMapResizeObserver?: () => void;
+      };
+      window.ResizeObserver = class TestResizeObserver extends NativeResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          super(callback);
+          callbacks.set(this, callback);
+        }
+
+        observe(target: Element, options?: ResizeObserverOptions) {
+          super.observe(target, options);
+          if (
+            target instanceof HTMLCanvasElement
+            && target.closest('.map-foundation-renderer')
+          ) {
+            testWindow.triggerMapResizeObserver = () => {
+              callbacks.get(this)?.([], this);
+            };
+          }
+        }
+      };
+    });
+    await page.reload();
+    await page.getByTestId('nav-map').click();
+    await page.getByTestId('map-view-galaxy').click();
+
+    const renderer = page.locator('.map-foundation-renderer');
+    await expect(renderer).toHaveAttribute('data-galaxy-point-count', '18000');
+    const canvas = renderer.locator('canvas');
+    await expect.poll(
+      () => canvas.evaluate((element) => element.dataset.drawingBufferSynced),
+    ).toBe('true');
+
+    const observation = await canvas.evaluate(async (element) => {
+      const testWindow = window as typeof window & {
+        triggerMapResizeObserver?: () => void;
+      };
+      const instrumented = element as HTMLCanvasElement & {
+        resizeTelemetryObserver?: MutationObserver;
+        resizeTelemetrySequence?: string[];
+      };
+      const before = element.getBoundingClientRect();
+      instrumented.resizeTelemetrySequence = [
+        element.dataset.drawingBufferSynced ?? 'missing',
+      ];
+      instrumented.resizeTelemetryObserver = new MutationObserver(() => {
+        instrumented.resizeTelemetrySequence?.push(
+          element.dataset.drawingBufferSynced ?? 'missing',
+        );
+      });
+      instrumented.resizeTelemetryObserver.observe(element, {
+        attributes: true,
+        attributeFilter: ['data-drawing-buffer-synced'],
+      });
+
+      const triggerInstalled = typeof testWindow.triggerMapResizeObserver === 'function';
+      testWindow.triggerMapResizeObserver?.();
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      const after = element.getBoundingClientRect();
+      instrumented.resizeTelemetryObserver.disconnect();
+      return {
+        before: { width: before.width, height: before.height },
+        after: { width: after.width, height: after.height },
+        sequence: instrumented.resizeTelemetrySequence ?? [],
+        triggerInstalled,
+      };
+    });
+
+    expect(observation.triggerInstalled).toBe(true);
+    expect(observation.after).toEqual(observation.before);
+    expect(observation.sequence.length).toBeGreaterThan(1);
+    expect(observation.sequence).not.toContain('false');
+  });
 });
 
 test.describe('ED Finder — cross-browser runtime', () => {

--- a/frontend/src/features/map-foundation/R3FMapFoundation.tsx
+++ b/frontend/src/features/map-foundation/R3FMapFoundation.tsx
@@ -219,12 +219,19 @@ function RendererSizeSync({ viewport }: { viewport: ViewportSize }) {
     const canvas = gl.domElement;
 
     let frame: number | null = null;
-    const sync = () => {
-      frame = null;
+    let lastWidth: number | null = null;
+    let lastHeight: number | null = null;
+    let lastDpr: number | null = null;
+    const measure = () => {
       const rect = canvas.getBoundingClientRect();
       const width = Math.max(1, Math.round(rect.width || viewport.width));
       const height = Math.max(1, Math.round(rect.height || viewport.height));
       const dpr = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
+      return { width, height, dpr };
+    };
+    const sync = () => {
+      frame = null;
+      const { width, height, dpr } = measure();
       const state = get();
 
       if (Math.abs(state.viewport.dpr - dpr) > 0.001) setDpr(dpr);
@@ -261,8 +268,22 @@ function RendererSizeSync({ viewport }: { viewport: ViewportSize }) {
         && Math.abs(syncedBuffer.y - expectedHeight) <= 1,
       );
       invalidate();
+      lastWidth = width;
+      lastHeight = height;
+      lastDpr = dpr;
     };
     const queueSync = () => {
+      const { width, height, dpr } = measure();
+      if (
+        lastWidth == null
+        || lastHeight == null
+        || lastDpr == null
+        || width !== lastWidth
+        || height !== lastHeight
+        || Math.abs(dpr - lastDpr) > 0.001
+      ) {
+        canvas.dataset.drawingBufferSynced = 'false';
+      }
       if (frame != null) window.cancelAnimationFrame(frame);
       frame = window.requestAnimationFrame(sync);
     };


### PR DESCRIPTION
## What changed

- Extracts one shared `measure()` helper for renderer width, height, and DPR using the existing measurement expressions.
- Tracks the last successfully synced measurement.
- Marks `data-drawing-buffer-synced="false"` only when width, height, or DPR actually differs, while preserving unconditional rAF scheduling.
- Adds regression coverage for both directions:
  - a real viewport resize must produce `false` and then `true`;
  - a same-size `ResizeObserver` fire must not produce `false`.

## Why

The earlier unconditional invalidation correctly closed a stale-telemetry window, but it also invalidated on same-size `ResizeObserver` notifications. Diagnostics captured Edge failing when a callback fired with rect `1111x733`, last-synced CSS `1111x733`, and unchanged DPR. Conditional invalidation preserves the telemetry contract without claiming a verified buffer is stale when no measurement changed.

## Validation

- TypeScript: 0 errors.
- New same-size test against the unconditional implementation: failed as required with sequence `["true", "false", "true"]`.
- After the amendment, both resize regression tests pass together on Edge.
- Full local matrix, retries=0, one worker, order Edge → Chromium → Firefox:
  - Edge: 10 passed, 0 failed, 1 skipped.
  - Chromium: 8 passed, 2 failed, 1 skipped. These are the pre-existing software-rendered map-navigation/initial-canvas timeouts already documented outside this change.
  - Firefox: 10 passed, 0 failed, 1 skipped.
- Ten separate Edge project executions: nine green; one had a Windows Playwright worker crash (`3221226505`) during the unrelated legacy `/api/watchlist` test. All map and both telemetry tests subsequently passed in that run. Two additional diagnostic executions reproduced environment instability (worker crash; one preview-server loss), not a resize assertion failure. No retries, timeout changes, or test relaxations were added.

## Scope

Only `R3FMapFoundation.tsx` and `smoke.spec.ts` are changed. No Playwright configuration or deployment changes.