### PR TITLE
26F-DEFAULTS-1: enable heatmap default and galaxy initial preset

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -190,14 +190,22 @@ test.describe('ED Finder — smoke', () => {
     const regionResponsePromise = page.waitForResponse((response) => (
       new URL(response.url()).pathname === '/stage26e/authoritative-regions.json'
     ));
+    const heatmapResponsePromise = page.waitForResponse((response) => (
+      new URL(response.url()).pathname === '/api/map/heatmap'
+    ));
 
     await page.getByTestId('nav-map').click();
 
-    const regionResponse = await regionResponsePromise;
+    const [regionResponse, heatmapResponse] = await Promise.all([
+      regionResponsePromise,
+      heatmapResponsePromise,
+    ]);
     expect(regionResponse.status()).toBe(200);
+    expect(heatmapResponse.status()).toBe(200);
     await expect(page.getByTestId('stage26e-production-map')).toBeVisible();
     await expect(page.getByTestId('stage26e-route-flag-state')).toContainText('Live map');
     await expect(page.getByTestId('stage26e-map-regions-toggle')).toBeChecked();
+    await expect(page.getByTestId('stage26e-map-heatmap-toggle')).toBeChecked();
 
     await page.getByTestId('map-view-galaxy').click();
     await expect(page.getByTestId('map-projection-2d')).toHaveCount(0);

--- a/frontend/src/features/map-foundation/ProductionMapTab.test.tsx
+++ b/frontend/src/features/map-foundation/ProductionMapTab.test.tsx
@@ -134,6 +134,14 @@ describe('Stage 26E production route composition', () => {
     render(<ProductionMapTab systems={[]} reference={{ name: 'Sol', x: 0, z: 0 }} />);
 
     expect(screen.getByTestId('r3f-production-renderer').getAttribute('data-view-preset')).toBe('galaxy');
+    expect(screen.queryByText('No systems to map yet')).toBeNull();
+  });
+
+  it('shows the empty state for Finder results with no systems', () => {
+    render(<ProductionMapTab systems={[]} reference={{ name: 'Sol', x: 0, z: 0 }} />);
+
+    fireEvent.click(screen.getByTestId('map-view-results'));
+    expect(screen.getByText('No systems to map yet')).toBeTruthy();
   });
 
   it('bounds Finder systems and composes authoritative regions plus enabled live overlays', () => {

--- a/frontend/src/features/map-foundation/ProductionMapTab.test.tsx
+++ b/frontend/src/features/map-foundation/ProductionMapTab.test.tsx
@@ -8,13 +8,14 @@ import type { SystemResult } from '@/types/api';
 vi.mock('@/features/map/useMapLayers');
 vi.mock('./production-regions');
 vi.mock('./R3FMapFoundation', () => ({
-  R3FMapFoundation: ({ scene, regions, productionOverlays, onInteraction, onZoomIntent }: {
+  R3FMapFoundation: ({ scene, regions, productionOverlays, viewPreset, onInteraction, onZoomIntent }: {
     scene: {
       systems: Array<{ id64: number }>;
       camera: { bearingDeg: number; pitchDeg: number; zoom: number };
     };
     regions: { labels: unknown[]; boundaries: unknown[] };
     productionOverlays: { heatmap: { cellCount: number } | null; aggregateHulls: { hullCount: number } | null };
+    viewPreset: string;
     onInteraction: (event: { type: 'selectSystem'; systemId64: number; clusterAnchorId64: null }) => void;
     onZoomIntent?: (deltaY: number) => void;
   }) => (
@@ -26,6 +27,7 @@ vi.mock('./R3FMapFoundation', () => ({
       data-camera-bearing={scene.camera.bearingDeg}
       data-camera-pitch={scene.camera.pitchDeg}
       data-camera-zoom={scene.camera.zoom}
+      data-view-preset={viewPreset}
       data-heatmap-count={productionOverlays.heatmap?.cellCount ?? 0}
       data-hull-count={productionOverlays.aggregateHulls?.hullCount ?? 0}
     >
@@ -124,9 +126,14 @@ describe('Stage 26E production route composition', () => {
   it('keeps the whole-galaxy chart available before Finder has results', () => {
     render(<ProductionMapTab systems={[]} reference={{ name: 'Sol', x: 0, z: 0 }} />);
 
-    expect(screen.getByText('No systems to map yet')).toBeTruthy();
-    fireEvent.click(screen.getByTestId('map-view-galaxy'));
+    expect(screen.getByTestId('map-view-galaxy').getAttribute('aria-pressed')).toBe('true');
     expect(screen.getByTestId('r3f-production-renderer')).toBeTruthy();
+  });
+
+  it('keeps galaxy framing on a cold open with no Finder systems', () => {
+    render(<ProductionMapTab systems={[]} reference={{ name: 'Sol', x: 0, z: 0 }} />);
+
+    expect(screen.getByTestId('r3f-production-renderer').getAttribute('data-view-preset')).toBe('galaxy');
   });
 
   it('bounds Finder systems and composes authoritative regions plus enabled live overlays', () => {
@@ -134,14 +141,24 @@ describe('Stage 26E production route composition', () => {
 
     expect(screen.getByTestId('stage26e-route-flag-state').textContent).toContain('Live map');
     expect((screen.getByTestId('stage26e-map-regions-toggle') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('stage26e-map-heatmap-toggle') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByTestId('stage26e-map-clusters-toggle') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByTestId('stage26e-map-timeline-toggle') as HTMLInputElement).checked).toBe(false);
+    expect(vi.mocked(useMapLayers)).toHaveBeenCalledWith(expect.objectContaining({
+      heatmap: { enabled: true, max_cells: 50_000 },
+    }));
     const renderer = screen.getByTestId('r3f-production-renderer');
     expect(renderer.getAttribute('data-system-count')).toBe('500');
     expect(renderer.getAttribute('data-region-label-count')).toBe('42');
     expect(renderer.getAttribute('data-region-boundary-count')).toBe('1');
-    expect(renderer.getAttribute('data-heatmap-count')).toBe('0');
+    expect(renderer.getAttribute('data-heatmap-count')).toBe('1');
     expect(renderer.getAttribute('data-hull-count')).toBe('0');
 
     fireEvent.click(screen.getByTestId('stage26e-map-heatmap-toggle'));
+    expect((screen.getByTestId('stage26e-map-heatmap-toggle') as HTMLInputElement).checked).toBe(false);
+    expect(renderer.getAttribute('data-heatmap-count')).toBe('0');
+    fireEvent.click(screen.getByTestId('stage26e-map-heatmap-toggle'));
+    expect((screen.getByTestId('stage26e-map-heatmap-toggle') as HTMLInputElement).checked).toBe(true);
     fireEvent.click(screen.getByTestId('stage26e-map-clusters-toggle'));
     fireEvent.click(screen.getByTestId('stage26e-map-timeline-toggle'));
 

--- a/frontend/src/features/map-foundation/ProductionMapTab.tsx
+++ b/frontend/src/features/map-foundation/ProductionMapTab.tsx
@@ -97,9 +97,9 @@ export function ProductionMapTab({
   );
   const [viewport, setViewport] = useState(DEFAULT_VIEWPORT);
   const [scene, setScene] = useState<MapSceneState>(() => emptyProductionScene(referenceCoords));
-  const [viewPreset, setViewPreset] = useState<MapViewPreset>('results');
+  const [viewPreset, setViewPreset] = useState<MapViewPreset>('galaxy');
   const [showRegions, setShowRegions] = useState(true);
-  const [showHeatmap, setShowHeatmap] = useState(false);
+  const [showHeatmap, setShowHeatmap] = useState(true);
   const [showClusters, setShowClusters] = useState(false);
   const [showTimeline, setShowTimeline] = useState(false);
   const [timelineBucket, setTimelineBucket] = useState<'month' | 'quarter' | 'year'>('month');
@@ -117,8 +117,9 @@ export function ProductionMapTab({
         continuationToken: null,
       },
     });
-    setScene(applyViewPreset(handoff.scene, 'results', referenceCoords, DEFAULT_VIEWPORT));
-    setViewPreset('results');
+    const preset = boundedSystems.length > 0 ? 'results' : 'galaxy';
+    setScene(applyViewPreset(handoff.scene, preset, referenceCoords, DEFAULT_VIEWPORT));
+    setViewPreset(preset);
   }, [boundedSystems, initialSelectedSystemId, referenceCoords, systems.length]);
 
   useLayoutEffect(() => {

--- a/frontend/stage26e-route/e2e/live-route-memory.spec.ts
+++ b/frontend/stage26e-route/e2e/live-route-memory.spec.ts
@@ -86,19 +86,35 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
     });
 
     let regionGeometryResponseStatus = 0;
+    let heatmapResponseStatus = 0;
+    let heatmapCellCount = 0;
+    let heatmapSourceTruncated = false;
     await test.step('mount the flagged production route candidate with bounded region geometry', async () => {
       const regionResponsePromise = page.waitForResponse((response) => (
         new URL(response.url()).pathname === '/stage26e/authoritative-regions.json'
       ));
+      const heatmapResponsePromise = page.waitForResponse((response) => (
+        new URL(response.url()).pathname === '/api/map/heatmap'
+      ));
       await page.getByTestId('nav-map').click();
-      const regionResponse = await regionResponsePromise;
+      const [regionResponse, heatmapResponse] = await Promise.all([
+        regionResponsePromise,
+        heatmapResponsePromise,
+      ]);
       regionGeometryResponseStatus = regionResponse.status();
+      heatmapResponseStatus = heatmapResponse.status();
       const regionBody = await regionResponse.json() as { labels?: unknown[]; boundaries?: unknown[] };
+      const heatmapBody = await heatmapResponse.json() as { cells?: unknown[]; truncated?: boolean };
+      heatmapCellCount = Math.min(50_000, heatmapBody.cells?.length ?? 0);
+      heatmapSourceTruncated = heatmapBody.truncated ?? false;
       expect(regionGeometryResponseStatus).toBe(200);
+      expect(heatmapResponseStatus).toBe(200);
       expect(regionBody.labels).toHaveLength(42);
       expect(regionBody.boundaries).toHaveLength(22_595);
+      expect(heatmapCellCount).toBeGreaterThan(0);
       await expect(page.getByTestId('stage26e-production-map')).toBeVisible();
       await expect(page.getByTestId('stage26e-production-map-viewport')).toBeVisible();
+      await expect(page.getByTestId('stage26e-map-heatmap-toggle')).toBeChecked();
       await expect.poll(async () => page.evaluate(() => window.__stage26eProductionMap?.snapshot().finderSystemCount ?? 0))
         .toBe(500);
       await expect.poll(async () => page.evaluate(() => window.__stage26eProductionMap?.snapshot().regionBoundaryCount ?? 0))
@@ -106,16 +122,13 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
     });
 
     let beforeOverlays!: Awaited<ReturnType<typeof measureHeap>>;
-    await test.step('sample precise heap before aggregate overlays', async () => {
+    await test.step('sample precise heap with default heatmap before optional overlays', async () => {
       beforeOverlays = await measureHeap(context, page);
       expect(beforeOverlays.supported).toBe(true);
     });
 
-    let heatmapResponseStatus = 0;
     let clusterResponseStatus = 0;
     let timelineResponseStatus = 0;
-    let heatmapCellCount = 0;
-    let heatmapSourceTruncated = false;
     let aggregateHullCount = 0;
     let timelinePointCount = 0;
     await test.step('load and compose live aggregate overlays', async () => {
@@ -140,15 +153,10 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
       const heatmapBody = JSON.parse(heatmapText) as { cells?: unknown[]; truncated?: boolean };
       const clusterBody = JSON.parse(clusterText) as { clusters?: unknown[] };
       const timelineBody = JSON.parse(timelineText) as { points?: unknown[] };
-      heatmapCellCount = Math.min(50_000, heatmapBody.cells?.length ?? 0);
-      heatmapSourceTruncated = heatmapBody.truncated ?? false;
+      expect(Math.min(50_000, heatmapBody.cells?.length ?? 0)).toBe(heatmapCellCount);
+      expect(heatmapBody.truncated ?? false).toBe(heatmapSourceTruncated);
       aggregateHullCount = Math.min(2_000, clusterBody.clusters?.length ?? 0);
       timelinePointCount = Math.min(1_200, timelineBody.points?.length ?? 0);
-      await page.route('**/api/map/heatmap?**', (route) => route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: heatmapText,
-      }));
       await page.route('**/api/map/clusters/hulls?**', (route) => route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -159,27 +167,20 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
         contentType: 'application/json',
         body: timelineText,
       }));
-      const heatmapResponsePromise = page.waitForResponse((response) => (
-        new URL(response.url()).pathname === '/api/map/heatmap'
-      ));
       const clusterResponsePromise = page.waitForResponse((response) => (
         new URL(response.url()).pathname === '/api/map/clusters/hulls'
       ));
       const timelineResponsePromise = page.waitForResponse((response) => (
         new URL(response.url()).pathname === '/api/map/timeline'
       ));
-      await page.getByTestId('stage26e-map-heatmap-toggle').click();
       await page.getByTestId('stage26e-map-clusters-toggle').click();
       await page.getByTestId('stage26e-map-timeline-toggle').click();
-      const [heatmapResponse, clusterResponse, timelineResponse] = await Promise.all([
-        heatmapResponsePromise,
+      const [clusterResponse, timelineResponse] = await Promise.all([
         clusterResponsePromise,
         timelineResponsePromise,
       ]);
-      heatmapResponseStatus = heatmapResponse.status();
       clusterResponseStatus = clusterResponse.status();
       timelineResponseStatus = timelineResponse.status();
-      expect(heatmapResponseStatus).toBe(200);
       expect(clusterResponseStatus).toBe(200);
       expect(timelineResponseStatus).toBe(200);
       expect(heatmapCellCount).toBeGreaterThan(0);
@@ -216,6 +217,7 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
       expect(snapshot.regionPositionBytes).toBe(542_280);
       expect(requestedApiPaths.some((apiPath) => apiPath.startsWith('/api/map/regions'))).toBe(false);
       expect(requestedApiPaths).toContain('/stage26e/authoritative-regions.json');
+      expect(requestedApiPaths).toContain('/api/map/heatmap?max_cells=50000');
     });
 
     return {
@@ -239,7 +241,7 @@ async function measureViewport(browser: Browser, viewport: typeof VIEWPORTS[numb
 const measurements: RouteMeasurement[] = [];
 
 for (const viewport of VIEWPORTS) {
-  test(`measures the default-off candidate at ${viewport.width}x${viewport.height}`, async ({ browser }) => {
+  test(`measures the default-on candidate at ${viewport.width}x${viewport.height}`, async ({ browser }) => {
     test.setTimeout(180_000);
     const measurement = await measureViewport(browser, viewport);
     measurements.push(measurement);


### PR DESCRIPTION
## Summary
- enable the production map heatmap by default while preserving the existing region/cluster/timeline/bucket defaults
- keep cold opens and zero-result searches in Whole galaxy framing; retain Finder-results framing whenever systems exist
- strengthen component, smoke, and Stage 26E route-memory assertions for the new defaults

## Root cause and fix
The initial `viewPreset='galaxy'` was inert because the Finder hand-off effect unconditionally reapplied `results` after mount. The effect now selects `results` only when `boundedSystems.length > 0`, otherwise `galaxy`, and uses that preset for both scene and UI state. The scene update remains unconditional.

## Runtime evidence
- cold open: preset remained `galaxy`; authoritative labels loaded 0 → 42 and visible labels 0 → 17 → 34
- real Finder search: 50 shown / 11,956 total; map preset `results`, centre `(0, 0)`, zoom `0.6764963346552604`
- forced zero-result Finder response: 0 shown / 0 total; map preset `galaxy`, 34 visible labels

## Regression proof
- new cold-open test before fix: failed, expected `galaxy`, received `results`
- after fix: passed; complete `ProductionMapTab.test.tsx` file is 6/6 green
- typecheck: 0 errors
- production build and build-contract checks: passed

## Playwright matrix (retries=0, one worker, msedge → chromium → firefox)
- msedge: 10 passed, 0 failed, 1 skipped
- chromium: 7 passed, 3 failed, 1 skipped; local software-rendering/navigation timeouts at smoke lines 212, 264, and 344, reported without retry or config changes
- firefox: 10 passed, 0 failed, 1 skipped

The separate Stage 26E route-memory timeout was reproduced on unmodified main before this amendment: its first viewport never issued `/api/local/search`; no retry or timeout change was made.

No deploy was run.