### PR TITLE
Make backup retention survive offsite failures

### DIFF
--- a/apps/maintenance/Dockerfile
+++ b/apps/maintenance/Dockerfile
@@ -9,9 +9,10 @@ FROM postgres:16-alpine
 # plays nicely with `docker logs`.
 #
 # `python3` + `py3-psycopg2` let the sidecar run the production-safe
-# invariants wrapper directly on its weekly schedule, and `rclone`
-# provides the optional offsite backup sync path.
-RUN apk add --no-cache dcron tini bash python3 py3-psycopg2 rclone
+# invariants wrapper directly on its weekly schedule, `rclone`
+# provides the optional offsite backup sync path, and `curl` sends the
+# optional dead-man's-switch heartbeats.
+RUN apk add --no-cache dcron tini bash python3 py3-psycopg2 rclone curl
 
 WORKDIR /opt/ed-finder
 

--- a/apps/maintenance/scripts/run_backup.sh
+++ b/apps/maintenance/scripts/run_backup.sh
@@ -19,6 +19,7 @@ TASK="${1:-nightly}"
 DB_URL="${DATABASE_URL:?DATABASE_URL must be set}"
 BACKUP_DIR="${BACKUP_DIR:-/data/backups/postgres}"
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
+RETENTION_MIN_ARCHIVES="${BACKUP_RETENTION_MIN_ARCHIVES:-3}"
 LOG_FILE="${BACKUP_LOG_FILE:-/data/logs/backup.log}"
 BACKUP_OFFSITE_REMOTE="${BACKUP_OFFSITE_REMOTE:-}"
 
@@ -48,14 +49,33 @@ cleanup_tmp_archive() {
 trap cleanup_tmp_archive EXIT
 
 prune_local_backups() {
-    find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump' -mtime +"$RETENTION_DAYS" -print -delete
-    find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.sha256' -mtime +"$RETENTION_DAYS" -print -delete
-    find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.json' -mtime +"$RETENTION_DAYS" -print -delete
+    local archive
+    local archive_count
+    local -a expired_archives=()
+
+    archive_count="$(find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump' | wc -l | tr -d '[:space:]')"
+    mapfile -t expired_archives < <(
+        find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump' -mtime +"$RETENTION_DAYS" -print | sort
+    )
+
+    for archive in "${expired_archives[@]}"; do
+        if (( archive_count <= RETENTION_MIN_ARCHIVES )); then
+            echo "retention floor: keeping $archive because only $archive_count archive(s) remain (minimum $RETENTION_MIN_ARCHIVES)"
+            break
+        fi
+
+        rm -f -- "$archive" "${archive}.sha256" "${archive}.json"
+        echo "$archive"
+        echo "${archive}.sha256"
+        echo "${archive}.json"
+        archive_count=$((archive_count - 1))
+    done
 }
 
 echo "===== Postgres backup starting ====="
 echo "backup dir: $BACKUP_DIR"
 echo "retention:  ${RETENTION_DAYS} days"
+echo "minimum:    ${RETENTION_MIN_ARCHIVES} archives"
 echo "archive:    $ARCHIVE"
 if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
     echo "offsite:    $BACKUP_OFFSITE_REMOTE"

--- a/apps/maintenance/scripts/run_backup.sh
+++ b/apps/maintenance/scripts/run_backup.sh
@@ -42,6 +42,11 @@ META_FILE="${ARCHIVE}.json"
 LATEST_LINK="$BACKUP_DIR/latest.dump"
 LATEST_META_LINK="$BACKUP_DIR/latest.json"
 
+cleanup_tmp_archive() {
+    rm -f -- "${TMP_ARCHIVE:-}" || true
+}
+trap cleanup_tmp_archive EXIT
+
 echo "===== Postgres backup starting ====="
 echo "backup dir: $BACKUP_DIR"
 echo "retention:  ${RETENTION_DAYS} days"
@@ -69,18 +74,12 @@ OFFSITE_SYNCED_AT_JSON="null"
 OFFSITE_REMOTE_JSON="null"
 
 if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
-    command -v rclone >/dev/null 2>&1 || {
-        echo "BACKUP_OFFSITE_REMOTE is set but rclone is unavailable" >&2
-        exit 1
-    }
+    OFFSITE_SYNC_STATUS="failed"
     OFFSITE_REMOTE_JSON="\"$BACKUP_OFFSITE_REMOTE\""
-    rclone copyto "$ARCHIVE" "$BACKUP_OFFSITE_REMOTE/$(basename "$ARCHIVE")"
-    rclone copyto "$SHA_FILE" "$BACKUP_OFFSITE_REMOTE/$(basename "$SHA_FILE")"
-    OFFSITE_SYNC_STATUS="synced"
-    OFFSITE_SYNCED_AT_JSON="\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\""
 fi
 
-cat > "$META_FILE" <<EOF
+write_metadata() {
+    cat > "$META_FILE" <<EOF
 {
   "created_at_utc": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')",
   "task": "$TASK",
@@ -95,11 +94,9 @@ cat > "$META_FILE" <<EOF
   "offsite_synced_at_utc": $OFFSITE_SYNCED_AT_JSON
 }
 EOF
+}
 
-if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
-    rclone copyto "$META_FILE" "$BACKUP_OFFSITE_REMOTE/$(basename "$META_FILE")"
-    rclone copyto "$META_FILE" "$BACKUP_OFFSITE_REMOTE/latest.json"
-fi
+write_metadata
 
 ln -sfn "$(basename "$ARCHIVE")" "$LATEST_LINK"
 ln -sfn "$(basename "$META_FILE")" "$LATEST_META_LINK"
@@ -108,7 +105,37 @@ find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump' -mtime +"$RETENTI
 find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.sha256' -mtime +"$RETENTION_DAYS" -print -delete
 find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.json' -mtime +"$RETENTION_DAYS" -print -delete
 
+OFFSITE_EXIT_CODE=0
+if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
+    if ! command -v rclone >/dev/null 2>&1; then
+        echo "BACKUP_OFFSITE_REMOTE is set but rclone is unavailable" >&2
+        OFFSITE_EXIT_CODE=1
+    elif rclone copyto "$ARCHIVE" "$BACKUP_OFFSITE_REMOTE/$(basename "$ARCHIVE")" \
+        && rclone copyto "$SHA_FILE" "$BACKUP_OFFSITE_REMOTE/$(basename "$SHA_FILE")"; then
+        OFFSITE_SYNC_STATUS="synced"
+        OFFSITE_SYNCED_AT_JSON="\"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\""
+        write_metadata
+        if ! rclone copyto "$META_FILE" "$BACKUP_OFFSITE_REMOTE/$(basename "$META_FILE")" \
+            || ! rclone copyto "$META_FILE" "$BACKUP_OFFSITE_REMOTE/latest.json"; then
+            OFFSITE_EXIT_CODE=1
+        fi
+    else
+        OFFSITE_EXIT_CODE=1
+    fi
+
+    if [[ "$OFFSITE_EXIT_CODE" -ne 0 ]]; then
+        OFFSITE_SYNC_STATUS="failed"
+        OFFSITE_SYNCED_AT_JSON="null"
+        write_metadata
+        echo "ERROR: offsite backup sync failed for $ARCHIVE; local archive, metadata, latest symlinks, and retention completed" >&2
+    fi
+fi
+
 echo "===== Postgres backup complete ====="
 echo "archive size bytes: $SIZE_BYTES"
 echo "latest symlink:     $LATEST_LINK"
 echo "offsite status:     $OFFSITE_SYNC_STATUS"
+
+if [[ "$OFFSITE_EXIT_CODE" -ne 0 ]]; then
+    exit "$OFFSITE_EXIT_CODE"
+fi

--- a/apps/maintenance/scripts/run_backup.sh
+++ b/apps/maintenance/scripts/run_backup.sh
@@ -22,6 +22,8 @@ RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-14}"
 RETENTION_MIN_ARCHIVES="${BACKUP_RETENTION_MIN_ARCHIVES:-3}"
 LOG_FILE="${BACKUP_LOG_FILE:-/data/logs/backup.log}"
 BACKUP_OFFSITE_REMOTE="${BACKUP_OFFSITE_REMOTE:-}"
+BACKUP_HEARTBEAT_URL="${BACKUP_HEARTBEAT_URL:-}"
+BACKUP_OFFSITE_HEARTBEAT_URL="${BACKUP_OFFSITE_HEARTBEAT_URL:-}"
 
 mkdir -p "$BACKUP_DIR" "$(dirname "$LOG_FILE")"
 
@@ -72,6 +74,35 @@ prune_local_backups() {
     done
 }
 
+log_heartbeat_skipped() {
+    local label="$1"
+    local url="$2"
+    local reason="$3"
+
+    if [[ -z "$url" ]]; then
+        echo "$label heartbeat: skipped (unconfigured)"
+    else
+        echo "$label heartbeat: skipped ($reason)"
+    fi
+}
+
+send_heartbeat() {
+    local label="$1"
+    local url="$2"
+
+    if [[ -z "$url" ]]; then
+        echo "$label heartbeat: skipped (unconfigured)"
+        return 0
+    fi
+
+    if curl -fsS -m 10 --retry 3 "$url"; then
+        echo "$label heartbeat: sent"
+    else
+        echo "$label heartbeat: failed" >&2
+    fi
+    return 0
+}
+
 echo "===== Postgres backup starting ====="
 echo "backup dir: $BACKUP_DIR"
 echo "retention:  ${RETENTION_DAYS} days"
@@ -93,6 +124,8 @@ if pg_dump "$DB_URL" \
 else
     DUMP_EXIT_CODE=$?
     prune_local_backups
+    log_heartbeat_skipped "local" "$BACKUP_HEARTBEAT_URL" "no valid local archive"
+    log_heartbeat_skipped "offsite" "$BACKUP_OFFSITE_HEARTBEAT_URL" "no valid local archive"
     echo "ERROR: pg_dump failed for $ARCHIVE; local retention completed" >&2
     exit "$DUMP_EXIT_CODE"
 fi
@@ -135,6 +168,7 @@ ln -sfn "$(basename "$ARCHIVE")" "$LATEST_LINK"
 ln -sfn "$(basename "$META_FILE")" "$LATEST_META_LINK"
 
 prune_local_backups
+send_heartbeat "local" "$BACKUP_HEARTBEAT_URL"
 
 OFFSITE_EXIT_CODE=0
 if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
@@ -166,6 +200,12 @@ if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
             echo "ERROR: offsite backup sync failed for $ARCHIVE; local archive, metadata, latest symlinks, and retention completed" >&2
         fi
     fi
+fi
+
+if [[ "$OFFSITE_SYNC_STATUS" == "synced" ]]; then
+    send_heartbeat "offsite" "$BACKUP_OFFSITE_HEARTBEAT_URL"
+else
+    log_heartbeat_skipped "offsite" "$BACKUP_OFFSITE_HEARTBEAT_URL" "offsite status $OFFSITE_SYNC_STATUS"
 fi
 
 echo "===== Postgres backup complete ====="

--- a/apps/maintenance/scripts/run_backup.sh
+++ b/apps/maintenance/scripts/run_backup.sh
@@ -47,6 +47,12 @@ cleanup_tmp_archive() {
 }
 trap cleanup_tmp_archive EXIT
 
+prune_local_backups() {
+    find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump' -mtime +"$RETENTION_DAYS" -print -delete
+    find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.sha256' -mtime +"$RETENTION_DAYS" -print -delete
+    find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.json' -mtime +"$RETENTION_DAYS" -print -delete
+}
+
 echo "===== Postgres backup starting ====="
 echo "backup dir: $BACKUP_DIR"
 echo "retention:  ${RETENTION_DAYS} days"
@@ -57,12 +63,19 @@ else
     echo "offsite:    disabled"
 fi
 
-pg_dump "$DB_URL" \
+if pg_dump "$DB_URL" \
     --format=custom \
     --compress=6 \
     --no-owner \
     --no-privileges \
-    --file="$TMP_ARCHIVE"
+    --file="$TMP_ARCHIVE"; then
+    ARCHIVE_CREATED_AT_UTC="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+else
+    DUMP_EXIT_CODE=$?
+    prune_local_backups
+    echo "ERROR: pg_dump failed for $ARCHIVE; local retention completed" >&2
+    exit "$DUMP_EXIT_CODE"
+fi
 
 mv "$TMP_ARCHIVE" "$ARCHIVE"
 pg_restore --list "$ARCHIVE" >/dev/null
@@ -81,7 +94,7 @@ fi
 write_metadata() {
     cat > "$META_FILE" <<EOF
 {
-  "created_at_utc": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')",
+  "created_at_utc": "$ARCHIVE_CREATED_AT_UTC",
   "task": "$TASK",
   "archive_file": "$(basename "$ARCHIVE")",
   "sha256_file": "$(basename "$SHA_FILE")",
@@ -101,9 +114,7 @@ write_metadata
 ln -sfn "$(basename "$ARCHIVE")" "$LATEST_LINK"
 ln -sfn "$(basename "$META_FILE")" "$LATEST_META_LINK"
 
-find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump' -mtime +"$RETENTION_DAYS" -print -delete
-find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.sha256' -mtime +"$RETENTION_DAYS" -print -delete
-find "$BACKUP_DIR" -maxdepth 1 -type f -name 'edfinder_*.dump.json' -mtime +"$RETENTION_DAYS" -print -delete
+prune_local_backups
 
 OFFSITE_EXIT_CODE=0
 if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
@@ -118,16 +129,22 @@ if [[ -n "$BACKUP_OFFSITE_REMOTE" ]]; then
         if ! rclone copyto "$META_FILE" "$BACKUP_OFFSITE_REMOTE/$(basename "$META_FILE")" \
             || ! rclone copyto "$META_FILE" "$BACKUP_OFFSITE_REMOTE/latest.json"; then
             OFFSITE_EXIT_CODE=1
+            OFFSITE_SYNC_STATUS="synced_metadata_failed"
+            write_metadata
         fi
     else
         OFFSITE_EXIT_CODE=1
     fi
 
     if [[ "$OFFSITE_EXIT_CODE" -ne 0 ]]; then
-        OFFSITE_SYNC_STATUS="failed"
-        OFFSITE_SYNCED_AT_JSON="null"
-        write_metadata
-        echo "ERROR: offsite backup sync failed for $ARCHIVE; local archive, metadata, latest symlinks, and retention completed" >&2
+        if [[ "$OFFSITE_SYNC_STATUS" == "synced_metadata_failed" ]]; then
+            echo "ERROR: offsite backup metadata sync failed for $ARCHIVE; archive and checksum are synced; local archive, metadata, latest symlinks, and retention completed" >&2
+        else
+            OFFSITE_SYNC_STATUS="failed"
+            OFFSITE_SYNCED_AT_JSON="null"
+            write_metadata
+            echo "ERROR: offsite backup sync failed for $ARCHIVE; local archive, metadata, latest symlinks, and retention completed" >&2
+        fi
     fi
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,9 @@ services:
       BACKUP_DIR:    /data/backups/postgres
       BACKUP_RETENTION_DAYS: ${BACKUP_RETENTION_DAYS:-14}
       BACKUP_OFFSITE_REMOTE: ${BACKUP_OFFSITE_REMOTE:-}
+      # Optional dead-man's-switch services alert when an expected ping does not arrive.
+      BACKUP_HEARTBEAT_URL: ${BACKUP_HEARTBEAT_URL:-}
+      BACKUP_OFFSITE_HEARTBEAT_URL: ${BACKUP_OFFSITE_HEARTBEAT_URL:-}
       EVIDENCE_RECORD_RETENTION_DAYS: ${EVIDENCE_RECORD_RETENTION_DAYS:-90}
       ADMIN_JOB_RUN_RETENTION_DAYS: ${ADMIN_JOB_RUN_RETENTION_DAYS:-60}
       BACKUP_LOG_FILE: /data/logs/backup.log

--- a/env.example
+++ b/env.example
@@ -30,6 +30,11 @@ DATABASE_MIGRATION_URL=
 # Leave blank to keep backups on the local host only.
 BACKUP_OFFSITE_REMOTE=
 
+# Optional dead-man's-switch heartbeat URLs. The external service alerts when
+# an expected ping does not arrive; leave blank to disable each ping entirely.
+BACKUP_HEARTBEAT_URL=
+BACKUP_OFFSITE_HEARTBEAT_URL=
+
 # Admin-token — required for /api/admin/* and /api/cache/clear.
 # Leave blank to disable those endpoints entirely (default / safest).
 # Generate with: openssl rand -hex 32

--- a/tests/test_backup_restore_ops.py
+++ b/tests/test_backup_restore_ops.py
@@ -27,7 +27,9 @@ def _run_backup_scenario(
     *,
     offsite: bool = False,
     rclone_result: str = 'success',
+    rclone_sleep_seconds: int = 0,
     pg_dump_result: str = 'success',
+    existing_latest: bool = False,
 ) -> dict[str, object]:
     bash = shutil.which('bash')
     assert bash is not None, 'bash is required for the backup-script behavior tests'
@@ -47,6 +49,18 @@ def _run_backup_scenario(
     for path in old_files:
         path.write_text('expired', encoding='utf-8')
         os.utime(path, (old_timestamp, old_timestamp))
+
+    previous_archive = None
+    previous_metadata = None
+    if existing_latest:
+        previous_archive = backup_dir / 'edfinder_20010101T000000Z.dump'
+        previous_metadata = Path(f'{previous_archive}.json')
+        previous_archive.write_text('previous valid archive', encoding='utf-8')
+        previous_metadata.write_text('{"previous": true}\n', encoding='utf-8')
+        (backup_dir / 'latest.dump').symlink_to(previous_archive.name)
+        (backup_dir / 'latest.json').symlink_to(previous_metadata.name)
+
+    baseline_metadata_files = set(backup_dir.glob('edfinder_*.dump.json'))
 
     _write_executable(fake_bin / 'pg_dump', '''#!/bin/bash
 set -eu
@@ -75,15 +89,24 @@ else
     echo 'old-absent' >> "${RCLONE_ORDER_LOG}"
 fi
 printf '%s\n' "$*" >> "${RCLONE_CALL_LOG}"
+if [[ "$2" == *.dump ]]; then
+    cp "${2}.json" "${RCLONE_PRE_UPLOAD_METADATA}"
+    sleep "${FAKE_RCLONE_SLEEP_SECONDS:-0}"
+fi
 if [[ "${FAKE_RCLONE_RESULT:-success}" == 'fail' ]]; then
     echo 'fake rclone failure' >&2
     exit 23
+fi
+if [[ "${FAKE_RCLONE_RESULT:-success}" == 'metadata-fail' && "$2" == *.dump.json ]]; then
+    echo 'fake rclone metadata failure' >&2
+    exit 24
 fi
 ''')
 
     log_file = tmp_path / 'backup.log'
     order_log = tmp_path / 'rclone-order.log'
     call_log = tmp_path / 'rclone-calls.log'
+    pre_upload_metadata = tmp_path / 'pre-upload-metadata.json'
     env = {
         **os.environ,
         'DATABASE_URL': 'postgresql://unused/backup-test',
@@ -93,9 +116,11 @@ fi
         'BACKUP_OFFSITE_REMOTE': 'fake:backups' if offsite else '',
         'FAKE_PG_DUMP_RESULT': pg_dump_result,
         'FAKE_RCLONE_RESULT': rclone_result,
+        'FAKE_RCLONE_SLEEP_SECONDS': str(rclone_sleep_seconds),
         'RCLONE_OBSERVED_OLD_FILE': str(old_base),
         'RCLONE_ORDER_LOG': str(order_log),
         'RCLONE_CALL_LOG': str(call_log),
+        'RCLONE_PRE_UPLOAD_METADATA': str(pre_upload_metadata),
         'PATH': f'{fake_bin}{os.pathsep}{os.environ.get("PATH", "")}',
     }
     completed = subprocess.run(
@@ -114,7 +139,7 @@ fi
         time.sleep(0.01)
 
     metadata_files = list(backup_dir.glob('edfinder_*.dump.json'))
-    current_metadata = [path for path in metadata_files if path not in old_files]
+    current_metadata = [path for path in metadata_files if path not in baseline_metadata_files]
     metadata = (
         json.loads(current_metadata[0].read_text(encoding='utf-8'))
         if len(current_metadata) == 1
@@ -124,7 +149,15 @@ fi
         'completed': completed,
         'backup_dir': backup_dir,
         'old_files': old_files,
+        'previous_archive': previous_archive,
+        'previous_metadata': previous_metadata,
         'metadata': metadata,
+        'metadata_files_created': current_metadata,
+        'pre_upload_metadata': (
+            json.loads(pre_upload_metadata.read_text(encoding='utf-8'))
+            if pre_upload_metadata.exists()
+            else None
+        ),
         'log': log_file.read_text(encoding='utf-8') if log_file.exists() else '',
         'order': order_log.read_text(encoding='utf-8').splitlines() if order_log.exists() else [],
         'calls': call_log.read_text(encoding='utf-8').splitlines() if call_log.exists() else [],
@@ -218,6 +251,23 @@ def test_successful_offsite_sync_runs_after_prune_and_records_synced(tmp_path: P
     assert len(observation['calls']) == 4
 
 
+def test_offsite_metadata_rewrite_preserves_archive_creation_time(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        offsite=True,
+        rclone_sleep_seconds=2,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert observation['pre_upload_metadata'] is not None
+    assert (
+        observation['pre_upload_metadata']['created_at_utc']
+        == observation['metadata']['created_at_utc']
+    )
+
+
 def test_failed_offsite_sync_still_prunes_and_records_loud_failure(tmp_path: Path):
     observation = _run_backup_scenario(tmp_path, offsite=True, rclone_result='fail')
     completed = observation['completed']
@@ -230,13 +280,45 @@ def test_failed_offsite_sync_still_prunes_and_records_loud_failure(tmp_path: Pat
     assert 'ERROR: offsite backup sync failed' in observation['log']
 
 
-def test_failed_pg_dump_removes_temporary_archive(tmp_path: Path):
-    observation = _run_backup_scenario(tmp_path, pg_dump_result='fail')
+def test_metadata_upload_failure_records_archive_as_synced_and_exits_nonzero(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        offsite=True,
+        rclone_result='metadata-fail',
+    )
     completed = observation['completed']
 
     assert isinstance(completed, subprocess.CompletedProcess)
     assert completed.returncode != 0
+    assert all(not path.exists() for path in observation['old_files'])
+    assert observation['metadata']['offsite_sync_status'] == 'synced_metadata_failed'
+    assert observation['metadata']['offsite_synced_at_utc'] is not None
+    assert 'ERROR: offsite backup metadata sync failed' in observation['log']
+    assert len(observation['calls']) == 3
+    assert '.dump ' in observation['calls'][0]
+    assert '.dump.sha256 ' in observation['calls'][1]
+    assert '.dump.json ' in observation['calls'][2]
+
+
+def test_failed_pg_dump_still_prunes_without_replacing_latest(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        pg_dump_result='fail',
+        existing_latest=True,
+    )
+    completed = observation['completed']
+    latest_dump = observation['backup_dir'] / 'latest.dump'
+    latest_metadata = observation['backup_dir'] / 'latest.json'
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert all(not path.exists() for path in observation['old_files'])
     assert list(observation['backup_dir'].glob('*.dump.tmp')) == []
+    assert observation['metadata_files_created'] == []
+    assert latest_dump.readlink() == Path(observation['previous_archive'].name)
+    assert latest_metadata.readlink() == Path(observation['previous_metadata'].name)
+    assert observation['previous_archive'].exists()
+    assert observation['previous_metadata'].exists()
 
 
 def test_backup_runbook_and_remediation_docs_reflect_current_state():

--- a/tests/test_backup_restore_ops.py
+++ b/tests/test_backup_restore_ops.py
@@ -1,4 +1,9 @@
+import json
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import time
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -10,6 +15,120 @@ def _read(*parts: str) -> str:
 
 def _squash(text: str) -> str:
     return ' '.join(text.split())
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding='utf-8', newline='\n')
+    path.chmod(0o755)
+
+
+def _run_backup_scenario(
+    tmp_path: Path,
+    *,
+    offsite: bool = False,
+    rclone_result: str = 'success',
+    pg_dump_result: str = 'success',
+) -> dict[str, object]:
+    bash = shutil.which('bash')
+    assert bash is not None, 'bash is required for the backup-script behavior tests'
+
+    backup_dir = tmp_path / 'backups'
+    fake_bin = tmp_path / 'bin'
+    backup_dir.mkdir()
+    fake_bin.mkdir()
+
+    old_base = backup_dir / 'edfinder_20000101T000000Z.dump'
+    old_files = [
+        old_base,
+        Path(f'{old_base}.sha256'),
+        Path(f'{old_base}.json'),
+    ]
+    old_timestamp = time.time() - (3 * 24 * 60 * 60)
+    for path in old_files:
+        path.write_text('expired', encoding='utf-8')
+        os.utime(path, (old_timestamp, old_timestamp))
+
+    _write_executable(fake_bin / 'pg_dump', '''#!/bin/bash
+set -eu
+output=''
+for argument in "$@"; do
+    case "$argument" in
+        --file=*) output="${argument#--file=}" ;;
+    esac
+done
+test -n "$output"
+: > "$output"
+if [[ "${FAKE_PG_DUMP_RESULT:-success}" == 'fail' ]]; then
+    echo 'fake pg_dump failure' >&2
+    exit 41
+fi
+printf 'valid fake archive\n' > "$output"
+''')
+    _write_executable(fake_bin / 'pg_restore', '''#!/bin/bash
+exit 0
+''')
+    _write_executable(fake_bin / 'rclone', '''#!/bin/bash
+set -eu
+if [[ -e "${RCLONE_OBSERVED_OLD_FILE}" ]]; then
+    echo 'old-present' >> "${RCLONE_ORDER_LOG}"
+else
+    echo 'old-absent' >> "${RCLONE_ORDER_LOG}"
+fi
+printf '%s\n' "$*" >> "${RCLONE_CALL_LOG}"
+if [[ "${FAKE_RCLONE_RESULT:-success}" == 'fail' ]]; then
+    echo 'fake rclone failure' >&2
+    exit 23
+fi
+''')
+
+    log_file = tmp_path / 'backup.log'
+    order_log = tmp_path / 'rclone-order.log'
+    call_log = tmp_path / 'rclone-calls.log'
+    env = {
+        **os.environ,
+        'DATABASE_URL': 'postgresql://unused/backup-test',
+        'BACKUP_DIR': str(backup_dir),
+        'BACKUP_LOG_FILE': str(log_file),
+        'BACKUP_RETENTION_DAYS': '0',
+        'BACKUP_OFFSITE_REMOTE': 'fake:backups' if offsite else '',
+        'FAKE_PG_DUMP_RESULT': pg_dump_result,
+        'FAKE_RCLONE_RESULT': rclone_result,
+        'RCLONE_OBSERVED_OLD_FILE': str(old_base),
+        'RCLONE_ORDER_LOG': str(order_log),
+        'RCLONE_CALL_LOG': str(call_log),
+        'PATH': f'{fake_bin}{os.pathsep}{os.environ.get("PATH", "")}',
+    }
+    completed = subprocess.run(
+        [bash, str(ROOT / 'apps' / 'maintenance' / 'scripts' / 'run_backup.sh'), 'manual'],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    # The script's process-substitution logger can finish a few milliseconds
+    # after the parent shell exits. Give it a bounded window to flush.
+    deadline = time.monotonic() + 1
+    while not log_file.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    metadata_files = list(backup_dir.glob('edfinder_*.dump.json'))
+    current_metadata = [path for path in metadata_files if path not in old_files]
+    metadata = (
+        json.loads(current_metadata[0].read_text(encoding='utf-8'))
+        if len(current_metadata) == 1
+        else None
+    )
+    return {
+        'completed': completed,
+        'backup_dir': backup_dir,
+        'old_files': old_files,
+        'metadata': metadata,
+        'log': log_file.read_text(encoding='utf-8') if log_file.exists() else '',
+        'order': order_log.read_text(encoding='utf-8').splitlines() if order_log.exists() else [],
+        'calls': call_log.read_text(encoding='utf-8').splitlines() if call_log.exists() else [],
+    }
 
 
 def test_backup_automation_is_wired_through_maintenance_sidecar():
@@ -72,6 +191,52 @@ def test_backup_script_can_optionally_mirror_archives_offsite():
     assert 'rclone copyto "$META_FILE"' in backup
     assert '"offsite_sync_status": "$OFFSITE_SYNC_STATUS"' in backup
     assert 'latest.json' in backup
+
+
+def test_backup_with_offsite_disabled_creates_metadata_and_prunes(tmp_path: Path):
+    observation = _run_backup_scenario(tmp_path)
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert observation['metadata']['offsite_sync_status'] == 'disabled'
+    assert observation['metadata']['offsite_synced_at_utc'] is None
+    assert all(not path.exists() for path in observation['old_files'])
+    assert len(list(observation['backup_dir'].glob('edfinder_*.dump'))) == 1
+
+
+def test_successful_offsite_sync_runs_after_prune_and_records_synced(tmp_path: Path):
+    observation = _run_backup_scenario(tmp_path, offsite=True)
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert observation['metadata']['offsite_sync_status'] == 'synced'
+    assert observation['metadata']['offsite_synced_at_utc'] is not None
+    assert all(not path.exists() for path in observation['old_files'])
+    assert observation['order'] == ['old-absent'] * 4
+    assert len(observation['calls']) == 4
+
+
+def test_failed_offsite_sync_still_prunes_and_records_loud_failure(tmp_path: Path):
+    observation = _run_backup_scenario(tmp_path, offsite=True, rclone_result='fail')
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert all(not path.exists() for path in observation['old_files'])
+    assert observation['metadata']['offsite_sync_status'] == 'failed'
+    assert observation['metadata']['offsite_synced_at_utc'] is None
+    assert 'ERROR: offsite backup sync failed' in observation['log']
+
+
+def test_failed_pg_dump_removes_temporary_archive(tmp_path: Path):
+    observation = _run_backup_scenario(tmp_path, pg_dump_result='fail')
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert list(observation['backup_dir'].glob('*.dump.tmp')) == []
 
 
 def test_backup_runbook_and_remediation_docs_reflect_current_state():

--- a/tests/test_backup_restore_ops.py
+++ b/tests/test_backup_restore_ops.py
@@ -30,6 +30,9 @@ def _run_backup_scenario(
     rclone_sleep_seconds: int = 0,
     pg_dump_result: str = 'success',
     existing_latest: bool = False,
+    old_archive_count: int = 1,
+    retention_min_archives: int | None = 1,
+    fresh_sidecars_for_oldest: bool = False,
 ) -> dict[str, object]:
     bash = shutil.which('bash')
     assert bash is not None, 'bash is required for the backup-script behavior tests'
@@ -39,23 +42,36 @@ def _run_backup_scenario(
     backup_dir.mkdir()
     fake_bin.mkdir()
 
-    old_base = backup_dir / 'edfinder_20000101T000000Z.dump'
-    old_files = [
-        old_base,
-        Path(f'{old_base}.sha256'),
-        Path(f'{old_base}.json'),
-    ]
+    old_archive_groups = []
     old_timestamp = time.time() - (3 * 24 * 60 * 60)
-    for path in old_files:
-        path.write_text('expired', encoding='utf-8')
-        os.utime(path, (old_timestamp, old_timestamp))
+    for index in range(old_archive_count):
+        old_base = backup_dir / f'edfinder_200001{index + 1:02d}T000000Z.dump'
+        old_group = [
+            old_base,
+            Path(f'{old_base}.sha256'),
+            Path(f'{old_base}.json'),
+        ]
+        for path in old_group:
+            path.write_text('expired', encoding='utf-8')
+            os.utime(path, (old_timestamp + index, old_timestamp + index))
+        old_archive_groups.append(old_group)
+
+    if fresh_sidecars_for_oldest:
+        for path in old_archive_groups[0][1:]:
+            os.utime(path, None)
+
+    old_archives = [group[0] for group in old_archive_groups]
+    old_files = [path for group in old_archive_groups for path in group]
+    old_base = old_archives[0]
 
     previous_archive = None
     previous_metadata = None
     if existing_latest:
         previous_archive = backup_dir / 'edfinder_20010101T000000Z.dump'
         previous_metadata = Path(f'{previous_archive}.json')
+        previous_checksum = Path(f'{previous_archive}.sha256')
         previous_archive.write_text('previous valid archive', encoding='utf-8')
+        previous_checksum.write_text('previous checksum', encoding='utf-8')
         previous_metadata.write_text('{"previous": true}\n', encoding='utf-8')
         (backup_dir / 'latest.dump').symlink_to(previous_archive.name)
         (backup_dir / 'latest.json').symlink_to(previous_metadata.name)
@@ -123,6 +139,8 @@ fi
         'RCLONE_PRE_UPLOAD_METADATA': str(pre_upload_metadata),
         'PATH': f'{fake_bin}{os.pathsep}{os.environ.get("PATH", "")}',
     }
+    if retention_min_archives is not None:
+        env['BACKUP_RETENTION_MIN_ARCHIVES'] = str(retention_min_archives)
     completed = subprocess.run(
         [bash, str(ROOT / 'apps' / 'maintenance' / 'scripts' / 'run_backup.sh'), 'manual'],
         cwd=ROOT,
@@ -148,6 +166,7 @@ fi
     return {
         'completed': completed,
         'backup_dir': backup_dir,
+        'old_archives': old_archives,
         'old_files': old_files,
         'previous_archive': previous_archive,
         'previous_metadata': previous_metadata,
@@ -162,6 +181,20 @@ fi
         'order': order_log.read_text(encoding='utf-8').splitlines() if order_log.exists() else [],
         'calls': call_log.read_text(encoding='utf-8').splitlines() if call_log.exists() else [],
     }
+
+
+def _assert_archive_sidecars_consistent(backup_dir: Path) -> None:
+    archives = list(backup_dir.glob('edfinder_*.dump'))
+    checksums = list(backup_dir.glob('edfinder_*.dump.sha256'))
+    metadata_files = list(backup_dir.glob('edfinder_*.dump.json'))
+
+    for archive in archives:
+        assert Path(f'{archive}.sha256').exists()
+        assert Path(f'{archive}.json').exists()
+    for checksum in checksums:
+        assert Path(str(checksum).removesuffix('.sha256')).exists()
+    for metadata_file in metadata_files:
+        assert Path(str(metadata_file).removesuffix('.json')).exists()
 
 
 def test_backup_automation_is_wired_through_maintenance_sidecar():
@@ -218,6 +251,7 @@ def test_backup_script_can_optionally_mirror_archives_offsite():
     backup = _read('apps', 'maintenance', 'scripts', 'run_backup.sh')
 
     assert 'BACKUP_OFFSITE_REMOTE="${BACKUP_OFFSITE_REMOTE:-}"' in backup
+    assert 'BACKUP_RETENTION_MIN_ARCHIVES:-3' in backup
     assert 'command -v rclone >/dev/null 2>&1' in backup
     assert 'rclone copyto "$ARCHIVE"' in backup
     assert 'rclone copyto "$SHA_FILE"' in backup
@@ -319,6 +353,70 @@ def test_failed_pg_dump_still_prunes_without_replacing_latest(tmp_path: Path):
     assert latest_metadata.readlink() == Path(observation['previous_metadata'].name)
     assert observation['previous_archive'].exists()
     assert observation['previous_metadata'].exists()
+
+
+def test_retention_floor_holds_under_repeated_dump_failure(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        pg_dump_result='fail',
+        old_archive_count=3,
+        retention_min_archives=None,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert all(path.exists() for path in observation['old_files'])
+    assert len(list(observation['backup_dir'].glob('edfinder_*.dump'))) == 3
+    assert 'retention floor: keeping' in completed.stdout + completed.stderr
+    _assert_archive_sidecars_consistent(observation['backup_dir'])
+
+
+def test_retention_floor_allows_normal_pruning_down_to_floor(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        old_archive_count=6,
+        retention_min_archives=None,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert len(list(observation['backup_dir'].glob('edfinder_*.dump'))) == 3
+    assert all(not path.exists() for path in observation['old_archives'][:4])
+    assert all(path.exists() for path in observation['old_archives'][4:])
+    _assert_archive_sidecars_consistent(observation['backup_dir'])
+
+
+def test_retention_prunes_archive_and_sidecars_as_one_unit(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        old_archive_count=4,
+        retention_min_archives=3,
+        fresh_sidecars_for_oldest=True,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    _assert_archive_sidecars_consistent(observation['backup_dir'])
+
+
+def test_retention_floor_is_configurable(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        pg_dump_result='fail',
+        old_archive_count=3,
+        retention_min_archives=1,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert len(list(observation['backup_dir'].glob('edfinder_*.dump'))) == 1
+    assert all(not path.exists() for path in observation['old_archives'][:2])
+    assert observation['old_archives'][2].exists()
+    _assert_archive_sidecars_consistent(observation['backup_dir'])
 
 
 def test_backup_runbook_and_remediation_docs_reflect_current_state():

--- a/tests/test_backup_restore_ops.py
+++ b/tests/test_backup_restore_ops.py
@@ -33,6 +33,9 @@ def _run_backup_scenario(
     old_archive_count: int = 1,
     retention_min_archives: int | None = 1,
     fresh_sidecars_for_oldest: bool = False,
+    local_heartbeat_url: str = '',
+    offsite_heartbeat_url: str = '',
+    curl_result: str = 'success',
 ) -> dict[str, object]:
     bash = shutil.which('bash')
     assert bash is not None, 'bash is required for the backup-script behavior tests'
@@ -118,10 +121,19 @@ if [[ "${FAKE_RCLONE_RESULT:-success}" == 'metadata-fail' && "$2" == *.dump.json
     exit 24
 fi
 ''')
+    _write_executable(fake_bin / 'curl', '''#!/bin/bash
+set -eu
+printf '%s\n' "${!#}" >> "${CURL_CALL_LOG}"
+if [[ "${FAKE_CURL_RESULT:-success}" == 'fail' ]]; then
+    echo 'fake curl failure' >&2
+    exit 28
+fi
+''')
 
     log_file = tmp_path / 'backup.log'
     order_log = tmp_path / 'rclone-order.log'
     call_log = tmp_path / 'rclone-calls.log'
+    curl_call_log = tmp_path / 'curl-calls.log'
     pre_upload_metadata = tmp_path / 'pre-upload-metadata.json'
     env = {
         **os.environ,
@@ -130,9 +142,13 @@ fi
         'BACKUP_LOG_FILE': str(log_file),
         'BACKUP_RETENTION_DAYS': '0',
         'BACKUP_OFFSITE_REMOTE': 'fake:backups' if offsite else '',
+        'BACKUP_HEARTBEAT_URL': local_heartbeat_url,
+        'BACKUP_OFFSITE_HEARTBEAT_URL': offsite_heartbeat_url,
         'FAKE_PG_DUMP_RESULT': pg_dump_result,
         'FAKE_RCLONE_RESULT': rclone_result,
         'FAKE_RCLONE_SLEEP_SECONDS': str(rclone_sleep_seconds),
+        'FAKE_CURL_RESULT': curl_result,
+        'CURL_CALL_LOG': str(curl_call_log),
         'RCLONE_OBSERVED_OLD_FILE': str(old_base),
         'RCLONE_ORDER_LOG': str(order_log),
         'RCLONE_CALL_LOG': str(call_log),
@@ -180,6 +196,11 @@ fi
         'log': log_file.read_text(encoding='utf-8') if log_file.exists() else '',
         'order': order_log.read_text(encoding='utf-8').splitlines() if order_log.exists() else [],
         'calls': call_log.read_text(encoding='utf-8').splitlines() if call_log.exists() else [],
+        'heartbeat_calls': (
+            curl_call_log.read_text(encoding='utf-8').splitlines()
+            if curl_call_log.exists()
+            else []
+        ),
     }
 
 
@@ -199,6 +220,7 @@ def _assert_archive_sidecars_consistent(backup_dir: Path) -> None:
 
 def test_backup_automation_is_wired_through_maintenance_sidecar():
     compose = _read('docker-compose.yml')
+    env_example = _read('env.example')
     crontab = _read('apps', 'maintenance', 'scripts', 'crontab')
     dockerfile = _read('apps', 'maintenance', 'Dockerfile')
 
@@ -206,12 +228,17 @@ def test_backup_automation_is_wired_through_maintenance_sidecar():
     assert 'dockerfile: apps/maintenance/Dockerfile' in compose
     assert 'BACKUP_DIR:    /data/backups/postgres' in compose
     assert 'BACKUP_OFFSITE_REMOTE: ${BACKUP_OFFSITE_REMOTE:-}' in compose
+    assert 'BACKUP_HEARTBEAT_URL: ${BACKUP_HEARTBEAT_URL:-}' in compose
+    assert 'BACKUP_OFFSITE_HEARTBEAT_URL: ${BACKUP_OFFSITE_HEARTBEAT_URL:-}' in compose
+    assert 'BACKUP_HEARTBEAT_URL=' in env_example
+    assert 'BACKUP_OFFSITE_HEARTBEAT_URL=' in env_example
+    assert "dead-man's-switch heartbeat URLs" in env_example
     assert '- /data/backups:/data/backups' in compose
     assert '- /data/receipts:/data/receipts' in compose
     assert '/usr/local/bin/run_backup.sh nightly' in crontab
     assert '/usr/local/bin/run_data_invariants_receipted.sh --target-rating-version 3.4' in crontab
     assert '--production-safe --allow-stale-colonisation-status' in crontab
-    assert 'apk add --no-cache dcron tini bash python3 py3-psycopg2 rclone' in dockerfile
+    assert 'apk add --no-cache dcron tini bash python3 py3-psycopg2 rclone curl' in dockerfile
     assert 'COPY apps/maintenance/scripts/run_backup.sh                /usr/local/bin/run_backup.sh' in dockerfile
     assert 'COPY scripts/run_data_invariants_receipted.sh              /usr/local/bin/run_data_invariants_receipted.sh' in dockerfile
     assert 'COPY scripts/checks/data_invariants.py                     /opt/ed-finder/scripts/checks/data_invariants.py' in dockerfile
@@ -251,7 +278,10 @@ def test_backup_script_can_optionally_mirror_archives_offsite():
     backup = _read('apps', 'maintenance', 'scripts', 'run_backup.sh')
 
     assert 'BACKUP_OFFSITE_REMOTE="${BACKUP_OFFSITE_REMOTE:-}"' in backup
+    assert 'BACKUP_HEARTBEAT_URL="${BACKUP_HEARTBEAT_URL:-}"' in backup
+    assert 'BACKUP_OFFSITE_HEARTBEAT_URL="${BACKUP_OFFSITE_HEARTBEAT_URL:-}"' in backup
     assert 'BACKUP_RETENTION_MIN_ARCHIVES:-3' in backup
+    assert 'curl -fsS -m 10 --retry 3 "$url"' in backup
     assert 'command -v rclone >/dev/null 2>&1' in backup
     assert 'rclone copyto "$ARCHIVE"' in backup
     assert 'rclone copyto "$SHA_FILE"' in backup
@@ -273,7 +303,14 @@ def test_backup_with_offsite_disabled_creates_metadata_and_prunes(tmp_path: Path
 
 
 def test_successful_offsite_sync_runs_after_prune_and_records_synced(tmp_path: Path):
-    observation = _run_backup_scenario(tmp_path, offsite=True)
+    local_url = 'https://heartbeat.invalid/local-offsite-success'
+    offsite_url = 'https://heartbeat.invalid/offsite-success'
+    observation = _run_backup_scenario(
+        tmp_path,
+        offsite=True,
+        local_heartbeat_url=local_url,
+        offsite_heartbeat_url=offsite_url,
+    )
     completed = observation['completed']
 
     assert isinstance(completed, subprocess.CompletedProcess)
@@ -283,6 +320,7 @@ def test_successful_offsite_sync_runs_after_prune_and_records_synced(tmp_path: P
     assert all(not path.exists() for path in observation['old_files'])
     assert observation['order'] == ['old-absent'] * 4
     assert len(observation['calls']) == 4
+    assert observation['heartbeat_calls'] == [local_url, offsite_url]
 
 
 def test_offsite_metadata_rewrite_preserves_archive_creation_time(tmp_path: Path):
@@ -315,10 +353,12 @@ def test_failed_offsite_sync_still_prunes_and_records_loud_failure(tmp_path: Pat
 
 
 def test_metadata_upload_failure_records_archive_as_synced_and_exits_nonzero(tmp_path: Path):
+    offsite_heartbeat_url = 'https://heartbeat.invalid/offsite-metadata-failure'
     observation = _run_backup_scenario(
         tmp_path,
         offsite=True,
         rclone_result='metadata-fail',
+        offsite_heartbeat_url=offsite_heartbeat_url,
     )
     completed = observation['completed']
 
@@ -332,6 +372,7 @@ def test_metadata_upload_failure_records_archive_as_synced_and_exits_nonzero(tmp
     assert '.dump ' in observation['calls'][0]
     assert '.dump.sha256 ' in observation['calls'][1]
     assert '.dump.json ' in observation['calls'][2]
+    assert observation['heartbeat_calls'] == []
 
 
 def test_failed_pg_dump_still_prunes_without_replacing_latest(tmp_path: Path):
@@ -417,6 +458,86 @@ def test_retention_floor_is_configurable(tmp_path: Path):
     assert all(not path.exists() for path in observation['old_archives'][:2])
     assert observation['old_archives'][2].exists()
     _assert_archive_sidecars_consistent(observation['backup_dir'])
+
+
+def test_unconfigured_heartbeats_are_skipped_without_attempting_a_ping(tmp_path: Path):
+    observation = _run_backup_scenario(tmp_path)
+    completed = observation['completed']
+    output = completed.stdout + completed.stderr
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, output
+    assert observation['heartbeat_calls'] == []
+    assert 'local heartbeat: skipped (unconfigured)' in output
+    assert 'offsite heartbeat: skipped (unconfigured)' in output
+
+
+def test_local_success_sends_the_local_heartbeat_once(tmp_path: Path):
+    heartbeat_url = 'https://heartbeat.invalid/local-success'
+    observation = _run_backup_scenario(
+        tmp_path,
+        local_heartbeat_url=heartbeat_url,
+    )
+    completed = observation['completed']
+    output = completed.stdout + completed.stderr
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, output
+    assert observation['heartbeat_calls'] == [heartbeat_url]
+    assert 'local heartbeat: sent' in output
+
+
+def test_offsite_failure_does_not_suppress_the_local_heartbeat(tmp_path: Path):
+    local_url = 'https://heartbeat.invalid/local-offsite-failure'
+    offsite_url = 'https://heartbeat.invalid/offsite-failure'
+    observation = _run_backup_scenario(
+        tmp_path,
+        offsite=True,
+        rclone_result='fail',
+        local_heartbeat_url=local_url,
+        offsite_heartbeat_url=offsite_url,
+    )
+    completed = observation['completed']
+    output = completed.stdout + completed.stderr
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['heartbeat_calls'] == [local_url]
+    assert 'local heartbeat: sent' in output
+    assert 'offsite heartbeat: skipped (offsite status failed)' in output
+
+
+def test_dump_failure_sends_no_heartbeat(tmp_path: Path):
+    observation = _run_backup_scenario(
+        tmp_path,
+        pg_dump_result='fail',
+        local_heartbeat_url='https://heartbeat.invalid/local-dump-failure',
+        offsite_heartbeat_url='https://heartbeat.invalid/offsite-dump-failure',
+    )
+    completed = observation['completed']
+    output = completed.stdout + completed.stderr
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['heartbeat_calls'] == []
+    assert 'local heartbeat: skipped (no valid local archive)' in output
+    assert 'offsite heartbeat: skipped (no valid local archive)' in output
+
+
+def test_heartbeat_failure_does_not_change_backup_success(tmp_path: Path):
+    heartbeat_url = 'https://heartbeat.invalid/local-ping-failure'
+    observation = _run_backup_scenario(
+        tmp_path,
+        local_heartbeat_url=heartbeat_url,
+        curl_result='fail',
+    )
+    completed = observation['completed']
+    output = completed.stdout + completed.stderr
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, output
+    assert observation['heartbeat_calls'] == [heartbeat_url]
+    assert 'local heartbeat: failed' in output
 
 
 def test_backup_runbook_and_remediation_docs_reflect_current_state():


### PR DESCRIPTION
## What changed

- complete local metadata, latest symlink updates, and local retention before any offsite transfer
- run local retention even when pg_dump fails, while leaving existing latest links and metadata untouched
- clean the current invocation's temporary dump through an EXIT trap
- capture created_at_utc once after the dump completes so metadata rewrites cannot drift
- distinguish full archive-sync failure from archive/checksum success with metadata-copy failure
- add BACKUP_RETENTION_MIN_ARCHIVES, defaulting to 3, and prune oldest complete archive groups without crossing the floor
- add independent optional local and offsite dead-man's-switch heartbeat URLs
- send the local heartbeat only after archive validation and retention, regardless of later offsite outcome
- send the offsite heartbeat only for a fully synced archive, checksum, and metadata result
- keep heartbeat failures observable but harmless to the backup exit code
- wire heartbeat configuration through Compose and env.example, and install curl in the maintenance image
- add fake pg_dump, rclone, and curl coverage for success, partial failure, hard failure, retention, and heartbeat paths

## Root causes

1. set -euo pipefail allowed rclone and pg_dump failures to terminate before local retention.
2. write_metadata evaluated date on every call, changing archive creation time after delayed uploads.
3. Metadata-copy failure collapsed into the same status as an archive-copy failure.
4. Age-only retention could eventually remove every archive during sustained dump failures.
5. Cron had no external success signal, so scheduled backup failures could remain unnoticed.

## Validation

- BACKUP-3 pre-fix guards: 3 failed; post-fix: 3 passed
- BACKUP-4 pre-fix guards: 4 failed; post-fix: 4 passed
- BACKUP-5 pre-fix guards: 5 failed; post-fix: 5 passed
- complete backup/config test selection: 23 passed, 1 Docker-runtime parity test skipped locally
- Compose config validation
- bash syntax validation
- Ruff on the changed Python test
- git diff --check

## Deployment

Not deployed. This PR must not restart or alter production, and BACKUP_OFFSITE_REMOTE remains unset.