### PR TITLE
26F-WATCHDOG-2: add disk free-space watchdog

### DIFF
--- a/apps/maintenance/Dockerfile
+++ b/apps/maintenance/Dockerfile
@@ -20,12 +20,13 @@ WORKDIR /opt/ed-finder
 COPY apps/maintenance/scripts/run_maintenance.sh           /usr/local/bin/run_maintenance.sh
 COPY apps/maintenance/scripts/run_backup.sh                /usr/local/bin/run_backup.sh
 COPY apps/maintenance/scripts/run_ingest_watchdog.sh       /usr/local/bin/run_ingest_watchdog.sh
+COPY apps/maintenance/scripts/run_disk_watchdog.sh         /usr/local/bin/run_disk_watchdog.sh
 COPY apps/maintenance/scripts/crontab                      /etc/crontabs/root
 COPY scripts/run_data_invariants_receipted.sh              /usr/local/bin/run_data_invariants_receipted.sh
 COPY scripts/checks/data_invariants.py                     /opt/ed-finder/scripts/checks/data_invariants.py
 COPY shared_contracts/__init__.py                          /opt/ed-finder/shared_contracts/__init__.py
 COPY shared_contracts/data_invariant_contracts.py          /opt/ed-finder/shared_contracts/data_invariant_contracts.py
-RUN chmod +x /usr/local/bin/run_maintenance.sh /usr/local/bin/run_backup.sh /usr/local/bin/run_ingest_watchdog.sh /usr/local/bin/run_data_invariants_receipted.sh
+RUN chmod +x /usr/local/bin/run_maintenance.sh /usr/local/bin/run_backup.sh /usr/local/bin/run_ingest_watchdog.sh /usr/local/bin/run_disk_watchdog.sh /usr/local/bin/run_data_invariants_receipted.sh
 
 # tini = proper PID 1 so SIGTERM from `docker stop` actually reaches
 # crond and any in-progress psql.

--- a/apps/maintenance/scripts/crontab
+++ b/apps/maintenance/scripts/crontab
@@ -15,6 +15,7 @@
 # /data/logs/maintenance.log inside the script itself.
 
 */15 * * * * /usr/local/bin/run_ingest_watchdog.sh >> /data/logs/ingest-watchdog.log 2>&1
+*/30 * * * * /usr/local/bin/run_disk_watchdog.sh >> /data/logs/disk-watchdog.log 2>&1
 10 2 * * *   /usr/local/bin/run_backup.sh nightly
 15 3 * * *   /usr/local/bin/run_maintenance.sh nightly
  0 4 * * 0   /usr/local/bin/run_maintenance.sh weekly

--- a/apps/maintenance/scripts/run_disk_watchdog.sh
+++ b/apps/maintenance/scripts/run_disk_watchdog.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+WATCHDOG_HEARTBEAT_URL="${DISK_WATCHDOG_HEARTBEAT_URL:-}"
+MIN_FREE_GB="${DISK_WATCHDOG_MIN_FREE_GB:-40}"
+WATCHDOG_PATH="${DISK_WATCHDOG_PATH:-/data}"
+
+if [[ -z "$WATCHDOG_HEARTBEAT_URL" ]]; then
+  echo "disk watchdog: skipped (heartbeat URL unconfigured)"
+  exit 0
+fi
+
+if [[ ! "$MIN_FREE_GB" =~ ^[0-9]+([.][0-9]+)?$ ]] || [[ "$MIN_FREE_GB" =~ ^0+([.]0+)?$ ]]; then
+  echo "ERROR: disk watchdog cannot measure free space: DISK_WATCHDOG_MIN_FREE_GB must be a positive number; heartbeat not sent" >&2
+  exit 1
+fi
+
+if ! df_output="$(df -B1 -P "$WATCHDOG_PATH" 2>&1)"; then
+  echo "ERROR: disk watchdog measurement failed for ${WATCHDOG_PATH}; heartbeat not sent: ${df_output}" >&2
+  exit 1
+fi
+
+available_bytes="$(printf '%s\n' "$df_output" | awk 'NR == 2 { print $4 }')"
+if [[ ! "$available_bytes" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: disk watchdog measurement output is unparseable for ${WATCHDOG_PATH}; heartbeat not sent: ${df_output}" >&2
+  exit 1
+fi
+
+if ! measurement_result="$(awk \
+  -v available_bytes="$available_bytes" \
+  -v threshold_gb="$MIN_FREE_GB" \
+  'BEGIN {
+    threshold_bytes = threshold_gb * 1000000000
+    actual_gb = available_bytes / 1000000000
+    state = (available_bytes >= threshold_bytes) ? "healthy" : "low"
+    printf "%.2f\t%s\n", actual_gb, state
+  }')"; then
+  echo "ERROR: disk watchdog could not evaluate free-space measurement for ${WATCHDOG_PATH}; heartbeat not sent" >&2
+  exit 1
+fi
+
+IFS=$'\t' read -r actual_free_gb disk_state <<< "$measurement_result"
+if [[ "$disk_state" == "low" ]]; then
+  echo "ERROR: disk watchdog low free space: actual free ${actual_free_gb} GB is below threshold ${MIN_FREE_GB} GB on ${WATCHDOG_PATH}; heartbeat not sent" >&2
+  exit 1
+fi
+if [[ "$disk_state" != "healthy" ]]; then
+  echo "ERROR: disk watchdog could not evaluate free-space state for ${WATCHDOG_PATH}; heartbeat not sent" >&2
+  exit 1
+fi
+
+echo "disk watchdog: healthy; actual free ${actual_free_gb} GB (threshold ${MIN_FREE_GB} GB) on ${WATCHDOG_PATH}"
+ping_exit_code=0
+curl -fsS -m 10 --retry 3 "$WATCHDOG_HEARTBEAT_URL" || ping_exit_code=$?
+if (( ping_exit_code == 0 )); then
+  echo "disk watchdog heartbeat: sent"
+else
+  echo "ERROR: disk watchdog heartbeat: failed (curl exit ${ping_exit_code}); disk state is healthy" >&2
+fi
+
+# Heartbeat delivery never changes the exit status of the disk health check.
+exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -290,6 +290,11 @@ services:
       # EDDN ingest dead-man's switch: the external service alerts when the ping does not arrive.
       EDDN_WATCHDOG_HEARTBEAT_URL: ${EDDN_WATCHDOG_HEARTBEAT_URL:-}
       EDDN_WATCHDOG_MAX_AGE_MINUTES: ${EDDN_WATCHDOG_MAX_AGE_MINUTES:-30}
+      # Inverted disk dead-man's switch: ping only while healthy. Default 40GB stays
+      # below the roughly 61GB nightly backup-before-prune dip; higher alerts nightly.
+      DISK_WATCHDOG_HEARTBEAT_URL: ${DISK_WATCHDOG_HEARTBEAT_URL:-}
+      DISK_WATCHDOG_MIN_FREE_GB: ${DISK_WATCHDOG_MIN_FREE_GB:-40}
+      DISK_WATCHDOG_PATH: ${DISK_WATCHDOG_PATH:-/data}
       EVIDENCE_RECORD_RETENTION_DAYS: ${EVIDENCE_RECORD_RETENTION_DAYS:-90}
       ADMIN_JOB_RUN_RETENTION_DAYS: ${ADMIN_JOB_RUN_RETENTION_DAYS:-60}
       BACKUP_LOG_FILE: /data/logs/backup.log

--- a/env.example
+++ b/env.example
@@ -47,6 +47,14 @@ BACKUP_OFFSITE_HEARTBEAT_URL=
 EDDN_WATCHDOG_HEARTBEAT_URL=
 EDDN_WATCHDOG_MAX_AGE_MINUTES=30
 
+# The disk watchdog uses an inverted dead-man's switch: it pings only while
+# healthy. Default 40GB because free space dips to roughly 61GB nightly while
+# the new backup is written before the old one is pruned; a higher threshold
+# would alert nightly on a healthy system.
+DISK_WATCHDOG_HEARTBEAT_URL=
+DISK_WATCHDOG_MIN_FREE_GB=40
+DISK_WATCHDOG_PATH=/data
+
 # Admin-token — required for /api/admin/* and /api/cache/clear.
 # Leave blank to disable those endpoints entirely (default / safest).
 # Generate with: openssl rand -hex 32

--- a/tests/test_disk_watchdog.py
+++ b/tests/test_disk_watchdog.py
@@ -1,0 +1,246 @@
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WATCHDOG = ROOT / 'apps' / 'maintenance' / 'scripts' / 'run_disk_watchdog.sh'
+
+
+def _read(*parts: str) -> str:
+    return ROOT.joinpath(*parts).read_text(encoding='utf-8')
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding='utf-8', newline='\n')
+    path.chmod(0o755)
+
+
+def _run_disk_watchdog(
+    tmp_path: Path,
+    *,
+    heartbeat_url: str = 'https://heartbeat.invalid/disk',
+    min_free_gb: str | int = 40,
+    watchdog_path: str = '/data',
+    free_bytes: int = 80_000_000_000,
+    df_result: str = 'success',
+    df_output: str = '',
+    curl_result: str = 'success',
+) -> dict[str, object]:
+    bash = shutil.which('bash')
+    assert bash is not None, 'bash is required for watchdog behavior tests'
+
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    df_log = tmp_path / 'df-calls.log'
+    curl_log = tmp_path / 'curl-calls.log'
+
+    _write_executable(fake_bin / 'df', '''#!/bin/bash
+set -eu
+printf '%s\n' "$*" >> "${DF_CALL_LOG}"
+if [[ "${FAKE_DF_RESULT:-success}" == 'fail' ]]; then
+    echo 'fake df measurement failure' >&2
+    exit 42
+fi
+if [[ -n "${FAKE_DF_OUTPUT:-}" ]]; then
+    printf '%s\n' "${FAKE_DF_OUTPUT}"
+    exit 0
+fi
+printf '%s\n' 'Filesystem 1B-blocks Used Available Capacity Mounted on'
+printf 'fakefs 100000000000 20000000000 %s 20%% %s\n' \
+    "${FAKE_FREE_BYTES}" \
+    "${DISK_WATCHDOG_PATH}"
+''')
+    _write_executable(fake_bin / 'curl', '''#!/bin/bash
+set -eu
+printf '%s\n' "${!#}" >> "${CURL_CALL_LOG}"
+if [[ "${FAKE_CURL_RESULT:-success}" == 'fail' ]]; then
+    echo 'fake curl failure' >&2
+    exit 28
+fi
+''')
+
+    env = {
+        **os.environ,
+        'DISK_WATCHDOG_HEARTBEAT_URL': heartbeat_url,
+        'DISK_WATCHDOG_MIN_FREE_GB': str(min_free_gb),
+        'DISK_WATCHDOG_PATH': watchdog_path,
+        'FAKE_FREE_BYTES': str(free_bytes),
+        'FAKE_DF_RESULT': df_result,
+        'FAKE_DF_OUTPUT': df_output,
+        'FAKE_CURL_RESULT': curl_result,
+        'DF_CALL_LOG': df_log.as_posix(),
+        'CURL_CALL_LOG': curl_log.as_posix(),
+        'PATH': f'{fake_bin}{os.pathsep}{os.environ.get("PATH", "")}',
+    }
+    completed = subprocess.run(
+        [bash, str(WATCHDOG)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    def calls(path: Path) -> list[str]:
+        return path.read_text(encoding='utf-8').splitlines() if path.exists() else []
+
+    return {
+        'completed': completed,
+        'output': completed.stdout + completed.stderr,
+        'df_calls': calls(df_log),
+        'curl_calls': calls(curl_log),
+    }
+
+
+def test_plenty_of_free_space_pings_once_and_exits_zero(tmp_path: Path):
+    heartbeat_url = 'https://heartbeat.invalid/disk-healthy'
+    observation = _run_disk_watchdog(
+        tmp_path,
+        heartbeat_url=heartbeat_url,
+        min_free_gb=40,
+        free_bytes=80_000_000_000,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, observation['output']
+    assert observation['curl_calls'] == [heartbeat_url]
+    assert len(observation['df_calls']) == 1
+    assert '-B1' in observation['df_calls'][0]
+    assert '/data' in observation['df_calls'][0]
+    assert 'actual free 80.00 GB' in observation['output']
+    assert 'threshold 40 GB' in observation['output']
+
+
+def test_below_threshold_skips_ping_logs_values_and_exits_nonzero(tmp_path: Path):
+    observation = _run_disk_watchdog(
+        tmp_path,
+        min_free_gb=40,
+        free_bytes=30_000_000_000,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['curl_calls'] == []
+    assert 'actual free 30.00 GB' in observation['output']
+    assert 'threshold 40 GB' in observation['output']
+    assert 'ERROR:' in observation['output']
+
+
+def test_exactly_at_threshold_is_healthy_and_pings(tmp_path: Path):
+    heartbeat_url = 'https://heartbeat.invalid/disk-boundary'
+    observation = _run_disk_watchdog(
+        tmp_path,
+        heartbeat_url=heartbeat_url,
+        min_free_gb=40,
+        free_bytes=40_000_000_000,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, observation['output']
+    assert observation['curl_calls'] == [heartbeat_url]
+    assert 'actual free 40.00 GB' in observation['output']
+    assert 'threshold 40 GB' in observation['output']
+
+
+def test_one_byte_below_threshold_is_unhealthy_despite_rounded_log(tmp_path: Path):
+    observation = _run_disk_watchdog(
+        tmp_path,
+        min_free_gb=40,
+        free_bytes=39_999_999_999,
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['curl_calls'] == []
+    assert 'actual free 40.00 GB' in observation['output']
+    assert 'threshold 40 GB' in observation['output']
+
+
+def test_invalid_threshold_skips_df_and_ping_and_exits_nonzero(tmp_path: Path):
+    observation = _run_disk_watchdog(tmp_path, min_free_gb='0')
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['df_calls'] == []
+    assert observation['curl_calls'] == []
+    assert 'ERROR: disk watchdog cannot measure free space' in observation['output']
+
+
+def test_df_failure_skips_ping_logs_loudly_and_exits_nonzero(tmp_path: Path):
+    observation = _run_disk_watchdog(tmp_path, df_result='fail')
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['curl_calls'] == []
+    assert 'ERROR: disk watchdog measurement failed' in observation['output']
+
+
+def test_unparseable_df_output_skips_ping_and_exits_nonzero(tmp_path: Path):
+    observation = _run_disk_watchdog(
+        tmp_path,
+        df_output='Filesystem nonsense\nthis output has no byte count',
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode != 0
+    assert observation['curl_calls'] == []
+    assert 'ERROR: disk watchdog measurement output is unparseable' in observation['output']
+
+
+def test_unset_url_skips_df_and_ping_and_exits_zero(tmp_path: Path):
+    observation = _run_disk_watchdog(tmp_path, heartbeat_url='')
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, observation['output']
+    assert observation['df_calls'] == []
+    assert observation['curl_calls'] == []
+    assert 'disk watchdog: skipped (heartbeat URL unconfigured)' in observation['output']
+
+
+def test_ping_failure_does_not_change_healthy_disk_exit_code(tmp_path: Path):
+    observation = _run_disk_watchdog(
+        tmp_path,
+        free_bytes=80_000_000_000,
+        curl_result='fail',
+    )
+    completed = observation['completed']
+
+    assert isinstance(completed, subprocess.CompletedProcess)
+    assert completed.returncode == 0, observation['output']
+    assert len(observation['curl_calls']) == 1
+    assert 'disk watchdog heartbeat: failed' in observation['output']
+
+
+def test_disk_watchdog_is_wired_into_maintenance_runtime():
+    script = _read('apps', 'maintenance', 'scripts', 'run_disk_watchdog.sh')
+    compose = _read('docker-compose.yml')
+    env_example = _read('env.example')
+    crontab = _read('apps', 'maintenance', 'scripts', 'crontab')
+    dockerfile = _read('apps', 'maintenance', 'Dockerfile')
+
+    assert 'df -B1' in script
+    assert 'DISK_WATCHDOG_HEARTBEAT_URL: ${DISK_WATCHDOG_HEARTBEAT_URL:-}' in compose
+    assert 'DISK_WATCHDOG_MIN_FREE_GB: ${DISK_WATCHDOG_MIN_FREE_GB:-40}' in compose
+    assert 'DISK_WATCHDOG_PATH: ${DISK_WATCHDOG_PATH:-/data}' in compose
+    assert 'DISK_WATCHDOG_HEARTBEAT_URL=' in env_example.splitlines()
+    assert 'DISK_WATCHDOG_MIN_FREE_GB=40' in env_example.splitlines()
+    assert 'DISK_WATCHDOG_PATH=/data' in env_example.splitlines()
+    assert "inverted dead-man's switch" in env_example
+    assert '61GB' in env_example
+    assert '40GB' in env_example
+    assert '*/30 * * * * /usr/local/bin/run_disk_watchdog.sh' in crontab
+    assert (
+        'COPY apps/maintenance/scripts/run_disk_watchdog.sh '
+        '/usr/local/bin/run_disk_watchdog.sh'
+    ) in ' '.join(dockerfile.split())
+    assert '/usr/local/bin/run_disk_watchdog.sh' in dockerfile


### PR DESCRIPTION
## Summary
- add an inverted disk free-space dead-man's-switch watchdog using exact df -B1 available bytes
- ping only when free space is at or above the configured threshold; fail closed on low, failed, or unparseable measurements
- schedule the watchdog every 30 minutes and wire its three settings through the maintenance image and Compose
- cover healthy, low, exact-boundary, one-byte-below, invalid configuration, measurement failures, disabled, ping-failure, and wiring behavior

## Threshold rationale
The default is 40GB because free space dips to roughly 61GB while the nightly backup writes a new archive before pruning the old one. A higher threshold would alert nightly on a healthy system.

## Test evidence
Pre-change focused run:
- 10 failed in 0.10s

Post-change focused Linux run:
- 10 passed in 0.07s

Additional validation:
- combined ingest and disk watchdog suite: 20 passed in 0.18s
- ShellCheck: passed
- Ruff and B905: passed
- docker compose config --quiet: passed
- static container image parity: 2 passed, 1 skipped
- maintenance Docker image build: passed

## Safety
Draft only. No merge, deploy, restart, or .env change performed.