### PR TITLE
Fix maintenance timeout and failure reporting

### DIFF
--- a/apps/maintenance/scripts/run_maintenance.sh
+++ b/apps/maintenance/scripts/run_maintenance.sh
@@ -14,8 +14,8 @@
 #   weekly  @ 04:00 UTC : run_maintenance.sh weekly  (Sundays)
 #
 # Failures: each step is independent. If ANALYZE bodies fails, we still
-# refresh the MVs. The whole script is wrapped in `set +e` for that
-# reason — we want best-effort, not all-or-nothing.
+# refresh the MVs. The script records every failed step and exits non-zero
+# after the remaining best-effort work has completed.
 #
 # Logs land on stdout (so docker compose logs picks them up) AND in
 # /data/logs/maintenance.log for grep-ability.
@@ -27,6 +27,9 @@ LOG_FILE="${LOG_FILE:-/data/logs/maintenance.log}"
 DB_URL="${DATABASE_URL:?DATABASE_URL must be set}"
 EVIDENCE_RECORD_RETENTION_DAYS="${EVIDENCE_RECORD_RETENTION_DAYS:-90}"
 ADMIN_JOB_RUN_RETENTION_DAYS="${ADMIN_JOB_RUN_RETENTION_DAYS:-60}"
+MAINTENANCE_PGOPTIONS="${PGOPTIONS:+${PGOPTIONS} }-c statement_timeout=0"
+FAILED_STEPS=0
+FAILED_LABELS=()
 
 mkdir -p "$(dirname "$LOG_FILE")"
 
@@ -40,12 +43,24 @@ run_step() {
     local sql="$*"
     local started; started=$(date +%s)
     echo "▶ $label"
-    if psql "$DB_URL" -v ON_ERROR_STOP=1 -X -q -c "$sql"; then
+    if PGOPTIONS="$MAINTENANCE_PGOPTIONS" psql "$DB_URL" -v ON_ERROR_STOP=1 -X -q -c "$sql"; then
         echo "  ✓ $label completed in $(( $(date +%s) - started ))s"
     else
-        echo "  ✗ $label FAILED (exit $?)" >&2
+        local psql_exit=$?
+        FAILED_STEPS=$((FAILED_STEPS + 1))
+        FAILED_LABELS+=("$label")
+        echo "  ✗ $label FAILED (exit $psql_exit)" >&2
+        return "$psql_exit"
+    fi
+}
+
+finish_task() {
+    local label="$1"
+    if (( FAILED_STEPS > 0 )); then
+        echo "===== $label maintenance FAILED: $FAILED_STEPS step(s): ${FAILED_LABELS[*]} =====" >&2
         return 1
     fi
+    echo "===== $label maintenance complete ====="
 }
 
 case "$TASK" in
@@ -147,7 +162,7 @@ SQL
         # remain available throughout the maintenance run.
         run_step "refresh_map_mviews()"  \
             "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(TRUE);"
-        echo "===== Nightly maintenance complete ====="
+        finish_task "Nightly"
         ;;
     weekly)
         echo "===== Weekly maintenance starting ====="
@@ -162,8 +177,8 @@ SQL
         # block the others.
         run_step "REINDEX idx_sys_name_lower_pattern" \
             "REINDEX INDEX CONCURRENTLY idx_sys_name_lower_pattern;"
-        run_step "REINDEX idx_sys_xyz" \
-            "REINDEX INDEX CONCURRENTLY idx_sys_xyz;"
+        run_step "REINDEX idx_sys_coords" \
+            "REINDEX INDEX CONCURRENTLY idx_sys_coords;"
         # VACUUM ANALYZE on the hot tables — autovacuum keeps up most
         # weeks but a manual sweep cleans dead-tuple drift after big
         # nightly EDDN bursts.
@@ -208,7 +223,7 @@ WITH deleted AS (
 SELECT COUNT(*)::int AS admin_job_rows_deleted FROM deleted;
 SQL
 )"
-        echo "===== Weekly maintenance complete ====="
+        finish_task "Weekly"
         ;;
     smoke)
         # Manual sanity check from `docker compose run --rm maintenance smoke`.
@@ -247,6 +262,7 @@ SQL
              FROM pg_class c
              LEFT JOIN pg_stat_user_tables s ON s.relname = c.relname
              WHERE c.relname='bodies';"
+        finish_task "Smoke"
         ;;
     *)
         echo "usage: $0 {nightly|weekly|smoke}" >&2

--- a/tests/test_admin_runtime_contracts.py
+++ b/tests/test_admin_runtime_contracts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -11,6 +13,88 @@ ROOT = Path(__file__).resolve().parents[1]
 MAIN_PATH = ROOT / 'apps' / 'api' / 'src' / 'main.py'
 ADMIN_PATH = ROOT / 'apps' / 'api' / 'src' / 'routers' / 'admin.py'
 MAINTENANCE_PATH = ROOT / 'apps' / 'maintenance' / 'scripts' / 'run_maintenance.sh'
+
+
+def _bash_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != 'nt':
+        return resolved.as_posix()
+    return f'/{resolved.drive[0].lower()}{resolved.as_posix()[2:]}'
+
+
+def _usable_bash() -> str:
+    candidates: list[str] = []
+    if os.name == 'nt':
+        program_files = Path(os.environ.get('ProgramFiles', r'C:\Program Files'))
+        candidates.append(str(program_files / 'Git' / 'bin' / 'bash.exe'))
+    discovered = shutil.which('bash')
+    if discovered:
+        candidates.append(discovered)
+
+    for candidate in dict.fromkeys(candidates):
+        if not Path(candidate).is_file():
+            continue
+        probe = subprocess.run(
+            [candidate, '-lc', 'printf ready'],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if probe.returncode == 0 and probe.stdout == 'ready':
+            return candidate
+    pytest.skip('usable bash is required for maintenance script tests')
+
+
+def _run_maintenance_with_stubbed_psql(
+    tmp_path: Path,
+    task: str,
+    *,
+    fail_match: str = '',
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    bash = _usable_bash()
+
+    stub_dir = tmp_path / 'bin'
+    stub_dir.mkdir()
+    call_log = tmp_path / 'psql-calls.log'
+    stub = stub_dir / 'psql'
+    stub.write_text(
+        '''#!/bin/bash
+{
+    printf '%s\t' "${PGOPTIONS:-}"
+    printf '%q ' "$@"
+    printf '\n'
+} >> "${PSQL_CALL_LOG:?}"
+if [[ -n "${PSQL_FAIL_MATCH:-}" && "$*" == *"$PSQL_FAIL_MATCH"* ]]; then
+    exit 9
+fi
+exit 0
+''',
+        encoding='utf-8',
+    )
+    stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update({
+        'DATABASE_URL': 'postgresql://test.invalid/edfinder',
+        'LOG_FILE': _bash_path(tmp_path / 'maintenance.log'),
+        'PSQL_CALL_LOG': _bash_path(call_log),
+        'PSQL_FAIL_MATCH': fail_match,
+    })
+    command = (
+        f'export PATH={shlex.quote(_bash_path(stub_dir))}:$PATH; '
+        f'exec {shlex.quote(_bash_path(MAINTENANCE_PATH))} {shlex.quote(task)}'
+    )
+    result = subprocess.run(
+        [bash, '-lc', command],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    calls = call_log.read_text(encoding='utf-8').splitlines() if call_log.exists() else []
+    return result, calls
 
 
 def test_startup_reaps_stale_admin_operation_runs_and_cron_status_is_schema_visible():
@@ -51,19 +135,7 @@ def test_maintenance_script_schedules_freshness_sweep_and_retention_pruning():
 
 
 def test_maintenance_script_has_valid_bash_syntax():
-    bash = shutil.which('bash')
-    if bash is None:
-        pytest.skip('bash is required for maintenance script syntax test')
-
-    probe = subprocess.run(
-        [bash, '-lc', 'printf ready'],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if probe.returncode != 0 or probe.stdout.strip() != 'ready':
-        pytest.skip('usable bash is unavailable for maintenance script syntax test')
+    bash = _usable_bash()
 
     result = subprocess.run(
         [bash, '-n', str(MAINTENANCE_PATH)],
@@ -73,3 +145,27 @@ def test_maintenance_script_has_valid_bash_syntax():
         check=False,
     )
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_weekly_maintenance_disables_role_timeout_and_targets_real_coordinate_index(tmp_path: Path):
+    result, calls = _run_maintenance_with_stubbed_psql(tmp_path, 'weekly')
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert len(calls) == 7
+    assert all('-c statement_timeout=0' in call.split('\t', 1)[0] for call in calls)
+    assert any('idx_sys_coords' in call for call in calls)
+    assert all('idx_sys_xyz' not in call for call in calls)
+
+
+def test_weekly_maintenance_finishes_remaining_steps_but_exits_nonzero_after_failure(tmp_path: Path):
+    result, calls = _run_maintenance_with_stubbed_psql(
+        tmp_path,
+        'weekly',
+        fail_match='idx_sys_name_lower_pattern',
+    )
+
+    assert result.returncode == 1
+    assert len(calls) == 7
+    combined_output = result.stdout + result.stderr
+    assert 'REINDEX idx_sys_name_lower_pattern FAILED (exit 9)' in combined_output
+    assert 'Weekly maintenance FAILED: 1 step(s)' in combined_output


### PR DESCRIPTION
## What changed

- pass `statement_timeout=0` through `PGOPTIONS` for every maintenance `psql` session, while preserving any existing `PGOPTIONS`
- reindex the repository-defined `idx_sys_coords` index instead of nonexistent `idx_sys_xyz`
- retain best-effort execution, record failed step labels, and return non-zero after all remaining steps finish
- add stubbed-`psql` runtime tests for timeout propagation, index selection, continued work, and final exit status

## Why

The production `edfinder` role has a database-only 15-second `statement_timeout`. Nightly `ANALYZE` and weekly `REINDEX`/`VACUUM` inherited that cap, even though those operations are expected to take longer. The weekly job also targeted an index absent from the schema and always ended with a successful completion status after failed steps.

This closes audit findings T-2, T-3, C-2, and S-1.

## Validation

- pre-fix: `3 passed, 2 failed` in `tests/test_admin_runtime_contracts.py`
- post-fix: `5 passed` in `tests/test_admin_runtime_contracts.py`
- adjacent contracts: `19 passed` across `test_admin_runtime_contracts.py`, `test_migration_script_contracts.py`, and `test_map_refresh.py`
- `git diff --check`

No deployment or restart is part of this PR.