### PR TITLE
Fail importer runs on incomplete work

### DIFF
--- a/apps/importer/Dockerfile
+++ b/apps/importer/Dockerfile
@@ -13,6 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # All importer scripts + the static region_map.json live under src/.
 COPY apps/importer/src/ ./
 COPY shared_contracts/ ./shared_contracts/
+COPY sql/002_indexes.sql ./sql/002_indexes.sql
 
 ENTRYPOINT ["python3"]
 CMD ["import_spansh.py", "--status"]

--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -159,9 +159,19 @@ else:
 # DB helpers
 # ---------------------------------------------------------------------------
 def get_conn() -> psycopg2.extensions.connection:
-    conn = psycopg2.connect(DB_DSN)
+    conn = psycopg2.connect(DB_DSN, options='-c statement_timeout=0')
     conn.autocommit = False
     return conn
+
+
+def resolve_index_sql_path() -> Path:
+    """Locate the vendored image SQL or the repository-root SQL in development."""
+    source_dir = Path(__file__).resolve().parent
+    for base_dir in (source_dir, *source_dir.parents):
+        candidate = base_dir / 'sql' / '002_indexes.sql'
+        if candidate.is_file():
+            return candidate
+    return source_dir / 'sql' / '002_indexes.sql'
 
 
 def set_import_optimisations(conn):
@@ -1685,7 +1695,7 @@ IMPORT_ORDER = [
 # ---------------------------------------------------------------------------
 # main()
 # ---------------------------------------------------------------------------
-def main():
+def main() -> int:
     global DUMP_DIR, BATCH_SIZE
 
     parser = argparse.ArgumentParser(
@@ -1712,11 +1722,11 @@ def main():
 
     if args.status:
         show_status(conn)
-        return
+        return 0
 
     if args.errors:
         show_errors(conn)
-        return
+        return 0
 
     if args.download or getattr(args, 'download_only', False):
         files = [args.file] if args.file else IMPORT_ORDER
@@ -1724,12 +1734,12 @@ def main():
 
     if getattr(args, 'download_only', False):
         log.info("Download complete. Run with --all (or --file) to import.")
-        return
+        return 0
 
     files_to_import = IMPORT_ORDER if args.all else ([args.file] if args.file else [])
     if not files_to_import:
         parser.print_help()
-        return
+        return 0
 
     def _get_status(fname: str) -> Optional[str]:
         try:
@@ -1741,16 +1751,19 @@ def main():
             return None
 
     total_start = time.time()
+    failures: list[str] = []
     for fname in files_to_import:
         dump_path = DUMP_DIR / fname
         if not dump_path.exists():
             log.error(f"Dump file not found: {dump_path}")
             log.error(f"Run with --download-only first, or place files in {DUMP_DIR}")
+            failures.append(f"{fname}: dump file missing")
             continue
 
         importer_fn = IMPORTER_MAP.get(fname)
         if not importer_fn:
             log.error(f"No importer for: {fname}")
+            failures.append(f"{fname}: no importer registered")
             continue
 
         current_status = _get_status(fname)
@@ -1773,9 +1786,9 @@ def main():
         except Exception as e:
             log.error(f"❌ {fname} failed: {e}", exc_info=True)
             mark_failed(conn, fname, str(e))
+            failures.append(f"{fname}: {e}")
 
     total_elapsed = time.time() - total_start
-    log.info(f"All imports complete in {total_elapsed/3600:.2f} hours")
 
     # Auto-rebuild indexes if they were dropped for the import
     if args.all or args.file:
@@ -1792,7 +1805,7 @@ def main():
                 log.info("--- AUTOMATIC INDEX REBUILD ---")
                 log.info("Indexes are missing (likely dropped for import). Starting rebuild from 002_indexes.sql ...")
                 log.info("This will take 1-3 hours. Do not interrupt.")
-                sql_path = Path(__file__).parent.parent / 'sql' / '002_indexes.sql'
+                sql_path = resolve_index_sql_path()
                 if sql_path.exists():
                     # Phase 2: run CREATE INDEX statements — requires autocommit mode.
                     # Only flip autocommit after the read transaction is fully closed.
@@ -1807,17 +1820,28 @@ def main():
                     finally:
                         conn.autocommit = old_autocommit
                 else:
-                    log.warning(f"Could not find {sql_path} — please run manually.")
+                    log.error(f"Could not find {sql_path} — automatic index rebuild failed.")
+                    failures.append(f"automatic index rebuild: missing {sql_path}")
             else:
                 log.info(f"Indexes already exist ({idx_count} found) — skipping auto-rebuild.")
         except Exception as e:
             log.error(f"Failed to auto-rebuild indexes: {e}")
+            failures.append(f"automatic index rebuild: {e}")
+
+    if failures:
+        log.error(
+            f"Import run completed with {len(failures)} failure(s) in "
+            f"{total_elapsed/3600:.2f} hours: {'; '.join(failures)}"
+        )
+    else:
+        log.info(f"All imports complete in {total_elapsed/3600:.2f} hours")
 
     log.info("Next steps (run in this exact order):")
     log.info("  1. python3 build_grid.py      — build 500 LY + 2000 LY spatial grids (~1-2h)")
     log.info("  2. python3 build_ratings.py   — compute economy scores (~3-5h)")
     log.info("  3. python3 build_clusters.py  — build cluster summaries (~2-4h)")
+    return 1 if failures else 0
 
 
 if __name__ == '__main__':
-    main()
+    raise SystemExit(main())

--- a/tests/test_import_spansh_runtime.py
+++ b/tests/test_import_spansh_runtime.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = ROOT / 'apps' / 'importer' / 'src'
+IMPORTER_DOCKERFILE = ROOT / 'apps' / 'importer' / 'Dockerfile'
+os.environ.setdefault('DATABASE_URL', 'postgresql://test.invalid/edfinder')
+sys.path.insert(0, str(IMPORTER_SRC))
+
+import import_spansh  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.last_sql = ''
+
+    def __enter__(self) -> '_FakeCursor':
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, sql: str, _params: object = None) -> None:
+        self.last_sql = sql
+
+    def fetchone(self) -> tuple[int] | None:
+        if 'FROM pg_indexes' in self.last_sql:
+            return (10,)
+        return None
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return _FakeCursor()
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def test_get_conn_disables_the_role_statement_timeout(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, object] = {}
+    fake_connection = _FakeConnection()
+
+    def fake_connect(dsn: str, **kwargs: object) -> _FakeConnection:
+        captured['dsn'] = dsn
+        captured.update(kwargs)
+        return fake_connection
+
+    monkeypatch.setattr(import_spansh.psycopg2, 'connect', fake_connect)
+
+    connection = import_spansh.get_conn()
+
+    assert connection is fake_connection
+    assert 'statement_timeout=0' in str(captured.get('options', ''))
+
+
+def test_automatic_index_rebuild_sql_exists_in_checkout_and_importer_image():
+    assert import_spansh.resolve_index_sql_path() == ROOT / 'sql' / '002_indexes.sql'
+    assert import_spansh.resolve_index_sql_path().is_file()
+    dockerfile = IMPORTER_DOCKERFILE.read_text(encoding='utf-8')
+    assert 'COPY sql/002_indexes.sql ./sql/002_indexes.sql' in dockerfile
+
+
+def test_failed_requested_import_returns_nonzero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    dump_name = 'systems_1day.json.gz'
+    (tmp_path / dump_name).write_bytes(b'not-read-by-stub')
+    fake_connection = _FakeConnection()
+
+    def fail_import(*_args: object) -> int:
+        raise RuntimeError('synthetic importer failure')
+
+    monkeypatch.setattr(import_spansh, 'DUMP_DIR', tmp_path)
+    monkeypatch.setattr(import_spansh, 'get_conn', lambda: fake_connection)
+    monkeypatch.setattr(import_spansh, 'IMPORTER_MAP', {dump_name: fail_import})
+    monkeypatch.setattr(sys, 'argv', ['import_spansh.py', '--file', dump_name])
+
+    assert import_spansh.main() == 1
+
+
+def test_all_mode_continues_after_failure_then_returns_nonzero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    first = 'first.json.gz'
+    second = 'second.json.gz'
+    for dump_name in (first, second):
+        (tmp_path / dump_name).write_bytes(b'not-read-by-stub')
+    processed: list[str] = []
+
+    def fail_first(*_args: object) -> int:
+        raise RuntimeError('first failed')
+
+    def pass_second(_conn: object, path: Path, _resume: int) -> int:
+        processed.append(path.name)
+        return 1
+
+    monkeypatch.setattr(import_spansh, 'DUMP_DIR', tmp_path)
+    monkeypatch.setattr(import_spansh, 'get_conn', _FakeConnection)
+    monkeypatch.setattr(import_spansh, 'IMPORT_ORDER', [first, second])
+    monkeypatch.setattr(import_spansh, 'IMPORTER_MAP', {
+        first: fail_first,
+        second: pass_second,
+    })
+    monkeypatch.setattr(sys, 'argv', ['import_spansh.py', '--all'])
+
+    assert import_spansh.main() == 1
+    assert processed == [second]
+
+
+def test_missing_requested_dump_returns_nonzero(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    dump_name = 'missing.json.gz'
+    monkeypatch.setattr(import_spansh, 'DUMP_DIR', tmp_path)
+    monkeypatch.setattr(import_spansh, 'get_conn', _FakeConnection)
+    monkeypatch.setattr(import_spansh, 'IMPORTER_MAP', {dump_name: lambda *_args: 1})
+    monkeypatch.setattr(sys, 'argv', ['import_spansh.py', '--file', dump_name])
+
+    assert import_spansh.main() == 1


### PR DESCRIPTION
## What changed

- start importer database sessions with `statement_timeout=0` so direct production imports and index rebuilds do not inherit the `edfinder` role's 15-second cap
- collect missing-file, unsupported-file, importer, and automatic-index-rebuild failures while preserving `--all` best-effort processing
- return non-zero after the remaining work finishes when any requested operation failed
- emit the success summary only when the run is actually clean
- vendor `sql/002_indexes.sql` into the importer image and resolve it both in the image and from a source checkout
- add isolated runtime tests with fake connections/importers; no database is touched

## Why

`import_spansh.py` caught per-file exceptions, logged them, printed `All imports complete`, and exited zero. The nightly wrapper therefore reported a failed requested delta as successful. Its direct connection also inherited the production role timeout. During verification, the automatic rebuild input was confirmed absent from both the path used by the source checkout and the importer image.

This closes audit findings T-7 and S-2, and fixes the directly coupled missing rebuild-input defect discovered while validating that path.

## Validation

- pre-fix: `4 failed` in `tests/test_import_spansh_runtime.py`
- post-fix: `4 passed` in the initial importer runtime suite; `8 passed, 1 skipped` after adding image/path coverage
- adjacent importer contracts: `134 passed`
- `git diff --check`

No deployment or restart is part of this PR.