### PR TITLE
Retry importer systems writes after deadlocks

### DIFF
--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -59,6 +59,7 @@ import ijson
 import psycopg2
 import psycopg2.extras
 import psycopg2.extensions
+import psycopg2.errors
 from tqdm import tqdm
 from ring_facts import ring_rows_for_body
 
@@ -358,6 +359,24 @@ def copy_records(conn, table: str, columns: List[str], rows: List[Tuple]) -> int
     return len(rows)
 
 
+def _run_with_deadlock_retry(conn, work, *, label, attempts=4, base_delay=0.5):
+    """Run `work()`, a self-contained self-committing unit against `conn`.
+    On a Postgres deadlock, roll back and retry with exponential backoff.
+    Re-raises after the final attempt so a persistent deadlock still fails
+    honestly (never a silent success)."""
+    for attempt in range(1, attempts + 1):
+        try:
+            return work()
+        except psycopg2.errors.DeadlockDetected:
+            conn.rollback()
+            if attempt == attempts:
+                log.error(f"{label}: deadlock persisted after {attempts} attempts — giving up")
+                raise
+            delay = base_delay * (2 ** (attempt - 1))
+            log.warning(f"{label}: deadlock on attempt {attempt}/{attempts}, retrying in {delay:.1f}s")
+            time.sleep(delay)
+
+
 def upsert_via_temp(conn, target_table: str, columns: List[str],
                     rows: List[Tuple], conflict_col: str,
                     update_cols: Optional[List[str]] = None) -> int:
@@ -379,84 +398,92 @@ def upsert_via_temp(conn, target_table: str, columns: List[str],
             for c in change_cols
         )
         where_clause = f"\n            WHERE {comparisons}"
-    with conn.cursor() as cur:
-        cur.execute(f"""
-            CREATE TEMP TABLE IF NOT EXISTS {temp}
-            (LIKE {target_table} INCLUDING DEFAULTS)
-            ON COMMIT DELETE ROWS
-        """)
+
+    def _do():
+        with conn.cursor() as cur:
+            cur.execute(f"""
+                CREATE TEMP TABLE IF NOT EXISTS {temp}
+                (LIKE {target_table} INCLUDING DEFAULTS)
+                ON COMMIT DELETE ROWS
+            """)
+            conn.commit()
+            buf = io.StringIO()
+            for row in rows:
+                parts = []
+                for val in row:
+                    if val is None:
+                        parts.append('\\N')
+                    elif isinstance(val, bool):
+                        parts.append('t' if val else 'f')
+                    elif isinstance(val, str):
+                        escaped = (val
+                            .replace('\\', '\\\\')
+                            .replace('\n', '\\n')
+                            .replace('\r', '\\r')
+                            .replace('\t', '\\t'))
+                        parts.append(escaped)
+                    else:
+                        parts.append(str(val))
+                buf.write('\t'.join(parts) + '\n')
+            buf.seek(0)
+            cur.copy_from(buf, temp, columns=columns, null='\\N')
+            cur.execute(f"""
+                INSERT INTO {target_table} ({col_list})
+                SELECT {col_list} FROM {temp}
+                ON CONFLICT ({conflict_col}) DO UPDATE
+                SET {set_clause}{where_clause}
+            """)
+            count = cur.rowcount
         conn.commit()
-        buf = io.StringIO()
-        for row in rows:
-            parts = []
-            for val in row:
-                if val is None:
-                    parts.append('\\N')
-                elif isinstance(val, bool):
-                    parts.append('t' if val else 'f')
-                elif isinstance(val, str):
-                    escaped = (val
-                        .replace('\\', '\\\\')
-                        .replace('\n', '\\n')
-                        .replace('\r', '\\r')
-                        .replace('\t', '\\t'))
-                    parts.append(escaped)
-                else:
-                    parts.append(str(val))
-            buf.write('\t'.join(parts) + '\n')
-        buf.seek(0)
-        cur.copy_from(buf, temp, columns=columns, null='\\N')
-        cur.execute(f"""
-            INSERT INTO {target_table} ({col_list})
-            SELECT {col_list} FROM {temp}
-            ON CONFLICT ({conflict_col}) DO UPDATE
-            SET {set_clause}{where_clause}
-        """)
-        count = cur.rowcount
-    conn.commit()
-    return count
+        return count
+
+    return _run_with_deadlock_retry(conn, _do, label=f"upsert_via_temp({target_table})")
 
 
 def upsert_body_rings(conn, rows: list[dict]) -> int:
     if not rows:
         return 0
     values = [_ring_row_tuple(row) for row in rows]
-    with conn.cursor() as cur:
-        psycopg2.extras.execute_values(
-            cur,
-            """
-            INSERT INTO body_rings (
-                system_id64, body_id, body_name,
-                ring_name, ring_type, ring_class,
-                mass_mt, inner_radius, outer_radius,
-                source, confidence, updated_at
-            ) VALUES %s
-            ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
-                body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
-                ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
-                ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
-                mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
-                inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
-                outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
-                confidence   = EXCLUDED.confidence,
-                updated_at   = NOW()
-            """,
-            values,
-        )
-        system_ids = sorted({row['system_id64'] for row in rows})
-        cur.execute(
-            """
-            UPDATE systems
-               SET rating_dirty = TRUE,
-                   cluster_dirty = TRUE,
-                   updated_at = NOW()
-             WHERE id64 = ANY(%s)
-            """,
-            (system_ids,),
-        )
-        count = len(rows)
-    conn.commit()
-    return count
+
+    def _do():
+        with conn.cursor() as cur:
+            psycopg2.extras.execute_values(
+                cur,
+                """
+                INSERT INTO body_rings (
+                    system_id64, body_id, body_name,
+                    ring_name, ring_type, ring_class,
+                    mass_mt, inner_radius, outer_radius,
+                    source, confidence, updated_at
+                ) VALUES %s
+                ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
+                    body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
+                    ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
+                    ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
+                    mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
+                    inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
+                    outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
+                    confidence   = EXCLUDED.confidence,
+                    updated_at   = NOW()
+                """,
+                values,
+            )
+            system_ids = sorted({row['system_id64'] for row in rows})
+            cur.execute(
+                """
+                UPDATE systems
+                   SET rating_dirty = TRUE,
+                       cluster_dirty = TRUE,
+                       updated_at = NOW()
+                 WHERE id64 = ANY(%s)
+                """,
+                (system_ids,),
+            )
+            count = len(rows)
+        conn.commit()
+        return count
+
+    return _run_with_deadlock_retry(conn, _do, label="upsert_body_rings")
 
 
 def _ring_row_tuple(row: dict) -> tuple:

--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -399,14 +399,17 @@ def upsert_via_temp(conn, target_table: str, columns: List[str],
         )
         where_clause = f"\n            WHERE {comparisons}"
 
+    with conn.cursor() as cur:
+        cur.execute(f"""
+            CREATE TEMP TABLE IF NOT EXISTS {temp}
+            (LIKE {target_table} INCLUDING DEFAULTS)
+            ON COMMIT DELETE ROWS
+        """)
+    conn.commit()
+
     def _do():
         with conn.cursor() as cur:
-            cur.execute(f"""
-                CREATE TEMP TABLE IF NOT EXISTS {temp}
-                (LIKE {target_table} INCLUDING DEFAULTS)
-                ON COMMIT DELETE ROWS
-            """)
-            conn.commit()
+            cur.execute(f"TRUNCATE {temp}")
             buf = io.StringIO()
             for row in rows:
                 parts = []

--- a/tests/test_import_spansh_runtime.py
+++ b/tests/test_import_spansh_runtime.py
@@ -51,6 +51,117 @@ class _FakeConnection:
         self.rollbacks += 1
 
 
+class _DeadlockCursor:
+    def __init__(self, connection: '_DeadlockConnection') -> None:
+        self.connection = connection
+        self.rowcount = 0
+
+    def __enter__(self) -> '_DeadlockCursor':
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def execute(self, sql: str, _params: object = None) -> None:
+        if self.connection.deadlock_sql in ' '.join(sql.split()):
+            self.connection.attempts += 1
+            if self.connection.attempts <= self.connection.deadlocks_before_success:
+                raise import_spansh.psycopg2.errors.DeadlockDetected()
+            self.rowcount = self.connection.success_rowcount
+
+    def copy_from(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+
+class _DeadlockConnection:
+    def __init__(
+        self,
+        *,
+        deadlock_sql: str,
+        deadlocks_before_success: int,
+        success_rowcount: int,
+    ) -> None:
+        self.deadlock_sql = deadlock_sql
+        self.deadlocks_before_success = deadlocks_before_success
+        self.success_rowcount = success_rowcount
+        self.attempts = 0
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _DeadlockCursor:
+        return _DeadlockCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def test_upsert_via_temp_retries_deadlocks_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    connection = _DeadlockConnection(
+        deadlock_sql='INSERT INTO systems',
+        deadlocks_before_success=2,
+        success_rowcount=2,
+    )
+    monkeypatch.setattr(import_spansh.time, 'sleep', lambda _delay: None)
+
+    count = import_spansh.upsert_via_temp(
+        connection,
+        'systems',
+        ['id64', 'name'],
+        [(1, 'Sol'), (2, 'Achenar')],
+        'id64',
+    )
+
+    assert count == 2
+    assert connection.attempts == 3
+    assert connection.rollbacks == 2
+
+
+def test_upsert_via_temp_reraises_after_final_deadlock(monkeypatch: pytest.MonkeyPatch):
+    connection = _DeadlockConnection(
+        deadlock_sql='INSERT INTO systems',
+        deadlocks_before_success=4,
+        success_rowcount=2,
+    )
+    monkeypatch.setattr(import_spansh.time, 'sleep', lambda _delay: None)
+
+    with pytest.raises(import_spansh.psycopg2.errors.DeadlockDetected):
+        import_spansh.upsert_via_temp(
+            connection,
+            'systems',
+            ['id64', 'name'],
+            [(1, 'Sol'), (2, 'Achenar')],
+            'id64',
+        )
+
+    assert connection.attempts == 4
+    assert connection.rollbacks == 4
+
+
+def test_upsert_body_rings_retries_deadlocks_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    connection = _DeadlockConnection(
+        deadlock_sql='UPDATE systems',
+        deadlocks_before_success=2,
+        success_rowcount=1,
+    )
+    monkeypatch.setattr(import_spansh.time, 'sleep', lambda _delay: None)
+    monkeypatch.setattr(import_spansh.psycopg2.extras, 'execute_values', lambda *_args, **_kwargs: None)
+
+    count = import_spansh.upsert_body_rings(connection, [{
+        'system_id64': 10477373803,
+        'body_id': 1,
+        'body_name': 'Sol A 1',
+        'ring_name': 'Sol A 1 A Ring',
+        'source': 'spansh_dump',
+    }])
+
+    assert count == 1
+    assert connection.attempts == 3
+    assert connection.rollbacks == 2
+
+
 def test_get_conn_disables_the_role_statement_timeout(monkeypatch: pytest.MonkeyPatch):
     captured: dict[str, object] = {}
     fake_connection = _FakeConnection()


### PR DESCRIPTION
## Summary

- retry self-contained importer upsert batches after PostgreSQL deadlocks
- cover both the temp-table systems upsert and body-ring systems-dirty update paths
- preserve honest failure by re-raising after four attempts

## Root cause

The importer and live EDDN listener can lock overlapping systems rows in different orders. PostgreSQL selects one transaction as the deadlock victim; the importer previously failed immediately even though each affected batch owns and commits its own idempotent transaction.

## Validation

- focused before change: 3 failed, 5 passed
- focused after change: 8 passed
- wider importer/ring suite: 72 passed
- ruff check .: passed