### PR TITLE
Exclude coordinate-less regional analysis targets

### DIFF
--- a/apps/importer/src/build_regional_analysis.py
+++ b/apps/importer/src/build_regional_analysis.py
@@ -167,16 +167,37 @@ def main() -> None:
 
 
 def _load_targets(cur: Any, args: argparse.Namespace) -> list[dict[str, Any]]:
-    where = ''
+    coord_filter = 'x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL'
+    missing_coord_filter = 'x IS NULL OR y IS NULL OR z IS NULL'
     if args.dirty:
         where = (
-            'WHERE rating_dirty = TRUE '
+            f'WHERE ({coord_filter}) AND (rating_dirty = TRUE '
             'OR (cluster_dirty = TRUE '
             'AND has_body_data = TRUE '
             'AND macro_grid_id IS NOT NULL)'
+            ')'
+        )
+        excluded_where = (
+            f'WHERE ({missing_coord_filter}) AND (rating_dirty = TRUE '
+            'OR (cluster_dirty = TRUE '
+            'AND has_body_data = TRUE '
+            'AND macro_grid_id IS NOT NULL)'
+            ')'
         )
     elif not args.all:
-        where = 'WHERE NOT EXISTS (SELECT 1 FROM system_regional_analysis r WHERE r.system_id64 = systems.id64)'
+        where = (
+            f'WHERE ({coord_filter}) AND NOT EXISTS '
+            '(SELECT 1 FROM system_regional_analysis r '
+            'WHERE r.system_id64 = systems.id64)'
+        )
+        excluded_where = (
+            f'WHERE ({missing_coord_filter}) AND NOT EXISTS '
+            '(SELECT 1 FROM system_regional_analysis r '
+            'WHERE r.system_id64 = systems.id64)'
+        )
+    else:
+        where = f'WHERE {coord_filter}'
+        excluded_where = f'WHERE {missing_coord_filter}'
     limit = f' LIMIT {int(args.limit)}' if args.limit else ''
     cur.execute(f"""
         SELECT id64, name, x, y, z, population, is_colonised, is_being_colonised
@@ -185,7 +206,15 @@ def _load_targets(cur: Any, args: argparse.Namespace) -> list[dict[str, Any]]:
         ORDER BY id64
         {limit}
     """)
-    return [dict(row) for row in cur.fetchall()]
+    targets = [dict(row) for row in cur.fetchall()]
+    cur.execute(f"""
+        SELECT COUNT(*) AS excluded_count
+        FROM systems
+        {excluded_where}
+    """)
+    excluded_count = int(cur.fetchone()['excluded_count'])
+    print(f'Excluded {excluded_count:,} coordinate-less systems from regional analysis this run')
+    return targets
 
 
 def _load_candidates(cur: Any, system: dict[str, Any]) -> list[dict[str, Any]]:

--- a/tests/test_regional_analysis.py
+++ b/tests/test_regional_analysis.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import os
 import sys
 from pathlib import Path
@@ -10,12 +11,48 @@ os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/tes
 os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'importer' / 'src'))
 
+from build_regional_analysis import _load_targets
 from edfinder_api.regional.regional_analysis import compute_regional_analysis, distance_ly, response_from_row
 from edfinder_api.regional.regional_roles import classify_regional_role
 from edfinder_api.regional.regional_scoring import archetype_regional_fit, regional_scores
 from edfinder_api.models import RegionalAnalysisResponse
 from edfinder_api.mechanics.versions import MECHANICS_VERSION
+
+
+class RecordingCursor:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def execute(self, query: str) -> None:
+        self.queries.append(' '.join(query.split()))
+
+    def fetchall(self) -> list[dict[str, object]]:
+        return []
+
+    def fetchone(self) -> dict[str, int]:
+        return {'excluded_count': 266_000}
+
+
+def test_load_targets_filters_coordinate_less_systems_in_all_modes(capsys):
+    modes = (
+        argparse.Namespace(dirty=True, all=False, limit=25),
+        argparse.Namespace(dirty=False, all=False, limit=25),
+        argparse.Namespace(dirty=False, all=True, limit=25),
+    )
+
+    for args in modes:
+        cursor = RecordingCursor()
+
+        assert _load_targets(cursor, args) == []
+        assert len(cursor.queries) == 2
+        target_query, excluded_query = cursor.queries
+        assert 'x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL' in target_query
+        assert 'x IS NULL OR y IS NULL OR z IS NULL' in excluded_query
+        assert 'ORDER BY id64 LIMIT 25' in target_query
+
+    assert capsys.readouterr().out.count('Excluded 266,000 coordinate-less systems') == 3
 
 
 def system(id64: int, x: float, y: float, z: float, *, colonised: bool = False, population: int = 0):


### PR DESCRIPTION
## Summary

- exclude systems with NULL x, y, or z from every regional-analysis target mode
- report the coordinate-less systems excluded by the active dirty/default/all branch
- retain target ordering and LIMIT behavior

## Root cause

The target loader admitted coordinate-less systems, and candidate loading attempted float(None), aborting the full backfill.

## Validation

- focused before change: 1 failed, 6 passed
- focused after change: 7 passed
- adjacent regional/cluster suite: 17 passed
- ruff check .: passed