### PR TITLE
Classify body ring associations on write

### DIFF
--- a/apps/api/src/ingest/eddn_client.py
+++ b/apps/api/src/ingest/eddn_client.py
@@ -43,6 +43,71 @@ RECONNECT_DELAY  = 5     # seconds between reconnect attempts
 DIRTY_MARK_BATCH_SIZE = 500
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = 5000
 
+BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
+CASE
+    WHEN $11 = 'eddn_scan'
+         AND NOT EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2
+               AND b.system_id64 = $1
+         )
+         AND (
+             $3 = 0
+             OR $2 = 0
+             OR $4 ILIKE '%% belt%%'
+             OR $5 ILIKE '%% belt%%'
+         )
+        THEN 'belt_source_evidence'
+    WHEN EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2
+               AND b.system_id64 = $1
+               AND (
+                   $4 IS NULL
+                   OR b.name = $4
+               )
+         )
+        THEN 'local_matched'
+    ELSE 'unresolved_body_identity'
+END
+""".strip()
+
+BODY_RING_UPSERT_SQL = f"""
+    INSERT INTO body_rings (
+        system_id64, body_id, source_body_id, body_name,
+        ring_name, ring_type, ring_class,
+        mass_mt, inner_radius, outer_radius,
+        source, confidence, association_status, updated_at
+    ) VALUES (
+        $1, $2, $3, $4,
+        $5, $6, $7,
+        $8, $9, $10,
+        $11, $12, {BODY_RING_ASSOCIATION_STATUS_CASE_SQL}, now()
+    )
+    ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
+        source_body_id = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
+        body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
+        ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
+        ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
+        mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
+        inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
+        outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
+        confidence   = EXCLUDED.confidence,
+        association_status = {BODY_RING_ASSOCIATION_STATUS_CASE_SQL},
+        updated_at   = now()
+    WHERE body_rings.source_body_id IS DISTINCT FROM COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id)
+       OR body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
+       OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
+       OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
+       OR body_rings.mass_mt IS DISTINCT FROM COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt)
+       OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
+       OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
+       OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
+       OR body_rings.association_status IS DISTINCT FROM {BODY_RING_ASSOCIATION_STATUS_CASE_SQL}
+"""
+
 # Event types we process for the simulation engine
 SIMULATION_EVENT_TYPES = {'Scan', 'FSSBodySignals', 'SAASignalsFound'}
 
@@ -319,39 +384,7 @@ async def _flush_batch(
                         for r in fact_rows
                     ])
                     for row in ring_rows:
-                        status = await conn.execute("""
-                            INSERT INTO body_rings (
-                                system_id64, body_id, source_body_id, body_name,
-                                ring_name, ring_type, ring_class,
-                                mass_mt, inner_radius, outer_radius,
-                                source, confidence, association_status, updated_at
-                            ) VALUES (
-                                $1, $2, $3, $4,
-                                $5, $6, $7,
-                                $8, $9, $10,
-                                $11, $12, $13, now()
-                            )
-                            ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
-                                source_body_id = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
-                                body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
-                                ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
-                                ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
-                                mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
-                                inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
-                                outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
-                                confidence   = EXCLUDED.confidence,
-                                association_status = 'local_matched',
-                                updated_at   = now()
-                            WHERE body_rings.source_body_id IS DISTINCT FROM COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id)
-                               OR body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
-                               OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
-                               OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
-                               OR body_rings.mass_mt IS DISTINCT FROM COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt)
-                               OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
-                               OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
-                               OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
-                               OR body_rings.association_status IS DISTINCT FROM 'local_matched'
-                        """, *_ring_row_tuple(row))
+                        status = await conn.execute(BODY_RING_UPSERT_SQL, *_ring_row_tuple(row))
                         if _command_row_count(status):
                             dirty_system_ids.add(int(row['system_id64']))
 
@@ -542,5 +575,4 @@ def _ring_row_tuple(row: dict) -> tuple:
         row.get('outer_radius'),
         row.get('source'),
         row.get('confidence'),
-        row.get('association_status', 'local_matched'),
     )

--- a/apps/api/src/journal_import/store.py
+++ b/apps/api/src/journal_import/store.py
@@ -29,6 +29,71 @@ MAX_DAILY_ROWS_PER_SYNC_KEY = 200_000
 DIRTY_MARK_BATCH_SIZE = 500
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = 5000
 
+BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
+CASE
+    WHEN $11 = 'eddn_scan'
+         AND NOT EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2
+               AND b.system_id64 = $1
+         )
+         AND (
+             $3 = 0
+             OR $2 = 0
+             OR $4 ILIKE '%% belt%%'
+             OR $5 ILIKE '%% belt%%'
+         )
+        THEN 'belt_source_evidence'
+    WHEN EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2
+               AND b.system_id64 = $1
+               AND (
+                   $4 IS NULL
+                   OR b.name = $4
+               )
+         )
+        THEN 'local_matched'
+    ELSE 'unresolved_body_identity'
+END
+""".strip()
+
+BODY_RING_UPSERT_SQL = f"""
+    INSERT INTO body_rings (
+        system_id64, body_id, source_body_id, body_name,
+        ring_name, ring_type, ring_class,
+        mass_mt, inner_radius, outer_radius,
+        source, confidence, association_status, updated_at
+    ) VALUES (
+        $1, $2, $3, $4,
+        $5, $6, $7,
+        $8, $9, $10,
+        $11, $12, {BODY_RING_ASSOCIATION_STATUS_CASE_SQL}, now()
+    )
+    ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
+        source_body_id = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
+        body_name = COALESCE(EXCLUDED.body_name, body_rings.body_name),
+        ring_type = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
+        ring_class = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
+        mass_mt = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
+        inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
+        outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
+        confidence = EXCLUDED.confidence,
+        association_status = {BODY_RING_ASSOCIATION_STATUS_CASE_SQL},
+        updated_at = now()
+    WHERE body_rings.source_body_id IS DISTINCT FROM COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id)
+       OR body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
+       OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
+       OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
+       OR body_rings.mass_mt IS DISTINCT FROM COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt)
+       OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
+       OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
+       OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
+       OR body_rings.association_status IS DISTINCT FROM {BODY_RING_ASSOCIATION_STATUS_CASE_SQL}
+"""
+
 
 class JournalImportRateLimitError(RuntimeError):
     """Raised when a bounded journal-import safety limit is exceeded."""
@@ -682,7 +747,6 @@ def _ring_row_tuple(row: dict) -> tuple:
         row.get('outer_radius'),
         row.get('source'),
         row.get('confidence'),
-        row.get('association_status', 'local_matched'),
     )
 
 
@@ -884,39 +948,7 @@ async def promote_journal_batch(
 
             for row in ring_rows:
                 status = await conn.execute(
-                    """
-                    INSERT INTO body_rings (
-                        system_id64, body_id, source_body_id, body_name,
-                        ring_name, ring_type, ring_class,
-                        mass_mt, inner_radius, outer_radius,
-                        source, confidence, association_status, updated_at
-                    ) VALUES (
-                        $1, $2, $3, $4,
-                        $5, $6, $7,
-                        $8, $9, $10,
-                        $11, $12, $13, now()
-                    )
-                    ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
-                        source_body_id = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
-                        body_name = COALESCE(EXCLUDED.body_name, body_rings.body_name),
-                        ring_type = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
-                        ring_class = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
-                        mass_mt = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
-                        inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
-                        outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
-                        confidence = EXCLUDED.confidence,
-                        association_status = 'local_matched',
-                        updated_at = now()
-                    WHERE body_rings.source_body_id IS DISTINCT FROM COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id)
-                       OR body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
-                       OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
-                       OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
-                       OR body_rings.mass_mt IS DISTINCT FROM COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt)
-                       OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
-                       OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
-                       OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
-                       OR body_rings.association_status IS DISTINCT FROM 'local_matched'
-                    """,
+                    BODY_RING_UPSERT_SQL,
                     *_ring_row_tuple(row),
                 )
                 if _command_row_count(status):

--- a/apps/eddn/src/eddn_listener.py
+++ b/apps/eddn/src/eddn_listener.py
@@ -76,6 +76,70 @@ EDDN_PUBSUB_CHANNEL = 'eddn_events'
 DIRTY_MARK_BATCH_SIZE = int(os.getenv('DIRTY_MARK_BATCH_SIZE', '500'))
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = int(os.getenv('DIRTY_MARK_STATEMENT_TIMEOUT_MS', '5000'))
 
+BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
+CASE
+    WHEN $11 = 'eddn_scan'
+         AND NOT EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2
+               AND b.system_id64 = $1
+         )
+         AND (
+             $3 = 0
+             OR $2 = 0
+             OR $4 ILIKE '%% belt%%'
+             OR $5 ILIKE '%% belt%%'
+         )
+        THEN 'belt_source_evidence'
+    WHEN EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2
+               AND b.system_id64 = $1
+               AND (
+                   $4 IS NULL
+                   OR b.name = $4
+               )
+         )
+        THEN 'local_matched'
+    ELSE 'unresolved_body_identity'
+END
+""".strip()
+
+BODY_RING_UPSERT_SQL = f"""
+    INSERT INTO body_rings (
+        system_id64, body_id, source_body_id, body_name,
+        ring_name, ring_type, ring_class,
+        mass_mt, inner_radius, outer_radius,
+        source, confidence, association_status, updated_at
+    ) VALUES (
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,
+        {BODY_RING_ASSOCIATION_STATUS_CASE_SQL},
+        NOW()
+    )
+    ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
+        source_body_id = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
+        body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
+        ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
+        ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
+        mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
+        inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
+        outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
+        confidence   = EXCLUDED.confidence,
+        association_status = {BODY_RING_ASSOCIATION_STATUS_CASE_SQL},
+        updated_at   = NOW()
+    WHERE body_rings.source_body_id IS DISTINCT FROM COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id)
+       OR body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
+       OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
+       OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
+       OR body_rings.mass_mt IS DISTINCT FROM COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt)
+       OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
+       OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
+       OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
+       OR body_rings.association_status IS DISTINCT FROM {BODY_RING_ASSOCIATION_STATUS_CASE_SQL}
+"""
+
 os.makedirs(os.path.dirname(os.path.abspath(LOG_FILE)), exist_ok=True)
 
 
@@ -963,40 +1027,12 @@ async def flush_pending(pool: asyncpg.Pool):
                 # ── Upsert ring facts ───────────────────────────────────
                 for ring in resolved_rings_snapshot:
                     try:
-                        status = await conn.execute("""
-                            INSERT INTO body_rings (
-                                system_id64, body_id, source_body_id, body_name,
-                                ring_name, ring_type, ring_class,
-                                mass_mt, inner_radius, outer_radius,
-                                source, confidence, association_status, updated_at
-                            ) VALUES (
-                                $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,NOW()
-                            )
-                            ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
-                                source_body_id = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
-                                body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
-                                ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
-                                ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
-                                mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
-                                inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
-                                outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
-                                confidence   = EXCLUDED.confidence,
-                                association_status = 'local_matched',
-                                updated_at   = NOW()
-                            WHERE body_rings.source_body_id IS DISTINCT FROM COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id)
-                               OR body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
-                               OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
-                               OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
-                               OR body_rings.mass_mt IS DISTINCT FROM COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt)
-                               OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
-                               OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
-                               OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
-                               OR body_rings.association_status IS DISTINCT FROM 'local_matched'
-                        """,
+                        status = await conn.execute(
+                            BODY_RING_UPSERT_SQL,
                             ring.get('system_id64'), ring.get('body_id'), ring.get('source_body_id'), ring.get('body_name'),
                             ring.get('ring_name'), ring.get('ring_type'), ring.get('ring_class'),
                             ring.get('mass_mt'), ring.get('inner_radius'), ring.get('outer_radius'),
-                            ring.get('source'), ring.get('confidence'), ring.get('association_status', 'local_matched'),
+                            ring.get('source'), ring.get('confidence'),
                         )
                         changed = _command_row_count(status)
                         if changed:

--- a/tests/test_ring_data_model.py
+++ b/tests/test_ring_data_model.py
@@ -1,4 +1,6 @@
 import os
+import re
+import sqlite3
 import sys
 
 import pytest
@@ -13,11 +15,93 @@ sys.path.insert(0, os.path.join(ROOT, 'apps', 'importer', 'src'))
 sys.path.insert(0, os.path.join(ROOT, 'apps', 'eddn', 'src'))
 
 eddn_listener = pytest.importorskip('eddn_listener')
+from ingest import eddn_client
 from ingest.journal_normaliser import normalise_scan_event
 from ingest.eddn_client import _resolve_ring_rows_with_local_bodies, _ring_rows_from_scan_facts
 from import_spansh import body_ring_rows_from_spansh_body
+from journal_import import store as journal_import_store
 from ring_facts import normalise_ring_payload, ring_rows_for_body
 from routers.systems import _body_payload_from_row
+
+
+def _evaluate_ring_status_case(
+    case_sql: str,
+    *,
+    bodies: list[tuple[int, int, str]],
+    system_id64: int = 42,
+    body_id: int = 7,
+    source_body_id: int = 7,
+    body_name: str | None = 'Test 4',
+    ring_name: str = 'Test 4 A Ring',
+    source: str = 'eddn_scan',
+) -> str:
+    conn = sqlite3.connect(':memory:')
+    try:
+        conn.execute('CREATE TABLE bodies (id INTEGER, system_id64 INTEGER, name TEXT)')
+        conn.executemany('INSERT INTO bodies (id, system_id64, name) VALUES (?, ?, ?)', bodies)
+        sqlite_case = re.sub(r'\$(\d+)', r':p\1', case_sql).replace(' ILIKE ', ' LIKE ')
+        params = {f'p{index}': None for index in range(1, 12)}
+        params['p1'] = system_id64
+        params['p2'] = body_id
+        params['p3'] = source_body_id
+        params['p4'] = body_name
+        params['p5'] = ring_name
+        params['p11'] = source
+        row = conn.execute(f'SELECT {sqlite_case}', params).fetchone()
+        assert row is not None
+        return str(row[0])
+    finally:
+        conn.close()
+
+
+def _assert_invariant_aligned_ring_upsert_sql(module) -> None:
+    case_sql = module.BODY_RING_ASSOCIATION_STATUS_CASE_SQL
+    upsert_sql = module.BODY_RING_UPSERT_SQL
+    normalized_case = ' '.join(case_sql.split())
+
+    assert upsert_sql.count(case_sql) == 3
+    assert normalized_case.index("THEN 'belt_source_evidence'") < normalized_case.index("THEN 'local_matched'")
+    assert (
+        "WHEN $11 = 'eddn_scan' AND NOT EXISTS ( SELECT 1 FROM bodies b "
+        "WHERE b.id = $2 AND b.system_id64 = $1 ) AND ( $3 = 0 OR $2 = 0 "
+        "OR $4 ILIKE '%% belt%%' OR $5 ILIKE '%% belt%%' ) THEN 'belt_source_evidence'"
+    ) in normalized_case
+    assert (
+        'WHEN EXISTS ( SELECT 1 FROM bodies b WHERE b.id = $2 AND b.system_id64 = $1 '
+        "AND ( $4 IS NULL OR b.name = $4 ) ) THEN 'local_matched'"
+    ) in normalized_case
+    assert normalized_case.endswith("ELSE 'unresolved_body_identity' END")
+    assert "'conflict'" not in case_sql
+    assert "'ambiguous_body_identity'" not in case_sql
+    assert f'association_status = {case_sql}' in upsert_sql
+    assert f'body_rings.association_status IS DISTINCT FROM {case_sql}' in upsert_sql
+    assert '$13' not in upsert_sql
+    assert _evaluate_ring_status_case(case_sql, bodies=[(7, 42, 'Test 4')]) == 'local_matched'
+    assert _evaluate_ring_status_case(
+        case_sql,
+        bodies=[(7, 42, 'Different body name')],
+    ) == 'unresolved_body_identity'
+    assert _evaluate_ring_status_case(
+        case_sql,
+        bodies=[(7, 99, 'Test 4')],
+        body_name='Test Belt',
+    ) == 'belt_source_evidence'
+    assert _evaluate_ring_status_case(
+        case_sql,
+        bodies=[(7, 99, 'Test 4')],
+    ) == 'unresolved_body_identity'
+
+
+def test_listener_ring_upsert_emits_invariant_aligned_association_status_case():
+    _assert_invariant_aligned_ring_upsert_sql(eddn_listener)
+
+
+def test_api_eddn_ring_upsert_emits_invariant_aligned_association_status_case():
+    _assert_invariant_aligned_ring_upsert_sql(eddn_client)
+
+
+def test_journal_ring_upsert_emits_invariant_aligned_association_status_case():
+    _assert_invariant_aligned_ring_upsert_sql(journal_import_store)
 
 
 def test_ring_payload_parses_one_ring_with_class_and_type():


### PR DESCRIPTION
## Summary
- classify `body_rings.association_status` atomically from the ring row and a same-system `bodies` lookup in the live EDDN listener, dormant API EDDN client, and journal promotion path
- require same-system body-name agreement before stamping `local_matched`
- retain the invariant classifier's EDDN belt-evidence branch and otherwise stamp `unresolved_body_identity`
- use the identical CASE for INSERT, conflict UPDATE, and change detection so unresolved rows do not rewrite on every message
- leave `conflict` and `ambiguous_body_identity` to the batch recompute

## Root cause
The three upserts accepted a globally valid `bodies.id` as locally matched without confirming that body belonged to the ring's `system_id64`. Cross-system ID collisions therefore accumulated false `local_matched` rows and kept the ring-association invariant red.

## Validation
- pre-change regression proof: `3 failed, 18 passed`
- post-change focused suite: `21 passed`
- adjacent unit/contract selection: `40 passed, 4 skipped`
- full-repo `ruff check .`
- Python compilation for all three changed modules
- `git diff --check`

No invariant SQL, repair script, schema default, deployment, restart, or `.env` value was changed.
