### PR TITLE
Cast ring status bind parameters to bigint

### DIFF
--- a/apps/api/src/ingest/eddn_client.py
+++ b/apps/api/src/ingest/eddn_client.py
@@ -43,18 +43,20 @@ RECONNECT_DELAY  = 5     # seconds between reconnect attempts
 DIRTY_MARK_BATCH_SIZE = 500
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = 5000
 
+# These casts are load-bearing: without them Postgres can infer the same bind
+# parameter as both integer and bigint across the CASE and INSERT target.
 BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
 CASE
     WHEN $11 = 'eddn_scan'
          AND NOT EXISTS (
              SELECT 1
              FROM bodies b
-             WHERE b.id = $2
-               AND b.system_id64 = $1
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
          )
          AND (
-             $3 = 0
-             OR $2 = 0
+             $3::bigint = 0
+             OR $2::bigint = 0
              OR $4 ILIKE '%% belt%%'
              OR $5 ILIKE '%% belt%%'
          )
@@ -62,8 +64,8 @@ CASE
     WHEN EXISTS (
              SELECT 1
              FROM bodies b
-             WHERE b.id = $2
-               AND b.system_id64 = $1
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
                AND (
                    $4 IS NULL
                    OR b.name = $4

--- a/apps/api/src/journal_import/store.py
+++ b/apps/api/src/journal_import/store.py
@@ -29,18 +29,20 @@ MAX_DAILY_ROWS_PER_SYNC_KEY = 200_000
 DIRTY_MARK_BATCH_SIZE = 500
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = 5000
 
+# These casts are load-bearing: without them Postgres can infer the same bind
+# parameter as both integer and bigint across the CASE and INSERT target.
 BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
 CASE
     WHEN $11 = 'eddn_scan'
          AND NOT EXISTS (
              SELECT 1
              FROM bodies b
-             WHERE b.id = $2
-               AND b.system_id64 = $1
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
          )
          AND (
-             $3 = 0
-             OR $2 = 0
+             $3::bigint = 0
+             OR $2::bigint = 0
              OR $4 ILIKE '%% belt%%'
              OR $5 ILIKE '%% belt%%'
          )
@@ -48,8 +50,8 @@ CASE
     WHEN EXISTS (
              SELECT 1
              FROM bodies b
-             WHERE b.id = $2
-               AND b.system_id64 = $1
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
                AND (
                    $4 IS NULL
                    OR b.name = $4

--- a/apps/eddn/src/eddn_listener.py
+++ b/apps/eddn/src/eddn_listener.py
@@ -76,18 +76,20 @@ EDDN_PUBSUB_CHANNEL = 'eddn_events'
 DIRTY_MARK_BATCH_SIZE = int(os.getenv('DIRTY_MARK_BATCH_SIZE', '500'))
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = int(os.getenv('DIRTY_MARK_STATEMENT_TIMEOUT_MS', '5000'))
 
+# These casts are load-bearing: without them Postgres can infer the same bind
+# parameter as both integer and bigint across the CASE and INSERT target.
 BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
 CASE
     WHEN $11 = 'eddn_scan'
          AND NOT EXISTS (
              SELECT 1
              FROM bodies b
-             WHERE b.id = $2
-               AND b.system_id64 = $1
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
          )
          AND (
-             $3 = 0
-             OR $2 = 0
+             $3::bigint = 0
+             OR $2::bigint = 0
              OR $4 ILIKE '%% belt%%'
              OR $5 ILIKE '%% belt%%'
          )
@@ -95,8 +97,8 @@ CASE
     WHEN EXISTS (
              SELECT 1
              FROM bodies b
-             WHERE b.id = $2
-               AND b.system_id64 = $1
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
                AND (
                    $4 IS NULL
                    OR b.name = $4

--- a/tests/test_ring_data_model.py
+++ b/tests/test_ring_data_model.py
@@ -39,7 +39,11 @@ def _evaluate_ring_status_case(
     try:
         conn.execute('CREATE TABLE bodies (id INTEGER, system_id64 INTEGER, name TEXT)')
         conn.executemany('INSERT INTO bodies (id, system_id64, name) VALUES (?, ?, ?)', bodies)
-        sqlite_case = re.sub(r'\$(\d+)', r':p\1', case_sql).replace(' ILIKE ', ' LIKE ')
+        sqlite_case = re.sub(
+            r'\$(\d+)',
+            r':p\1',
+            case_sql.replace('::bigint', ''),
+        ).replace(' ILIKE ', ' LIKE ')
         params = {f'p{index}': None for index in range(1, 12)}
         params['p1'] = system_id64
         params['p2'] = body_id
@@ -63,16 +67,25 @@ def _assert_invariant_aligned_ring_upsert_sql(module) -> None:
     assert normalized_case.index("THEN 'belt_source_evidence'") < normalized_case.index("THEN 'local_matched'")
     assert (
         "WHEN $11 = 'eddn_scan' AND NOT EXISTS ( SELECT 1 FROM bodies b "
-        "WHERE b.id = $2 AND b.system_id64 = $1 ) AND ( $3 = 0 OR $2 = 0 "
+        "WHERE b.id = $2::bigint AND b.system_id64 = $1::bigint ) AND ( "
+        "$3::bigint = 0 OR $2::bigint = 0 "
         "OR $4 ILIKE '%% belt%%' OR $5 ILIKE '%% belt%%' ) THEN 'belt_source_evidence'"
     ) in normalized_case
     assert (
-        'WHEN EXISTS ( SELECT 1 FROM bodies b WHERE b.id = $2 AND b.system_id64 = $1 '
+        'WHEN EXISTS ( SELECT 1 FROM bodies b WHERE b.id = $2::bigint '
+        'AND b.system_id64 = $1::bigint '
         "AND ( $4 IS NULL OR b.name = $4 ) ) THEN 'local_matched'"
     ) in normalized_case
     assert normalized_case.endswith("ELSE 'unresolved_body_identity' END")
     assert "'conflict'" not in case_sql
     assert "'ambiguous_body_identity'" not in case_sql
+    assert case_sql.count('b.id = $2::bigint') == 2
+    assert case_sql.count('b.system_id64 = $1::bigint') == 2
+    assert case_sql.count('$3::bigint = 0') == 1
+    assert case_sql.count('$2::bigint = 0') == 1
+    assert upsert_sql.count('$1::bigint') == 6
+    assert upsert_sql.count('$2::bigint') == 9
+    assert upsert_sql.count('$3::bigint') == 3
     assert f'association_status = {case_sql}' in upsert_sql
     assert f'body_rings.association_status IS DISTINCT FROM {case_sql}' in upsert_sql
     assert '$13' not in upsert_sql


### PR DESCRIPTION
## Urgent production fix

Follow-up to merged #403. Every ring upsert is currently failing because PostgreSQL infers the same bind parameters as both `integer` and `bigint` after the association-status CASE introduced literal-zero comparisons.

## Change
- cast every `$1` system ID, `$2` body ID, and `$3` source body ID comparison inside the CASE to `::bigint`
- preserve the CASE ordering and classification logic exactly
- document that the casts are load-bearing for PostgreSQL parameter type deduction
- assert every comparison site and all three rendered CASE copies contain the casts

## Validation
- pre-change cast regression: `3 failed, 18 passed`
- post-change focused suite: `21 passed`
- adjacent unit/contract selection: `40 passed, 4 skipped`
- full-repo `ruff check .`
- Python compilation for all three changed modules
- `git diff --check`

No deployment or restart performed.
