### PR TITLE
Set regional backfill statement timeout

### DIFF
--- a/apps/importer/src/build_regional_analysis.py
+++ b/apps/importer/src/build_regional_analysis.py
@@ -152,7 +152,9 @@ def main() -> None:
     args = parser.parse_args()
 
     dsn = os.environ['DATABASE_URL']
-    with psycopg2.connect(dsn) as conn:
+    # These backfill queries scan 188M rows, so the role's 15s timeout is far too low.
+    # Keep this connection-level: SET LOCAL would not survive each 1,000-row commit.
+    with psycopg2.connect(dsn, options='-c statement_timeout=1800000') as conn:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             targets = _load_targets(cur, args)
             for index, system in enumerate(targets, start=1):

--- a/tests/test_regional_analysis.py
+++ b/tests/test_regional_analysis.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 
 os.environ.setdefault('CORS_ORIGINS', 'http://test')
@@ -13,6 +14,7 @@ os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'importer' / 'src'))
 
+import build_regional_analysis
 from build_regional_analysis import _load_targets
 from edfinder_api.regional.regional_analysis import compute_regional_analysis, distance_ly, response_from_row
 from edfinder_api.regional.regional_roles import classify_regional_role
@@ -33,6 +35,22 @@ class RecordingCursor:
 
     def fetchone(self) -> dict[str, int]:
         return {'excluded_count': 266_000}
+
+
+def test_main_sets_bounded_session_statement_timeout(monkeypatch):
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    cursor.fetchone.return_value = {'excluded_count': 0}
+    connection = MagicMock()
+    connection.__enter__.return_value = connection
+    connection.cursor.return_value.__enter__.return_value = cursor
+    connect = MagicMock(return_value=connection)
+    monkeypatch.setattr(build_regional_analysis.psycopg2, 'connect', connect)
+    monkeypatch.setattr(sys, 'argv', ['build_regional_analysis.py'])
+
+    build_regional_analysis.main()
+
+    assert 'statement_timeout=1800000' in connect.call_args.kwargs['options']
 
 
 def test_load_targets_filters_coordinate_less_systems_in_all_modes(capsys):


### PR DESCRIPTION
## Summary

- set a bounded 30-minute session `statement_timeout` on the regional-analysis backfill connection
- keep the timeout across the backfill's periodic commits
- cover the connection option through `main()` with a stubbed connection and cursor

## Verification

- Before production change: `1 failed, 7 passed` (`options` was absent)
- After production change: `8 passed`
- `python -m ruff check .`: passed
- `git diff --check`: passed

No deployment, restart, or environment changes were performed.
