### PR TITLE
Guard bodies upsert against cross-system id collisions

### DIFF
--- a/apps/eddn/src/eddn_listener.py
+++ b/apps/eddn/src/eddn_listener.py
@@ -977,30 +977,32 @@ async def flush_pending(pool: asyncpg.Pool):
                                 estimated_scan_value = COALESCE(EXCLUDED.estimated_scan_value, bodies.estimated_scan_value),
                                 updated_at        = NOW()
                             WHERE
-                                bodies.system_id64 IS DISTINCT FROM EXCLUDED.system_id64
-                                OR bodies.name IS DISTINCT FROM COALESCE(NULLIF(EXCLUDED.name, 'Unknown'), bodies.name)
-                                OR bodies.body_type IS DISTINCT FROM EXCLUDED.body_type
-                                OR bodies.subtype IS DISTINCT FROM COALESCE(EXCLUDED.subtype, bodies.subtype)
-                                OR bodies.is_main_star IS DISTINCT FROM EXCLUDED.is_main_star
-                                OR bodies.distance_from_star IS DISTINCT FROM COALESCE(EXCLUDED.distance_from_star, bodies.distance_from_star)
-                                OR bodies.radius IS DISTINCT FROM COALESCE(EXCLUDED.radius, bodies.radius)
-                                OR bodies.mass IS DISTINCT FROM COALESCE(EXCLUDED.mass, bodies.mass)
-                                OR bodies.gravity IS DISTINCT FROM COALESCE(EXCLUDED.gravity, bodies.gravity)
-                                OR bodies.is_landable IS DISTINCT FROM EXCLUDED.is_landable
-                                OR bodies.is_terraformable IS DISTINCT FROM EXCLUDED.is_terraformable
-                                OR bodies.is_earth_like IS DISTINCT FROM EXCLUDED.is_earth_like
-                                OR bodies.is_water_world IS DISTINCT FROM EXCLUDED.is_water_world
-                                OR bodies.is_ammonia_world IS DISTINCT FROM EXCLUDED.is_ammonia_world
-                                OR bodies.surface_temp IS DISTINCT FROM COALESCE(EXCLUDED.surface_temp, bodies.surface_temp)
-                                OR bodies.surface_pressure IS DISTINCT FROM COALESCE(EXCLUDED.surface_pressure, bodies.surface_pressure)
-                                OR bodies.volcanism IS DISTINCT FROM COALESCE(EXCLUDED.volcanism, bodies.volcanism)
-                                OR bodies.atmosphere_type IS DISTINCT FROM COALESCE(EXCLUDED.atmosphere_type, bodies.atmosphere_type)
-                                OR bodies.is_tidal_lock IS DISTINCT FROM COALESCE(EXCLUDED.is_tidal_lock, bodies.is_tidal_lock)
-                                OR bodies.spectral_class IS DISTINCT FROM COALESCE(EXCLUDED.spectral_class, bodies.spectral_class)
-                                OR bodies.stellar_mass IS DISTINCT FROM COALESCE(EXCLUDED.stellar_mass, bodies.stellar_mass)
-                                OR bodies.is_scoopable IS DISTINCT FROM COALESCE(EXCLUDED.is_scoopable, bodies.is_scoopable)
-                                OR bodies.estimated_mapping_value IS DISTINCT FROM COALESCE(EXCLUDED.estimated_mapping_value, bodies.estimated_mapping_value)
-                                OR bodies.estimated_scan_value IS DISTINCT FROM COALESCE(EXCLUDED.estimated_scan_value, bodies.estimated_scan_value)
+                                bodies.system_id64 = EXCLUDED.system_id64
+                                AND (
+                                    bodies.name IS DISTINCT FROM COALESCE(NULLIF(EXCLUDED.name, 'Unknown'), bodies.name)
+                                    OR bodies.body_type IS DISTINCT FROM EXCLUDED.body_type
+                                    OR bodies.subtype IS DISTINCT FROM COALESCE(EXCLUDED.subtype, bodies.subtype)
+                                    OR bodies.is_main_star IS DISTINCT FROM EXCLUDED.is_main_star
+                                    OR bodies.distance_from_star IS DISTINCT FROM COALESCE(EXCLUDED.distance_from_star, bodies.distance_from_star)
+                                    OR bodies.radius IS DISTINCT FROM COALESCE(EXCLUDED.radius, bodies.radius)
+                                    OR bodies.mass IS DISTINCT FROM COALESCE(EXCLUDED.mass, bodies.mass)
+                                    OR bodies.gravity IS DISTINCT FROM COALESCE(EXCLUDED.gravity, bodies.gravity)
+                                    OR bodies.is_landable IS DISTINCT FROM EXCLUDED.is_landable
+                                    OR bodies.is_terraformable IS DISTINCT FROM EXCLUDED.is_terraformable
+                                    OR bodies.is_earth_like IS DISTINCT FROM EXCLUDED.is_earth_like
+                                    OR bodies.is_water_world IS DISTINCT FROM EXCLUDED.is_water_world
+                                    OR bodies.is_ammonia_world IS DISTINCT FROM EXCLUDED.is_ammonia_world
+                                    OR bodies.surface_temp IS DISTINCT FROM COALESCE(EXCLUDED.surface_temp, bodies.surface_temp)
+                                    OR bodies.surface_pressure IS DISTINCT FROM COALESCE(EXCLUDED.surface_pressure, bodies.surface_pressure)
+                                    OR bodies.volcanism IS DISTINCT FROM COALESCE(EXCLUDED.volcanism, bodies.volcanism)
+                                    OR bodies.atmosphere_type IS DISTINCT FROM COALESCE(EXCLUDED.atmosphere_type, bodies.atmosphere_type)
+                                    OR bodies.is_tidal_lock IS DISTINCT FROM COALESCE(EXCLUDED.is_tidal_lock, bodies.is_tidal_lock)
+                                    OR bodies.spectral_class IS DISTINCT FROM COALESCE(EXCLUDED.spectral_class, bodies.spectral_class)
+                                    OR bodies.stellar_mass IS DISTINCT FROM COALESCE(EXCLUDED.stellar_mass, bodies.stellar_mass)
+                                    OR bodies.is_scoopable IS DISTINCT FROM COALESCE(EXCLUDED.is_scoopable, bodies.is_scoopable)
+                                    OR bodies.estimated_mapping_value IS DISTINCT FROM COALESCE(EXCLUDED.estimated_mapping_value, bodies.estimated_mapping_value)
+                                    OR bodies.estimated_scan_value IS DISTINCT FROM COALESCE(EXCLUDED.estimated_scan_value, bodies.estimated_scan_value)
+                                )
                         """,
                             body['id'], body['system_id64'], body['name'],
                             body.get('body_type', 'Unknown'),


### PR DESCRIPTION
## Summary
- `bodies.id` is application-supplied with no sequence and no composite key — journal `BodyID` is unique only within a system, not globally.
- The eddn listener's `INSERT ... ON CONFLICT (id) DO UPDATE` for `bodies` unconditionally reset `system_id64` on any collision, silently re-parenting the row (and everything FK'd to it: `attractions`, `station_body_links`, `body_rings`) to whichever system scanned last.
- This is the confirmed root cause of the `body_rings.association_status = 'local_matched'` drift tracked by the data-invariants gate (751 on 08-02, 1,661 on 08-03, 1,805 by 08-04), which PRs #403/#404 reduced but did not stop.

## Change
Scope the `bodies` `ON CONFLICT ... DO UPDATE` to same-system writes only, by adding `bodies.system_id64 = EXCLUDED.system_id64` as a guard ahead of the existing change-detection `OR` chain. A colliding id from a different system is now a no-op (0 rows affected) instead of a steal. No migration; no change to `association_status` classification logic (verified correct); no change to the `name` COALESCE fallback (the system_id64 guard already closes the "reparented row keeps previous holder's name" path it was implicated in).

## Expected post-deploy state
The 1,805 pre-existing bad rows are **not** fixed by this change — that's the known-cause backlog, to be cleared by `scripts/repair_body_ring_association_status.py` in a follow-up once this stops new corruption. The post-deploy data-invariants gate is expected to still report that backlog; this is not a rollback trigger for this PR.

## Test plan
- [x] `python -c "import ast; ast.parse(...)"` — syntax check passes
- [ ] Deploy, then confirm the drift count does not climb over 1 hour at full EDDN rate
- [ ] Only then run the ring repair dry-run / apply for the pre-existing backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)