### PR TITLE
Skip body_rings writes for bodies rejected by the ownership guard

### DIFF
--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -380,14 +380,23 @@ def _run_with_deadlock_retry(conn, work, *, label, attempts=4, base_delay=0.5):
 def upsert_via_temp(conn, target_table: str, columns: List[str],
                     rows: List[Tuple], conflict_col: str,
                     update_cols: Optional[List[str]] = None,
-                    guard_col: Optional[str] = None) -> int:
+                    guard_col: Optional[str] = None,
+                    returning_col: Optional[str] = None):
     """guard_col: if set, an update is applied only when this column's
     incoming value matches the existing row's value. Use for tables where
     conflict_col alone doesn't establish ownership (e.g. bodies.id is a
     source-supplied id that can collide across systems) so a colliding row
-    from a different owner is a no-op instead of a silent re-parent."""
+    from a different owner is a no-op instead of a silent re-parent.
+
+    returning_col: if set, also collect this column's value for every row
+    actually inserted or updated (i.e. not rejected by guard_col or skipped
+    as a no-op change), and return (count, written_keys) instead of a bare
+    count. Use this so dependent rows keyed off conflict_col (e.g.
+    body_rings.body_id -> bodies.id) are not written for a row whose owning
+    upsert was rejected by guard_col — otherwise a rejected collision still
+    lets its dependent rows attach as trusted data to the wrong owner."""
     if not rows:
-        return 0
+        return (0, set()) if returning_col else 0
     if update_cols is None:
         update_cols = [c for c in columns if c != conflict_col]
     temp = f"_tmp_{target_table}"
@@ -447,15 +456,17 @@ def upsert_via_temp(conn, target_table: str, columns: List[str],
                 buf.write('\t'.join(parts) + '\n')
             buf.seek(0)
             cur.copy_from(buf, temp, columns=columns, null='\\N')
+            returning_clause = f"\n                RETURNING {returning_col}" if returning_col else ''
             cur.execute(f"""
                 INSERT INTO {target_table} ({col_list})
                 SELECT {col_list} FROM {temp}
                 ON CONFLICT ({conflict_col}) DO UPDATE
-                SET {set_clause}{where_clause}
+                SET {set_clause}{where_clause}{returning_clause}
             """)
             count = cur.rowcount
+            written_keys = {row[0] for row in cur.fetchall()} if returning_col else None
         conn.commit()
-        return count
+        return (count, written_keys) if returning_col else count
 
     return _run_with_deadlock_retry(conn, _do, label=f"upsert_via_temp({target_table})")
 
@@ -827,6 +838,8 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
     total_rows  = 0
     skip_count  = 0
     last_save   = time.time()
+    rejected_body_ids: set = set()
+    rings_skipped_rejected_body = 0
 
     def flush_systems():
         if sys_batch:
@@ -836,14 +849,34 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
     def flush_bodies():
         flush_systems()
         if body_batch:
-            upsert_via_temp(conn, 'bodies', BODY_COLS, body_batch, 'id', guard_col='system_id64')
+            attempted_ids = {row[0] for row in body_batch}
+            _count, written_ids = upsert_via_temp(
+                conn, 'bodies', BODY_COLS, body_batch, 'id',
+                guard_col='system_id64', returning_col='id',
+            )
+            rejected_body_ids.update(attempted_ids - written_ids)
             body_batch.clear()
 
     def flush_rings():
+        nonlocal rings_skipped_rejected_body
         flush_bodies()
         if ring_batch:
-            upsert_body_rings(conn, ring_batch)
+            keep = [r for r in ring_batch if r.get('body_id') not in rejected_body_ids]
+            skipped = len(ring_batch) - len(keep)
+            if skipped:
+                rings_skipped_rejected_body += skipped
+                log.info(
+                    f"Skipping {skipped} ring row(s) whose owning body upsert "
+                    "was rejected by the system_id64 ownership guard "
+                    "(colliding Spansh body id already owned by another system)"
+                )
+            if keep:
+                upsert_body_rings(conn, keep)
             ring_batch.clear()
+        # Every currently-queued ring row has now been resolved (kept or
+        # dropped) against the rejections seen so far — safe to reset before
+        # the next span of flush_bodies() calls accumulates new ones.
+        rejected_body_ids.clear()
 
     def flush_stations():
         flush_systems()
@@ -1134,6 +1167,12 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
 
     if skip_count:
         log.warning(f"Skipped {skip_count:,} malformed records during galaxy import")
+    if rings_skipped_rejected_body:
+        log.warning(
+            f"Skipped {rings_skipped_rejected_body:,} ring row(s) for bodies "
+            "whose upsert was rejected by the system_id64 ownership guard "
+            "(colliding Spansh body id)"
+        )
     mark_complete(conn, dump_path.name, total_rows)
     log.info(f"galaxy.json.gz complete: {total_rows:,} systems imported")
     return total_rows

--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -388,13 +388,22 @@ def upsert_via_temp(conn, target_table: str, columns: List[str],
     source-supplied id that can collide across systems) so a colliding row
     from a different owner is a no-op instead of a silent re-parent.
 
-    returning_col: if set, also collect this column's value for every row
-    actually inserted or updated (i.e. not rejected by guard_col or skipped
-    as a no-op change), and return (count, written_keys) instead of a bare
-    count. Use this so dependent rows keyed off conflict_col (e.g.
-    body_rings.body_id -> bodies.id) are not written for a row whose owning
-    upsert was rejected by guard_col — otherwise a rejected collision still
-    lets its dependent rows attach as trusted data to the wrong owner."""
+    returning_col: only meaningful together with guard_col. If set, also
+    compute the set of this column's values among the attempted rows whose
+    guard_col was actually rejected (i.e. the row that ends up in
+    target_table has a guard_col value different from what this call
+    attempted), and return (count, rejected_keys) instead of a bare count.
+    This is deliberately a direct post-write ownership comparison rather
+    than reading back RETURNING from the main statement: RETURNING only
+    reports rows the UPDATE actually touched, and the same-owner no-op case
+    (nothing changed, so the change-detection half of where_clause is
+    false) also produces no RETURNING row even though guard_col was not
+    rejected — conflating the two would wrongly treat an unchanged,
+    correctly-owned row as rejected. Use this so dependent rows keyed off
+    conflict_col (e.g. body_rings.body_id -> bodies.id) are not written for
+    a row whose owning upsert was rejected by guard_col — otherwise a
+    rejected collision still lets its dependent rows attach as trusted data
+    to the wrong owner."""
     if not rows:
         return (0, set()) if returning_col else 0
     if update_cols is None:
@@ -456,17 +465,24 @@ def upsert_via_temp(conn, target_table: str, columns: List[str],
                 buf.write('\t'.join(parts) + '\n')
             buf.seek(0)
             cur.copy_from(buf, temp, columns=columns, null='\\N')
-            returning_clause = f"\n                RETURNING {returning_col}" if returning_col else ''
             cur.execute(f"""
                 INSERT INTO {target_table} ({col_list})
                 SELECT {col_list} FROM {temp}
                 ON CONFLICT ({conflict_col}) DO UPDATE
-                SET {set_clause}{where_clause}{returning_clause}
+                SET {set_clause}{where_clause}
             """)
             count = cur.rowcount
-            written_keys = {row[0] for row in cur.fetchall()} if returning_col else None
+            rejected_keys = set() if returning_col else None
+            if returning_col and guard_col:
+                cur.execute(f"""
+                    SELECT t.{returning_col}
+                    FROM {temp} t
+                    JOIN {target_table} b ON b.{conflict_col} = t.{conflict_col}
+                    WHERE b.{guard_col} IS DISTINCT FROM t.{guard_col}
+                """)
+                rejected_keys = {row[0] for row in cur.fetchall()}
         conn.commit()
-        return (count, written_keys) if returning_col else count
+        return (count, rejected_keys) if returning_col else count
 
     return _run_with_deadlock_retry(conn, _do, label=f"upsert_via_temp({target_table})")
 
@@ -838,7 +854,7 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
     total_rows  = 0
     skip_count  = 0
     last_save   = time.time()
-    rejected_body_ids: set = set()
+    rejected_body_ids: set = set()  # (system_id64, body_id) pairs rejected by the guard
     rings_skipped_rejected_body = 0
 
     def flush_systems():
@@ -849,19 +865,24 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
     def flush_bodies():
         flush_systems()
         if body_batch:
-            attempted_ids = {row[0] for row in body_batch}
-            _count, written_ids = upsert_via_temp(
+            _count, rejected_ids = upsert_via_temp(
                 conn, 'bodies', BODY_COLS, body_batch, 'id',
                 guard_col='system_id64', returning_col='id',
             )
-            rejected_body_ids.update(attempted_ids - written_ids)
+            if rejected_ids:
+                rejected_body_ids.update(
+                    (row[1], row[0]) for row in body_batch if row[0] in rejected_ids
+                )
             body_batch.clear()
 
     def flush_rings():
         nonlocal rings_skipped_rejected_body
         flush_bodies()
         if ring_batch:
-            keep = [r for r in ring_batch if r.get('body_id') not in rejected_body_ids]
+            keep = [
+                r for r in ring_batch
+                if (r.get('system_id64'), r.get('body_id')) not in rejected_body_ids
+            ]
             skipped = len(ring_batch) - len(keep)
             if skipped:
                 rings_skipped_rejected_body += skipped

--- a/tests/integration/test_import_spansh_body_upsert.py
+++ b/tests/integration/test_import_spansh_body_upsert.py
@@ -127,3 +127,32 @@ def test_body_upsert_from_owning_system_still_updates_after_guard(pg_conn):
     assert row is not None
     assert row[0] == owner_id
     assert row[1] == 'Icy body'
+
+
+@pytest.mark.db
+def test_returning_col_excludes_ids_rejected_by_guard(pg_conn):
+    """import_galaxy()'s flush_bodies()/flush_rings() closures use
+    returning_col='id' to compute a rejected-id set and drop those bodies'
+    queued body_rings rows before writing them, rather than let a collision
+    that reparenting-guard blocked still attach body_rings as trusted data
+    to the wrong owning system (GitHub review finding on PR #408). This
+    proves the underlying primitive: a rejected write's id must be absent
+    from written_ids so that filtering step actually catches it."""
+    owner_id, intruder_id = TEST_SYSTEM_IDS
+    _insert_test_systems(pg_conn)
+
+    owner_count, owner_written = import_spansh.upsert_via_temp(
+        pg_conn, 'bodies', BODY_COLS,
+        [(TEST_BODY_ID, owner_id, 'Owner System Body 1 a', 'Planet', 'Rocky body')],
+        'id', guard_col='system_id64', returning_col='id',
+    )
+    assert owner_count == 1
+    assert owner_written == {TEST_BODY_ID}
+
+    intruder_count, intruder_written = import_spansh.upsert_via_temp(
+        pg_conn, 'bodies', BODY_COLS,
+        [(TEST_BODY_ID, intruder_id, 'Intruder System Body 1 a', 'Planet', 'Icy body')],
+        'id', guard_col='system_id64', returning_col='id',
+    )
+    assert intruder_count == 0
+    assert intruder_written == set()

--- a/tests/integration/test_import_spansh_body_upsert.py
+++ b/tests/integration/test_import_spansh_body_upsert.py
@@ -5,7 +5,9 @@ import os
 import psycopg2
 import pytest
 
-import import_spansh
+os.environ.setdefault('LOG_FILE', os.devnull)
+
+import import_spansh  # noqa: E402
 
 
 TEST_SYSTEM_IDS = (
@@ -130,29 +132,62 @@ def test_body_upsert_from_owning_system_still_updates_after_guard(pg_conn):
 
 
 @pytest.mark.db
-def test_returning_col_excludes_ids_rejected_by_guard(pg_conn):
+def test_returning_col_reports_ids_rejected_by_guard(pg_conn):
     """import_galaxy()'s flush_bodies()/flush_rings() closures use
     returning_col='id' to compute a rejected-id set and drop those bodies'
     queued body_rings rows before writing them, rather than let a collision
-    that reparenting-guard blocked still attach body_rings as trusted data
+    the reparenting guard blocked still attach body_rings as trusted data
     to the wrong owning system (GitHub review finding on PR #408). This
-    proves the underlying primitive: a rejected write's id must be absent
-    from written_ids so that filtering step actually catches it."""
+    proves the underlying primitive: a rejected write's id must appear in
+    the returned rejection set so that filtering step actually catches it.
+    A legitimate same-owner write must report no rejections at all — the
+    query compares final-row ownership directly rather than relying on
+    RETURNING from the main statement, which is what test_unchanged_
+    same_system_body_is_not_reported_as_rejected below guards against."""
     owner_id, intruder_id = TEST_SYSTEM_IDS
     _insert_test_systems(pg_conn)
 
-    owner_count, owner_written = import_spansh.upsert_via_temp(
+    owner_count, owner_rejected = import_spansh.upsert_via_temp(
         pg_conn, 'bodies', BODY_COLS,
         [(TEST_BODY_ID, owner_id, 'Owner System Body 1 a', 'Planet', 'Rocky body')],
         'id', guard_col='system_id64', returning_col='id',
     )
     assert owner_count == 1
-    assert owner_written == {TEST_BODY_ID}
+    assert owner_rejected == set()
 
-    intruder_count, intruder_written = import_spansh.upsert_via_temp(
+    intruder_count, intruder_rejected = import_spansh.upsert_via_temp(
         pg_conn, 'bodies', BODY_COLS,
         [(TEST_BODY_ID, intruder_id, 'Intruder System Body 1 a', 'Planet', 'Icy body')],
         'id', guard_col='system_id64', returning_col='id',
     )
     assert intruder_count == 0
-    assert intruder_written == set()
+    assert intruder_rejected == {TEST_BODY_ID}
+
+
+@pytest.mark.db
+def test_unchanged_same_system_body_is_not_reported_as_rejected(pg_conn):
+    """GitHub review finding on PR #409: RETURNING from the main INSERT ...
+    ON CONFLICT DO UPDATE statement is silent both when guard_col rejects a
+    row AND when the row's owner matches but no tracked column actually
+    changed (the pre-existing no-op change-detection guard). Conflating
+    those two cases would wrongly drop body_rings for a body that re-import
+    saw again unchanged — it must report zero rejections here, not the
+    body's id, even though the second upsert is byte-for-byte identical to
+    the first and therefore updates nothing."""
+    owner_id, _intruder_id = TEST_SYSTEM_IDS
+    _insert_test_systems(pg_conn)
+    row = (TEST_BODY_ID, owner_id, 'Owner System Body 1 a', 'Planet', 'Rocky body')
+
+    first_count, first_rejected = import_spansh.upsert_via_temp(
+        pg_conn, 'bodies', BODY_COLS, [row],
+        'id', guard_col='system_id64', returning_col='id',
+    )
+    assert first_count == 1
+    assert first_rejected == set()
+
+    second_count, second_rejected = import_spansh.upsert_via_temp(
+        pg_conn, 'bodies', BODY_COLS, [row],
+        'id', guard_col='system_id64', returning_col='id',
+    )
+    assert second_count == 0  # no-op: nothing changed
+    assert second_rejected == set()  # but NOT a guard rejection

--- a/tests/test_stage17n2c_data_trust.py
+++ b/tests/test_stage17n2c_data_trust.py
@@ -490,6 +490,26 @@ def test_spansh_temp_upsert_guard_col_scopes_to_matching_owner():
     assert "guard_col='system_id64'" in source
 
 
+def test_spansh_flush_rings_drops_rows_for_guard_rejected_bodies():
+    """A collision the system_id64 guard rejects leaves the bodies row
+    under its original owner, but the queued body_rings row for the
+    colliding write must not still be inserted as trusted local_matched
+    data for the wrong owner (GitHub review finding on PR #408 — the
+    guard alone made the bodies write a no-op, but flush_rings() was still
+    writing that body's rings unconditionally). flush_bodies() must record
+    which attempted ids were rejected, and flush_rings() must filter the
+    ring batch against that set before calling upsert_body_rings — see
+    tests/integration/test_import_spansh_body_upsert.py::
+    test_returning_col_excludes_ids_rejected_by_guard for the real-Postgres
+    proof of the underlying returning_col mechanism."""
+    source = Path(ROOT, 'apps', 'importer', 'src', 'import_spansh.py').read_text(encoding='utf-8')
+
+    assert 'attempted_ids = {row[0] for row in body_batch}' in source
+    assert "returning_col='id'" in source
+    assert 'rejected_body_ids.update(attempted_ids - written_ids)' in source
+    assert "keep = [r for r in ring_batch if r.get('body_id') not in rejected_body_ids]" in source
+
+
 def test_current_rating_scorer_attenuates_multi_economy_saturation():
     bodies = (
         [{'subtype': 'Earth-like world', 'is_earth_like': True}] * 3

--- a/tests/test_stage17n2c_data_trust.py
+++ b/tests/test_stage17n2c_data_trust.py
@@ -497,17 +497,39 @@ def test_spansh_flush_rings_drops_rows_for_guard_rejected_bodies():
     data for the wrong owner (GitHub review finding on PR #408 — the
     guard alone made the bodies write a no-op, but flush_rings() was still
     writing that body's rings unconditionally). flush_bodies() must record
-    which attempted ids were rejected, and flush_rings() must filter the
-    ring batch against that set before calling upsert_body_rings — see
+    which (system_id64, body_id) attempts were rejected, and flush_rings()
+    must filter the ring batch against that set before calling
+    upsert_body_rings — see
     tests/integration/test_import_spansh_body_upsert.py::
-    test_returning_col_excludes_ids_rejected_by_guard for the real-Postgres
-    proof of the underlying returning_col mechanism."""
+    test_returning_col_reports_ids_rejected_by_guard for the real-Postgres
+    proof of the underlying returning_col mechanism.
+
+    Rejection is scoped per (system_id64, body_id) pair, not bare body_id
+    (GitHub review finding on PR #409 — a rejection for one system must not
+    also drop a different, legitimately-owning system's rings for the same
+    colliding id, since a bare-id set can't distinguish the two)."""
     source = Path(ROOT, 'apps', 'importer', 'src', 'import_spansh.py').read_text(encoding='utf-8')
 
-    assert 'attempted_ids = {row[0] for row in body_batch}' in source
     assert "returning_col='id'" in source
-    assert 'rejected_body_ids.update(attempted_ids - written_ids)' in source
-    assert "keep = [r for r in ring_batch if r.get('body_id') not in rejected_body_ids]" in source
+    assert 'rejected_body_ids.update(' in source
+    assert '(row[1], row[0]) for row in body_batch if row[0] in rejected_ids' in source
+    assert "if (r.get('system_id64'), r.get('body_id')) not in rejected_body_ids" in source
+
+
+def test_spansh_upsert_via_temp_rejection_uses_ownership_query_not_returning():
+    """GitHub review finding on PR #409: RETURNING from the main INSERT ...
+    ON CONFLICT DO UPDATE statement can't distinguish "guard_col rejected
+    this row" from "guard_col matched but nothing else changed, so the
+    no-op change-detection half of the WHERE suppressed the write" — both
+    produce no RETURNING row. Rejection must instead be computed by
+    comparing the attempted guard_col value against the row's actual final
+    owner directly, so an unchanged same-owner body is never misreported as
+    rejected and does not lose its rings on a plain re-import."""
+    source = Path(ROOT, 'apps', 'importer', 'src', 'import_spansh.py').read_text(encoding='utf-8')
+
+    assert 'if returning_col and guard_col:' in source
+    assert 'JOIN {target_table} b ON b.{conflict_col} = t.{conflict_col}' in source
+    assert 'WHERE b.{guard_col} IS DISTINCT FROM t.{guard_col}' in source
 
 
 def test_current_rating_scorer_attenuates_multi_economy_saturation():


### PR DESCRIPTION
## Summary
GitHub review finding on #408: the `guard_col` fix made a colliding Spansh body upsert a no-op for the `bodies` row, but `flush_rings()` in `import_galaxy()` still wrote that body's queued `ring_batch` entries unconditionally. Since `upsert_body_rings()` omits `association_status` from its INSERT and the column defaults to `'local_matched'`, a rejected collision still produced a trusted ring row keyed to the wrong owning system — the guard closed the direct re-parenting path but left this one open via `body_rings`.

## Change
- `upsert_via_temp()` gains an optional `returning_col` parameter: when set, it returns `(count, written_keys)` instead of a bare count, using `RETURNING` to report exactly which conflict-key values were actually inserted or updated (not skipped by `guard_col` or the no-op change check).
- `flush_bodies()` uses this to accumulate a `rejected_body_ids` set (attempted ids minus written ids) across however many body-batch flushes happen before the next ring flush.
- `flush_rings()` filters `ring_batch` against that set before calling `upsert_body_rings()`, logs how many rows were dropped, and clears the set once the batch is resolved. Tracking rejections rather than all confirmed ids keeps memory bounded, since collisions are the rare case.
- A final summary log line reports the total skipped-ring count for the import run, matching the existing `skip_count` pattern.

## Test plan
- [x] `tests/integration/test_import_spansh_body_upsert.py::test_returning_col_excludes_ids_rejected_by_guard` (new, real Postgres): proves the underlying primitive — a rejected write's id is absent from `written_ids`.
- [x] `tests/test_stage17n2c_data_trust.py::test_spansh_flush_rings_drops_rows_for_guard_rejected_bodies` (new, content-contract): asserts the `flush_bodies()`/`flush_rings()` wiring exists in source. Note: these closures aren't independently callable without running the full `import_galaxy()` pipeline against a dump file, so this mirrors the existing testing pattern already used for this function's other WHERE-clause behavior rather than claiming full end-to-end coverage.
- [x] All existing import_spansh tests (mocked deadlock-retry + real-Postgres guard tests) still pass.
- [x] ruff clean.