### PR TITLE
CI: skip Frontend build/Playwright for changes confined to importer/eddn/docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       needs_frontend_ci: ${{ steps.filter.outputs.needs_frontend_ci }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           # A filter made only of negated ('!') patterns never matches
@@ -29,6 +29,7 @@ jobs:
           # explicit catch-all pattern to exclude *from*, plus
           # 'some-with-excludes' so the exclusions actually exclude
           # rather than being ignored under the default quantifier.
+          # some-with-excludes requires v4 - v3 only accepts every/some.
           predicate-quantifier: 'some-with-excludes'
           filters: |
             needs_frontend_ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ concurrency:
   cancel-in-progress:  true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      needs_frontend_ci: ${{ steps.filter.outputs.needs_frontend_ci }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            needs_frontend_ci:
+              - '!apps/importer/**'
+              - '!apps/eddn/**'
+              - '!docs/**'
+              - '!**/*.md'
+              - '!scripts/operator/**'
+
   # ─── Backend ────────────────────────────────────────────────────────
   backend:
     name: Backend unit tests + compose validate
@@ -256,6 +274,8 @@ jobs:
   # again, this job fails on PR before it ever reaches production.
   v2:
     name: Frontend build
+    needs: changes
+    if: needs.changes.outputs.needs_frontend_ci == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -463,6 +483,8 @@ jobs:
   # production round-trip without paying for a hosted preview env.
   e2e:
     name: Frontend v2 E2E (Playwright)
+    needs: changes
+    if: needs.changes.outputs.needs_frontend_ci == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,15 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # A filter made only of negated ('!') patterns never matches
+          # anything (see dorny/paths-filter's README) - it needs an
+          # explicit catch-all pattern to exclude *from*, plus
+          # 'some-with-excludes' so the exclusions actually exclude
+          # rather than being ignored under the default quantifier.
+          predicate-quantifier: 'some-with-excludes'
           filters: |
             needs_frontend_ci:
+              - '**'
               - '!apps/importer/**'
               - '!apps/eddn/**'
               - '!docs/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       needs_frontend_ci: ${{ steps.filter.outputs.needs_frontend_ci }}
     steps:
@@ -34,7 +36,12 @@ jobs:
           filters: |
             needs_frontend_ci:
               - '**'
-              - '!apps/importer/**'
+              # Only the importer's flat .py scripts, not the whole tree -
+              # apps/importer/src/data/region_map.json feeds the frontend
+              # build directly (frontend/vite.authoritative-regions.ts
+              # reads it to emit stage26e/authoritative-regions.json), so
+              # a change there must still run Frontend build/Playwright.
+              - '!apps/importer/src/*.py'
               - '!apps/eddn/**'
               - '!docs/**'
               - '!**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
     name: Detect changed paths
     runs-on: ubuntu-latest
     permissions:
+      # Declaring job-level permissions resets every unlisted scope to
+      # 'none' - contents: read must be listed explicitly or the
+      # actions/checkout step below has no repo read access.
+      contents: read
       pull-requests: read
     outputs:
       needs_frontend_ci: ${{ steps.filter.outputs.needs_frontend_ci }}

--- a/docs/ci-path-filter-skip-test.md
+++ b/docs/ci-path-filter-skip-test.md
@@ -1,0 +1,1 @@
+Temporary file to empirically validate the CI path-filter skip behavior on PR #414. Will be removed before this branch is merged.

--- a/docs/ci-path-filter-skip-test.md
+++ b/docs/ci-path-filter-skip-test.md
@@ -1,1 +1,0 @@
-Temporary file to empirically validate the CI path-filter skip behavior on PR #414. Will be removed before this branch is merged.


### PR DESCRIPTION
## Summary
- Adds a `changes` job using `dorny/paths-filter@v3` to detect whether any changed file falls outside a known-safe exclusion list (`apps/importer/**`, `apps/eddn/**`, `docs/**`, `**/*.md`, `scripts/operator/**`).
- Gates the two most expensive jobs — `Frontend build` and `Frontend v2 E2E (Playwright)` — on that detection via job-level `if:`, not a workflow-level `paths:` filter, so the workflow itself always triggers and a skip reports as "passed" for branch protection rather than leaving a required check permanently missing.
- Every other required job (backend tests, script contracts, integration, canonical safety, Nginx, OpenAPI types) is untouched and always runs, as does Review Lab and Built image parity in their separate workflow files.

This PR itself touches only `.github/workflows/ci.yml`, which is outside the exclusion list, so both frontend jobs are expected to run normally here — that's the first real test case. I'll push a follow-up commit touching only an excluded path (e.g. `apps/importer/`) to this same branch to confirm the skip path also works, before merging.

## Test plan
- [x] YAML validates
- [ ] This PR (ci.yml-only change) runs Frontend build + Playwright E2E for real (expected: needs_frontend_ci=true)
- [ ] A follow-up commit touching only `apps/importer/**` shows Frontend build + Playwright E2E as skipped, and the PR remains mergeable
- [ ] A follow-up commit touching `frontend/**` shows both jobs running for real again

🤖 Generated with [Claude Code](https://claude.com/claude-code)