### PR TITLE
Fix round6-report F-014/F-015: broken ring writes, blank-name overwrites

### DIFF
--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -552,20 +552,22 @@ def upsert_body_rings(conn, rows: list[dict]) -> int:
                 cur,
                 """
                 INSERT INTO body_rings (
-                    system_id64, body_id, body_name,
+                    system_id64, body_id, source_body_id, body_name,
                     ring_name, ring_type, ring_class,
                     mass_mt, inner_radius, outer_radius,
-                    source, confidence, updated_at
+                    source, confidence, association_status
                 ) VALUES %s
                 ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
-                    body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
-                    ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
-                    ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
-                    mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
-                    inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
-                    outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
-                    confidence   = EXCLUDED.confidence,
-                    updated_at   = NOW()
+                    source_body_id      = COALESCE(EXCLUDED.source_body_id, body_rings.source_body_id),
+                    body_name           = COALESCE(EXCLUDED.body_name, body_rings.body_name),
+                    ring_type           = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
+                    ring_class          = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
+                    mass_mt             = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
+                    inner_radius        = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
+                    outer_radius        = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
+                    confidence          = EXCLUDED.confidence,
+                    association_status  = EXCLUDED.association_status,
+                    updated_at          = NOW()
                 """,
                 values,
             )
@@ -591,6 +593,7 @@ def _ring_row_tuple(row: dict) -> tuple:
     return (
         row.get('system_id64'),
         row.get('body_id'),
+        row.get('source_body_id'),
         row.get('body_name'),
         row.get('ring_name'),
         row.get('ring_type'),
@@ -600,6 +603,7 @@ def _ring_row_tuple(row: dict) -> tuple:
         row.get('outer_radius'),
         row.get('source'),
         row.get('confidence'),
+        row.get('association_status'),
     )
 
 
@@ -610,8 +614,22 @@ def body_ring_rows_from_spansh_body(system_id64: int, body_id: int, body_name: s
         body_id=body_id,
         body_name=body_name,
         source='spansh_dump',
+        source_body_id=body_id,
         trusted_empty_means_no_rings=False,
     )
+    for row in rows:
+        # Every row returned here only ever reaches upsert_body_rings() via
+        # flush_rings(), which filters ring_batch against rejected_body_ids
+        # first - a ring survives that filter only when its owning body's
+        # upsert was NOT rejected by the system_id64 ownership guard. The
+        # body linkage is therefore already verified locally by the time
+        # this runs, the same guarantee eddn_listener.py's
+        # BODY_RING_ASSOCIATION_STATUS_CASE_SQL computes via a live query
+        # for its own 'local_matched' case - set explicitly here instead of
+        # left to fall through to body_rings.association_status's schema
+        # default, which silently asserts the same claim with no code
+        # anyone can audit.
+        row['association_status'] = 'local_matched'
     return rows
 
 
@@ -843,6 +861,19 @@ def _parse_system_population(sys_obj: dict) -> int | None:
         return None
 
 
+def _require_name(obj: dict, entity_id) -> Optional[str]:
+    """systems.name, bodies.name, and stations.name are all NOT NULL with
+    no default. A source record missing entity_id or name is malformed,
+    not a legitimate "no name" entity - upsert_via_temp's SET clause has
+    no NULL/empty guard, so writing '' here would blank out an existing
+    real name on the next conflict (F-014, docs/audits/round6-report.md).
+    Callers should skip the record entirely when this returns None."""
+    if not entity_id:
+        return None
+    name = obj.get('name')
+    return name if name else None
+
+
 # ---------------------------------------------------------------------------
 # IMPORTER 1 — galaxy.json.gz  (systems + bodies + stations, all-in-one)
 def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
@@ -981,7 +1012,8 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
         try:
             for sys_obj in items_iter:
                 id64 = sys_obj.get('id64')
-                if not id64:
+                name = _require_name(sys_obj, id64)
+                if name is None:
                     continue
 
                 now_iso = datetime.now(timezone.utc).isoformat()
@@ -1027,7 +1059,7 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
                     )
                     sys_batch.append((
                         id64,
-                        sys_obj.get('name', ''),
+                        name,
                         sx, sy, sz,
                         norm_economy(sys_obj.get('primaryEconomy') or sys_obj.get('primary_economy')),
                         norm_economy(sys_obj.get('secondaryEconomy') or sys_obj.get('secondary_economy')),
@@ -1060,7 +1092,8 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
                 # ── Bodies rows ────────────────────────────────────────────
                 for b in bodies_raw:
                     bid = b.get('id64') or b.get('id') or b.get('bodyId')
-                    if not bid:
+                    body_name = _require_name(b, bid)
+                    if body_name is None:
                         continue
                     try:
                         btype_raw = b.get('type', 'Unknown')
@@ -1086,7 +1119,6 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
                         )
                         mass = b.get('earthMasses') or b.get('mass')
                         stellar_mass = b.get('solarMasses') or b.get('stellar_mass')
-                        body_name = b.get('name', '')
 
                         body_batch.append((
                             bid, id64,
@@ -1133,9 +1165,10 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
                 stations_raw = sys_obj.get('stations', []) or []
                 for s in stations_raw:
                     sid = s.get('id') or s.get('marketId') or s.get('market_id')
-                    if not sid:
+                    sta_name = _require_name(s, sid)
+                    if sta_name is None:
                         skip_count += 1
-                        log.debug(f"Skipping station with no id in system {id64}")
+                        log.debug(f"Skipping station with no id/name in system {id64}")
                         continue
                     try:
                         svcs = (s.get('services') or
@@ -1159,7 +1192,7 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
                                          bool(s.get('hasOutfitting') or s.get('has_outfitting', False)))
                         sta_batch.append((
                             sid, id64,
-                            s.get('name', ''),
+                            sta_name,
                             station_type_from_record(s),
                             station_distance_from_record(s),
                             station_body_name_from_record(s),
@@ -1353,7 +1386,8 @@ def import_populated(conn, dump_path: Path, resume_offset: int = 0) -> int:
         try:
             for sys_obj in items_iter:
                 id64 = sys_obj.get('id64')
-                if not id64:
+                name = _require_name(sys_obj, id64)
+                if name is None:
                     continue
 
                 now_iso = datetime.now(timezone.utc).isoformat()
@@ -1383,7 +1417,7 @@ def import_populated(conn, dump_path: Path, resume_offset: int = 0) -> int:
                     sx, sy, sz = _extract_system_coords(sys_obj)
                     sys_batch.append((
                         id64,
-                        sys_obj.get('name', ''),
+                        name,
                         sx, sy, sz,
                         norm_economy(sys_obj.get('primaryEconomy') or sys_obj.get('primary_economy')),
                         norm_economy(sys_obj.get('secondaryEconomy') or sys_obj.get('secondary_economy')),
@@ -1506,7 +1540,8 @@ def import_stations(conn, dump_path: Path, resume_offset: int = 0) -> int:
             for s in items_iter:
                 sid      = s.get('id') or s.get('marketId') or s.get('market_id')
                 sys_id64 = s.get('systemId64') or s.get('system_id64')
-                if not sid or not sys_id64:
+                sta_name = _require_name(s, sid and sys_id64)
+                if sta_name is None:
                     continue
 
                 now_iso  = datetime.now(timezone.utc).isoformat()
@@ -1524,7 +1559,7 @@ def import_stations(conn, dump_path: Path, resume_offset: int = 0) -> int:
 
                     sta_batch.append((
                         sid, sys_id64,
-                        s.get('name', ''),
+                        sta_name,
                         station_type_from_record(s),
                         station_distance_from_record(s),
                         station_body_name_from_record(s),
@@ -1634,7 +1669,8 @@ def import_systems_delta(conn, dump_path: Path, resume_offset: int = 0) -> int:
                     continue
 
                 id64 = sys_obj.get('id64')
-                if not id64:
+                name = _require_name(sys_obj, id64)
+                if name is None:
                     continue
 
                 now_iso = datetime.now(timezone.utc).isoformat()
@@ -1655,7 +1691,7 @@ def import_systems_delta(conn, dump_path: Path, resume_offset: int = 0) -> int:
 
                 sys_batch.append((
                     id64,
-                    sys_obj.get('name', ''),
+                    name,
                     sx, sy, sz,
                     norm_economy(sys_obj.get('primaryEconomy') or sys_obj.get('primary_economy')),
                     norm_economy(sys_obj.get('secondaryEconomy') or sys_obj.get('secondary_economy')),

--- a/tests/integration/test_import_spansh_ring_upsert.py
+++ b/tests/integration/test_import_spansh_ring_upsert.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import os
+
+import psycopg2
+import pytest
+
+os.environ.setdefault('LOG_FILE', os.devnull)
+
+import import_spansh  # noqa: E402
+
+
+TEST_SYSTEM_ID = 97_000_000_000_001
+TEST_BODY_ID = 970_000_001
+
+
+@pytest.fixture
+def pg_conn():
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute('DELETE FROM body_rings WHERE system_id64 = %s', (TEST_SYSTEM_ID,))
+            cur.execute('DELETE FROM bodies WHERE id = %s', (TEST_BODY_ID,))
+            cur.execute('DELETE FROM systems WHERE id64 = %s', (TEST_SYSTEM_ID,))
+            cur.execute(
+                "INSERT INTO systems (id64, name) VALUES (%s, 'Ring Upsert Test System')",
+                (TEST_SYSTEM_ID,),
+            )
+            cur.execute(
+                "INSERT INTO bodies (id, system_id64, name) VALUES (%s, %s, 'Ring Upsert Test Body')",
+                (TEST_BODY_ID, TEST_SYSTEM_ID),
+            )
+        conn.commit()
+        yield conn
+    finally:
+        with conn.cursor() as cur:
+            cur.execute('DELETE FROM body_rings WHERE system_id64 = %s', (TEST_SYSTEM_ID,))
+            cur.execute('DELETE FROM bodies WHERE id = %s', (TEST_BODY_ID,))
+            cur.execute('DELETE FROM systems WHERE id64 = %s', (TEST_SYSTEM_ID,))
+        conn.commit()
+        conn.close()
+
+
+@pytest.mark.db
+def test_upsert_body_rings_writes_all_columns_without_sql_error(pg_conn):
+    """Regression test for a real bug found during the round6 audit
+    follow-up (2026-08-06): the INSERT's explicit column list and
+    _ring_row_tuple()'s value tuple had drifted out of sync (the column
+    list named updated_at with no corresponding value in the tuple),
+    which execute_values (deriving its VALUES template from the tuple
+    length, not the column list) turned into a hard
+    "INSERT has more target columns than expressions" failure on every
+    single call - confirmed by direct reproduction against real Postgres
+    before this fix, not just static reading. Because the only existing
+    test for this function replaces execute_values with a no-op lambda,
+    it could not have caught this - the SQL text itself was never
+    executed. This test lets it run for real."""
+    rows = import_spansh.body_ring_rows_from_spansh_body(
+        TEST_SYSTEM_ID, TEST_BODY_ID, 'Ring Upsert Test Body',
+        {'rings': [{
+            'name': 'Ring Upsert Test Body A Ring',
+            'type': 'Icy',
+            'mass': 2.5e21,
+            'innerRad': 74000,
+            'outerRad': 120000,
+        }]},
+    )
+
+    count = import_spansh.upsert_body_rings(pg_conn, rows)
+    assert count == 1
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            '''
+            SELECT system_id64, body_id, source_body_id, body_name, ring_name,
+                   ring_type, source, confidence, association_status
+            FROM body_rings
+            WHERE system_id64 = %s
+            ''',
+            (TEST_SYSTEM_ID,),
+        )
+        row = cur.fetchone()
+
+    assert row == (
+        TEST_SYSTEM_ID, TEST_BODY_ID, TEST_BODY_ID, 'Ring Upsert Test Body',
+        'Ring Upsert Test Body A Ring', 'Icy', 'spansh_dump',
+        'source_ring_payload', 'local_matched',
+    )
+
+
+@pytest.mark.db
+def test_upsert_body_rings_second_call_preserves_fields_omitted_by_delta(pg_conn):
+    """A second import (e.g. a later Spansh dump for the same system)
+    that reports the ring with less detail must not blank out fields the
+    first import already established - matching the COALESCE-preserve
+    pattern already proven for the bodies upsert."""
+    first_rows = import_spansh.body_ring_rows_from_spansh_body(
+        TEST_SYSTEM_ID, TEST_BODY_ID, 'Ring Upsert Test Body',
+        {'rings': [{
+            'name': 'Ring Upsert Test Body A Ring',
+            'type': 'Icy',
+            'class': 'Class One',
+            'mass': 2.5e21,
+        }]},
+    )
+    import_spansh.upsert_body_rings(pg_conn, first_rows)
+
+    second_rows = import_spansh.body_ring_rows_from_spansh_body(
+        TEST_SYSTEM_ID, TEST_BODY_ID, 'Ring Upsert Test Body',
+        {'rings': [{'name': 'Ring Upsert Test Body A Ring'}]},
+    )
+    count = import_spansh.upsert_body_rings(pg_conn, second_rows)
+    assert count == 1
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            '''
+            SELECT ring_type, ring_class, mass_mt, association_status
+            FROM body_rings
+            WHERE system_id64 = %s AND ring_name = %s
+            ''',
+            (TEST_SYSTEM_ID, 'Ring Upsert Test Body A Ring'),
+        )
+        row = cur.fetchone()
+
+    assert row == ('Icy', 'Class One', 2.5e21, 'local_matched')

--- a/tests/test_import_spansh_runtime.py
+++ b/tests/test_import_spansh_runtime.py
@@ -16,6 +16,28 @@ sys.path.insert(0, str(IMPORTER_SRC))
 import import_spansh  # noqa: E402
 
 
+def test_require_name_returns_name_when_id_and_name_present():
+    assert import_spansh._require_name({'name': 'Sol'}, 12345) == 'Sol'
+
+
+def test_require_name_returns_none_when_name_missing():
+    """Regression test for F-014 (docs/audits/round6-report.md): a source
+    record missing its name field must be rejected outright, not passed
+    through as '' - upsert_via_temp's SET clause writes EXCLUDED.col
+    unconditionally with no NULL/empty guard, so a blank name here would
+    silently blank out an existing system/body/station's real name on the
+    very next conflict."""
+    assert import_spansh._require_name({}, 12345) is None
+    assert import_spansh._require_name({'name': None}, 12345) is None
+    assert import_spansh._require_name({'name': ''}, 12345) is None
+
+
+def test_require_name_returns_none_when_id_missing():
+    assert import_spansh._require_name({'name': 'Sol'}, None) is None
+    assert import_spansh._require_name({'name': 'Sol'}, 0) is None
+    assert import_spansh._require_name({'name': 'Sol'}, '') is None
+
+
 class _FakeCursor:
     def __init__(self) -> None:
         self.last_sql = ''


### PR DESCRIPTION
## Summary
- **Major finding while implementing F-015**: `upsert_body_rings()` has been completely broken since before this session — its INSERT column list and `_ring_row_tuple()`'s value tuple had drifted out of sync (`updated_at` named with no corresponding tuple value). `psycopg2.extras.execute_values` derives its VALUES template from the tuple length, not the column list, so **every single Spansh-sourced ring write has been failing outright** with `INSERT has more target columns than expressions`. Confirmed by direct reproduction against real Postgres before fixing, not just static reading. The only existing test for this function replaces `execute_values` with a no-op lambda, so it could never have caught this.
- **F-015**: adds the previously-omitted `source_body_id` and `association_status` columns. `association_status` is set explicitly to `'local_matched'` (not left to the schema default) — every ring reaching this function has already passed `flush_rings()`'s ownership-rejection filter, the same local-verification guarantee `eddn_listener.py` computes via a live query for its own `'local_matched'` case.
- **F-014**: adds a shared `_require_name()` helper used at all six systems/bodies/stations record-construction sites. All three tables have `NOT NULL` name columns with no default, but every site was writing `obj.get('name', '')` — silently blanking an existing real name to `''` on the next conflict for any source record missing that field. Now skipped as malformed, same as the existing id-only check each site already had.
- F-014's broader claim (population/security/allegiance/government) is **not** resolved here — Spansh's own normalisation already degrades missing values to `'Unknown'`/`NULL` rather than raw blanks, and a correct fix needs to know whether a Spansh delta omitting a field means "unchanged" or "now genuinely unknown", which isn't determinable from this codebase alone.

## Test plan
- [x] New `tests/integration/test_import_spansh_ring_upsert.py` — proves `upsert_body_rings()` writes successfully with all columns correct, and that a second call preserves delta-omitted fields. Red/green verified against pre-fix code (reproduces the exact `SyntaxError`).
- [x] New unit tests for `_require_name()`'s three cases in `tests/test_import_spansh_runtime.py`.
- [x] Full related suite (74 tests) passes locally against real Postgres.
- [x] ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)