### PR TITLE
Stop nightly/weekly Spansh delta imports blanking real system data

### DIFF
--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -1644,6 +1644,28 @@ def import_systems_delta(conn, dump_path: Path, resume_offset: int = 0) -> int:
         'updated_at', 'rating_dirty', 'cluster_dirty',
     ]
 
+    # Confirmed by direct inspection of real systems_1day.json.gz (84,118
+    # records) and systems_1week.json.gz (978,213 records) on 2026-08-06:
+    # every record in both files has exactly {coords, id64, mainStar,
+    # name, updateTime} - these seven fields are never present, 0 of
+    # over 1M records checked across both files. Without this exclusion,
+    # norm_economy/norm_security/norm_allegiance/norm_government's
+    # missing-input fallback to 'Unknown' and _parse_system_population's
+    # fallback to None meant every conflict on this import path was
+    # unconditionally overwriting an existing system's real economy,
+    # population, security, government, allegiance, and controlling
+    # faction - confirmed as the active, ongoing worst case of F-014
+    # (docs/audits/round6-report.md), not just a latent risk: this
+    # import runs nightly (1-day) and weekly (1-week) per
+    # scripts/nightly_update.sh. Still included in SYS_COLS/the INSERT
+    # so a brand-new system seen for the first time still gets a
+    # baseline value - only excluded from update_cols so an existing
+    # system's already-known values are never touched by this source.
+    DELTA_NEVER_PROVIDES = {
+        'primary_economy', 'secondary_economy', 'population',
+        'security', 'allegiance', 'government', 'controlling_faction',
+    }
+
     sys_batch  = []
     total_rows = 0
     last_save  = time.time()
@@ -1651,7 +1673,10 @@ def import_systems_delta(conn, dump_path: Path, resume_offset: int = 0) -> int:
     def flush():
         if sys_batch:
             upsert_via_temp(conn, 'systems', SYS_COLS, sys_batch, 'id64',
-                            update_cols=[c for c in SYS_COLS if c != 'id64'])
+                            update_cols=[
+                                c for c in SYS_COLS
+                                if c != 'id64' and c not in DELTA_NEVER_PROVIDES
+                            ])
             sys_batch.clear()
 
     with open(dump_path, 'rb') as f_raw, gzip.open(f_raw, 'rb') as f:

--- a/tests/integration/test_import_spansh_systems_delta_upsert.py
+++ b/tests/integration/test_import_spansh_systems_delta_upsert.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import os
+
+import psycopg2
+import pytest
+
+os.environ.setdefault('LOG_FILE', os.devnull)
+
+import import_spansh  # noqa: E402
+
+
+TEST_SYSTEM_ID = 98_000_000_000_001
+
+SYS_COLS = [
+    'id64', 'name', 'x', 'y', 'z',
+    'primary_economy', 'secondary_economy',
+    'population', 'security', 'allegiance', 'government',
+    'controlling_faction', 'galaxy_region_id',
+    'updated_at', 'rating_dirty', 'cluster_dirty',
+]
+
+# The exact exclusion set import_systems_delta() now applies, confirmed
+# by direct inspection of real systems_1day.json.gz/systems_1week.json.gz
+# (2026-08-06) - these fields are never present in either file.
+DELTA_NEVER_PROVIDES = {
+    'primary_economy', 'secondary_economy', 'population',
+    'security', 'allegiance', 'government', 'controlling_faction',
+}
+DELTA_UPDATE_COLS = [
+    c for c in SYS_COLS if c != 'id64' and c not in DELTA_NEVER_PROVIDES
+]
+
+
+@pytest.fixture
+def pg_conn():
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            cur.execute('DELETE FROM systems WHERE id64 = %s', (TEST_SYSTEM_ID,))
+        conn.commit()
+        yield conn
+    finally:
+        with conn.cursor() as cur:
+            cur.execute('DELETE FROM systems WHERE id64 = %s', (TEST_SYSTEM_ID,))
+        conn.commit()
+        conn.close()
+
+
+@pytest.mark.db
+def test_systems_delta_upsert_preserves_fields_the_delta_never_carries(pg_conn):
+    """Regression test for F-014 (docs/audits/round6-report.md), confirmed
+    as an active nightly/weekly bug rather than a latent risk: Spansh's
+    systems_1day.json.gz and systems_1week.json.gz delta files (verified
+    by direct download and inspection) never carry economy, population,
+    security, allegiance, government, or controlling_faction - every
+    record is just {coords, id64, mainStar, name, updateTime}. Before
+    this fix, import_systems_delta() included all of those in
+    update_cols, so norm_economy/norm_security/etc.'s missing-input
+    fallback to 'Unknown' (and _parse_system_population's fallback to
+    None) unconditionally overwrote every touched system's real values
+    on every nightly/weekly delta import."""
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO systems (
+                id64, name, x, y, z,
+                primary_economy, secondary_economy,
+                population, security, allegiance, government,
+                controlling_faction
+            ) VALUES (
+                %s, 'Delta Preserve Test System', 1.0, 2.0, 3.0,
+                'Industrial', 'Extraction',
+                123456, 'High', 'Federation', 'Democracy',
+                'Delta Preserve Test Faction'
+            )
+            """,
+            (TEST_SYSTEM_ID,),
+        )
+    pg_conn.commit()
+
+    now_iso = '2026-08-06T00:00:00+00:00'
+    delta_row = (
+        TEST_SYSTEM_ID,
+        'Delta Preserve Test System',
+        1.5, 2.5, 3.5,
+        import_spansh.norm_economy(None),
+        import_spansh.norm_economy(None),
+        import_spansh._parse_system_population({}),
+        import_spansh.norm_security(None),
+        import_spansh.norm_allegiance(None),
+        import_spansh.norm_government(None),
+        None,
+        None,
+        now_iso, True, True,
+    )
+
+    count = import_spansh.upsert_via_temp(
+        pg_conn, 'systems', SYS_COLS, [delta_row], 'id64',
+        update_cols=DELTA_UPDATE_COLS,
+    )
+    assert count == 1
+
+    with pg_conn.cursor() as cur:
+        cur.execute(
+            '''
+            SELECT x, y, z, primary_economy, secondary_economy,
+                   population, security, allegiance, government,
+                   controlling_faction
+            FROM systems WHERE id64 = %s
+            ''',
+            (TEST_SYSTEM_ID,),
+        )
+        row = cur.fetchone()
+
+    # Coordinates: the delta DOES carry these, so they update.
+    assert row[0:3] == (1.5, 2.5, 3.5)
+    # Everything the delta never carries: untouched, still the real values.
+    assert row[3:] == (
+        'Industrial', 'Extraction', 123456, 'High', 'Federation',
+        'Democracy', 'Delta Preserve Test Faction',
+    )


### PR DESCRIPTION
## Summary

Confirmed by downloading and inspecting real `systems_1day.json.gz` (84,118 records) and `systems_1week.json.gz` (978,213 records) directly from `downloads.spansh.co.uk`: **every single record in both files** is exactly `{coords, id64, mainStar, name, updateTime}` — economy, population, security, allegiance, government, and controlling faction are never present, 0 of over 1M records checked.

`import_systems_delta()` — which `scripts/nightly_update.sh` runs against both files every night and every Monday — had all of those columns in `update_cols`. The normalisation helpers' missing-input fallback (`'Unknown'` for economy/security/allegiance/government, `None` for population) meant every conflict on this path was **unconditionally overwriting an existing system's real values with those placeholders**. Directly reproduced: a system seeded with real values (`Industrial`/`Extraction` economy, `High` security, `Federation`/`Democracy`, a named controlling faction, population `123456`) became `('Unknown', 'Unknown', None, None)` after one upsert using the pre-fix `update_cols` shape.

This is the active, ongoing production case of F-014 (`docs/audits/round6-report.md`) — not a latent risk. It runs nightly.

## Fix

Exclude `primary_economy`, `secondary_economy`, `population`, `security`, `allegiance`, `government`, `controlling_faction` from `update_cols` in `import_systems_delta()` specifically. They stay in the INSERT column list (a brand-new system still gets a baseline value on first sight); only the `ON CONFLICT` `UPDATE SET` clause is narrowed, so an existing system's already-known values are never touched by this lightweight source. `x`/`y`/`z`/`name` are unaffected — both files do carry those.

## Test plan
- [x] New `tests/integration/test_import_spansh_systems_delta_upsert.py` — seeds a system with real values, runs `upsert_via_temp()` with the exact `update_cols` shape this import now uses, asserts real values survive while coordinates (which the delta does carry) still update.
- [x] Red/green verified against the pre-fix `update_cols` shape — reproduces the exact corruption pattern described above.
- [x] Full related suite (75 tests) passes locally against real Postgres.
- [x] ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)