### PR TITLE
Add opt-in GlitchTip error tracking (backend + frontend)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ credentials.json
 config/grafana_admin_password.local
 config/healthchecks_targets.local.yml
 config/healthchecks_readonly_api_key.local
+config/glitchtip_grafana_auth_token.local
 
 # Local scratch clones / promotion worktrees kept outside git history
 _promote_chip/

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -11,3 +11,7 @@ slowapi==0.1.9
 
 # OpenGraph share-card rendering (/api/share/og/{id64}).
 Pillow==12.2.0
+
+# Optional error tracking (GlitchTip/Sentry-API-compatible). Only active
+# when SENTRY_DSN is set — see config.py and docs/operations/glitchtip-error-tracking.md.
+sentry-sdk==2.66.1

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -17,6 +17,7 @@ import logging
 import sys
 from typing import Optional
 
+import sentry_sdk
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from slowapi import Limiter
@@ -65,6 +66,9 @@ class Settings(BaseSettings):
     # Set CORS_ORIGINS=https://ed-finder.app,https://www.ed-finder.app in .env
     cors_origins:       str  = '__unset__'
     expose_error_detail: bool = False
+    # Optional error tracking (GlitchTip, Sentry-API-compatible). Blank
+    # disables it entirely — sentry_sdk.init() below is only called when set.
+    sentry_dsn:         Optional[str] = None
 
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 
@@ -72,6 +76,7 @@ class Settings(BaseSettings):
         'database_readonly_url',
         'enrichment_status_json_path',
         'enrichment_warehouse_status_json_path',
+        'sentry_dsn',
         mode='before',
     )
     @classmethod
@@ -113,6 +118,21 @@ logging.basicConfig(
     handlers=[logging.StreamHandler(sys.stdout)],
 )
 log = logging.getLogger('ed_finder')
+
+
+# ---------------------------------------------------------------------------
+# Error tracking (GlitchTip, Sentry-API-compatible) — opt-in via SENTRY_DSN.
+# generic_error_handler in main.py calls sentry_sdk.capture_exception()
+# explicitly, since it swallows every unhandled exception into a JSON
+# response before it can reach sentry_sdk's automatic ASGI-level capture.
+# ---------------------------------------------------------------------------
+if settings.sentry_dsn:
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        release=settings.build_sha,
+        send_default_pii=False,
+        traces_sample_rate=0,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -30,6 +30,7 @@ from typing import Any, Optional
 
 import asyncpg
 import redis.asyncio as aioredis
+import sentry_sdk
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -308,6 +309,10 @@ async def problem_details_handler(request: Request, exc: HTTPException):
 async def generic_error_handler(request: Request, exc: Exception):
     _metrics['errors_total'] += 1
     log.exception('Unhandled error on %s %s', request.method, request.url)
+    # This handler is what stops the exception from ever reaching an ASGI
+    # middleware, so sentry_sdk's automatic capture never fires — report
+    # explicitly instead. No-ops when SENTRY_DSN isn't set (config.py).
+    sentry_sdk.capture_exception(exc)
     detail = str(exc) if settings.expose_error_detail else 'Internal server error'
     return JSONResponse(
         status_code=500,

--- a/config/glitchtip_grafana_auth_token.disabled
+++ b/config/glitchtip_grafana_auth_token.disabled
@@ -1,0 +1,1 @@
+not-configured

--- a/config/grafana/provisioning/datasources/glitchtip.yml
+++ b/config/grafana/provisioning/datasources/glitchtip.yml
@@ -1,0 +1,24 @@
+apiVersion: 1
+
+# GlitchTip (self-hosted, Sentry-API-compatible error tracking) surfaced as a
+# Grafana data source, so error-rate trends sit next to the existing infra
+# metrics dashboard. Opt-in — see docker-compose.yml's glitchtip_* services
+# and docs/operations/glitchtip-error-tracking.md.
+#
+# Uses the community-maintained "Sentry" data source plugin
+# (grafana-sentry-datasource), which documents itself as Sentry-API-compatible
+# and therefore usable against GlitchTip directly.
+#
+# The `url` below is the internal Docker network address — Grafana's backend
+# makes this request server-side (access: proxy), so it never needs the
+# public GLITCHTIP_DOMAIN.
+datasources:
+  - name: GlitchTip
+    type: grafana-sentry-datasource
+    access: proxy
+    jsonData:
+      url: http://glitchtip_web:8000
+      orgSlug: ${GLITCHTIP_GRAFANA_ORG_SLUG}
+    secureJsonData:
+      authToken: ${GLITCHTIP_GRAFANA_AUTH_TOKEN}
+    editable: false

--- a/config/grafana/start-with-secret.sh
+++ b/config/grafana/start-with-secret.sh
@@ -16,4 +16,20 @@ case "$GF_SECURITY_ADMIN_PASSWORD" in
 esac
 export GF_SECURITY_ADMIN_PASSWORD
 
+# GlitchTip Grafana datasource token — optional (error tracking is opt-in).
+# Unlike the admin password above, an unconfigured token is not fatal: it
+# just leaves the Sentry datasource (config/grafana/provisioning/datasources/
+# glitchtip.yml) provisioned with an empty/placeholder authToken, which
+# Grafana surfaces as a datasource-level auth error, not a startup failure.
+glitchtip_token_file=/run/secrets/glitchtip_grafana_auth_token
+if [ -s "$glitchtip_token_file" ]; then
+  IFS= read -r GLITCHTIP_GRAFANA_AUTH_TOKEN < "$glitchtip_token_file" || true
+  case "$GLITCHTIP_GRAFANA_AUTH_TOKEN" in
+    ''|not-configured) GLITCHTIP_GRAFANA_AUTH_TOKEN='not-configured' ;;
+  esac
+else
+  GLITCHTIP_GRAFANA_AUTH_TOKEN='not-configured'
+fi
+export GLITCHTIP_GRAFANA_AUTH_TOKEN
+
 exec /run.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,6 +199,12 @@ services:
       CORS_ORIGINS:         ${CORS_ORIGINS:-https://ed-finder.app,https://www.ed-finder.app}
       # Keep internal error details out of HTTP responses by default.
       EXPOSE_ERROR_DETAIL:  ${EXPOSE_ERROR_DETAIL:-false}
+      # Optional error tracking (GlitchTip, Sentry-API-compatible). Blank
+      # disables it entirely — sentry_sdk.init() is only called when set.
+      # Can point at the internal glitchtip_web service (this container
+      # never leaves the docker network for its own DSN), e.g.:
+      #   http://<key>@glitchtip_web:8000/<project_id>
+      SENTRY_DSN:           ${SENTRY_DSN:-}
     volumes:
       - /data/logs:/data/logs
       # Operator-written invariant receipts; the API reads fixed JSON aliases
@@ -453,6 +459,18 @@ services:
       GF_SECURITY_ADMIN_USER:     ${GRAFANA_USER:-admin}
       GF_USERS_ALLOW_SIGN_UP:     "false"
       GF_SERVER_ROOT_URL:         "%(protocol)s://%(domain)s:%(http_port)s/"
+      # Community plugin required for config/grafana/provisioning/datasources/
+      # glitchtip.yml (type: grafana-sentry-datasource) — not bundled by default.
+      GF_INSTALL_PLUGINS: grafana-sentry-datasource
+      # Read by start-with-secret.sh and exported as GLITCHTIP_GRAFANA_AUTH_TOKEN
+      # (empty/placeholder by default — GlitchTip integration is opt-in). The
+      # Sentry datasource provisioning YAML then consumes that env var directly:
+      # Grafana provisioning only supports ${ENV_VAR} substitution, not
+      # file-content substitution, so the token can't stay a bare secret file.
+      GLITCHTIP_GRAFANA_AUTH_TOKEN_SECRET_FILE: /run/secrets/glitchtip_grafana_auth_token
+      # Set once you've created the GlitchTip org in its UI — see
+      # docs/operations/glitchtip-error-tracking.md.
+      GLITCHTIP_GRAFANA_ORG_SLUG: ${GLITCHTIP_GRAFANA_ORG_SLUG:-not-configured}
     entrypoint: ["/bin/sh", "/etc/grafana/start-with-secret.sh"]
     volumes:
       - grafana_data:/var/lib/grafana
@@ -461,6 +479,7 @@ services:
       - ./config/grafana/start-with-secret.sh:/etc/grafana/start-with-secret.sh:ro
     secrets:
       - grafana_admin_password
+      - glitchtip_grafana_auth_token
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:
@@ -529,17 +548,129 @@ services:
     depends_on:
       - redis
 
+  # ── GlitchTip (self-hosted, Sentry-API-compatible error tracking) ────────
+  # OPT-IN, own Postgres + Redis (never the app's) so a GlitchTip migration,
+  # restart, or Renovate-driven version bump can never touch app data or
+  # the app's migration-ledger discipline (see CLAUDE.md's "Debugging data
+  # drift" section on why that separation matters here). Enable with:
+  #   docker compose --profile errortracking up -d
+  #
+  # First-run bootstrap is manual (not achievable from compose alone):
+  # create an org + project in the GlitchTip UI to get SENTRY_DSN /
+  # VITE_SENTRY_DSN, and an internal integration auth token (Read access to
+  # Project/Issue&Event/Organization) for the Grafana datasource secret.
+  # See docs/operations/glitchtip-error-tracking.md.
+  glitchtip_postgres:
+    image: postgres:16-alpine
+    container_name: ed-glitchtip-postgres
+    profiles: ["errortracking"]
+    restart: unless-stopped
+    logging: *default-logging
+    mem_limit: 512m
+    cpus: 1.0
+    environment:
+      POSTGRES_USER:     glitchtip
+      POSTGRES_PASSWORD: ${GLITCHTIP_POSTGRES_PASSWORD}
+      POSTGRES_DB:       glitchtip
+    volumes:
+      - glitchtip_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U glitchtip -d glitchtip"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  glitchtip_redis:
+    image: redis:7-alpine
+    container_name: ed-glitchtip-redis
+    profiles: ["errortracking"]
+    restart: unless-stopped
+    logging: *default-logging
+    # Pure cache + Celery broker for GlitchTip — no persistence needed,
+    # matching the main redis service's --save ""/--appendonly no pattern.
+    mem_limit: 512m
+    cpus: 0.5
+    command: redis-server --save "" --appendonly no
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+
+  # One-shot: applies GlitchTip's own Django migrations (unrelated to
+  # sql/NNN_*.sql / scripts/apply_migrations.sh) and exits. web/worker
+  # wait for it via `service_completed_successfully`.
+  glitchtip_migrate:
+    image: glitchtip/glitchtip:6.2.3
+    container_name: ed-glitchtip-migrate
+    profiles: ["errortracking"]
+    logging: *default-logging
+    mem_limit: 512m
+    cpus: 1.0
+    command: ./manage.py migrate
+    environment: &glitchtip-environment
+      SECRET_KEY:       ${GLITCHTIP_SECRET_KEY}
+      # generate both with: openssl rand -hex 24 / 32 — see env.example.
+      DATABASE_URL:     postgresql://glitchtip:${GLITCHTIP_POSTGRES_PASSWORD}@glitchtip_postgres:5432/glitchtip
+      REDIS_URL:        redis://glitchtip_redis:6379/0
+      GLITCHTIP_DOMAIN: ${GLITCHTIP_DOMAIN:-http://localhost:8080}
+      ENABLE_USER_REGISTRATION: "false"
+      DEFAULT_FROM_EMAIL: ${GLITCHTIP_DEFAULT_FROM_EMAIL:-glitchtip@ed-finder.app}
+    depends_on:
+      glitchtip_postgres:
+        condition: service_healthy
+
+  glitchtip_web:
+    image: glitchtip/glitchtip:6.2.3
+    container_name: ed-glitchtip-web
+    profiles: ["errortracking"]
+    restart: unless-stopped
+    logging: *default-logging
+    mem_limit: 1g
+    cpus: 1.0
+    environment: *glitchtip-environment
+    ports:
+      - "127.0.0.1:8080:8000"
+    depends_on:
+      glitchtip_postgres:
+        condition: service_healthy
+      glitchtip_redis:
+        condition: service_healthy
+      glitchtip_migrate:
+        condition: service_completed_successfully
+
+  glitchtip_worker:
+    image: glitchtip/glitchtip:6.2.3
+    container_name: ed-glitchtip-worker
+    profiles: ["errortracking"]
+    restart: unless-stopped
+    logging: *default-logging
+    mem_limit: 1g
+    cpus: 1.0
+    command: ./bin/run-celery-with-beat.sh
+    environment: *glitchtip-environment
+    depends_on:
+      glitchtip_postgres:
+        condition: service_healthy
+      glitchtip_redis:
+        condition: service_healthy
+      glitchtip_migrate:
+        condition: service_completed_successfully
+
 volumes:
   postgres_data:
   redis_data:
   prometheus_data:
   grafana_data:
+  glitchtip_postgres_data:
 
 secrets:
   grafana_admin_password:
     file: ${GRAFANA_PASSWORD_FILE:-./config/grafana_admin_password.disabled}
   healthchecks_readonly_api_key:
     file: ${HEALTHCHECKS_PROMETHEUS_TOKEN_FILE:-./config/healthchecks_readonly_api_key.disabled}
+  glitchtip_grafana_auth_token:
+    file: ${GLITCHTIP_GRAFANA_AUTH_TOKEN_FILE:-./config/glitchtip_grafana_auth_token.disabled}
 
 networks:
   default:

--- a/docs/operations/glitchtip-error-tracking.md
+++ b/docs/operations/glitchtip-error-tracking.md
@@ -1,0 +1,128 @@
+# GlitchTip error tracking
+
+Error tracking is opt-in at every layer: the `glitchtip_*` containers, the
+API's error capture, and the frontend's error capture each require their own
+explicit configuration. Deploying the compose changes alone starts nothing
+and sends no data anywhere.
+
+GlitchTip is a self-hosted, Sentry-API-compatible error tracker. It gets its
+own Postgres and Redis (`glitchtip_postgres`, `glitchtip_redis`) — never the
+app's — so a GlitchTip migration, restart, or version bump can never touch
+app data or the app's migration-ledger discipline (see CLAUDE.md's
+"Debugging data drift" section on why that separation matters here).
+
+## 1. Start the stack
+
+```bash
+docker compose --profile errortracking up -d
+```
+
+This brings up `glitchtip_postgres`, `glitchtip_redis`, a one-shot
+`glitchtip_migrate` (Django migrations, unrelated to `sql/NNN_*.sql`), then
+`glitchtip_web` (bound to `127.0.0.1:8080`, same loopback-only pattern as
+Grafana/Prometheus) and `glitchtip_worker` (Celery + beat).
+
+Required `.env` values before first start:
+
+```dotenv
+GLITCHTIP_POSTGRES_PASSWORD=   # openssl rand -hex 24
+GLITCHTIP_SECRET_KEY=          # openssl rand -hex 32
+```
+
+These use a bare `${VAR}` reference in `docker-compose.yml`, not the `:?`
+required-variable syntax used elsewhere — that syntax's error message needs
+an unquoted colon (`generate with: openssl ...`), which breaks YAML parsing
+in a mapping context and fails the CI `compose validate` job even for
+services gated behind `profiles: ["errortracking"]` (profile gating doesn't
+skip interpolation at `docker compose config` time). Leaving them unset
+prints a compose warning, not an error, and the containers themselves fail
+at their own startup instead — same fail-closed outcome, just enforced one
+layer up. Matches the existing `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}`
+pattern used by the main `postgres` service.
+
+`GLITCHTIP_DOMAIN` defaults to `http://localhost:8080`; set it to the real
+public URL if GlitchTip is ever exposed past nginx (not currently wired —
+today it's loopback-only, reached via SSH port-forward or a local tunnel).
+
+## 2. Bootstrap the org and project (manual, UI-only)
+
+There's no compose-level bootstrap for this — GlitchTip has no first-run API
+for it. Once `glitchtip_web` is healthy:
+
+1. Open `http://127.0.0.1:8080` (port-forward if running against a remote
+   host) and create the first user — this is GlitchTip's own account system,
+   unrelated to ed-finder's (deferred) accounts work.
+2. Create an organization and a project (e.g. project type "Python" for the
+   API, "React" for the frontend — or one project for both, either works).
+3. Each project's settings page shows a DSN — copy it into `.env` as
+   `SENTRY_DSN` (API) and/or `VITE_SENTRY_DSN` (frontend).
+
+## 3. Wire up capture
+
+**API** (`apps/api/src/config.py` / `main.py`): `sentry_sdk.init()` runs only
+when `SENTRY_DSN` is set. Because `main.py`'s catch-all `Exception` handler
+converts every unhandled error into a JSON response before it can propagate,
+it explicitly calls `sentry_sdk.capture_exception(exc)` — sentry_sdk's usual
+automatic ASGI-level capture never sees these, since nothing re-raises past
+the handler.
+
+**Frontend** (`frontend/src/main.tsx`): `Sentry.init()` runs only when
+`VITE_SENTRY_DSN` is present at build time (it's inlined by Vite like any
+other `VITE_`-prefixed variable — set it in the shell or `.env` *before*
+`yarn build`, not after). `ErrorBoundary.componentDidCatch` calls
+`Sentry.captureException` so the same critical-UI-error path that currently
+only logs to the console also reaches GlitchTip.
+
+Set `SENTRY_DSN` / `VITE_SENTRY_DSN` blank (the default) to leave both call
+sites as documented no-ops — `sentry_sdk.capture_exception` and
+`Sentry.captureException` are safe to call uninitialized.
+
+Redeploying with a DSN set follows the normal sequence — see CLAUDE.md's
+"Frontend deployment" section; `VITE_SENTRY_DSN` must be exported into the
+shell (or present in `frontend/.env`) before the `yarn build` step for it to
+be baked into the bundle.
+
+## 4. Optional: Grafana datasource
+
+`config/grafana/provisioning/datasources/glitchtip.yml` provisions GlitchTip
+as a Grafana data source (community `grafana-sentry-datasource` plugin,
+installed via `GF_INSTALL_PLUGINS` in `docker-compose.yml`) so error-rate
+trends sit next to the existing infra dashboards. This is independent of
+whether the monitoring profile or the errortracking profile is running —
+Grafana provisions the datasource either way, it just has nothing to query
+until `glitchtip_web` is up and a token is configured.
+
+To wire it:
+
+1. In GlitchTip, create an **internal integration** with Read access to
+   Project, Issue & Event, and Organization — this yields an auth token
+   (distinct from the project DSNs above).
+2. Write only that token to `config/glitchtip_grafana_auth_token.local`
+   (never commit it — same pattern as `grafana_admin_password.local` in
+   `docs/operations/monitoring.md`).
+3. Set in `.env`:
+   ```dotenv
+   GLITCHTIP_GRAFANA_ORG_SLUG=<your-org-slug>
+   GLITCHTIP_GRAFANA_AUTH_TOKEN_FILE=./config/glitchtip_grafana_auth_token.local
+   ```
+4. Restart Grafana: `docker compose up -d grafana`.
+
+Leaving `GLITCHTIP_GRAFANA_ORG_SLUG` at its `not-configured` default and the
+token file at the committed `config/glitchtip_grafana_auth_token.disabled`
+placeholder leaves the datasource provisioned but unauthenticated — Grafana
+surfaces that as a datasource-level auth error, not a startup failure
+(`config/grafana/start-with-secret.sh` treats a missing/placeholder token as
+non-fatal, unlike the Grafana admin password).
+
+## Stopping / disabling
+
+```bash
+docker compose --profile errortracking stop \
+  glitchtip_web glitchtip_worker glitchtip_migrate glitchtip_redis glitchtip_postgres
+```
+
+Named volumes (`glitchtip_postgres_data`) are retained between rehearsals,
+matching the monitoring stack's convention. To fully disable error capture
+without stopping the containers, blank `SENTRY_DSN` and `VITE_SENTRY_DSN`
+(rebuild the frontend for the latter to take effect) — both call sites
+degrade to no-ops.

--- a/env.example
+++ b/env.example
@@ -123,3 +123,26 @@ GRAFANA_PASSWORD_FILE=./config/grafana_admin_password.local
 # blank to use the committed disabled/empty defaults and make no external call.
 HEALTHCHECKS_PROMETHEUS_TARGETS_FILE=
 HEALTHCHECKS_PROMETHEUS_TOKEN_FILE=
+
+# Error tracking (GlitchTip, self-hosted Sentry-API-compatible) — fully
+# opt-in end to end. See docs/operations/glitchtip-error-tracking.md.
+#
+# Enable the stack itself with: docker compose --profile errortracking up -d
+GLITCHTIP_POSTGRES_PASSWORD=
+GLITCHTIP_SECRET_KEY=
+GLITCHTIP_DOMAIN=http://localhost:8080
+GLITCHTIP_DEFAULT_FROM_EMAIL=glitchtip@ed-finder.app
+
+# After creating an org + project in the GlitchTip UI (see the runbook), set
+# the DSNs it gives you here. Leave blank to disable API/frontend error
+# capture entirely even if the glitchtip_* containers are running.
+SENTRY_DSN=
+VITE_SENTRY_DSN=
+
+# Grafana's Sentry-compatible datasource, so error-rate trends sit next to
+# the infra metrics dashboard. Requires a GlitchTip internal integration
+# auth token (Read access to Project/Issue&Event/Organization) written to
+# GLITCHTIP_GRAFANA_AUTH_TOKEN_FILE. Leave both blank/default to leave the
+# datasource provisioned but unauthenticated.
+GLITCHTIP_GRAFANA_ORG_SLUG=not-configured
+GLITCHTIP_GRAFANA_AUTH_TOKEN_FILE=./config/glitchtip_grafana_auth_token.disabled

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "@radix-ui/react-tooltip": "^1.2.12",
     "@radix-ui/react-visually-hidden": "^1.2.7",
     "@react-three/fiber": "9.6.1",
+    "@sentry/react": "^10.69.0",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-query-devtools": "^5.100.9",
     "clsx": "^2.1.1",

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import * as Sentry from '@sentry/react';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -17,6 +18,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     console.error('[ED:Finder] Critical UI error caught by boundary:', error, errorInfo);
+    // No-ops when VITE_SENTRY_DSN isn't set (main.tsx never calls Sentry.init).
+    Sentry.captureException(error, { extra: { componentStack: errorInfo.componentStack } });
   }
 
   render() {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,19 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import * as Sentry from '@sentry/react';
 import { ErrorBoundary } from './components/ErrorBoundary';
+
+// Optional error tracking (GlitchTip, Sentry-API-compatible). Blank disables
+// it entirely — see docs/operations/glitchtip-error-tracking.md.
+const sentryDsn = import.meta.env.VITE_SENTRY_DSN;
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    environment: import.meta.env.PROD ? 'production' : 'development',
+    tracesSampleRate: 0,
+    sendDefaultPii: false,
+  });
+}
 
 const rootEl = document.getElementById('root');
 if (!rootEl) {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -5,4 +5,5 @@ declare const __APP_VERSION__: string;
 
 interface ImportMetaEnv {
   readonly VITE_STAGE26E_PRODUCTION_MAP?: string;
+  readonly VITE_SENTRY_DSN?: string;
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2239,6 +2239,70 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz"
   integrity sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==
 
+"@sentry/browser-utils@10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser-utils/-/browser-utils-10.69.0.tgz#448fe7237bb5e9ee27e6b875a56cfd47360888ee"
+  integrity sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.69.0"
+
+"@sentry/browser@10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.69.0.tgz#0e9d3aa4a21a3fc6a5f84bba8cd46aafb8739391"
+  integrity sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==
+  dependencies:
+    "@sentry/browser-utils" "10.69.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.69.0"
+    "@sentry/feedback" "10.69.0"
+    "@sentry/replay" "10.69.0"
+    "@sentry/replay-canvas" "10.69.0"
+
+"@sentry/conventions@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
+  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+
+"@sentry/core@10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.69.0.tgz#746cb2efd3e52a69afed1255b06a0b4549d00caa"
+  integrity sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+
+"@sentry/feedback@10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/feedback/-/feedback-10.69.0.tgz#6c9dc64fa1f3a2328bcb51e8209f536cf38c3642"
+  integrity sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==
+  dependencies:
+    "@sentry/core" "10.69.0"
+
+"@sentry/react@^10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-10.69.0.tgz#5abb5cdbc2fc5eb2f36fdd60fe54eed9dcc8a8d9"
+  integrity sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==
+  dependencies:
+    "@sentry/browser" "10.69.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.69.0"
+
+"@sentry/replay-canvas@10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz#e67efefedaad3d4b8b339fd86888f0a3d23e004b"
+  integrity sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==
+  dependencies:
+    "@sentry/core" "10.69.0"
+    "@sentry/replay" "10.69.0"
+
+"@sentry/replay@10.69.0":
+  version "10.69.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-10.69.0.tgz#4afef2510578a879e4937a4eec242a394af19fe9"
+  integrity sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==
+  dependencies:
+    "@sentry/browser-utils" "10.69.0"
+    "@sentry/core" "10.69.0"
+
 "@tanstack/query-core@5.100.9":
   version "5.100.9"
   resolved "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.9.tgz"


### PR DESCRIPTION
## Summary
- Self-hosted, Sentry-API-compatible error tracking behind a docker-compose `errortracking` profile, with its own Postgres/Redis (never the app's).
- Backend: `sentry_sdk.init()` gated on `SENTRY_DSN`; the catch-all exception handler explicitly calls `sentry_sdk.capture_exception()` since it swallows errors before they'd reach automatic ASGI-level capture.
- Frontend: `@sentry/react` init gated on `VITE_SENTRY_DSN`, wired into `main.tsx` and `ErrorBoundary`.
- Grafana Sentry-compatible datasource + new runbook (`docs/operations/glitchtip-error-tracking.md`).
- Everything is blank/off by default at every layer.
- Fixes an unquoted colon in the compose file's `:?` required-variable messages that broke YAML parsing and would have failed the CI compose-validate job; switched those two vars to the bare `${VAR}` pattern already used by the main postgres service.

## Test plan
- [x] Backend: `main.py`/`config.py` import cleanly, `sentry_sdk.get_client().is_active()` confirmed `True` with `SENTRY_DSN` set
- [x] `ruff check` on changed backend files
- [x] Frontend `yarn typecheck`, `yarn lint`, `yarn build` all pass
- [x] `docker compose config --quiet` (plain + `--profile errortracking`) under CI's exact no-env-vars condition
- [x] `tests/test_repo_hygiene_contract.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)