### PR TITLE
Fix three findings from adversarial review (association_status trust gate, silent cache errors, SQL duplication)

### DIFF
--- a/apps/api/src/ingest/eddn_client.py
+++ b/apps/api/src/ingest/eddn_client.py
@@ -30,6 +30,7 @@ from typing import Optional, TYPE_CHECKING
 
 from edfinder_api.evidence_store.store import promote_canonical_evidence_for_systems
 from edfinder_api.ring_facts import ring_rows_for_body
+from shared_contracts.body_ring_association_status import BODY_RING_ASSOCIATION_STATUS_CASE_SQL
 
 if TYPE_CHECKING:
     import asyncpg
@@ -42,39 +43,6 @@ MAX_BATCH_SIZE   = 200   # flush early if batch exceeds this
 RECONNECT_DELAY  = 5     # seconds between reconnect attempts
 DIRTY_MARK_BATCH_SIZE = 500
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = 5000
-
-# These casts are load-bearing: without them Postgres can infer the same bind
-# parameter as both integer and bigint across the CASE and INSERT target.
-BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
-CASE
-    WHEN $11 = 'eddn_scan'
-         AND NOT EXISTS (
-             SELECT 1
-             FROM bodies b
-             WHERE b.id = $2::bigint
-               AND b.system_id64 = $1::bigint
-         )
-         AND (
-             $3::bigint = 0
-             OR $2::bigint = 0
-             OR $4 ILIKE '%% belt%%'
-             OR $5 ILIKE '%% belt%%'
-         )
-        THEN 'belt_source_evidence'
-    WHEN EXISTS (
-             SELECT 1
-             FROM bodies b
-             WHERE b.id = $2::bigint
-               AND b.system_id64 = $1::bigint
-               AND (
-                   $4 IS NULL
-                   OR b.name = $4
-               )
-         )
-        THEN 'local_matched'
-    ELSE 'unresolved_body_identity'
-END
-""".strip()
 
 BODY_RING_UPSERT_SQL = f"""
     INSERT INTO body_rings (

--- a/apps/api/src/journal_import/store.py
+++ b/apps/api/src/journal_import/store.py
@@ -24,43 +24,11 @@ from edfinder_api.journal_import.api_models import (
 )
 from edfinder_api.ring_facts import ring_rows_for_body
 from edfinder_api.source_precedence import BODY_SCAN_FACT_FIELDS, merge_body_scan_fact
+from shared_contracts.body_ring_association_status import BODY_RING_ASSOCIATION_STATUS_CASE_SQL
 
 MAX_DAILY_ROWS_PER_SYNC_KEY = 200_000
 DIRTY_MARK_BATCH_SIZE = 500
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = 5000
-
-# These casts are load-bearing: without them Postgres can infer the same bind
-# parameter as both integer and bigint across the CASE and INSERT target.
-BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
-CASE
-    WHEN $11 = 'eddn_scan'
-         AND NOT EXISTS (
-             SELECT 1
-             FROM bodies b
-             WHERE b.id = $2::bigint
-               AND b.system_id64 = $1::bigint
-         )
-         AND (
-             $3::bigint = 0
-             OR $2::bigint = 0
-             OR $4 ILIKE '%% belt%%'
-             OR $5 ILIKE '%% belt%%'
-         )
-        THEN 'belt_source_evidence'
-    WHEN EXISTS (
-             SELECT 1
-             FROM bodies b
-             WHERE b.id = $2::bigint
-               AND b.system_id64 = $1::bigint
-               AND (
-                   $4 IS NULL
-                   OR b.name = $4
-               )
-         )
-        THEN 'local_matched'
-    ELSE 'unresolved_body_identity'
-END
-""".strip()
 
 BODY_RING_UPSERT_SQL = f"""
     INSERT INTO body_rings (

--- a/apps/api/src/routers/archetypes.py
+++ b/apps/api/src/routers/archetypes.py
@@ -147,13 +147,19 @@ _PROFILES = [
 # from a mysterious latency regression. Throttled so a sustained outage
 # logs once per interval, not once per request.
 _CACHE_ERROR_LOG_INTERVAL_SECONDS = 60
-_last_cache_error_logged_at = 0.0
+# None, not 0.0: time.monotonic()'s reference point is platform-defined and
+# commonly host-boot-relative, not guaranteed far from zero — a literal 0.0
+# sentinel would suppress the first failure (and everything for up to 60s
+# after it) whenever `now` itself is under 60, e.g. shortly after a host
+# reboot. None always compares as "never logged yet" regardless of what
+# time.monotonic() actually returns.
+_last_cache_error_logged_at: float | None = None
 
 
 def _log_cache_error_throttled(where: str, exc: Exception) -> None:
     global _last_cache_error_logged_at
     now = time.monotonic()
-    if now - _last_cache_error_logged_at >= _CACHE_ERROR_LOG_INTERVAL_SECONDS:
+    if _last_cache_error_logged_at is None or now - _last_cache_error_logged_at >= _CACHE_ERROR_LOG_INTERVAL_SECONDS:
         _last_cache_error_logged_at = now
         log.warning('Archetype cache %s failed, degrading to DB: %s', where, exc)
 

--- a/apps/api/src/routers/archetypes.py
+++ b/apps/api/src/routers/archetypes.py
@@ -141,6 +141,23 @@ _PROFILES = [
 # Cache helpers
 # ---------------------------------------------------------------------------
 
+# A Redis outage degrades every request to a DB read, which is correct
+# behavior — but with a bare `except Exception: pass`, that outage was
+# previously invisible: no log line, no metric, nothing to distinguish it
+# from a mysterious latency regression. Throttled so a sustained outage
+# logs once per interval, not once per request.
+_CACHE_ERROR_LOG_INTERVAL_SECONDS = 60
+_last_cache_error_logged_at = 0.0
+
+
+def _log_cache_error_throttled(where: str, exc: Exception) -> None:
+    global _last_cache_error_logged_at
+    now = time.monotonic()
+    if now - _last_cache_error_logged_at >= _CACHE_ERROR_LOG_INTERVAL_SECONDS:
+        _last_cache_error_logged_at = now
+        log.warning('Archetype cache %s failed, degrading to DB: %s', where, exc)
+
+
 async def _cache_version(redis) -> int:
     """Return the current cache version counter (default 1)."""
     if redis is None:
@@ -148,7 +165,8 @@ async def _cache_version(redis) -> int:
     try:
         v = await redis.get('arch:version')
         return int(v) if v else 1
-    except Exception:
+    except Exception as exc:
+        _log_cache_error_throttled('version', exc)
         return 1
 
 
@@ -158,7 +176,8 @@ async def _cache_get(redis, key: str) -> Optional[Any]:
     try:
         raw = await redis.get(key)
         return json.loads(raw) if raw else None
-    except Exception:
+    except Exception as exc:
+        _log_cache_error_throttled('get', exc)
         return None
 
 
@@ -167,8 +186,8 @@ async def _cache_set(redis, key: str, value: Any, ttl: int = 300):
         return
     try:
         await redis.set(key, json.dumps(value), ex=ttl)
-    except Exception:
-        pass
+    except Exception as exc:
+        _log_cache_error_throttled('set', exc)
 
 
 def _json_object(value: Any) -> dict[str, Any]:

--- a/apps/eddn/src/eddn_listener.py
+++ b/apps/eddn/src/eddn_listener.py
@@ -54,6 +54,7 @@ import asyncpg
 import redis.asyncio as aioredis
 
 from canonical_evidence import promote_canonical_evidence_for_systems
+from shared_contracts.body_ring_association_status import BODY_RING_ASSOCIATION_STATUS_CASE_SQL
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -75,39 +76,6 @@ EDDN_PUBSUB_CHANNEL = 'eddn_events'
 
 DIRTY_MARK_BATCH_SIZE = int(os.getenv('DIRTY_MARK_BATCH_SIZE', '500'))
 DIRTY_MARK_STATEMENT_TIMEOUT_MS = int(os.getenv('DIRTY_MARK_STATEMENT_TIMEOUT_MS', '5000'))
-
-# These casts are load-bearing: without them Postgres can infer the same bind
-# parameter as both integer and bigint across the CASE and INSERT target.
-BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
-CASE
-    WHEN $11 = 'eddn_scan'
-         AND NOT EXISTS (
-             SELECT 1
-             FROM bodies b
-             WHERE b.id = $2::bigint
-               AND b.system_id64 = $1::bigint
-         )
-         AND (
-             $3::bigint = 0
-             OR $2::bigint = 0
-             OR $4 ILIKE '%% belt%%'
-             OR $5 ILIKE '%% belt%%'
-         )
-        THEN 'belt_source_evidence'
-    WHEN EXISTS (
-             SELECT 1
-             FROM bodies b
-             WHERE b.id = $2::bigint
-               AND b.system_id64 = $1::bigint
-               AND (
-                   $4 IS NULL
-                   OR b.name = $4
-               )
-         )
-        THEN 'local_matched'
-    ELSE 'unresolved_body_identity'
-END
-""".strip()
 
 BODY_RING_UPSERT_SQL = f"""
     INSERT INTO body_rings (

--- a/apps/importer/src/body_ring_enrichment_plan.py
+++ b/apps/importer/src/body_ring_enrichment_plan.py
@@ -26,11 +26,17 @@ SAFETY_RULES = (
 
 
 def is_trusted_ring_row(row: Mapping[str, Any]) -> bool:
-    """Return whether a planned/existing ring row confirms local ring state."""
+    """Return whether a planned/existing ring row confirms local ring state.
+
+    A row with no association_status key at all is untrusted, not trusted —
+    silently defaulting a missing trust signal to "trusted" would promote
+    any caller that omits the column (a narrower SELECT, a hand-built dict)
+    into the trusted set with no error. Requires the key be explicitly
+    present and equal to TRUSTED_RING_ASSOCIATION_STATUS.
+    """
     return (
         row.get('body_id') is not None
-        and row.get('association_status', TRUSTED_RING_ASSOCIATION_STATUS)
-        == TRUSTED_RING_ASSOCIATION_STATUS
+        and row.get('association_status') == TRUSTED_RING_ASSOCIATION_STATUS
     )
 
 

--- a/shared_contracts/body_ring_association_status.py
+++ b/shared_contracts/body_ring_association_status.py
@@ -1,0 +1,47 @@
+"""Canonical body_rings.association_status classification SQL.
+
+Single source of truth for the CASE expression that decides whether a ring
+row's owning body is a confirmed local match, an unresolved identity, or
+belt-source evidence. Previously defined independently in three files
+(apps/eddn/src/eddn_listener.py, apps/api/src/ingest/eddn_client.py,
+apps/api/src/journal_import/store.py) with no shared module — identical at
+the time this was extracted, but nothing enforced that, and CLAUDE.md's own
+"Known hazards" section documents this as exactly the kind of copy that
+silently drifts. Import this constant instead of redefining it.
+
+Positional placeholders ($1-$5, $11) match each call site's own parameter
+order for its body_rings UPSERT — this is asyncpg-style SQL text meant to be
+embedded via an f-string into a larger query, not executed standalone.
+"""
+from __future__ import annotations
+
+BODY_RING_ASSOCIATION_STATUS_CASE_SQL = """
+CASE
+    WHEN $11 = 'eddn_scan'
+         AND NOT EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
+         )
+         AND (
+             $3::bigint = 0
+             OR $2::bigint = 0
+             OR $4 ILIKE '%% belt%%'
+             OR $5 ILIKE '%% belt%%'
+         )
+        THEN 'belt_source_evidence'
+    WHEN EXISTS (
+             SELECT 1
+             FROM bodies b
+             WHERE b.id = $2::bigint
+               AND b.system_id64 = $1::bigint
+               AND (
+                   $4 IS NULL
+                   OR b.name = $4
+               )
+         )
+        THEN 'local_matched'
+    ELSE 'unresolved_body_identity'
+END
+""".strip()

--- a/tests/test_archetypes_cache_helpers.py
+++ b/tests/test_archetypes_cache_helpers.py
@@ -20,9 +20,9 @@ import routers.archetypes as archetypes  # noqa: E402
 @pytest.fixture(autouse=True)
 def _reset_throttle():
     """Each test starts with a cold throttle, matching a fresh process."""
-    archetypes._last_cache_error_logged_at = 0.0
+    archetypes._last_cache_error_logged_at = None
     yield
-    archetypes._last_cache_error_logged_at = 0.0
+    archetypes._last_cache_error_logged_at = None
 
 
 def _broken_redis() -> AsyncMock:
@@ -81,5 +81,22 @@ async def test_repeated_failures_within_interval_log_once():
     with patch.object(archetypes, 'log') as mock_log:
         for _ in range(5):
             await archetypes._cache_get(redis, 'arch:v1:sys:1')
+
+    mock_log.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_first_failure_logs_even_when_monotonic_clock_is_young():
+    """Codex Review finding: time.monotonic()'s reference point is
+    platform-defined and commonly host-boot-relative, not guaranteed far
+    from zero. A 0.0 sentinel would make `now - 0.0 >= 60` false whenever
+    `now` itself is under 60 (e.g. shortly after a host reboot), silently
+    swallowing the first failure — and everything else for up to a minute
+    — instead of logging it. Simulates that by patching time.monotonic()
+    to return a small value, proving the None sentinel doesn't have the
+    same blind spot."""
+    with patch.object(archetypes.time, 'monotonic', return_value=5.0):
+        with patch.object(archetypes, 'log') as mock_log:
+            await archetypes._cache_get(_broken_redis(), 'arch:v1:sys:1')
 
     mock_log.warning.assert_called_once()

--- a/tests/test_archetypes_cache_helpers.py
+++ b/tests/test_archetypes_cache_helpers.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+os.environ.setdefault('CORS_ORIGINS', 'http://test')
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'apps' / 'api' / 'src'))
+
+import routers.archetypes as archetypes  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttle():
+    """Each test starts with a cold throttle, matching a fresh process."""
+    archetypes._last_cache_error_logged_at = 0.0
+    yield
+    archetypes._last_cache_error_logged_at = 0.0
+
+
+def _broken_redis() -> AsyncMock:
+    redis = AsyncMock()
+    redis.get.side_effect = ConnectionError('redis unreachable')
+    redis.set.side_effect = ConnectionError('redis unreachable')
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_cache_get_degrades_and_logs_on_redis_error(caplog):
+    """2026-08-07 Codex Review finding: a Redis outage silently bypassed the
+    cache with zero log line — correct degrade-to-DB behavior, invisible
+    failure. Confirms both halves: still returns None (degrades), and now
+    logs a warning (visible)."""
+    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+        result = await archetypes._cache_get(_broken_redis(), 'arch:v1:sys:1')
+
+    assert result is None
+    assert any('cache get failed' in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_cache_set_degrades_and_logs_on_redis_error(caplog):
+    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+        await archetypes._cache_set(_broken_redis(), 'arch:v1:sys:1', {'x': 1})
+
+    assert any('cache set failed' in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_cache_version_degrades_and_logs_on_redis_error(caplog):
+    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+        result = await archetypes._cache_version(_broken_redis())
+
+    assert result == 1
+    assert any('cache version failed' in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_repeated_failures_within_interval_log_once(caplog):
+    """A sustained outage must not log once per request — that's log spam
+    under exactly the condition (many requests, all failing) most likely to
+    flood the log right when an operator needs a clean signal."""
+    redis = _broken_redis()
+    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+        for _ in range(5):
+            await archetypes._cache_get(redis, 'arch:v1:sys:1')
+
+    warnings = [r for r in caplog.records if 'cache get failed' in r.message]
+    assert len(warnings) == 1

--- a/tests/test_archetypes_cache_helpers.py
+++ b/tests/test_archetypes_cache_helpers.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import logging
 import os
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -33,45 +32,54 @@ def _broken_redis() -> AsyncMock:
     return redis
 
 
+# Mocking archetypes.log directly, rather than using pytest's caplog fixture,
+# so this test's outcome depends only on this module's own code — not on
+# root-logger handler/propagation state, which (unlike a fresh process) can
+# be left in an unknown configuration by whichever of the other ~1600 tests
+# in the full suite happened to run first in the same pytest session.
+
+
 @pytest.mark.asyncio
-async def test_cache_get_degrades_and_logs_on_redis_error(caplog):
+async def test_cache_get_degrades_and_logs_on_redis_error():
     """2026-08-07 Codex Review finding: a Redis outage silently bypassed the
     cache with zero log line — correct degrade-to-DB behavior, invisible
     failure. Confirms both halves: still returns None (degrades), and now
     logs a warning (visible)."""
-    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+    with patch.object(archetypes, 'log') as mock_log:
         result = await archetypes._cache_get(_broken_redis(), 'arch:v1:sys:1')
 
     assert result is None
-    assert any('cache get failed' in record.message for record in caplog.records)
+    mock_log.warning.assert_called_once()
+    assert 'get' in mock_log.warning.call_args.args[1]
 
 
 @pytest.mark.asyncio
-async def test_cache_set_degrades_and_logs_on_redis_error(caplog):
-    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+async def test_cache_set_degrades_and_logs_on_redis_error():
+    with patch.object(archetypes, 'log') as mock_log:
         await archetypes._cache_set(_broken_redis(), 'arch:v1:sys:1', {'x': 1})
 
-    assert any('cache set failed' in record.message for record in caplog.records)
+    mock_log.warning.assert_called_once()
+    assert 'set' in mock_log.warning.call_args.args[1]
 
 
 @pytest.mark.asyncio
-async def test_cache_version_degrades_and_logs_on_redis_error(caplog):
-    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+async def test_cache_version_degrades_and_logs_on_redis_error():
+    with patch.object(archetypes, 'log') as mock_log:
         result = await archetypes._cache_version(_broken_redis())
 
     assert result == 1
-    assert any('cache version failed' in record.message for record in caplog.records)
+    mock_log.warning.assert_called_once()
+    assert 'version' in mock_log.warning.call_args.args[1]
 
 
 @pytest.mark.asyncio
-async def test_repeated_failures_within_interval_log_once(caplog):
+async def test_repeated_failures_within_interval_log_once():
     """A sustained outage must not log once per request — that's log spam
     under exactly the condition (many requests, all failing) most likely to
     flood the log right when an operator needs a clean signal."""
     redis = _broken_redis()
-    with caplog.at_level(logging.WARNING, logger='ed_finder'):
+    with patch.object(archetypes, 'log') as mock_log:
         for _ in range(5):
             await archetypes._cache_get(redis, 'arch:v1:sys:1')
 
-    warnings = [r for r in caplog.records if 'cache get failed' in r.message]
-    assert len(warnings) == 1
+    mock_log.warning.assert_called_once()

--- a/tests/test_body_ring_association_status_shared_constant.py
+++ b/tests/test_body_ring_association_status_shared_constant.py
@@ -1,0 +1,46 @@
+"""2026-08-07 Codex Review finding: BODY_RING_ASSOCIATION_STATUS_CASE_SQL was
+defined independently in three files with no shared module — identical at
+the time, but CLAUDE.md's own "Known hazards" section already documents
+this pattern (BODY_RING_ASSOCIATION_STATUS_CASE_SQL / body_rings writers)
+as exactly the kind of copy that silently drifts. Now a single definition
+in shared_contracts/body_ring_association_status.py, imported everywhere.
+This test asserts identity, not just equal-looking text — the whole point
+is that "changing one changes all three" is now structurally true rather
+than something a future editor has to remember to keep in sync by hand.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault('CORS_ORIGINS', 'http://test')
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+os.environ.setdefault('LOG_FILE', str(Path.cwd() / 'test-local.log'))
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / 'apps' / 'eddn' / 'src'))
+sys.path.insert(0, str(ROOT / 'apps' / 'api' / 'src'))
+sys.path.insert(0, str(ROOT))
+
+from shared_contracts.body_ring_association_status import (  # noqa: E402
+    BODY_RING_ASSOCIATION_STATUS_CASE_SQL as canonical_sql,
+)
+
+
+def test_eddn_listener_uses_the_shared_constant():
+    import eddn_listener
+
+    assert eddn_listener.BODY_RING_ASSOCIATION_STATUS_CASE_SQL is canonical_sql
+
+
+def test_ingest_eddn_client_uses_the_shared_constant():
+    from ingest import eddn_client
+
+    assert eddn_client.BODY_RING_ASSOCIATION_STATUS_CASE_SQL is canonical_sql
+
+
+def test_journal_import_store_uses_the_shared_constant():
+    from journal_import import store
+
+    assert store.BODY_RING_ASSOCIATION_STATUS_CASE_SQL is canonical_sql

--- a/tests/test_body_ring_enrichment_plan.py
+++ b/tests/test_body_ring_enrichment_plan.py
@@ -80,6 +80,16 @@ def test_only_local_matched_body_ring_rows_confirm_ringed_state():
     }
 
 
+def test_row_missing_association_status_key_is_not_trusted():
+    """A row with no association_status key at all — a narrower SELECT, a
+    hand-built dict from a caller that hasn't been updated — must be
+    treated as untrusted, not silently promoted to trusted by a default
+    fallback. This is the trust gate this function exists to enforce."""
+    missing_key = {'system_id64': 42, 'body_id': 7, 'ring_name': 'Test 5 A Ring'}
+
+    assert is_trusted_ring_row(missing_key) is False
+
+
 def test_body_ring_dry_run_report_shape_counts_safety_rules():
     report = build_body_ring_dry_run_report(
         source='spansh_dump',


### PR DESCRIPTION
## Summary
Three findings from tonight's Emergent adversarial review, each independently verified against actual code/behavior before fixing:

- **Silent default-to-trusted**: `body_ring_enrichment_plan.py`'s `is_trusted_ring_row()` treated a row with no `association_status` key as trusted by default. Currently unreachable (module is pre-wiring for a not-yet-built feature, confirmed zero callers elsewhere in `apps/`), but fixed now before it goes live with the unsafe default.
- **Silent cache-error swallow**: `archetypes.py`'s Redis cache helpers had bare `except Exception: return None/1/pass` — correct degrade-to-DB behavior, but a Redis outage was completely invisible. Added a throttled warning (60s interval) so a sustained outage logs once, not once per request.
- **Triplicated classifier SQL**: `BODY_RING_ASSOCIATION_STATUS_CASE_SQL` was independently defined in three files — identical today, but this is the exact drift pattern CLAUDE.md's "Known hazards" section already warns about. Extracted to `shared_contracts/`, which both the `eddn` and `api` Docker images already copy in.

A fourth review finding (catch-all exception handler blocking ASGI middleware from seeing errors) was already resolved by tonight's earlier GlitchTip PR.

## Test plan
- [x] New regression test for the trust-gate default (`test_row_missing_association_status_key_is_not_trusted`)
- [x] New tests for cache-error logging + throttling (4 tests, including one proving 5 rapid failures log exactly once)
- [x] New identity test proving all three writers now share the *same* object, not just equal text
- [x] Full existing suites for all touched files pass unmodified (99 unit tests)
- [x] Real-Postgres integration tests for the eddn/import write paths pass (`test_eddn_system_colonisation_writes.py`, `test_import_spansh_body_upsert.py`)
- [x] `ruff check` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)