### PR TITLE
Add rating_dirty_no_bodies as a tracked Prometheus metric

### DIFF
--- a/config/sql_exporter_ed_finder.collector.yml
+++ b/config/sql_exporter_ed_finder.collector.yml
@@ -14,6 +14,20 @@ metrics:
     values: [cluster_dirty]
     query_ref: dirty_counts
 
+  - metric_name: ed_finder_dirty_counts_rating_dirty_no_bodies
+    type: gauge
+    help: >-
+      Number of systems with rating_dirty = true and has_body_data = false —
+      the "truthful no-bodies" backlog scripts/run_dirty_ratings_if_needed.sh
+      clears on its own 30-minute cycle (see CLAUDE.md's "Dirty ratings
+      maintenance"). Expected to be transiently nonzero; only worth alerting
+      on if it trends upward across cycles rather than draining, which would
+      mean that reconciliation job has stopped working (2026-08-07 incident:
+      this exact count, previously visible only via one-off manual SQL, was
+      the source of a false-positive deploy failure).
+    values: [rating_dirty_no_bodies]
+    query_ref: dirty_counts
+
   - metric_name: ed_finder_import_progress_rows_processed
     type: gauge
     help: Import rows processed so far.
@@ -64,7 +78,11 @@ queries:
            FROM systems
           WHERE cluster_dirty = TRUE
             AND has_body_data = TRUE
-            AND macro_grid_id IS NOT NULL) AS cluster_dirty
+            AND macro_grid_id IS NOT NULL) AS cluster_dirty,
+        (SELECT COUNT(*)
+           FROM systems
+          WHERE rating_dirty = TRUE
+            AND has_body_data = FALSE) AS rating_dirty_no_bodies
 
   - query_name: import_progress
     query: |

--- a/config/sql_exporter_ed_finder.collector.yml
+++ b/config/sql_exporter_ed_finder.collector.yml
@@ -17,14 +17,20 @@ metrics:
   - metric_name: ed_finder_dirty_counts_rating_dirty_no_bodies
     type: gauge
     help: >-
-      Number of systems with rating_dirty = true and has_body_data = false —
-      the "truthful no-bodies" backlog scripts/run_dirty_ratings_if_needed.sh
-      clears on its own 30-minute cycle (see CLAUDE.md's "Dirty ratings
-      maintenance"). Expected to be transiently nonzero; only worth alerting
-      on if it trends upward across cycles rather than draining, which would
-      mean that reconciliation job has stopped working (2026-08-07 incident:
-      this exact count, previously visible only via one-off manual SQL, was
-      the source of a false-positive deploy failure).
+      Number of systems matching reconcile_no_body_ratings.py's cleanup
+      predicate exactly (rating_dirty = true, has_body_data = false, and no
+      bodies rows exist) — the "truthful no-bodies" backlog
+      scripts/run_dirty_ratings_if_needed.sh clears on its own 30-minute
+      cycle (see CLAUDE.md's "Dirty ratings maintenance"). Deliberately
+      excludes systems where has_body_data = false but bodies rows still
+      exist (legacy body-contract drift migration 033 does not backfill) —
+      those aren't touched by the cleanup job, so counting them here would
+      make this metric permanently nonzero regardless of whether the job is
+      working. Expected to be transiently nonzero; only worth alerting on if
+      it trends upward across cycles rather than draining, which would mean
+      the reconciliation job has stopped working (2026-08-07 incident: this
+      exact count, previously visible only via one-off manual SQL, was the
+      source of a false-positive deploy failure).
     values: [rating_dirty_no_bodies]
     query_ref: dirty_counts
 
@@ -80,9 +86,14 @@ queries:
             AND has_body_data = TRUE
             AND macro_grid_id IS NOT NULL) AS cluster_dirty,
         (SELECT COUNT(*)
-           FROM systems
-          WHERE rating_dirty = TRUE
-            AND has_body_data = FALSE) AS rating_dirty_no_bodies
+           FROM systems s
+          WHERE s.rating_dirty = TRUE
+            AND COALESCE(s.has_body_data, FALSE) = FALSE
+            AND NOT EXISTS (
+                SELECT 1
+                  FROM bodies b
+                 WHERE b.system_id64 = s.id64
+            )) AS rating_dirty_no_bodies
 
   - query_name: import_progress
     query: |

--- a/tests/test_monitoring_contracts.py
+++ b/tests/test_monitoring_contracts.py
@@ -114,11 +114,18 @@ def test_dirty_backlog_export_uses_partial_index_predicates_and_cache():
     exporter = _read('config', 'sql_exporter.yml')
 
     assert 'COUNT(*) FILTER' not in queries
-    assert queries.count('FROM systems') == 2
+    # 2026-08-07: a third scalar subquery (rating_dirty_no_bodies) was added
+    # to the same query_ref, same pattern as the other two — see
+    # ed_finder_dirty_counts_rating_dirty_no_bodies below. Bumped from 2 to
+    # 3 deliberately, not loosened to an inequality: this assertion exists
+    # to catch an *unexpected* new full-table scan sneaking in, and a fixed
+    # count still does that as long as it's kept in sync with real changes.
+    assert queries.count('FROM systems') == 3
     assert 'WHERE rating_dirty = TRUE' in queries
     assert 'WHERE cluster_dirty = TRUE' in queries
     assert 'AND has_body_data = TRUE' in queries
     assert 'AND macro_grid_id IS NOT NULL' in queries
+    assert 'AND has_body_data = FALSE' in queries
     assert 'min_interval: 5m' in exporter
 
 
@@ -144,6 +151,7 @@ def test_custom_queries_use_supported_sql_exporter_contract():
     assert 'disabled:disabled' in sql_config
     assert 'ed_finder_dirty_counts_rating_dirty' in collector
     assert 'ed_finder_dirty_counts_cluster_dirty' in collector
+    assert 'ed_finder_dirty_counts_rating_dirty_no_bodies' in collector
 
 
 def test_healthchecks_is_optional_and_uses_a_read_only_secret_file():

--- a/tests/test_monitoring_contracts.py
+++ b/tests/test_monitoring_contracts.py
@@ -125,7 +125,15 @@ def test_dirty_backlog_export_uses_partial_index_predicates_and_cache():
     assert 'WHERE cluster_dirty = TRUE' in queries
     assert 'AND has_body_data = TRUE' in queries
     assert 'AND macro_grid_id IS NOT NULL' in queries
-    assert 'AND has_body_data = FALSE' in queries
+    # Must match reconcile_no_body_ratings.py's cleanup predicate exactly
+    # (COALESCE + NOT EXISTS on bodies), not just has_body_data = FALSE —
+    # Codex Review finding on PR #433: a looser predicate would count
+    # legacy body-contract drift systems the cleanup job never touches,
+    # making the metric permanently nonzero regardless of job health.
+    assert 'COALESCE(s.has_body_data, FALSE) = FALSE' in queries
+    assert 'NOT EXISTS' in queries
+    assert 'FROM bodies b' in queries
+    assert 'WHERE b.system_id64 = s.id64' in queries
     assert 'min_interval: 5m' in exporter
 
 


### PR DESCRIPTION
## Summary
Item #5 from tonight's process/oversight list. `dirty_truthful_no_bodies` — the exact metric behind tonight's deploy-gate false positive — was only visible via one-off manual SQL, not tracked as a trend anywhere. Added alongside the existing `ed_finder_dirty_counts_*` metrics, same pattern, verified fast against production directly.

Deliberately scoped down from the original plan: also drafted a `ring_association_status_drift` metric reusing the canonical drift query, but that query hit its own 5-minute statement timeout against production. Shipping it as a live periodic scrape would either never populate or cause real load on every cache expiry — needs its own investigation (likely a missing index for the query's `system_id64`+`name` join on `bodies`), not a rushed addition here.

## Test plan
- [x] Updated existing `test_dirty_backlog_export_uses_partial_index_predicates_and_cache` for the new subquery (bumped an exact-count assertion from 2→3 deliberately, not loosened, so it still catches an unexpected new full scan)
- [x] New assertion for the metric name's presence
- [x] Verified the underlying query directly against production (~347 rows, sub-second, using the existing `idx_sys_rating_dirty` partial index)
- [x] `ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)