### PR TITLE
Fix F5.1: observation mutations now refresh every observed-facts reader

### DIFF
--- a/frontend/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
+++ b/frontend/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.test.tsx
@@ -376,6 +376,32 @@ describe('ObservedEvidencePanel — Stage 6B manual observed evidence UI', () =>
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['observation-review', 123] });
   });
 
+  it('invalidates every observed-facts read model, not just the Evidence panel and Validation panel', async () => {
+    // Regression test for the adversarial-frontend-review-2026-06 F5.1
+    // finding: Provenance Cockpit, Export Readiness, and the role-review
+    // panel each read observed facts under their own query-key root
+    // (provenance-cockpit-observed-facts / observed-facts-export /
+    // role-review-observed-facts), and none of the three were being
+    // invalidated after a create/update/delete — they'd show stale
+    // evidence for up to their staleTime after a write.
+    mockedList.mockResolvedValue(emptyResponse());
+    mockedCreate.mockResolvedValue(fact());
+    const { client } = renderPanel();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    await screen.findByRole('region', { name: 'Observed Evidence' });
+    fireEvent.change(screen.getByLabelText(/^Notes$/), {
+      target: { value: 'Evidence that should refresh every reader.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Record observed evidence/i }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['observed-facts', 123] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['provenance-cockpit-observed-facts', 123] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['observed-facts-export', 123] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['role-review-observed-facts', 123] });
+  });
+
   it('shows backend validation errors clearly when create fails with 422', async () => {
     mockedList.mockResolvedValue(emptyResponse());
     mockedCreate.mockRejectedValue(

--- a/frontend/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
+++ b/frontend/src/features/system-detail/simulation-preview/observations/ObservedEvidencePanel.tsx
@@ -29,6 +29,7 @@ import {
   statusLabel,
 } from './observationLabels';
 import { describeApiError } from './observationUtils';
+import { invalidateObservedFactQueries } from './observedFactsQueryKeys';
 
 interface ObservedEvidencePanelProps {
   systemId64: number;
@@ -110,7 +111,10 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
       setCreateError(null);
       // Force form remount to reset state on success.
       setCreateFormKey((value) => value + 1);
-      void queryClient.invalidateQueries({ queryKey: ['observed-facts', systemId64] });
+      // Invalidates every observed-facts read model (Evidence panel,
+      // Provenance Cockpit, Export Readiness, role-review) in one call —
+      // see observedFactsQueryKeys.ts for why this must be centralised.
+      invalidateObservedFactQueries(queryClient, systemId64);
       // Stage 6D: the Validation panel reads from the same persisted
       // evidence pool. Invalidate its compare query so the user can see
       // the new evidence reflected after recording it. The Validation
@@ -132,7 +136,7 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
         delete next[variables.observationId];
         return next;
       });
-      void queryClient.invalidateQueries({ queryKey: ['observed-facts', systemId64] });
+      invalidateObservedFactQueries(queryClient, systemId64);
       void queryClient.invalidateQueries({ queryKey: ['observation-compare', systemId64] });
       void queryClient.invalidateQueries({ queryKey: ['observation-review', systemId64] });
     },
@@ -149,7 +153,7 @@ export function ObservedEvidencePanel({ systemId64, suggestedArchetype }: Observ
         delete next[observationId];
         return next;
       });
-      void queryClient.invalidateQueries({ queryKey: ['observed-facts', systemId64] });
+      invalidateObservedFactQueries(queryClient, systemId64);
       void queryClient.invalidateQueries({ queryKey: ['observation-compare', systemId64] });
       void queryClient.invalidateQueries({ queryKey: ['observation-review', systemId64] });
     },

--- a/frontend/src/features/system-detail/simulation-preview/observations/index.ts
+++ b/frontend/src/features/system-detail/simulation-preview/observations/index.ts
@@ -4,3 +4,4 @@ export { ObservedEvidenceList } from './ObservedEvidenceList';
 export { ObservedEvidenceCard } from './ObservedEvidenceCard';
 export * from './observationLabels';
 export * from './observationUtils';
+export * from './observedFactsQueryKeys';

--- a/frontend/src/features/system-detail/simulation-preview/observations/observedFactsQueryKeys.test.ts
+++ b/frontend/src/features/system-detail/simulation-preview/observations/observedFactsQueryKeys.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OBSERVED_FACTS_QUERY_KEY_ROOTS, invalidateObservedFactQueries } from './observedFactsQueryKeys';
+
+describe('observedFactsQueryKeys', () => {
+  it('lists every known observed-facts query-key root', () => {
+    expect(OBSERVED_FACTS_QUERY_KEY_ROOTS).toEqual([
+      'observed-facts',
+      'provenance-cockpit-observed-facts',
+      'observed-facts-export',
+      'role-review-observed-facts',
+    ]);
+  });
+
+  it('invalidates every root for the given system, prefix-keyed', () => {
+    const invalidateQueries = vi.fn();
+    const queryClient = { invalidateQueries } as unknown as import('@tanstack/react-query').QueryClient;
+
+    invalidateObservedFactQueries(queryClient, 123);
+
+    expect(invalidateQueries).toHaveBeenCalledTimes(OBSERVED_FACTS_QUERY_KEY_ROOTS.length);
+    for (const root of OBSERVED_FACTS_QUERY_KEY_ROOTS) {
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: [root, 123] });
+    }
+  });
+});

--- a/frontend/src/features/system-detail/simulation-preview/observations/observedFactsQueryKeys.ts
+++ b/frontend/src/features/system-detail/simulation-preview/observations/observedFactsQueryKeys.ts
@@ -1,0 +1,31 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Every query-key root that reads `listObservedFacts` for a system, across
+ * every consumer. Four independent call sites each invented their own root
+ * (`observed-facts`, `provenance-cockpit-observed-facts`,
+ * `observed-facts-export`, `role-review-observed-facts`) with no shared
+ * hook — a mutation invalidating only the roots its author happened to
+ * know about left the other panels showing stale evidence after a create/
+ * update/delete. Kept as an explicit list (not derived) so a 5th consumer
+ * shows up here as a one-line addition instead of another chance to miss
+ * a root.
+ */
+export const OBSERVED_FACTS_QUERY_KEY_ROOTS = [
+  'observed-facts',
+  'provenance-cockpit-observed-facts',
+  'observed-facts-export',
+  'role-review-observed-facts',
+] as const;
+
+/**
+ * Invalidate every observed-facts read model for a system in one call.
+ * TanStack Query's default `invalidateQueries` matching is prefix-based,
+ * so `['root', systemId64]` matches a query keyed `['root', systemId64,
+ * targetArchetype]` regardless of the trailing params each consumer adds.
+ */
+export function invalidateObservedFactQueries(queryClient: QueryClient, systemId64: number): void {
+  for (const root of OBSERVED_FACTS_QUERY_KEY_ROOTS) {
+    void queryClient.invalidateQueries({ queryKey: [root, systemId64] });
+  }
+}


### PR DESCRIPTION
## Summary
Fixes F5.1/F5.2 from `docs/development/adversarial-frontend-review-2026-06.md` — verified against current `main` before fixing (frontend tree unchanged since the audited commit; all query-key definitions and invalidation call sites matched the report exactly, file:line).

- `ObservedEvidencePanel`'s create/update/delete mutations only invalidated the Evidence panel's own query plus the Validation panel's two keys — three other panels reading the same `listObservedFacts` data under independently-invented query-key roots (Provenance Cockpit, Export Readiness, role-review) never got invalidated, showing stale evidence within their staleTime.
- Root cause: 4 independent call sites, 4 unrelated key schemes, no shared hook.
- Fix: a shared `observedFactsQueryKeys.ts` (explicit list of all 4 known roots + one `invalidateObservedFactQueries()` helper) that the 3 mutation handlers now call, so a future 5th consumer is a one-line addition instead of another chance to miss a root.
- Deliberately left the 4 *read*-side query definitions separate (different params/staleTime/enabled per consumer) — unifying those is a bigger, separate refactor this fix doesn't need.

## Test plan
- [x] New regression test proves all 4 roots are invalidated (previously only 1 was)
- [x] New unit test for the shared helper module
- [x] `yarn vitest run src/features/system-detail/simulation-preview/observations/` — 28 passed
- [x] `yarn test:planner` (scoped colony-planner + simulation-preview suite) — 355 passed
- [x] `yarn typecheck`, `yarn lint`, `yarn knip --files` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)