### PR TITLE
Fix nightly MV refresh timeout bug, move it to maintenance container

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,15 +289,22 @@ order.
 
 - **body\_rings.association\_status is `NOT NULL DEFAULT 'local\_matched'`.**
   Any INSERT that omits the column silently asserts a verified local match.
-  Two of the five ring writers omit it.
+  As of 2026-08-08 (Emergent recurrence report B1) all five ring writers set
+  it explicitly — `importer/enrich_system_data.py` was the last one relying
+  on the schema default; watch for this regressing on any new writer.
 
-- **body\_rings has five writers**, three naming association_status with a
-  CASE and two omitting it: eddn_listener.py, ingest/eddn_client.py,
-  journal_import/store.py, importer/import_spansh.py,
-  importer/enrich_system_data.py.
+- **body\_rings has five writers**: eddn_listener.py, ingest/eddn_client.py,
+  and journal_import/store.py compute it via the shared
+  `BODY_RING_ASSOCIATION_STATUS_CASE_SQL` (see below); importer/import_spansh.py
+  and importer/enrich_system_data.py each set it explicitly in Python instead,
+  justified by their own local-match guarantee (a rejection-filter and a
+  system-scoped body lookup, respectively — see the comment at each call site).
 
-- **BODY\_RING\_ASSOCIATION\_STATUS\_CASE\_SQL is defined three times**, once per
-  file, with no shared module. Changing one does not change the others.
+- **BODY\_RING\_ASSOCIATION\_STATUS\_CASE\_SQL lives in
+  `shared_contracts/body_ring_association_status.py`**, imported by the three
+  asyncpg-based writers above. It used to be defined three times independently
+  with no shared module (the exact kind of copy CLAUDE.md warns about
+  elsewhere) — already consolidated, so don't reintroduce a fourth copy.
 
 - **The role `edfinder` has `statement\_timeout = 15000` set via ALTER ROLE.**
   It exists nowhere in the repo. Any shell or psql path that does not

--- a/apps/api/src/models.py
+++ b/apps/api/src/models.py
@@ -1120,13 +1120,20 @@ class FacilityTemplateResponse(BaseModel):
     pad_size:            Optional[str] = None
     confidence:          Optional[str] = None
     notes:               Optional[str] = None
-    prerequisites:       list[dict[str, Any]] = Field(default_factory=list)
-    economy_effects:     dict[str, Any] = Field(default_factory=dict)
+    # list[dict[str, Any]] / dict[str, Any] still emit as
+    # Record<string, never> via openapi-typescript (its handling of Pydantic's
+    # `additionalProperties: {}` schema for a bare Any value type) — the exact
+    # unusable-generated-type trap this file's own module docstring warns
+    # about. These three catalogue fields are genuinely free-form (frontend
+    # code defensively probes several possible keys), so `Any` is the
+    # documented remedy rather than inventing a fixed sub-model shape.
+    prerequisites:       list[Any] = Field(default_factory=list)
+    economy_effects:     Any = Field(default_factory=dict)
     yellow_cp_generated: int = 0
     green_cp_generated:  int = 0
     yellow_cp_cost:      int = 0
     green_cp_cost:       int = 0
-    stat_effects:        dict[str, Any] = Field(default_factory=dict)
+    stat_effects:        Any = Field(default_factory=dict)
 
 
 SimulationSource = Literal['precomputed', 'computed', 'insufficient_data']

--- a/apps/importer/src/enrich_system_data.py
+++ b/apps/importer/src/enrich_system_data.py
@@ -24,6 +24,7 @@ import psycopg2
 from psycopg2.extras import RealDictCursor
 
 import edsm_station_enrichment_probe as edsm_probe
+from body_ring_enrichment_plan import TRUSTED_RING_ASSOCIATION_STATUS
 from dirty_flags import mark_systems_rating_dirty
 from ring_facts import normalise_ring_payload, ring_rows_for_body
 
@@ -534,6 +535,17 @@ def build_ring_plan(
                     'reason': 'missing_ring_identity',
                 })
                 continue
+            # match_local_body() (above) only ever returns a match drawn from
+            # local_bodies, which fetch_local_bodies() scoped to this exact
+            # system_id64 — body_id here is therefore already a verified
+            # local match, same guarantee import_spansh.py's
+            # body_ring_rows_from_spansh_body() establishes via its own
+            # rejected_body_ids filter. Set explicitly (2026-08-08, Emergent
+            # recurrence report B1) instead of leaving it to
+            # body_rings.association_status's NOT NULL DEFAULT
+            # 'local_matched' to silently assert the same claim with no
+            # code anyone can audit — see CLAUDE.md's Known Hazards section.
+            row['association_status'] = TRUSTED_RING_ASSOCIATION_STATUS
             rows.append(row)
 
     counts['ring_rows_planned'] = len(rows)
@@ -570,19 +582,20 @@ def apply_ring_rows(
                     system_id64, body_id, body_name,
                     ring_name, ring_type, ring_class,
                     mass_mt, inner_radius, outer_radius,
-                    source, confidence, updated_at
+                    source, confidence, association_status, updated_at
                 ) VALUES (
-                    %s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NOW()
+                    %s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,NOW()
                 )
                 ON CONFLICT (system_id64, body_id, ring_name, source) DO UPDATE SET
-                    body_name    = COALESCE(EXCLUDED.body_name, body_rings.body_name),
-                    ring_type    = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
-                    ring_class   = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
-                    mass_mt      = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
-                    inner_radius = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
-                    outer_radius = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
-                    confidence   = EXCLUDED.confidence,
-                    updated_at   = NOW()
+                    body_name          = COALESCE(EXCLUDED.body_name, body_rings.body_name),
+                    ring_type          = COALESCE(EXCLUDED.ring_type, body_rings.ring_type),
+                    ring_class         = COALESCE(EXCLUDED.ring_class, body_rings.ring_class),
+                    mass_mt            = COALESCE(EXCLUDED.mass_mt, body_rings.mass_mt),
+                    inner_radius       = COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius),
+                    outer_radius       = COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius),
+                    confidence         = EXCLUDED.confidence,
+                    association_status = EXCLUDED.association_status,
+                    updated_at         = NOW()
                 WHERE body_rings.body_name IS DISTINCT FROM COALESCE(EXCLUDED.body_name, body_rings.body_name)
                    OR body_rings.ring_type IS DISTINCT FROM COALESCE(EXCLUDED.ring_type, body_rings.ring_type)
                    OR body_rings.ring_class IS DISTINCT FROM COALESCE(EXCLUDED.ring_class, body_rings.ring_class)
@@ -590,6 +603,7 @@ def apply_ring_rows(
                    OR body_rings.inner_radius IS DISTINCT FROM COALESCE(EXCLUDED.inner_radius, body_rings.inner_radius)
                    OR body_rings.outer_radius IS DISTINCT FROM COALESCE(EXCLUDED.outer_radius, body_rings.outer_radius)
                    OR body_rings.confidence IS DISTINCT FROM EXCLUDED.confidence
+                   OR body_rings.association_status IS DISTINCT FROM EXCLUDED.association_status
                 RETURNING system_id64, body_id, body_name, ring_name, source, confidence
             """, _ring_row_tuple(row))
             returned = cur.fetchone()
@@ -607,6 +621,14 @@ def apply_ringed_scan_facts(_conn, rows: Sequence[Mapping[str, Any]]) -> tuple[l
     stores the journal/source BodyID (INTEGER). The coordinated ring backfill
     only plans ED-Finder body IDs, so writing them to body_scan_facts would either
     overflow the current schema or corrupt that identity.
+
+    _scan_fact_skip_reason() has exactly two outcomes and both are skips —
+    there is currently no code path in this function that can populate
+    `applied`; it always returns []. That's by design, not a bug or a
+    forgotten TODO (see Emergent recurrence report B4, 2026-08-08): this
+    function keeps the tuple[applied, skipped] shape so a real write path
+    can be added later (e.g. if body_scan_facts.body_id is ever widened to
+    BIGINT) without changing every caller's unpacking again.
     """
     applied: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
@@ -1166,6 +1188,7 @@ def _ring_row_tuple(row: Mapping[str, Any]) -> tuple[Any, ...]:
         row.get('outer_radius'),
         row.get('source'),
         row.get('confidence'),
+        row.get('association_status'),
     )
 
 

--- a/apps/importer/src/import_spansh.py
+++ b/apps/importer/src/import_spansh.py
@@ -62,6 +62,7 @@ import psycopg2.extensions
 import psycopg2.errors
 from tqdm import tqdm
 from ring_facts import ring_rows_for_body
+from body_ring_enrichment_plan import TRUSTED_RING_ASSOCIATION_STATUS
 
 # ---------------------------------------------------------------------------
 # Galaxy Region Lookup (klightspeed/EliteDangerousRegionMap)
@@ -613,6 +614,25 @@ def upsert_body_rings(conn, rows: list[dict]) -> int:
     return _run_with_deadlock_retry(conn, _do, label="upsert_body_rings")
 
 
+def _filter_rings_by_rejected_bodies(
+    ring_batch: list[dict], rejected_body_ids: set,
+) -> tuple[list[dict], int]:
+    """Drop ring rows whose owning body upsert was rejected by the
+    system_id64 ownership guard (a colliding Spansh body id already owned
+    by another system — see the bodies.id hazard in CLAUDE.md). This is
+    the filter body_ring_rows_from_spansh_body's 'local_matched' comment
+    depends on: association_status is only a true claim for a ring whose
+    body survived this check. Extracted from flush_rings()'s closure into
+    a standalone function (2026-08-08, Emergent recurrence report A2) so
+    the invariant is independently testable instead of living only in an
+    inline list comprehension nothing else could exercise."""
+    keep = [
+        r for r in ring_batch
+        if (r.get('system_id64'), r.get('body_id')) not in rejected_body_ids
+    ]
+    return keep, len(ring_batch) - len(keep)
+
+
 def _ring_row_tuple(row: dict) -> tuple:
     return (
         row.get('system_id64'),
@@ -653,7 +673,7 @@ def body_ring_rows_from_spansh_body(system_id64: int, body_id: int, body_name: s
         # left to fall through to body_rings.association_status's schema
         # default, which silently asserts the same claim with no code
         # anyone can audit.
-        row['association_status'] = 'local_matched'
+        row['association_status'] = TRUSTED_RING_ASSOCIATION_STATUS
     return rows
 
 
@@ -986,11 +1006,7 @@ def import_galaxy(conn, dump_path: Path, resume_offset: int = 0) -> int:
         nonlocal rings_skipped_rejected_body
         flush_bodies()
         if ring_batch:
-            keep = [
-                r for r in ring_batch
-                if (r.get('system_id64'), r.get('body_id')) not in rejected_body_ids
-            ]
-            skipped = len(ring_batch) - len(keep)
+            keep, skipped = _filter_rings_by_rejected_bodies(ring_batch, rejected_body_ids)
             if skipped:
                 rings_skipped_rejected_body += skipped
                 log.info(

--- a/apps/maintenance/scripts/run_maintenance.sh
+++ b/apps/maintenance/scripts/run_maintenance.sh
@@ -186,6 +186,21 @@ SQL
         # remain available throughout the maintenance run.
         run_step "refresh_map_mviews()"  \
             "SET statement_timeout = '60min'; SELECT * FROM refresh_map_mviews(TRUE);"
+        # mv_archetype_rankings refresh (moved here 2026-08-08 from
+        # scripts/nightly_update.sh — see that script's comment above
+        # NIGHTLY_PGOPTIONS). It used to need its own fixed nightly
+        # statement_timeout, and kept outgrowing it as the view grew
+        # (6m30s at 10M rows on 2026-07-15, per known-issues.md, up to
+        # 52m33s at 20M rows by this move) — worse than linear growth, so
+        # picking a bigger fixed number here would just repeat the same
+        # bug. No inline SET: this inherits MAINTENANCE_PGOPTIONS'
+        # genuinely unbounded statement_timeout=0, the budget this kind of
+        # long-running, independent, best-effort step is meant to have.
+        # nightly_update.sh (02:00 UTC) rebuilds the underlying
+        # system_archetype_scores rows on its own schedule before this
+        # task runs (03:15 UTC).
+        run_step "refresh mv_archetype_rankings" \
+            "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;"
         finish_task "Nightly"
         ;;
     weekly)

--- a/apps/maintenance/scripts/run_maintenance.sh
+++ b/apps/maintenance/scripts/run_maintenance.sh
@@ -198,7 +198,13 @@ SQL
         # long-running, independent, best-effort step is meant to have.
         # nightly_update.sh (02:00 UTC) rebuilds the underlying
         # system_archetype_scores rows on its own schedule before this
-        # task runs (03:15 UTC).
+        # task runs (03:15 UTC) — a 75-minute assumption, not a guarantee.
+        # If that rebuild (e.g. the --limit 5000000 new-system backfill)
+        # is still running past 03:15, this refresh reflects the
+        # scores as of 03:15, not that night's finished rebuild. Low
+        # impact and self-healing (this step is unconditional and runs
+        # again every night regardless), but a real gap: there is
+        # currently no explicit ordering/wait between the two schedules.
         run_step "refresh mv_archetype_rankings" \
             "REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;"
         finish_task "Nightly"

--- a/env.example
+++ b/env.example
@@ -153,3 +153,36 @@ EDDN_SIMULATION_INGEST_ENABLED=true
 # datasource provisioned but unauthenticated.
 GLITCHTIP_GRAFANA_ORG_SLUG=not-configured
 GLITCHTIP_GRAFANA_AUTH_TOKEN_FILE=./config/glitchtip_grafana_auth_token.disabled
+
+# Undocumented-env-var sweep (Emergent recurrence report A5, 2026-08-08).
+# All nine have working code-level defaults already — none of these are
+# required for a normal run — but none were discoverable from this file
+# before now.
+#
+# apps/api/src/local_search.py's local-search radius tuning.
+MAX_SEARCH_RADIUS_LY=10000
+CLUSTER_RADIUS_LY=500
+#
+# apps/importer/src/build_grid.py's macro-grid cell size (light years).
+CELL_SIZE=500
+#
+# apps/importer/src/inara_api.py: Inara API credentials for the (currently
+# unused-by-default) Inara enrichment path. Leave the key as the placeholder
+# to leave that path effectively disabled.
+INARA_API_KEY=PLACEHOLDER_SET_INARA_API_KEY_IN_ENV
+INARA_APP_NAME=ED-Finder
+INARA_APP_VERSION=3.0
+#
+# apps/importer/src/region_map.py: override the bundled region_map.json
+# path. Leave unset to use the committed file at
+# apps/importer/src/data/region_map.json.
+REGION_MAP_JSON=
+#
+# import_spansh.py / build_topology.py / build_ratings.py / build_grid.py:
+# bypass pgbouncer and :5433 rewriting for a direct Postgres DSN. Leave
+# unset to use each script's own derived-from-DATABASE_URL default.
+DB_DSN_DIRECT=
+#
+# apps/importer/src/build_ratings.py: batch size for the dirty-ratings
+# cleanup loop. RATING_DIRTY_CLEANUP_CHUNK takes precedence if both are set.
+DIRTY_CLEANUP_CHUNK_SIZE=1000

--- a/frontend/src/features/colony-planner/SystemBuildMapCanvas.test.tsx
+++ b/frontend/src/features/colony-planner/SystemBuildMapCanvas.test.tsx
@@ -36,8 +36,7 @@ const system = {
 const templates: FacilityTemplate[] = [
   {
     id: 'dodec_starport',
-    display_name: 'Dodec Starport',
-    name: 'Fallback Dodec',
+    name: 'Dodec Starport',
     category: 'port',
     tier: 3,
     economy: 'Industrial',
@@ -60,7 +59,7 @@ const templates: FacilityTemplate[] = [
       standard_of_living: 30.4,
       development_level: 27.6,
     },
-  } as FacilityTemplate & { display_name: string },
+  },
   {
     id: 'surface_refinery',
     name: 'Surface Refinery Hub',

--- a/frontend/src/features/colony-planner/plannerCanvasUtils.ts
+++ b/frontend/src/features/colony-planner/plannerCanvasUtils.ts
@@ -376,7 +376,9 @@ function readTemplateStat(template: FacilityTemplate | undefined, field: string)
   if (!template) return 0;
   const direct = numericValue((template as unknown as Record<string, unknown>)[field]);
   if (direct != null) return direct;
-  const effects = template.stat_effects ?? (template as unknown as { statEffects?: Record<string, unknown> }).statEffects;
+  const effects = (template.stat_effects ?? (template as unknown as { statEffects?: Record<string, unknown> }).statEffects) as
+    | Record<string, unknown>
+    | undefined;
   return numericValue(effects?.[field]) ?? 0;
 }
 

--- a/frontend/src/features/colony-planner/structurePlanningRules.test.ts
+++ b/frontend/src/features/colony-planner/structurePlanningRules.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { FacilityTemplate } from '@/types/api';
+import { templateDisplayName, templatePrerequisiteDescriptions } from './structurePlanningRules';
+
+const BASE_TEMPLATE: FacilityTemplate = {
+  id: 'outpost',
+  name: 'Outpost',
+  category: 'port',
+  tier: 1,
+  economy: null,
+  is_port: true,
+  is_support_facility: false,
+  allowed_location: 'orbital',
+  pad_size: 'medium',
+  confidence: 'confirmed',
+  notes: null,
+  yellow_cp_generated: 0,
+  green_cp_generated: 0,
+  yellow_cp_cost: 0,
+  green_cp_cost: 0,
+};
+
+describe('templateDisplayName', () => {
+  it('returns the template name — the API never sends a separate display_name field', () => {
+    expect(templateDisplayName(BASE_TEMPLATE)).toBe('Outpost');
+  });
+});
+
+describe('templatePrerequisiteDescriptions', () => {
+  it('reads prerequisites directly off the template without a cast', () => {
+    const template: FacilityTemplate = {
+      ...BASE_TEMPLATE,
+      prerequisites: [{ description: 'Requires an Extraction economy' }, 'Requires tier 2'],
+    };
+
+    expect(templatePrerequisiteDescriptions(template)).toEqual([
+      'Requires an Extraction economy',
+      'Requires tier 2',
+    ]);
+  });
+
+  it('returns an empty list when prerequisites is absent or not an array', () => {
+    expect(templatePrerequisiteDescriptions(BASE_TEMPLATE)).toEqual([]);
+    expect(templatePrerequisiteDescriptions(undefined)).toEqual([]);
+  });
+});

--- a/frontend/src/features/colony-planner/structurePlanningRules.ts
+++ b/frontend/src/features/colony-planner/structurePlanningRules.ts
@@ -103,8 +103,7 @@ export function placementLaneForTemplate(
 }
 
 export function templateDisplayName(template: FacilityTemplate): string {
-  const displayName = (template as unknown as { display_name?: unknown }).display_name;
-  return typeof displayName === 'string' && displayName.trim() ? displayName.trim() : template.name;
+  return template.name;
 }
 
 export function structureFamilyLabel(template: FacilityTemplate): string {
@@ -146,7 +145,7 @@ export function contextualRoleLabel(template: FacilityTemplate | undefined, plac
 }
 
 export function templatePrerequisiteDescriptions(template: FacilityTemplate | undefined): string[] {
-  const raw = (template as unknown as { prerequisites?: unknown } | undefined)?.prerequisites;
+  const raw = template?.prerequisites;
   if (!Array.isArray(raw)) return [];
   return raw
     .map((item) => prerequisiteDescription(item))

--- a/frontend/src/types/api.gen.ts
+++ b/frontend/src/types/api.gen.ts
@@ -2721,9 +2721,9 @@ export interface components {
             /** Notes */
             notes?: string | null;
             /** Prerequisites */
-            prerequisites?: Record<string, never>[];
+            prerequisites?: unknown[];
             /** Economy Effects */
-            economy_effects?: Record<string, never>;
+            economy_effects?: unknown;
             /**
              * Yellow Cp Generated
              * @default 0
@@ -2745,7 +2745,7 @@ export interface components {
              */
             green_cp_cost: number;
             /** Stat Effects */
-            stat_effects?: Record<string, never>;
+            stat_effects?: unknown;
         };
         /** GalaxySearchRequest */
         GalaxySearchRequest: {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -999,13 +999,13 @@ export interface FacilityTemplate {
   pad_size?: string | null;
   confidence?: string | null;
   notes?: string | null;
-  prerequisites?: Array<Record<string, unknown>> | null;
-  economy_effects?: Record<string, unknown> | null;
+  prerequisites?: unknown[] | null;
+  economy_effects?: unknown;
   yellow_cp_generated: number;
   green_cp_generated: number;
   yellow_cp_cost: number;
   green_cp_cost: number;
-  stat_effects?: Record<string, unknown>;
+  stat_effects?: unknown;
   population?: number | null;
   max_population?: number | null;
   security?: number | null;

--- a/scripts/nightly_update.sh
+++ b/scripts/nightly_update.sh
@@ -149,6 +149,24 @@ run_importer() {
 # night. Anything longer belongs in the maintenance container's weekly path.
 # Passing PGOPTIONS through docker compose exec also works for VACUUM, which
 # cannot share a transaction with an inline SET statement.
+#
+# 2026-08-08: the three `REFRESH MATERIALIZED VIEW CONCURRENTLY
+# mv_archetype_rankings` call sites used to add their own inline
+# `SET statement_timeout = '10min';` ahead of the REFRESH, which overrode
+# this 30-minute budget down to a third of it on every single call —
+# confirmed as the cause of "MV refresh failed" firing nightly since at
+# least 2026-07-14 (mv_archetype_rankings is ~9.6GB / 20M rows). A manual
+# untimed refresh on production measured 52m33s — already past this budget
+# and, per known-issues.md's 2026-07-15 entry, growing worse than linearly
+# with row count (6m30s at 10M rows -> 52m33s at 20M rows). Rather than
+# picking a second, bigger fixed nightly timeout (the same bug class with a
+# bigger constant), the refresh itself moved to
+# apps/maintenance/scripts/run_maintenance.sh's nightly task, which already
+# has a genuinely unbounded statement_timeout=0 budget for exactly this
+# kind of long-running, independent, best-effort step — see
+# MAINTENANCE_PGOPTIONS there. This script's own comment above already said
+# "anything longer belongs in the maintenance container['s]... path"; this
+# is that.
 NIGHTLY_PGOPTIONS="-c statement_timeout=1800000"
 
 run_psql() {
@@ -423,8 +441,6 @@ pg_count_into TOPO_DIRTY "SELECT COUNT(*) FROM (
 pg_count_into ARCH_SCORE_DIRTY "SELECT COUNT(*) FROM system_archetype_scores WHERE dirty = TRUE"
 log "Topology dirty (rating_dirty): $TOPO_DIRTY | Archetype scores dirty: $ARCH_SCORE_DIRTY"
 
-ARCH_BUILD_RAN=0
-
 if (( TOPO_DIRTY > 0 )); then
     log "Running build_topology.py --dirty ..."
     run_importer "build_topology" build_topology.py --dirty \
@@ -440,15 +456,8 @@ log "Archetype scores dirty after topology pass: $ARCH_SCORE_DIRTY"
 if (( ARCH_SCORE_DIRTY > 0 )); then
     log "Running build_archetype_scores.py --dirty ..."
     run_importer "build_archetype_scores" build_archetype_scores.py --dirty \
-        && { success "Archetype scores rebuilt"; ARCH_BUILD_RAN=1; } \
+        && success "Archetype scores rebuilt" \
         || warn "Archetype score rebuild had errors (check ${LOG_DIR}/build_archetype_scores.log)"
-
-    log "Refreshing mv_archetype_rankings ..."
-    run_psql \
-        -c "SET statement_timeout = '10min'; REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;" \
-        >> "$LOG" 2>&1 \
-        && success "mv_archetype_rankings refreshed" \
-        || warn "MV refresh failed"
 
     # Post-rebuild verification
     pg_count_into STILL_DIRTY_A "SELECT COUNT(*) FROM system_archetype_scores WHERE dirty = TRUE"
@@ -477,30 +486,15 @@ if (( ARCH_SCORE_MISSING > 0 )); then
     # Remove the cap once the backlog is cleared and replace with
     # a smaller maintenance cap (e.g. --limit 500000).
     run_importer "build_archetype_scores_new" build_archetype_scores.py --limit 5000000 \
-        && { success "New archetype scores backfilled"; ARCH_BUILD_RAN=1; } \
+        && success "New archetype scores backfilled" \
         || warn "New archetype score backfill had errors (check ${LOG_DIR}/build_archetype_scores_new.log)"
-
-    log "Refreshing mv_archetype_rankings ..."
-    run_psql \
-        -c "SET statement_timeout = '10min'; REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;" \
-        >> "$LOG" 2>&1 \
-        && success "mv_archetype_rankings refreshed" \
-        || warn "MV refresh failed"
 fi
 
-# Catch-up: if any archetype build ran in this invocation, ensure the
-# MV reflects the new data. The inline refreshes inside each block may
-# have failed or been skipped (the build clears dirty flags, so the
-# post-build count can be zero even though data changed).
-if (( ARCH_BUILD_RAN == 1 )); then
-    pg_count_into MV_ROWS "SELECT COUNT(*) FROM mv_archetype_rankings"
-    log "Archetype build ran this cycle — verifying MV is current ($MV_ROWS rows) ..."
-    run_psql \
-        -c "SET statement_timeout = '10min'; REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;" \
-        >> "$LOG" 2>&1 \
-        && success "mv_archetype_rankings refreshed (catch-up)" \
-        || warn "MV catch-up refresh failed"
-fi
+# mv_archetype_rankings itself is refreshed by
+# apps/maintenance/scripts/run_maintenance.sh's nightly task (2026-08-08),
+# not here — see the incident note above NIGHTLY_PGOPTIONS. It runs on its
+# own schedule (03:15 UTC) against the archetype scores this step just
+# rebuilt.
 
 # Re-check for systems with body data but no regional analysis row at all —
 # build_regional_analysis.py's default mode only covers systems missing a

--- a/tests/test_env_example_documents_undocumented_vars.py
+++ b/tests/test_env_example_documents_undocumented_vars.py
@@ -1,0 +1,29 @@
+"""Regression test for Emergent recurrence report A5 (2026-08-08): nine
+real, code-read env vars (all with working defaults, none previously
+documented anywhere in env.example) were only discoverable by grepping
+source. Asserts each now has an entry."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+UNDOCUMENTED_VARS = (
+    'CLUSTER_RADIUS_LY',
+    'MAX_SEARCH_RADIUS_LY',
+    'CELL_SIZE',
+    'INARA_API_KEY',
+    'INARA_APP_NAME',
+    'INARA_APP_VERSION',
+    'REGION_MAP_JSON',
+    'DB_DSN_DIRECT',
+    'DIRTY_CLEANUP_CHUNK_SIZE',
+)
+
+
+def test_a5_env_vars_are_documented_in_env_example():
+    env_example = (ROOT / 'env.example').read_text(encoding='utf-8')
+    lines = env_example.splitlines()
+
+    for var in UNDOCUMENTED_VARS:
+        assert any(line.startswith(f'{var}=') for line in lines), (
+            f'{var} is read via os.getenv() in apps/ but has no entry in env.example'
+        )

--- a/tests/test_import_spansh_ring_rejection_filter.py
+++ b/tests/test_import_spansh_ring_rejection_filter.py
@@ -1,0 +1,79 @@
+"""Regression test for import_spansh.py's ring/rejected-body filter.
+
+Emergent adversarial-review recurrence check (2026-08-07), item A2:
+body_ring_rows_from_spansh_body() hardcodes association_status='local_matched'
+on every ring row, with a comment claiming this is only safe because
+flush_rings() filters ring_batch against rejected_body_ids first (bodies
+whose upsert was rejected by the system_id64 ownership guard — see the
+bodies.id hazard in CLAUDE.md). That filter used to live only as an inline
+list comprehension inside flush_rings()'s closure, nested inside the ~1500
+line import_galaxy() function — the invariant the comment claims was
+untestable without driving a full dump-file import against a real database.
+Extracted into _filter_rings_by_rejected_bodies() so it can be tested
+directly, the same pattern used for save_checkpoint_safely() in
+test_import_spansh_checkpoint_failure_handling.py.
+"""
+import os
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORTER_SRC = str(ROOT / 'apps' / 'importer' / 'src')
+if IMPORTER_SRC not in sys.path:
+    sys.path.insert(0, IMPORTER_SRC)
+
+os.environ.setdefault('DATABASE_URL', 'postgresql://test:test@localhost:5432/test')
+
+import import_spansh  # noqa: E402
+
+
+def test_ring_owned_by_rejected_body_is_dropped():
+    ring_batch = [
+        {'system_id64': 1, 'body_id': 100, 'ring_name': 'A Ring'},
+    ]
+    rejected_body_ids = {(1, 100)}
+
+    keep, skipped = import_spansh._filter_rings_by_rejected_bodies(ring_batch, rejected_body_ids)
+
+    assert keep == []
+    assert skipped == 1
+
+
+def test_ring_owned_by_accepted_body_is_kept():
+    ring_batch = [
+        {'system_id64': 1, 'body_id': 100, 'ring_name': 'A Ring'},
+    ]
+    rejected_body_ids: set = set()
+
+    keep, skipped = import_spansh._filter_rings_by_rejected_bodies(ring_batch, rejected_body_ids)
+
+    assert keep == ring_batch
+    assert skipped == 0
+
+
+def test_only_the_rejected_body_ids_ring_rows_are_dropped_from_a_mixed_batch():
+    """A single flush can contain rings for many bodies across many
+    systems — rejecting one colliding body must not touch any other
+    row's ring in the same batch."""
+    ring_batch = [
+        {'system_id64': 1, 'body_id': 100, 'ring_name': 'Rejected Body Ring'},
+        {'system_id64': 1, 'body_id': 101, 'ring_name': 'Accepted Body Ring'},
+        {'system_id64': 2, 'body_id': 100, 'ring_name': 'Different System, Same Body Id'},
+    ]
+    rejected_body_ids = {(1, 100)}
+
+    keep, skipped = import_spansh._filter_rings_by_rejected_bodies(ring_batch, rejected_body_ids)
+
+    assert keep == [
+        {'system_id64': 1, 'body_id': 101, 'ring_name': 'Accepted Body Ring'},
+        {'system_id64': 2, 'body_id': 100, 'ring_name': 'Different System, Same Body Id'},
+    ]
+    assert skipped == 1
+
+
+def test_empty_ring_batch_and_empty_rejection_set():
+    keep, skipped = import_spansh._filter_rings_by_rejected_bodies([], set())
+
+    assert keep == []
+    assert skipped == 0

--- a/tests/test_run_maintenance_mv_refresh.py
+++ b/tests/test_run_maintenance_mv_refresh.py
@@ -1,0 +1,54 @@
+"""Regression test for moving the mv_archetype_rankings refresh out of
+scripts/nightly_update.sh into apps/maintenance/scripts/run_maintenance.sh
+(2026-08-08). The view had outgrown every fixed nightly timeout tried
+(10min, then 30min via inherited NIGHTLY_PGOPTIONS, then a dedicated 1h
+budget) as it grew worse than linearly with row count (6m30s at 10M rows,
+52m33s at 20M rows) — moving it to the maintenance container's nightly task
+gives it the genuinely unbounded MAINTENANCE_PGOPTIONS budget that already
+exists there for exactly this kind of long-running, best-effort step,
+instead of repeatedly guessing a bigger fixed constant.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+NIGHTLY_UPDATE = ROOT / 'scripts' / 'nightly_update.sh'
+RUN_MAINTENANCE = ROOT / 'apps' / 'maintenance' / 'scripts' / 'run_maintenance.sh'
+
+_CASE_LABEL = re.compile(r'\n {4}\w+\)')
+
+
+def _nightly_case_block(text: str, case: str) -> str:
+    start = text.index(f'    {case})')
+    next_label = _CASE_LABEL.search(text, start + 1)
+    end = next_label.start() if next_label else len(text)
+    return text[start:end]
+
+
+def test_nightly_update_no_longer_refreshes_mv_archetype_rankings():
+    nightly = NIGHTLY_UPDATE.read_text(encoding='utf-8')
+
+    assert 'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings' not in nightly
+    assert 'run_psql_mv_refresh' not in nightly
+    assert 'MV_REFRESH_PGOPTIONS' not in nightly
+
+
+def test_run_maintenance_nightly_task_refreshes_mv_archetype_rankings_unbounded():
+    maintenance = RUN_MAINTENANCE.read_text(encoding='utf-8')
+    nightly_block = _nightly_case_block(maintenance, 'nightly')
+
+    assert 'REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings' in nightly_block
+    # No inline SET statement_timeout ahead of this specific REFRESH — it
+    # must inherit MAINTENANCE_PGOPTIONS' statement_timeout=0 (genuinely
+    # unbounded), not a second fixed ceiling picked to clear today's
+    # measured runtime.
+    refresh_line_start = nightly_block.index('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings')
+    step_start = nightly_block.rindex('run_step', 0, refresh_line_start)
+    step_call = nightly_block[step_start:refresh_line_start + len('REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings;')]
+    assert 'SET statement_timeout' not in step_call
+
+
+def test_run_maintenance_defines_a_genuinely_unbounded_pgoptions_budget():
+    maintenance = RUN_MAINTENANCE.read_text(encoding='utf-8')
+
+    assert 'statement_timeout=0' in maintenance

--- a/tests/test_stage17n2d_backfill_framework.py
+++ b/tests/test_stage17n2d_backfill_framework.py
@@ -169,6 +169,7 @@ class RingApplyConnection:
                 outer_radius,
                 source,
                 confidence,
+                association_status,
             ) = params
             key = (system_id64, body_id, ring_name, source)
             next_row = {
@@ -183,6 +184,7 @@ class RingApplyConnection:
                 'outer_radius': outer_radius,
                 'source': source,
                 'confidence': confidence,
+                'association_status': association_status,
             }
             if self.rings.get(key) == next_row:
                 self.last_row = None
@@ -1084,6 +1086,7 @@ def test_spansh_ring_payload_plans_trusted_body_ring_rows():
         'outer_radius': 25.0,
         'source': 'spansh_dump',
         'confidence': 'source_ring_payload',
+        'association_status': 'local_matched',
     }]
 
 
@@ -1098,6 +1101,29 @@ def test_missing_ring_payload_remains_unknown_not_false():
     assert plan['rows'] == []
     assert plan['skipped'][0]['reason'] == 'missing_ring_array_unknown'
     assert plan['counts']['missing_ring_array_unknown'] == 1
+
+
+def test_apply_ringed_scan_facts_never_populates_applied():
+    """Emergent recurrence report B4 (2026-08-08): apply_ringed_scan_facts
+    returns tuple[applied, skipped] but no code path in it can currently
+    populate `applied` — body_scan_facts.body_id is INTEGER while
+    body_rings.body_id (ED-Finder bodies.id) is BIGINT, so every row is
+    always skipped for one of exactly two reasons. This is by design, not
+    a bug, but nothing previously proved that invariant — a future edit
+    that accidentally started appending to `applied` without actually
+    fixing the id-width mismatch would corrupt data silently."""
+    rows = [
+        {'system_id64': SYSTEM['id64'], 'body_id': 11, 'body_name': 'Exioce 1'},
+        {'system_id64': SYSTEM['id64'], 'body_id': BIG_BODY_ID, 'body_name': 'Exioce 3'},
+    ]
+
+    applied, skipped = enrich.apply_ringed_scan_facts(None, rows)
+
+    assert applied == []
+    assert {row['reason'] for row in skipped} == {
+        'body_scan_facts_source_body_id_unavailable',
+        'body_scan_facts_body_id_schema_mismatch',
+    }
 
 
 def test_explicit_no_rings_full_scan_sets_false():


### PR DESCRIPTION
## Summary

- **nightly_update.sh MV refresh bug (root cause of 3+ nights of "MV refresh failed")**: all 3 `REFRESH MATERIALIZED VIEW CONCURRENTLY mv_archetype_rankings` call sites added their own inline `SET statement_timeout = '10min';`, silently overriding the script's intended 30-minute PGOPTIONS budget down to a third of it. A manual untimed refresh on production measured **52m33s** and the view is growing worse-than-linearly with row count (6m30s at 10M rows per `known-issues.md`'s 2026-07-15 entry → 52m33s at 20M rows now). Rather than picking a bigger fixed nightly timeout (same bug, bigger constant), the refresh moves to `apps/maintenance/scripts/run_maintenance.sh`'s nightly task, which already has a genuinely unbounded `statement_timeout=0` budget for exactly this kind of long-running, best-effort step.
- **F8.1** (`FacilityTemplateResponse` type contract): `prerequisites`/`economy_effects`/`stat_effects` widened from `dict[str, Any]` to `Any` so `openapi-typescript` stops emitting the unusable `Record<string, never>`. Removed the frontend casts this forced, including a dead `display_name` lookup the API never actually populates.
- **A2**: `import_spansh.py`'s ring-rejection filter extracted into a standalone, directly-testable function; reuses the existing `TRUSTED_RING_ASSOCIATION_STATUS` constant instead of a hardcoded literal.
- **B1**: `enrich_system_data.py`'s `body_rings` writer now sets `association_status` explicitly instead of relying on the schema default (the exact hazard CLAUDE.md's Known Hazards section warns about).
- **A5**: documented 9 previously-undocumented env vars in `env.example`.
- **B4**: clarified `apply_ringed_scan_facts`'s always-empty `applied` list is by design, with a test locking in the invariant.
- Corrected CLAUDE.md's stale claim that the ring-association-status SQL is "defined three times with no shared module" — it's been consolidated into `shared_contracts/`.

Ran an 8-angle adversarial code-review pass over the diff before finalizing; findings from that pass (a redundant catch-up-refresh in the original nightly-only fix, a test harness bug, and a frontend type-consistency gap) are folded into this version rather than the earlier iteration.

## Test plan
- [x] `pytest` full suite for every touched backend/script file — all pass
- [x] `ruff check` — clean
- [x] `bash -n` on both shell scripts — clean
- [x] `yarn typecheck` / `yarn lint` / `yarn knip --files` — clean
- [x] `yarn test:planner` — 358 tests pass
- [x] New regression tests: MV refresh moved out of `nightly_update.sh` and into `run_maintenance.sh`'s nightly task with an unbounded budget; `FacilityTemplate` display-name/prerequisites behavior; ring-rejection filter; `association_status` writer; env.example doc coverage; `apply_ringed_scan_facts` always-empty invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)