### PR TITLE
Expand Dependabot to pip and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,52 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # 2026-08-08: extended from github-actions-only to pip/npm — real
+  # production dependencies (fastapi, pydantic, psycopg2, etc.) for a
+  # service handling live user data, and every Dependabot PR already goes
+  # through the full required-checks CI gauntlet before it can merge, so
+  # the safety net for a bad bump already exists.
+  - package-ecosystem: "pip"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      api-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/apps/eddn"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      eddn-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/apps/importer"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      importer-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Extends `.github/dependabot.yml` from github-actions-only to also cover:
- `pip` for each of `apps/api`, `apps/eddn`, `apps/importer` (independent `requirements.txt` per service)
- `npm` for `frontend` (`yarn.lock`)

Same shape as the existing github-actions entry: weekly, grouped into one PR per ecosystem, 7-day cooldown before proposing a newly-published version.

Real production dependencies (fastapi, pydantic, psycopg2, etc.) for a service handling live user data — worth keeping patched. Every Dependabot PR goes through the full required-checks CI gauntlet (now including Semgrep) before it can merge, so the safety net already exists.

## Test plan
- [x] YAML validated
- [x] Semgrep clean (`p/ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)