### PR TITLE
Bump CI Node from 20 to 22 to support jsdom 30

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,10 +308,10 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - name: Set up Node 20
+      - name: Set up Node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
           cache-dependency-path: frontend/yarn.lock
 
@@ -436,10 +436,10 @@ jobs:
           cache: pip
           cache-dependency-path: apps/api/requirements.txt
 
-      - name: Set up Node 20
+      - name: Set up Node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
           cache-dependency-path: frontend/yarn.lock
 
@@ -541,10 +541,10 @@ jobs:
           cache: pip
           cache-dependency-path: apps/api/requirements.txt
 
-      - name: Set up Node 20
+      - name: Set up Node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
           cache-dependency-path: frontend/yarn.lock
 

--- a/.github/workflows/review-lab.yml
+++ b/.github/workflows/review-lab.yml
@@ -32,10 +32,10 @@ jobs:
           cache: pip
           cache-dependency-path: apps/api/requirements.txt
 
-      - name: Set up Node 20
+      - name: Set up Node 22
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: yarn
           cache-dependency-path: frontend/yarn.lock
 


### PR DESCRIPTION
## Summary
- CI pinned Node 20 in 4 required jobs (`Backend unit tests + compose validate`... actually frontend jobs: Frontend build, OpenAPI types drift check, Frontend v2 E2E, Review Lab).
- Dependabot PR #446 (frontend-dependencies, 37 updates) bumps `jsdom` to 30.0.1, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0` — `yarn install` hard-fails on Node 20 with `error Found incompatible module.`
- Bumps `node-version` from `"20"` to `"22"` in all 4 spots (`ci.yml` x3, `review-lab.yml` x1).

## Test plan
- [ ] All required CI checks pass on this PR
- [ ] Once merged, re-check PR #446 goes green and auto-merges