### PR TITLE
Fix Windows hang in EDDN simulation ingest: add tornado for zmq/Proactor compat

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -19,6 +19,22 @@ defusedxml==0.7.1
 # (logs a warning, sleeps) even when enabled.
 pyzmq==27.1.0
 
+# Windows-only zmq.asyncio compatibility shim (root-caused 2026-08-08).
+# On Windows, asyncio's default ProactorEventLoop doesn't implement the
+# add_reader family pyzmq needs; without tornado, the first zmq socket
+# recv() raises RuntimeError, and because zmq's own Socket._get_loop()
+# marks the loop as registered *before* attempting that registration, the
+# subsequent close() cleanup hits the identical RuntimeError before it can
+# call the real native close — leaking the socket, and a later
+# Context.term() on that leaked socket blocks the entire asyncio event
+# loop indefinitely (verified directly: a concurrent heartbeat coroutine
+# stops being scheduled and never resumes). pyzmq detects tornado
+# automatically at runtime and uses its AddThreadSelectorEventLoop shim
+# instead of raising, with no application code changes needed. A no-op on
+# Linux (production): this code path is only reached when the running
+# loop is an instance of asyncio.ProactorEventLoop, which is Windows-only.
+tornado==6.5.8
+
 # OpenGraph share-card rendering (/api/share/og/{id64}).
 Pillow==12.3.0
 

--- a/tests/test_eddn_simulation_ingest_config.py
+++ b/tests/test_eddn_simulation_ingest_config.py
@@ -33,6 +33,27 @@ def test_pyzmq_is_a_declared_api_dependency():
     assert 'pyzmq==' in requirements
 
 
+def test_tornado_is_a_declared_api_dependency():
+    """Root-caused 2026-08-08: on Windows, asyncio's default ProactorEventLoop
+    doesn't implement add_reader, which pyzmq needs. Without tornado, the
+    first zmq socket recv() raises RuntimeError, and because zmq's own
+    Socket._get_loop() marks the loop as registered *before* attempting that
+    registration, the subsequent close() cleanup hits the identical
+    RuntimeError before it can call the real native close — leaking the
+    socket. A later Context.term() on that leaked socket then blocks the
+    entire asyncio event loop indefinitely (verified directly: a concurrent
+    heartbeat coroutine stops being scheduled and never resumes), taking
+    down request handling for the whole API process, not just this task.
+    pyzmq detects tornado automatically at runtime and uses its
+    AddThreadSelectorEventLoop shim instead of raising — no application code
+    changes needed. A no-op on Linux (production): this path only runs when
+    the event loop is an instance of asyncio.ProactorEventLoop, which is
+    Windows-only."""
+    requirements = (ROOT / 'apps' / 'api' / 'requirements.txt').read_text(encoding='utf-8')
+
+    assert 'tornado==' in requirements
+
+
 def test_config_defaults_the_flag_on():
     config = (ROOT / 'apps' / 'api' / 'src' / 'config.py').read_text(encoding='utf-8')
 


### PR DESCRIPTION
## Summary
- Root-causes and fixes a real bug found while doing manual local-dev verification for #452: the local API becomes completely unresponsive to HTTP requests on Windows shortly after boot, whenever `EDDN_SIMULATION_INGEST_ENABLED` is on (its actual default since #437, 2026-08-07).
- Root cause (confirmed via isolated reproduction, not just inference): on Windows, asyncio's default `ProactorEventLoop` doesn't implement `add_reader`, which pyzmq's `zmq.asyncio` needs. Without `tornado` installed:
  1. The first `socket.recv()` raises `RuntimeError`.
  2. Because `zmq`'s own `Socket._get_loop()` marks the loop as registered *before* attempting that registration, the subsequent `close()` cleanup hits the identical `RuntimeError` — and since that happens *before* the real native close call, the underlying socket is leaked instead of released.
  3. A later `Context.term()` (or the equivalent cleanup during garbage collection) on that leaked socket blocks the **entire asyncio event loop indefinitely** — not just the EDDN task. I proved this directly with a minimal repro script: a concurrent heartbeat coroutine ticking every 0.2s stops being scheduled the instant this happens, and never resumes.
- Fix: add `tornado==6.5.8` as an `apps/api` dependency. pyzmq detects it automatically at runtime and uses its `AddThreadSelectorEventLoop` shim instead of raising — no application code changes needed. This is a no-op on Linux/production: the affected code path only runs when the event loop is an `asyncio.ProactorEventLoop` instance, which only exists on Windows.
- Verified fix directly: re-ran the identical isolated repro with `tornado` installed — all cycles complete cleanly (~0.2-0.4s each instead of hanging forever), heartbeat never stalls. Also verified end-to-end against the real API with `EDDN_SIMULATION_INGEST_ENABLED` left at its actual default (on) — `/api/health` now returns `200 OK` where it previously hung forever.

## Test plan
- [x] Added `test_tornado_is_a_declared_api_dependency` to `tests/test_eddn_simulation_ingest_config.py`, following the existing `test_pyzmq_is_a_declared_api_dependency` pattern in the same file.
- [x] `pytest tests/test_eddn_simulation_ingest_config.py` — 5/5 pass.
- [x] `ruff check tests/test_eddn_simulation_ingest_config.py` — clean.
- [x] Isolated repro (before/after) directly confirms the fix.
- [x] Real local API end-to-end verification (before/after) directly confirms the fix.
- [ ] All required CI checks pass on this PR