### PR TITLE
Add Colonisation event types to journal-import staging allowlist

### DIFF
--- a/apps/api/src/journal_import/api_models.py
+++ b/apps/api/src/journal_import/api_models.py
@@ -11,6 +11,12 @@ _SYNC_KEY_RE = re.compile(r'^[A-Za-z0-9_-]{16,128}$')
 
 _ALLOWED_EVENT_TYPES = {
     'CarrierJump',
+    'ColonisationBeaconDeployed',
+    'ColonisationConstructionDepot',
+    'ColonisationContribution',
+    'ColonisationSystemClaim',
+    'ColonisationSystemClaimRelease',
+    'CompleteConstruction',
     'Docked',
     'FSDJump',
     'FSSAllBodiesFound',

--- a/frontend/src/features/journal-import/journalImportWorker.test.ts
+++ b/frontend/src/features/journal-import/journalImportWorker.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { parseFiles } from './journalImportWorker';
+
+function journalFile(name: string, events: Record<string, unknown>[]): File {
+  const text = events.map((event) => JSON.stringify(event)).join('\n');
+  return new File([text], name, { type: 'text/plain' });
+}
+
+describe('journal import worker: Colonisation event system-context tracking', () => {
+  it('attributes ColonisationSystemClaim/Release to their own SystemAddress', async () => {
+    const file = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'ColonisationSystemClaim',
+        StarSystem: 'Claim System',
+        SystemAddress: 111,
+      },
+      {
+        timestamp: '2026-08-08T10:05:00Z',
+        event: 'ColonisationSystemClaimRelease',
+        StarSystem: 'Claim System',
+        SystemAddress: 111,
+      },
+    ]);
+
+    const result = await parseFiles([file]);
+
+    expect(result.observations).toHaveLength(2);
+    expect(result.observations.map((o) => o.event_type)).toEqual([
+      'ColonisationSystemClaim',
+      'ColonisationSystemClaimRelease',
+    ]);
+    expect(result.observations.every((o) => o.system_id64 === 111 && o.system_name === 'Claim System')).toBe(true);
+  });
+
+  it('attributes context-less Colonisation events to the most recently seen system', async () => {
+    const file = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'FSDJump',
+        StarSystem: 'Colony Prime',
+        SystemAddress: 222,
+      },
+      {
+        timestamp: '2026-08-08T10:10:00Z',
+        event: 'ColonisationBeaconDeployed',
+      },
+      {
+        timestamp: '2026-08-08T10:15:00Z',
+        event: 'ColonisationConstructionDepot',
+        MarketID: 999,
+        ConstructionProgress: 0.5,
+        ConstructionComplete: false,
+        ConstructionFailed: false,
+        ResourcesRequired: [
+          { Name: 'steel', Name_Localised: 'Steel', RequiredAmount: 100, ProvidedAmount: 50, Payment: 0 },
+        ],
+      },
+      {
+        timestamp: '2026-08-08T10:20:00Z',
+        event: 'ColonisationContribution',
+        MarketID: 999,
+        Contributions: [{ Name: 'steel', Name_Localised: 'Steel', Amount: 25 }],
+      },
+      {
+        timestamp: '2026-08-08T10:30:00Z',
+        event: 'CompleteConstruction',
+      },
+    ]);
+
+    const result = await parseFiles([file]);
+
+    expect(result.observations).toHaveLength(5);
+    for (const observation of result.observations) {
+      expect(observation.system_id64).toBe(222);
+      expect(observation.system_name).toBe('Colony Prime');
+    }
+
+    const depot = result.observations.find((o) => o.event_type === 'ColonisationConstructionDepot');
+    expect(depot?.payload).toEqual({
+      MarketID: 999,
+      ConstructionProgress: 0.5,
+      ConstructionComplete: false,
+      ConstructionFailed: false,
+      ResourcesRequired: [
+        { Name: 'steel', Name_Localised: 'Steel', RequiredAmount: 100, ProvidedAmount: 50, Payment: 0 },
+      ],
+    });
+
+    const contribution = result.observations.find((o) => o.event_type === 'ColonisationContribution');
+    expect(contribution?.payload).toEqual({
+      MarketID: 999,
+      Contributions: [{ Name: 'steel', Name_Localised: 'Steel', Amount: 25 }],
+    });
+  });
+
+  it('carries system context across rotated journal files, not just within one file', async () => {
+    const firstFile = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'FSDJump',
+        StarSystem: 'Colony Prime',
+        SystemAddress: 222,
+      },
+    ]);
+    const secondFile = journalFile('Journal.02.log', [
+      {
+        timestamp: '2026-08-08T11:00:00Z',
+        event: 'CompleteConstruction',
+      },
+    ]);
+
+    const result = await parseFiles([firstFile, secondFile]);
+
+    const completion = result.observations.find((o) => o.event_type === 'CompleteConstruction');
+    expect(completion?.system_id64).toBe(222);
+    expect(completion?.system_name).toBe('Colony Prime');
+  });
+
+  it('drops a context-less Colonisation event that appears before any system context is known', async () => {
+    const file = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'ColonisationBeaconDeployed',
+      },
+    ]);
+
+    const result = await parseFiles([file]);
+
+    expect(result.observations).toHaveLength(0);
+    expect(result.preview.skipped_lines).toBe(1);
+  });
+});

--- a/frontend/src/features/journal-import/journalImportWorker.test.ts
+++ b/frontend/src/features/journal-import/journalImportWorker.test.ts
@@ -94,7 +94,7 @@ describe('journal import worker: Colonisation event system-context tracking', ()
     });
   });
 
-  it('carries system context across rotated journal files, not just within one file', async () => {
+  it('carries system context across rotated journal files within the same session', async () => {
     const firstFile = journalFile('Journal.01.log', [
       {
         timestamp: '2026-08-08T10:00:00Z',
@@ -103,9 +103,11 @@ describe('journal import worker: Colonisation event system-context tracking', ()
         SystemAddress: 222,
       },
     ]);
+    // 5 minutes later, well inside SESSION_GAP_RESET_MS -- a real file
+    // rotation, not a new session.
     const secondFile = journalFile('Journal.02.log', [
       {
-        timestamp: '2026-08-08T11:00:00Z',
+        timestamp: '2026-08-08T10:05:00Z',
         event: 'CompleteConstruction',
       },
     ]);
@@ -129,5 +131,105 @@ describe('journal import worker: Colonisation event system-context tracking', ()
 
     expect(result.observations).toHaveLength(0);
     expect(result.preview.skipped_lines).toBe(1);
+  });
+
+  it('resets tracked context across a large timestamp gap instead of misattributing to a stale system', async () => {
+    const file = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'FSDJump',
+        StarSystem: 'Old Session System',
+        SystemAddress: 111,
+      },
+      // 90 minutes later -- past SESSION_GAP_RESET_MS (30 min), a different
+      // play session's worth of files selected together.
+      {
+        timestamp: '2026-08-08T11:30:00Z',
+        event: 'CompleteConstruction',
+      },
+    ]);
+
+    const result = await parseFiles([file]);
+
+    expect(result.observations.map((o) => o.event_type)).toEqual(['FSDJump']);
+    expect(result.preview.skipped_lines).toBe(1);
+  });
+
+  it('does not fall back to stale context for an ordinarily self-contained event with a missing address', async () => {
+    const file = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'FSDJump',
+        StarSystem: 'Colony Prime',
+        SystemAddress: 222,
+      },
+      // Docked normally carries its own SystemAddress; this one is missing
+      // it (malformed/older record) and must be dropped, not silently
+      // attributed to the previous FSDJump's system.
+      {
+        timestamp: '2026-08-08T10:05:00Z',
+        event: 'Docked',
+        StationName: 'Some Station',
+      },
+    ]);
+
+    const result = await parseFiles([file]);
+
+    expect(result.observations.map((o) => o.event_type)).toEqual(['FSDJump']);
+    expect(result.preview.skipped_lines).toBe(1);
+  });
+
+  it('tracks context from a non-allowlisted event type that still carries a system address', async () => {
+    const file = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'FSDJump',
+        StarSystem: 'Colony Prime',
+        SystemAddress: 222,
+      },
+      // Not in ALLOWED_EVENT_TYPES, never staged as its own observation --
+      // but it carries a newer system address that should still update the
+      // tracked context for the context-less event after it.
+      {
+        timestamp: '2026-08-08T10:05:00Z',
+        event: 'SupercruiseExit',
+        StarSystem: 'Second System',
+        SystemAddress: 333,
+      },
+      {
+        timestamp: '2026-08-08T10:10:00Z',
+        event: 'CompleteConstruction',
+      },
+    ]);
+
+    const result = await parseFiles([file]);
+
+    const completion = result.observations.find((o) => o.event_type === 'CompleteConstruction');
+    expect(completion?.system_id64).toBe(333);
+    expect(completion?.system_name).toBe('Second System');
+  });
+
+  it('sorts files chronologically by name before processing, regardless of selection order', async () => {
+    const earlierFile = journalFile('Journal.01.log', [
+      {
+        timestamp: '2026-08-08T10:00:00Z',
+        event: 'FSDJump',
+        StarSystem: 'Colony Prime',
+        SystemAddress: 222,
+      },
+    ]);
+    const laterFile = journalFile('Journal.02.log', [
+      {
+        timestamp: '2026-08-08T10:05:00Z',
+        event: 'CompleteConstruction',
+      },
+    ]);
+
+    // Passed out of order (later file first) -- the worker must still sort
+    // by filename before tracking context sequentially.
+    const result = await parseFiles([laterFile, earlierFile]);
+
+    const completion = result.observations.find((o) => o.event_type === 'CompleteConstruction');
+    expect(completion?.system_id64).toBe(222);
   });
 });

--- a/frontend/src/features/journal-import/journalImportWorker.ts
+++ b/frontend/src/features/journal-import/journalImportWorker.ts
@@ -20,6 +20,12 @@ type ParseFailure = {
 
 const ALLOWED_EVENT_TYPES = new Set<JournalImportObservationInput['event_type']>([
   'CarrierJump',
+  'ColonisationBeaconDeployed',
+  'ColonisationConstructionDepot',
+  'ColonisationContribution',
+  'ColonisationSystemClaim',
+  'ColonisationSystemClaimRelease',
+  'CompleteConstruction',
   'Docked',
   'FSDJump',
   'FSSAllBodiesFound',
@@ -76,6 +82,18 @@ function summaryForEvent(eventType: JournalImportObservationInput['event_type'],
       return `Body signals observed for ${typeof raw.BodyName === 'string' ? raw.BodyName : 'a body'}.`;
     case 'SAASignalsFound':
       return `Surface signals observed for ${typeof raw.BodyName === 'string' ? raw.BodyName : 'a body'}.`;
+    case 'ColonisationSystemClaim':
+      return 'Colonisation claim filed for the system.';
+    case 'ColonisationSystemClaimRelease':
+      return 'Colonisation claim released for the system.';
+    case 'ColonisationConstructionDepot':
+      return 'Construction depot progress observed from local journal.';
+    case 'ColonisationContribution':
+      return 'Contribution to a colonisation construction depot observed.';
+    case 'ColonisationBeaconDeployed':
+      return 'Colonisation beacon deployed.';
+    case 'CompleteConstruction':
+      return 'Colonisation construction completed.';
   }
 }
 
@@ -133,6 +151,32 @@ function payloadForEvent(eventType: JournalImportObservationInput['event_type'],
         Signals: raw.Signals,
         Genuses: raw.Genuses,
       });
+    case 'ColonisationSystemClaim':
+    case 'ColonisationSystemClaimRelease':
+      return pickDefined({
+        StarSystem: raw.StarSystem,
+        SystemAddress: asPositiveInt(raw.SystemAddress),
+      });
+    case 'ColonisationConstructionDepot':
+      return pickDefined({
+        MarketID: asPositiveInt(raw.MarketID),
+        ConstructionProgress: raw.ConstructionProgress,
+        ConstructionComplete: raw.ConstructionComplete,
+        ConstructionFailed: raw.ConstructionFailed,
+        ResourcesRequired: Array.isArray(raw.ResourcesRequired) ? raw.ResourcesRequired : undefined,
+      });
+    case 'ColonisationContribution':
+      return pickDefined({
+        MarketID: asPositiveInt(raw.MarketID),
+        Contributions: Array.isArray(raw.Contributions) ? raw.Contributions : undefined,
+      });
+    // These two events carry only { timestamp, event } per Frontier's
+    // journal schema -- no market, system, or body fields at all. Their
+    // system context comes entirely from trackSystemContext's fallback in
+    // normaliseObservation below.
+    case 'ColonisationBeaconDeployed':
+    case 'CompleteConstruction':
+      return {};
   }
 }
 
@@ -150,16 +194,40 @@ async function sha256Hex(value: string): Promise<string> {
   return `fallback-${(hash >>> 0).toString(16).padStart(8, '0')}`;
 }
 
+type SystemContext = { systemId64: number; systemName: string | null };
+
+// ColonisationConstructionDepot, ColonisationContribution,
+// ColonisationBeaconDeployed, and CompleteConstruction carry no
+// StarSystem/SystemAddress of their own (verified against Frontier's
+// journal schema) -- only MarketID, or nothing at all. Elite Dangerous
+// journals are a strictly sequential per-session event stream, so these
+// events always follow an earlier event in the same file (or an earlier
+// file from the same session) that did carry system context. Track the
+// most recently seen one and fall back to it.
+function extractSystemContext(raw: Record<string, unknown>): SystemContext | null {
+  const systemId64 = asPositiveInt(raw.SystemAddress);
+  if (systemId64 == null) return null;
+  return {
+    systemId64,
+    systemName: typeof raw.StarSystem === 'string' ? raw.StarSystem : null,
+  };
+}
+
 async function normaliseObservation(
   raw: Record<string, unknown>,
   sourceFile: string,
+  systemContext: { current: SystemContext | null },
 ): Promise<JournalImportObservationInput | null> {
   const eventType = typeof raw.event === 'string' ? raw.event : null;
   if (!eventType || !ALLOWED_EVENT_TYPES.has(eventType as JournalImportObservationInput['event_type'])) {
     return null;
   }
-  const systemId64 = asPositiveInt(raw.SystemAddress);
-  if (systemId64 == null) return null;
+
+  const ownContext = extractSystemContext(raw);
+  if (ownContext) systemContext.current = ownContext;
+  const resolvedContext = ownContext ?? systemContext.current;
+  if (!resolvedContext) return null;
+  const systemId64 = resolvedContext.systemId64;
 
   const subjectType: JournalImportObservationInput['subject_type'] =
     eventType === 'Scan' || eventType === 'FSSBodySignals' || eventType === 'SAASignalsFound'
@@ -184,7 +252,7 @@ async function normaliseObservation(
     event_type: eventType as JournalImportObservationInput['event_type'],
     observed_at: typeof raw.timestamp === 'string' ? raw.timestamp : null,
     system_id64: systemId64,
-    system_name: typeof raw.StarSystem === 'string' ? raw.StarSystem : null,
+    system_name: resolvedContext.systemName,
     subject_type: subjectType,
     subject_id: subjectId,
     summary,
@@ -193,13 +261,17 @@ async function normaliseObservation(
   };
 }
 
-async function parseFiles(files: File[]): Promise<JournalImportParseResult> {
+export async function parseFiles(files: File[]): Promise<JournalImportParseResult> {
   const observations: JournalImportObservationInput[] = [];
   const seenKeys = new Set<string>();
   const eventCounts: Record<string, number> = {};
   const manifestFiles: Array<{ name: string; event_count: number }> = [];
   let linesRead = 0;
   let skippedLines = 0;
+  // Carried across files, not reset per file: a session can span multiple
+  // rotated journal files without a fresh Location event at the start of
+  // the next one.
+  const systemContext: { current: SystemContext | null } = { current: null };
 
   for (const file of files) {
     const text = await file.text();
@@ -216,7 +288,7 @@ async function parseFiles(files: File[]): Promise<JournalImportParseResult> {
         skippedLines += 1;
         continue;
       }
-      const observation = await normaliseObservation(raw, file.name);
+      const observation = await normaliseObservation(raw, file.name, systemContext);
       if (!observation) {
         skippedLines += 1;
         continue;

--- a/frontend/src/features/journal-import/journalImportWorker.ts
+++ b/frontend/src/features/journal-import/journalImportWorker.ts
@@ -194,17 +194,32 @@ async function sha256Hex(value: string): Promise<string> {
   return `fallback-${(hash >>> 0).toString(16).padStart(8, '0')}`;
 }
 
-type SystemContext = { systemId64: number; systemName: string | null };
+type SystemContext = { systemId64: number; systemName: string | null; lastSeenAtMs: number | null };
 
 // ColonisationConstructionDepot, ColonisationContribution,
 // ColonisationBeaconDeployed, and CompleteConstruction carry no
 // StarSystem/SystemAddress of their own (verified against Frontier's
-// journal schema) -- only MarketID, or nothing at all. Elite Dangerous
-// journals are a strictly sequential per-session event stream, so these
-// events always follow an earlier event in the same file (or an earlier
-// file from the same session) that did carry system context. Track the
-// most recently seen one and fall back to it.
-function extractSystemContext(raw: Record<string, unknown>): SystemContext | null {
+// journal schema) -- only MarketID, or nothing at all. Every other
+// allowlisted event type (including ColonisationSystemClaim/Release) does
+// carry its own SystemAddress and must keep using it directly -- the
+// carried-context fallback below is deliberately scoped to only these four,
+// so a malformed/older event of a normally-self-contained type is still
+// dropped rather than silently misattributed to a stale system.
+const CONTEXT_LESS_EVENT_TYPES = new Set<JournalImportObservationInput['event_type']>([
+  'ColonisationBeaconDeployed',
+  'ColonisationConstructionDepot',
+  'ColonisationContribution',
+  'CompleteConstruction',
+]);
+
+// A gap this large between the last tracked system-bearing event and the
+// current one means the selected files most likely span more than one play
+// session (a different day, a different commander, files picked out of
+// order) -- carrying context across that boundary risks silently attributing
+// a context-less event to the wrong system entirely.
+const SESSION_GAP_RESET_MS = 30 * 60 * 1000;
+
+function extractSystemContext(raw: Record<string, unknown>): { systemId64: number; systemName: string | null } | null {
   const systemId64 = asPositiveInt(raw.SystemAddress);
   if (systemId64 == null) return null;
   return {
@@ -213,19 +228,41 @@ function extractSystemContext(raw: Record<string, unknown>): SystemContext | nul
   };
 }
 
+function eventTimestampMs(raw: Record<string, unknown>): number | null {
+  if (typeof raw.timestamp !== 'string') return null;
+  const ms = Date.parse(raw.timestamp);
+  return Number.isFinite(ms) ? ms : null;
+}
+
 async function normaliseObservation(
   raw: Record<string, unknown>,
   sourceFile: string,
   systemContext: { current: SystemContext | null },
 ): Promise<JournalImportObservationInput | null> {
+  const eventTimeMs = eventTimestampMs(raw);
+
+  if (
+    systemContext.current?.lastSeenAtMs != null
+    && eventTimeMs != null
+    && eventTimeMs - systemContext.current.lastSeenAtMs > SESSION_GAP_RESET_MS
+  ) {
+    systemContext.current = null;
+  }
+
+  // Extracted from *every* parsed event, not only allowlisted/staged ones --
+  // an intermediate event type this worker never stages (e.g.
+  // SupercruiseExit) can still be the most recent true system context for a
+  // later context-less Colonisation event.
+  const ownContext = extractSystemContext(raw);
+  if (ownContext) systemContext.current = { ...ownContext, lastSeenAtMs: eventTimeMs };
+
   const eventType = typeof raw.event === 'string' ? raw.event : null;
   if (!eventType || !ALLOWED_EVENT_TYPES.has(eventType as JournalImportObservationInput['event_type'])) {
     return null;
   }
 
-  const ownContext = extractSystemContext(raw);
-  if (ownContext) systemContext.current = ownContext;
-  const resolvedContext = ownContext ?? systemContext.current;
+  const isContextLess = CONTEXT_LESS_EVENT_TYPES.has(eventType as JournalImportObservationInput['event_type']);
+  const resolvedContext = isContextLess ? (ownContext ?? systemContext.current) : ownContext;
   if (!resolvedContext) return null;
   const systemId64 = resolvedContext.systemId64;
 
@@ -268,12 +305,19 @@ export async function parseFiles(files: File[]): Promise<JournalImportParseResul
   const manifestFiles: Array<{ name: string; event_count: number }> = [];
   let linesRead = 0;
   let skippedLines = 0;
-  // Carried across files, not reset per file: a session can span multiple
-  // rotated journal files without a fresh Location event at the start of
-  // the next one.
+  // System context is carried across files, not reset per file: a session
+  // can span multiple rotated journal files without a fresh Location event
+  // at the start of the next one. That carry-over is only safe if files are
+  // processed in chronological order -- Elite Dangerous journal filenames
+  // (Journal.<timestamp>.NN.log) sort lexicographically in timestamp order,
+  // so sort explicitly rather than trust the order the UI happened to hand
+  // over (e.g. a browser file picker's multi-select order is unspecified).
+  // SESSION_GAP_RESET_MS above still resets context on a large timestamp
+  // gap even within this sorted order, covering a genuinely missing file.
+  const sortedFiles = [...files].sort((a, b) => a.name.localeCompare(b.name));
   const systemContext: { current: SystemContext | null } = { current: null };
 
-  for (const file of files) {
+  for (const file of sortedFiles) {
     const text = await file.text();
     const lines = text.split(/\r?\n/);
     let fileEventCount = 0;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -95,7 +95,7 @@ export interface JournalImportClientManifest {
 export interface JournalImportObservationInput {
   observation_key: string;
   source_file: string;
-  event_type: 'CarrierJump' | 'Docked' | 'FSDJump' | 'FSSAllBodiesFound' | 'FSSBodySignals' | 'FSSDiscoveryScan' | 'Location' | 'SAASignalsFound' | 'Scan';
+  event_type: 'CarrierJump' | 'ColonisationBeaconDeployed' | 'ColonisationConstructionDepot' | 'ColonisationContribution' | 'ColonisationSystemClaim' | 'ColonisationSystemClaimRelease' | 'CompleteConstruction' | 'Docked' | 'FSDJump' | 'FSSAllBodiesFound' | 'FSSBodySignals' | 'FSSDiscoveryScan' | 'Location' | 'SAASignalsFound' | 'Scan';
   observed_at?: string | null;
   system_id64: number;
   system_name?: string | null;

--- a/tests/test_journal_import.py
+++ b/tests/test_journal_import.py
@@ -288,6 +288,46 @@ def test_journal_import_request_normalizes_observed_at_to_utc_datetime():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize('event_type', [
+    'ColonisationBeaconDeployed',
+    'ColonisationConstructionDepot',
+    'ColonisationContribution',
+    'ColonisationSystemClaim',
+    'ColonisationSystemClaimRelease',
+    'CompleteConstruction',
+])
+def test_journal_import_request_accepts_colonisation_event_types(event_type: str):
+    """The client-side worker's ALLOWED_EVENT_TYPES
+    (frontend/src/features/journal-import/journalImportWorker.ts) and this
+    backend validator are two independent allowlists for the same set of
+    event types -- staging a journal containing one of these events only
+    actually works end-to-end if both agree. Regression for the frontend-only
+    half of this fix silently 422'ing every Colonisation event it staged."""
+    request = JournalImportRequest.model_validate({
+        'sync_key': 'sync-key-1234567890',
+        'client_manifest': {
+            'parser_version': 'journal-import-worker-v1',
+            'files': [],
+        },
+        'observations': [
+            {
+                'observation_key': '0123456789abcdef0123456789abcdef',
+                'source_file': 'Journal.demo.log',
+                'event_type': event_type,
+                'observed_at': '2026-07-08T18:00:00Z',
+                'system_id64': 123,
+                'subject_type': 'system',
+                'subject_id': None,
+                'payload': {},
+                'privacy_boundary': {},
+            },
+        ],
+    })
+
+    assert request.observations[0].event_type == event_type
+
+
+@pytest.mark.unit
 def test_journal_import_migration_is_manifested_and_bounded():
     sql = SQL_PATH.read_text(encoding='utf-8')
     manifest = MANIFEST_PATH.read_text(encoding='utf-8')


### PR DESCRIPTION
## Summary
Recovered from a stale local `git stash` (uncommitted WIP on a since-abandoned `docs/july-15-reports` branch) found while cleaning up the stash stack, and completed properly rather than landed as-is.

- The original stash only added 6 Colonisation event type names to both the frontend worker's and backend Pydantic validator's allowlists, without handling their actual journal field shape.
- Verified the real Frontier journal schema for all 6 event types before writing any extraction code (schemas.edomh.nl), rather than guessing field names:
  - `ColonisationSystemClaim` / `ColonisationSystemClaimRelease`: carry `StarSystem` + `SystemAddress` directly.
  - `ColonisationConstructionDepot`: `MarketID`, `ConstructionProgress`, `ConstructionComplete`, `ConstructionFailed`, `ResourcesRequired[]` — no system fields at all.
  - `ColonisationContribution`: `MarketID`, `Contributions[]` — also no system fields.
  - `ColonisationBeaconDeployed` / `CompleteConstruction`: only `{ timestamp, event }`.
- **4 of the 6 event types carry no system context of their own.** The worker previously required every event to carry its own `SystemAddress`, which would have silently dropped all four forever — the allowlist entries alone would have done nothing. Added system-context tracking across the sequential journal stream (carried across rotated files, not reset per file) so a context-less event is attributed to the most recently seen system-bearing event.
- Backend and frontend allowlists are two independent checks for the same event-type set; both needed updating for this to actually work end-to-end.
- Exported `parseFiles` from the previously fully-private worker module to make this properly testable.

## Test plan
- [x] New backend test: `test_journal_import_request_accepts_colonisation_event_types` (parametrized over all 6 event types) — verified RED before the backend allowlist fix, GREEN after.
- [x] New frontend test suite (`journalImportWorker.test.ts`, 4 tests): system-context attribution for events with/without their own `SystemAddress`, cross-file context carry-over, and correct drop behavior when no context is available yet — all verified RED before the worker fix, GREEN after.
- [x] `yarn typecheck`, `yarn lint`, `yarn build` all pass.
- [x] `pytest tests/test_journal_import.py` (14/14) and `ruff check` pass.
- [ ] All required CI checks pass on this PR