### PR TITLE
fix: scope nightly rating_dirty check to has_body_data, run no-body cleanup

### DIFF
--- a/scripts/nightly_update.sh
+++ b/scripts/nightly_update.sh
@@ -394,9 +394,27 @@ run_importer "import_stations" import_spansh.py --file galaxy_stations.json.gz \
 
 # ---------------------------------------------------------------------------
 # 3. Re-rate dirty systems
+#
+# rating_dirty=TRUE systems split into two populations that need different
+# handling: has_body_data=TRUE systems get a real rating from
+# build_ratings.py --dirty, but has_body_data=FALSE systems have nothing to
+# rate and build_ratings.py --dirty never touches them — they only clear
+# truthfully via reconcile_no_body_ratings.py (see
+# run_dirty_ratings_if_needed.sh, which already does both steps in this
+# order). Without the no-body cleanup, and with the dirty-count check
+# unfiltered by has_body_data, this step reported "incomplete" every single
+# night regardless of whether the actual rateable backlog was cleared,
+# because a normal, continuously-regenerating no-body population can never
+# satisfy a bare `rating_dirty = TRUE` count going to zero.
 # ---------------------------------------------------------------------------
 log "--- Step 3: Re-rate dirty systems ---"
-pg_count_into DIRTY_COUNT "SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE"
+log "Running truthful no-body cleanup ..."
+run_importer "reconcile_no_body_ratings" /opt/ed-finder/scripts/reconcile_no_body_ratings.py \
+    --apply --batch-size 5000 --limit 50000 --skip-summary --json \
+    && success "No-body ratings reconciled" \
+    || warn "No-body reconciliation had errors (check ${LOG_DIR}/reconcile_no_body_ratings.log)"
+
+pg_count_into DIRTY_COUNT "SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE AND has_body_data = TRUE"
 log "Dirty systems to re-rate: $DIRTY_COUNT"
 
 if (( DIRTY_COUNT > 0 )); then
@@ -406,11 +424,11 @@ if (( DIRTY_COUNT > 0 )); then
         || warn "Rating rebuild had errors (check ${LOG_DIR}/build_ratings.log)"
 
     # Post-rebuild verification: how many are still dirty?
-    pg_count_into STILL_DIRTY "SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE"
+    pg_count_into STILL_DIRTY "SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE AND has_body_data = TRUE"
     if (( STILL_DIRTY > 0 )); then
-        warn "Rating rebuild incomplete: $STILL_DIRTY systems still have rating_dirty=TRUE"
+        warn "Rating rebuild incomplete: $STILL_DIRTY systems still have rating_dirty=TRUE AND has_body_data=TRUE"
     else
-        success "All rating_dirty flags cleared"
+        success "All body-backed rating_dirty flags cleared"
     fi
 fi
 

--- a/tests/test_rating_dirty_eligibility.py
+++ b/tests/test_rating_dirty_eligibility.py
@@ -1,0 +1,70 @@
+"""Regression test for the nightly rating_dirty verification bug (2026-08-09).
+
+nightly_update.sh Step 3 counted `rating_dirty = TRUE` with no
+`has_body_data` filter, both before and after running
+`build_ratings.py --dirty`. `build_ratings.py --dirty` only ever rates
+has_body_data=TRUE candidates - a has_body_data=FALSE system can never
+satisfy that count going to zero, and no-body dirty rows are a normal,
+continuously-regenerating byproduct of ingest. The unscoped check
+therefore reported "Rating rebuild incomplete" every single night
+(confirmed in /data/logs/nightly.log for at least six consecutive
+nights, 2026-08-04 through 2026-08-09) regardless of whether the real,
+rateable backlog was actually cleared.
+
+The already-working `run_dirty_ratings_if_needed.sh` (the 30-minute
+cron) solves this correctly: it runs `reconcile_no_body_ratings.py`
+first to truthfully clear the no-body population, then scopes its own
+dirty count to `rating_dirty = TRUE AND has_body_data = TRUE`. This is
+also the same class of bug already fixed once before for the sibling
+`cluster_dirty` query - see test_cluster_dirty_eligibility.py - but Step
+3's rating_dirty check was never brought in line.
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NIGHTLY_UPDATE_PATH = ROOT / 'scripts' / 'nightly_update.sh'
+WORKING_SCRIPT_PATH = ROOT / 'scripts' / 'run_dirty_ratings_if_needed.sh'
+
+
+def test_nightly_step3_runs_no_body_reconciliation_before_rebuild():
+    source = NIGHTLY_UPDATE_PATH.read_text(encoding='utf-8')
+
+    assert 'reconcile_no_body_ratings.py' in source
+    assert '--apply' in source
+
+
+def test_nightly_step3_dirty_counts_are_scoped_to_has_body_data():
+    source = NIGHTLY_UPDATE_PATH.read_text(encoding='utf-8')
+
+    assert (
+        'pg_count_into DIRTY_COUNT '
+        '"SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE AND has_body_data = TRUE"'
+        in source
+    )
+    assert (
+        'pg_count_into STILL_DIRTY '
+        '"SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE AND has_body_data = TRUE"'
+        in source
+    )
+    # The old unscoped queries must not still be present anywhere in Step 3.
+    assert 'SELECT COUNT(*) FROM systems WHERE rating_dirty = TRUE"' not in source
+
+
+def test_nightly_reconcile_invocation_uses_the_repo_mounted_script_path():
+    source = NIGHTLY_UPDATE_PATH.read_text(encoding='utf-8')
+
+    # build_ratings.py lives baked into the importer image at /app/; the
+    # no-body reconcile script is repo-mounted at /opt/ed-finder/scripts/
+    # (see docker-compose.yml's importer volumes) - using the wrong path
+    # here would silently fail with "No such file".
+    assert '/opt/ed-finder/scripts/reconcile_no_body_ratings.py' in source
+
+
+def test_nightly_reconcile_invocation_matches_the_working_scripts_flags():
+    nightly_source = NIGHTLY_UPDATE_PATH.read_text(encoding='utf-8')
+    working_source = WORKING_SCRIPT_PATH.read_text(encoding='utf-8')
+
+    for flag in ('--apply', '--batch-size', '--limit', '--skip-summary', '--json'):
+        assert flag in nightly_source, f'nightly_update.sh missing {flag}'
+        assert flag in working_source, f'run_dirty_ratings_if_needed.sh missing {flag}'


### PR DESCRIPTION
## Summary
- Root-caused via production log/DB investigation (read-only: nightly.log history, dirty-ratings.log, and a live DB query): `nightly_update.sh` Step 3's "Rating rebuild incomplete" warning + "sent-fail" heartbeat has fired **every single night for at least 6 consecutive nights** (2026-08-04 through 2026-08-09).
- Root cause: Step 3's dirty-count check queried `rating_dirty = TRUE` with no `has_body_data` filter. `build_ratings.py --dirty` only ever rates `has_body_data=TRUE` candidates, so a `has_body_data=FALSE` system can never satisfy that count going to zero — and no-body dirty rows are a normal, continuously-regenerating byproduct of ingest, not an actual backlog. Verified live: at a healthy moment (30-min cron freshly cleared everything it could), the no-body dirty population (54) was *larger* than the with-body one (34) — a persistent floor, not something the rebuild step was ever going to zero out.
- The already-working `run_dirty_ratings_if_needed.sh` (30-min cron) already solves this correctly: `reconcile_no_body_ratings.py` first, then scope the count to `has_body_data=TRUE`. This fix mirrors that exact pattern in Step 3.
- Same class of bug already fixed once before for the sibling `cluster_dirty` query (`test_cluster_dirty_eligibility.py`) — this query was just never brought in line.

## Test plan
- [x] New regression test (`tests/test_rating_dirty_eligibility.py`) verified RED against the pre-fix script content, GREEN after the fix
- [x] All existing nightly-update-related tests still pass (`test_cluster_dirty_eligibility.py`, `test_nightly_update_heartbeat.py`, `test_admin_cron_status.py`, `test_ci_stall_detection.py`) — 28 passed, 2 pre-existing skips unrelated to this change
- [x] `bash -n` syntax check clean
- [x] Verified the `reconcile_no_body_ratings.py` invocation's flags against its real argparse definition, and its repo-mounted path (`/opt/ed-finder/scripts/...`, not the importer image's `/app/`) against `docker-compose.yml`'s importer volume mounts
- [ ] CI green on this PR

**Not yet done:** this only fixes the script in the repo. Production's `/opt/ed-finder` checkout needs the normal update step to pick this up before it affects tonight's cron run — flagging that as the next step after merge, not doing it as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)