### PR TITLE
ops: add log rotation for /data/logs on production

### DIFF
--- a/config/ed-finder.logrotate
+++ b/config/ed-finder.logrotate
@@ -1,0 +1,19 @@
+# Rotation for /data/logs/*.log on the production host. Nothing rotated
+# these before (import.log reached 4.7G, nightly.log 673M, unbounded) and
+# contributed to disk staying pinned near the 80% disk-watchdog threshold.
+# copytruncate is required, not optional: several of these logs are held
+# open continuously by long-running containers (eddn.log) or written by
+# cron-invoked scripts with no signal-based reopen support, so a plain
+# rename-and-recreate rotation would leave those writers appending to a
+# file no longer visible under its original name.
+#
+# Install: symlink or copy to /etc/logrotate.d/ed-finder on the host.
+/data/logs/*.log {
+    daily
+    rotate 3
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/tests/test_ed_finder_logrotate_config.py
+++ b/tests/test_ed_finder_logrotate_config.py
@@ -7,12 +7,29 @@ the right path, and it uses copytruncate (required because several of
 these logs are held open continuously by long-running containers or
 written by cron-invoked scripts with no signal-based reopen support - a
 plain rename-based rotation would silently orphan those writers).
+
+Directive checks run against _active_directive_lines(), not the raw file
+text: the file's own explanatory comments mention "copytruncate" and
+other directive words too, so a plain substring search over the whole
+file would still pass even if the real directive line were deleted or
+misspelled (Codex Review finding, 2026-08-09).
 """
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 LOGROTATE_CONFIG_PATH = ROOT / 'config' / 'ed-finder.logrotate'
+
+
+def _active_directive_lines() -> list[str]:
+    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
+    lines = []
+    for raw_line in source.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        lines.append(stripped)
+    return lines
 
 
 def test_logrotate_config_exists():
@@ -22,20 +39,18 @@ def test_logrotate_config_exists():
 
 
 def test_logrotate_config_targets_the_right_path():
-    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
-    assert '/data/logs/*.log {' in source
+    assert '/data/logs/*.log {' in _active_directive_lines()
 
 
 def test_logrotate_config_uses_copytruncate():
-    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
     # Required, not optional - see module docstring. A plain rotation
     # (rename + recreate) would leave continuously-open writers (e.g. the
     # EDDN listener container) appending to a file no longer visible
     # under its original name.
-    assert 'copytruncate' in source
+    assert 'copytruncate' in _active_directive_lines()
 
 
 def test_logrotate_config_keeps_only_a_few_days():
-    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
-    assert 'daily' in source
-    assert 'rotate 3' in source
+    active_lines = _active_directive_lines()
+    assert 'daily' in active_lines
+    assert 'rotate 3' in active_lines

--- a/tests/test_ed_finder_logrotate_config.py
+++ b/tests/test_ed_finder_logrotate_config.py
@@ -1,0 +1,41 @@
+"""Regression test for the production log-rotation config (2026-08-09).
+
+/data/logs/*.log had no rotation at all: import.log reached 4.7G and
+nightly.log reached 673M on an already-89%-full disk. This locks in the
+config's presence and its two safety-critical properties: it targets
+the right path, and it uses copytruncate (required because several of
+these logs are held open continuously by long-running containers or
+written by cron-invoked scripts with no signal-based reopen support - a
+plain rename-based rotation would silently orphan those writers).
+"""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOGROTATE_CONFIG_PATH = ROOT / 'config' / 'ed-finder.logrotate'
+
+
+def test_logrotate_config_exists():
+    assert LOGROTATE_CONFIG_PATH.is_file(), (
+        f'{LOGROTATE_CONFIG_PATH} is missing - production log rotation depends on it.'
+    )
+
+
+def test_logrotate_config_targets_the_right_path():
+    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
+    assert '/data/logs/*.log {' in source
+
+
+def test_logrotate_config_uses_copytruncate():
+    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
+    # Required, not optional - see module docstring. A plain rotation
+    # (rename + recreate) would leave continuously-open writers (e.g. the
+    # EDDN listener container) appending to a file no longer visible
+    # under its original name.
+    assert 'copytruncate' in source
+
+
+def test_logrotate_config_keeps_only_a_few_days():
+    source = LOGROTATE_CONFIG_PATH.read_text(encoding='utf-8')
+    assert 'daily' in source
+    assert 'rotate 3' in source


### PR DESCRIPTION
## Summary
- Discovered while investigating production disk usage (89% full): `/data/logs/*.log` had no rotation at all. `import.log` had grown to 4.7G, `nightly.log` to 673M.
- Adds `config/ed-finder.logrotate`: daily rotation, keep 3 rotated copies (a few days of history), compressed, `copytruncate` (required since several of these logs are held open continuously by long-running containers like the EDDN listener, or written by cron-invoked scripts with no signal-based reopen support).
- `logrotate` and its daily cron trigger are already present on the host (`/etc/cron.daily/logrotate`) — this just needs the config dropped into `/etc/logrotate.d/ed-finder` to take effect.

## Test plan
- [x] New regression test (`tests/test_ed_finder_logrotate_config.py`) verifies the config exists, targets the right path, uses `copytruncate`, and keeps only a few days
- [ ] CI green on this PR
- [ ] Deploy config to production after merge (separate step, not done as part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)