### PR TITLE
feat(db): retire dead ratings.score_breakdown column (migration 043)

### DIFF
--- a/scripts/dev/review_environment_seed.py
+++ b/scripts/dev/review_environment_seed.py
@@ -393,7 +393,6 @@ async def _upsert_ratings(conn: asyncpg.Connection) -> None:
                 rating['signal_quality'],
                 rating['orbital_safety'],
                 rating['star_bonus'],
-                json.dumps(rating['score_breakdown'], sort_keys=True),
                 rating['rating_version'],
                 _rating_confidence(rating.get('confidence')),
                 rating['rationale'],
@@ -434,12 +433,11 @@ async def _upsert_ratings(conn: asyncpg.Connection) -> None:
           signal_quality,
           orbital_safety,
           star_bonus,
-          score_breakdown,
           rating_version,
           confidence,
           rationale
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33::jsonb, $34, $35, $36)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35)
         ON CONFLICT (system_id64) DO UPDATE
         SET score = EXCLUDED.score,
             score_agriculture = EXCLUDED.score_agriculture,
@@ -472,7 +470,6 @@ async def _upsert_ratings(conn: asyncpg.Connection) -> None:
             signal_quality = EXCLUDED.signal_quality,
             orbital_safety = EXCLUDED.orbital_safety,
             star_bonus = EXCLUDED.star_bonus,
-            score_breakdown = EXCLUDED.score_breakdown,
             rating_version = EXCLUDED.rating_version,
             confidence = EXCLUDED.confidence,
             rationale = EXCLUDED.rationale,

--- a/sql/043_drop_ratings_score_breakdown.sql
+++ b/sql/043_drop_ratings_score_breakdown.sql
@@ -1,0 +1,57 @@
+-- 043_drop_ratings_score_breakdown.sql
+--
+-- Retire the dead ratings.score_breakdown column (entirely NULL since the
+-- 2026-07-15 storage-recovery repack; reconstructed at read time from the
+-- score_<economy> columns by apps/api/src/ratings_breakdown.py, never read
+-- from the column). See docs/superpowers/plans/2026-08-10-scoring-cleanup-migration.md.
+--
+-- Landmines handled here:
+--   * system_detail view selects r.score_breakdown directly (HARD dependency --
+--     blocks the column drop). CREATE OR REPLACE VIEW cannot remove a column,
+--     so drop + recreate without it. The s.* / r.* column set below reproduces
+--     the live view definition (verified 2026-08-10 via pg_get_viewdef) minus
+--     the single r.score_breakdown line.
+--   * search_galaxy_economy() / search_economy_near() reference the column via
+--     dynamic EXECUTE (soft dependency; latent-broken after the drop). Both are
+--     orphaned (no caller in apps/ or scripts/) -- dropped.
+--   * The identically-named system_archetype_scores.score_breakdown column is
+--     ALIVE and is deliberately NOT touched.
+--
+-- Every statement below is a metadata operation (the column is 100% NULL), so
+-- this is effectively instant and holds ACCESS EXCLUSIVE on ratings only
+-- momentarily.
+
+BEGIN;
+
+-- 1. Recreate system_detail without score_breakdown (hard blocker).
+DROP VIEW IF EXISTS system_detail;
+CREATE VIEW system_detail AS
+SELECT
+    s.*,
+    gr.name AS galaxy_region,
+    r.score,
+    r.score_agriculture, r.score_refinery, r.score_industrial,
+    r.score_hightech, r.score_military, r.score_tourism,
+    r.economy_suggestion,
+    r.elw_count, r.ww_count, r.ammonia_count,
+    r.gas_giant_count, r.rocky_count, r.metal_rich_count,
+    r.icy_count, r.rocky_ice_count, r.hmc_count,
+    r.landable_count, r.terraformable_count,
+    r.bio_signal_total, r.geo_signal_total,
+    r.neutron_count, r.black_hole_count, r.white_dwarf_count,
+    r.slots, r.body_quality, r.compactness,
+    r.signal_quality, r.orbital_safety, r.star_bonus,
+    r.computed_at AS score_computed_at
+FROM systems s
+LEFT JOIN galaxy_regions gr ON gr.id = s.galaxy_region_id
+LEFT JOIN ratings r ON r.system_id64 = s.id64;
+
+-- 2. Drop the two orphaned functions that reference the column via dynamic SQL.
+--    (Confirmed unused: verify zero calls on production first -- see runbook.)
+DROP FUNCTION IF EXISTS search_galaxy_economy(TEXT, SMALLINT, INTEGER, INTEGER, SMALLINT);
+DROP FUNCTION IF EXISTS search_economy_near(TEXT, REAL, REAL, REAL, REAL, SMALLINT, INTEGER, INTEGER, SMALLINT);
+
+-- 3. Drop the dead column (targets ratings only -- NOT system_archetype_scores).
+ALTER TABLE ratings DROP COLUMN IF EXISTS score_breakdown;
+
+COMMIT;

--- a/sql/migration-manifest.txt
+++ b/sql/migration-manifest.txt
@@ -54,3 +54,4 @@
 040_cluster_summary_widen_counts.sql
 041_bodies_composite_identity_index.sql|manual
 042_exploration_facts.sql
+043_drop_ratings_score_breakdown.sql

--- a/tests/integration/test_drop_ratings_score_breakdown_migration.py
+++ b/tests/integration/test_drop_ratings_score_breakdown_migration.py
@@ -78,3 +78,23 @@ def test_orphaned_search_functions_removed():
             assert cur.fetchall() == []
     finally:
         conn.close()
+
+
+def test_reconstruction_unaffected_by_column_drop():
+    # The API's score_breakdown response field is rebuilt from the
+    # score_<economy> columns (which Phase 1 keeps), not read from the dropped
+    # column. Prove reconstruction still runs and yields a JSON-serialisable
+    # result from a rating row with no rocky bodies (the common path — the
+    # function only touches `bodies` when rating_row['rocky_count'] is truthy).
+    import json
+    sys.path.insert(0, str(ROOT / 'apps' / 'api' / 'src'))
+    from ratings_breakdown import reconstruct_score_breakdown  # noqa: E402
+
+    row = {
+        'score_agriculture': 10, 'score_refinery': 20, 'score_industrial': 30,
+        'score_hightech': 40, 'score_military': 50, 'score_tourism': 60,
+        'score_extraction': 15, 'rocky_count': 0,
+    }
+    out = reconstruct_score_breakdown(row, ())
+    assert isinstance(out, dict) and out   # non-empty reconstruction
+    json.dumps(out)                        # matches the JSONB API contract

--- a/tests/integration/test_drop_ratings_score_breakdown_migration.py
+++ b/tests/integration/test_drop_ratings_score_breakdown_migration.py
@@ -1,0 +1,80 @@
+"""Real-Postgres regression for migration 043 (drop ratings.score_breakdown).
+
+Landmine-aware: (1) the ratings column is dropped; (2) the same-named
+system_archetype_scores.score_breakdown column is NOT touched (collision
+guard); (3) the system_detail view still exists and no longer exposes the
+column; (4) the two orphaned search functions are gone.
+
+pg_depend check (run 2026-08-10 against a migrated local DB) confirmed the
+system_detail view is the only hard dependency on ratings.score_breakdown.
+Connection style mirrors tests/integration/test_bodies_composite_identity.py.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+pytestmark = pytest.mark.db
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _conn():
+    return psycopg2.connect(os.environ['DATABASE_URL'])
+
+
+def _column_exists(cur, table: str, column: str) -> bool:
+    cur.execute(
+        "SELECT 1 FROM information_schema.columns "
+        "WHERE table_name = %s AND column_name = %s",
+        (table, column),
+    )
+    return cur.fetchone() is not None
+
+
+def test_ratings_score_breakdown_column_dropped():
+    conn = _conn()
+    try:
+        with conn.cursor() as cur:
+            assert not _column_exists(cur, 'ratings', 'score_breakdown')
+    finally:
+        conn.close()
+
+
+def test_archetype_score_breakdown_column_preserved():
+    # Collision guard: the same-named archetype column is alive and untouched.
+    conn = _conn()
+    try:
+        with conn.cursor() as cur:
+            assert _column_exists(cur, 'system_archetype_scores', 'score_breakdown')
+    finally:
+        conn.close()
+
+
+def test_system_detail_view_valid_without_column():
+    conn = _conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM pg_class WHERE relname = 'system_detail' AND relkind = 'v'")
+            assert cur.fetchone() is not None
+            assert not _column_exists(cur, 'system_detail', 'score_breakdown')
+            cur.execute("SELECT * FROM system_detail LIMIT 0")  # view still resolves
+    finally:
+        conn.close()
+
+
+def test_orphaned_search_functions_removed():
+    conn = _conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT proname FROM pg_proc "
+                "WHERE proname IN ('search_galaxy_economy', 'search_economy_near')"
+            )
+            assert cur.fetchall() == []
+    finally:
+        conn.close()


### PR DESCRIPTION
Executes Phase 1 of `docs/superpowers/plans/2026-08-10-scoring-cleanup-migration.md`: retire the dead, NULL, unread `ratings.score_breakdown` column.

## What migration 043 does
1. **Recreates the `system_detail` view without the column** — it selected `r.score_breakdown` directly (a *hard* dependency that blocks the drop; `CREATE OR REPLACE VIEW` can't remove a view column, so drop+recreate). Reproduces the live view definition (verified via `pg_get_viewdef`) minus that one line.
2. **Drops two orphaned search functions** (`search_galaxy_economy`, `search_economy_near`) that referenced the column via dynamic `EXECUTE` (soft dependency; no caller in `apps/` or `scripts/`).
3. **Drops `ratings.score_breakdown`** — targets `ratings` only.

## Landmines handled
- **Name collision** — the identically-named, *alive* `system_archetype_scores.score_breakdown` (written by `build_archetype_scores.py`, read by `routers/archetypes.py`) is **not** touched. A collision-guard test asserts it survives.
- **`pg_depend` verified** the `system_detail` view is the *only* hard dependency on the column (no hidden matview/FK).
- **Reconstruction unaffected** — the API `score_breakdown` field is rebuilt from the `score_<economy>` columns (kept), not read from the dropped column; a test proves it still works.

## Proof
Proven against a real `postgres:16-alpine` (not mocks — the PR #403 lesson): migration applies cleanly (`ON_ERROR_STOP=1`), and the 5-test regression file goes red→green across the drop. Migration-script-contract tests pass with `043` in the manifest.

## Scope / boundaries
- Ledger-discipline migration (new numbered file; base `001`/`003` untouched).
- No scoring/CP/economy/optimiser behaviour change — the column was NULL and unread.
- **Merging this does NOT apply it to production.** The prod apply is a separate owner-approved step (runbook in the plan), including a `pg_stat_user_functions` zero-call check before trusting the function drops.

Plan: `docs/superpowers/plans/2026-08-10-scoring-cleanup-migration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)