### PR TITLE
fix(deploy): --ignore-engines so prod Node 20 can build the frontend

### DIFF
--- a/scripts/deploy_main.sh
+++ b/scripts/deploy_main.sh
@@ -175,7 +175,13 @@ else
 say "Build $FRONTEND_DIR"
 (
   cd "$FRONTEND_DIR"
-  yarn install --frozen-lockfile --no-progress --non-interactive
+  # --ignore-engines: production Node is currently 20.x, but the test-only jsdom
+  # devDependency declares "engines: node >=22". jsdom is not used by the vite
+  # build (only by vitest), so the build itself runs fine on Node 20 — without
+  # this flag `yarn install` aborts with "engine incompatible" and blocks the
+  # whole deploy. Remove this flag once production Node is upgraded to >= 22
+  # (or once jsdom is pinned back to a Node-20-compatible major in the frontend).
+  yarn install --frozen-lockfile --no-progress --non-interactive --ignore-engines
   yarn build
 )
 ok "frontend built"


### PR DESCRIPTION
During the 2026-08-10 catch-up deploy, `deploy_main.sh` failed at `yarn install`:

\`\`\`
error jsdom@30.0.1: The engine "node" is incompatible... Expected ">=22". Got "20.20.2"
\`\`\`

Production Node is **20.x**. The frontend's **test-only** `jsdom` devDependency now requires Node 22+, so plain `yarn install` aborts and blocks the entire deploy. `jsdom` is only used by vitest — **the vite build itself runs fine on Node 20** — so this adds `--ignore-engines` to the deploy's install step (verified working: the catch-up deploy completed once I ran it this way manually).

**Follow-up (not this PR):** remove `--ignore-engines` once prod Node is upgraded to ≥22, or once `jsdom` is pinned back to a Node-20-compatible major. Tracked as the proper long-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)