### PR TITLE
chore(nginx): commit the octopus.ed-finder.app reverse-proxy config

### DIFF
--- a/config/nginx-ci.conf
+++ b/config/nginx-ci.conf
@@ -186,4 +186,9 @@ http {
             include /tmp/ngx/snippets/security-headers.conf;
         }
     }
+
+    # NOTE: config/nginx.conf also carries an octopus.ed-finder.app reverse-proxy
+    # block. It is deliberately NOT mirrored here — it depends on a prod-only TLS
+    # cert and the octopus-web upstream, neither of which exists in this cert-free
+    # CI syntax sandbox. Its syntax is exercised by the running prod deployment.
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -431,4 +431,72 @@ http {
             proxy_set_header   X-Admin-Token     $http_x_admin_token;
         }
     }
+
+    # ── Octopus (self-hosted PR review) — added 2026-08-09 ──────────────
+    # Reverse-proxy for the co-tenant Octopus review app (its containers live in
+    # the separate /opt/octopus compose project and join this stack's network).
+    # Prod-only: the TLS cert and octopus-web upstream exist only on the box, so
+    # this block is intentionally absent from config/nginx-ci.conf (the cert-free
+    # CI syntax sandbox) and from the review environments.
+    map $http_upgrade $octopus_conn_upgrade { default upgrade; '' close; }
+
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name octopus.ed-finder.app;
+        location /.well-known/acme-challenge/ { root /var/www/certbot; }
+        location / { return 301 https://$host$request_uri; }
+    }
+
+    server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        http2 on;
+        server_name octopus.ed-finder.app;
+
+        ssl_certificate     /etc/letsencrypt/live/octopus.ed-finder.app/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/octopus.ed-finder.app/privkey.pem;
+        ssl_protocols             TLSv1.2 TLSv1.3;
+        ssl_ciphers               ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+        ssl_session_cache         shared:SSL:10m;
+        ssl_session_timeout       1d;
+        ssl_session_tickets       off;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        client_max_body_size 25m;
+
+        # Re-resolve upstream at request time via Docker's embedded DNS so a
+        # recreated octopus-web (new IP) is picked up — avoids the cached-upstream
+        # 502 pattern noted elsewhere in this file.
+        resolver 127.0.0.11 valid=30s ipv6=off;
+
+        # GitHub webhooks: GitHub POSTs here (no browser) -> must bypass basic-auth.
+        location = /api/github/webhook {
+            set $octopus_upstream http://octopus-web:3000;
+            proxy_pass         $octopus_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        # Everything else: password-gated (basic-auth), proxied to Octopus web.
+        location / {
+            auth_basic           "Octopus";
+            auth_basic_user_file /etc/nginx/octopus.htpasswd;
+
+            set $octopus_upstream http://octopus-web:3000;
+            proxy_pass         $octopus_upstream;
+            proxy_http_version 1.1;
+            proxy_set_header   Upgrade           $http_upgrade;
+            proxy_set_header   Connection        $octopus_conn_upgrade;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 300s;
+        }
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,6 +338,7 @@ services:
       - ./frontend/dist:/var/www/app:ro  # current frontend build output, served at /
       - /opt/ed-finder-review/frontend/dist:/var/www/review:ro
       - /opt/ed-finder-review/.secrets/review.htpasswd:/etc/nginx/review.htpasswd:ro
+      - /opt/octopus/ui.htpasswd:/etc/nginx/octopus.htpasswd:ro  # basic-auth for octopus.ed-finder.app (see nginx.conf octopus block)
       - /opt/ed-finder-review/.review/nginx-logs:/var/log/nginx-review
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - /var/lib/letsencrypt:/var/lib/letsencrypt:ro


### PR DESCRIPTION
The `octopus.ed-finder.app` proxy block + its htpasswd mount were added **directly on the prod box** during the 2026-08-09 Octopus setup and never committed. That left `config/nginx.conf` and `docker-compose.yml` with **permanent uncommitted local edits on prod**, so `scripts/deploy_main.sh` refuses to run (`tracked files have local edits`) and every deploy needs a manual `git stash`/`pull`/`pop` dance (hit during the 2026-08-10 catch-up).

This commits the **exact running block** so the prod tree can be made clean.

## Safety
- **Prod-only by design:** the block references a TLS cert + `octopus-web` upstream that exist only on the box, so it's intentionally **not** mirrored into `config/nginx-ci.conf` (the cert-free CI syntax sandbox) — a note there records why.
- **No required check validates `config/nginx.conf` directly** — CI's nginx job uses `nginx-ci.conf`; Review Lab doesn't mount it. And nginx only starts on prod, so the `/opt/octopus` mount is inert in CI/dev/review (same pattern as the existing `/opt/ed-finder-review` mounts).
- The committed block is byte-for-byte the config already proven running in production.

## After merge (one-time, operator)
On the box: `git stash push -- config/nginx.conf docker-compose.yml && git pull --ff-only && git stash drop` to align the working tree, then future deploys via `deploy_main.sh` are clean. (No nginx reload needed — the running config is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)