### PR TITLE
feat(map): soft-glow star points

### DIFF
--- a/docs/superpowers/plans/2026-08-11-map-glow-and-body-thumbnails.md
+++ b/docs/superpowers/plans/2026-08-11-map-glow-and-body-thumbnails.md
@@ -1,0 +1,151 @@
+# Map Glow + Procedural Body Thumbnails Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Two bounded frontend visual wins — (#2) soft glowing stars on the R3F galaxy map, and (#3) small WebGL procedural planet thumbnails per body in the system-detail panel.
+
+**Architecture:** #2 is a dependency-free swap of the flat `<pointsMaterial>` on the map's *star* point layers for one shared soft-glow point `ShaderMaterial` (radial `gl_PointCoord` falloff + additive blending). #3 adds a shared offscreen Three.js renderer that draws a parametric planet (typed by ED `body_type`) once per unique body, caches the result as a data-URL, and shows it as an `<img>` in each body row. Both reuse the existing `three` 0.185 / `@react-three/fiber` 9.7 stack — **no new dependencies.**
+
+**Tech Stack:** React 19, TypeScript, `@react-three/fiber` 9.7, `three` 0.185, Vite, Vitest.
+
+## Global Constraints
+- **No new dependencies.** #2 is a hand-written shader; #3 uses core `three` (WebGLRenderTarget → data-URL). (A future Bloom pass via `@react-three/postprocessing` is explicitly out of scope here.)
+- **Frontend gates must pass:** `yarn typecheck`, `yarn lint`, `yarn knip --files`, `yarn test:map` + `yarn test`, `yarn build`.
+- **Map is production, "in observation."** Changes must be visually revertable and must not break existing `map-foundation` tests. This is sanctioned *bounded polish*; keep it clean and self-contained.
+- **Do not hand-edit `src/types/api.gen.ts`** — `BodyModel` fields come from there.
+- Follow existing `features/map-foundation/` R3F idioms (functional components, `useMemo` for buffers).
+- **The score heatmap layer is NOT a star layer — do not apply glow to it.** Glow applies to system dots + decorative starfield only.
+
+---
+
+## Task 1: #2 — Soft-glow star points (map), dependency-free
+
+**Files:**
+- Create: `frontend/src/features/map-foundation/glowPointsMaterial.ts` (shared material factory + GLSL)
+- Create: `frontend/src/features/map-foundation/glowPointsMaterial.test.ts`
+- Modify: `frontend/src/features/map-foundation/SceneContents.tsx` (system dot layers)
+- Modify: `frontend/src/features/map-foundation/GalaxyBackdrop.tsx` (18k decorative stars)
+- Modify: `frontend/src/features/map-foundation/SceneDecorations.tsx` (decorative point stars)
+
+**Interfaces:**
+- Produces: `makeGlowPointsMaterial({ color?, size, sizeAttenuation?, vertexColors? }): THREE.ShaderMaterial` — a soft round additive point. Consumed by the three map files above via `<primitive object={material} attach="material" />` (or a small `<glowPoints>`-style wrapper), replacing `<pointsMaterial>`.
+
+- [ ] **Step 1: Write the material factory + GLSL**
+
+```ts
+// glowPointsMaterial.ts
+import * as THREE from 'three';
+
+const VERT = /* glsl */`
+  uniform float uSize;
+  uniform bool uAttenuate;
+  attribute vec3 color;
+  varying vec3 vColor;
+  void main() {
+    vColor = color;
+    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+    gl_PointSize = uSize * (uAttenuate ? (300.0 / -mv.z) : 1.0);
+    gl_Position = projectionMatrix * mv;
+  }`;
+
+const FRAG = /* glsl */`
+  uniform vec3 uColor;
+  uniform bool uUseVertexColor;
+  varying vec3 vColor;
+  void main() {
+    float d = length(gl_PointCoord - vec2(0.5));
+    float alpha = smoothstep(0.5, 0.0, d);   // soft round core->edge
+    alpha = pow(alpha, 1.6);                  // tighter core, wide halo
+    if (alpha < 0.01) discard;
+    vec3 c = uUseVertexColor ? vColor : uColor;
+    gl_FragColor = vec4(c, alpha);
+  }`;
+
+export function makeGlowPointsMaterial(opts: {
+  color?: THREE.ColorRepresentation; size: number;
+  sizeAttenuation?: boolean; vertexColors?: boolean;
+}): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      uColor: { value: new THREE.Color(opts.color ?? '#ffffff') },
+      uSize: { value: opts.size },
+      uAttenuate: { value: opts.sizeAttenuation ?? true },
+      uUseVertexColor: { value: opts.vertexColors ?? false },
+    },
+    vertexShader: VERT, fragmentShader: FRAG,
+    transparent: true, blending: THREE.AdditiveBlending,
+    depthWrite: false, depthTest: false,
+  });
+}
+```
+
+- [ ] **Step 2: Test the factory** (jsdom, no real GL needed)
+
+```ts
+// glowPointsMaterial.test.ts
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { makeGlowPointsMaterial } from './glowPointsMaterial';
+
+describe('makeGlowPointsMaterial', () => {
+  it('is an additive, non-depth-writing transparent points material', () => {
+    const m = makeGlowPointsMaterial({ size: 8 });
+    expect(m).toBeInstanceOf(THREE.ShaderMaterial);
+    expect(m.blending).toBe(THREE.AdditiveBlending);
+    expect(m.depthWrite).toBe(false);
+    expect(m.transparent).toBe(true);
+    expect(m.fragmentShader).toContain('gl_PointCoord');
+  });
+  it('honors vertexColors + size uniforms', () => {
+    const m = makeGlowPointsMaterial({ size: 12, vertexColors: true });
+    expect(m.uniforms.uUseVertexColor.value).toBe(true);
+    expect(m.uniforms.uSize.value).toBe(12);
+  });
+});
+```
+Run: `yarn vitest run src/features/map-foundation/glowPointsMaterial.test.ts` → PASS.
+
+- [ ] **Step 3: Swap into the star layers.** In `SceneContents.tsx`, replace each system-dot `<pointsMaterial …>` (background/guaranteed/selected — NOT the heatmap `<pointsMaterial>` and NOT the aggregate-hull `<lineBasicMaterial>`) with the glow material via a `useMemo` + `<primitive object={mat} attach="material" />`, preserving each layer's existing `color` and `attenuatedPointSize(...)` size. Do the same for `GalaxyBackdrop.tsx` (use `vertexColors:true` since it has a color buffer) and the `SceneDecorations.tsx` point-star material(s). Keep `emphasizedSystems` marker rings as-is.
+
+- [ ] **Step 4: Run the map suite + typecheck.** `yarn test:map` and `yarn typecheck` → PASS (existing `ProductionMapTab`/`GalacticMap` tests must stay green — they assert structure, not pixels).
+
+- [ ] **Step 5: Visual check + commit.** Local preview (`VITE_STAGE26E_PRODUCTION_MAP=enabled yarn dev`): stars are soft round glows, not squares; heatmap unchanged. Commit `feat(map): soft-glow star points`.
+
+---
+
+## Task 2: #3 — WebGL procedural body thumbnails (system-detail)
+
+**Files:**
+- Create: `frontend/src/features/system-detail/body-thumbnail/bodyThumbnailParams.ts` (body_type/flags → planet params) + `.test.ts`
+- Create: `frontend/src/features/system-detail/body-thumbnail/renderBodyThumbnail.ts` (shared offscreen renderer → data-URL, cached)
+- Create: `frontend/src/features/system-detail/body-thumbnail/BodyThumbnail.tsx` + `.test.tsx`
+- Modify: `frontend/src/features/system-detail/SystemBodiesAndStationsSections.tsx` (add a leading thumbnail cell to each body row in `BodiesSection`)
+
+**Interfaces:**
+- `bodyThumbnailParams(body: SystemBody): PlanetParams` — pure mapping (base color, roughness/noise, `hasAtmosphere`, `hasRings`, `isStar`, `emissive`) keyed by `body_type` + `is_water_world`/`is_ammonia_world`/`is_earth_like`/`is_landable`/`spectral_class`.
+- `renderBodyThumbnail(params: PlanetParams, seed: number, px = 72): string` — returns a cached PNG data-URL; lazily creates ONE hidden `WebGLRenderer` + reusable sphere; renders once per cache key `${type}:${seed}` and memoizes. Falls back to `''` (→ CSS disc) if WebGL is unavailable (e.g. jsdom/tests).
+- `<BodyThumbnail body={body} />` — 36px `<img>` (or CSS-gradient disc fallback).
+
+- [ ] **Step 1: Write the param mapping + test.** Map each ED `body_type`/flag combo to a `PlanetParams` (rocky→brown noise; High metal content→dark metallic; Metal-rich→bright metallic; Icy→pale blue-white; Rocky ice→grey-blue; lava/volcanic→dark+emissive-cracks; Water world→blue+white cloud; Ammonia→amber; Earth-like→blue-green+cloud; Gas giant classes→banded, `hasRings` heuristic; Star→emissive by `spectral_class` via the blackbody ramp). Test: a few representative bodies produce the expected `isStar`/`hasRings`/base-color-family.
+
+- [ ] **Step 2: Write the offscreen renderer** — one module-level lazy `WebGLRenderer({ alpha:true, antialias:true, preserveDrawingBuffer:true })` at `px`×`px`, an `IcosahedronGeometry` sphere + a `ShaderMaterial` driven by `PlanetParams` (fbm noise surface, simple lambert + terminator, banded flow for gas giants, additive rim for atmosphere, a `RingGeometry` when `hasRings`, emissive for stars). Render once → `renderer.domElement.toDataURL('image/png')` → store in a `Map<string,string>` cache. Guard: if `WebGLRenderingContext` is absent (tests), return `''`.
+
+- [ ] **Step 3: `<BodyThumbnail>` component + test.** Calls `bodyThumbnailParams` + `renderBodyThumbnail`; renders `<img width=36 height=36>` when a data-URL exists, else a typed CSS radial-gradient disc (so tests + no-WebGL environments still show *something* deterministic). Test (jsdom, WebGL absent): renders the fallback disc with a `data-body-thumb` attr and doesn't throw.
+
+- [ ] **Step 4: Wire into `BodiesSection`.** Add a leading `<td>` with `<BodyThumbnail body={body} />` to each body `<tr>` (and a header cell). Keep the table layout/tests intact.
+
+- [ ] **Step 5: Gates + commit.** `yarn typecheck`, `yarn lint`, `yarn knip --files`, `yarn test` (system-detail suite) → PASS. Commit `feat(system-detail): procedural body thumbnails`.
+
+---
+
+## Final verification (both tasks)
+- [ ] `yarn typecheck && yarn lint && yarn knip --files` clean.
+- [ ] `yarn test:ci` (the split suite CI runs) green.
+- [ ] `yarn build` succeeds.
+- [ ] Open PR(s) (Task 1 and Task 2 can be separate PRs — Task 1 is lower-risk); watch checks incl. Review Lab; self-review; merge on green.
+- [ ] Production deploy is a **separate owner-approved step** (frontend deploy sequence ends with `docker compose restart nginx`) — not part of the merge.
+
+## Self-review
+- **Coverage:** Task 1 = #2 (glow) on star layers only; Task 2 = #3 (WebGL thumbnails) in bodies table. Both dependency-free.
+- **Placeholder scan:** shader + factory + test code are literal; the offscreen-renderer body (Task 2 Step 2) is described precisely rather than fully quoted because the exact shader is iterated during implementation against the visual result — the interface + guards are pinned.
+- **Risk:** the WebGL-absent guard (Task 2) keeps jsdom tests green; the heatmap-exclusion note (Task 1) prevents recoloring the data layer.

--- a/frontend/src/features/map-foundation/GalaxyBackdrop.tsx
+++ b/frontend/src/features/map-foundation/GalaxyBackdrop.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
+import { GlowPointsMaterial } from './glowPoints';
 
 export const GALAXY_CENTER = { x: 25.2, z: 25_899.9 } as const;
 export const GALAXY_RADIUS_LY = 50_000;
@@ -203,13 +204,11 @@ export function GalaxyBackdrop({ spatial, zoom }: { spatial: boolean; zoom: numb
         <bufferAttribute attach="attributes-position" args={[galaxy.positions, 3]} />
         <bufferAttribute attach="attributes-color" args={[galaxy.colors, 3]} />
       </bufferGeometry>
-      <pointsMaterial
+      <GlowPointsMaterial
         vertexColors
         size={Math.max(18, zoom * (spatial ? 1.4 : 1.1))}
         sizeAttenuation
-        transparent
         opacity={spatial ? 0.44 : 0.34}
-        depthWrite={false}
       />
     </points>
   </group>;

--- a/frontend/src/features/map-foundation/SceneContents.tsx
+++ b/frontend/src/features/map-foundation/SceneContents.tsx
@@ -19,6 +19,7 @@ import type {
 } from './types';
 import { measureRendererGpuTiming } from './performance';
 import { declutterRegionLabels } from './map-presentation';
+import { GlowPointsMaterial } from './glowPoints';
 import {
   buildClusterGeometry,
   clusterAnchorIdForSystem,
@@ -347,13 +348,10 @@ export function SceneContents(props: FoundationRendererProps & { visible: Return
       renderOrder={8}
     >
       <bufferGeometry><bufferAttribute attach="attributes-position" args={[backgroundPositions, 3]} /></bufferGeometry>
-      <pointsMaterial
+      <GlowPointsMaterial
         color="#ff9a3d"
         size={attenuatedPointSize(props.scene.camera.zoom, 8)}
         sizeAttenuation
-        transparent
-        opacity={1}
-        depthTest={false}
       />
     </points>
     <points
@@ -363,20 +361,18 @@ export function SceneContents(props: FoundationRendererProps & { visible: Return
       renderOrder={9}
     >
       <bufferGeometry><bufferAttribute attach="attributes-position" args={[guaranteedPositions, 3]} /></bufferGeometry>
-      <pointsMaterial
+      <GlowPointsMaterial
         color="#ff9a3d"
         size={attenuatedPointSize(props.scene.camera.zoom, 7)}
         sizeAttenuation
-        depthTest={false}
       />
     </points>
     <points onPointerDown={(event) => select(selected, event)} renderOrder={10}>
       <bufferGeometry><bufferAttribute attach="attributes-position" args={[selectedPositions, 3]} /></bufferGeometry>
-      <pointsMaterial
+      <GlowPointsMaterial
         color="#ffffff"
         size={attenuatedPointSize(props.scene.camera.zoom, 7)}
         sizeAttenuation
-        depthTest={false}
       />
     </points>
     {emphasizedSystems.map((system) => <mesh

--- a/frontend/src/features/map-foundation/glowPoints.test.ts
+++ b/frontend/src/features/map-foundation/glowPoints.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import * as THREE from 'three';
+import { makeGlowPointsMaterial } from './glowPointsMaterial';
+
+describe('makeGlowPointsMaterial', () => {
+  it('is an additive, non-depth-writing transparent points shader', () => {
+    const material = makeGlowPointsMaterial({ size: 8 });
+    expect(material).toBeInstanceOf(THREE.ShaderMaterial);
+    expect(material.blending).toBe(THREE.AdditiveBlending);
+    expect(material.depthWrite).toBe(false);
+    expect(material.transparent).toBe(true);
+    // The soft-glow effect is a radial gl_PointCoord falloff in the fragment shader.
+    expect(material.fragmentShader).toContain('gl_PointCoord');
+    expect(material.fragmentShader).toContain('smoothstep');
+  });
+
+  it('defaults to a flat color with size attenuation on', () => {
+    const material = makeGlowPointsMaterial({ size: 5, color: '#ff9a3d' });
+    expect(material.uniforms.uUseVertexColor.value).toBe(false);
+    expect(material.uniforms.uAttenuate.value).toBe(true);
+    expect(material.uniforms.uSize.value).toBe(5);
+    expect(material.uniforms.uColor.value).toBeInstanceOf(THREE.Color);
+  });
+
+  it('honors vertexColors and disabled attenuation', () => {
+    const material = makeGlowPointsMaterial({ size: 12, vertexColors: true, sizeAttenuation: false });
+    expect(material.uniforms.uUseVertexColor.value).toBe(true);
+    expect(material.uniforms.uAttenuate.value).toBe(false);
+    expect(material.uniforms.uSize.value).toBe(12);
+  });
+});

--- a/frontend/src/features/map-foundation/glowPoints.tsx
+++ b/frontend/src/features/map-foundation/glowPoints.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useMemo } from 'react';
+import { makeGlowPointsMaterial, type GlowPointsMaterialOptions } from './glowPointsMaterial';
+
+// Drop-in replacement for <pointsMaterial>: attaches to a <points> the same way,
+// rendering each point as a soft round additive glow. The material is created
+// once; its uniforms are refreshed from props each render so zoom-driven
+// `size`/`opacity` stay live without recreating it.
+export type GlowPointsMaterialProps = GlowPointsMaterialOptions;
+
+export function GlowPointsMaterial(props: GlowPointsMaterialProps) {
+  const material = useMemo(
+    () => makeGlowPointsMaterial({ size: props.size }),
+    // Created once; live values are pushed into uniforms below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  material.uniforms.uSize.value = props.size;
+  material.uniforms.uAttenuate.value = props.sizeAttenuation ?? true;
+  material.uniforms.uUseVertexColor.value = props.vertexColors ?? false;
+  material.uniforms.uOpacity.value = props.opacity ?? 1;
+  if (props.color != null && !props.vertexColors) {
+    material.uniforms.uColor.value.set(props.color);
+  }
+
+  useEffect(() => () => material.dispose(), [material]);
+
+  return <primitive object={material} attach="material" />;
+}

--- a/frontend/src/features/map-foundation/glowPointsMaterial.ts
+++ b/frontend/src/features/map-foundation/glowPointsMaterial.ts
@@ -1,0 +1,71 @@
+import * as THREE from 'three';
+
+// Soft-glow point material for the map's star layers: renders each GL point as
+// a soft round additive glow (radial gl_PointCoord falloff) instead of a flat
+// opaque square, so stars read as glowing stars. Dependency-free — a
+// hand-written ShaderMaterial, not a postprocessing pass. Deliberately NOT
+// applied to the score heatmap (that's a density layer, not stars).
+//
+// Size handling mirrors THREE.PointsMaterial: with sizeAttenuation the point
+// shrinks with view-space depth (the `300.0 / -mv.z` factor approximates
+// PointsMaterial's attenuation closely enough for this map's scale).
+
+const VERTEX_SHADER = /* glsl */ `
+  uniform float uSize;
+  uniform bool uAttenuate;
+  attribute vec3 color;
+  varying vec3 vColor;
+  void main() {
+    vColor = color;
+    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+    gl_PointSize = uSize * (uAttenuate ? (300.0 / -mv.z) : 1.0);
+    gl_Position = projectionMatrix * mv;
+  }
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `
+  uniform vec3 uColor;
+  uniform bool uUseVertexColor;
+  uniform float uOpacity;
+  varying vec3 vColor;
+  void main() {
+    float d = length(gl_PointCoord - vec2(0.5));
+    float alpha = smoothstep(0.5, 0.0, d); // soft round core -> transparent edge
+    alpha = pow(alpha, 1.6);               // tighter bright core, wider faint halo
+    alpha *= uOpacity;                     // per-layer brightness (keep backdrop subtle)
+    if (alpha < 0.01) discard;             // trim the fully-transparent corners
+    vec3 c = uUseVertexColor ? vColor : uColor;
+    gl_FragColor = vec4(c, alpha);
+  }
+`;
+
+export interface GlowPointsMaterialOptions {
+  /** Flat color for the whole layer (ignored when vertexColors is true). */
+  color?: THREE.ColorRepresentation;
+  /** Base point size, same units as PointsMaterial.size. */
+  size: number;
+  /** Shrink points with distance (default true), matching PointsMaterial. */
+  sizeAttenuation?: boolean;
+  /** Use a per-point `color` buffer attribute instead of the flat color. */
+  vertexColors?: boolean;
+  /** Overall alpha multiplier (default 1); lower it to keep faint layers subtle. */
+  opacity?: number;
+}
+
+export function makeGlowPointsMaterial(options: GlowPointsMaterialOptions): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      uColor: { value: new THREE.Color(options.color ?? '#ffffff') },
+      uSize: { value: options.size },
+      uAttenuate: { value: options.sizeAttenuation ?? true },
+      uUseVertexColor: { value: options.vertexColors ?? false },
+      uOpacity: { value: options.opacity ?? 1 },
+    },
+    vertexShader: VERTEX_SHADER,
+    fragmentShader: FRAGMENT_SHADER,
+    transparent: true,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false,
+    depthTest: false,
+  });
+}


### PR DESCRIPTION
Swaps the flat square `<pointsMaterial>` on the map's **star** layers for a dependency-free soft-glow point `ShaderMaterial` — radial `gl_PointCoord` falloff + additive blending — so stars render as soft round glows instead of hard squares.

## Scope
- **Applied to:** the system-dot layers (background/guaranteed/selected) + the `GalaxyBackdrop` 18k ambient starfield (kept subtle via an `opacity` uniform multiplier).
- **Left untouched:** the score heatmap (a density layer, not stars) and the reference "you-are-here" marker.
- **No new dependencies** — hand-written shader, not a postprocessing pass. (A future Bloom pass is a separate later item.)

## Structure
- `glowPointsMaterial.ts` — pure factory `makeGlowPointsMaterial()` (unit-tested).
- `glowPoints.tsx` — `<GlowPointsMaterial>` R3F drop-in for `<pointsMaterial>`; created once, uniforms refreshed per render so zoom-driven size/opacity stay live.

## Verification
`tsc --noEmit` clean, `eslint src --max-warnings 10` passes (net-zero new warnings), map + material tests green (23). Visual behaviour is exercised by the Review Lab browser journey.

First of the #1/#2/#3 map-polish bundle (this is #2). Plan: `docs/superpowers/plans/2026-08-11-map-glow-and-body-thumbnails.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)