### PR TITLE
feat(system-detail): procedural body thumbnails

### DIFF
--- a/frontend/src/features/system-detail/SystemBodiesAndStationsSections.tsx
+++ b/frontend/src/features/system-detail/SystemBodiesAndStationsSections.tsx
@@ -3,6 +3,7 @@ import type { SystemBody, SystemStation } from '@/types/api';
 import { compareBodiesByHierarchy } from '@/lib/bodyHierarchySort';
 import { transientStationPlanningReason } from '@/features/colony-planner/existingInfrastructure';
 import { Section } from './SystemDetailSectionShell';
+import { BodyThumbnail } from './body-thumbnail/BodyThumbnail';
 
 export function BodiesSection({ bodies, systemName }: { bodies?: SystemBody[]; systemName?: string | null }) {
   if (!bodies || bodies.length === 0) return null;
@@ -23,6 +24,7 @@ export function BodiesSection({ bodies, systemName }: { bodies?: SystemBody[]; s
         <table className="w-full text-xs font-mono">
           <thead className="text-silver-dk uppercase tracking-[0.16em] text-[10px]" style={tableHeadStyle}>
             <tr>
+              <th className="px-3 py-2.5 w-9" aria-hidden></th>
               <th className="px-3 py-2.5 text-left">Name</th>
               <th className="px-3 py-2.5 text-left">Type</th>
               <th className="px-3 py-2.5 text-left">Tags</th>
@@ -32,6 +34,7 @@ export function BodiesSection({ bodies, systemName }: { bodies?: SystemBody[]; s
           <tbody>
             {sorted.map((body) => (
               <tr key={body.id} className="border-t border-border/50 hover:bg-orange/5 transition-colors">
+                <td className="px-3 py-1.5 align-middle"><BodyThumbnail body={body} /></td>
                 <td className="px-3 py-2 text-orange-lt font-semibold">{body.name}</td>
                 <td className="px-3 py-2 text-silver">{body.subtype || body.body_type || '—'}</td>
                 <td className="px-3 py-2 text-silver-dk text-[10px]">

--- a/frontend/src/features/system-detail/body-thumbnail/BodyThumbnail.test.tsx
+++ b/frontend/src/features/system-detail/body-thumbnail/BodyThumbnail.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import type { SystemBody } from '../../../types/api';
+import { BodyThumbnail } from './BodyThumbnail';
+
+const body = (overrides: Partial<SystemBody>): SystemBody => overrides as SystemBody;
+
+// jsdom has no WebGL, so renderBodyThumbnail returns '' and the component falls
+// back to the deterministic CSS disc — which is what we assert here.
+describe('BodyThumbnail', () => {
+  it('renders a typed CSS disc fallback when WebGL is unavailable', () => {
+    const { container } = render(<BodyThumbnail body={body({ body_type: 'Planet', subtype: 'Rocky body', id: 1 })} />);
+    const el = container.querySelector('[data-body-thumb]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('data-body-thumb')).toBe('css');
+    expect((el as HTMLElement).style.borderRadius).toBe('50%');
+  });
+
+  it('renders an empty placeholder (not a disc) for a barycentre', () => {
+    const { container } = render(<BodyThumbnail body={body({ body_type: 'Barycentre', id: 2 })} />);
+    expect(container.querySelector('[data-body-thumb="none"]')).not.toBeNull();
+    expect(container.querySelector('[data-body-thumb="css"]')).toBeNull();
+  });
+
+  it('does not throw and renders a thumbnail element for a star', () => {
+    const { container } = render(<BodyThumbnail body={body({ body_type: 'Star', spectral_class: 'G2 V', id: 3 })} />);
+    const el = container.querySelector('[data-body-thumb]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('title')).toBe('Star');
+  });
+});

--- a/frontend/src/features/system-detail/body-thumbnail/BodyThumbnail.tsx
+++ b/frontend/src/features/system-detail/body-thumbnail/BodyThumbnail.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import type { SystemBody } from '../../../types/api';
+import { bodyThumbnailParams } from './bodyThumbnailParams';
+import { renderBodyThumbnail, seedFromBody } from './renderBodyThumbnail';
+
+const SIZE = 36;
+
+// A small procedural planet/star preview for a body. Renders the WebGL thumbnail
+// (cached, deterministic per body) when available, otherwise a typed CSS disc so
+// no-WebGL environments and tests still show a recognisable, deterministic dot.
+export function BodyThumbnail({ body }: { body: SystemBody }) {
+  const params = useMemo(() => bodyThumbnailParams(body), [body]);
+  const seed = useMemo(() => seedFromBody(body.id ?? body.name), [body.id, body.name]);
+  // Render at 2x for crispness on HiDPI, display at SIZE.
+  const url = useMemo(
+    () => (params.kind === 'none' ? '' : renderBodyThumbnail(params, seed, SIZE * 2)),
+    [params, seed],
+  );
+
+  if (params.kind === 'none') {
+    return <span data-body-thumb="none" aria-hidden style={{ display: 'inline-block', width: SIZE, height: SIZE }} />;
+  }
+
+  const title = params.kind === 'star' ? 'Star' : undefined;
+
+  if (url) {
+    return (
+      <img
+        data-body-thumb="img"
+        src={url}
+        width={SIZE}
+        height={SIZE}
+        alt=""
+        aria-hidden
+        title={title}
+        style={{ borderRadius: '50%', display: 'block' }}
+      />
+    );
+  }
+
+  // No-WebGL fallback: a deterministic CSS disc in the body's own colors.
+  return (
+    <span
+      data-body-thumb="css"
+      aria-hidden
+      title={title}
+      style={{
+        display: 'inline-block',
+        width: SIZE,
+        height: SIZE,
+        borderRadius: '50%',
+        background: `radial-gradient(circle at 34% 30%, ${params.accent}, ${params.base} 68%)`,
+        boxShadow: params.kind === 'star' ? `0 0 6px ${params.base}` : 'none',
+      }}
+    />
+  );
+}

--- a/frontend/src/features/system-detail/body-thumbnail/bodyThumbnailParams.test.ts
+++ b/frontend/src/features/system-detail/body-thumbnail/bodyThumbnailParams.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import type { SystemBody } from '../../../types/api';
+import { bodyThumbnailParams, spectralStarColor } from './bodyThumbnailParams';
+
+const body = (overrides: Partial<SystemBody>): SystemBody => overrides as SystemBody;
+
+describe('bodyThumbnailParams', () => {
+  it('skips barycentres', () => {
+    expect(bodyThumbnailParams(body({ body_type: 'Barycentre' })).kind).toBe('none');
+  });
+
+  it('renders stars as glowing, colored by spectral class', () => {
+    const m = bodyThumbnailParams(body({ body_type: 'Star', spectral_class: 'M5 V' }));
+    expect(m.kind).toBe('star');
+    expect(m.base).toBe(spectralStarColor('M'));
+    const g = bodyThumbnailParams(body({ body_type: 'Star', spectral_class: 'G2 V' }));
+    expect(g.base).toBe(spectralStarColor('G'));
+    expect(g.base).not.toBe(m.base);
+  });
+
+  it('classes earth-like and water worlds with an atmosphere', () => {
+    expect(bodyThumbnailParams(body({ body_type: 'Planet', is_earth_like: true })).atmosphere).toBe(true);
+    const w = bodyThumbnailParams(body({ body_type: 'Planet', is_water_world: true }));
+    expect(w.kind).toBe('planet');
+    expect(w.atmosphere).toBe(true);
+    expect(w.gasGiant).toBe(false);
+  });
+
+  it('detects gas giants from subtype and gives class I/II rings', () => {
+    const g = bodyThumbnailParams(body({ body_type: 'Planet', subtype: 'Sudarsky class II gas giant' }));
+    expect(g.gasGiant).toBe(true);
+    expect(g.rings).toBe(true);
+    const g3 = bodyThumbnailParams(body({ body_type: 'Planet', subtype: 'Sudarsky class III gas giant' }));
+    expect(g3.gasGiant).toBe(true);
+    expect(g3.rings).toBe(false);
+  });
+
+  it('classes rocky / metal / icy planets without gas or (usually) atmosphere', () => {
+    expect(bodyThumbnailParams(body({ body_type: 'Planet', subtype: 'High metal content world' })).gasGiant).toBe(false);
+    expect(bodyThumbnailParams(body({ body_type: 'Planet', subtype: 'Rocky body' })).kind).toBe('planet');
+    expect(bodyThumbnailParams(body({ body_type: 'Planet', subtype: 'Icy body' })).atmosphere).toBe(true);
+  });
+
+  it('returns none for an unknown body with no subtype', () => {
+    expect(bodyThumbnailParams(body({ body_type: 'Unknown', subtype: '' })).kind).toBe('none');
+  });
+});
+
+describe('spectralStarColor', () => {
+  it('maps the first spectral letter and defaults for unknown', () => {
+    expect(spectralStarColor('O9 V')).toBe('#9bb0ff');
+    expect(spectralStarColor('m')).toBe('#ffb37a');
+    expect(spectralStarColor(null)).toBe('#ffe0b0');
+    expect(spectralStarColor('???')).toBe('#ffe0b0');
+  });
+});

--- a/frontend/src/features/system-detail/body-thumbnail/bodyThumbnailParams.ts
+++ b/frontend/src/features/system-detail/body-thumbnail/bodyThumbnailParams.ts
@@ -1,0 +1,135 @@
+import type { SystemBody } from '../../../types/api';
+
+// Maps an Elite-Dangerous body to the parameters used to render its procedural
+// thumbnail. `body_type` is coarse (Star/Planet/Moon/Barycentre/Unknown); the
+// fine ED class (Icy body, High metal content world, Gas giant, ...) lives in
+// the free-text `subtype`, so the mapping keys off subtype + the boolean flags.
+
+export interface BodyThumbnailParams {
+  /** 'none' → do not render a thumbnail (barycentres, null/unknown-without-subtype). */
+  kind: 'planet' | 'star' | 'none';
+  /** Base surface color, hex. Stars use this as their glow color. */
+  base: string;
+  /** Accent for bands / clouds / surface detail, hex. */
+  accent: string;
+  /** Render banded gas-giant flow instead of a rocky/icy surface. */
+  gasGiant: boolean;
+  /** Draw a ring around the body. */
+  rings: boolean;
+  /** Draw an atmospheric rim halo. */
+  atmosphere: boolean;
+  /** Atmosphere rim color, hex. */
+  atmosphereColor: string;
+  /** Surface noise contrast, 0 (smooth) .. 1 (rough). */
+  contrast: number;
+}
+
+// First letter of a spectral class -> representative color (a small blackbody
+// approximation; the full-fidelity table is deferred to feature #1).
+const STAR_COLORS: Record<string, string> = {
+  O: '#9bb0ff', B: '#aabfff', A: '#e6ecff', F: '#fbf8ff',
+  G: '#fff4e8', K: '#ffd6a0', M: '#ffb37a', L: '#ff8a5c',
+  T: '#d1663f', Y: '#a04a3a', W: '#a6c0ff', // Wolf-Rayet -> blue
+  N: '#ffcf9c', S: '#ffb37a', C: '#ff7a5c', // carbon stars -> reddish
+  D: '#dfe8ff',                              // white dwarf
+};
+
+export function spectralStarColor(spectralClass?: string | null): string {
+  const first = (spectralClass ?? '').trim().charAt(0).toUpperCase();
+  return STAR_COLORS[first] ?? '#ffe0b0';
+}
+
+const has = (s: string | null | undefined, needle: string): boolean =>
+  (s ?? '').toLowerCase().includes(needle);
+
+export function bodyThumbnailParams(body: SystemBody): BodyThumbnailParams {
+  const type = body.body_type ?? '';
+  const subtype = body.subtype ?? '';
+
+  if (type === 'Barycentre') {
+    return neutral('none');
+  }
+
+  if (type === 'Star') {
+    const color = spectralStarColor(body.spectral_class);
+    return { kind: 'star', base: color, accent: color, gasGiant: false, rings: false, atmosphere: true, atmosphereColor: color, contrast: 0.35 };
+  }
+
+  // --- planets & moons, classed by subtype / flags ---
+  if (body.is_earth_like || has(subtype, 'earth-like')) {
+    return planet('#2f6f4f', '#d8ecff', { atmosphere: true, atmosphereColor: '#9fd0ff', contrast: 0.5 });
+  }
+  if (body.is_water_world || has(subtype, 'water world')) {
+    return planet('#20486f', '#eaf4ff', { atmosphere: true, atmosphereColor: '#bfe0ff', contrast: 0.45 });
+  }
+  if (body.is_ammonia_world || has(subtype, 'ammonia')) {
+    return planet('#8a6a37', '#e6c98f', { atmosphere: true, atmosphereColor: '#d8b878', contrast: 0.5 });
+  }
+  if (has(subtype, 'giant')) { // gas giant / water giant / helium-rich giant
+    const [base, accent] = gasGiantColors(subtype);
+    return { kind: 'planet', base, accent, gasGiant: true, rings: gasGiantHasRings(subtype), atmosphere: true, atmosphereColor: accent, contrast: 0.7 };
+  }
+  if (has(subtype, 'high metal content')) {
+    return planet('#5a4b40', '#8a7360', { contrast: 0.75 });
+  }
+  if (has(subtype, 'metal-rich') || has(subtype, 'metal rich')) {
+    return planet('#7c7168', '#c9bcae', { contrast: 0.8 });
+  }
+  if (has(subtype, 'rocky ice')) {
+    return planet('#6d7c86', '#cfe2ec', { contrast: 0.6 });
+  }
+  if (has(subtype, 'icy')) {
+    return planet('#7fa7bd', '#eaf6ff', { atmosphere: true, atmosphereColor: '#cfeaff', contrast: 0.45 });
+  }
+  if (has(subtype, 'rocky') || type === 'Planet' || type === 'Moon') {
+    return planet('#7a5a3f', '#b9967a', { contrast: 0.72 });
+  }
+
+  // Unknown planet/moon without a recognisable subtype.
+  return type === 'Unknown' && subtype === '' ? neutral('none') : planet('#6f6f6f', '#a0a0a0', { contrast: 0.6 });
+}
+
+function planet(
+  base: string,
+  accent: string,
+  extra?: Partial<Pick<BodyThumbnailParams, 'atmosphere' | 'atmosphereColor' | 'rings' | 'contrast'>>,
+): BodyThumbnailParams {
+  return {
+    kind: 'planet', base, accent, gasGiant: false,
+    rings: extra?.rings ?? false,
+    atmosphere: extra?.atmosphere ?? false,
+    atmosphereColor: extra?.atmosphereColor ?? accent,
+    contrast: extra?.contrast ?? 0.6,
+  };
+}
+
+function neutral(kind: BodyThumbnailParams['kind']): BodyThumbnailParams {
+  return { kind, base: '#3a3a3a', accent: '#555555', gasGiant: false, rings: false, atmosphere: false, atmosphereColor: '#555555', contrast: 0.3 };
+}
+
+// Extract the Sudarsky class roman numeral with a word boundary so that
+// 'class iii' does not also substring-match 'class ii' / 'class i'.
+function gasGiantClass(subtype: string): string | null {
+  const match = /\bclass\s+(iv|iii|ii|i|v)\b/.exec(subtype.toLowerCase());
+  return match ? match[1] : null;
+}
+
+function gasGiantColors(subtype: string): [string, string] {
+  if (has(subtype, 'water giant')) return ['#3a6f7a', '#bfe6ea'];
+  if (has(subtype, 'helium')) return ['#b8a06a', '#efe0b8'];
+  switch (gasGiantClass(subtype)) {
+    case 'i': return ['#c9a06a', '#f0dcc0'];   // Sudarsky I: warm bands
+    case 'ii': return ['#e8e8ea', '#ffffff'];  // II: ammonia cloud, pale
+    case 'iii': return ['#9aa7b5', '#d6e0ea']; // III: clear, bluish
+    case 'iv':
+    case 'v': return ['#8a5540', '#c98f6a'];   // IV/V: hot, dark red
+    default: return ['#c08a55', '#efd3a8'];    // generic gas giant
+  }
+}
+
+function gasGiantHasRings(subtype: string): boolean {
+  // Sudarsky class I/II giants (and water giants) most commonly carry rings.
+  if (has(subtype, 'water giant')) return true;
+  const cls = gasGiantClass(subtype);
+  return cls === 'i' || cls === 'ii';
+}

--- a/frontend/src/features/system-detail/body-thumbnail/renderBodyThumbnail.ts
+++ b/frontend/src/features/system-detail/body-thumbnail/renderBodyThumbnail.ts
@@ -1,0 +1,222 @@
+import * as THREE from 'three';
+import type { BodyThumbnailParams } from './bodyThumbnailParams';
+
+// Renders a small procedural planet/star thumbnail for a body offscreen and
+// returns a PNG data-URL, cached per (params, seed, size). One hidden
+// WebGLRenderer + sphere/ring is reused for every body. Returns '' when WebGL
+// is unavailable (jsdom / headless) so the caller can fall back to a CSS disc.
+
+const PLANET_VERTEX = /* glsl */ `
+  varying vec3 vObjNormal;
+  varying vec3 vWorldNormal;
+  varying vec3 vViewDir;
+  void main() {
+    vObjNormal = normal;
+    vWorldNormal = normalize(mat3(modelMatrix) * normal);
+    vec4 wp = modelMatrix * vec4(position, 1.0);
+    vViewDir = cameraPosition - wp.xyz;
+    gl_Position = projectionMatrix * viewMatrix * wp;
+  }
+`;
+
+const PLANET_FRAGMENT = /* glsl */ `
+  varying vec3 vObjNormal;
+  varying vec3 vWorldNormal;
+  varying vec3 vViewDir;
+  uniform vec3 uBase;
+  uniform vec3 uAccent;
+  uniform vec3 uAtmo;
+  uniform float uContrast;
+  uniform float uSeed;
+  uniform bool uGas;
+  uniform bool uStar;
+  uniform bool uAtmoOn;
+
+  float hash(vec3 p) {
+    p = fract(p * 0.3183099 + 0.1);
+    p *= 17.0;
+    return fract(p.x * p.y * p.z * (p.x + p.y + p.z));
+  }
+  float noise(vec3 x) {
+    vec3 i = floor(x); vec3 f = fract(x); f = f * f * (3.0 - 2.0 * f);
+    return mix(mix(mix(hash(i + vec3(0,0,0)), hash(i + vec3(1,0,0)), f.x),
+                   mix(hash(i + vec3(0,1,0)), hash(i + vec3(1,1,0)), f.x), f.y),
+               mix(mix(hash(i + vec3(0,0,1)), hash(i + vec3(1,0,1)), f.x),
+                   mix(hash(i + vec3(0,1,1)), hash(i + vec3(1,1,1)), f.x), f.y), f.z);
+  }
+  float fbm(vec3 p) {
+    float v = 0.0; float a = 0.5;
+    for (int i = 0; i < 5; i++) { v += a * noise(p); p *= 2.0; a *= 0.5; }
+    return v;
+  }
+
+  void main() {
+    vec3 n = normalize(vObjNormal);
+    vec3 sp = n * 2.2 + uSeed;
+    float f;
+    if (uGas) {
+      float bands = sin(n.y * 9.0 + fbm(sp * 1.5) * 3.0);
+      f = 0.5 + 0.5 * bands;
+    } else {
+      f = fbm(sp * 2.6);
+    }
+    f = clamp((f - 0.5) * uContrast * 2.0 + 0.5, 0.0, 1.0);
+    vec3 col = mix(uBase, uAccent, f);
+
+    if (uStar) {
+      float gr = fbm(sp * 6.0);
+      gl_FragColor = vec4(uBase * (0.82 + 0.34 * gr), 1.0);
+      return;
+    }
+
+    vec3 L = normalize(vec3(0.6, 0.5, 0.85));
+    float diff = clamp(dot(normalize(vWorldNormal), L), 0.0, 1.0);
+    col *= 0.15 + 0.95 * diff; // ambient + diffuse -> terminator
+
+    if (uAtmoOn) {
+      float fres = pow(1.0 - clamp(dot(normalize(vWorldNormal), normalize(vViewDir)), 0.0, 1.0), 2.5);
+      col += uAtmo * fres * (0.35 + 0.65 * diff);
+    }
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+const RING_FRAGMENT = /* glsl */ `
+  varying vec2 vUv;
+  uniform vec3 uColor;
+  void main() {
+    float r = length(vUv - 0.5) * 2.0;      // 0 (inner-ish) .. 1 (outer)
+    float bands = 0.55 + 0.45 * sin(r * 34.0);
+    float gap = smoothstep(0.62, 0.66, r) * (1.0 - smoothstep(0.70, 0.74, r));
+    float alpha = bands * (1.0 - gap) * 0.7;
+    if (alpha < 0.02) discard;
+    gl_FragColor = vec4(uColor, alpha);
+  }
+`;
+
+const RING_VERTEX = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+interface Rig {
+  renderer: THREE.WebGLRenderer;
+  scene: THREE.Scene;
+  camera: THREE.PerspectiveCamera;
+  group: THREE.Group;
+  planet: THREE.Mesh;
+  planetMat: THREE.ShaderMaterial;
+  ring: THREE.Mesh;
+  ringMat: THREE.ShaderMaterial;
+  size: number;
+}
+
+let rig: Rig | null = null;
+let rigFailed = false;
+const cache = new Map<string, string>();
+
+function getRig(size: number): Rig | null {
+  if (rigFailed) return null;
+  if (rig && rig.size === size) return rig;
+  try {
+    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true, preserveDrawingBuffer: true });
+    renderer.setSize(size, size, false);
+    renderer.setClearColor(0x000000, 0);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(30, 1, 0.1, 100);
+    camera.position.set(0, 0.35, 4.4);
+    camera.lookAt(0, 0, 0);
+
+    const group = new THREE.Group();
+    group.rotation.set(0.42, 0.0, 0.15); // slight 3/4 tilt so rings read as ellipses
+    scene.add(group);
+
+    const planetMat = new THREE.ShaderMaterial({
+      vertexShader: PLANET_VERTEX,
+      fragmentShader: PLANET_FRAGMENT,
+      uniforms: {
+        uBase: { value: new THREE.Color('#888') },
+        uAccent: { value: new THREE.Color('#aaa') },
+        uAtmo: { value: new THREE.Color('#88a') },
+        uContrast: { value: 0.6 },
+        uSeed: { value: 0 },
+        uGas: { value: false },
+        uStar: { value: false },
+        uAtmoOn: { value: false },
+      },
+    });
+    const planet = new THREE.Mesh(new THREE.IcosahedronGeometry(1, 5), planetMat);
+    group.add(planet);
+
+    const ringMat = new THREE.ShaderMaterial({
+      vertexShader: RING_VERTEX,
+      fragmentShader: RING_FRAGMENT,
+      uniforms: { uColor: { value: new THREE.Color('#cbb') } },
+      transparent: true,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+    const ring = new THREE.Mesh(new THREE.RingGeometry(1.4, 2.2, 96), ringMat);
+    ring.rotation.x = Math.PI / 2;
+    ring.visible = false;
+    group.add(ring);
+
+    rig = { renderer, scene, camera, group, planet, planetMat, ring, ringMat, size };
+    return rig;
+  } catch {
+    rigFailed = true;
+    return null;
+  }
+}
+
+function cacheKey(p: BodyThumbnailParams, seed: number, size: number): string {
+  return [p.kind, p.base, p.accent, p.atmosphereColor, p.gasGiant, p.rings, p.atmosphere, p.contrast, seed, size].join('|');
+}
+
+export function renderBodyThumbnail(params: BodyThumbnailParams, seed: number, size = 72): string {
+  if (params.kind === 'none') return '';
+  const key = cacheKey(params, seed, size);
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+
+  const r = getRig(size);
+  if (!r) {
+    cache.set(key, '');
+    return '';
+  }
+
+  const u = r.planetMat.uniforms;
+  u.uBase.value.set(params.base);
+  u.uAccent.value.set(params.accent);
+  u.uAtmo.value.set(params.atmosphereColor);
+  u.uContrast.value = params.contrast;
+  u.uSeed.value = (seed % 997) * 0.031;
+  u.uGas.value = params.gasGiant;
+  u.uStar.value = params.kind === 'star';
+  u.uAtmoOn.value = params.atmosphere;
+
+  r.ring.visible = params.rings;
+  if (params.rings) r.ringMat.uniforms.uColor.value.set(params.accent);
+
+  try {
+    r.renderer.render(r.scene, r.camera);
+    const url = r.renderer.domElement.toDataURL('image/png');
+    cache.set(key, url);
+    return url;
+  } catch {
+    cache.set(key, '');
+    return '';
+  }
+}
+
+// Stable small seed from a body's id/name so a body always renders the same.
+export function seedFromBody(idOrName: string | number | null | undefined): number {
+  const s = String(idOrName ?? '');
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+  return h >>> 0;
+}


### PR DESCRIPTION
Adds a small **WebGL procedural planet/star preview** per body in the system-detail bodies table, keyed by Elite-Dangerous body type — the #3 item of the map-polish bundle, and the stepping stone that de-risks the parametric body shaders for the future 3D system view.

## How
- **`bodyThumbnailParams`** — `body_type` is coarse (Star/Planet/Moon/Barycentre); the fine class (Icy body, gas giant, water world, HMC…) comes from the free-text `subtype` + boolean flags → render params (base/accent color, gas-giant banding, rings, atmosphere, star emissive/spectral color). Sudarsky class parsed with a word-boundary regex so `class iii` ≠ `class ii`.
- **`renderBodyThumbnail`** — one hidden `WebGLRenderer` + sphere/ring reused for all bodies; a parametric shader (fbm surface, banded gas giants, terminator lighting, fresnel atmosphere, ringed giants, emissive stars) rendered once per unique body → cached PNG data-URL.
- **`<BodyThumbnail>`** — shows the image, or a deterministic **typed CSS disc fallback** when WebGL is unavailable (jsdom/headless) so tests and no-WebGL environments still render.

## Verification
`tsc` clean, `eslint --max-warnings 10` passes, `knip` clean, and **265 system-detail tests + 10 new thumbnail tests** green. jsdom exercises the CSS-fallback path; the WebGL render is exercised in-browser by Review Lab (which would flag a shader compile error via its console-error check).

Dependency-free (core `three` only). Plan: `docs/superpowers/plans/2026-08-11-map-glow-and-body-thumbnails.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)