### PR TITLE
feat(map): /api/map/systems viewport endpoint (real-star streaming Phase 1)

### DIFF
--- a/apps/api/src/routers/map.py
+++ b/apps/api/src/routers/map.py
@@ -14,6 +14,10 @@ router = APIRouter(tags=['map'])
 
 MAX_MAP_HEATMAP_CELLS = 50_000
 
+# Real-star viewport lane (the zoom-in detail lane; heatmap is the aggregate lane).
+MAX_MAP_VIEWPORT_SYSTEMS = 40_000   # hard cap on individual systems per viewport
+MAX_MAP_VIEWPORT_LY = 15_000        # per-axis box guard; wider -> stay on the heatmap
+
 
 
 
@@ -341,4 +345,86 @@ async def map_timeline(
         'total': sum(r['systems_discovered'] for r in rows),
     }
     await cache_set(cache_key, result, settings.ttl_cluster, redis)
+    return result
+
+
+@router.get('/api/map/systems')
+@limiter.limit('60/minute')
+async def map_systems(
+    request: Request,
+    min_x: float = Query(..., description='Viewport bounding-box min X (LY)'),
+    max_x: float = Query(..., description='Viewport bounding-box max X (LY)'),
+    min_y: float = Query(..., description='Viewport bounding-box min Y (LY)'),
+    max_y: float = Query(..., description='Viewport bounding-box max Y (LY)'),
+    min_z: float = Query(..., description='Viewport bounding-box min Z (LY)'),
+    max_z: float = Query(..., description='Viewport bounding-box max Z (LY)'),
+    limit: int = Query(
+        20_000, ge=1, le=MAX_MAP_VIEWPORT_SYSTEMS,
+        description='Maximum individual systems returned',
+    ),
+    pool: asyncpg.Pool = Depends(get_pool),
+    redis: Optional[aioredis.Redis] = Depends(get_redis),
+):
+    """Individual star systems within a viewport bounding box — the zoom-in
+    real-star detail lane (the heatmap is the zoomed-out aggregate lane).
+
+    Read-only. Returns up to `limit` systems ordered notable-first (populated,
+    then by star-brightness proxy from spectral class), so the important stars
+    appear first at partial zoom and fill in as you zoom deeper. An over-wide
+    box is rejected with `too_wide=True` (the client should stay on the heatmap)
+    rather than forcing a whole-galaxy scan.
+    """
+    # Tolerate min/max sent in either order.
+    lo_x, hi_x = sorted((min_x, max_x))
+    lo_y, hi_y = sorted((min_y, max_y))
+    lo_z, hi_z = sorted((min_z, max_z))
+
+    if ((hi_x - lo_x) > MAX_MAP_VIEWPORT_LY
+            or (hi_y - lo_y) > MAX_MAP_VIEWPORT_LY
+            or (hi_z - lo_z) > MAX_MAP_VIEWPORT_LY):
+        return {'systems': [], 'count': 0, 'truncated': False, 'too_wide': True, 'cached': False}
+
+    cache_key = (
+        f'map:systems:v1:{lo_x:.0f}:{hi_x:.0f}:{lo_y:.0f}:{hi_y:.0f}:'
+        f'{lo_z:.0f}:{hi_z:.0f}:{limit}'
+    )
+    cached = await cache_get(cache_key, redis)
+    if cached is not None:
+        return JSONResponse(content=cached)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch("""
+            SELECT id64, name, x, y, z, main_star_type,
+                   (population IS NOT NULL AND population > 0) AS populated
+            FROM   systems
+            WHERE  x BETWEEN $1 AND $2
+              AND  y BETWEEN $3 AND $4
+              AND  z BETWEEN $5 AND $6
+            ORDER BY (population IS NOT NULL AND population > 0) DESC,
+                     CASE left(main_star_type, 1)
+                        WHEN 'O' THEN 0 WHEN 'B' THEN 1 WHEN 'A' THEN 2
+                        WHEN 'F' THEN 3 WHEN 'G' THEN 4 WHEN 'K' THEN 5
+                        WHEN 'M' THEN 6 ELSE 7 END,
+                     id64
+            LIMIT  $7
+        """, lo_x, hi_x, lo_y, hi_y, lo_z, hi_z, limit + 1)
+
+    truncated = len(rows) > limit
+    if truncated:
+        rows = rows[:limit]
+    result = {
+        'systems': [
+            {
+                'id64': r['id64'], 'name': r['name'],
+                'x': r['x'], 'y': r['y'], 'z': r['z'],
+                'star': r['main_star_type'], 'populated': r['populated'],
+            }
+            for r in rows
+        ],
+        'count': len(rows),
+        'truncated': truncated,
+        'too_wide': False,
+        'cached': False,
+    }
+    await cache_set(cache_key, result, settings.ttl_search, redis)
     return result

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -214,6 +214,14 @@ competing roadmap source.
   coverage, and related trust signals.
 - Harden the `systems.has_body_data` / `systems.body_count` contract so rating
   eligibility cannot drift away from actual `bodies` rows under live ingest.
+- Real-star viewport streaming on the Explore map is authorized as a bounded,
+  **read-only** capability: a capped `/api/map/systems` bounding-box endpoint
+  plus a client LOD switch that renders individual systems (colored by spectral
+  class) on zoom-in, complementing — not replacing — the aggregate heatmap. It
+  writes nothing, adds no planner-map fusion, and rides the existing `systems`
+  spatial indexes (`idx_sys_coords`); a precomputed tile pyramid stays out of
+  scope unless measured performance requires it. See
+  `docs/superpowers/plans/2026-08-11-map-real-star-streaming.md`.
 
 ### Deferred Product Expansion
 

--- a/frontend/src/types/api.gen.ts
+++ b/frontend/src/types/api.gen.ts
@@ -1081,6 +1081,33 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/map/systems": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Map Systems
+         * @description Individual star systems within a viewport bounding box — the zoom-in
+         *     real-star detail lane (the heatmap is the zoomed-out aggregate lane).
+         *
+         *     Read-only. Returns up to `limit` systems ordered notable-first (populated,
+         *     then by star-brightness proxy from spectral class), so the important stars
+         *     appear first at partial zoom and fill in as you zoom deeper. An over-wide
+         *     box is rejected with `too_wide=True` (the client should stay on the heatmap)
+         *     rather than forcing a whole-galaxy scan.
+         */
+        get: operations["map_systems_api_map_systems_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/archetypes/rankings": {
         parameters: {
             query?: never;
@@ -7216,6 +7243,50 @@ export interface operations {
         parameters: {
             query?: {
                 bucket?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    map_systems_api_map_systems_get: {
+        parameters: {
+            query: {
+                /** @description Viewport bounding-box min X (LY) */
+                min_x: number;
+                /** @description Viewport bounding-box max X (LY) */
+                max_x: number;
+                /** @description Viewport bounding-box min Y (LY) */
+                min_y: number;
+                /** @description Viewport bounding-box max Y (LY) */
+                max_y: number;
+                /** @description Viewport bounding-box min Z (LY) */
+                min_z: number;
+                /** @description Viewport bounding-box max Z (LY) */
+                max_z: number;
+                /** @description Maximum individual systems returned */
+                limit?: number;
             };
             header?: never;
             path?: never;

--- a/tests/integration/test_map_systems_viewport.py
+++ b/tests/integration/test_map_systems_viewport.py
@@ -1,0 +1,80 @@
+"""Integration: GET /api/map/systems — the real-star viewport detail lane.
+
+Seeds a few systems at coordinates far outside the real galaxy (~+-50k LY) so
+only our rows fall inside the test bounding box, then asserts the endpoint:
+  * filters to the box (out-of-box rows excluded),
+  * orders notable-first (populated, then brighter spectral class),
+  * honors the cap via `truncated`,
+  * rejects an over-wide box with `too_wide`,
+  * rejects an out-of-range `limit` at the edge (422).
+"""
+import pytest
+import pytest_asyncio
+
+pytestmark = pytest.mark.asyncio
+
+BASE = 800_000.0  # far outside the real galaxy so the box is otherwise empty
+TEST_IDS = [9_900_000_001, 9_900_000_002, 9_900_000_003, 9_900_000_004]
+
+# (id64, name, x, y, z, population, main_star_type)
+SEED = [
+    (9_900_000_001, 'VP Test Populated K', BASE,         BASE,       BASE,       12_000, 'K'),
+    (9_900_000_002, 'VP Test Bright O',    BASE + 100.0, BASE,       BASE,       0,      'O'),
+    (9_900_000_003, 'VP Test Dim M',       BASE + 200.0, BASE,       BASE,       0,      'M'),
+    (9_900_000_004, 'VP Test OutOfBox',    900_000.0,    900_000.0,  900_000.0,  0,      'G'),
+]
+
+IN_BOX = {
+    'min_x': BASE - 1_000, 'max_x': BASE + 1_000,
+    'min_y': BASE - 1_000, 'max_y': BASE + 1_000,
+    'min_z': BASE - 1_000, 'max_z': BASE + 1_000,
+}
+
+
+@pytest_asyncio.fixture
+async def seeded_viewport_systems(pool):
+    async with pool.acquire() as conn:
+        await conn.execute('DELETE FROM systems WHERE id64 = ANY($1::bigint[])', TEST_IDS)
+        await conn.executemany(
+            'INSERT INTO systems (id64, name, x, y, z, population, main_star_type) '
+            'VALUES ($1, $2, $3, $4, $5, $6, $7)',
+            SEED,
+        )
+    yield
+    async with pool.acquire() as conn:
+        await conn.execute('DELETE FROM systems WHERE id64 = ANY($1::bigint[])', TEST_IDS)
+
+
+async def test_viewport_filters_to_box_and_orders_notable_first(client, seeded_viewport_systems):
+    r = await client.get('/api/map/systems', params=IN_BOX)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    ids = [s['id64'] for s in body['systems'] if s['id64'] in TEST_IDS]
+    # out-of-box row excluded; exactly the three in-box seeds, notable-first:
+    # populated K first, then bright O before dim M.
+    assert ids == [9_900_000_001, 9_900_000_002, 9_900_000_003]
+    assert body['too_wide'] is False
+    assert body['truncated'] is False
+
+
+async def test_viewport_rejects_overwide_box(client):
+    params = {'min_x': 0, 'max_x': 100_000, 'min_y': 0, 'max_y': 10, 'min_z': 0, 'max_z': 10}
+    r = await client.get('/api/map/systems', params=params)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body['too_wide'] is True
+    assert body['systems'] == []
+
+
+async def test_viewport_truncates_at_limit(client, seeded_viewport_systems):
+    r = await client.get('/api/map/systems', params={**IN_BOX, 'limit': 2})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    ids = [s['id64'] for s in body['systems'] if s['id64'] in TEST_IDS]
+    assert ids == [9_900_000_001, 9_900_000_002]  # notable-first, capped at 2
+    assert body['truncated'] is True
+
+
+async def test_viewport_rejects_out_of_range_limit(client):
+    r = await client.get('/api/map/systems', params={**IN_BOX, 'limit': 999_999})
+    assert r.status_code == 422


### PR DESCRIPTION
**Phase 1** of the committed real-star LOD streaming project — the read-only backend viewport endpoint that powers zoom-in real stars (the aggregate heatmap stays the zoomed-out lane).

## What
`GET /api/map/systems` — given a viewport bounding box + cap, returns individual systems (`id64, name, x/y/z, star, populated`) **ordered notable-first** (populated, then by spectral-class brightness), so important stars appear first at partial zoom and fill in as you zoom deeper.

## Safety / scope
- **Read-only**, cached + rate-limited like the other map endpoints; rides the existing `idx_sys_coords`.
- Hard **40k per-viewport cap** + a per-axis **box guard** (`too_wide`) so an over-wide request returns empty (client stays on the heatmap) instead of scanning the galaxy.
- Authorized as a bounded, read-only Explore-map capability in `docs/ROADMAP.md`; no planner-map fusion.

## Verification
Real-Postgres integration test (bbox filtering, notable-first ordering, truncation, `too_wide`, limit-range 422); ruff + frontend typecheck clean; `api.gen.ts` regenerated (no openapi drift). Local EXPLAIN seq-scans the tiny dev table — prod's 186M rows use the index; perf is measured in Phase 3.

Phase 2 (client LOD + rendering) reuses the already-merged glow shader + `spectralStarColor`. Plan: `docs/superpowers/plans/2026-08-11-map-real-star-streaming.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)