### PR TITLE
Fix operator DB health password parsing

### DIFF
--- a/scripts/operator/actions/db-readonly-health.sh
+++ b/scripts/operator/actions/db-readonly-health.sh
@@ -6,88 +6,89 @@ cd /opt/ed-finder
 echo "== DB read-only health =="
 echo "Loading POSTGRES_PASSWORD from /opt/ed-finder/.env without sourcing unrelated values..."
 
-POSTGRES_PASSWORD="$(python3 -c '
+POSTGRES_PASSWORD="$(python3 <<'PY'
 from pathlib import Path
 
 value = None
-for raw in Path("/opt/ed-finder/.env").read_text(encoding="utf-8").splitlines():
+for raw in Path('/opt/ed-finder/.env').read_text(encoding='utf-8').splitlines():
     line = raw.strip()
-    if not line or line.startswith("#") or "=" not in line:
+    if not line or line.startswith('#') or '=' not in line:
         continue
-    key, candidate = line.split("=", 1)
-    if key.strip() != "POSTGRES_PASSWORD":
+    key, candidate = line.split('=', 1)
+    if key.strip() != 'POSTGRES_PASSWORD':
         continue
     candidate = candidate.strip()
-    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in ("\"", "\'"):
+    if len(candidate) >= 2 and candidate[0] == candidate[-1] and candidate[0] in (chr(34), chr(39)):
         candidate = candidate[1:-1]
     value = candidate
 if value is None:
-    raise SystemExit("POSTGRES_PASSWORD is not set in /opt/ed-finder/.env")
+    raise SystemExit('POSTGRES_PASSWORD is not set in /opt/ed-finder/.env')
 print(value)
-')"
+PY
+)"
 export POSTGRES_PASSWORD
 
 test -n "${POSTGRES_PASSWORD:-}" || { echo "STOP: POSTGRES_PASSWORD is empty" >&2; exit 1; }
 
-python3 -c '
+python3 <<'PY'
 import os
 import psycopg2
 import psycopg2.extras
 
-password = os.environ.get("POSTGRES_PASSWORD")
+password = os.environ.get('POSTGRES_PASSWORD')
 dsn = (
-    "host=127.0.0.1 "
-    "port=5432 "
-    "dbname=edfinder "
-    "user=edfinder "
-    f"password={password} "
-    "sslmode=disable"
+    'host=127.0.0.1 '
+    'port=5432 '
+    'dbname=edfinder '
+    'user=edfinder '
+    f'password={password} '
+    'sslmode=disable'
 )
 
 conn = psycopg2.connect(dsn)
 try:
     conn.set_session(readonly=True, autocommit=True)
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-        cur.execute("SHOW transaction_read_only")
-        read_only = cur.fetchone()["transaction_read_only"]
+        cur.execute('SHOW transaction_read_only')
+        read_only = cur.fetchone()['transaction_read_only']
 
-        cur.execute("""
+        cur.execute('''
             SELECT
               current_database() AS current_database,
               current_user AS current_user,
               inet_server_addr()::text AS server_addr,
               inet_server_port() AS server_port
-        """)
+        ''')
         ident = dict(cur.fetchone())
 
-        cur.execute("SELECT COUNT(*)::int AS station_rows FROM stations")
-        station_rows = dict(cur.fetchone())["station_rows"]
+        cur.execute('SELECT COUNT(*)::int AS station_rows FROM stations')
+        station_rows = dict(cur.fetchone())['station_rows']
 
-        cur.execute("SELECT COUNT(*)::int AS identity_rows FROM station_external_identity")
-        identity_rows = dict(cur.fetchone())["identity_rows"]
+        cur.execute('SELECT COUNT(*)::int AS identity_rows FROM station_external_identity')
+        identity_rows = dict(cur.fetchone())['identity_rows']
 
-        cur.execute("""
+        cur.execute('''
             SELECT station_type::text AS station_type, COUNT(*)::int AS rows
             FROM stations
             GROUP BY station_type
             ORDER BY station_type
-        """)
+        ''')
         type_counts = [dict(row) for row in cur.fetchall()]
 
-        print("transaction_read_only:", read_only)
-        print("current_database:", ident["current_database"])
-        print("current_user:", ident["current_user"])
-        print("server_addr:", ident["server_addr"])
-        print("server_port:", ident["server_port"])
-        print("station_rows:", station_rows)
-        print("identity_rows:", identity_rows)
-        print("station_type_counts:", type_counts)
+        print('transaction_read_only:', read_only)
+        print('current_database:', ident['current_database'])
+        print('current_user:', ident['current_user'])
+        print('server_addr:', ident['server_addr'])
+        print('server_port:', ident['server_port'])
+        print('station_rows:', station_rows)
+        print('identity_rows:', identity_rows)
+        print('station_type_counts:', type_counts)
 
-        if read_only != "on":
-            raise SystemExit("STOP: transaction was not read-only")
+        if read_only != 'on':
+            raise SystemExit('STOP: transaction was not read-only')
 finally:
     conn.close()
-'
+PY
 
 echo
 echo "== Safety boundary =="


### PR DESCRIPTION
Fixes the DB read-only health helper introduced with the ChatGPT ops control plane. The previous implementation avoided sourcing the whole `.env` but accidentally introduced a shell quoting error. This version uses shell-safe Python heredocs, reads only `POSTGRES_PASSWORD`, and preserves the read-only database session and safety receipt.