### PR TITLE
Add bounded Linux Codex worker

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -1,4 +1,4 @@
-name: Codex Laptop Worker
+name: Codex Worker
 
 on:
   workflow_dispatch:
@@ -21,12 +21,12 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: codex-laptop-worker
+  group: codex-worker
   cancel-in-progress: false
 
 jobs:
   codex:
-    runs-on: [self-hosted, Windows, X64, codex-laptop]
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 120
     steps:
       - name: Checkout
@@ -34,36 +34,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify bounded worker identity
-        shell: pwsh
+      - name: Verify worker identity
+        shell: bash
         run: |
-          $ErrorActionPreference = 'Stop'
-          $codex = 'C:\Users\brian\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe'
-          if (-not (Test-Path $codex)) { throw "Codex CLI not found at expected path: $codex" }
-          Write-Host "runner=$env:RUNNER_NAME"
-          Write-Host "workspace=$env:GITHUB_WORKSPACE"
-          & $codex --version
+          set -euo pipefail
+          echo "runner=$RUNNER_NAME"
+          echo "workspace=$GITHUB_WORKSPACE"
+          id
+          uname -a
+          if ! command -v codex >/dev/null 2>&1; then
+            echo "CODEX_NOT_INSTALLED"
+            exit 42
+          fi
+          codex --version
 
       - name: Run Codex investigation
         if: inputs.mode == 'investigate'
-        shell: pwsh
+        shell: bash
         env:
           CODEX_TASK: ${{ inputs.task }}
         run: |
-          $ErrorActionPreference = 'Stop'
-          $codex = 'C:\Users\brian\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe'
-          $prompt = @"
+          set -euo pipefail
+          prompt=$(cat <<'EOF'
           You are operating in the ED-Finder repository as an investigation-only worker.
           Do not modify files, commit, push, deploy, access production, or use production credentials.
           Inspect the repository and answer the task below with concrete file paths and findings.
+          EOF
+          )
+          prompt="$prompt
 
-          TASK:
-          $env:CODEX_TASK
-          "@
-          & $codex exec --sandbox read-only $prompt
+TASK:
+$CODEX_TASK"
+          codex exec --sandbox read-only "$prompt"
 
       - name: Implement mode safety stop
         if: inputs.mode == 'implement'
-        shell: pwsh
+        shell: bash
         run: |
-          throw 'Implement mode is intentionally disabled until the investigation-only worker is proven end-to-end.'
+          echo 'Implement mode is intentionally disabled until the investigation-only worker is proven end-to-end.' >&2
+          exit 64

--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -1,0 +1,69 @@
+name: Codex Laptop Worker
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Task for Codex CLI"
+        required: true
+        type: string
+      mode:
+        description: "Execution mode"
+        required: true
+        default: investigate
+        type: choice
+        options:
+          - investigate
+          - implement
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: codex-laptop-worker
+  cancel-in-progress: false
+
+jobs:
+  codex:
+    runs-on: [self-hosted, Windows, X64, codex-laptop]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+
+      - name: Verify bounded worker identity
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $codex = 'C:\Users\brian\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe'
+          if (-not (Test-Path $codex)) { throw "Codex CLI not found at expected path: $codex" }
+          Write-Host "runner=$env:RUNNER_NAME"
+          Write-Host "workspace=$env:GITHUB_WORKSPACE"
+          & $codex --version
+
+      - name: Run Codex investigation
+        if: inputs.mode == 'investigate'
+        shell: pwsh
+        env:
+          CODEX_TASK: ${{ inputs.task }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $codex = 'C:\Users\brian\AppData\Local\Programs\OpenAI\Codex\bin\codex.exe'
+          $prompt = @"
+          You are operating in the ED-Finder repository as an investigation-only worker.
+          Do not modify files, commit, push, deploy, access production, or use production credentials.
+          Inspect the repository and answer the task below with concrete file paths and findings.
+
+          TASK:
+          $env:CODEX_TASK
+          "@
+          & $codex exec --sandbox read-only $prompt
+
+      - name: Implement mode safety stop
+        if: inputs.mode == 'implement'
+        shell: pwsh
+        run: |
+          throw 'Implement mode is intentionally disabled until the investigation-only worker is proven end-to-end.'


### PR DESCRIPTION
Adds the first bounded GitHub Actions bridge to the dedicated Contabo Linux Codex worker. Initial mode is investigation-only; implementation mode deliberately fails closed until the read-only path is proven. The job targets a self-hosted Linux x64 runner, verifies runner identity, requires Codex CLI to be installed, and invokes Codex with a read-only sandbox. No production credentials or ed-new access are part of this worker.