### PR TITLE
Cover Codex worker in CI stall contract

### DIFF
--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -41,6 +41,7 @@ CHECKED_WORKFLOWS = (
     'chatgpt-ops.yml',
     'ci.yml',
     'codeql.yml',
+    'codex-laptop.yml',
     'container-image-parity.yml',
     'coverage.yml',
     'dependabot-auto-merge.yml',


### PR DESCRIPTION
Superseded by #500, which now includes this exact one-line `codex-laptop.yml` stall-contract entry alongside the other bounded CI infrastructure repairs. Closed unmerged; no production or deployment action.