### PR TITLE
Allow parallel Codex worker runs

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -25,13 +25,9 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: codex-worker
-  cancel-in-progress: false
-
 jobs:
   codex:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, codex-worker]
     timeout-minutes: 120
     steps:
       - name: Checkout request

--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   codex:
-    runs-on: [self-hosted, Linux, X64, codex-worker]
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 120
     steps:
       - name: Checkout request


### PR DESCRIPTION
Bounded Codex machinery change only. Removes the workflow-level concurrency group that serialized every Codex Worker run. The existing `runs-on: [self-hosted, Linux, X64]` selector is intentionally preserved: three read-only probe runs on the request branch overlapped and dispatched successfully to all three known Codex runners (`contabo-codex-worker`, `contabo-codex-worker-2`, and `contabo-codex-worker-3`).

Preserved unchanged: the 120-minute job timeout, strict repository state gate, investigation workspace-cleanliness gate, isolated implementation branches, and the explicit no-production/no-deploy workflow behavior.

This remains a draft setup PR. Do not merge or deploy as part of machinery validation.