### PR TITLE
Make Codex bridge dispatch asynchronous

### DIFF
--- a/.github/workflows/codex-dispatch.yml
+++ b/.github/workflows/codex-dispatch.yml
@@ -90,21 +90,25 @@ jobs:
 
           worker_run_id=""
           for _ in 1 2 3 4 5; do
-            runs="$(curl --silent --show-error --location \
+            runs_file="$(mktemp)"
+            curl --silent --show-error --location \
+              --output "$runs_file" \
               --header 'Accept: application/vnd.github+json' \
               --header "Authorization: Bearer $GH_TOKEN" \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "https://api.github.com/repos/$REPOSITORY/actions/workflows/codex-laptop.yml/runs?event=workflow_dispatch&per_page=20")"
-            worker_run_id="$(RUNS="$runs" python3 - <<'PY'
-          import json, os
-          request_id = os.environ["CODEX_REQUEST_ID"]
-          data = json.loads(os.environ["RUNS"])
+              "https://api.github.com/repos/$REPOSITORY/actions/workflows/codex-laptop.yml/runs?event=workflow_dispatch&per_page=20"
+            worker_run_id="$(python3 - "$runs_file" "$CODEX_REQUEST_ID" <<'PY'
+          import json, sys
+          path, request_id = sys.argv[1], sys.argv[2]
+          with open(path, encoding="utf-8") as handle:
+              data = json.load(handle)
           for run in data.get("workflow_runs", []):
               if request_id in (run.get("display_title") or ""):
                   print(run["id"])
                   break
           PY
             )"
+            rm -f "$runs_file"
             [ -n "$worker_run_id" ] && break
             sleep 2
           done

--- a/.github/workflows/codex-dispatch.yml
+++ b/.github/workflows/codex-dispatch.yml
@@ -1,0 +1,121 @@
+name: Codex Dispatch
+run-name: Codex Dispatch · ${{ github.sha }}
+
+on:
+  push:
+    branches:
+      - codex-task-requests
+    paths:
+      - '.github/codex-requests/*.json'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Checkout request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Resolve request
+        id: request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- '.github/codex-requests/*.json')
+          [ "${#files[@]}" -eq 1 ] || { echo "Expected exactly one Codex request file" >&2; exit 64; }
+          file="${files[0]}"
+          mode="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); extra=set(d)-{"task","mode"}; extra and sys.exit("unsupported request keys"); m=d.get("mode","investigate"); m in {"investigate","implement"} or sys.exit("unsupported mode"); print(m)' "$file")"
+          task="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); t=d.get("task"); isinstance(t,str) and t.strip() or sys.exit("task must be non-empty"); print(t.replace("\n"," "))' "$file")"
+          stem="$(basename "$file" .json)"
+          request_id="${stem}-${CURRENT_SHA:0:8}"
+          {
+            echo "mode=$mode"
+            echo "request_id=$request_id"
+            echo "request_file=$file"
+            echo "task<<EOF"
+            echo "$task"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch worker asynchronously
+        id: dispatch
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          CODEX_TASK: ${{ steps.request.outputs.task }}
+          CODEX_MODE: ${{ steps.request.outputs.mode }}
+          CODEX_REQUEST_ID: ${{ steps.request.outputs.request_id }}
+          CODEX_REQUEST_FILE: ${{ steps.request.outputs.request_file }}
+        run: |
+          set -euo pipefail
+          payload="$(python3 - <<'PY'
+          import json, os
+          print(json.dumps({
+              "ref": "main",
+              "inputs": {
+                  "task": os.environ["CODEX_TASK"],
+                  "mode": os.environ["CODEX_MODE"],
+                  "request_id": os.environ["CODEX_REQUEST_ID"],
+              },
+          }))
+          PY
+          )"
+
+          response_file="$(mktemp)"
+          http_code="$(curl --silent --show-error --location \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/$REPOSITORY/actions/workflows/codex-laptop.yml/dispatches" \
+            --data "$payload")"
+
+          if [ "$http_code" != "204" ]; then
+            echo "Codex worker dispatch failed with HTTP $http_code" >&2
+            cat "$response_file" >&2
+            exit 68
+          fi
+
+          worker_run_id=""
+          for _ in 1 2 3 4 5; do
+            runs="$(curl --silent --show-error --location \
+              --header 'Accept: application/vnd.github+json' \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$REPOSITORY/actions/workflows/codex-laptop.yml/runs?event=workflow_dispatch&per_page=20")"
+            worker_run_id="$(RUNS="$runs" python3 - <<'PY'
+          import json, os
+          request_id = os.environ["CODEX_REQUEST_ID"]
+          data = json.loads(os.environ["RUNS"])
+          for run in data.get("workflow_runs", []):
+              if request_id in (run.get("display_title") or ""):
+                  print(run["id"])
+                  break
+          PY
+            )"
+            [ -n "$worker_run_id" ] && break
+            sleep 2
+          done
+
+          echo "CODEX_DISPATCH_ACCEPTED=true"
+          echo "CODEX_REQUEST_ID=$CODEX_REQUEST_ID"
+          echo "CODEX_REQUEST_FILE=$CODEX_REQUEST_FILE"
+          if [ -n "$worker_run_id" ]; then
+            echo "CODEX_WORKER_RUN_ID=$worker_run_id"
+            echo "worker_run_id=$worker_run_id" >> "$GITHUB_OUTPUT"
+          else
+            echo "CODEX_WORKER_RUN_ID=pending"
+          fi
+          echo "The long-running Codex worker is now independent of this dispatch job. Do not wait for it here."

--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -1,4 +1,5 @@
 name: Codex Worker
+run-name: Codex Worker · ${{ inputs.request_id }}
 
 on:
   workflow_dispatch:
@@ -15,11 +16,11 @@ on:
         options:
           - investigate
           - implement
-  push:
-    branches:
-      - codex-task-requests
-    paths:
-      - '.github/codex-requests/*.json'
+      request_id:
+        description: "Stable request identifier supplied by the async dispatcher"
+        required: false
+        default: manual
+        type: string
 
 permissions:
   contents: write
@@ -34,40 +35,35 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 120
     steps:
-      - name: Checkout request
+      - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          fetch-depth: 2
+          fetch-depth: 10
+          ref: main
 
       - name: Resolve request
         id: request
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_TASK: ${{ inputs.task }}
           INPUT_MODE: ${{ inputs.mode }}
-          BEFORE_SHA: ${{ github.event.before }}
-          CURRENT_SHA: ${{ github.sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            task="$INPUT_TASK"
-            mode="$INPUT_MODE"
-          elif [ "$EVENT_NAME" = "push" ]; then
-            mapfile -t files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- '.github/codex-requests/*.json')
-            [ "${#files[@]}" -eq 1 ] || { echo "Expected exactly one Codex request file" >&2; exit 64; }
-            mode="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); extra=set(d)-{"task","mode"}; extra and sys.exit("unsupported request keys"); m=d.get("mode","investigate"); m in {"investigate","implement"} or sys.exit("unsupported mode"); print(m)' "${files[0]}")"
-            task="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); t=d.get("task"); isinstance(t,str) and t.strip() or sys.exit("task must be non-empty"); print(t.replace("\n"," "))' "${files[0]}")"
-          else
-            echo "Unsupported event: $EVENT_NAME" >&2
-            exit 64
-          fi
+          task="$INPUT_TASK"
+          mode="$INPUT_MODE"
+          [ -n "${task//[[:space:]]/}" ] || { echo "task must be non-empty" >&2; exit 64; }
+          case "$mode" in
+            investigate|implement) ;;
+            *) echo "unsupported mode: $mode" >&2; exit 64 ;;
+          esac
           {
             echo "mode=$mode"
             echo "task<<EOF"
             echo "$task"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          echo "CODEX_REQUEST_ID=$REQUEST_ID"
 
       - name: Switch to main workspace
         shell: bash

--- a/docs/development/chatgpt-ops-control-plane.md
+++ b/docs/development/chatgpt-ops-control-plane.md
@@ -41,6 +41,22 @@ Server connectivity must use already-authorized deployment/SSH credentials if th
 
 If the repository does not already have suitable Actions credentials, the workflow may be merged in an inert state and the one remaining owner action is to add the required GitHub Actions secret/runner connection.
 
+## Codex bridge
+
+Codex task requests are intentionally asynchronous so a ChatGPT web or desktop turn never needs to stay open for the full Codex execution time.
+
+The request path is:
+
+`ChatGPT -> codex-task-requests -> Codex Dispatch -> workflow_dispatch -> Codex Worker -> self-hosted runner -> codex exec`
+
+A request is a single JSON file committed under `.github/codex-requests/` on the `codex-task-requests` branch. `.github/workflows/codex-dispatch.yml` validates that request on a GitHub-hosted runner, dispatches `.github/workflows/codex-laptop.yml` through `workflow_dispatch`, records a stable request identifier, and then exits. Its bounded job must never wait for the Codex worker to finish.
+
+The long-running self-hosted job is a separate workflow run. Its run name includes the stable request identifier, and the dispatcher prints `CODEX_DISPATCH_ACCEPTED=true` plus `CODEX_WORKER_RUN_ID=<id>` when the worker run becomes visible. If GitHub has accepted the dispatch but the worker run has not appeared within the short lookup window, the dispatcher prints `CODEX_WORKER_RUN_ID=pending` and still exits successfully.
+
+ChatGPT clients should therefore report the dispatch acknowledgement/run ID immediately. A later turn may query the worker run for progress or results. A client-side timeout must not be treated as evidence that Codex failed unless the GitHub worker run itself failed or timed out.
+
+The Codex Worker retains its 120-minute execution limit, serial `codex-worker` concurrency group, repository state gate, investigation immutability check, and isolated implementation-branch behavior.
+
 ## Receipts
 
 Every run should record at least:

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -41,6 +41,7 @@ CHECKED_WORKFLOWS = (
     'chatgpt-ops.yml',
     'ci.yml',
     'codeql.yml',
+    'codex-dispatch.yml',
     'codex-laptop.yml',
     'container-image-parity.yml',
     'coverage.yml',

--- a/tests/test_codex_async_bridge.py
+++ b/tests/test_codex_async_bridge.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DISPATCH = ROOT / ".github" / "workflows" / "codex-dispatch.yml"
+WORKER = ROOT / ".github" / "workflows" / "codex-laptop.yml"
+
+
+def test_codex_request_push_is_acknowledged_by_short_dispatch_workflow() -> None:
+    text = DISPATCH.read_text(encoding="utf-8")
+
+    assert "branches:\n      - codex-task-requests" in text
+    assert "actions: write" in text
+    assert "timeout-minutes: 2" in text
+    assert "codex-laptop.yml/dispatches" in text
+    assert "CODEX_DISPATCH_ACCEPTED=true" in text
+    assert "CODEX_WORKER_RUN_ID=" in text
+    assert "Do not wait for it here." in text
+
+
+def test_long_codex_worker_only_runs_from_explicit_dispatch() -> None:
+    text = WORKER.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in text
+    assert "request_id:" in text
+    assert "run-name: Codex Worker · ${{ inputs.request_id }}" in text
+    assert "timeout-minutes: 120" in text
+    assert "codex exec --sandbox danger-full-access" in text
+    assert "codex-task-requests" not in text


### PR DESCRIPTION
## Summary
- split Codex request acknowledgement from the long-running self-hosted worker
- add a fast `Codex Dispatch` workflow on `codex-task-requests`
- invoke the existing Codex worker via `workflow_dispatch` with a stable request ID
- report `CODEX_DISPATCH_ACCEPTED` and the worker run ID without waiting for Codex completion
- preserve the 120-minute worker timeout, state gate, investigation immutability checks, and implementation branch behavior
- add a focused bridge contract test and document the fire-and-return semantics

## Motivation
ChatGPT Desktop can time out while polling a valid long-running Codex job. This change makes the GitHub bridge explicitly asynchronous so the client only needs to wait for the short dispatch acknowledgement and can check the worker in a later turn.

## Safety
No production deployment, server, database, DNS, or V3 runtime changes. The `codex-task-requests` live branch will not be switched to the new dispatcher until this PR is merged and verified.