### PR TITLE
Harden Codex workflow branch pushes

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -156,7 +156,7 @@ jobs:
           set -euo pipefail
           workflow_changes="$(git diff --name-only refs/remotes/origin/main...HEAD | grep -E '^\.github/workflows/' || true)"
           if [ -n "$workflow_changes" ] && [ -z "$CODEX_WORKER_GIT_TOKEN" ]; then
-            echo "::error::Codex changed GitHub workflow files, but CODEX_WORKER_GIT_TOKEN is not configured. Add a repository secret backed by a fine-grained token or GitHub App installation token with Contents: read/write and Workflows: read/write for this repository."
+            echo "::error::Codex changed GitHub workflow files, but CODEX_WORKER_GIT_TOKEN is not configured. Add that repository secret using a fine-grained personal access token limited to this repository with Contents: read/write and Workflows: read/write."
             printf 'Workflow files requiring privileged push:\n%s\n' "$workflow_changes"
             exit 68
           fi

--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -142,9 +142,48 @@ jobs:
           git status --short
           git add -A
           git commit -m "Codex implementation run ${GITHUB_RUN_ID}"
-          git push --force-with-lease origin "$branch"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "CODEX_BRANCH=$branch"
+          echo "CODEX_BRANCH_LOCAL=$branch"
+
+      - name: Push implementation branch
+        if: steps.request.outputs.mode == 'implement' && steps.implement.outputs.branch != ''
+        shell: bash
+        env:
+          CODEX_BRANCH: ${{ steps.implement.outputs.branch }}
+          CODEX_WORKER_GIT_TOKEN: ${{ secrets.CODEX_WORKER_GIT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          workflow_changes="$(git diff --name-only refs/remotes/origin/main...HEAD | grep -E '^\.github/workflows/' || true)"
+          if [ -n "$workflow_changes" ] && [ -z "$CODEX_WORKER_GIT_TOKEN" ]; then
+            echo "::error::Codex changed GitHub workflow files, but CODEX_WORKER_GIT_TOKEN is not configured. Add a repository secret backed by a fine-grained token or GitHub App installation token with Contents: read/write and Workflows: read/write for this repository."
+            printf 'Workflow files requiring privileged push:\n%s\n' "$workflow_changes"
+            exit 68
+          fi
+
+          push_token="${CODEX_WORKER_GIT_TOKEN:-$GITHUB_TOKEN}"
+
+          # actions/checkout persists the ordinary GITHUB_TOKEN as an HTTP extraheader.
+          # Remove it only after Codex has finished, then authenticate this wrapper-owned
+          # push through GIT_ASKPASS so the privileged token is never present in argv,
+          # a remote URL, the repository config, or the Codex process environment.
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          askpass="$(mktemp)"
+          trap 'rm -f "$askpass"' EXIT
+          cat > "$askpass" <<'EOF'
+          #!/usr/bin/env sh
+          case "$1" in
+            *Username*) printf '%s\n' 'x-access-token' ;;
+            *Password*) printf '%s\n' "$CODEX_PUSH_TOKEN" ;;
+            *) exit 1 ;;
+          esac
+          EOF
+          chmod 700 "$askpass"
+          export CODEX_PUSH_TOKEN="$push_token"
+          export GIT_ASKPASS="$askpass"
+          export GIT_TERMINAL_PROMPT=0
+          git -c credential.helper= push --force-with-lease origin "$CODEX_BRANCH"
+          echo "CODEX_BRANCH=$CODEX_BRANCH"
 
       - name: Implementation branch summary
         if: steps.request.outputs.mode == 'implement' && steps.implement.outputs.branch != ''

--- a/docs/development/chatgpt-ops-control-plane.md
+++ b/docs/development/chatgpt-ops-control-plane.md
@@ -61,7 +61,7 @@ The Codex Worker retains its 120-minute execution limit, serial `codex-worker` c
 
 Ordinary Codex implementation branches may be pushed with the workflow's normal `GITHUB_TOKEN`. GitHub refuses that token when a commit creates or modifies files under `.github/workflows/`, so workflow-file changes require the repository secret `CODEX_WORKER_GIT_TOKEN`.
 
-`CODEX_WORKER_GIT_TOKEN` must be backed by a credential scoped to this repository with `Contents: read/write` and `Workflows: read/write`. A fine-grained personal access token or a GitHub App installation token with the equivalent repository permissions is appropriate; a broad classic token is not preferred.
+`CODEX_WORKER_GIT_TOKEN` should contain a fine-grained personal access token limited to this repository with `Contents: read/write` and `Workflows: read/write`. A broad classic token is not preferred. A GitHub App can be adopted later, but the workflow would need to generate a fresh installation token at runtime rather than storing a short-lived installation token as this repository secret.
 
 The privileged credential is intentionally not passed to `actions/checkout`, the Codex CLI, the task prompt, or the Codex execution environment. Codex finishes first using the ordinary worker environment. The wrapper then inspects the resulting commit and exposes `CODEX_WORKER_GIT_TOKEN` only to the final branch-push step. Authentication is provided through a temporary `GIT_ASKPASS` helper so the token is not embedded in command arguments, remote URLs, or repository configuration.
 

--- a/docs/development/chatgpt-ops-control-plane.md
+++ b/docs/development/chatgpt-ops-control-plane.md
@@ -57,6 +57,16 @@ ChatGPT clients should therefore report the dispatch acknowledgement/run ID imme
 
 The Codex Worker retains its 120-minute execution limit, serial `codex-worker` concurrency group, repository state gate, investigation immutability check, and isolated implementation-branch behavior.
 
+### Codex implementation push credential
+
+Ordinary Codex implementation branches may be pushed with the workflow's normal `GITHUB_TOKEN`. GitHub refuses that token when a commit creates or modifies files under `.github/workflows/`, so workflow-file changes require the repository secret `CODEX_WORKER_GIT_TOKEN`.
+
+`CODEX_WORKER_GIT_TOKEN` must be backed by a credential scoped to this repository with `Contents: read/write` and `Workflows: read/write`. A fine-grained personal access token or a GitHub App installation token with the equivalent repository permissions is appropriate; a broad classic token is not preferred.
+
+The privileged credential is intentionally not passed to `actions/checkout`, the Codex CLI, the task prompt, or the Codex execution environment. Codex finishes first using the ordinary worker environment. The wrapper then inspects the resulting commit and exposes `CODEX_WORKER_GIT_TOKEN` only to the final branch-push step. Authentication is provided through a temporary `GIT_ASKPASS` helper so the token is not embedded in command arguments, remote URLs, or repository configuration.
+
+If a Codex implementation changes `.github/workflows/*` while `CODEX_WORKER_GIT_TOKEN` is absent, the worker fails closed before attempting the push and reports the missing secret explicitly. Implementations that do not change workflow files continue to fall back to the normal `GITHUB_TOKEN`.
+
 ## Receipts
 
 Every run should record at least:

--- a/tests/test_codex_async_bridge.py
+++ b/tests/test_codex_async_bridge.py
@@ -27,3 +27,22 @@ def test_long_codex_worker_only_runs_from_explicit_dispatch() -> None:
     assert "timeout-minutes: 120" in text
     assert "codex exec --sandbox danger-full-access" in text
     assert "codex-task-requests" not in text
+
+
+def test_privileged_workflow_push_token_is_isolated_from_codex() -> None:
+    text = WORKER.read_text(encoding="utf-8")
+
+    implementation = text.split("- name: Run Codex implementation", 1)[1].split(
+        "- name: Push implementation branch", 1
+    )[0]
+    push_wrapper = text.split("- name: Push implementation branch", 1)[1].split(
+        "- name: Implementation branch summary", 1
+    )[0]
+
+    assert "CODEX_WORKER_GIT_TOKEN" not in implementation
+    assert "git push" not in implementation
+    assert "CODEX_WORKER_GIT_TOKEN: ${{ secrets.CODEX_WORKER_GIT_TOKEN }}" in push_wrapper
+    assert "^\\.github/workflows/" in push_wrapper
+    assert "Contents: read/write and Workflows: read/write" in push_wrapper
+    assert "GIT_ASKPASS" in push_wrapper
+    assert "git -c credential.helper= push --force-with-lease origin \"$CODEX_BRANCH\"" in push_wrapper


### PR DESCRIPTION
## Summary

Fixes the Codex worker failure mode seen in run `33306322119`, where implementation completed successfully but GitHub rejected the final branch push because the commit modified `.github/workflows/chatgpt-ed-new-ops.yml` and the ordinary Actions token lacked workflow-file write permission.

### Changes
- split Codex execution/commit from the final branch push;
- keep the privileged credential out of the Codex process environment entirely;
- use repository secret `CODEX_WORKER_GIT_TOKEN` only in the wrapper-owned push step;
- authenticate the final push via temporary `GIT_ASKPASS`, avoiding tokens in argv, remotes, or repo config;
- continue using `GITHUB_TOKEN` for ordinary implementation branches;
- fail closed with a clear error before push when `.github/workflows/*` changed but the privileged secret is absent;
- add regression coverage for credential isolation and push behavior;
- document the required fine-grained token permissions and setup.

## Required owner setup

Add repository Actions secret `CODEX_WORKER_GIT_TOKEN` containing a fine-grained PAT limited to this repository with:
- Contents: Read and write
- Workflows: Read and write

No secret value belongs in source control or this PR.

## Security boundary

The privileged token is not passed to `actions/checkout`, Codex CLI, the task prompt, or the Codex execution step. It only becomes available after Codex has exited and the wrapper is ready to push the inspected commit.
