### PR TITLE
Fix Codex push credential precedence

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           fetch-depth: 10
           ref: main
+          persist-credentials: false
 
       - name: Resolve request
         id: request
@@ -163,11 +164,9 @@ jobs:
 
           push_token="${CODEX_WORKER_GIT_TOKEN:-$GITHUB_TOKEN}"
 
-          # actions/checkout persists the ordinary GITHUB_TOKEN as an HTTP extraheader.
-          # Remove it only after Codex has finished, then authenticate this wrapper-owned
-          # push through GIT_ASKPASS so the privileged token is never present in argv,
-          # a remote URL, the repository config, or the Codex process environment.
-          git config --local --unset-all http.https://github.com/.extraheader || true
+          # Checkout deliberately does not persist credentials. Authenticate only this
+          # wrapper-owned push through GIT_ASKPASS so the selected token is never present
+          # in argv, a remote URL, repository config, or the Codex process environment.
           askpass="$(mktemp)"
           trap 'rm -f "$askpass"' EXIT
           cat > "$askpass" <<'EOF'

--- a/tests/test_codex_async_bridge.py
+++ b/tests/test_codex_async_bridge.py
@@ -32,6 +32,9 @@ def test_long_codex_worker_only_runs_from_explicit_dispatch() -> None:
 def test_privileged_workflow_push_token_is_isolated_from_codex() -> None:
     text = WORKER.read_text(encoding="utf-8")
 
+    checkout = text.split("- name: Checkout main", 1)[1].split(
+        "- name: Resolve request", 1
+    )[0]
     implementation = text.split("- name: Run Codex implementation", 1)[1].split(
         "- name: Push implementation branch", 1
     )[0]
@@ -39,6 +42,7 @@ def test_privileged_workflow_push_token_is_isolated_from_codex() -> None:
         "- name: Implementation branch summary", 1
     )[0]
 
+    assert "persist-credentials: false" in checkout
     assert "CODEX_WORKER_GIT_TOKEN" not in implementation
     assert "git push" not in implementation
     assert "CODEX_WORKER_GIT_TOKEN: ${{ secrets.CODEX_WORKER_GIT_TOKEN }}" in push_wrapper


### PR DESCRIPTION
## Summary

Fixes the remaining workflow-file push failure observed in recovery run `33316636917`.

The repository secret `CODEX_WORKER_GIT_TOKEN` was present, but `actions/checkout` had persisted the built-in GitHub App credential through an `includeIf` credential config. Git therefore authenticated the push with the GitHub App token before `GIT_ASKPASS` could supply the workflow-write PAT.

### Changes
- set `persist-credentials: false` on the worker checkout;
- keep all final push authentication in the wrapper-owned `GIT_ASKPASS` path;
- preserve the existing security boundary: the privileged token is never available to Codex;
- add regression coverage requiring checkout credential persistence to remain disabled.

This should allow workflow-editing implementation branches to use `CODEX_WORKER_GIT_TOKEN`, while ordinary branches continue to fall back to `GITHUB_TOKEN` in the wrapper push step.