### PR TITLE
Prepare PostgreSQL 18 production candidate promotion

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - host-status
+          - production-candidate-readiness
   push:
     branches:
       - chatgpt-ed-new-ops-requests
@@ -55,7 +56,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status) ;;
+            host-status|production-candidate-readiness) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -93,3 +94,76 @@ jobs:
               -o StrictHostKeyChecking=yes \
               "$SSH_USER@$SSH_HOST" \
               'set -eu; echo "== ed-new bootstrap status =="; printf "hostname: "; hostname; printf "fqdn: "; hostname -f 2>/dev/null || true; printf "kernel: "; uname -sr; echo "== filesystem =="; df -hT /; echo "== docker =="; if command -v docker >/dev/null 2>&1; then docker ps --format "{{.Names}}\t{{.Status}}\t{{.Image}}" | head -50; else echo "docker: not installed"; fi; echo "== repo candidates =="; for p in /opt/ed-finder /root/ed-finder /srv/ed-finder; do [ -d "$p" ] && echo "$p"; done; echo "== safety =="; echo "db_access_performed: false"; echo "db_writes_performed: false"; echo "migrations_performed: false"; echo "canonical_apply_performed: false"'
+
+      - name: Run read-only production-candidate readiness audit
+        id: candidate_audit
+        if: steps.request.outputs.operation == 'production-candidate-readiness'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          CANDIDATE_DATABASE_URL: ${{ secrets.ED_NEW_CANDIDATE_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          test -n "$CANDIDATE_DATABASE_URL" || { echo "Missing ED_NEW_CANDIDATE_DATABASE_URL" >&2; exit 1; }
+          echo "::add-mask::$CANDIDATE_DATABASE_URL"
+          set +e
+          printf '%s\n' "$CANDIDATE_DATABASE_URL" | ssh \
+              -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              "$SSH_USER@$SSH_HOST" \
+              'set -eu; IFS= read -r DATABASE_URL; test -n "$DATABASE_URL"; export DATABASE_URL; unset REPLY; cd /opt/ed-finder; test -f scripts/operator/audit_production_candidate.py; receipt="$(mktemp)"; trap '\''rm -f "$receipt"'\'' EXIT; set +e; python3 scripts/operator/audit_production_candidate.py --json-output "$receipt" >&2; status=$?; set -e; test -s "$receipt" && cat "$receipt"; exit "$status"' \
+              > production-candidate-readiness.json
+          audit_status=$?
+          set -e
+          echo "audit_status=$audit_status" >> "$GITHUB_OUTPUT"
+          if [ "$audit_status" -gt 2 ]; then
+            echo "Unexpected readiness-audit exit status: $audit_status" >&2
+          fi
+
+      - name: Validate readiness receipt is JSON and credential-free
+        if: steps.request.outputs.operation == 'production-candidate-readiness' && always()
+        shell: bash
+        env:
+          CANDIDATE_DATABASE_URL: ${{ secrets.ED_NEW_CANDIDATE_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = Path('production-candidate-readiness.json')
+          raw = receipt.read_text(encoding='utf-8')
+          json.loads(raw)
+          secret = os.environ.get('CANDIDATE_DATABASE_URL', '')
+          if secret and secret in raw:
+              raise SystemExit('Readiness receipt contains the candidate database URL')
+          PY
+
+      - name: Retain production-candidate readiness receipt
+        if: steps.request.outputs.operation == 'production-candidate-readiness' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-candidate-readiness-${{ github.run_id }}
+          path: production-candidate-readiness.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce production-candidate readiness result
+        if: steps.request.outputs.operation == 'production-candidate-readiness' && always()
+        shell: bash
+        env:
+          AUDIT_STATUS: ${{ steps.candidate_audit.outputs.audit_status }}
+        run: |
+          set -euo pipefail
+          case "$AUDIT_STATUS" in
+            0) echo "Production-candidate readiness audit passed." ;;
+            1) echo "Production candidate has readiness blockers; inspect the JSON receipt." >&2; exit 1 ;;
+            2) echo "Production-candidate audit failed closed; inspect the run without exposing credentials." >&2; exit 2 ;;
+            *) echo "Production-candidate audit did not produce a valid result." >&2; exit 2 ;;
+          esac

--- a/docs/operations/production-pg18-candidate-promotion.md
+++ b/docs/operations/production-pg18-candidate-promotion.md
@@ -1,0 +1,141 @@
+# Existing PostgreSQL 18 Production-Candidate Promotion
+
+## Purpose and boundary
+
+This runbook is for assessing and, in a later separately approved operation,
+promoting the **existing PostgreSQL 18 rehearsal/test database** to production.
+It is not a database rebuild. Do not create an empty database, restore V2 into
+V3, reset the candidate, run migrations, start a rebuild, change DNS, or cut
+over application traffic while following the audit portion of this runbook.
+
+The readiness audit is evidence, not cutover approval. Keep its JSON receipt
+with the snapshot identity and the candidate database identity that it
+describes. Never paste or store a `DATABASE_URL`, password, or other credential
+in the receipt.
+
+## One-time full-build order
+
+The production bootstrap has this dependency order. Do not skip ahead because
+a downstream command happens to run successfully:
+
+1. **Snapshot/backup.** Freeze an identifiable recovery point for the PG18
+   candidate and prove the backup can be listed and restored using
+   [postgres-backup-and-restore.md](./postgres-backup-and-restore.md). Record
+   backup identifier, start/end UTC, database identity, and verification result.
+2. **Schema and migration audit.** Run the production-candidate readiness audit
+   read-only. The PostgreSQL server must report major version 18. Every entry in
+   `sql/migration-manifest.txt` must agree with the migration ledger: no pending
+   automatic or manual migration and no checksum mismatch. An unexpected or
+   unreadable ledger is a stop condition, not permission to apply migrations.
+3. **Base-data validation/import gaps.** Validate `systems`, `bodies`,
+   `stations`, and `body_rings` when present. Reconcile counts and source
+   coverage against the accepted rehearsal baseline. Investigate missing joins,
+   rejected-row spikes, and implausible count decreases before scheduling any
+   bounded gap import.
+4. **Grid.** Fully populate both `grid_cell_id` and `macro_grid_id` wherever the
+   canonical contract requires them. Completion means zero eligible null or
+   invalid assignments, not merely that a nightly batch made progress.
+5. **Ratings v3.4.** Fully build ratings with current `rating_version = 3.4`.
+   Completion means every eligible canonical system has its required rating,
+   no stale/non-3.4 eligible row remains, and `rating_dirty` has no unresolved
+   eligible work.
+6. **Topology and economy-pair synergy.** Complete the topology dataset first,
+   then economy-pair synergy. Require full eligible coverage and zero required
+   backlog/dirty rows for each before continuing.
+7. **Archetypes.** Complete archetype scores and traits. Every eligible system
+   must have the required current score/trait representation, and archetype
+   dirty work must be zero.
+8. **Regional analysis.** Fully populate the required regional-analysis
+   products for every eligible system/region, with no required backlog.
+9. **Station/body links and canonical backfills.** Complete station-to-body
+   links and every other canonical backfill identified by the audit. Each
+   backfill needs an explicit eligible denominator and must reach that
+   denominator; unexplained orphans are blockers.
+10. **Full clusters.** Build `cluster_summary` only after its dependencies are
+    complete. Require complete eligible cluster coverage and an empty
+    `cluster_dirty` backlog.
+11. **Materialized views and maintenance refresh.** Refresh every required
+    serving materialized view after the underlying full builds, then perform
+    the documented database maintenance. Record view presence, row counts,
+    refresh completion/time, and maintenance result.
+12. **Strict invariant audit.** Run the strict data-invariant suite against the
+    candidate. Every required invariant must pass; skipped, unavailable, or
+    partially checked invariants are promotion blockers.
+13. **Application smoke/release gate.** With writes and public traffic still
+    controlled, verify API startup, representative search/detail/map/planning
+    reads, database compatibility, and rollback readiness. Cutover needs a
+    separate owner-approved release procedure and receipt.
+
+Nightly jobs use deliberately bounded backfills so routine maintenance cannot
+monopolise the database. A bounded nightly run, a decreasing backlog, or one
+successful batch is **not** completion evidence for this one-time production
+bootstrap. Use explicit full-build commands only in a later reviewed operator
+plan, and measure every dataset against its eligible denominator.
+
+## Readiness receipt and interpretation
+
+The preferred replacement-host control plane is the existing **ChatGPT ed-new
+Ops** workflow's narrowly allowlisted `production-candidate-readiness`
+operation. It requires the `ED_NEW_CANDIDATE_DATABASE_URL` environment secret,
+transmits it over SSH standard input rather than a command argument, runs
+`scripts/operator/audit_production_candidate.py --json-output <private-temp>`
+from `/opt/ed-finder`,
+checks that the output is valid JSON and does not contain the URL, and retains
+the receipt as a 30-day Actions artifact. Exit status `1` means audited but not
+ready; `2` means the audit failed closed. Both block the workflow. This
+operation performs reads only and does not run a migration or backfill.
+
+For a reviewed direct operator-shell run, export `DATABASE_URL` from the
+operator's protected secret source without printing it, then run:
+
+```sh
+python3 scripts/operator/audit_production_candidate.py \
+  --json-output /path/to/private/production-candidate-readiness.json
+```
+
+Unset `DATABASE_URL` after the command. Do not put it on the command line, in
+shell history, or in an artifact. The audit must be read-only and fail closed.
+Preserve its human-readable summary or JSON receipt with the snapshot evidence;
+publish the JSON only after confirming it is credential-free.
+
+Classify audit results in two groups:
+
+- **Must be fully built:** grid and macro-grid assignment, ratings v3.4 and
+  rating dirty state, topology, economy-pair synergy, archetype scores/traits
+  and dirty state, regional analysis, station/body links, cluster summary and
+  cluster dirty state, plus required serving materialized views. Missing
+  objects, incomplete eligible coverage, stale versions, or non-zero required
+  backlogs block promotion.
+- **Runtime/feature populated:** later journal, evidence, exploration,
+  powerplay, route, frontier-account, and similar feature tables. The audit
+  records whether each exists and its row count; zero or partial population is
+  not by itself a bootstrap failure unless a separate product release gate has
+  declared that feature required.
+
+Optional missing tables/views must be explicit in the receipt rather than
+causing the audit to crash. Conversely, “optional” means optional to inspect,
+not permission to ignore a missing object listed above as must be fully built.
+
+## Measurable promotion gate
+
+The candidate can enter a separate cutover review only when all of these are
+recorded together:
+
+- a verified, restorable pre-promotion snapshot/backup;
+- PostgreSQL major version 18 and the expected database identity/size;
+- zero pending manifest entries (automatic and manual), zero ledger checksum
+  mismatches, and no unexpected migration-ledger state;
+- accepted base-table counts and source/join coverage with every discrepancy
+  resolved or explicitly accepted;
+- 100% eligible coverage for every must-be-fully-built dataset, current ratings
+  version 3.4, and zero required dirty/backlog rows;
+- every required materialized view present and refreshed after the last full
+  dependency build;
+- a fully passing strict invariant audit with no required check skipped;
+- passing read-only application smoke tests and a documented rollback target.
+
+Any unknown denominator, missing receipt, checksum mismatch, partial full
+build, stale materialized view, failed/skipped invariant, or incomplete
+external-database deployment configuration is a promotion blocker. Stop and
+plan the exact population or remediation operation; do not turn the audit into
+an implicit migration or repair lane.

--- a/env.example
+++ b/env.example
@@ -24,6 +24,13 @@ DATABASE_IMPORT_URL=
 DATABASE_MAINTENANCE_URL=
 DATABASE_MIGRATION_URL=
 
+# Explicit production mode for an existing external/hosted PostgreSQL 18 DB.
+# Keep false for the historical bundled postgres:16 deployment. When true (or
+# when deploy_main.sh is passed --external-db), all five role-specific URLs
+# above are mandatory; the deploy preflights PostgreSQL 18 read-only and uses
+# --no-deps so Compose cannot silently start its bundled postgres service.
+EDFINDER_EXTERNAL_DB_MODE=false
+
 # Optional rclone remote path for offsite Postgres backup copies, for example:
 #   s3:ed-finder-prod/postgres
 #   storagebox:ed-finder/backups/postgres

--- a/scripts/deploy_main.sh
+++ b/scripts/deploy_main.sh
@@ -19,6 +19,7 @@
 #   bash scripts/deploy_main.sh --skip-pull
 #   bash scripts/deploy_main.sh --skip-migrations
 #   bash scripts/deploy_main.sh --skip-frontend
+#   bash scripts/deploy_main.sh --external-db
 #   bash scripts/deploy_main.sh --frontend-archive /tmp/frontend-dist.tar.gz
 #
 # Environment overrides:
@@ -38,6 +39,8 @@ SKIP_PULL=0
 SKIP_MIGRATIONS=0
 SKIP_FRONTEND=0
 SKIP_INVARIANTS=0
+EXTERNAL_DB_MODE="${EDFINDER_EXTERNAL_DB_MODE:-false}"
+EXTERNAL_DB_FLAG=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -45,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --skip-migrations) SKIP_MIGRATIONS=1; shift ;;
     --skip-frontend)   SKIP_FRONTEND=1; shift ;;
     --skip-invariants) SKIP_INVARIANTS=1; shift ;;
+    --external-db)     EXTERNAL_DB_MODE=true; EXTERNAL_DB_FLAG=1; shift ;;
     --frontend-archive) FRONTEND_ARCHIVE="$2"; shift 2 ;;
     --branch)          BRANCH="$2"; shift 2 ;;
     --repo-dir)        REPO_DIR="$2"; shift 2 ;;
@@ -77,7 +81,11 @@ on_error() {
     echo "  cd $REPO_DIR" >&2
     echo "  git reset --hard \$(awk '{print \$1}' $PRE_DEPLOY_FILE)" >&2
     echo "  ( cd $FRONTEND_DIR && yarn build )" >&2
-    echo "  docker compose up -d --build api eddn maintenance" >&2
+    if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+      echo "  docker compose up -d --build --no-deps api eddn maintenance" >&2
+    else
+      echo "  docker compose up -d --build api eddn maintenance" >&2
+    fi
     echo "  docker compose exec nginx nginx -s reload" >&2
   fi
 }
@@ -95,6 +103,25 @@ say "Sanity checks"
 command -v git >/dev/null || die "git not found"
 command -v docker >/dev/null || die "docker not found"
 command -v curl >/dev/null || die "curl not found"
+
+# Compose reads .env automatically; load it here too so the explicit mode and
+# its role-separated URLs are validated against exactly the same configuration.
+set -a
+# shellcheck source=/dev/null
+source .env
+set +a
+if [[ "$EXTERNAL_DB_FLAG" -eq 0 ]]; then
+  EXTERNAL_DB_MODE="${EDFINDER_EXTERNAL_DB_MODE:-false}"
+fi
+
+case "$EXTERNAL_DB_MODE" in
+  true)
+    bash scripts/validate_external_db_config.sh --config-only
+    bash scripts/validate_external_db_config.sh
+    ;;
+  false) ;;
+  *) die "EDFINDER_EXTERNAL_DB_MODE must be exactly true or false" ;;
+esac
 if [[ "$SKIP_FRONTEND" -eq 0 ]]; then
   if [[ -n "$FRONTEND_ARCHIVE" ]]; then
     command -v tar >/dev/null || die "tar not found; required to extract --frontend-archive"
@@ -122,9 +149,11 @@ else
 fi
 
 say "Check core services are available"
-docker compose ps postgres >/dev/null
+if [[ "$EXTERNAL_DB_MODE" == "false" ]]; then
+  docker compose ps postgres >/dev/null
+fi
 docker compose ps redis >/dev/null
-ok "compose can see postgres and redis"
+ok "required database and redis services are available"
 
 if [[ "$SKIP_MIGRATIONS" -eq 0 ]]; then
   say "Apply pending ledgered SQL migrations"
@@ -194,11 +223,22 @@ say "Rebuild/restart application containers"
 export EDFINDER_BUILD_SHA
 EDFINDER_BUILD_SHA="$(git rev-parse HEAD)"
 ok "deployment build SHA: $EDFINDER_BUILD_SHA"
-docker compose up -d --build api eddn maintenance
+if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+  # --no-deps is the critical isolation boundary: api/eddn/maintenance retain
+  # their default bundled-postgres dependency for existing deployments, but an
+  # explicit external deployment must never create or start that service.
+  docker compose up -d --build --no-deps api eddn maintenance
+else
+  docker compose up -d --build api eddn maintenance
+fi
 ok "application containers updated"
 
 say "Recreate nginx to pick up config and volume changes"
-docker compose up -d --force-recreate nginx
+if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+  docker compose up -d --force-recreate --no-deps nginx
+else
+  docker compose up -d --force-recreate nginx
+fi
 ok "nginx container recreated"
 
 say "Wait for API health"
@@ -215,10 +255,16 @@ for i in {1..30}; do
 done
 
 say "Verify facility catalogue"
-facility_count="$(
-  docker compose exec -T postgres psql -U edfinder -d edfinder -At \
-    -c "SELECT COUNT(*) FROM facility_templates;"
-)"
+if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+  facility_count="$(PGCONNECT_TIMEOUT=10 PGOPTIONS='-c default_transaction_read_only=on' \
+    psql --no-psqlrc --dbname="$DATABASE_READONLY_URL" -AtX \
+      -c "SELECT COUNT(*) FROM facility_templates;")"
+else
+  facility_count="$(
+    docker compose exec -T postgres psql -U edfinder -d edfinder -At \
+      -c "SELECT COUNT(*) FROM facility_templates;"
+  )"
+fi
 [[ "$facility_count" -ge 1 ]] || die "facility_templates is empty or missing"
 ok "facility_templates rows: $facility_count"
 

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -16,6 +16,10 @@ does not touch the database.
 
 Current scripts:
 
+- `audit_production_candidate.py`: read-only, fail-closed readiness audit for an
+  existing PostgreSQL production candidate. It requires an explicit
+  `DATABASE_URL`/`--database-url`, emits human output by default, and supports
+  `--json` or `--json-output PATH` for a durable, credential-free receipt.
 - `require_hetzner_operator_env.sh`: reusable fail-fast guard for
   Hetzner-only commands.
 - `stage18j_run_station_type_dry_run.sh`: generates the Stage 18J-P

--- a/scripts/operator/audit_production_candidate.py
+++ b/scripts/operator/audit_production_candidate.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Fail-closed, read-only readiness audit for an existing production candidate DB."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "sql" / "migration-manifest.txt"
+TARGET_RATING_VERSION = "3.4"
+
+# These are populated by application features or live/user input. Their emptiness is
+# not evidence that the one-time canonical warehouse build is incomplete.
+INVENTORY_ONLY_TABLES = (
+    "journal_events",
+    "body_scan_facts",
+    "body_slot_predictions",
+    "buildability_analysis",
+    "colony_simulations",
+    "observed_facts",
+    "journal_import_staging",
+    "evidence_records",
+    "derived_features",
+    "rule_proposals",
+    "rule_decisions",
+    "exploration_facts",
+    "exploration_visits",
+    "exploration_expedition_routes",
+    "exploration_body_completeness",
+    "exobiology_sales",
+    "exobiology_organisms",
+    "codex_observations",
+    "powerplay_observations",
+    "commander_powerplay_events",
+    "commander_powerplay_state",
+    "powerplay_cycles",
+    "routes",
+    "route_events",
+    "app_users",
+    "web_sessions",
+    "oauth_login_states",
+)
+
+
+@dataclass(frozen=True)
+class Migration:
+    filename: str
+    mode: str
+    checksum: str
+
+
+def load_manifest(path: Path) -> list[Migration]:
+    migrations: list[Migration] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        filename, separator, mode = line.partition("|")
+        mode = mode if separator else "auto"
+        if mode not in {"auto", "manual"} or not filename.endswith(".sql"):
+            raise ValueError(f"invalid migration manifest entry: {raw!r}")
+        migration_path = path.parent / filename
+        if not migration_path.is_file():
+            raise ValueError(f"manifested migration is missing: {filename}")
+        checksum = hashlib.sha256(migration_path.read_bytes()).hexdigest()
+        migrations.append(Migration(filename, mode, checksum))
+    if not migrations:
+        raise ValueError("migration manifest is empty")
+    return migrations
+
+
+class Reader:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def one(self, query: str, params: tuple[Any, ...] = ()) -> Any:
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("audit query unexpectedly returned no row")
+        return row[0]
+
+    def rows(self, query: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, params)
+            return list(cursor.fetchall())
+
+    def relation_kind(self, name: str) -> str | None:
+        return self.one(
+            "SELECT (SELECT c.relkind::text FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname='public' AND c.relname=%s)",
+            (name,),
+        )
+
+    def count(self, name: str) -> int:
+        # All names passed here are constants owned by this file.
+        return int(self.one(f'SELECT COUNT(*)::bigint FROM public."{name}"'))
+
+
+def _relation(reader: Reader, name: str, *, classification: str) -> dict[str, Any]:
+    kind = reader.relation_kind(name)
+    if kind is None:
+        return {"name": name, "classification": classification, "present": False, "row_count": None}
+    result = {"name": name, "classification": classification, "present": True, "row_count": reader.count(name)}
+    if kind == "m":
+        result["populated"] = bool(
+            reader.one("SELECT relispopulated FROM pg_catalog.pg_class WHERE oid=to_regclass('public.' || %s)", (name,))
+        )
+    return result
+
+
+def _metric(reader: Reader, name: str, query: str, dependencies: tuple[str, ...], *, required: bool = True) -> dict[str, Any]:
+    missing = [relation for relation in dependencies if reader.relation_kind(relation) is None]
+    if missing:
+        return {"name": name, "classification": "required_build" if required else "optional", "present": False,
+                "missing_relations": missing}
+    values = reader.rows(query)
+    # Metric SQL always returns key/value pairs; avoiding cursor metadata keeps fakes simple.
+    data = {str(key): int(value) for key, value in values}
+    return {"name": name, "classification": "required_build" if required else "optional", "present": True, **data}
+
+
+def migration_audit(reader: Reader, migrations: list[Migration]) -> dict[str, Any]:
+    if reader.relation_kind("schema_migrations") is None:
+        return {"ledger_present": False, "pending_auto": [m.filename for m in migrations if m.mode == "auto"],
+                "pending_manual": [m.filename for m in migrations if m.mode == "manual"], "checksum_mismatches": [],
+                "unexpected_ledger_entries": []}
+    ledger = {name: checksum for name, checksum in reader.rows(
+        "SELECT filename, checksum_sha256 FROM public.schema_migrations ORDER BY filename"
+    )}
+    expected = {m.filename: m for m in migrations}
+    return {
+        "ledger_present": True,
+        "pending_auto": [m.filename for m in migrations if m.mode == "auto" and m.filename not in ledger],
+        "pending_manual": [m.filename for m in migrations if m.mode == "manual" and m.filename not in ledger],
+        "checksum_mismatches": [m.filename for m in migrations if m.filename in ledger and ledger[m.filename] != m.checksum],
+        "unexpected_ledger_entries": sorted(set(ledger) - set(expected)),
+        "applied_count": len(ledger),
+        "manifest_count": len(migrations),
+    }
+
+
+REQUIRED_METRICS = (
+    ("grid", ("systems",), "SELECT 'eligible'::text, COUNT(*)::bigint FROM systems WHERE x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL UNION ALL SELECT 'missing', COUNT(*) FROM systems WHERE x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL AND (grid_cell_id IS NULL OR macro_grid_id IS NULL)"),
+    ("ratings", ("systems", "ratings"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM systems WHERE has_body_data UNION ALL SELECT 'rows', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data UNION ALL SELECT 'wrong_version', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version IS DISTINCT FROM '3.4' UNION ALL SELECT 'dirty', COUNT(*) FROM systems WHERE has_body_data AND rating_dirty"),
+    ("topology", ("systems", "ratings", "system_slot_topology"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' UNION ALL SELECT 'rows', COUNT(*) FROM system_slot_topology"),
+    ("economy_pair_synergy", ("systems", "ratings", "system_slot_topology", "economy_pair_synergy"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' UNION ALL SELECT 'source_built', COUNT(*) FROM system_slot_topology UNION ALL SELECT 'rows', COUNT(*) FROM economy_pair_synergy UNION ALL SELECT 'covered', COUNT(DISTINCT system_id64) FROM economy_pair_synergy"),
+    ("archetypes", ("systems", "ratings", "system_archetype_scores", "system_archetype_traits"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' UNION ALL SELECT 'scores', COUNT(*) FROM system_archetype_scores UNION ALL SELECT 'traits', COUNT(*) FROM system_archetype_traits UNION ALL SELECT 'dirty', COUNT(*) FROM system_archetype_scores WHERE dirty"),
+    ("regional_analysis", ("systems", "system_regional_analysis"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM systems WHERE x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL UNION ALL SELECT 'rows', COUNT(*) FROM system_regional_analysis"),
+    ("station_body_links", ("stations", "station_body_links"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM stations WHERE body_name IS NOT NULL AND btrim(body_name) <> '' UNION ALL SELECT 'covered', COUNT(DISTINCT station_id) FROM station_body_links WHERE association_status='confirmed' AND body_id IS NOT NULL"),
+    ("clusters", ("systems", "cluster_summary"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM systems WHERE has_body_data UNION ALL SELECT 'rows', COUNT(*) FROM cluster_summary UNION ALL SELECT 'dirty_rows', COUNT(*) FROM cluster_summary WHERE dirty UNION ALL SELECT 'system_dirty', COUNT(*) FROM systems WHERE has_body_data AND cluster_dirty"),
+)
+
+
+def blockers_for(report: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if report["server"]["version_num"] // 10000 != 18:
+        blockers.append("PostgreSQL server major version is not 18")
+    migrations = report["migrations"]
+    if not migrations["ledger_present"]:
+        blockers.append("migration ledger is missing")
+    for key in ("pending_auto", "pending_manual", "checksum_mismatches", "unexpected_ledger_entries"):
+        if migrations[key]:
+            blockers.append(f"migration {key.replace('_', ' ')}: {len(migrations[key])}")
+    for table in report["base_tables"]:
+        if not table["present"]:
+            blockers.append(f"required base table missing: {table['name']}")
+    for metric in report["required_builds"]:
+        if not metric["present"]:
+            blockers.append(f"required build missing or unreadable: {metric['name']}")
+            continue
+        if metric["name"] == "grid" and metric["missing"]:
+            blockers.append(f"grid assignments missing: {metric['missing']}")
+        elif metric["name"] == "ratings" and (metric["rows"] != metric["eligible"] or metric["wrong_version"] or metric["dirty"]):
+            blockers.append("ratings v3.4 build incomplete")
+        elif metric["name"] == "archetypes" and (metric["scores"] != metric["eligible"] or metric["traits"] != metric["eligible"] or metric["dirty"]):
+            blockers.append("archetype build incomplete")
+        elif metric["name"] == "clusters" and (metric["dirty_rows"] or metric["system_dirty"]):
+            blockers.append("cluster build has dirty backlog")
+        elif metric["name"] == "economy_pair_synergy":
+            if metric["source_built"] < metric["eligible"]:
+                blockers.append("economy_pair_synergy source build incomplete")
+            if metric["covered"] < metric["eligible"]:
+                blockers.append("economy_pair_synergy coverage incomplete")
+        elif metric["name"] not in {"grid", "ratings", "archetypes", "clusters"}:
+            built = metric.get("rows", metric.get("covered", 0))
+            if built < metric["eligible"]:
+                blockers.append(f"{metric['name']} coverage incomplete")
+    for view in report["materialized_views"]:
+        if not view["present"] or not view.get("populated", False):
+            blockers.append(f"materialized view unavailable: {view['name']}")
+    return blockers
+
+
+def run_audit(connection: Any, manifest: Path = DEFAULT_MANIFEST) -> dict[str, Any]:
+    connection.set_session(readonly=True, autocommit=False)
+    reader = Reader(connection)
+    if reader.one("SHOW transaction_read_only") != "on":
+        raise RuntimeError("database did not honor read-only transaction mode")
+    report: dict[str, Any] = {
+        "audit_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "read_only": True,
+        "server": {"version": reader.one("SHOW server_version"), "version_num": int(reader.one("SHOW server_version_num")),
+                   "database_size_bytes": int(reader.one("SELECT pg_database_size(current_database())"))},
+        "migrations": migration_audit(reader, load_manifest(manifest)),
+        "base_tables": [_relation(reader, name, classification="required_base") for name in ("systems", "bodies", "stations", "body_rings")],
+        "base_coverage": [
+            _metric(reader, "body_system_coverage", "SELECT 'systems_with_bodies'::text, COUNT(DISTINCT system_id64)::bigint FROM bodies UNION ALL SELECT 'systems_flagged', COUNT(*) FROM systems WHERE has_body_data", ("systems", "bodies"), required=False),
+            _metric(reader, "station_system_coverage", "SELECT 'systems_with_stations'::text, COUNT(DISTINCT system_id64)::bigint FROM stations UNION ALL SELECT 'station_rows', COUNT(*) FROM stations", ("stations",), required=False),
+            _metric(reader, "ring_system_coverage", "SELECT 'systems_with_rings'::text, COUNT(DISTINCT system_id64)::bigint FROM body_rings UNION ALL SELECT 'ring_rows', COUNT(*) FROM body_rings", ("body_rings",), required=False),
+        ],
+        "required_builds": [_metric(reader, name, query, dependencies) for name, dependencies, query in REQUIRED_METRICS],
+        "materialized_views": [_relation(reader, name, classification="required_build") for name in ("mv_map_regions", "mv_map_heatmap_200ly", "mv_map_heatmap_500ly", "mv_map_heatmap_1000ly", "mv_map_timeline_month", "mv_archetype_rankings")],
+        "runtime_feature_tables": [_relation(reader, name, classification="inventory_only") for name in INVENTORY_ONLY_TABLES],
+    }
+    report["blockers"] = blockers_for(report)
+    report["ready"] = not report["blockers"]
+    connection.rollback()
+    return report
+
+
+def render_human(report: dict[str, Any]) -> str:
+    state = "READY" if report["ready"] else "NOT READY"
+    lines = [f"Production candidate: {state}", f"PostgreSQL {report['server']['version']} ({report['server']['database_size_bytes']} bytes)",
+             f"Read-only audit: {report['read_only']}"]
+    migration = report["migrations"]
+    lines.append(f"Migrations: pending auto={len(migration['pending_auto'])}, manual={len(migration['pending_manual'])}, checksum mismatches={len(migration['checksum_mismatches'])}")
+    for relation in report["base_tables"] + report["materialized_views"]:
+        lines.append(f"{relation['classification']} {relation['name']}: " + (f"{relation['row_count']} rows" if relation["present"] else "MISSING"))
+    for metric in report["required_builds"]:
+        values = ", ".join(f"{k}={v}" for k, v in metric.items() if k not in {"name", "classification", "present"})
+        lines.append(f"required_build {metric['name']}: {values or 'MISSING'}")
+    for metric in report.get("base_coverage", []):
+        values = ", ".join(f"{k}={v}" for k, v in metric.items() if k not in {"name", "classification", "present"})
+        lines.append(f"base_coverage {metric['name']}: {values or 'MISSING'}")
+    for item in report["runtime_feature_tables"]:
+        lines.append(f"inventory_only {item['name']}: " + (f"present, {item['row_count']} rows" if item["present"] else "missing (reported, not a population blocker)"))
+    lines.extend(f"BLOCKER: {blocker}" for blocker in report["blockers"])
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database-url", default=os.getenv("DATABASE_URL", ""), help="Explicit PostgreSQL DSN (or DATABASE_URL).")
+    parser.add_argument("--compose", action="store_true", help="Resolve DATA_INVARIANTS_DATABASE_URL from docker compose config without starting services.")
+    parser.add_argument("--compose-file", type=Path, default=ROOT / "docker-compose.yml")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--json", action="store_true", help="Emit JSON only, suitable for a durable receipt.")
+    parser.add_argument("--json-output", type=Path, help="Also write the JSON receipt to this path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.compose and args.database_url:
+        print("ERROR: choose either explicit DATABASE_URL or --compose", file=sys.stderr)
+        return 2
+    if args.compose:
+        try:
+            completed = subprocess.run(
+                ["docker", "compose", "-f", str(args.compose_file), "config", "--format", "json"],
+                check=True, capture_output=True, text=True,
+            )
+            config = json.loads(completed.stdout)
+            args.database_url = config["services"]["maintenance"]["environment"]["DATA_INVARIANTS_DATABASE_URL"]
+        except Exception:
+            args.database_url = ""
+    if not args.database_url:
+        print("ERROR: DATABASE_URL or --database-url is required; no database was contacted", file=sys.stderr)
+        return 2
+    try:
+        connection = psycopg2.connect(args.database_url, connect_timeout=10, application_name="edfinder-production-candidate-audit")
+        try:
+            report = run_audit(connection, args.manifest)
+        finally:
+            connection.close()
+        payload = json.dumps(report, indent=2, sort_keys=True)
+        if args.json_output:
+            args.json_output.write_text(payload + "\n", encoding="utf-8")
+        print(payload if args.json else render_human(report))
+        return 0 if report["ready"] else 1
+    except Exception as exc:  # fail closed; intentionally never echo DSNs or exception text
+        failure = {"audit_version": 1, "ready": False, "read_only": True,
+                   "error": exc.__class__.__name__, "blockers": ["audit execution failed"]}
+        payload = json.dumps(failure, indent=2, sort_keys=True)
+        if args.json_output:
+            try:
+                args.json_output.write_text(payload + "\n", encoding="utf-8")
+            except OSError:
+                pass
+        if args.json:
+            print(payload)
+        print(f"ERROR: production-candidate audit failed ({exc.__class__.__name__}); no credentials shown", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_external_db_config.sh
+++ b/scripts/validate_external_db_config.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Validate the explicit external PostgreSQL production mode without printing DSNs.
+set -euo pipefail
+
+CONFIG_ONLY=0
+[[ "${1:-}" == "--config-only" ]] && CONFIG_ONLY=1
+
+die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+required_urls=(
+  DATABASE_APP_URL
+  DATABASE_READONLY_URL
+  DATABASE_IMPORT_URL
+  DATABASE_MAINTENANCE_URL
+  DATABASE_MIGRATION_URL
+)
+
+for name in "${required_urls[@]}"; do
+  value="${!name:-}"
+  [[ -n "$value" ]] || die "$name is required in external database mode"
+  case "$value" in
+    postgres://*|postgresql://*) ;;
+    *) die "$name must be a PostgreSQL URL" ;;
+  esac
+done
+
+# A URL naming the Compose service would make --external-db appear configured
+# while still depending on the bundled database that this mode must bypass.
+python3 - <<'PY'
+import os
+from urllib.parse import urlsplit
+
+names = (
+    "DATABASE_APP_URL", "DATABASE_READONLY_URL", "DATABASE_IMPORT_URL",
+    "DATABASE_MAINTENANCE_URL", "DATABASE_MIGRATION_URL",
+)
+for name in names:
+    hostname = (urlsplit(os.environ[name]).hostname or "").lower()
+    if not hostname:
+        raise SystemExit(f"[ERROR] {name} must include a database host")
+    if hostname == "postgres":
+        raise SystemExit(f"[ERROR] {name} must not target the bundled Compose postgres service")
+PY
+
+if [[ "$CONFIG_ONLY" -eq 1 ]]; then
+  printf '[OK] external database configuration is complete\n'
+  exit 0
+fi
+
+command -v psql >/dev/null 2>&1 || die "psql is required for external database preflight"
+version_num="$(PGCONNECT_TIMEOUT=10 PGOPTIONS='-c default_transaction_read_only=on' \
+  psql --no-psqlrc --dbname="$DATABASE_READONLY_URL" -AtX \
+    -c "SELECT current_setting('server_version_num')")" || die "external database preflight connection failed"
+[[ "$version_num" =~ ^18[0-9]{4}$ ]] || die "external database must be PostgreSQL 18 (server reported a different major version)"
+printf '[OK] external PostgreSQL 18 read-only preflight passed\n'

--- a/tests/test_external_db_deploy_mode.py
+++ b/tests/test_external_db_deploy_mode.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_external_db_config.sh"
+
+
+def _env(password: str = "do-not-print-this") -> dict[str, str]:
+    env = os.environ.copy()
+    for name, role in (
+        ("DATABASE_APP_URL", "app"),
+        ("DATABASE_READONLY_URL", "readonly"),
+        ("DATABASE_IMPORT_URL", "import"),
+        ("DATABASE_MAINTENANCE_URL", "maintenance"),
+        ("DATABASE_MIGRATION_URL", "migration"),
+    ):
+        env[name] = f"postgresql://{role}:{password}@db.example.invalid/edfinder"
+    return env
+
+
+def test_external_config_fails_closed_when_a_role_url_is_missing():
+    env = _env()
+    env.pop("DATABASE_MIGRATION_URL")
+    result = subprocess.run(
+        ["bash", str(VALIDATOR), "--config-only"], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "DATABASE_MIGRATION_URL is required" in result.stderr
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_external_config_rejects_the_bundled_compose_database():
+    env = _env()
+    env["DATABASE_APP_URL"] = "postgresql://app:do-not-print-this@postgres/edfinder"
+    result = subprocess.run(
+        ["bash", str(VALIDATOR), "--config-only"], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "bundled Compose postgres" in result.stderr
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_external_config_accepts_complete_role_urls_without_leaking_them():
+    result = subprocess.run(
+        ["bash", str(VALIDATOR), "--config-only"], env=_env(),
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 0
+    assert "configuration is complete" in result.stdout
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_deploy_external_mode_never_starts_compose_dependencies():
+    deploy = (ROOT / "scripts" / "deploy_main.sh").read_text(encoding="utf-8")
+    assert "--external-db" in deploy
+    assert "bash scripts/validate_external_db_config.sh" in deploy
+    assert "docker compose up -d --build --no-deps api eddn maintenance" in deploy
+    assert "docker compose up -d --force-recreate --no-deps nginx" in deploy
+    assert 'if [[ "$EXTERNAL_DB_MODE" == "false" ]]; then\n  docker compose ps postgres' in deploy

--- a/tests/test_pg18_promotion_runbook.py
+++ b/tests/test_pg18_promotion_runbook.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / '.github' / 'workflows' / 'chatgpt-ed-new-ops.yml'
+RUNBOOK_PATH = ROOT / 'docs' / 'operations' / 'production-pg18-candidate-promotion.md'
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding='utf-8')
+
+
+def test_ed_new_workflow_narrowly_allowlists_readiness_audit():
+    workflow = _workflow_text()
+
+    assert '- production-candidate-readiness' in workflow
+    assert 'host-status|production-candidate-readiness)' in workflow
+    assert 'scripts/operator/audit_production_candidate.py --json-output' in workflow
+    assert 'run-governed-migrations' not in workflow
+
+
+def test_ed_new_readiness_operation_keeps_database_url_off_argv_and_receipt():
+    workflow = _workflow_text()
+
+    assert 'printf \'%s\\n\' "$CANDIDATE_DATABASE_URL" | ssh' in workflow
+    assert 'IFS= read -r DATABASE_URL' in workflow
+    assert '--database-url "$CANDIDATE_DATABASE_URL"' not in workflow
+    assert 'secret in raw' in workflow
+    assert 'json.loads(raw)' in workflow
+
+
+def test_ed_new_readiness_operation_retains_receipt_and_preserves_exit_meaning():
+    workflow = _workflow_text()
+
+    assert 'production-candidate-readiness.json' in workflow
+    assert 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' in workflow
+    assert 'AUDIT_STATUS' in workflow
+    assert '1) echo "Production candidate has readiness blockers' in workflow
+    assert '2) echo "Production-candidate audit failed closed' in workflow
+    yaml.safe_load(workflow)
+
+
+def test_pg18_runbook_defines_order_completion_and_non_goals():
+    runbook = RUNBOOK_PATH.read_text(encoding='utf-8')
+    normalized = ' '.join(runbook.split())
+
+    ordered_terms = (
+        '**Snapshot/backup.**',
+        '**Schema and migration audit.**',
+        '**Base-data validation/import gaps.**',
+        '**Grid.**',
+        '**Ratings v3.4.**',
+        '**Topology and economy-pair synergy.**',
+        '**Archetypes.**',
+        '**Regional analysis.**',
+        '**Station/body links and canonical backfills.**',
+        '**Full clusters.**',
+        '**Materialized views and maintenance refresh.**',
+        '**Strict invariant audit.**',
+        '**Application smoke/release gate.**',
+    )
+    positions = [runbook.index(term) for term in ordered_terms]
+    assert positions == sorted(positions)
+    assert 'bounded nightly run' in runbook
+    assert '100% eligible coverage' in runbook
+    assert 'restore V2 into V3' in normalized
+    assert 'does not run a migration or backfill' in runbook

--- a/tests/test_production_candidate_audit.py
+++ b/tests/test_production_candidate_audit.py
@@ -151,6 +151,7 @@ def test_compose_resolution_is_explicit_and_does_not_start_services(monkeypatch)
         called.append(command)
         return Completed()
 
+    monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setattr(audit.subprocess, "run", fake_run)
     monkeypatch.setattr(audit.psycopg2, "connect", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()))
     assert audit.main(["--compose"]) == 2

--- a/tests/test_production_candidate_audit.py
+++ b/tests/test_production_candidate_audit.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "operator" / "audit_production_candidate.py"
+SPEC = importlib.util.spec_from_file_location("audit_production_candidate", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = audit
+SPEC.loader.exec_module(audit)
+
+
+def test_manifest_modes_and_checksums_are_authoritative(tmp_path):
+    (tmp_path / "001.sql").write_text("SELECT 1;\n", encoding="utf-8")
+    (tmp_path / "002.sql").write_text("SELECT 2;\n", encoding="utf-8")
+    manifest = tmp_path / "migration-manifest.txt"
+    manifest.write_text("001.sql\n002.sql|manual\n", encoding="utf-8")
+
+    entries = audit.load_manifest(manifest)
+
+    assert [(entry.filename, entry.mode) for entry in entries] == [("001.sql", "auto"), ("002.sql", "manual")]
+    assert entries[0].checksum == hashlib.sha256(b"SELECT 1;\n").hexdigest()
+
+
+class LedgerReader:
+    def relation_kind(self, name):
+        return "r" if name == "schema_migrations" else None
+
+    def rows(self, query, params=()):
+        assert "schema_migrations" in query
+        return [("001.sql", "wrong"), ("unexpected.sql", "abc")]
+
+
+def test_migration_audit_separates_auto_manual_checksum_and_unexpected(tmp_path):
+    (tmp_path / "001.sql").write_text("SELECT 1;", encoding="utf-8")
+    (tmp_path / "002.sql").write_text("SELECT 2;", encoding="utf-8")
+    manifest = tmp_path / "migration-manifest.txt"
+    manifest.write_text("001.sql\n002.sql|manual\n", encoding="utf-8")
+
+    result = audit.migration_audit(LedgerReader(), audit.load_manifest(manifest))
+
+    assert result["pending_auto"] == []
+    assert result["pending_manual"] == ["002.sql"]
+    assert result["checksum_mismatches"] == ["001.sql"]
+    assert result["unexpected_ledger_entries"] == ["unexpected.sql"]
+
+
+def _otherwise_ready_report():
+    required = [
+        {"name": "grid", "present": True, "eligible": 2, "missing": 0},
+        {"name": "ratings", "present": True, "eligible": 2, "rows": 2, "wrong_version": 0, "dirty": 0},
+        {"name": "topology", "present": True, "eligible": 2, "rows": 2},
+        {"name": "economy_pair_synergy", "present": True, "eligible": 2, "source_built": 2, "rows": 2, "covered": 2},
+        {"name": "archetypes", "present": True, "eligible": 2, "scores": 2, "traits": 2, "dirty": 0},
+        {"name": "regional_analysis", "present": True, "eligible": 2, "rows": 2},
+        {"name": "station_body_links", "present": True, "eligible": 2, "covered": 2},
+        {"name": "clusters", "present": True, "eligible": 2, "rows": 1, "dirty_rows": 0, "system_dirty": 0},
+    ]
+    return {
+        "server": {"version_num": 180000},
+        "migrations": {"ledger_present": True, "pending_auto": [], "pending_manual": [], "checksum_mismatches": [], "unexpected_ledger_entries": []},
+        "base_tables": [{"name": name, "classification": "required_base", "present": True, "row_count": 2} for name in ("systems", "bodies", "stations", "body_rings")],
+        "required_builds": required,
+        "materialized_views": [{"name": "mv", "classification": "required_build", "present": True, "populated": True, "row_count": 2}],
+        "runtime_feature_tables": [],
+    }
+
+
+def test_required_builds_block_but_runtime_feature_tables_do_not():
+    report = _otherwise_ready_report()
+    report["runtime_feature_tables"] = [
+        {"name": "journal_events", "classification": "inventory_only", "present": True, "row_count": 0},
+        {"name": "routes", "classification": "inventory_only", "present": False, "row_count": None},
+        {"name": "app_users", "classification": "inventory_only", "present": True, "row_count": 0},
+    ]
+    assert audit.blockers_for(report) == []
+
+    report["required_builds"][1]["wrong_version"] = 1
+    assert audit.blockers_for(report) == ["ratings v3.4 build incomplete"]
+
+
+def test_requires_exact_postgres_18_and_complete_synergy_coverage():
+    report = _otherwise_ready_report()
+    report["server"]["version_num"] = 190000
+    report["required_builds"][3].update(source_built=2, covered=1)
+
+    assert audit.blockers_for(report) == [
+        "PostgreSQL server major version is not 18",
+        "economy_pair_synergy coverage incomplete",
+    ]
+
+
+def test_command_fails_closed_without_database_url(monkeypatch, capsys):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    assert audit.main([]) == 2
+    assert "no database was contacted" in capsys.readouterr().err
+
+
+def test_connection_failure_does_not_leak_database_url_or_password(monkeypatch, capsys):
+    secret = "postgresql://user:super-secret@example.invalid/db"
+
+    def fail(*args, **kwargs):
+        raise RuntimeError(f"could not connect to {secret}")
+
+    monkeypatch.setattr(audit.psycopg2, "connect", fail)
+    assert audit.main(["--database-url", secret, "--json"]) == 2
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["error"] == "RuntimeError"
+    assert secret not in captured.out + captured.err
+    assert "super-secret" not in captured.out + captured.err
+
+
+def test_missing_optional_relation_is_reported_without_querying_it():
+    class MissingReader:
+        def relation_kind(self, name):
+            return None
+
+        def count(self, name):
+            raise AssertionError("missing relation must not be counted")
+
+    assert audit._relation(MissingReader(), "routes", classification="inventory_only") == {
+        "name": "routes", "classification": "inventory_only", "present": False, "row_count": None
+    }
+
+
+def test_missing_metric_dependency_is_reported_without_aborting_transaction():
+    class MissingReader:
+        def relation_kind(self, name):
+            return None if name == "ratings" else "r"
+
+        def rows(self, query):
+            raise AssertionError("metric SQL must not run with missing dependencies")
+
+    result = audit._metric(MissingReader(), "ratings", "SELECT forbidden", ("systems", "ratings"))
+    assert result["present"] is False
+    assert result["missing_relations"] == ["ratings"]
+
+
+def test_compose_resolution_is_explicit_and_does_not_start_services(monkeypatch):
+    called = []
+
+    class Completed:
+        stdout = json.dumps({"services": {"maintenance": {"environment": {"DATA_INVARIANTS_DATABASE_URL": "postgresql://resolved.invalid/db"}}}})
+
+    def fake_run(command, **kwargs):
+        called.append(command)
+        return Completed()
+
+    monkeypatch.setattr(audit.subprocess, "run", fake_run)
+    monkeypatch.setattr(audit.psycopg2, "connect", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()))
+    assert audit.main(["--compose"]) == 2
+    assert called[0][-3:] == ["config", "--format", "json"]
+    assert "up" not in called[0] and "run" not in called[0] and "exec" not in called[0]
+
+
+def test_read_only_contract_and_json_human_rendering():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "set_session(readonly=True, autocommit=False)" in source
+    assert 'SHOW transaction_read_only' in source
+    assert not any(token in source for token in ("INSERT INTO systems", "UPDATE systems", "DELETE FROM systems", "CREATE TABLE schema_migrations"))
+
+    report = _otherwise_ready_report()
+    report.update({"ready": True, "read_only": True, "server": {"version": "18.1", "version_num": 180001, "database_size_bytes": 42}, "blockers": []})
+    assert json.loads(json.dumps(report))["read_only"] is True
+    assert "PostgreSQL 18.1" in audit.render_human(report)


### PR DESCRIPTION
## Summary

Recovers the already-completed implementation from failed Codex run `33306322119` without reimplementing it.

The original implementation completed successfully and created local commit `e63285d2`, but its branch push was rejected because the worker credential could not update `.github/workflows/chatgpt-ed-new-ops.yml`. The Codex bridge credential path has since been fixed in PRs #522 and #523.

## Recovery evidence

Recovery run `33316833025` located the original `e63285d2` object on `contabo-codex-worker-2` and applied its stored patch only. It verified:
- exactly the original 10 changed paths;
- every initially recovered file blob hash matched `e63285d2`;
- every initially recovered file mode matched `e63285d2`;
- `git diff --check` passed;
- no production systems or credentials were accessed;
- no replacement implementation was performed.

## CI follow-up

The first PR CI run exposed one test-environment assumption in `test_compose_resolution_is_explicit_and_does_not_start_services`: GitHub CI already supplies `DATABASE_URL`, while the test intended to exercise `--compose` in isolation. The production code correctly failed closed when both inputs were present.

A second commit (`d26f7960`) changes only that test setup to explicitly clear inherited `DATABASE_URL` before invoking `--compose`. Production behavior was not weakened or otherwise changed.

After that fix, the complete current-head GitHub Actions suite passed, including:
- CI, including backend unit tests and `docker compose` validation;
- canonical safety tests;
- backend integration tests;
- OpenAPI drift checks;
- frontend build/tests;
- Review Lab;
- CodeQL;
- Semgrep;
- Cypress parity;
- container image parity;
- coverage tracking.

## Original implementation validation

The original Codex run completed its focused validation before the rejected push:
- 32 focused pytest tests passed;
- Ruff passed;
- shell syntax checks passed;
- `git diff --check` passed;
- Docker was unavailable in the self-hosted worker workspace, so `docker compose config --quiet` was not run there; the PR CI has now supplied that validation successfully.

## Scope

- read-only, fail-closed PostgreSQL 18 production-candidate audit;
- migration/checksum and dataset readiness checks;
- explicit external PostgreSQL 18 deploy mode that cannot silently start bundled PostgreSQL 16;
- production promotion runbook and dependency order;
- allowlisted `production-candidate-readiness` operations workflow path;
- regression tests for audit, runbook, and external DB deploy behavior.

No production deployment is performed by this PR.