### PR TITLE
Allow parallel Codex workers on current main

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -26,10 +26,6 @@ permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: codex-worker
-  cancel-in-progress: false
-
 jobs:
   codex:
     runs-on: [self-hosted, Linux, X64]

--- a/tests/test_codex_async_bridge.py
+++ b/tests/test_codex_async_bridge.py
@@ -29,6 +29,14 @@ def test_long_codex_worker_only_runs_from_explicit_dispatch() -> None:
     assert "codex-task-requests" not in text
 
 
+def test_codex_workers_are_not_globally_serialized() -> None:
+    text = WORKER.read_text(encoding="utf-8")
+
+    assert "runs-on: [self-hosted, Linux, X64]" in text
+    assert "group: codex-worker" not in text
+    assert "cancel-in-progress:" not in text
+
+
 def test_privileged_workflow_push_token_is_isolated_from_codex() -> None:
     text = WORKER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Rebuilds the bounded worker-pool change from draft PR #506 on current `main`, preserving today’s credential-isolation fixes.

Changes:
- removes only the workflow-level `codex-worker` concurrency group so independent Codex jobs can use the three healthy Linux self-hosted runners concurrently;
- preserves the existing Linux runner selector, state gate, isolated implementation branches, 120-minute timeout, no-production/no-deploy worker prompt, and wrapper-owned privileged push token isolation;
- adds a regression test so global serialization cannot silently return.

Prior pool probes from #506 already demonstrated overlapping dispatch to `contabo-codex-worker`, `contabo-codex-worker-2`, and `contabo-codex-worker-3`. This fresh PR exists so the change is reviewed/tested against the current bridge rather than merging the stale draft directly.