### PR TITLE
Harden PostgreSQL 18 production-candidate promotion tooling

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - host-status
+          - production-candidate-readiness
   push:
     branches:
       - chatgpt-ed-new-ops-requests
@@ -55,7 +56,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status) ;;
+            host-status|production-candidate-readiness) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -66,16 +67,28 @@ jobs:
           SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
           SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
           SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
           test -n "$SSH_KEY" || { echo "Missing ED_NEW_OPERATOR_SSH_KEY" >&2; exit 1; }
           test -n "$SSH_HOST" || { echo "Missing ED_NEW_OPERATOR_HOST" >&2; exit 1; }
           test -n "$SSH_PORT" || { echo "Missing ED_NEW_OPERATOR_PORT" >&2; exit 1; }
+          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing ED_NEW_OPERATOR_SSH_KNOWN_HOSTS" >&2; exit 1; }
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
           chmod 600 ~/.ssh/ed_new_operator_key
-          ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          if [ "$SSH_PORT" = 22 ]; then
+            known_hosts_target="$SSH_HOST"
+          else
+            known_hosts_target="[$SSH_HOST]:$SSH_PORT"
+          fi
+          ssh-keygen -F "$known_hosts_target" -f ~/.ssh/known_hosts >/dev/null || {
+            echo "ED_NEW_OPERATOR_SSH_KNOWN_HOSTS has no trusted key for the configured host and port" >&2
+            exit 1
+          }
 
       - name: Run bounded ed-new bootstrap status
         if: steps.request.outputs.operation == 'host-status'
@@ -90,6 +103,104 @@ jobs:
           ssh -i ~/.ssh/ed_new_operator_key \
               -p "$SSH_PORT" \
               -o IdentitiesOnly=yes \
+              -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+              -o GlobalKnownHostsFile=/dev/null \
               -o StrictHostKeyChecking=yes \
               "$SSH_USER@$SSH_HOST" \
               'set -eu; echo "== ed-new bootstrap status =="; printf "hostname: "; hostname; printf "fqdn: "; hostname -f 2>/dev/null || true; printf "kernel: "; uname -sr; echo "== filesystem =="; df -hT /; echo "== docker =="; if command -v docker >/dev/null 2>&1; then docker ps --format "{{.Names}}\t{{.Status}}\t{{.Image}}" | head -50; else echo "docker: not installed"; fi; echo "== repo candidates =="; for p in /opt/ed-finder /root/ed-finder /srv/ed-finder; do [ -d "$p" ] && echo "$p"; done; echo "== safety =="; echo "db_access_performed: false"; echo "db_writes_performed: false"; echo "migrations_performed: false"; echo "canonical_apply_performed: false"'
+
+      - name: Run read-only production-candidate readiness audit
+        id: candidate_audit
+        if: steps.request.outputs.operation == 'production-candidate-readiness'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          CANDIDATE_DATABASE_URL: ${{ secrets.ED_NEW_CANDIDATE_DATABASE_URL }}
+          REVIEWED_REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          test -n "$CANDIDATE_DATABASE_URL" || { echo "Missing ED_NEW_CANDIDATE_DATABASE_URL" >&2; exit 1; }
+          [[ "$REVIEWED_REVISION" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid reviewed revision" >&2; exit 1; }
+          echo "::add-mask::$CANDIDATE_DATABASE_URL"
+          audit_bundle="$(mktemp)"
+          trap 'rm -f "$audit_bundle"' EXIT
+          # Package the implementation and its complete migration authority from
+          # this exact checkout. The remote host copy is deliberately not used.
+          tar -czf "$audit_bundle" scripts/operator/audit_production_candidate.py sql
+          scp -q -i ~/.ssh/ed_new_operator_key \
+              -P "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+              -o GlobalKnownHostsFile=/dev/null \
+              -o StrictHostKeyChecking=yes \
+              "$audit_bundle" "$SSH_USER@$SSH_HOST:/tmp/ed-finder-candidate-audit-$GITHUB_RUN_ID.tar.gz"
+          set +e
+          printf '%s\n' "$CANDIDATE_DATABASE_URL" | ssh \
+              -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+              -o GlobalKnownHostsFile=/dev/null \
+              -o StrictHostKeyChecking=yes \
+              "$SSH_USER@$SSH_HOST" \
+              "set -eu; bundle=/tmp/ed-finder-candidate-audit-$GITHUB_RUN_ID.tar.gz; workdir=\"\$(mktemp -d)\"; receipt=\"\$(mktemp)\"; trap 'rm -rf \"\$workdir\"; rm -f \"\$receipt\" \"\$bundle\"' EXIT; tar -xzf \"\$bundle\" -C \"\$workdir\"; IFS= read -r DATABASE_URL; test -n \"\$DATABASE_URL\"; export DATABASE_URL; cd \"\$workdir\"; set +e; python3 scripts/operator/audit_production_candidate.py --reviewed-revision '$REVIEWED_REVISION' --json-output \"\$receipt\" >&2; status=\$?; set -e; test -s \"\$receipt\" && cat \"\$receipt\"; exit \"\$status\"" \
+              > production-candidate-readiness.json
+          audit_status=$?
+          set -e
+          echo "audit_status=$audit_status" >> "$GITHUB_OUTPUT"
+          if [ "$audit_status" -gt 2 ]; then
+            echo "Unexpected readiness-audit exit status: $audit_status" >&2
+          fi
+
+      - name: Validate readiness receipt is JSON and credential-free
+        id: validate_candidate_receipt
+        if: steps.request.outputs.operation == 'production-candidate-readiness' && always()
+        shell: bash
+        env:
+          CANDIDATE_DATABASE_URL: ${{ secrets.ED_NEW_CANDIDATE_DATABASE_URL }}
+          REVIEWED_REVISION: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = Path('production-candidate-readiness.json')
+          raw = receipt.read_text(encoding='utf-8')
+          payload = json.loads(raw)
+          if payload.get('reviewed_revision') != os.environ['REVIEWED_REVISION']:
+              raise SystemExit('Readiness receipt is not bound to the reviewed revision')
+          identity = payload.get('candidate_identity', {})
+          if 'error' not in payload and (not identity.get('database') or not identity.get('system_identifier')):
+              raise SystemExit('Readiness receipt lacks stable candidate identity')
+          secret = os.environ.get('CANDIDATE_DATABASE_URL', '')
+          if secret and secret in raw:
+              raise SystemExit('Readiness receipt contains the candidate database URL')
+          PY
+
+      - name: Retain production-candidate readiness receipt
+        if: steps.request.outputs.operation == 'production-candidate-readiness' && always() && steps.validate_candidate_receipt.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-candidate-readiness-${{ github.run_id }}
+          path: production-candidate-readiness.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce production-candidate readiness result
+        if: steps.request.outputs.operation == 'production-candidate-readiness' && always()
+        shell: bash
+        env:
+          AUDIT_STATUS: ${{ steps.candidate_audit.outputs.audit_status }}
+        run: |
+          set -euo pipefail
+          case "$AUDIT_STATUS" in
+            0) echo "Production-candidate readiness audit passed." ;;
+            1) echo "Production candidate has readiness blockers; inspect the JSON receipt." >&2; exit 1 ;;
+            2) echo "Production-candidate audit failed closed; inspect the run without exposing credentials." >&2; exit 2 ;;
+            *) echo "Production-candidate audit did not produce a valid result." >&2; exit 2 ;;
+          esac

--- a/docs/operations/production-pg18-candidate-promotion.md
+++ b/docs/operations/production-pg18-candidate-promotion.md
@@ -1,0 +1,186 @@
+# Existing PostgreSQL 18 Production-Candidate Promotion
+
+## Purpose and boundary
+
+This runbook is for assessing and, in a later separately approved operation,
+promoting the **existing PostgreSQL 18 rehearsal/test database** to production.
+It is not a database rebuild. Do not create an empty database, restore V2 into
+V3, reset the candidate, run migrations, start a rebuild, change DNS, or cut
+over application traffic while following the audit portion of this runbook.
+
+The readiness audit is evidence, not cutover approval. Keep its JSON receipt
+with the snapshot identity and the candidate database identity that it
+describes. Never paste or store a `DATABASE_URL`, password, or other credential
+in the receipt.
+
+## One-time full-build order
+
+The production bootstrap has this dependency order. Do not skip ahead because
+a downstream command happens to run successfully:
+
+1. **Snapshot/backup.** Freeze an identifiable recovery point for the PG18
+   candidate and prove the backup can be listed and restored using
+   [postgres-backup-and-restore.md](./postgres-backup-and-restore.md). Record
+   backup identifier, start/end UTC, database identity, and verification result.
+2. **Schema and migration audit.** Run the production-candidate readiness audit
+   read-only. The PostgreSQL server must report major version 18. Every entry in
+   `sql/migration-manifest.txt` must agree with the migration ledger: no pending
+   automatic or manual migration and no checksum mismatch. An unexpected or
+   unreadable ledger is a stop condition, not permission to apply migrations.
+   If production sets `MIGRATION_LEDGER_TABLE`, export the same value for the
+   audit; both paths accept only a simple SQL identifier.
+3. **Base-data validation/import gaps.** Validate `systems`, `bodies`,
+   `stations`, and `body_rings` when present. Reconcile counts and source
+   coverage against the accepted rehearsal baseline. Investigate missing joins,
+   rejected-row spikes, and implausible count decreases before scheduling any
+   bounded gap import.
+4. **Grid.** Fully populate both `grid_cell_id` and `macro_grid_id` wherever the
+   canonical contract requires them. Completion means zero eligible null or
+   invalid assignments, not merely that a nightly batch made progress.
+5. **Ratings v3.4.** Fully build ratings with current `rating_version = 3.4`.
+   Completion means every eligible canonical system has its required rating,
+   no stale/non-3.4 eligible row remains, and `rating_dirty` has no unresolved
+   eligible work.
+6. **Topology and economy-pair synergy.** Complete the topology dataset first,
+   then economy-pair synergy. Require topology to postdate the current system,
+   ratings, and body source rows, and require all eleven canonical pairs from
+   `apps/importer/src/build_topology.py` for every eligible system (one pair row
+   is not complete coverage). Require full eligible coverage and zero required
+   backlog/dirty rows for each before continuing.
+7. **Archetypes.** Complete archetype scores and traits. Every eligible system
+   must have the required current score/trait representation, and archetype
+   dirty work must be zero.
+8. **Regional analysis.** Fully populate the required regional-analysis
+   products for every eligible system/region, with no required backlog.
+9. **Station/body links and canonical backfills.** Complete station-to-body
+   links and every other canonical backfill identified by the audit. Each
+   backfill needs an explicit eligible denominator and must reach that
+   denominator; unexplained orphans are blockers.
+10. **Full clusters.** Build `cluster_summary` only after its dependencies are
+    complete. Require complete eligible cluster coverage and an empty
+    `cluster_dirty` backlog.
+11. **Materialized views and maintenance refresh.** Refresh every required
+    serving materialized view after the underlying full builds, then perform
+    the documented database maintenance. Record view presence, row counts,
+    refresh completion/time, and maintenance result.
+12. **Strict invariant audit.** Run the strict data-invariant suite against the
+    candidate. Every required invariant must pass; skipped, unavailable, or
+    partially checked invariants are promotion blockers.
+13. **Application smoke/release gate.** With writes and public traffic still
+    controlled, verify API startup, representative search/detail/map/planning
+    reads, database compatibility, and rollback readiness. Cutover needs a
+    separate owner-approved release procedure and receipt.
+
+Nightly jobs use deliberately bounded backfills so routine maintenance cannot
+monopolise the database. A bounded nightly run, a decreasing backlog, or one
+successful batch is **not** completion evidence for this one-time production
+bootstrap. Use explicit full-build commands only in a later reviewed operator
+plan, and measure every dataset against its eligible denominator.
+
+The current schema has a durable per-system topology timestamp which can be
+compared with its system, Ratings v3.4, and body-source timestamps; the audit
+uses that contract and fails closed when topology predates any input. Pair rows
+are written in the same transaction as that topology marker. The current
+schema has no trustworthy materialized-view refresh watermark.
+PostgreSQL's `pg_class.relispopulated` proves only that a view was populated at
+least once, not that it was refreshed after its source builds. The audit must
+therefore fail closed on freshness. Before promotion, add a reviewed durable
+refresh ledger, updated only after each successful refresh, and compare its
+completion timestamp with durable completion timestamps for every source
+build. An operator log or an assertion that a command ran is not equivalent.
+
+## Readiness receipt and interpretation
+
+The preferred replacement-host control plane is the existing **ChatGPT ed-new
+Ops** workflow's narrowly allowlisted `production-candidate-readiness`
+operation. It requires the `ED_NEW_CANDIDATE_DATABASE_URL` environment secret,
+transmits it over SSH standard input rather than a command argument, runs
+`scripts/operator/audit_production_candidate.py --json-output <private-temp>`
+from `/opt/ed-finder`,
+checks that the output is valid JSON and does not contain the URL, and retains
+the receipt as a 30-day Actions artifact. Exit status `1` means audited but not
+ready; `2` means the audit failed closed. Both block the workflow. This
+operation performs reads only and does not run a migration or backfill.
+
+The `ed-new-operator` GitHub environment must also provide
+`ED_NEW_OPERATOR_SSH_KNOWN_HOSTS`, containing trusted OpenSSH `known_hosts`
+entries for `ED_NEW_OPERATOR_HOST` and `ED_NEW_OPERATOR_PORT`. Verify the host
+fingerprint with the owner through an independent channel before storing it.
+The workflow deliberately does not use `ssh-keyscan`: a key learned from the
+connection being authenticated cannot safely establish trust before the
+candidate database secret is transmitted.
+
+For a reviewed direct operator-shell run, export `DATABASE_URL` from the
+operator's protected secret source without printing it, then run:
+
+```sh
+python3 scripts/operator/audit_production_candidate.py \
+  --json-output /path/to/private/production-candidate-readiness.json
+```
+
+Unset `DATABASE_URL` after the command. Do not put it on the command line, in
+shell history, or in an artifact. The audit must be read-only and fail closed.
+Preserve its human-readable summary or JSON receipt with the snapshot evidence;
+publish the JSON only after confirming it is credential-free.
+
+Classify audit results in two groups:
+
+- **Must be fully built:** grid and macro-grid assignment, ratings v3.4 and
+  rating dirty state, topology, economy-pair synergy, archetype scores/traits
+  and dirty state, regional analysis, station/body links, cluster summary and
+  cluster dirty state, plus required serving materialized views. Missing
+  objects, incomplete eligible coverage, stale versions, or non-zero required
+  backlogs block promotion.
+- **Runtime/feature populated:** later journal, evidence, exploration,
+  powerplay, route, frontier-account, and similar feature tables. The audit
+  records whether each exists and its row count; zero or partial population is
+  not by itself a bootstrap failure unless a separate product release gate has
+  declared that feature required.
+
+Optional missing tables/views must be explicit in the receipt rather than
+causing the audit to crash. Conversely, “optional” means optional to inspect,
+not permission to ignore a missing object listed above as must be fully built.
+
+## Measurable promotion gate
+
+The candidate can enter a separate cutover review only when all of these are
+recorded together:
+
+- a verified, restorable pre-promotion snapshot/backup;
+- PostgreSQL major version 18 and the expected database identity/size;
+- zero pending manifest entries (automatic and manual), zero ledger checksum
+  mismatches, and no unexpected migration-ledger state;
+- accepted base-table counts and source/join coverage with every discrepancy
+  resolved or explicitly accepted;
+- 100% eligible coverage for every must-be-fully-built dataset, current ratings
+  version 3.4, and zero required dirty/backlog rows;
+- every required materialized view present and refreshed after the last full
+  dependency build;
+- a fully passing strict invariant audit with no required check skipped;
+- passing read-only application smoke tests and a documented rollback target.
+
+Any unknown denominator, missing receipt, checksum mismatch, partial full
+build, stale materialized view, failed/skipped invariant, or incomplete
+external-database deployment configuration is a promotion blocker. Stop and
+plan the exact population or remediation operation; do not turn the audit into
+an implicit migration or repair lane.
+
+## External-database deployment preflight
+
+External mode requires all five role URLs: `DATABASE_APP_URL`,
+`DATABASE_READONLY_URL`, `DATABASE_IMPORT_URL`,
+`DATABASE_MAINTENANCE_URL`, and `DATABASE_MIGRATION_URL`. The preflight connects
+to every URL in a read-only session and proves that each is PostgreSQL 18 and
+targets the same server/database identity. It also proves five distinct
+`current_user` identities: the reader has SELECT but no DML, MAINTAIN, or schema
+CREATE capability; app/import roles have serving-table DML but no schema CREATE;
+maintenance has DELETE and PostgreSQL 18 MAINTAIN but no schema CREATE; and the
+migration role can CREATE in the application schema. Reused roles and
+overprivileged read/app/import/maintenance roles fail closed. It never prints a
+URL, credential, or role name.
+
+`deploy_main.sh --external-db` starts and waits for bundled Redis while using
+dependency-free application starts so bundled PostgreSQL cannot be started.
+Operator-exported environment values take precedence over `.env`; `.env`
+supplies only values absent from the invoking shell. Any bundled PostgreSQL
+container running in external mode is an isolation failure.

--- a/env.example
+++ b/env.example
@@ -24,6 +24,14 @@ DATABASE_IMPORT_URL=
 DATABASE_MAINTENANCE_URL=
 DATABASE_MIGRATION_URL=
 
+# Explicit production mode for an existing external/hosted PostgreSQL 18 DB.
+# Keep false for the historical bundled postgres:16 deployment. When true (or
+# when deploy_main.sh is passed --external-db), all five role-specific URLs
+# above are mandatory; the deploy checks every role against the same PostgreSQL
+# 18 cluster/database, starts Redis explicitly, and uses --no-deps for the app
+# services so Compose cannot silently start its bundled postgres service.
+EDFINDER_EXTERNAL_DB_MODE=false
+
 # Optional rclone remote path for offsite Postgres backup copies, for example:
 #   s3:ed-finder-prod/postgres
 #   storagebox:ed-finder/backups/postgres

--- a/scripts/apply_migrations.sh
+++ b/scripts/apply_migrations.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ENV_FILE="${ENV_FILE:-$ROOT_DIR/.env}"
-if [[ -f "$ENV_FILE" ]]; then
+if [[ "${EDFINDER_ENV_ALREADY_RESOLVED:-0}" != "1" && -f "$ENV_FILE" ]]; then
   set -a
   # shellcheck source=/dev/null
   source "$ENV_FILE"
@@ -48,6 +48,9 @@ say() { printf '\n[INFO] %s\n' "$*"; }
 ok()  { printf '[OK]   %s\n' "$*"; }
 warn() { printf '[WARN] %s\n' "$*"; }
 die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+[[ "$LEDGER_TABLE" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] ||
+  die "MIGRATION_LEDGER_TABLE must be a simple unquoted SQL identifier"
 
 validate_timeout() {
   local name="$1"

--- a/scripts/deploy_main.sh
+++ b/scripts/deploy_main.sh
@@ -19,6 +19,7 @@
 #   bash scripts/deploy_main.sh --skip-pull
 #   bash scripts/deploy_main.sh --skip-migrations
 #   bash scripts/deploy_main.sh --skip-frontend
+#   bash scripts/deploy_main.sh --external-db
 #   bash scripts/deploy_main.sh --frontend-archive /tmp/frontend-dist.tar.gz
 #
 # Environment overrides:
@@ -38,6 +39,8 @@ SKIP_PULL=0
 SKIP_MIGRATIONS=0
 SKIP_FRONTEND=0
 SKIP_INVARIANTS=0
+EXTERNAL_DB_MODE="${EDFINDER_EXTERNAL_DB_MODE:-false}"
+EXTERNAL_DB_FLAG=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -45,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --skip-migrations) SKIP_MIGRATIONS=1; shift ;;
     --skip-frontend)   SKIP_FRONTEND=1; shift ;;
     --skip-invariants) SKIP_INVARIANTS=1; shift ;;
+    --external-db)     EXTERNAL_DB_MODE=true; EXTERNAL_DB_FLAG=1; shift ;;
     --frontend-archive) FRONTEND_ARCHIVE="$2"; shift 2 ;;
     --branch)          BRANCH="$2"; shift 2 ;;
     --repo-dir)        REPO_DIR="$2"; shift 2 ;;
@@ -77,7 +81,11 @@ on_error() {
     echo "  cd $REPO_DIR" >&2
     echo "  git reset --hard \$(awk '{print \$1}' $PRE_DEPLOY_FILE)" >&2
     echo "  ( cd $FRONTEND_DIR && yarn build )" >&2
-    echo "  docker compose up -d --build api eddn maintenance" >&2
+    if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+      echo "  docker compose up -d --build --no-deps api eddn maintenance" >&2
+    else
+      echo "  docker compose up -d --build api eddn maintenance" >&2
+    fi
     echo "  docker compose exec nginx nginx -s reload" >&2
   fi
 }
@@ -95,6 +103,39 @@ say "Sanity checks"
 command -v git >/dev/null || die "git not found"
 command -v docker >/dev/null || die "docker not found"
 command -v curl >/dev/null || die "curl not found"
+
+# Compose reads .env automatically; load it here too so the explicit mode and
+# its role-separated URLs are validated. Preserve every value explicitly
+# exported by the operator: shell overrides have the same precedence here that
+# Docker Compose gives them over values from .env.
+declare -A OPERATOR_EXPORTED_ENV=()
+while IFS= read -r name; do
+  OPERATOR_EXPORTED_ENV["$name"]="${!name}"
+done < <(compgen -e)
+set -a
+# shellcheck source=/dev/null
+source .env
+set +a
+for name in "${!OPERATOR_EXPORTED_ENV[@]}"; do
+  export "$name=${OPERATOR_EXPORTED_ENV[$name]}"
+done
+unset OPERATOR_EXPORTED_ENV name
+# Child scripts must consume this already-resolved environment. In particular,
+# the migration applier must not source .env again and replace operator-exported
+# role URLs with file values.
+export EDFINDER_ENV_ALREADY_RESOLVED=1
+if [[ "$EXTERNAL_DB_FLAG" -eq 0 ]]; then
+  EXTERNAL_DB_MODE="${EDFINDER_EXTERNAL_DB_MODE:-false}"
+fi
+
+case "$EXTERNAL_DB_MODE" in
+  true)
+    bash scripts/validate_external_db_config.sh --config-only
+    bash scripts/validate_external_db_config.sh
+    ;;
+  false) ;;
+  *) die "EDFINDER_EXTERNAL_DB_MODE must be exactly true or false" ;;
+esac
 if [[ "$SKIP_FRONTEND" -eq 0 ]]; then
   if [[ -n "$FRONTEND_ARCHIVE" ]]; then
     command -v tar >/dev/null || die "tar not found; required to extract --frontend-archive"
@@ -122,9 +163,27 @@ else
 fi
 
 say "Check core services are available"
-docker compose ps postgres >/dev/null
+if [[ "$EXTERNAL_DB_MODE" == "false" ]]; then
+  docker compose ps postgres >/dev/null
+else
+  if [[ -n "$(docker compose ps --status running --services postgres)" ]]; then
+    die "bundled postgres is running in external database mode"
+  fi
+  # Start Redis explicitly because --no-deps below deliberately prevents
+  # Compose from starting either Redis or the bundled PostgreSQL dependency.
+  docker compose up -d --no-deps redis
+  redis_healthy=0
+  for i in {1..30}; do
+    if [[ "$(docker compose exec -T redis redis-cli ping 2>/dev/null || true)" == "PONG" ]]; then
+      redis_healthy=1
+      break
+    fi
+    sleep 2
+  done
+  [[ "$redis_healthy" -eq 1 ]] || die "redis did not become healthy"
+fi
 docker compose ps redis >/dev/null
-ok "compose can see postgres and redis"
+ok "required database and redis services are available"
 
 if [[ "$SKIP_MIGRATIONS" -eq 0 ]]; then
   say "Apply pending ledgered SQL migrations"
@@ -194,11 +253,22 @@ say "Rebuild/restart application containers"
 export EDFINDER_BUILD_SHA
 EDFINDER_BUILD_SHA="$(git rev-parse HEAD)"
 ok "deployment build SHA: $EDFINDER_BUILD_SHA"
-docker compose up -d --build api eddn maintenance
+if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+  # --no-deps is the critical isolation boundary: api/eddn/maintenance retain
+  # their default bundled-postgres dependency for existing deployments, but an
+  # explicit external deployment must never create or start that service.
+  docker compose up -d --build --no-deps api eddn maintenance
+else
+  docker compose up -d --build api eddn maintenance
+fi
 ok "application containers updated"
 
 say "Recreate nginx to pick up config and volume changes"
-docker compose up -d --force-recreate nginx
+if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+  docker compose up -d --force-recreate --no-deps nginx
+else
+  docker compose up -d --force-recreate nginx
+fi
 ok "nginx container recreated"
 
 say "Wait for API health"
@@ -215,10 +285,16 @@ for i in {1..30}; do
 done
 
 say "Verify facility catalogue"
-facility_count="$(
-  docker compose exec -T postgres psql -U edfinder -d edfinder -At \
-    -c "SELECT COUNT(*) FROM facility_templates;"
-)"
+if [[ "$EXTERNAL_DB_MODE" == "true" ]]; then
+  facility_count="$(PGCONNECT_TIMEOUT=10 PGOPTIONS='-c default_transaction_read_only=on' \
+    psql --no-psqlrc --dbname="$DATABASE_READONLY_URL" -AtX \
+      -c "SELECT COUNT(*) FROM facility_templates;")"
+else
+  facility_count="$(
+    docker compose exec -T postgres psql -U edfinder -d edfinder -At \
+      -c "SELECT COUNT(*) FROM facility_templates;"
+  )"
+fi
 [[ "$facility_count" -ge 1 ]] || die "facility_templates is empty or missing"
 ok "facility_templates rows: $facility_count"
 

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -16,6 +16,13 @@ does not touch the database.
 
 Current scripts:
 
+- `audit_production_candidate.py`: read-only, fail-closed readiness audit for an
+  existing PostgreSQL production candidate. It requires an explicit
+  `DATABASE_URL`/`--database-url`, emits human output by default, and supports
+  `--json` or `--json-output PATH` for a durable, credential-free receipt. It
+  honors the validated `MIGRATION_LEDGER_TABLE` setting and currently blocks on
+  materialized-view freshness because the schema has no durable ordered refresh
+  watermark.
 - `require_hetzner_operator_env.sh`: reusable fail-fast guard for
   Hetzner-only commands.
 - `stage18j_run_station_type_dry_run.sh`: generates the Stage 18J-P

--- a/scripts/operator/audit_production_candidate.py
+++ b/scripts/operator/audit_production_candidate.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Fail-closed, read-only readiness audit for an existing production candidate DB."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import psycopg2
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "sql" / "migration-manifest.txt"
+TARGET_RATING_VERSION = "3.4"
+DEFAULT_LEDGER_TABLE = "schema_migrations"
+IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+REVISION_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+
+# These are populated by application features or live/user input. Their emptiness is
+# not evidence that the one-time canonical warehouse build is incomplete.
+INVENTORY_ONLY_TABLES = (
+    "journal_events",
+    "body_scan_facts",
+    "body_slot_predictions",
+    "buildability_analysis",
+    "colony_simulations",
+    "observed_facts",
+    "journal_import_staging",
+    "evidence_records",
+    "derived_features",
+    "rule_proposals",
+    "rule_decisions",
+    "exploration_facts",
+    "exploration_visits",
+    "exploration_expedition_routes",
+    "exploration_body_completeness",
+    "exobiology_sales",
+    "exobiology_organisms",
+    "codex_observations",
+    "powerplay_observations",
+    "commander_powerplay_events",
+    "commander_powerplay_state",
+    "powerplay_cycles",
+    "routes",
+    "route_events",
+    "app_users",
+    "web_sessions",
+    "oauth_login_states",
+)
+
+
+@dataclass(frozen=True)
+class Migration:
+    filename: str
+    mode: str
+    checksum: str
+
+
+def load_manifest(path: Path) -> list[Migration]:
+    migrations: list[Migration] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        filename, separator, mode = line.partition("|")
+        mode = mode if separator else "auto"
+        if mode not in {"auto", "manual"} or not filename.endswith(".sql"):
+            raise ValueError(f"invalid migration manifest entry: {raw!r}")
+        migration_path = path.parent / filename
+        if not migration_path.is_file():
+            raise ValueError(f"manifested migration is missing: {filename}")
+        checksum = hashlib.sha256(migration_path.read_bytes()).hexdigest()
+        migrations.append(Migration(filename, mode, checksum))
+    if not migrations:
+        raise ValueError("migration manifest is empty")
+    return migrations
+
+
+class Reader:
+    def __init__(self, connection: Any):
+        self.connection = connection
+
+    def one(self, query: str, params: tuple[Any, ...] = ()) -> Any:
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("audit query unexpectedly returned no row")
+        return row[0]
+
+    def rows(self, query: str, params: tuple[Any, ...] = ()) -> list[tuple[Any, ...]]:
+        with self.connection.cursor() as cursor:
+            cursor.execute(query, params)
+            return list(cursor.fetchall())
+
+    def relation_kind(self, name: str) -> str | None:
+        return self.one(
+            "SELECT (SELECT c.relkind::text FROM pg_catalog.pg_class c "
+            "JOIN pg_catalog.pg_namespace n ON n.oid=c.relnamespace "
+            "WHERE n.nspname='public' AND c.relname=%s)",
+            (name,),
+        )
+
+    def count(self, name: str) -> int:
+        # All names passed here are constants owned by this file.
+        return int(self.one(f'SELECT COUNT(*)::bigint FROM public."{name}"'))
+
+
+def _relation(reader: Reader, name: str, *, classification: str) -> dict[str, Any]:
+    kind = reader.relation_kind(name)
+    if kind is None:
+        return {"name": name, "classification": classification, "present": False, "row_count": None}
+    result = {"name": name, "classification": classification, "present": True, "row_count": reader.count(name)}
+    if kind == "m":
+        result["populated"] = bool(
+            reader.one("SELECT relispopulated FROM pg_catalog.pg_class WHERE oid=to_regclass('public.' || %s)", (name,))
+        )
+    return result
+
+
+def _metric(reader: Reader, name: str, query: str, dependencies: tuple[str, ...], *, required: bool = True) -> dict[str, Any]:
+    missing = [relation for relation in dependencies if reader.relation_kind(relation) is None]
+    if missing:
+        return {"name": name, "classification": "required_build" if required else "optional", "present": False,
+                "missing_relations": missing}
+    values = reader.rows(query)
+    # Metric SQL always returns key/value pairs; avoiding cursor metadata keeps fakes simple.
+    data = {str(key): int(value) for key, value in values}
+    return {"name": name, "classification": "required_build" if required else "optional", "present": True, **data}
+
+
+def validate_ledger_table(value: str) -> str:
+    if not IDENTIFIER_RE.fullmatch(value):
+        raise ValueError("MIGRATION_LEDGER_TABLE must be one unqualified PostgreSQL identifier")
+    return value
+
+
+def migration_audit(reader: Reader, migrations: list[Migration], ledger_table: str = DEFAULT_LEDGER_TABLE) -> dict[str, Any]:
+    ledger_table = validate_ledger_table(ledger_table)
+    if reader.relation_kind(ledger_table) is None:
+        return {"ledger_present": False, "pending_auto": [m.filename for m in migrations if m.mode == "auto"],
+                "pending_manual": [m.filename for m in migrations if m.mode == "manual"], "checksum_mismatches": [],
+                "unexpected_ledger_entries": []}
+    ledger = {name: checksum for name, checksum in reader.rows(
+        f'SELECT filename, checksum_sha256 FROM public."{ledger_table}" ORDER BY filename'
+    )}
+    expected = {m.filename: m for m in migrations}
+    return {
+        "ledger_present": True,
+        "pending_auto": [m.filename for m in migrations if m.mode == "auto" and m.filename not in ledger],
+        "pending_manual": [m.filename for m in migrations if m.mode == "manual" and m.filename not in ledger],
+        "checksum_mismatches": [m.filename for m in migrations if m.filename in ledger and ledger[m.filename] != m.checksum],
+        "unexpected_ledger_entries": sorted(set(ledger) - set(expected)),
+        "applied_count": len(ledger),
+        "manifest_count": len(migrations),
+    }
+
+
+REQUIRED_METRICS = (
+    ("grid", ("systems", "spatial_grid", "macro_grid", "app_meta"), """WITH meta AS (SELECT MAX(value::double precision) FILTER (WHERE key='grid_min_x') min_x, MAX(value::double precision) FILTER (WHERE key='grid_min_y') min_y, MAX(value::double precision) FILTER (WHERE key='grid_min_z') min_z, MAX(value::double precision) FILTER (WHERE key='grid_cell_size') cell_size FROM app_meta), eligible AS (SELECT s.*, m.* FROM systems s CROSS JOIN meta m WHERE x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL) SELECT 'eligible', COUNT(*) FROM eligible UNION ALL SELECT 'metadata_missing', COUNT(*) FROM meta WHERE min_x IS NULL OR min_y IS NULL OR min_z IS NULL OR cell_size IS NULL OR cell_size <= 0 UNION ALL SELECT 'missing', COUNT(*) FROM eligible WHERE grid_cell_id IS NULL OR macro_grid_id IS NULL UNION ALL SELECT 'invalid_grid', COUNT(*) FROM eligible e LEFT JOIN spatial_grid g ON g.cell_id=e.grid_cell_id WHERE g.cell_id IS NULL OR e.x < g.min_x OR e.x >= g.max_x OR e.y < g.min_y OR e.y >= g.max_y OR e.z < g.min_z OR e.z >= g.max_z OR e.grid_cell_id IS DISTINCT FROM (floor((e.x-e.min_x)/e.cell_size)::bigint*100000000 + floor((e.y-e.min_y)/e.cell_size)::bigint*10000 + floor((e.z-e.min_z)/e.cell_size)::bigint) UNION ALL SELECT 'invalid_macro', COUNT(*) FROM eligible e LEFT JOIN macro_grid g ON g.cell_id=e.macro_grid_id WHERE g.cell_id IS NULL OR e.x < g.min_x OR e.x >= g.max_x OR e.y < g.min_y OR e.y >= g.max_y OR e.z < g.min_z OR e.z >= g.max_z OR e.macro_grid_id IS DISTINCT FROM (floor((e.x-e.min_x)/2000.0)::bigint*100000000 + floor((e.y-e.min_y)/2000.0)::bigint*10000 + floor((e.z-e.min_z)/2000.0)::bigint)"""),
+    ("ratings", ("systems", "ratings"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM systems WHERE has_body_data UNION ALL SELECT 'missing', COUNT(*) FROM systems s WHERE s.has_body_data AND NOT EXISTS (SELECT 1 FROM ratings r WHERE r.system_id64=s.id64 AND r.rating_version='3.4') UNION ALL SELECT 'wrong_version', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version IS DISTINCT FROM '3.4' UNION ALL SELECT 'dirty', COUNT(*) FROM systems WHERE has_body_data AND rating_dirty"),
+    ("topology", ("systems", "bodies", "ratings", "system_slot_topology"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' UNION ALL SELECT 'missing', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' AND NOT EXISTS (SELECT 1 FROM system_slot_topology t WHERE t.system_id64=s.id64) UNION ALL SELECT 'stale', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 JOIN system_slot_topology t ON t.system_id64=s.id64 WHERE s.has_body_data AND r.rating_version='3.4' AND t.updated_at < GREATEST(s.updated_at, r.updated_at, COALESCE((SELECT MAX(b.updated_at) FROM bodies b WHERE b.system_id64=s.id64), '-infinity'::timestamptz))"),
+    # build_topology.py is repository authority for these eleven pairs. A VALUES
+    # relation makes completeness exact per eligible system instead of accepting
+    # one arbitrary row (or relying on mutable database seed contents).
+    ("economy_pair_synergy", ("systems", "ratings", "system_slot_topology", "economy_pair_synergy"), "WITH canonical(economy_a, economy_b) AS (VALUES ('Agriculture', 'HighTech'), ('Agriculture', 'Tourism'), ('Agriculture', 'Refinery'), ('Extraction', 'Industrial'), ('Extraction', 'Refinery'), ('HighTech', 'Military'), ('HighTech', 'Tourism'), ('Industrial', 'Military'), ('Refinery', 'Industrial'), ('Refinery', 'Military'), ('Tourism', 'Refinery')), eligible AS (SELECT s.id64 FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4') SELECT 'eligible'::text, COUNT(*)::bigint FROM eligible UNION ALL SELECT 'source_missing', COUNT(*) FROM eligible x WHERE NOT EXISTS (SELECT 1 FROM system_slot_topology t WHERE t.system_id64=x.id64) UNION ALL SELECT 'missing', COUNT(*) FROM eligible x CROSS JOIN canonical c WHERE NOT EXISTS (SELECT 1 FROM economy_pair_synergy e WHERE e.system_id64=x.id64 AND e.economy_a::text=c.economy_a AND e.economy_b::text=c.economy_b) UNION ALL SELECT 'unexpected', COUNT(*) FROM economy_pair_synergy e JOIN eligible x ON x.id64=e.system_id64 WHERE NOT EXISTS (SELECT 1 FROM canonical c WHERE c.economy_a=e.economy_a::text AND c.economy_b=e.economy_b::text)"),
+    ("archetypes", ("systems", "ratings", "system_archetype_scores", "system_archetype_traits"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' UNION ALL SELECT 'scores_missing', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' AND NOT EXISTS (SELECT 1 FROM system_archetype_scores a WHERE a.system_id64=s.id64) UNION ALL SELECT 'traits_missing', COUNT(*) FROM ratings r JOIN systems s ON s.id64=r.system_id64 WHERE s.has_body_data AND r.rating_version='3.4' AND NOT EXISTS (SELECT 1 FROM system_archetype_traits a WHERE a.system_id64=s.id64) UNION ALL SELECT 'dirty', COUNT(*) FROM system_archetype_scores a JOIN systems s ON s.id64=a.system_id64 WHERE s.has_body_data AND a.dirty"),
+    ("regional_analysis", ("systems", "system_regional_analysis"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM systems WHERE x IS NOT NULL AND y IS NOT NULL AND z IS NOT NULL UNION ALL SELECT 'missing', COUNT(*) FROM systems s WHERE s.x IS NOT NULL AND s.y IS NOT NULL AND s.z IS NOT NULL AND NOT EXISTS (SELECT 1 FROM system_regional_analysis r WHERE r.system_id64=s.id64)"),
+    ("station_body_links", ("stations", "station_body_links"), "SELECT 'eligible'::text, COUNT(*)::bigint FROM stations WHERE body_name IS NOT NULL AND btrim(body_name) <> '' UNION ALL SELECT 'missing', COUNT(*) FROM stations s WHERE s.body_name IS NOT NULL AND btrim(s.body_name) <> '' AND NOT EXISTS (SELECT 1 FROM station_body_links l WHERE l.station_id=s.id AND l.association_status='confirmed' AND l.body_id IS NOT NULL)"),
+    ("clusters", ("systems", "ratings", "cluster_summary"), "WITH ranked AS (SELECT s.id64, row_number() OVER (PARTITION BY s.macro_grid_id ORDER BY r.score DESC, s.id64) AS cell_rank FROM systems s JOIN ratings r ON r.system_id64=s.id64 WHERE s.has_body_data AND s.macro_grid_id IS NOT NULL AND r.score IS NOT NULL AND r.score >= 65), eligible AS (SELECT id64 FROM ranked WHERE cell_rank <= 50) SELECT 'eligible'::text, COUNT(*)::bigint FROM eligible UNION ALL SELECT 'missing', COUNT(*) FROM eligible e WHERE NOT EXISTS (SELECT 1 FROM cluster_summary c WHERE c.system_id64=e.id64) UNION ALL SELECT 'dirty_rows', COUNT(*) FROM cluster_summary WHERE dirty UNION ALL SELECT 'system_dirty', COUNT(*) FROM systems WHERE has_body_data AND cluster_dirty"),
+)
+
+
+def blockers_for(report: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if report["server"]["version_num"] // 10000 != 18:
+        blockers.append("PostgreSQL server major version is not 18")
+    migrations = report["migrations"]
+    if not migrations["ledger_present"]:
+        blockers.append("migration ledger is missing")
+    for key in ("pending_auto", "pending_manual", "checksum_mismatches", "unexpected_ledger_entries"):
+        if migrations[key]:
+            blockers.append(f"migration {key.replace('_', ' ')}: {len(migrations[key])}")
+    for table in report["base_tables"]:
+        if not table["present"]:
+            blockers.append(f"required base table missing: {table['name']}")
+    for metric in report["required_builds"]:
+        if not metric["present"]:
+            blockers.append(f"required build missing or unreadable: {metric['name']}")
+            continue
+        if metric["name"] == "grid" and (metric["metadata_missing"] or metric["missing"] or metric["invalid_grid"] or metric["invalid_macro"]):
+            blockers.append("grid assignments missing, stale, or inconsistent")
+        elif metric["name"] == "ratings" and (metric["missing"] or metric["wrong_version"] or metric["dirty"]):
+            blockers.append("ratings v3.4 build incomplete")
+        elif metric["name"] == "archetypes" and (metric["scores_missing"] or metric["traits_missing"] or metric["dirty"]):
+            blockers.append("archetype build incomplete")
+        elif metric["name"] == "clusters":
+            if metric["missing"]:
+                blockers.append("cluster coverage incomplete")
+            if metric["dirty_rows"] or metric["system_dirty"]:
+                blockers.append("cluster build has dirty backlog")
+        elif metric["name"] == "topology":
+            if metric["missing"]:
+                blockers.append("topology coverage incomplete")
+            if metric["stale"]:
+                blockers.append("topology build is stale relative to ratings/source state")
+        elif metric["name"] == "economy_pair_synergy":
+            if metric["source_missing"]:
+                blockers.append("economy_pair_synergy source build incomplete")
+            if metric["missing"]:
+                blockers.append("economy_pair_synergy coverage incomplete")
+            if metric["unexpected"]:
+                blockers.append("economy_pair_synergy contains non-canonical pairs")
+        elif metric["name"] not in {"grid", "ratings", "archetypes", "clusters"}:
+            if metric.get("missing", 0):
+                blockers.append(f"{metric['name']} coverage incomplete")
+    for view in report["materialized_views"]:
+        if not view["present"] or not view.get("populated", False):
+            blockers.append(f"materialized view unavailable: {view['name']}")
+        elif not view.get("freshness_verified", False):
+            blockers.append(f"materialized view freshness unverified: {view['name']}")
+    return blockers
+
+
+def validate_reviewed_revision(value: str) -> str:
+    if not REVISION_RE.fullmatch(value):
+        raise ValueError("reviewed revision must be a full 40- or 64-character lowercase hexadecimal digest")
+    return value
+
+
+def run_audit(
+    connection: Any,
+    manifest: Path = DEFAULT_MANIFEST,
+    ledger_table: str = DEFAULT_LEDGER_TABLE,
+    reviewed_revision: str = "0" * 40,
+) -> dict[str, Any]:
+    reviewed_revision = validate_reviewed_revision(reviewed_revision)
+    # set_session configures the next transaction before the first statement.
+    # Every audit query below therefore observes one non-mutating snapshot.
+    connection.set_session(readonly=True, autocommit=False, isolation_level="REPEATABLE READ")
+    reader = Reader(connection)
+    if reader.one("SHOW transaction_read_only") != "on":
+        raise RuntimeError("database did not honor read-only transaction mode")
+    if reader.one("SHOW transaction_isolation") != "repeatable read":
+        raise RuntimeError("database did not honor repeatable-read transaction mode")
+    database_name, system_identifier = reader.rows(
+        "SELECT current_database()::text, system_identifier::text FROM pg_catalog.pg_control_system()"
+    )[0]
+    report: dict[str, Any] = {
+        "audit_version": 1,
+        "reviewed_revision": reviewed_revision,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "read_only": True,
+        "snapshot": {"isolation_level": "repeatable read"},
+        "candidate_identity": {"database": database_name, "system_identifier": system_identifier},
+        "server": {"version": reader.one("SHOW server_version"), "version_num": int(reader.one("SHOW server_version_num")),
+                   "database_size_bytes": int(reader.one("SELECT pg_database_size(current_database())"))},
+        "migrations": migration_audit(reader, load_manifest(manifest), ledger_table),
+        "base_tables": [_relation(reader, name, classification="required_base") for name in ("systems", "bodies", "stations", "body_rings")],
+        "base_coverage": [
+            _metric(reader, "body_system_coverage", "SELECT 'systems_with_bodies'::text, COUNT(DISTINCT system_id64)::bigint FROM bodies UNION ALL SELECT 'systems_flagged', COUNT(*) FROM systems WHERE has_body_data", ("systems", "bodies"), required=False),
+            _metric(reader, "station_system_coverage", "SELECT 'systems_with_stations'::text, COUNT(DISTINCT system_id64)::bigint FROM stations UNION ALL SELECT 'station_rows', COUNT(*) FROM stations", ("stations",), required=False),
+            _metric(reader, "ring_system_coverage", "SELECT 'systems_with_rings'::text, COUNT(DISTINCT system_id64)::bigint FROM body_rings UNION ALL SELECT 'ring_rows', COUNT(*) FROM body_rings", ("body_rings",), required=False),
+        ],
+        "required_builds": [_metric(reader, name, query, dependencies) for name, dependencies, query in REQUIRED_METRICS],
+        # PostgreSQL exposes whether an MV was populated, not when or after which
+        # source build it was refreshed. No durable ordered refresh watermark exists
+        # in this schema, so readiness deliberately fails closed. A safe mechanism
+        # must record source-build generation and successful MV refresh generation
+        # atomically, then prove refresh_generation >= source_generation here.
+        "materialized_views": [{**_relation(reader, name, classification="required_build"), "freshness_verified": False, "freshness_reason": "no durable ordered source-build/refresh watermark"} for name in ("mv_map_regions", "mv_map_heatmap_200ly", "mv_map_heatmap_500ly", "mv_map_heatmap_1000ly", "mv_map_timeline_month", "mv_archetype_rankings")],
+        "runtime_feature_tables": [_relation(reader, name, classification="inventory_only") for name in INVENTORY_ONLY_TABLES],
+    }
+    report["blockers"] = blockers_for(report)
+    report["ready"] = not report["blockers"]
+    connection.rollback()
+    return report
+
+
+def render_human(report: dict[str, Any]) -> str:
+    state = "READY" if report["ready"] else "NOT READY"
+    lines = [f"Production candidate: {state}", f"PostgreSQL {report['server']['version']} ({report['server']['database_size_bytes']} bytes)",
+             f"Read-only audit: {report['read_only']}"]
+    migration = report["migrations"]
+    lines.append(f"Migrations: pending auto={len(migration['pending_auto'])}, manual={len(migration['pending_manual'])}, checksum mismatches={len(migration['checksum_mismatches'])}")
+    for relation in report["base_tables"] + report["materialized_views"]:
+        lines.append(f"{relation['classification']} {relation['name']}: " + (f"{relation['row_count']} rows" if relation["present"] else "MISSING"))
+    for metric in report["required_builds"]:
+        values = ", ".join(f"{k}={v}" for k, v in metric.items() if k not in {"name", "classification", "present"})
+        lines.append(f"required_build {metric['name']}: {values or 'MISSING'}")
+    for metric in report.get("base_coverage", []):
+        values = ", ".join(f"{k}={v}" for k, v in metric.items() if k not in {"name", "classification", "present"})
+        lines.append(f"base_coverage {metric['name']}: {values or 'MISSING'}")
+    for item in report["runtime_feature_tables"]:
+        lines.append(f"inventory_only {item['name']}: " + (f"present, {item['row_count']} rows" if item["present"] else "missing (reported, not a population blocker)"))
+    lines.extend(f"BLOCKER: {blocker}" for blocker in report["blockers"])
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database-url", default=os.getenv("DATABASE_URL", ""), help="Explicit PostgreSQL DSN (or DATABASE_URL).")
+    parser.add_argument("--compose", action="store_true", help="Resolve DATA_INVARIANTS_DATABASE_URL from docker compose config without starting services.")
+    parser.add_argument("--compose-file", type=Path, default=ROOT / "docker-compose.yml")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--ledger-table", default=os.getenv("MIGRATION_LEDGER_TABLE", DEFAULT_LEDGER_TABLE))
+    parser.add_argument("--reviewed-revision", default=os.getenv("AUDIT_REVIEWED_REVISION", ""),
+                        help="Full Git commit/digest of the reviewed audit bundle (required before connecting).")
+    parser.add_argument("--json", action="store_true", help="Emit JSON only, suitable for a durable receipt.")
+    parser.add_argument("--json-output", type=Path, help="Also write the JSON receipt to this path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.compose and args.database_url:
+        print("ERROR: choose either explicit DATABASE_URL or --compose", file=sys.stderr)
+        return 2
+    if args.compose:
+        try:
+            completed = subprocess.run(
+                ["docker", "compose", "-f", str(args.compose_file), "config", "--format", "json"],
+                check=True, capture_output=True, text=True,
+            )
+            config = json.loads(completed.stdout)
+            args.database_url = config["services"]["maintenance"]["environment"]["DATA_INVARIANTS_DATABASE_URL"]
+        except Exception:
+            args.database_url = ""
+    if not args.database_url:
+        print("ERROR: DATABASE_URL or --database-url is required; no database was contacted", file=sys.stderr)
+        return 2
+    try:
+        # Reject unsafe/mismatched ledger configuration before making any
+        # network connection. apply_migrations.sh uses this same environment
+        # setting, so the audit must inspect exactly that ledger.
+        ledger_table = validate_ledger_table(args.ledger_table)
+        reviewed_revision = validate_reviewed_revision(args.reviewed_revision)
+        connection = psycopg2.connect(args.database_url, connect_timeout=10, application_name="edfinder-production-candidate-audit")
+        try:
+            report = run_audit(connection, args.manifest, ledger_table, reviewed_revision)
+        finally:
+            connection.close()
+        payload = json.dumps(report, indent=2, sort_keys=True)
+        if args.json_output:
+            args.json_output.write_text(payload + "\n", encoding="utf-8")
+        print(payload if args.json else render_human(report))
+        return 0 if report["ready"] else 1
+    except Exception as exc:  # fail closed; intentionally never echo DSNs or exception text
+        failure = {"audit_version": 1, "reviewed_revision": args.reviewed_revision,
+                   "ready": False, "read_only": True,
+                   "error": exc.__class__.__name__, "blockers": ["audit execution failed"]}
+        payload = json.dumps(failure, indent=2, sort_keys=True)
+        if args.json_output:
+            try:
+                args.json_output.write_text(payload + "\n", encoding="utf-8")
+            except OSError:
+                pass
+        if args.json:
+            print(payload)
+        print(f"ERROR: production-candidate audit failed ({exc.__class__.__name__}); no credentials shown", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_external_db_config.sh
+++ b/scripts/validate_external_db_config.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Validate the explicit external PostgreSQL production mode without printing DSNs.
+set -euo pipefail
+
+CONFIG_ONLY=0
+[[ "${1:-}" == "--config-only" ]] && CONFIG_ONLY=1
+
+die() { printf '[ERROR] %s\n' "$*" >&2; exit 1; }
+
+required_urls=(
+  DATABASE_APP_URL
+  DATABASE_READONLY_URL
+  DATABASE_IMPORT_URL
+  DATABASE_MAINTENANCE_URL
+  DATABASE_MIGRATION_URL
+)
+
+for name in "${required_urls[@]}"; do
+  value="${!name:-}"
+  [[ -n "$value" ]] || die "$name is required in external database mode"
+  case "$value" in
+    postgres://*|postgresql://*) ;;
+    *) die "$name must be a PostgreSQL URL" ;;
+  esac
+done
+
+# A URL naming the Compose service would make --external-db appear configured
+# while still depending on the bundled database that this mode must bypass.
+python3 - <<'PY'
+import os
+from urllib.parse import urlsplit
+
+names = (
+    "DATABASE_APP_URL", "DATABASE_READONLY_URL", "DATABASE_IMPORT_URL",
+    "DATABASE_MAINTENANCE_URL", "DATABASE_MIGRATION_URL",
+)
+for name in names:
+    value = os.environ[name]
+    if any(character.isspace() or ord(character) < 32 for character in value):
+        raise SystemExit(f"[ERROR] {name} must percent-encode whitespace and control characters")
+    hostname = (urlsplit(value).hostname or "").lower()
+    if not hostname:
+        raise SystemExit(f"[ERROR] {name} must include a database host")
+    if hostname == "postgres":
+        raise SystemExit(f"[ERROR] {name} must not target the bundled Compose postgres service")
+PY
+
+if [[ "$CONFIG_ONLY" -eq 1 ]]; then
+  printf '[OK] external database configuration is complete\n'
+  exit 0
+fi
+
+command -v psql >/dev/null 2>&1 || die "psql is required for external database preflight"
+
+# Keep credentials out of argv (and therefore /proc/<pid>/cmdline). libpq reads
+# the URI from this owner-only service file while psql receives only a constant
+# service name. The file is replaced for each role and removed on every exit.
+service_file="$(mktemp)"
+chmod 600 "$service_file"
+cleanup() { rm -f "$service_file"; }
+trap cleanup EXIT
+
+# Connect through every credential, not just the read-only role. In addition to
+# proving each URL works, pg_control_system() gives us the cluster identity; the
+# database name distinguishes databases within that cluster. Hostnames alone
+# are insufficient because aliases/load balancers can legitimately differ.
+expected_identity=""
+declare -A observed_roles=()
+for name in "${required_urls[@]}"; do
+  value="${!name}"
+  printf '[external_preflight]\ndbname=%s\n' "$value" >"$service_file"
+  identity="$(PGCONNECT_TIMEOUT=10 PGOPTIONS='-c default_transaction_read_only=on' \
+    PGSERVICEFILE="$service_file" EDFINDER_VALIDATING_URL_NAME="$name" \
+    psql --no-psqlrc --dbname='service=external_preflight' -AtX --field-separator='|' \
+      -c "SELECT current_setting('server_version_num'), system_identifier, current_database(), encode(convert_to(current_user, 'UTF8'), 'hex'), has_table_privilege(current_user, 'public.systems', 'SELECT'), has_table_privilege(current_user, 'public.systems', 'INSERT'), has_table_privilege(current_user, 'public.systems', 'UPDATE'), has_table_privilege(current_user, 'public.systems', 'DELETE'), has_table_privilege(current_user, 'public.systems', 'MAINTAIN'), has_schema_privilege(current_user, 'public', 'CREATE') FROM pg_control_system()")" \
+    || die "$name external database preflight connection/identity check failed"
+
+  IFS='|' read -r version_num system_identifier database_name role_id can_select can_insert can_update can_delete can_maintain can_ddl extra <<<"$identity"
+  [[ -z "${extra:-}" && -n "$system_identifier" && -n "$database_name" && "$role_id" =~ ^[0-9a-f]+$ ]] \
+    || die "$name returned an invalid database identity"
+  [[ "$version_num" =~ ^18[0-9]{4}$ ]] \
+    || die "$name must target PostgreSQL 18 (server reported a different major version)"
+  role_identity="${system_identifier}|${database_name}"
+  if [[ -z "$expected_identity" ]]; then
+    expected_identity="$role_identity"
+  elif [[ "$role_identity" != "$expected_identity" ]]; then
+    die "$name does not target the same PostgreSQL cluster and database as the other external role URLs"
+  fi
+  [[ -z "${observed_roles[$role_id]:-}" ]] \
+    || die "$name resolves to the same database role as ${observed_roles[$role_id]}; external roles must be separated"
+  observed_roles[$role_id]="$name"
+
+  case "$name" in
+    DATABASE_READONLY_URL)
+      [[ "$can_select" == "t" && "$can_insert" == "f" && "$can_update" == "f" \
+        && "$can_delete" == "f" && "$can_maintain" == "f" && "$can_ddl" == "f" ]] \
+        || die "$name role is not strictly read-only"
+      ;;
+    DATABASE_APP_URL|DATABASE_IMPORT_URL)
+      [[ "$can_select" == "t" && "$can_insert" == "t" && "$can_update" == "t" \
+        && "$can_delete" == "t" && "$can_ddl" == "f" ]] \
+        || die "$name role lacks required DML or is overprivileged for schema DDL"
+      ;;
+    DATABASE_MAINTENANCE_URL)
+      [[ "$can_select" == "t" && "$can_delete" == "t" && "$can_maintain" == "t" \
+        && "$can_ddl" == "f" ]] \
+        || die "$name role lacks required maintenance privileges or is overprivileged for schema DDL"
+      ;;
+    DATABASE_MIGRATION_URL)
+      [[ "$can_ddl" == "t" ]] || die "$name role lacks required schema DDL capability"
+      ;;
+  esac
+done
+printf '[OK] separated external roles have suitable privileges on one PostgreSQL 18 cluster and database\n'

--- a/tests/test_external_db_deploy_mode.py
+++ b/tests/test_external_db_deploy_mode.py
@@ -1,0 +1,238 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_external_db_config.sh"
+APPLIER = ROOT / "scripts" / "apply_migrations.sh"
+
+
+def _env(password: str = "do-not-print-this") -> dict[str, str]:
+    env = os.environ.copy()
+    for name, role in (
+        ("DATABASE_APP_URL", "app"),
+        ("DATABASE_READONLY_URL", "readonly"),
+        ("DATABASE_IMPORT_URL", "import"),
+        ("DATABASE_MAINTENANCE_URL", "maintenance"),
+        ("DATABASE_MIGRATION_URL", "migration"),
+    ):
+        env[name] = f"postgresql://{role}:{password}@db.example.invalid/edfinder"
+    return env
+
+
+def test_external_config_fails_closed_when_a_role_url_is_missing():
+    env = _env()
+    env.pop("DATABASE_MIGRATION_URL")
+    result = subprocess.run(
+        ["bash", str(VALIDATOR), "--config-only"], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "DATABASE_MIGRATION_URL is required" in result.stderr
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_external_config_rejects_the_bundled_compose_database():
+    env = _env()
+    env["DATABASE_APP_URL"] = "postgresql://app:do-not-print-this@postgres/edfinder"
+    result = subprocess.run(
+        ["bash", str(VALIDATOR), "--config-only"], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "bundled Compose postgres" in result.stderr
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_external_config_accepts_complete_role_urls_without_leaking_them():
+    result = subprocess.run(
+        ["bash", str(VALIDATOR), "--config-only"], env=_env(),
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 0
+    assert "configuration is complete" in result.stdout
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_deploy_external_mode_never_starts_compose_dependencies():
+    deploy = (ROOT / "scripts" / "deploy_main.sh").read_text(encoding="utf-8")
+    assert "--external-db" in deploy
+    assert "bash scripts/validate_external_db_config.sh" in deploy
+    assert "docker compose up -d --build --no-deps api eddn maintenance" in deploy
+    assert "docker compose up -d --force-recreate --no-deps nginx" in deploy
+    assert "docker compose up -d --no-deps redis" in deploy
+    assert "docker compose exec -T redis redis-cli ping" in deploy
+    assert "docker compose ps --status running --services postgres" in deploy
+    assert "bundled postgres is running in external database mode" in deploy
+    assert 'if [[ "$EXTERNAL_DB_MODE" == "false" ]]; then\n  docker compose ps postgres' in deploy
+
+
+def _fake_psql(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    psql = fake_bin / "psql"
+    psql.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$*\" >>\"$FAKE_PSQL_ARGV_LOG\"\n"
+        "stat -c '%a' \"$PGSERVICEFILE\" >>\"$FAKE_SERVICE_MODE_LOG\"\n"
+        "case \"$EDFINDER_VALIDATING_URL_NAME\" in\n"
+        "  DATABASE_APP_URL) printf '%s\\n' \"$FAKE_APP_IDENTITY\";;\n"
+        "  DATABASE_READONLY_URL) printf '%s\\n' \"$FAKE_READONLY_IDENTITY\";;\n"
+        "  DATABASE_IMPORT_URL) printf '%s\\n' \"$FAKE_IMPORT_IDENTITY\";;\n"
+        "  DATABASE_MAINTENANCE_URL) printf '%s\\n' \"$FAKE_MAINTENANCE_IDENTITY\";;\n"
+        "  DATABASE_MIGRATION_URL) printf '%s\\n' \"$FAKE_MIGRATION_IDENTITY\";;\n"
+        "  *) exit 2;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    psql.chmod(psql.stat().st_mode | stat.S_IXUSR)
+    return fake_bin
+
+
+def _preflight_env(tmp_path: Path) -> dict[str, str]:
+    env = _env()
+    fake_bin = _fake_psql(tmp_path)
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAKE_PSQL_ARGV_LOG"] = str(tmp_path / "psql-argv.log")
+    env["FAKE_SERVICE_MODE_LOG"] = str(tmp_path / "service-mode.log")
+    capabilities = {
+        "APP": "t|t|t|t|f|f",
+        "READONLY": "t|f|f|f|f|f",
+        "IMPORT": "t|t|t|t|f|f",
+        "MAINTENANCE": "t|f|f|t|t|f",
+        "MIGRATION": "t|t|t|t|t|t",
+    }
+    for index, (role, flags) in enumerate(capabilities.items(), start=1):
+        env[f"FAKE_{role}_IDENTITY"] = f"180002|72623859790382856|edfinder|726f6c65{index:02x}|{flags}"
+    return env
+
+
+def test_external_preflight_connects_every_role_and_accepts_one_pg18_identity(tmp_path):
+    env = _preflight_env(tmp_path)
+    result = subprocess.run(
+        ["bash", str(VALIDATOR)], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "separated external roles have suitable privileges" in result.stdout
+    assert "do-not-print-this" not in result.stdout + result.stderr
+    argv = Path(env["FAKE_PSQL_ARGV_LOG"]).read_text(encoding="utf-8")
+    assert "service=external_preflight" in argv
+    assert "postgresql://" not in argv
+    assert "do-not-print-this" not in argv
+    assert set(Path(env["FAKE_SERVICE_MODE_LOG"]).read_text().splitlines()) == {"600"}
+
+
+def test_external_preflight_rejects_role_on_a_different_cluster(tmp_path):
+    env = _preflight_env(tmp_path)
+    env["FAKE_IMPORT_IDENTITY"] = "180002|99999999999999999|edfinder|696d706f7274|t|t|t|t|f|f"
+    result = subprocess.run(
+        ["bash", str(VALIDATOR)], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "DATABASE_IMPORT_URL does not target the same PostgreSQL cluster and database" in result.stderr
+    assert "do-not-print-this" not in result.stdout + result.stderr
+
+
+def test_external_preflight_rejects_role_on_a_different_database(tmp_path):
+    env = _preflight_env(tmp_path)
+    env["FAKE_MIGRATION_IDENTITY"] = "180002|72623859790382856|postgres|6d6967726174696f6e|t|t|t|t|t|t"
+    result = subprocess.run(
+        ["bash", str(VALIDATOR)], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "DATABASE_MIGRATION_URL does not target the same PostgreSQL cluster and database" in result.stderr
+
+
+def test_external_preflight_checks_pg18_for_every_role(tmp_path):
+    env = _preflight_env(tmp_path)
+    env["FAKE_MAINTENANCE_IDENTITY"] = "170009|72623859790382856|edfinder|6d61696e74656e616e6365|t|f|f|t|t|f"
+    result = subprocess.run(
+        ["bash", str(VALIDATOR)], env=env,
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode != 0
+    assert "DATABASE_MAINTENANCE_URL must target PostgreSQL 18" in result.stderr
+
+
+def test_external_preflight_rejects_reused_role_credentials(tmp_path):
+    env = _preflight_env(tmp_path)
+    env["FAKE_READONLY_IDENTITY"] = env["FAKE_APP_IDENTITY"]
+    result = subprocess.run(["bash", str(VALIDATOR)], env=env, text=True, capture_output=True, check=False)
+    assert result.returncode != 0
+    assert "same database role as DATABASE_APP_URL" in result.stderr
+
+
+def test_external_preflight_rejects_overprivileged_reader(tmp_path):
+    env = _preflight_env(tmp_path)
+    env["FAKE_READONLY_IDENTITY"] = "180002|72623859790382856|edfinder|726561646572|t|t|f|f|f|f"
+    result = subprocess.run(["bash", str(VALIDATOR)], env=env, text=True, capture_output=True, check=False)
+    assert result.returncode != 0
+    assert "role is not strictly read-only" in result.stderr
+
+
+def test_external_preflight_requires_migration_ddl_and_maintenance_capability(tmp_path):
+    env = _preflight_env(tmp_path)
+    env["FAKE_MIGRATION_IDENTITY"] = "180002|72623859790382856|edfinder|6d6967726174696f6e|t|t|t|t|t|f"
+    result = subprocess.run(["bash", str(VALIDATOR)], env=env, text=True, capture_output=True, check=False)
+    assert result.returncode != 0
+    assert "lacks required schema DDL capability" in result.stderr
+
+
+def test_deploy_preserves_operator_exported_values_after_loading_dotenv():
+    deploy = (ROOT / "scripts" / "deploy_main.sh").read_text(encoding="utf-8")
+    assert 'done < <(compgen -e)' in deploy
+    assert 'source .env' in deploy
+    assert 'export "$name=${OPERATOR_EXPORTED_ENV[$name]}"' in deploy
+    assert "export EDFINDER_ENV_ALREADY_RESOLVED=1" in deploy
+
+
+def test_migration_applier_does_not_resource_dotenv_after_deploy_resolution():
+    applier = (ROOT / "scripts" / "apply_migrations.sh").read_text(encoding="utf-8")
+    assert '"${EDFINDER_ENV_ALREADY_RESOLVED:-0}" != "1"' in applier
+    assert 'DATABASE_URL="${DATABASE_MIGRATION_URL:-${DATABASE_URL:-}}"' in applier
+
+
+def test_migration_applier_runtime_preserves_resolved_operator_url(tmp_path):
+    sql_dir = tmp_path / "sql"
+    sql_dir.mkdir()
+    manifest = sql_dir / "migration-manifest.txt"
+    manifest.write_text("# intentionally empty\n", encoding="utf-8")
+    dotenv = tmp_path / ".env"
+    dotenv.write_text(
+        "DATABASE_MIGRATION_URL=postgresql://dotenv:wrong@db.invalid/edfinder\n",
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    argv_log = tmp_path / "migration-argv.log"
+    psql = fake_bin / "psql"
+    psql.write_text(
+        "#!/usr/bin/env bash\n"
+        "printf '%s\\n' \"$*\" >>\"$FAKE_MIGRATION_ARGV_LOG\"\n",
+        encoding="utf-8",
+    )
+    psql.chmod(psql.stat().st_mode | stat.S_IXUSR)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "ENV_FILE": str(dotenv),
+            "SQL_DIR": str(sql_dir),
+            "MIGRATION_MANIFEST": str(manifest),
+            "DATABASE_MIGRATION_URL": "postgresql://operator:correct@db.invalid/edfinder",
+            "EDFINDER_ENV_ALREADY_RESOLVED": "1",
+            "FAKE_MIGRATION_ARGV_LOG": str(argv_log),
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(APPLIER)], env=env, text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    argv = argv_log.read_text(encoding="utf-8")
+    assert "postgresql://operator:correct@db.invalid/edfinder" in argv
+    assert "dotenv:wrong" not in argv

--- a/tests/test_migration_script_contracts.py
+++ b/tests/test_migration_script_contracts.py
@@ -24,6 +24,8 @@ def test_apply_migrations_uses_manifest_ledger_and_checksum_guards():
     assert 'DATABASE_URL="${DATABASE_MIGRATION_URL:-${DATABASE_URL:-}}"' in script
     assert 'MANIFEST_FILE="${MIGRATION_MANIFEST:-$SQL_DIR/migration-manifest.txt}"' in script
     assert 'LEDGER_TABLE="${MIGRATION_LEDGER_TABLE:-schema_migrations}"' in script
+    assert 'MIGRATION_LEDGER_TABLE must be a simple unquoted SQL identifier' in script
+    assert '^[A-Za-z_][A-Za-z0-9_]*$' in script
     assert 'COMPOSE_FILE_OVERRIDE="${EDFINDER_DOCKER_COMPOSE_FILE:-}"' in script
     assert '--compose-file' in script
     assert 'dc exec -T "$MIGRATION_DB_SERVICE" sh -lc' in script

--- a/tests/test_pg18_promotion_runbook.py
+++ b/tests/test_pg18_promotion_runbook.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / '.github' / 'workflows' / 'chatgpt-ed-new-ops.yml'
+RUNBOOK_PATH = ROOT / 'docs' / 'operations' / 'production-pg18-candidate-promotion.md'
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding='utf-8')
+
+
+def test_ed_new_workflow_narrowly_allowlists_readiness_audit():
+    workflow = _workflow_text()
+
+    assert '- production-candidate-readiness' in workflow
+    assert 'host-status|production-candidate-readiness)' in workflow
+    assert 'scripts/operator/audit_production_candidate.py --reviewed-revision' in workflow
+    assert '--json-output' in workflow
+    assert 'tar -czf "$audit_bundle" scripts/operator/audit_production_candidate.py sql' in workflow
+    assert 'cd /opt/ed-finder' not in workflow
+    assert 'run-governed-migrations' not in workflow
+
+
+def test_ed_new_readiness_operation_keeps_database_url_off_argv_and_receipt():
+    workflow = _workflow_text()
+
+    assert 'printf \'%s\\n\' "$CANDIDATE_DATABASE_URL" | ssh' in workflow
+    assert 'IFS= read -r DATABASE_URL' in workflow
+    assert '--database-url "$CANDIDATE_DATABASE_URL"' not in workflow
+    assert 'secret in raw' in workflow
+    assert 'json.loads(raw)' in workflow
+
+
+def test_ed_new_workflow_requires_a_trusted_host_key_for_the_configured_endpoint():
+    workflow = _workflow_text()
+
+    assert 'secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS' in workflow
+    assert 'ssh-keygen -F "$known_hosts_target" -f ~/.ssh/known_hosts' in workflow
+    assert 'ssh-keyscan' not in workflow
+    # host status plus the bundle copy and isolated audit execution each use
+    # the same pinned host-key policy.
+    assert workflow.count('-o UserKnownHostsFile="$HOME/.ssh/known_hosts"') == 3
+    assert workflow.count('-o GlobalKnownHostsFile=/dev/null') == 3
+    assert '-o StrictHostKeyChecking=yes' in workflow
+
+
+def test_ed_new_readiness_operation_retains_receipt_and_preserves_exit_meaning():
+    workflow = _workflow_text()
+
+    assert 'production-candidate-readiness.json' in workflow
+    assert 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' in workflow
+    assert 'AUDIT_STATUS' in workflow
+    assert '1) echo "Production candidate has readiness blockers' in workflow
+    assert '2) echo "Production-candidate audit failed closed' in workflow
+    yaml.safe_load(workflow)
+
+
+def test_ed_new_workflow_uploads_only_a_validated_credential_free_receipt():
+    workflow = _workflow_text()
+
+    assert 'id: validate_candidate_receipt' in workflow
+    assert "steps.validate_candidate_receipt.outcome == 'success'" in workflow
+    validation_position = workflow.index('id: validate_candidate_receipt')
+    upload_position = workflow.index('actions/upload-artifact@')
+    assert validation_position < upload_position
+
+
+def test_pg18_runbook_defines_order_completion_and_non_goals():
+    runbook = RUNBOOK_PATH.read_text(encoding='utf-8')
+    normalized = ' '.join(runbook.split())
+
+    ordered_terms = (
+        '**Snapshot/backup.**',
+        '**Schema and migration audit.**',
+        '**Base-data validation/import gaps.**',
+        '**Grid.**',
+        '**Ratings v3.4.**',
+        '**Topology and economy-pair synergy.**',
+        '**Archetypes.**',
+        '**Regional analysis.**',
+        '**Station/body links and canonical backfills.**',
+        '**Full clusters.**',
+        '**Materialized views and maintenance refresh.**',
+        '**Strict invariant audit.**',
+        '**Application smoke/release gate.**',
+    )
+    positions = [runbook.index(term) for term in ordered_terms]
+    assert positions == sorted(positions)
+    assert 'bounded nightly run' in runbook
+    assert '100% eligible coverage' in runbook
+    assert 'restore V2 into V3' in normalized
+    assert 'does not run a migration or backfill' in runbook

--- a/tests/test_production_candidate_audit.py
+++ b/tests/test_production_candidate_audit.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REVISION = "a" * 40
+SCRIPT = ROOT / "scripts" / "operator" / "audit_production_candidate.py"
+SPEC = importlib.util.spec_from_file_location("audit_production_candidate", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = audit
+SPEC.loader.exec_module(audit)
+
+
+def test_manifest_modes_and_checksums_are_authoritative(tmp_path):
+    (tmp_path / "001.sql").write_text("SELECT 1;\n", encoding="utf-8")
+    (tmp_path / "002.sql").write_text("SELECT 2;\n", encoding="utf-8")
+    manifest = tmp_path / "migration-manifest.txt"
+    manifest.write_text("001.sql\n002.sql|manual\n", encoding="utf-8")
+
+    entries = audit.load_manifest(manifest)
+
+    assert [(entry.filename, entry.mode) for entry in entries] == [("001.sql", "auto"), ("002.sql", "manual")]
+    assert entries[0].checksum == hashlib.sha256(b"SELECT 1;\n").hexdigest()
+
+
+class LedgerReader:
+    def relation_kind(self, name):
+        return "r" if name == "schema_migrations" else None
+
+    def rows(self, query, params=()):
+        assert "schema_migrations" in query
+        return [("001.sql", "wrong"), ("unexpected.sql", "abc")]
+
+
+def test_migration_audit_separates_auto_manual_checksum_and_unexpected(tmp_path):
+    (tmp_path / "001.sql").write_text("SELECT 1;", encoding="utf-8")
+    (tmp_path / "002.sql").write_text("SELECT 2;", encoding="utf-8")
+    manifest = tmp_path / "migration-manifest.txt"
+    manifest.write_text("001.sql\n002.sql|manual\n", encoding="utf-8")
+
+    result = audit.migration_audit(LedgerReader(), audit.load_manifest(manifest))
+
+    assert result["pending_auto"] == []
+    assert result["pending_manual"] == ["002.sql"]
+    assert result["checksum_mismatches"] == ["001.sql"]
+    assert result["unexpected_ledger_entries"] == ["unexpected.sql"]
+
+
+def test_migration_audit_uses_validated_configured_ledger_table(tmp_path):
+    (tmp_path / "001.sql").write_text("SELECT 1;", encoding="utf-8")
+    manifest = tmp_path / "migration-manifest.txt"
+    manifest.write_text("001.sql\n", encoding="utf-8")
+
+    class CustomLedgerReader(LedgerReader):
+        def relation_kind(self, name):
+            assert name == "custom_ledger"
+            return "r"
+
+        def rows(self, query, params=()):
+            assert 'public."custom_ledger"' in query
+            return [("001.sql", hashlib.sha256(b"SELECT 1;").hexdigest())]
+
+    result = audit.migration_audit(CustomLedgerReader(), audit.load_manifest(manifest), "custom_ledger")
+    assert result["pending_auto"] == []
+
+    for unsafe in ("public.schema_migrations", "ledger;DROP TABLE systems", 'ledger"'):
+        try:
+            audit.validate_ledger_table(unsafe)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"unsafe ledger identifier accepted: {unsafe}")
+
+
+def _otherwise_ready_report():
+    required = [
+        {"name": "grid", "present": True, "eligible": 2, "metadata_missing": 0, "missing": 0, "invalid_grid": 0, "invalid_macro": 0},
+        {"name": "ratings", "present": True, "eligible": 2, "missing": 0, "wrong_version": 0, "dirty": 0},
+        {"name": "topology", "present": True, "eligible": 2, "missing": 0, "stale": 0},
+        {"name": "economy_pair_synergy", "present": True, "eligible": 2, "source_missing": 0, "missing": 0, "unexpected": 0},
+        {"name": "archetypes", "present": True, "eligible": 2, "scores_missing": 0, "traits_missing": 0, "dirty": 0},
+        {"name": "regional_analysis", "present": True, "eligible": 2, "missing": 0},
+        {"name": "station_body_links", "present": True, "eligible": 2, "missing": 0},
+        {"name": "clusters", "present": True, "eligible": 2, "missing": 0, "dirty_rows": 0, "system_dirty": 0},
+    ]
+    return {
+        "server": {"version_num": 180000},
+        "migrations": {"ledger_present": True, "pending_auto": [], "pending_manual": [], "checksum_mismatches": [], "unexpected_ledger_entries": []},
+        "base_tables": [{"name": name, "classification": "required_base", "present": True, "row_count": 2} for name in ("systems", "bodies", "stations", "body_rings")],
+        "required_builds": required,
+        "materialized_views": [{"name": "mv", "classification": "required_build", "present": True, "populated": True, "freshness_verified": True, "row_count": 2}],
+        "runtime_feature_tables": [],
+    }
+
+
+def test_required_builds_block_but_runtime_feature_tables_do_not():
+    report = _otherwise_ready_report()
+    report["runtime_feature_tables"] = [
+        {"name": "journal_events", "classification": "inventory_only", "present": True, "row_count": 0},
+        {"name": "routes", "classification": "inventory_only", "present": False, "row_count": None},
+        {"name": "app_users", "classification": "inventory_only", "present": True, "row_count": 0},
+    ]
+    assert audit.blockers_for(report) == []
+
+    report["required_builds"][1]["wrong_version"] = 1
+    assert audit.blockers_for(report) == ["ratings v3.4 build incomplete"]
+
+
+def test_requires_exact_postgres_18_and_complete_synergy_coverage():
+    report = _otherwise_ready_report()
+    report["server"]["version_num"] = 190000
+    report["required_builds"][3].update(missing=1)
+
+    assert audit.blockers_for(report) == [
+        "PostgreSQL server major version is not 18",
+        "economy_pair_synergy coverage incomplete",
+    ]
+
+
+def test_stale_extra_rows_cannot_mask_missing_eligible_ids():
+    sql = {name: query for name, _dependencies, query in audit.REQUIRED_METRICS}
+    for name in ("ratings", "topology", "economy_pair_synergy", "archetypes", "regional_analysis", "station_body_links", "clusters"):
+        assert "NOT EXISTS" in sql[name], name
+    assert "COUNT(*) FROM system_slot_topology" not in sql["topology"]
+
+
+def test_synergy_requires_every_repository_canonical_pair_per_system():
+    query = {name: query for name, _dependencies, query in audit.REQUIRED_METRICS}["economy_pair_synergy"]
+    assert "eligible x CROSS JOIN canonical c" in query
+    assert "e.economy_a::text=c.economy_a" in query
+    assert "e.economy_b::text=c.economy_b" in query
+    # This is the exact authority in build_topology.py, not all enum combinations.
+    assert query.count("), ('") == 10
+
+
+def test_partial_pair_rows_and_noncanonical_pairs_fail_closed():
+    report = _otherwise_ready_report()
+    report["required_builds"][3].update(missing=1, unexpected=1)
+    assert audit.blockers_for(report) == [
+        "economy_pair_synergy coverage incomplete",
+        "economy_pair_synergy contains non-canonical pairs",
+    ]
+
+
+def test_topology_must_postdate_current_rating_and_source_rows():
+    query = {name: query for name, _dependencies, query in audit.REQUIRED_METRICS}["topology"]
+    assert "t.updated_at < GREATEST(s.updated_at, r.updated_at" in query
+    assert "SELECT MAX(b.updated_at) FROM bodies b" in query
+
+    report = _otherwise_ready_report()
+    report["required_builds"][2]["stale"] = 1
+    assert audit.blockers_for(report) == [
+        "topology build is stale relative to ratings/source state"
+    ]
+
+
+def test_grid_checks_current_coordinates_relations_and_derived_ids():
+    query = {name: query for name, _dependencies, query in audit.REQUIRED_METRICS}["grid"]
+    assert "LEFT JOIN spatial_grid" in query
+    assert "LEFT JOIN macro_grid" in query
+    assert "e.x < g.min_x OR e.x >= g.max_x" in query
+    assert "floor((e.x-e.min_x)/e.cell_size)" in query
+    assert "floor((e.x-e.min_x)/2000.0)" in query
+
+
+def test_populated_materialized_view_without_ordered_watermark_fails_closed():
+    report = _otherwise_ready_report()
+    report["materialized_views"][0]["freshness_verified"] = False
+    assert audit.blockers_for(report) == ["materialized view freshness unverified: mv"]
+
+
+def test_command_fails_closed_without_database_url(monkeypatch, capsys):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    assert audit.main([]) == 2
+    assert "no database was contacted" in capsys.readouterr().err
+
+
+def test_unsafe_ledger_configuration_is_rejected_before_connection(monkeypatch):
+    monkeypatch.setattr(
+        audit.psycopg2,
+        "connect",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not connect")),
+    )
+    assert audit.main(["--database-url", "postgresql://example.invalid/db", "--ledger-table", "bad.name", "--reviewed-revision", REVISION]) == 2
+
+
+def test_connection_failure_does_not_leak_database_url_or_password(monkeypatch, capsys):
+    secret = "postgresql://user:super-secret@example.invalid/db"
+
+    def fail(*args, **kwargs):
+        raise RuntimeError(f"could not connect to {secret}")
+
+    monkeypatch.setattr(audit.psycopg2, "connect", fail)
+    assert audit.main(["--database-url", secret, "--json", "--reviewed-revision", REVISION]) == 2
+    captured = capsys.readouterr()
+    assert json.loads(captured.out)["error"] == "RuntimeError"
+    assert secret not in captured.out + captured.err
+    assert "super-secret" not in captured.out + captured.err
+
+
+def test_missing_optional_relation_is_reported_without_querying_it():
+    class MissingReader:
+        def relation_kind(self, name):
+            return None
+
+        def count(self, name):
+            raise AssertionError("missing relation must not be counted")
+
+    assert audit._relation(MissingReader(), "routes", classification="inventory_only") == {
+        "name": "routes", "classification": "inventory_only", "present": False, "row_count": None
+    }
+
+
+def test_missing_metric_dependency_is_reported_without_aborting_transaction():
+    class MissingReader:
+        def relation_kind(self, name):
+            return None if name == "ratings" else "r"
+
+        def rows(self, query):
+            raise AssertionError("metric SQL must not run with missing dependencies")
+
+    result = audit._metric(MissingReader(), "ratings", "SELECT forbidden", ("systems", "ratings"))
+    assert result["present"] is False
+    assert result["missing_relations"] == ["ratings"]
+
+
+def test_compose_resolution_is_explicit_and_does_not_start_services(monkeypatch):
+    called = []
+
+    class Completed:
+        stdout = json.dumps({"services": {"maintenance": {"environment": {"DATA_INVARIANTS_DATABASE_URL": "postgresql://resolved.invalid/db"}}}})
+
+    def fake_run(command, **kwargs):
+        called.append(command)
+        return Completed()
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(audit.subprocess, "run", fake_run)
+    monkeypatch.setattr(audit.psycopg2, "connect", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError()))
+    assert audit.main(["--compose", "--reviewed-revision", REVISION]) == 2
+    assert called[0][-3:] == ["config", "--format", "json"]
+    assert "up" not in called[0] and "run" not in called[0] and "exec" not in called[0]
+
+
+def test_read_only_contract_and_json_human_rendering():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'set_session(readonly=True, autocommit=False, isolation_level="REPEATABLE READ")' in source
+    assert 'SHOW transaction_read_only' in source
+    assert 'SHOW transaction_isolation' in source
+    assert "pg_catalog.pg_control_system()" in source
+    assert not any(token in source for token in ("INSERT INTO systems", "UPDATE systems", "DELETE FROM systems", "CREATE TABLE schema_migrations"))
+
+    report = _otherwise_ready_report()
+    report.update({"ready": True, "read_only": True, "server": {"version": "18.1", "version_num": 180001, "database_size_bytes": 42}, "blockers": []})
+    assert json.loads(json.dumps(report))["read_only"] is True
+    assert "PostgreSQL 18.1" in audit.render_human(report)
+
+
+def test_reviewed_revision_must_be_a_full_stable_digest():
+    assert audit.validate_reviewed_revision(REVISION) == REVISION
+    for unsafe in ("", "main", "A" * 40, "a" * 39, "a" * 41):
+        try:
+            audit.validate_reviewed_revision(unsafe)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"unsafe reviewed revision accepted: {unsafe!r}")
+
+
+def test_audit_uses_one_read_only_repeatable_read_snapshot_and_records_identity(monkeypatch):
+    class Connection:
+        session = None
+        rolled_back = False
+
+        def set_session(self, **kwargs):
+            self.session = kwargs
+
+        def rollback(self):
+            self.rolled_back = True
+
+    class SnapshotReader:
+        def __init__(self, connection):
+            assert connection.session == {
+                "readonly": True,
+                "autocommit": False,
+                "isolation_level": "REPEATABLE READ",
+            }
+
+        def one(self, query, params=()):
+            return {
+                "SHOW transaction_read_only": "on",
+                "SHOW transaction_isolation": "repeatable read",
+                "SHOW server_version": "18.1",
+                "SHOW server_version_num": "180001",
+                "SELECT pg_database_size(current_database())": 42,
+            }[query]
+
+        def rows(self, query, params=()):
+            assert "pg_catalog.pg_control_system()" in query
+            return [("candidate_db", "765432109876543210")]
+
+    connection = Connection()
+    monkeypatch.setattr(audit, "Reader", SnapshotReader)
+    monkeypatch.setattr(audit, "load_manifest", lambda _manifest: [])
+    monkeypatch.setattr(audit, "migration_audit", lambda *_args: {
+        "ledger_present": True, "pending_auto": [], "pending_manual": [],
+        "checksum_mismatches": [], "unexpected_ledger_entries": [],
+    })
+    monkeypatch.setattr(audit, "_relation", lambda _reader, name, classification: {
+        "name": name, "classification": classification, "present": False, "row_count": None,
+    })
+    monkeypatch.setattr(audit, "_metric", lambda _reader, name, *_args, **_kwargs: {
+        "name": name, "classification": "optional", "present": False,
+    })
+    monkeypatch.setattr(audit, "REQUIRED_METRICS", ())
+    monkeypatch.setattr(audit, "INVENTORY_ONLY_TABLES", ())
+
+    report = audit.run_audit(connection, reviewed_revision=REVISION)
+
+    assert connection.rolled_back is True
+    assert report["reviewed_revision"] == REVISION
+    assert report["snapshot"] == {"isolation_level": "repeatable read"}
+    assert report["candidate_identity"] == {
+        "database": "candidate_db",
+        "system_identifier": "765432109876543210",
+    }
+
+
+def test_workflow_transports_reviewed_bundle_and_validates_receipt_binding():
+    workflow = (ROOT / ".github" / "workflows" / "chatgpt-ed-new-ops.yml").read_text(encoding="utf-8")
+    assert 'tar -czf "$audit_bundle" scripts/operator/audit_production_candidate.py sql' in workflow
+    assert "cd /opt/ed-finder" not in workflow
+    assert "--reviewed-revision '$REVIEWED_REVISION'" in workflow
+    assert "payload.get('reviewed_revision') != os.environ['REVIEWED_REVISION']" in workflow
+    assert "payload.get('candidate_identity', {})" in workflow


### PR DESCRIPTION
Replacement for the unsafe PG18 promotion draft after the completed P1 hardening pass.

This branch preserves the existing PostgreSQL 18 candidate and adds fail-closed/read-only promotion auditing plus external-DB deployment support. The hardening pass specifically replaces opportunistic ssh-keyscan trust with a pinned known-hosts secret, keeps the candidate DSN off argv/logs by passing it over stdin, validates the retained JSON receipt, and preserves audit exit semantics.

Scope includes the production-candidate audit, PG18 promotion runbook, external DB validation/deploy mode, chatgpt-ed-new-ops readiness operation, and focused tests.

Do not merge on prose alone: require CI/security/review gates to complete against current main.