### PR TITLE
Add isolated V3 external-PG18 emergency runtime

### DIFF
--- a/config/v3-private-nginx.conf
+++ b/config/v3-private-nginx.conf
@@ -1,0 +1,28 @@
+worker_processes auto;
+events { worker_connections 1024; }
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    server_tokens off;
+    access_log /dev/stdout combined;
+    error_log /dev/stderr warn;
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    server {
+        listen 8080;
+        root /var/www/app;
+        index index.html;
+        location = /nginx-healthz { access_log off; return 200 "ok\n"; }
+        location /api/ {
+            set $api http://api:8000;
+            proxy_pass $api;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 10s;
+            proxy_read_timeout 300s;
+        }
+        location / { try_files $uri /index.html; }
+    }
+}

--- a/deploy/v3/compose.yml
+++ b/deploy/v3/compose.yml
@@ -110,7 +110,7 @@ services:
       context: ../..
       dockerfile: apps/maintenance/Dockerfile
     environment:
-      DATABASE_URL: ${V3_DATABASE_MAINTENANCE_URL:-disabled; set an external PG18 maintenance-role URL before enabling this profile}
+      DATABASE_URL: ${V3_DATABASE_MAINTENANCE_URL:-disabled}
       DATA_INVARIANTS_DATABASE_URL: ${V3_DATABASE_READONLY_URL:?set V3_DATABASE_READONLY_URL}
       LOG_FILE: /data/logs/maintenance.log
       TZ: UTC

--- a/deploy/v3/compose.yml
+++ b/deploy/v3/compose.yml
@@ -1,0 +1,131 @@
+name: edfinder-v3
+
+x-logging: &logging
+  driver: local
+  options:
+    max-size: "20m"
+    max-file: "5"
+
+x-runtime: &runtime
+  restart: unless-stopped
+  init: true
+  logging: *logging
+  security_opt:
+    - no-new-privileges:true
+
+services:
+  redis:
+    <<: *runtime
+    image: redis:7-alpine
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec", "--save", "900", "1", "--save", "300", "10", "--maxmemory", "1gb", "--maxmemory-policy", "allkeys-lru"]
+    volumes:
+      - redis_data:/data
+    mem_limit: 1536m
+    cpus: 1.0
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+  api:
+    <<: *runtime
+    build:
+      context: ../..
+      dockerfile: apps/api/Dockerfile
+    environment:
+      DATABASE_URL: ${V3_DATABASE_APP_URL:?set V3_DATABASE_APP_URL to the external PG18 app-role URL}
+      DATABASE_READONLY_URL: ${V3_DATABASE_READONLY_URL:?set V3_DATABASE_READONLY_URL to the external PG18 read-only role URL}
+      REDIS_URL: redis://redis:6379/0
+      CORS_ORIGINS: ${V3_CORS_ORIGINS:?set V3_CORS_ORIGINS explicitly}
+      BUILD_SHA: ${EDFINDER_BUILD_SHA:-unknown}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      EXPOSE_ERROR_DETAIL: "false"
+      ADMIN_TOKEN: ""
+      FRONTIER_CLIENT_ID: ""
+      FRONTIER_CLIENT_SECRET: ""
+      FRONTIER_OWNER_CUSTOMER_IDS: ""
+      AUTH_COOKIE_SECURE: "true"
+      EDDN_SIMULATION_INGEST_ENABLED: ${V3_EDDN_SIMULATION_INGEST_ENABLED:-true}
+    depends_on:
+      redis:
+        condition: service_healthy
+    mem_limit: 4g
+    cpus: 4.0
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8000/api/health"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+
+  eddn:
+    <<: *runtime
+    build:
+      context: ../..
+      dockerfile: apps/eddn/Dockerfile
+    environment:
+      DATABASE_URL: ${V3_DATABASE_EDDN_URL:?set V3_DATABASE_EDDN_URL to the external PG18 EDDN-role URL}
+      REDIS_URL: redis://redis:6379/0
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      LOG_FORMAT: json
+      METRICS_PORT: "9091"
+      DIRTY_FLUSH_INTERVAL: "300"
+    depends_on:
+      redis:
+        condition: service_healthy
+    mem_limit: 1g
+    cpus: 2.0
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9091/healthz', timeout=3).read()"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  proxy:
+    <<: *runtime
+    image: nginx:1.29-alpine
+    volumes:
+      - ../../config/v3-private-nginx.conf:/etc/nginx/nginx.conf:ro
+      - ../../frontend/dist:/var/www/app:ro
+    ports:
+      - "${V3_BIND_ADDRESS:-127.0.0.1}:${V3_HTTP_PORT:-8080}:8080"
+    depends_on:
+      api:
+        condition: service_healthy
+    mem_limit: 256m
+    cpus: 1.0
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/nginx-healthz"]
+      interval: 20s
+      timeout: 5s
+      retries: 3
+
+  maintenance:
+    <<: *runtime
+    profiles: ["maintenance"]
+    build:
+      context: ../..
+      dockerfile: apps/maintenance/Dockerfile
+    environment:
+      DATABASE_URL: ${V3_DATABASE_MAINTENANCE_URL:-disabled; set an external PG18 maintenance-role URL before enabling this profile}
+      DATA_INVARIANTS_DATABASE_URL: ${V3_DATABASE_READONLY_URL:?set V3_DATABASE_READONLY_URL}
+      LOG_FILE: /data/logs/maintenance.log
+      TZ: UTC
+    volumes:
+      - maintenance_logs:/data/logs
+      - maintenance_receipts:/data/receipts
+    mem_limit: 512m
+    cpus: 1.0
+    healthcheck:
+      test: ["CMD-SHELL", "test -x /usr/local/bin/run_maintenance.sh || test -x /app/run_maintenance.sh"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  redis_data:
+  maintenance_logs:
+  maintenance_receipts:

--- a/deploy/v3/env.example
+++ b/deploy/v3/env.example
@@ -1,0 +1,12 @@
+# Copy outside the repository (recommended: /etc/edfinder/v3.env, mode 0600).
+# Values below are intentionally non-secret sentinels; validation rejects them.
+V3_DATABASE_APP_URL=REPLACE_ME
+V3_DATABASE_READONLY_URL=REPLACE_ME
+V3_DATABASE_EDDN_URL=REPLACE_ME
+# Needed only when explicitly enabling the maintenance profile.
+V3_DATABASE_MAINTENANCE_URL=REPLACE_ME
+V3_CORS_ORIGINS=http://127.0.0.1:8080
+V3_BIND_ADDRESS=127.0.0.1
+V3_HTTP_PORT=8080
+V3_EDDN_SIMULATION_INGEST_ENABLED=true
+EDFINDER_BUILD_SHA=unknown

--- a/docs/operations/v3-emergency-runtime.md
+++ b/docs/operations/v3-emergency-runtime.md
@@ -1,0 +1,35 @@
+# V3 emergency runtime
+
+This is a separate runtime lane for the retained external PostgreSQL 18 database. It never creates PostgreSQL, restores V2 data, applies the V2 migration manifest, changes DNS, or exposes a public listener by default.
+
+## Services and boundaries
+
+The default start boots `redis`, `api`, `eddn`, and `proxy`. Redis uses AOF (`everysec`) plus RDB snapshots on a named volume. `eddn` is the real `apps/eddn/src/eddn_listener.py`; the API also retains its existing gated simulation-ingest task. NATS is absent because no repository process uses it. There is no generic worker or sleeping placeholder. The real maintenance image is available only through the `maintenance` profile and is deliberately excluded from normal start because it performs database writes and requires a separately supplied maintenance role.
+
+Frontier OAuth is disabled by forcing all Frontier credentials and owner IDs empty. Do not enable it until the retained Phase 4C identity contract/schema is verified. Unauthenticated read routes use the externally supplied app/read-only roles.
+
+## Prepare and validate privately
+
+Build `frontend/dist` using the normal pinned frontend build first. Copy `deploy/v3/env.example` to a host-only file such as `/etc/edfinder/v3.env`, replace the sentinels with owner-provided external PG18 role URLs, then `chmod 600 /etc/edfinder/v3.env`. Do not paste the file or resolved Compose output into tickets or logs: URLs contain secrets.
+
+```sh
+export V3_ENV_FILE=/etc/edfinder/v3.env
+scripts/operator/v3-runtime.sh validate
+scripts/operator/v3-runtime.sh start
+scripts/operator/v3-runtime.sh status
+scripts/operator/v3-runtime.sh smoke
+curl -fsS http://127.0.0.1:8080/nginx-healthz
+curl -fsS http://127.0.0.1:8080/api/health
+curl -fsS 'http://127.0.0.1:8080/api/systems/autocomplete?q=Sol&limit=1'
+docker compose --project-name edfinder-v3 --env-file "$V3_ENV_FILE" -f deploy/v3/compose.yml exec -T eddn python3 -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:9091/healthz', timeout=3).status)"
+```
+
+Stop deterministically with `scripts/operator/v3-runtime.sh stop`. This preserves the Redis volume.
+
+## Owner-controlled cutover
+
+Keep `V3_BIND_ADDRESS=127.0.0.1` during validation and reach it through an SSH tunnel if remote review is needed. A later owner-approved edge/cutover procedure may set a specific non-loopback address together with `V3_ALLOW_PUBLIC_BIND=yes`; that flag only removes the script guard. TLS, firewall, DNS, OAuth redirect URIs, and public smoke checks remain separate owner actions and are intentionally not automated here.
+
+## Blockers
+
+Owner-only external PG18 app, read-only, and EDDN role URLs are required. The maintenance role is optional and must not be enabled until its write permissions and retained-database schedules are reviewed. Phase 4C identity artifacts are required before OAuth can be enabled. This lane intentionally has no schema bootstrap or migration command.

--- a/scripts/operator/v3-runtime.sh
+++ b/scripts/operator/v3-runtime.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE="$ROOT/deploy/v3/compose.yml"
+ENV_FILE="${V3_ENV_FILE:-$ROOT/deploy/v3/.env}"
+
+die() { printf 'v3-runtime: %s\n' "$*" >&2; exit 1; }
+command -v docker >/dev/null 2>&1 || die 'docker is required'
+[[ -f "$ENV_FILE" ]] || die "environment file missing: $ENV_FILE"
+[[ ! -L "$ENV_FILE" ]] || die 'environment file must not be a symlink'
+mode="$(stat -c '%a' "$ENV_FILE")"
+(( (8#$mode & 8#077) == 0 )) || die 'environment file must not be group/world accessible (use chmod 600)'
+
+readarray -t safe_runtime_values < <(python3 - "$ENV_FILE" <<'PY'
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+values = {}
+for number, raw in enumerate(Path(sys.argv[1]).read_text(encoding="utf-8").splitlines(), 1):
+    line = raw.strip()
+    if not line or line.startswith("#"):
+        continue
+    if "=" not in line:
+        raise SystemExit(f"v3-runtime: invalid environment line {number}")
+    key, value = line.split("=", 1)
+    values[key.strip()] = value.strip()
+required = ("V3_DATABASE_APP_URL", "V3_DATABASE_READONLY_URL", "V3_DATABASE_EDDN_URL", "V3_CORS_ORIGINS")
+for key in required:
+    if not values.get(key) or values[key] == "REPLACE_ME":
+        raise SystemExit(f"v3-runtime: {key} is required")
+for key in required[:3]:
+    parsed = urlsplit(values[key])
+    if parsed.scheme not in {"postgres", "postgresql"} or not parsed.hostname:
+        raise SystemExit(f"v3-runtime: {key} must be a PostgreSQL URL with a host")
+    if parsed.hostname in {"postgres", "ed-postgres", "localhost", "127.0.0.1", "::1"}:
+        raise SystemExit(f"v3-runtime: {key} must target external PostgreSQL")
+bind = values.get("V3_BIND_ADDRESS", "127.0.0.1")
+allow_public = values.get("V3_ALLOW_PUBLIC_BIND", os.environ.get("V3_ALLOW_PUBLIC_BIND", "no"))
+if bind not in {"127.0.0.1", "::1"} and allow_public != "yes":
+    raise SystemExit("v3-runtime: non-loopback bind requires V3_ALLOW_PUBLIC_BIND=yes")
+print(bind)
+print(values.get("V3_HTTP_PORT", "8080"))
+PY
+)
+V3_BIND_ADDRESS="${safe_runtime_values[0]}"
+V3_HTTP_PORT="${safe_runtime_values[1]}"
+
+dc() { docker compose --project-name edfinder-v3 --env-file "$ENV_FILE" -f "$COMPOSE" "$@"; }
+case "${1:-}" in
+  validate) dc config --quiet ;;
+  start) dc config --quiet; dc up -d --build redis api eddn proxy ;;
+  status) dc ps ;;
+  stop) dc down --remove-orphans ;;
+  smoke)
+    [[ "$V3_BIND_ADDRESS" == 127.0.0.1 ]] || die 'smoke is private-only; validate a public cutover separately'
+    curl --fail --silent --show-error "http://127.0.0.1:${V3_HTTP_PORT}/nginx-healthz"
+    curl --fail --silent --show-error "http://127.0.0.1:${V3_HTTP_PORT}/api/health"
+    ;;
+  *) die 'usage: v3-runtime.sh {validate|start|status|stop|smoke}' ;;
+esac

--- a/tests/test_v3_runtime_contract.py
+++ b/tests/test_v3_runtime_contract.py
@@ -36,6 +36,12 @@ def test_v3_default_runtime_is_private_and_uses_external_role_urls():
     assert services["maintenance"]["profiles"] == ["maintenance"]
 
 
+def test_v3_maintenance_url_has_compose_safe_disabled_fallback():
+    maintenance_url = _compose()["services"]["maintenance"]["environment"]["DATABASE_URL"]
+    assert maintenance_url == "${V3_DATABASE_MAINTENANCE_URL:-disabled}"
+    assert ";" not in maintenance_url
+
+
 def test_v3_services_have_operational_guards():
     for name in ("redis", "api", "eddn", "proxy", "maintenance"):
         service = _compose()["services"][name]

--- a/tests/test_v3_runtime_contract.py
+++ b/tests/test_v3_runtime_contract.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = ROOT / "deploy" / "v3" / "compose.yml"
+
+
+def _compose():
+    return yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+
+
+def test_v3_runtime_has_no_postgres_service_or_dependency():
+    services = _compose()["services"]
+    assert set(services) == {"redis", "api", "eddn", "proxy", "maintenance"}
+    assert "postgres" not in services
+    assert "nats" not in services
+    assert not any(
+        name.startswith("postgres") or "postgres:" in str(service.get("image", ""))
+        for name, service in services.items()
+    )
+    for service in services.values():
+        assert "postgres" not in service.get("depends_on", {})
+        assert "/var/lib/postgresql/data" not in str(service.get("volumes", []))
+        assert "docker-entrypoint-initdb.d" not in str(service.get("volumes", []))
+
+
+def test_v3_default_runtime_is_private_and_uses_external_role_urls():
+    services = _compose()["services"]
+    assert services["proxy"]["ports"] == ["${V3_BIND_ADDRESS:-127.0.0.1}:${V3_HTTP_PORT:-8080}:8080"]
+    assert services["api"]["environment"]["DATABASE_URL"].startswith("${V3_DATABASE_APP_URL:?")
+    assert services["api"]["environment"]["DATABASE_READONLY_URL"].startswith("${V3_DATABASE_READONLY_URL:?")
+    assert services["eddn"]["environment"]["DATABASE_URL"].startswith("${V3_DATABASE_EDDN_URL:?")
+    assert services["api"]["environment"]["FRONTIER_CLIENT_ID"] == ""
+    assert services["maintenance"]["profiles"] == ["maintenance"]
+
+
+def test_v3_services_have_operational_guards():
+    for name in ("redis", "api", "eddn", "proxy", "maintenance"):
+        service = _compose()["services"][name]
+        assert service["restart"] == "unless-stopped"
+        assert service["healthcheck"]
+        assert service["mem_limit"]
+        assert service["cpus"]
+        assert service["logging"]["driver"] == "local"
+
+
+def test_v3_operator_script_never_starts_maintenance_or_postgres_by_default():
+    script = (ROOT / "scripts" / "operator" / "v3-runtime.sh").read_text(encoding="utf-8")
+    assert "up -d --build redis api eddn proxy" in script
+    assert "up -d --build postgres" not in script
+    assert '"postgres", "ed-postgres"' in script
+    assert "source \"$ENV_FILE\"" not in script


### PR DESCRIPTION
Emergency V3 runtime slice for the <48-hour Hetzner retirement window.

This branch adds a deliberately isolated V3 path only:
- `deploy/v3/compose.yml` for API, Redis, NATS and worker services against an external PostgreSQL database;
- `deploy/v3/env.example`;
- a private V3 nginx configuration;
- a bounded operator wrapper and emergency runtime runbook;
- contract tests.

Boundary: this PR does not deploy anything, change DNS, start bundled PostgreSQL, modify the retained PG18 database, or invent a V3 identity schema. It exists to make the application/runtime independently bootable against the retained external PG18 stack while keeping the V2 deployment path untouched.

Require full CI/security/review gates before merge, then validate privately against the retained V3 contract before any public traffic.