### PR TITLE
Add read-only retained V3 runtime recovery operation

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - host-status
+          - recover-v3-runtime-contract
   push:
     branches:
       - chatgpt-ed-new-ops-requests
@@ -47,18 +48,30 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             operation="$INPUT_OPERATION"
           elif [ "$EVENT_NAME" = "push" ]; then
-            mapfile -t request_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" -- '.github/ed-new-ops-requests/*.json')
-            [ "${#request_files[@]}" -eq 1 ] || { echo "Expected exactly one ed-new request file" >&2; exit 64; }
+            mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+            [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one changed ed-new request file" >&2; exit 64; }
+            case "${changed_files[0]}" in
+              .github/ed-new-ops-requests/*.json) ;;
+              *) echo "Push changed a path outside the request allowlist" >&2; exit 64 ;;
+            esac
+            request_files=("${changed_files[0]}")
             operation="$(python -c 'import json,pathlib,sys; d=json.loads(pathlib.Path(sys.argv[1]).read_text()); extra=set(d)-{"operation"}; extra and sys.exit(f"Unsupported request keys: {sorted(extra)}"); op=d.get("operation"); (isinstance(op,str) and op) or sys.exit("operation must be a non-empty string"); print(op)' "${request_files[0]}")"
           else
             echo "Unsupported event: $EVENT_NAME" >&2
             exit 64
           fi
           case "$operation" in
-            host-status) ;;
+            host-status|recover-v3-runtime-contract) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trusted operator implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
 
       - name: Prepare SSH
         shell: bash
@@ -66,16 +79,28 @@ jobs:
           SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
           SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
           SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
           test -n "$SSH_KEY" || { echo "Missing ED_NEW_OPERATOR_SSH_KEY" >&2; exit 1; }
           test -n "$SSH_HOST" || { echo "Missing ED_NEW_OPERATOR_HOST" >&2; exit 1; }
           test -n "$SSH_PORT" || { echo "Missing ED_NEW_OPERATOR_PORT" >&2; exit 1; }
+          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing ED_NEW_OPERATOR_KNOWN_HOSTS" >&2; exit 1; }
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
           chmod 600 ~/.ssh/ed_new_operator_key
-          ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" >> ~/.ssh/known_hosts
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          if [ "$SSH_PORT" = "22" ]; then
+            known_host_lookup="$SSH_HOST"
+          else
+            known_host_lookup="[$SSH_HOST]:$SSH_PORT"
+          fi
+          ssh-keygen -F "$known_host_lookup" -f ~/.ssh/known_hosts >/dev/null || {
+            echo "Pinned known-host trust does not cover the configured host and port" >&2
+            exit 1
+          }
 
       - name: Run bounded ed-new bootstrap status
         if: steps.request.outputs.operation == 'host-status'
@@ -91,5 +116,66 @@ jobs:
               -p "$SSH_PORT" \
               -o IdentitiesOnly=yes \
               -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
               "$SSH_USER@$SSH_HOST" \
               'set -eu; echo "== ed-new bootstrap status =="; printf "hostname: "; hostname; printf "fqdn: "; hostname -f 2>/dev/null || true; printf "kernel: "; uname -sr; echo "== filesystem =="; df -hT /; echo "== docker =="; if command -v docker >/dev/null 2>&1; then docker ps --format "{{.Names}}\t{{.Status}}\t{{.Image}}" | head -50; else echo "docker: not installed"; fi; echo "== repo candidates =="; for p in /opt/ed-finder /root/ed-finder /srv/ed-finder; do [ -d "$p" ] && echo "$p"; done; echo "== safety =="; echo "db_access_performed: false"; echo "db_writes_performed: false"; echo "migrations_performed: false"; echo "canonical_apply_performed: false"'
+
+      - name: Recover retained V3 runtime contract
+        if: steps.request.outputs.operation == 'recover-v3-runtime-contract'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECOVERY_DIR: ${{ runner.temp }}/edfinder-v3-runtime-recovery
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          mkdir -p "$RECOVERY_DIR"
+          archive="$RECOVERY_DIR/edfinder-v3-phase4c-r5-runtime-contract.tar.gz"
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'python3 - --container edfinder-v3-phase4c-full-20260827_r5-postgres' \
+              < trusted-main/scripts/operator/recover_v3_runtime_contract.py \
+              > "$archive"
+          test -s "$archive"
+          (cd "$RECOVERY_DIR" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
+          python3 - "$archive" <<'PY'
+          import pathlib
+          import shutil
+          import sys
+          import tarfile
+
+          archive = pathlib.Path(sys.argv[1])
+          output = archive.parent
+          expected = ("recovery-manifest.json", "recovery-receipt.json")
+          with tarfile.open(archive, "r:gz") as bundle:
+              members = {member.name: member for member in bundle.getmembers()}
+              for name in expected:
+                  member = members.get(name)
+                  if member is None or not member.isfile():
+                      raise SystemExit(f"Missing required recovery metadata member: {name}")
+                  source = bundle.extractfile(member)
+                  if source is None:
+                      raise SystemExit(f"Unable to read recovery metadata member: {name}")
+                  with source, (output / name).open("wb") as target:
+                      shutil.copyfileobj(source, target)
+          PY
+        working-directory: ${{ github.workspace }}
+
+      - name: Upload retained V3 runtime recovery
+        if: steps.request.outputs.operation == 'recover-v3-runtime-contract'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: edfinder-v3-phase4c-r5-runtime-contract
+          path: |
+            ${{ runner.temp }}/edfinder-v3-runtime-recovery/edfinder-v3-phase4c-r5-runtime-contract.tar.gz
+            ${{ runner.temp }}/edfinder-v3-runtime-recovery/edfinder-v3-phase4c-r5-runtime-contract.tar.gz.sha256
+            ${{ runner.temp }}/edfinder-v3-runtime-recovery/recovery-manifest.json
+            ${{ runner.temp }}/edfinder-v3-runtime-recovery/recovery-receipt.json
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/operations/github-actions-hetzner-operator.md
+++ b/docs/operations/github-actions-hetzner-operator.md
@@ -64,3 +64,23 @@ Repository secrets:
 
 Any future production DB write stage must be added by a separate PR and must not use arbitrary command input.
 
+## Separate ed-new V3 recovery lane
+
+The `ChatGPT ed-new Ops` workflow has one narrowly scoped recovery operation:
+`recover-v3-runtime-contract`. It targets only the retained container
+`edfinder-v3-phase4c-full-20260827_r5-postgres` and derives the source root and
+Compose files from Docker Compose labels. It never inspects container
+environment values, contacts the database, or writes to the remote host. The
+archive is streamed to the Actions runner and uploaded with a file manifest,
+machine-readable safety receipt, and archive SHA-256 sidecar.
+
+The lane requires the environment secret `ED_NEW_OPERATOR_KNOWN_HOSTS` to hold
+the pinned OpenSSH known-host entry for `ED_NEW_OPERATOR_HOST` and
+`ED_NEW_OPERATOR_PORT`. Runtime host discovery (`ssh-keyscan`) is prohibited.
+
+Recovery is limited to Compose YAML, Dockerfile/Containerfile build inputs,
+`.sql`, `.sh`, `.py`, and non-secret-name `.md`, `.txt`, and `.json` files.
+It fails closed on `.env` and secret/credential/token/key/certificate names,
+logs, backups, dumps, database data/volumes, pgBackRest or SSH material,
+symlinks, special files, paths outside the label-resolved source root, and
+file-count or byte limits. File contents are not printed to Actions logs.

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -18,6 +18,11 @@ Current scripts:
 
 - `require_hetzner_operator_env.sh`: reusable fail-fast guard for
   Hetzner-only commands.
+- `recover_v3_runtime_contract.py`: read-only helper for the allowlisted ed-new
+  `recover-v3-runtime-contract` operation. It identifies the retained Phase 4C
+  R5 Compose source root from container labels, rejects secret-like and unsafe
+  paths, and streams a bounded checksummed source archive without database
+  access or remote-host writes.
 - `stage18j_run_station_type_dry_run.sh`: generates the Stage 18J-P
   station-type dry-run artifact from the validated reconciliation artifact
   after verifying its SHA-256. It requires bounded `MAX_ROWS`, caps blocked

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Stream a fail-closed, non-secret V3 source recovery archive to stdout.
+
+This helper is intentionally read-only: Docker is queried only for selected
+Compose labels and every selected file is read from the resolved Compose source
+root.  The tar stream is written to stdout so the remote host is not mutated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import stat
+import subprocess
+import sys
+import tarfile
+from typing import BinaryIO, Iterable
+
+
+CONTAINER_NAME = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+MAX_FILES = 2_000
+MAX_TOTAL_BYTES = 100 * 1024 * 1024
+MAX_FILE_BYTES = 20 * 1024 * 1024
+ALLOWED_SUFFIXES = {".yml", ".yaml", ".sql", ".sh", ".py", ".md", ".txt", ".json"}
+BUILD_FILE_PREFIXES = ("dockerfile", "containerfile")
+FORBIDDEN_PARTS = {
+    ".env",
+    ".git",
+    "backup",
+    "backups",
+    "cert",
+    "certs",
+    "credential",
+    "credentials",
+    "data",
+    "dump",
+    "dumps",
+    "id_rsa",
+    "id_ed25519",
+    "key",
+    "keys",
+    "log",
+    "logs",
+    "pgbackrest",
+    "private",
+    "secret",
+    "secrets",
+    "ssh",
+    "token",
+    "tokens",
+    "volume",
+    "volumes",
+}
+FORBIDDEN_FRAGMENTS = (
+    "password",
+    "passwd",
+    "credential",
+    "secret",
+    "token",
+    "private_key",
+    "apikey",
+    "api_key",
+    "id_rsa",
+    "id_ed25519",
+)
+COMPOSE_WORKING_DIR_LABEL = "com.docker.compose.project.working_dir"
+COMPOSE_CONFIG_FILES_LABEL = "com.docker.compose.project.config_files"
+COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
+SCHEMA = "edfinder-v3-runtime-recovery/v1"
+
+
+class RecoveryError(RuntimeError):
+    """A safety contract failed; no partial archive should be trusted."""
+
+
+def parse_compose_labels(raw: str) -> tuple[Path, tuple[Path, ...], str]:
+    try:
+        labels = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RecoveryError("Docker Compose labels were not valid JSON") from exc
+    if not isinstance(labels, dict):
+        raise RecoveryError("Docker labels must be a JSON object")
+    working_value = labels.get(COMPOSE_WORKING_DIR_LABEL)
+    configs_value = labels.get(COMPOSE_CONFIG_FILES_LABEL)
+    project_value = labels.get(COMPOSE_PROJECT_LABEL)
+    if not isinstance(working_value, str) or not working_value.startswith("/"):
+        raise RecoveryError("Compose working directory label is missing or not absolute")
+    if not isinstance(configs_value, str) or not configs_value.strip():
+        raise RecoveryError("Compose config-files label is missing")
+    if not isinstance(project_value, str) or not project_value.strip():
+        raise RecoveryError("Compose project label is missing")
+    root = Path(working_value).resolve(strict=True)
+    if not root.is_dir():
+        raise RecoveryError("Compose working directory is not a directory")
+    configs: list[Path] = []
+    for value in configs_value.split(","):
+        value = value.strip()
+        if not value:
+            raise RecoveryError("Compose config-files label contains an empty path")
+        candidate = Path(value) if value.startswith("/") else root / value
+        resolved = candidate.resolve(strict=True)
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise RecoveryError("Compose config file escapes the source root") from exc
+        configs.append(resolved)
+    return root, tuple(configs), project_value
+
+
+def _safe_name(relative: PurePosixPath) -> bool:
+    for part in relative.parts:
+        lower = part.lower()
+        if lower in FORBIDDEN_PARTS or lower.startswith(".env"):
+            return False
+        if any(fragment in lower for fragment in FORBIDDEN_FRAGMENTS):
+            return False
+        if lower.endswith((".pem", ".key", ".crt", ".cer", ".p12", ".pfx", ".jks")):
+            return False
+    name = relative.name.lower()
+    return relative.suffix.lower() in ALLOWED_SUFFIXES or name.startswith(BUILD_FILE_PREFIXES)
+
+
+def collect_files(root: Path, required_configs: Iterable[Path]) -> list[tuple[Path, str, os.stat_result]]:
+    root = root.resolve(strict=True)
+    required = {path.resolve(strict=True) for path in required_configs}
+    selected: list[tuple[Path, str, os.stat_result]] = []
+    total = 0
+    for directory, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        directory_path = Path(directory)
+        kept_dirs: list[str] = []
+        for name in sorted(dirnames):
+            path = directory_path / name
+            relative = PurePosixPath(path.relative_to(root).as_posix())
+            if path.is_symlink():
+                raise RecoveryError(f"Source tree contains a directory symlink: {relative}")
+            if all(part.lower() not in FORBIDDEN_PARTS for part in relative.parts):
+                kept_dirs.append(name)
+        dirnames[:] = kept_dirs
+        for name in sorted(filenames):
+            path = directory_path / name
+            relative = PurePosixPath(path.relative_to(root).as_posix())
+            if not _safe_name(relative):
+                continue
+            lst = path.lstat()
+            if stat.S_ISLNK(lst.st_mode):
+                raise RecoveryError(f"Selected path is a symlink: {relative}")
+            if not stat.S_ISREG(lst.st_mode):
+                raise RecoveryError(f"Selected path is not a regular file: {relative}")
+            resolved = path.resolve(strict=True)
+            try:
+                resolved.relative_to(root)
+            except ValueError as exc:
+                raise RecoveryError(f"Selected path escapes source root: {relative}") from exc
+            if lst.st_size > MAX_FILE_BYTES:
+                raise RecoveryError(f"Selected file exceeds per-file limit: {relative}")
+            total += lst.st_size
+            if total > MAX_TOTAL_BYTES:
+                raise RecoveryError("Selected files exceed total-size limit")
+            selected.append((path, relative.as_posix(), lst))
+            if len(selected) > MAX_FILES:
+                raise RecoveryError("Selected files exceed file-count limit")
+    selected_paths = {path.resolve(strict=True) for path, _, _ in selected}
+    if not required.issubset(selected_paths):
+        raise RecoveryError("A labeled Compose config file was rejected by the allowlist")
+    return selected
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_manifest(files: Iterable[tuple[Path, str, os.stat_result]]) -> dict[str, object]:
+    entries = [
+        {
+            "path": relative,
+            "size": metadata.st_size,
+            "mode": f"{stat.S_IMODE(metadata.st_mode):04o}",
+            "sha256": _sha256_file(path),
+        }
+        for path, relative, metadata in files
+    ]
+    return {
+        "schema": SCHEMA,
+        "file_count": len(entries),
+        "total_bytes": sum(int(entry["size"]) for entry in entries),
+        "files": entries,
+    }
+
+
+def _add_bytes(archive: tarfile.TarFile, name: str, payload: bytes, mode: int = 0o644) -> None:
+    info = tarfile.TarInfo(name)
+    info.size = len(payload)
+    info.mode = mode
+    info.mtime = 0
+    archive.addfile(info, io.BytesIO(payload))
+
+
+def stream_archive(
+    root: Path, project: str, files: list[tuple[Path, str, os.stat_result]], output: BinaryIO
+) -> None:
+    manifest = build_manifest(files)
+    receipt = {
+        "schema": SCHEMA,
+        "operation": "recover-v3-runtime-contract",
+        "container": CONTAINER_NAME,
+        "source_root": str(root),
+        "compose_project": project,
+        "docker_metadata_fields": [COMPOSE_PROJECT_LABEL, COMPOSE_WORKING_DIR_LABEL, COMPOSE_CONFIG_FILES_LABEL],
+        "docker_inspect_env": False,
+        "db_access": False,
+        "host_mutation": False,
+        "file_count": manifest["file_count"],
+        "total_bytes": manifest["total_bytes"],
+        "limits": {"max_files": MAX_FILES, "max_total_bytes": MAX_TOTAL_BYTES, "max_file_bytes": MAX_FILE_BYTES},
+    }
+    with tarfile.open(fileobj=output, mode="w|gz", format=tarfile.PAX_FORMAT) as archive:
+        for path, relative, metadata in files:
+            info = tarfile.TarInfo(f"source/{relative}")
+            info.size = metadata.st_size
+            info.mode = stat.S_IMODE(metadata.st_mode)
+            info.mtime = 0
+            with path.open("rb") as handle:
+                archive.addfile(info, handle)
+        _add_bytes(archive, "recovery-manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode() + b"\n")
+        _add_bytes(archive, "recovery-receipt.json", json.dumps(receipt, indent=2, sort_keys=True).encode() + b"\n")
+
+
+def docker_compose_labels(container: str) -> str:
+    result = subprocess.run(
+        ["docker", "inspect", "--type", "container", "--format", "{{json .Config.Labels}}", container],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RecoveryError("Unable to read Docker labels for the retained container")
+    return result.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--container", default=CONTAINER_NAME, choices=[CONTAINER_NAME])
+    args = parser.parse_args(argv)
+    try:
+        root, configs, project = parse_compose_labels(docker_compose_labels(args.container))
+        files = collect_files(root, configs)
+        stream_archive(root, project, files, sys.stdout.buffer)
+    except (OSError, RecoveryError, subprocess.SubprocessError) as exc:
+        print(f"STOP: V3 runtime recovery failed closed: {exc}", file=sys.stderr)
+        return 1
+    print("V3 runtime recovery stream completed without DB access or host mutation", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v3_runtime_recovery.py
+++ b/tests/test_v3_runtime_recovery.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+
+import pytest
+
+from scripts.operator import recover_v3_runtime_contract as recovery
+
+
+def _labels(root: Path, configs: str = "compose.yml") -> str:
+    return json.dumps(
+        {
+            recovery.COMPOSE_PROJECT_LABEL: "edfinder-v3-phase4c-full-20260827_r5",
+            recovery.COMPOSE_WORKING_DIR_LABEL: str(root),
+            recovery.COMPOSE_CONFIG_FILES_LABEL: configs,
+        }
+    )
+
+
+def test_docker_metadata_parsing_requires_compose_contract_and_confines_configs(tmp_path: Path):
+    (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    root, configs, project = recovery.parse_compose_labels(_labels(tmp_path))
+    assert root == tmp_path.resolve()
+    assert configs == ((tmp_path / "compose.yml").resolve(),)
+    assert project == "edfinder-v3-phase4c-full-20260827_r5"
+
+    outside = tmp_path.parent / "outside.yml"
+    outside.write_text("services: {}\n", encoding="utf-8")
+    with pytest.raises(recovery.RecoveryError, match="escapes"):
+        recovery.parse_compose_labels(_labels(tmp_path, str(outside)))
+
+    parsed = json.loads(_labels(tmp_path))
+    del parsed[recovery.COMPOSE_PROJECT_LABEL]
+    with pytest.raises(recovery.RecoveryError, match="project label"):
+        recovery.parse_compose_labels(json.dumps(parsed))
+
+
+@pytest.mark.parametrize(
+    "name",
+    (
+        ".env",
+        ".env.production",
+        "credentials.json",
+        "client-secret.yaml",
+        "API_TOKEN.txt",
+        "private_key.py",
+        "server.pem",
+        "server.crt",
+        "id_rsa.txt",
+    ),
+)
+def test_secret_names_are_rejected_case_insensitively(tmp_path: Path, name: str):
+    (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / name).write_text("must not be archived\n", encoding="utf-8")
+    files = recovery.collect_files(tmp_path, [tmp_path / "compose.yml"])
+    assert [relative for _, relative, _ in files] == ["compose.yml"]
+
+
+def test_symlink_and_config_traversal_fail_closed(tmp_path: Path):
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "compose.yml").write_text("services: {}\n", encoding="utf-8")
+    outside = tmp_path / "outside.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    (source / "linked.py").symlink_to(outside)
+    with pytest.raises(recovery.RecoveryError, match="symlink"):
+        recovery.collect_files(source, [source / "compose.yml"])
+
+
+def test_file_count_per_file_and_total_size_bounds_are_inclusive(tmp_path: Path, monkeypatch):
+    compose = tmp_path / "compose.yml"
+    compose.write_bytes(b"1234")
+    (tmp_path / "safe.py").write_bytes(b"5678")
+    monkeypatch.setattr(recovery, "MAX_FILES", 2)
+    monkeypatch.setattr(recovery, "MAX_FILE_BYTES", 4)
+    monkeypatch.setattr(recovery, "MAX_TOTAL_BYTES", 8)
+    assert len(recovery.collect_files(tmp_path, [compose])) == 2
+
+    (tmp_path / "extra.md").write_bytes(b"x")
+    with pytest.raises(recovery.RecoveryError, match="total-size|file-count"):
+        recovery.collect_files(tmp_path, [compose])
+
+    (tmp_path / "extra.md").unlink()
+    (tmp_path / "safe.py").write_bytes(b"12345")
+    with pytest.raises(recovery.RecoveryError, match="per-file"):
+        recovery.collect_files(tmp_path, [compose])
+
+
+def test_archive_manifest_and_receipt_prove_no_db_and_no_mutation(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    script = tmp_path / "Dockerfile"
+    script.write_text("FROM scratch\n", encoding="utf-8")
+    files = recovery.collect_files(tmp_path, [compose])
+    output = io.BytesIO()
+    recovery.stream_archive(tmp_path.resolve(), "retained-project", files, output)
+
+    archive_bytes = output.getvalue()
+    assert hashlib.sha256(archive_bytes).hexdigest()
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as bundle:
+        names = bundle.getnames()
+        manifest = json.load(bundle.extractfile("recovery-manifest.json"))
+        receipt = json.load(bundle.extractfile("recovery-receipt.json"))
+    assert names == ["source/Dockerfile", "source/compose.yml", "recovery-manifest.json", "recovery-receipt.json"]
+    assert [entry["path"] for entry in manifest["files"]] == ["Dockerfile", "compose.yml"]
+    assert all(len(entry["sha256"]) == 64 for entry in manifest["files"])
+    assert receipt["db_access"] is False
+    assert receipt["host_mutation"] is False
+    assert receipt["docker_inspect_env"] is False
+    assert receipt["compose_project"] == "retained-project"
+
+
+def test_workflow_uses_exact_allowlist_pinned_trust_and_artifact_upload():
+    workflow = (Path(__file__).parents[1] / ".github/workflows/chatgpt-ed-new-ops.yml").read_text()
+    assert "recover-v3-runtime-contract" in workflow
+    assert "ED_NEW_OPERATOR_KNOWN_HOSTS" in workflow
+    assert "ssh-keyscan" not in workflow
+    assert "StrictHostKeyChecking=yes" in workflow
+    assert "ref: main" in workflow
+    assert "trusted-main/scripts/operator/recover_v3_runtime_contract.py" in workflow
+    assert 'git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA"' in workflow
+    assert "{{json .Config.Labels}}" in (Path(__file__).parents[1] / "scripts/operator/recover_v3_runtime_contract.py").read_text()
+    assert "Config.Env" not in (Path(__file__).parents[1] / "scripts/operator/recover_v3_runtime_contract.py").read_text()
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow


### PR DESCRIPTION
Emergency retained-V3 authority recovery slice for the <48-hour Hetzner retirement window.

This branch adds a narrowly allowlisted operator operation and recovery script to inventory/checksum the retained Phase 4C R5 runtime contract on the V3 host: source/compose/scripts/schema/catalog/provenance/retention/remediation metadata needed to reconstruct the authoritative V3 contract in Git.

Safety boundary: read-only inventory/checksum work only. It must not expose `.env` values or secrets, mutate Docker, write to the database, run migrations/backfills, deploy, or change DNS. Tests cover the recovery contract and operator behavior.

This is intentionally separate from the V3 runtime implementation so the recovered retained artifacts can be reviewed as authority rather than silently mixed into new code.