### PR TITLE
Make the self-hosted Codex test environment deterministic

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -71,15 +71,50 @@ jobs:
           git reset --hard refs/remotes/origin/main
           git clean -ffdx
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+
       - name: Prepare repository state gate
         shell: bash
         run: |
           set -euo pipefail
+          if ! command -v python >/dev/null 2>&1; then
+            echo "::error::Codex Worker requires Python 3.12, but the selected interpreter is unavailable."
+            exit 69
+          fi
+          if ! python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 12) else 1)'; then
+            echo "::error::The selected interpreter did not report the required Python 3.12 version."
+            python --version >&2 || true
+            exit 69
+          fi
           if [ ! -x .venv/bin/python ]; then
-            python3 -m venv .venv
+            python -m venv .venv
+          fi
+          if ! .venv/bin/python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 12) else 1)'; then
+            echo "::error::The repository venv does not use the required Python 3.12 interpreter."
+            .venv/bin/python --version >&2 || true
+            exit 69
           fi
           PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B scripts/dev/resolve_project_state.py --strict
           echo "CODEX_STATE_GATE=PASS"
+
+      - name: Bootstrap pinned Python test environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          .venv/bin/python -m pip install --requirement tests/requirements-ci.txt
+          echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Verify pinned Python test environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip check
+          python -m pytest --version
+          python -m ruff --version
 
       - name: Verify worker identity
         shell: bash

--- a/docs/development/chatgpt-ops-control-plane.md
+++ b/docs/development/chatgpt-ops-control-plane.md
@@ -55,7 +55,21 @@ The long-running self-hosted job is a separate workflow run. Its run name includ
 
 ChatGPT clients should therefore report the dispatch acknowledgement/run ID immediately. A later turn may query the worker run for progress or results. A client-side timeout must not be treated as evidence that Codex failed unless the GitHub worker run itself failed or timed out.
 
-The Codex Worker retains its 120-minute execution limit, serial `codex-worker` concurrency group, repository state gate, investigation immutability check, and isolated implementation-branch behavior.
+The Codex Worker retains its 120-minute execution limit, repository state gate,
+investigation immutability check, and isolated implementation-branch behavior.
+The self-hosted runner pool processes independent worker runs in parallel; the
+workflow deliberately has no global concurrency group.
+
+After the clean checkout, the worker selects Python 3.12 through the same pinned
+setup action used by CI, verifies the exact interpreter version or fails closed,
+creates the repo-local `.venv`, and runs the strict repository state gate before
+installing dependencies. Only after that gate passes does it
+install the existing pinned `tests/requirements-ci.txt` authority with the venv
+interpreter. It then exports `VIRTUAL_ENV` and prepends `.venv/bin` for all later
+steps, and verifies the bootstrap with `python -m pip check`,
+`python -m pytest --version`, and `python -m ruff --version`. Thus Codex commands
+documented with `python -m pytest` or `python -m ruff` use the deterministic
+worker environment rather than packages left on the runner host.
 
 ### Codex implementation push credential
 

--- a/tests/test_codex_async_bridge.py
+++ b/tests/test_codex_async_bridge.py
@@ -37,6 +37,54 @@ def test_codex_workers_are_not_globally_serialized() -> None:
     assert "cancel-in-progress:" not in text
 
 
+def test_worker_bootstrap_fails_closed_on_wrong_python_before_state_gate() -> None:
+    text = WORKER.read_text(encoding="utf-8")
+    gate = text.split("- name: Prepare repository state gate", 1)[1].split(
+        "- name: Bootstrap pinned Python test environment", 1
+    )[0]
+
+    setup = text.split("- name: Set up Python 3.12", 1)[1].split(
+        "- name: Prepare repository state gate", 1
+    )[0]
+
+    assert "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97" in setup
+    assert 'python-version: "3.12"' in setup
+    assert "command -v python" in gate
+    assert "::error::" in gate
+    assert "sys.version_info[:2] == (3, 12)" in gate
+    assert "python -m venv .venv" in gate
+    assert "The repository venv does not use the required Python 3.12" in gate
+    assert "resolve_project_state.py --strict" in gate
+
+
+def test_pinned_test_environment_is_installed_only_after_state_gate() -> None:
+    text = WORKER.read_text(encoding="utf-8")
+    gate_position = text.index("resolve_project_state.py --strict")
+    bootstrap_position = text.index("- name: Bootstrap pinned Python test environment")
+    install_position = text.index(
+        ".venv/bin/python -m pip install --requirement tests/requirements-ci.txt"
+    )
+
+    assert gate_position < bootstrap_position < install_position
+    assert "pip install" not in text[:gate_position]
+
+
+def test_worker_activates_and_verifies_the_pinned_venv() -> None:
+    text = WORKER.read_text(encoding="utf-8")
+    bootstrap = text.split(
+        "- name: Bootstrap pinned Python test environment", 1
+    )[1].split("- name: Verify pinned Python test environment", 1)[0]
+    verification = text.split(
+        "- name: Verify pinned Python test environment", 1
+    )[1].split("- name: Verify worker identity", 1)[0]
+
+    assert 'echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.venv" >> "$GITHUB_ENV"' in bootstrap
+    assert 'echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"' in bootstrap
+    assert "python -m pip check" in verification
+    assert "python -m pytest --version" in verification
+    assert "python -m ruff --version" in verification
+
+
 def test_privileged_workflow_push_token_is_isolated_from_codex() -> None:
     text = WORKER.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Closes #533.

Make the self-hosted Codex worker rebuild a deterministic Python test environment after its deliberate `git clean -ffdx`:

- select Python 3.12 using the same pinned `actions/setup-python` action as CI;
- fail closed if the selected interpreter or newly created `.venv` is not Python 3.12;
- preserve the strict repository/project state gate before dependency installation or implementation work;
- install the existing pinned authority `tests/requirements-ci.txt` with the venv interpreter;
- export `VIRTUAL_ENV` through `GITHUB_ENV` and prepend `.venv/bin` through `GITHUB_PATH`;
- verify the activated environment with `python -m pip check`, `python -m pytest --version`, and `python -m ruff --version`;
- retain the 120-minute timeout, parallel worker pool, checkout credential isolation, wrapper-only push credential, clean-workspace checks, and no-deploy/no-production boundaries;
- correct the operations-control-plane documentation’s stale claim that workers are globally serialized;
- add focused structural regression tests for interpreter selection, ordering, pinned installation, activation, probes, parallelism, and credential isolation.

This changes worker/test infrastructure, documentation, and its contracts only. It does not change application runtime behaviour, product/data behaviour, production, deployment, databases, Stage 27 implementation, CRE/CPE mechanics, or Journal work.

## Worker validation

Performed under Python 3.12.3 after installing the existing pinned manifest:

- `python -m pip check` — passed (`No broken requirements found`)
- `python -m pytest --version` — pytest 8.3.4
- `python -m ruff --version` — Ruff 0.15.22
- `python -m pytest -q tests/test_codex_async_bridge.py tests/test_ci_dependency_contract.py tests/test_ci_stall_detection.py tests/test_repo_hygiene_contract.py tests/test_bounded_hygiene_pass.py` — 24 passed in 1.05s
- `python -m ruff check tests/test_codex_async_bridge.py` — passed
- workflow YAML parse and 120-minute timeout assertion — passed
- `git diff --check` — passed

## Review limitation

The implementation was created by the old worker definition, so its own bootstrap steps could only be validated structurally and by equivalent local commands. The updated workflow must receive fresh GitHub CI and automated review against head `733623de6d4f2b5a1d7e36a6d6a5712aba8175f6`; after merge, a separate clean self-hosted worker run should prove the full bootstrap path end-to-end. No merge or deployment is authorized by this PR.