### PR TITLE
Add guarded Octopus Qdrant healthcheck repair op

### DIFF
--- a/.github/workflows/chatgpt-ops.yml
+++ b/.github/workflows/chatgpt-ops.yml
@@ -12,6 +12,7 @@ on:
           - db-readonly-health
           - latest-artifacts
           - latest-artifact-summary
+          - octopus-qdrant-healthcheck-repair
       artifact_stage:
         description: "Artifact stage for artifact operations"
         required: false
@@ -32,7 +33,7 @@ concurrency:
 
 jobs:
   execute:
-    name: Run allowlisted production read operation
+    name: Run allowlisted production operation
     runs-on: ubuntu-latest
     environment: hetzner-operator
     timeout-minutes: 10
@@ -81,6 +82,7 @@ jobs:
             db-readonly-health) stage=db-readonly-health ;;
             latest-artifacts) stage=latest-artifacts ;;
             latest-artifact-summary) stage=latest-artifact-summary ;;
+            octopus-qdrant-healthcheck-repair) stage=octopus-qdrant-healthcheck-repair ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
 

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -18,6 +18,10 @@ Current scripts:
 
 - `require_hetzner_operator_env.sh`: reusable fail-fast guard for
   Hetzner-only commands.
+- `actions/octopus-qdrant-healthcheck-repair.sh`: narrowly repairs the known
+  broken `wget` healthcheck in Octopus v1.0.122's Qdrant Compose service,
+  recreates only Qdrant, and starts/verifies the blocked web service. It does
+  not read `.env`, access a database, or modify volumes.
 - `recover_v3_runtime_contract.py`: read-only helper for the allowlisted ed-new
   `recover-v3-runtime-contract` operation. It identifies the retained Phase 4C
   R5 Compose source root from container labels, rejects secret-like and unsafe

--- a/scripts/operator/actions/dispatch.sh
+++ b/scripts/operator/actions/dispatch.sh
@@ -20,6 +20,9 @@ case "$stage" in
   db-readonly-health)
     exec bash scripts/operator/actions/db-readonly-health.sh
     ;;
+  octopus-qdrant-healthcheck-repair)
+    exec bash scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+    ;;
   latest-stage18j-summary)
     exec bash scripts/operator/actions/latest-artifact-summary.sh "stage-18j"
     ;;

--- a/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+++ b/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OCTOPUS_DIR="/opt/octopus"
+COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"
+EXPECTED_HOST="ed-finder-prod"
+EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"
+BACKUP=""
+EDIT_COMMITTED=false
+QDRANT_RECREATED=false
+WEB_STARTED=false
+
+receipt() {
+  local status="$1" reason="$2"
+  python3 - "$status" "$reason" "$BACKUP" "$QDRANT_RECREATED" "$WEB_STARTED" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "schema_version": "ed-finder/operator-operation-result/v1",
+    "operation": "octopus-qdrant-healthcheck-repair",
+    "status": sys.argv[1],
+    "reason": sys.argv[2],
+    "compose_backup": sys.argv[3] or None,
+    "qdrant_recreated": sys.argv[4] == "true",
+    "web_started": sys.argv[5] == "true",
+    "db_access_performed": False,
+    "db_writes_performed": False,
+    "volume_configuration_modified": False,
+    "migrations_performed": False,
+    "env_values_modified": False,
+}, separators=(",", ":")))
+PY
+}
+
+stop() {
+  receipt "stopped" "$1" >&2
+  exit 1
+}
+
+on_exit() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ "$EDIT_COMMITTED" = false ] && [ -n "$BACKUP" ] && [ -f "$BACKUP" ]; then
+    cp --preserve=mode,ownership,timestamps -- "$BACKUP" "$COMPOSE_FILE"
+  fi
+}
+trap on_exit EXIT
+
+[ "$(hostname -s)" = "$EXPECTED_HOST" ] || stop "unexpected_host"
+[ "$(id -u)" -eq 0 ] || stop "root_required"
+[ "$(pwd -P)" = "/opt/ed-finder" ] || stop "unexpected_working_directory"
+[ -d "$OCTOPUS_DIR" ] || stop "octopus_directory_missing"
+[ -f "$COMPOSE_FILE" ] || stop "compose_file_missing"
+command -v docker >/dev/null 2>&1 || stop "docker_missing"
+docker compose version >/dev/null 2>&1 || stop "docker_compose_missing"
+
+# Validate the rendered service identity without displaying interpolated values.
+read -r rendered_image rendered_web_image < <(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" config --format json \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin).get("services",{}); print((d.get("qdrant",{}) or {}).get("image", ""), (d.get("web",{}) or {}).get("image", ""))') \
+  || stop "compose_render_failed"
+[ "$rendered_image" = "$EXPECTED_IMAGE" ] || stop "unexpected_qdrant_image"
+case "$rendered_web_image" in
+  ghcr.io/octopusreview/octopus-selfhost:1.0.122) ;;
+  *) stop "unexpected_octopus_web_image" ;;
+esac
+current_qdrant_id="$(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" ps -q qdrant)"
+[ -n "$current_qdrant_id" ] || stop "existing_qdrant_container_missing"
+current_qdrant_image="$(docker inspect --format '{{.Config.Image}}' "$current_qdrant_id" 2>/dev/null)" \
+  || stop "existing_qdrant_inspect_failed"
+[ "$current_qdrant_image" = "$EXPECTED_IMAGE" ] || stop "unexpected_running_qdrant_image"
+
+# The editor accepts exactly one qdrant healthcheck block and exactly the known
+# wget /readyz failure mode. It changes only healthcheck.test, preserving timing.
+replacement_file="$(mktemp "$OCTOPUS_DIR/.qdrant-healthcheck.XXXXXX")"
+if ! python3 - "$COMPOSE_FILE" "$replacement_file" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+lines = source.splitlines(keepends=True)
+
+services_match = re.search(r"(?m)^services:\s*(?:#.*)?$", source)
+if not services_match:
+    raise SystemExit("top-level services mapping missing")
+service_match = re.search(r"(?m)^  qdrant:\s*(?:#.*)?$", source[services_match.end():])
+if not service_match:
+    raise SystemExit("qdrant service missing")
+service_offset = services_match.end()
+indent = 2
+start = source[:service_offset + service_match.start()].count("\n")
+end = len(lines)
+for index in range(start + 1, len(lines)):
+    stripped = lines[index].lstrip(" ")
+    if stripped.strip() and not stripped.startswith("#"):
+        current_indent = len(lines[index]) - len(stripped)
+        if current_indent <= indent:
+            end = index
+            break
+
+health = [i for i in range(start + 1, end) if re.match(r"^ {%d}healthcheck:\s*(?:#.*)?$" % (indent + 2), lines[i].rstrip("\n"))]
+if len(health) != 1:
+    raise SystemExit("expected exactly one qdrant healthcheck")
+hstart = health[0]
+hend = end
+for index in range(hstart + 1, end):
+    stripped = lines[index].lstrip(" ")
+    if stripped.strip() and not stripped.startswith("#"):
+        current_indent = len(lines[index]) - len(stripped)
+        if current_indent <= indent + 2:
+            hend = index
+            break
+
+tests = [i for i in range(hstart + 1, hend) if re.match(r"^ {%d}test:" % (indent + 4), lines[i])]
+if len(tests) != 1:
+    raise SystemExit("expected exactly one qdrant healthcheck test")
+test_index = tests[0]
+test_line = lines[test_index]
+expected = ('test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", '
+            '"http://localhost:6333/readyz"]')
+if test_line.strip() != expected:
+    raise SystemExit("qdrant healthcheck is not the expected broken wget readiness check")
+if any("wget" in line for i, line in enumerate(lines) if i != test_index and start <= i < hend):
+    raise SystemExit("unexpected additional wget content in qdrant healthcheck")
+
+prefix = " " * (indent + 4)
+command = ('test: ["CMD-SHELL", "while read -r _ local _ state _; do if [ $$state = 0A ]; '
+           'then case $$local in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp; '
+           'while read -r _ local _ state _; do if [ $$state = 0A ]; then case $$local '
+           'in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp6; exit 1"]\n')
+lines[test_index] = prefix + command
+Path(sys.argv[2]).write_text("".join(lines), encoding="utf-8")
+PY
+then
+  rm -f -- "$replacement_file"
+  stop "expected_broken_healthcheck_not_found"
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP="$COMPOSE_FILE.before-qdrant-healthcheck-repair.$timestamp"
+[ ! -e "$BACKUP" ] || { rm -f -- "$replacement_file"; stop "backup_already_exists"; }
+cp --preserve=mode,ownership,timestamps -- "$COMPOSE_FILE" "$BACKUP"
+chown --reference="$COMPOSE_FILE" "$replacement_file"
+chmod --reference="$COMPOSE_FILE" "$replacement_file"
+mv -- "$replacement_file" "$COMPOSE_FILE"
+
+docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" config --quiet \
+  || stop "edited_compose_validation_failed"
+EDIT_COMMITTED=true
+
+docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" up -d --no-deps --force-recreate qdrant \
+  >/dev/null || stop "qdrant_recreate_failed"
+QDRANT_RECREATED=true
+
+qdrant_id="$(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" ps -q qdrant)"
+[ -n "$qdrant_id" ] || stop "qdrant_container_missing"
+healthy=false
+for _ in $(seq 1 60); do
+  health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$qdrant_id" 2>/dev/null || true)"
+  if [ "$health" = healthy ]; then healthy=true; break; fi
+  [ "$health" != unhealthy ] || stop "qdrant_became_unhealthy"
+  sleep 2
+done
+[ "$healthy" = true ] || stop "qdrant_health_timeout"
+
+python3 - <<'PY' || stop "host_qdrant_readyz_failed"
+from urllib.request import urlopen
+with urlopen("http://127.0.0.1:43333/readyz", timeout=5) as response:
+    body = response.read(1024).decode("utf-8", "replace").strip()
+    if response.status != 200 or body != "all shards are ready":
+        raise SystemExit(1)
+PY
+
+docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" up -d web >/dev/null \
+  || stop "web_start_failed"
+WEB_STARTED=true
+
+web_ready=false
+for _ in $(seq 1 60); do
+  if python3 - <<'PY'
+from urllib.request import urlopen
+for path in ("/", "/api/health", "/api/version"):
+    with urlopen("http://127.0.0.1:43300" + path, timeout=5) as response:
+        if not 200 <= response.status < 400:
+            raise SystemExit(1)
+PY
+  then web_ready=true; break; fi
+  sleep 2
+done
+[ "$web_ready" = true ] || stop "web_health_timeout"
+
+receipt "success" "repair_complete"

--- a/tests/test_octopus_qdrant_healthcheck_repair.py
+++ b/tests/test_octopus_qdrant_healthcheck_repair.py
@@ -1,0 +1,106 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "chatgpt-ops.yml"
+DISPATCH = ROOT / "scripts" / "operator" / "actions" / "dispatch.sh"
+ACTION = ROOT / "scripts" / "operator" / "actions" / "octopus-qdrant-healthcheck-repair.sh"
+OPERATION = "octopus-qdrant-healthcheck-repair"
+
+
+def _editor_source():
+    source = ACTION.read_text(encoding="utf-8")
+    marker = 'if ! python3 - "$COMPOSE_FILE" "$replacement_file" <<\'PY\'\n'
+    return source.split(marker, 1)[1].split("\nPY\nthen", 1)[0]
+
+
+def _run_editor(tmp_path, healthcheck):
+    compose = tmp_path / "docker-compose.selfhost.yml"
+    output = tmp_path / "edited.yml"
+    compose.write_text(
+        "services:\n"
+        "  web:\n"
+        "    image: ghcr.io/octopusreview/octopus-selfhost:1.0.122\n"
+        "    depends_on:\n"
+        "      qdrant:\n"
+        "        condition: service_healthy\n"
+        "  qdrant:\n"
+        "    image: qdrant/qdrant:v1.17.0\n"
+        "    healthcheck:\n"
+        f"      {healthcheck}\n"
+        "      interval: 5s\n"
+        "    restart: unless-stopped\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, "-", str(compose), str(output)],
+        input=_editor_source(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, compose, output
+
+
+def test_chatgpt_ops_allowlists_and_routes_repair_operation():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    assert source.count(f"          - {OPERATION}\n") == 1
+    assert f"{OPERATION}) stage={OPERATION} ;;" in source
+
+
+def test_dispatcher_uses_dedicated_repair_action():
+    source = DISPATCH.read_text(encoding="utf-8")
+    assert f"{OPERATION})" in source
+    assert f"exec bash scripts/operator/actions/{OPERATION}.sh" in source
+
+
+def test_repair_action_has_fail_closed_scope_and_guards():
+    source = ACTION.read_text(encoding="utf-8")
+    required = (
+        'EXPECTED_HOST="ed-finder-prod"',
+        'COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"',
+        'EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"',
+        'ghcr.io/octopusreview/octopus-selfhost:1.0.122',
+        'test_line.strip() != expected',
+        '"CMD", "wget", "--no-verbose", "--tries=1", "--spider"',
+        "*:18BD) exit 0",
+        "cp --preserve=mode,ownership,timestamps",
+        "config --quiet",
+        "up -d --no-deps --force-recreate qdrant",
+        "qdrant_health_timeout",
+        "http://127.0.0.1:43333/readyz",
+        "http://127.0.0.1:43300",
+        'for path in ("/", "/api/health", "/api/version")',
+    )
+    for guard in required:
+        assert guard in source
+
+    assert ".env" not in source
+    assert "POSTGRES" not in source
+    assert "password" not in source.lower()
+    assert '"db_access_performed": False' in source
+    assert '"volume_configuration_modified": False' in source
+
+
+def test_editor_replaces_only_exact_broken_healthcheck(tmp_path):
+    broken = ('test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", '
+              '"http://localhost:6333/readyz"]')
+    result, compose, output = _run_editor(tmp_path, broken)
+    assert result.returncode == 0, result.stderr
+    before = compose.read_text(encoding="utf-8")
+    after = output.read_text(encoding="utf-8")
+    assert after.replace(after.split("      test:", 1)[1].split("\n", 1)[0],
+                         before.split("      test:", 1)[1].split("\n", 1)[0]) == before
+    assert 'test: ["CMD-SHELL"' in after
+    assert "*:18BD) exit 0" in after
+    assert "wget" not in after
+
+
+def test_editor_refuses_drifted_healthcheck(tmp_path):
+    result, _, output = _run_editor(
+        tmp_path,
+        'test: ["CMD", "wget", "--spider", "http://localhost:6333/readyz"]',
+    )
+    assert result.returncode != 0
+    assert not output.exists()


### PR DESCRIPTION
Adds a narrowly scoped ChatGPT Ops operation to repair the known Octopus v1.0.122 / Qdrant v1.17.0 healthcheck mismatch on ed-finder-prod. The operator action fails closed on host/image/version/healthcheck drift, backs up the compose file, edits only the Qdrant healthcheck, recreates Qdrant only, verifies /readyz, then starts and health-checks Octopus. It does not read .env or touch Postgres, volumes, migrations, or model data.

Codex worker evidence: focused tests passed and git diff --check passed. Implementation was produced without production access.