### PR TITLE
Add conservative Octopus review ignore policy

### DIFF
--- a/.octopusignore
+++ b/.octopusignore
@@ -1,0 +1,42 @@
+# Octopus uses gitignore syntax. Keep this narrower than .gitignore because
+# matches are excluded from both repository indexing and pull-request review.
+
+# Reproducible dependency and local-environment content.
+/node_modules/
+/frontend/node_modules/
+/.venv/
+
+# Generated build, test, cache, and coverage outputs.
+**/__pycache__/
+/.pytest_cache/
+/.coverage
+/.coverage.*
+/coverage/
+/htmlcov/
+/build/
+/dist/
+/frontend/dist/
+/frontend/coverage/
+/frontend/.vite/
+/frontend/playwright-report/
+/frontend/test-results/
+
+# This client is regenerated from the API's OpenAPI schema; review the schema,
+# generator, and handwritten frontend API boundary instead.
+/frontend/src/types/api.gen.ts
+
+# Yarn v1 rewrites this large machine-managed dependency graph. Dependency
+# intent and reviewable version changes remain visible in package.json.
+/frontend/yarn.lock
+
+# Browser-validation screenshots are durable visual receipts, but their binary
+# contents provide no useful text context. Keep adjacent README/JSON evidence.
+/docs/development/evidence/**/*.png
+/docs/development/evidence/**/*.jpg
+/docs/development/evidence/**/*.jpeg
+/artifacts/**/*.png
+/artifacts/**/*.jpg
+/artifacts/**/*.jpeg
+
+# Historical root-level captured diffs are archived residue, not live source.
+/*.patch

--- a/.octopusignore
+++ b/.octopusignore
@@ -25,10 +25,6 @@
 # generator, and handwritten frontend API boundary instead.
 /frontend/src/types/api.gen.ts
 
-# Yarn v1 rewrites this large machine-managed dependency graph. Dependency
-# intent and reviewable version changes remain visible in package.json.
-/frontend/yarn.lock
-
 # Browser-validation screenshots are durable visual receipts, but their binary
 # contents provide no useful text context. Keep adjacent README/JSON evidence.
 /docs/development/evidence/**/*.png

--- a/tests/test_repo_hygiene_contract.py
+++ b/tests/test_repo_hygiene_contract.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import subprocess
+import tempfile
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -54,3 +55,51 @@ def test_repo_hygiene_policy_exists_and_names_the_machine_guards():
     assert 'tests/test_bounded_hygiene_pass.py' in source
     assert 'tests/test_repo_hygiene_contract.py' in source
     assert 'Repo root is allowlist-only for tracked visible files.' in source
+
+
+def _octopus_ignored_paths(paths: set[str]) -> set[str]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        sandbox = Path(temp_dir)
+        subprocess.run(
+            ['git', 'init', '--quiet', str(sandbox)],
+            check=True,
+        )
+        (sandbox / '.gitignore').write_text(
+            (ROOT / '.octopusignore').read_text(encoding='utf-8'),
+            encoding='utf-8',
+        )
+        result = subprocess.run(
+            ['git', '-C', str(sandbox), 'check-ignore', '--no-index', *sorted(paths)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    assert result.returncode in {0, 1}
+    return set(result.stdout.splitlines())
+
+
+def test_octopus_ignore_excludes_only_review_noise():
+    expected_noise = {
+        'frontend/dist/assets/app.js',
+        'frontend/src/types/api.gen.ts',
+        'frontend/yarn.lock',
+        'docs/development/evidence/example/browser.png',
+        'artifacts/map-foundation/example/screenshot.jpg',
+        'captured-review.patch',
+    }
+    protected_review_targets = {
+        '.github/workflows/ci.yml',
+        'apps/api/src/main.py',
+        'config/grafana/provisioning/dashboards/default.yml',
+        'docker-compose.yml',
+        'env.example',
+        'frontend/package.json',
+        'frontend/public/assets/elite-dangerous-region-map.svg',
+        'scripts/apply_migrations.sh',
+        'sql/001_initial_schema.sql',
+        'tests/fixtures/edsm_body_ring_snapshot.json',
+        'tests/test_repo_hygiene_contract.py',
+    }
+
+    candidates = expected_noise | protected_review_targets
+    assert _octopus_ignored_paths(candidates) == expected_noise

--- a/tests/test_repo_hygiene_contract.py
+++ b/tests/test_repo_hygiene_contract.py
@@ -82,7 +82,6 @@ def test_octopus_ignore_excludes_only_review_noise():
     expected_noise = {
         'frontend/dist/assets/app.js',
         'frontend/src/types/api.gen.ts',
-        'frontend/yarn.lock',
         'docs/development/evidence/example/browser.png',
         'artifacts/map-foundation/example/screenshot.jpg',
         'captured-review.patch',
@@ -94,6 +93,7 @@ def test_octopus_ignore_excludes_only_review_noise():
         'docker-compose.yml',
         'env.example',
         'frontend/package.json',
+        'frontend/yarn.lock',
         'frontend/public/assets/elite-dangerous-region-map.svg',
         'scripts/apply_migrations.sh',
         'sql/001_initial_schema.sql',


### PR DESCRIPTION
Adds a narrow `.octopusignore` so Octopus skips generated/build/cache/coverage output, generated OpenAPI client code, binary evidence screenshots, and historical root patch residue while keeping application source, CI/workflows, migrations/SQL, operator scripts, configuration/security files, tests, JSON fixtures/receipts, runtime SVG assets, package manifests, and `frontend/yarn.lock` reviewable. Includes a contract test that verifies representative protected paths remain visible.