### PR TITLE
[Superseded by #548] Add read-only Octopus edge status operation

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - host-status
+          - octopus-edge-status
           - recover-v3-runtime-contract
           - octopus-qdrant-healthcheck-repair
   push:
@@ -62,7 +63,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair) ;;
+            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -120,6 +121,25 @@ jobs:
               -o UserKnownHostsFile=~/.ssh/known_hosts \
               "$SSH_USER@$SSH_HOST" \
               'set -eu; echo "== ed-new bootstrap status =="; printf "hostname: "; hostname; printf "fqdn: "; hostname -f 2>/dev/null || true; printf "kernel: "; uname -sr; echo "== filesystem =="; df -hT /; echo "== docker =="; if command -v docker >/dev/null 2>&1; then docker ps --format "{{.Names}}\t{{.Status}}\t{{.Image}}" | head -50; else echo "docker: not installed"; fi; echo "== repo candidates =="; for p in /opt/ed-finder /root/ed-finder /srv/ed-finder; do [ -d "$p" ] && echo "$p"; done; echo "== safety =="; echo "db_access_performed: false"; echo "db_writes_performed: false"; echo "migrations_performed: false"; echo "canonical_apply_performed: false"'
+
+      - name: Inspect Octopus edge status (read only)
+        if: steps.request.outputs.operation == 'octopus-edge-status'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'bash -s' \
+              < trusted-main/scripts/operator/actions/octopus-edge-status.sh
 
       - name: Repair Octopus Qdrant healthcheck and boot web
         if: steps.request.outputs.operation == 'octopus-qdrant-healthcheck-repair'

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -22,6 +22,10 @@ Current scripts:
   broken `wget` healthcheck in Octopus v1.0.122's Qdrant Compose service,
   recreates only Qdrant, and starts/verifies the blocked web service. It does
   not read `.env`, access a database, or modify volumes.
+- `actions/octopus-edge-status.sh`: read-only, fail-closed MevSpace edge
+  inspection for the Octopus v1.0.122 service. It reports bounded listener,
+  container, health, DNS, route-directive, HTTP status, and public certificate
+  name evidence without reading environment files, databases, or private keys.
 - `recover_v3_runtime_contract.py`: read-only helper for the allowlisted ed-new
   `recover-v3-runtime-contract` operation. It identifies the retained Phase 4C
   R5 Compose source root from container labels, rejects secret-like and unsafe

--- a/scripts/operator/actions/dispatch.sh
+++ b/scripts/operator/actions/dispatch.sh
@@ -23,6 +23,9 @@ case "$stage" in
   octopus-qdrant-healthcheck-repair)
     exec bash scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
     ;;
+  octopus-edge-status)
+    exec bash scripts/operator/actions/octopus-edge-status.sh
+    ;;
   latest-stage18j-summary)
     exec bash scripts/operator/actions/latest-artifact-summary.sh "stage-18j"
     ;;

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_HOST="ed-finder-prod"
+EXPECTED_FQDN="nb79a3d.mevnode.com"
+OCTOPUS_HOST="octopus.ed-finder.app"
+OCTOPUS_UPSTREAM="127.0.0.1:43300"
+
+stop() {
+  python3 - "$1" <<'PY' >&2
+import json, sys
+print(json.dumps({
+    "schema_version": "ed-finder/operator-operation-result/v1",
+    "operation": "octopus-edge-status",
+    "status": "stopped",
+    "reason": sys.argv[1],
+    "read_only": True,
+    "db_access_performed": False,
+}, separators=(",", ":")))
+PY
+  exit 1
+}
+
+[ "$(hostname -s)" = "$EXPECTED_HOST" ] || stop "unexpected_host"
+[ "$(hostname -f 2>/dev/null)" = "$EXPECTED_FQDN" ] || stop "unexpected_fqdn"
+[ "$(id -u)" -eq 0 ] || stop "root_required"
+command -v python3 >/dev/null 2>&1 || stop "python3_missing"
+command -v ss >/dev/null 2>&1 || stop "ss_missing"
+command -v curl >/dev/null 2>&1 || stop "curl_missing"
+command -v openssl >/dev/null 2>&1 || stop "openssl_missing"
+
+tmp_dir="$(mktemp -d)" || stop "temporary_directory_failed"
+trap 'rm -rf -- "$tmp_dir"' EXIT
+
+# Collect only explicitly bounded, read-only inputs. Docker formatting avoids
+# Config.Env, mounts, labels, and other fields that can contain secrets.
+ss -H -ltnp > "$tmp_dir/listeners" || stop "listener_inspection_failed"
+: > "$tmp_dir/containers"
+: > "$tmp_dir/proxy-config"
+if command -v docker >/dev/null 2>&1; then
+  docker ps --no-trunc --format '{{json .}}' > "$tmp_dir/containers" \
+    || stop "docker_listing_failed"
+  while IFS=$'\t' read -r container image; do
+    case "${container,,} ${image,,}" in
+      *nginx*|*traefik*|*caddy*|*haproxy*)
+        # nginx -T is captured, filtered, and sanitized before anything is emitted.
+        case "${image,,}" in
+          *nginx*) docker exec "$container" nginx -T > "$tmp_dir/proxy-raw" 2>&1 || true ;;
+          *) continue ;;
+        esac
+        python3 - "$container" "$tmp_dir/proxy-raw" >> "$tmp_dir/proxy-config" <<'PY'
+import re, sys
+name, path = sys.argv[1:]
+for raw in open(path, encoding="utf-8", errors="replace"):
+    line = raw.strip()
+    if not re.match(r"^(server_name|proxy_pass)\s+", line):
+        continue
+    if not any(x in line for x in ("ed-finder.app", "43300")):
+        continue
+    line = re.sub(r"(https?://)[^/@\s]+@", r"\1[redacted]@", line)
+    line = re.sub(r"([?&][^=\s]+)=([^&;\s]+)", r"\1=[redacted]", line)
+    print(f"container={name}\t{line[:500]}")
+PY
+        ;;
+    esac
+  done < <(docker ps --format '{{.Names}}\t{{.Image}}')
+fi
+
+# Host nginx output is likewise never emitted directly.
+if command -v nginx >/dev/null 2>&1; then
+  nginx -T > "$tmp_dir/proxy-raw" 2>&1 || true
+  python3 - "$tmp_dir/proxy-raw" >> "$tmp_dir/proxy-config" <<'PY'
+import re, sys
+for raw in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    line = raw.strip()
+    if not re.match(r"^(server_name|proxy_pass)\s+", line):
+        continue
+    if not any(x in line for x in ("ed-finder.app", "43300")):
+        continue
+    line = re.sub(r"(https?://)[^/@\s]+@", r"\1[redacted]@", line)
+    line = re.sub(r"([?&][^=\s]+)=([^&;\s]+)", r"\1=[redacted]", line)
+    print(f"host\t{line[:500]}")
+PY
+fi
+
+getent ahosts "$OCTOPUS_HOST" > "$tmp_dir/dns" 2>/dev/null || :
+curl -sS -o /dev/null --max-time 5 -w '%{http_code}' \
+  -H "Host: $OCTOPUS_HOST" http://127.0.0.1/ > "$tmp_dir/http-status" 2>/dev/null || echo -n 000 > "$tmp_dir/http-status"
+curl -sS -k -o /dev/null --max-time 5 -w '%{http_code}' \
+  --resolve "$OCTOPUS_HOST:443:127.0.0.1" "https://$OCTOPUS_HOST/" \
+  > "$tmp_dir/https-status" 2>/dev/null || echo -n 000 > "$tmp_dir/https-status"
+for endpoint in health version; do
+  curl -sS -o /dev/null --max-time 5 -w '%{http_code}' \
+    "http://$OCTOPUS_UPSTREAM/api/$endpoint" > "$tmp_dir/$endpoint-status" 2>/dev/null \
+    || echo -n 000 > "$tmp_dir/$endpoint-status"
+done
+: > "$tmp_dir/certificate"
+if grep -Eq '(^|[[:space:]])[^[:space:]]*:443[[:space:]]' "$tmp_dir/listeners"; then
+  openssl s_client -connect 127.0.0.1:443 -servername "$OCTOPUS_HOST" </dev/null 2>/dev/null \
+    | openssl x509 -noout -subject -ext subjectAltName > "$tmp_dir/certificate" 2>/dev/null || :
+fi
+# Inspect public certificate metadata only. Never enumerate or open privkey.pem.
+if [ -d /etc/letsencrypt/live ]; then
+  while IFS= read -r -d '' certificate; do
+    openssl x509 -in "$certificate" -noout -subject -ext subjectAltName \
+      >> "$tmp_dir/certificate" 2>/dev/null || :
+  done < <(find /etc/letsencrypt/live -maxdepth 3 \( -type f -o -type l \) \
+    \( -name fullchain.pem -o -name cert.pem \) -print0 2>/dev/null)
+fi
+
+python3 - "$tmp_dir" "$EXPECTED_HOST" "$EXPECTED_FQDN" "$OCTOPUS_HOST" <<'PY'
+import json, pathlib, re, sys
+
+root = pathlib.Path(sys.argv[1])
+hostname, fqdn, octopus_host = sys.argv[2:]
+listeners_raw = (root / "listeners").read_text(errors="replace").splitlines()
+
+def listeners(port):
+    found = []
+    for line in listeners_raw:
+        if re.search(rf"(?:^|\s)(?:\[[^]]+\]|[^\s]+):{port}\s", line):
+            # ss process metadata is useful ownership evidence; cap every line.
+            found.append(line[:500])
+    return found
+
+container_rows = []
+for line in (root / "containers").read_text(errors="replace").splitlines():
+    try:
+        row = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    haystack = " ".join(str(row.get(k, "")) for k in ("Names", "Image", "Ports"))
+    if any(term in haystack.lower() for term in ("octopus", "nginx", "traefik", "caddy", "haproxy", "43300", ":80->", ":443->")):
+        container_rows.append({k: row.get(k, "") for k in ("Names", "Image", "Ports", "Status")})
+
+routes = (root / "proxy-config").read_text(errors="replace").splitlines()
+dns_addresses = sorted({line.split()[0] for line in (root / "dns").read_text().splitlines() if line.split()})
+certificate_names = sorted(set(re.findall(r"DNS:([^,\s]+)", (root / "certificate").read_text(errors="replace"))))
+code = lambda name: (root / name).read_text().strip()[-3:] or "000"
+l80, l443, l43300 = listeners(80), listeners(443), listeners(43300)
+health_code, version_code = code("health-status"), code("version-status")
+route_present = any(octopus_host in line for line in routes) and any("43300" in line for line in routes)
+certificate_present = octopus_host in certificate_names or any(
+    name.startswith("*.") and octopus_host.endswith(name[1:]) and octopus_host.count(".") == name.count(".")
+    for name in certificate_names
+)
+needed = []
+if not dns_addresses:
+    needed.append("create_dns_record")
+if not l80:
+    needed.append("provide_port_80_listener")
+if not l443:
+    needed.append("provide_port_443_listener")
+if not route_present:
+    needed.append("configure_reverse_proxy_to_127.0.0.1_43300")
+if not certificate_present:
+    needed.append("issue_certificate_for_octopus_ed_finder_app")
+receipt = {
+    "schema_version": "ed-finder/operator-operation-result/v1",
+    "operation": "octopus-edge-status",
+    "status": "success",
+    "hostname": hostname,
+    "fqdn": fqdn,
+    "target": {"hostname": octopus_host, "upstream": "127.0.0.1:43300", "expected_version": "1.0.122"},
+    "listeners": {"80": l80, "443": l443, "43300": l43300},
+    "containers": container_rows,
+    "proxy_directives": routes,
+    "dns_addresses": dns_addresses,
+    "http_status": code("http-status"),
+    "https_status": code("https-status"),
+    "octopus_api": {"health_status": health_code, "version_status": version_code},
+    "certificate_names": certificate_names,
+    "needed": needed,
+    "conclusions": {
+        "dns_present": bool(dns_addresses),
+        "listener_80": bool(l80),
+        "listener_443": bool(l443),
+        "listener_43300": bool(l43300),
+        "octopus_internal_healthy": health_code.startswith("2") and version_code.startswith("2"),
+        "route_present": route_present,
+        "certificate_present": certificate_present,
+    },
+    "read_only": True,
+    "db_access_performed": False,
+    "writes_performed": False,
+    "service_restarts_performed": False,
+}
+print(json.dumps(receipt, separators=(",", ":")))
+PY

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/chatgpt-ed-new-ops.yml"
+DISPATCH = ROOT / "scripts/operator/actions/dispatch.sh"
+ACTION = ROOT / "scripts/operator/actions/octopus-edge-status.sh"
+OPERATION = "octopus-edge-status"
+
+
+def test_ed_new_workflow_allowlists_and_uses_pinned_trusted_action():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    assert source.count(f"          - {OPERATION}\n") == 1
+    assert f"host-status|{OPERATION}|recover-v3-runtime-contract" in source
+    block = source.split("- name: Inspect Octopus edge status (read only)", 1)[1].split("- name:", 1)[0]
+    assert "StrictHostKeyChecking=yes" in block
+    assert "UserKnownHostsFile=~/.ssh/known_hosts" in block
+    assert "trusted-main/scripts/operator/actions/octopus-edge-status.sh" in block
+    assert "git pull" not in block
+
+
+def test_dispatcher_is_fail_closed_and_routes_only_the_named_action():
+    source = DISPATCH.read_text(encoding="utf-8")
+    assert f"  {OPERATION})" in source
+    assert f"exec bash scripts/operator/actions/{OPERATION}.sh" in source
+    assert 'STOP: unsupported operator stage: $stage' in source
+
+
+def test_edge_action_is_read_only_secret_safe_and_host_pinned():
+    source = ACTION.read_text(encoding="utf-8")
+    for required in (
+        'EXPECTED_HOST="ed-finder-prod"',
+        'EXPECTED_FQDN="nb79a3d.mevnode.com"',
+        'OCTOPUS_UPSTREAM="127.0.0.1:43300"',
+        'docker ps --no-trunc --format',
+        'Config.Env',
+        'nginx -T',
+        'server_name|proxy_pass',
+        '--resolve "$OCTOPUS_HOST:443:127.0.0.1"',
+        'openssl x509 -noout -subject -ext subjectAltName',
+        '-name fullchain.pem -o -name cert.pem',
+        '"db_access_performed": False',
+        '"service_restarts_performed": False',
+    ):
+        assert required in source
+
+    forbidden = (
+        "docker compose up",
+        "docker restart",
+        "systemctl restart",
+        "service restart",
+        "psql",
+        "DATABASE_URL",
+        "private_key",
+        "BEGIN PRIVATE KEY",
+        "cat .env",
+        "source .env",
+    )
+    lowered = source.lower()
+    for token in forbidden:
+        assert token.lower() not in lowered
+
+
+def test_receipt_contains_required_machine_readable_conclusions():
+    source = ACTION.read_text(encoding="utf-8")
+    for field in (
+        '"dns_present"',
+        '"listener_80"',
+        '"listener_443"',
+        '"listener_43300"',
+        '"octopus_internal_healthy"',
+        '"route_present"',
+        '"certificate_present"',
+        '"needed"',
+    ):
+        assert field in source


### PR DESCRIPTION
Superseded by #550, which contains the hardened corrected implementation from the follow-up Codex worker. The original implementation is intentionally not being merged.