### PR TITLE
Align Octopus edge audit with production proxy topology

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -81,13 +81,13 @@ jobs:
           SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
           SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
           SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
-          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
           test -n "$SSH_KEY" || { echo "Missing ED_NEW_OPERATOR_SSH_KEY" >&2; exit 1; }
           test -n "$SSH_HOST" || { echo "Missing ED_NEW_OPERATOR_HOST" >&2; exit 1; }
           test -n "$SSH_PORT" || { echo "Missing ED_NEW_OPERATOR_PORT" >&2; exit 1; }
-          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing ED_NEW_OPERATOR_KNOWN_HOSTS" >&2; exit 1; }
+          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing pinned ed-new known-hosts secret" >&2; exit 1; }
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -184,7 +184,7 @@ nginx_candidates = [item["name"] for item in containers
 proxy_items = []
 route_found = False
 all_inspected = bool(nginx_candidates)
-for candidate in nginx_candidates[:10]:
+for candidate in nginx_candidates:
     nginx_result = run(["docker", "exec", candidate, "nginx", "-T"])
     item = {
         "name": candidate,
@@ -203,6 +203,7 @@ for candidate in nginx_candidates[:10]:
 proxy = {
     "inspection_succeeded": all_inspected,
     "candidate_count": len(nginx_candidates),
+    "inspected_count": len(proxy_items),
     "route_present": route_found,
     "items": proxy_items,
     "multi_proxy_topology_supported": True,

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -156,10 +156,15 @@ if listeners_result.returncode == 0:
         if match:
             ports.add(int(match.group(1)))
 receipt["listeners"] = {str(port): port in ports for port in (80, 443, 43300)}
-receipt["listeners"]["inspection_succeeded"] = listeners_result.returncode == 0
+receipt["listeners"].update({
+    "inspection_succeeded": listeners_result.returncode == 0,
+    "required_origin_ports": [80, 43300],
+    "host_tls_listener_required": False,
+    "tls_termination": "host" if 443 in ports else "external_or_container_edge",
+})
 if listeners_result.returncode:
     failures.append("listener_inspection_failed")
-elif not all(port in ports for port in (80, 443, 43300)):
+elif not all(port in ports for port in (80, 43300)):
     failures.append("required_listener_missing")
 
 docker_result = run(["docker", "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Status}}"])
@@ -176,19 +181,38 @@ if docker_result.returncode:
 
 nginx_candidates = [item["name"] for item in containers
                     if re.search(r"nginx|proxy", item["name"] + " " + item["image"], re.I)]
-proxy = {"inspection_succeeded": False, "route_present": False, "directives": [], "resolved_proxy_targets": []}
-if len(nginx_candidates) != 1:
-    failures.append("proxy_container_not_unique")
-else:
-    nginx_result = run(["docker", "exec", nginx_candidates[0], "nginx", "-T"])
-    proxy["inspection_succeeded"] = nginx_result.returncode == 0
+proxy_items = []
+route_found = False
+all_inspected = bool(nginx_candidates)
+for candidate in nginx_candidates[:10]:
+    nginx_result = run(["docker", "exec", candidate, "nginx", "-T"])
+    item = {
+        "name": candidate,
+        "inspection_succeeded": nginx_result.returncode == 0,
+        "route_present": False,
+        "directives": [],
+        "resolved_proxy_targets": [],
+    }
     if nginx_result.returncode:
-        failures.append("proxy_inspection_failed")
+        all_inspected = False
     else:
         servers = parse_proxy_servers(nginx_result.stdout)
-        proxy["route_present"], proxy["resolved_proxy_targets"], proxy["directives"] = route_present(servers)
-        if not proxy["route_present"]:
-            failures.append("octopus_route_missing")
+        item["route_present"], item["resolved_proxy_targets"], item["directives"] = route_present(servers)
+        route_found = route_found or item["route_present"]
+    proxy_items.append(item)
+proxy = {
+    "inspection_succeeded": all_inspected,
+    "candidate_count": len(nginx_candidates),
+    "route_present": route_found,
+    "items": proxy_items,
+    "multi_proxy_topology_supported": True,
+}
+if not nginx_candidates:
+    failures.append("proxy_container_missing")
+elif not all_inspected:
+    failures.append("proxy_inspection_failed")
+if nginx_candidates and all_inspected and not route_found:
+    failures.append("octopus_route_missing")
 receipt["proxy"] = proxy
 
 health, _ = bounded_get("http://127.0.0.1:43300/api/health")

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -92,13 +92,15 @@ def test_version_requires_exact_expected_release_not_http_success_or_substring()
     assert matches("x" * 4097 + "1.0.122") is False
 
 
-def test_multi_proxy_topology_is_inspected_and_route_can_exist_in_any_candidate():
+def test_multi_proxy_topology_inspects_every_candidate_and_route_can_exist_in_any():
     source = ACTION.read_text(encoding="utf-8")
     inspection = source.split("nginx_candidates =", 1)[1].split('receipt["proxy"] = proxy', 1)[0]
-    assert 'for candidate in nginx_candidates[:10]:' in inspection
+    assert 'for candidate in nginx_candidates:' in inspection
+    assert 'nginx_candidates[:10]' not in inspection
     assert 'run(["docker", "exec", candidate, "nginx", "-T"])' in inspection
     assert 'route_found = route_found or item["route_present"]' in inspection
     assert '"candidate_count": len(nginx_candidates)' in inspection
+    assert '"inspected_count": len(proxy_items)' in inspection
     assert '"multi_proxy_topology_supported": True' in inspection
     assert 'failures.append("proxy_container_missing")' in inspection
     assert 'failures.append("proxy_inspection_failed")' in inspection

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -25,6 +25,7 @@ def test_ed_new_workflow_and_dispatch_allowlist_dedicated_action():
     assert f"host-status|{OPERATION}|recover-v3-runtime-contract" in workflow
     assert f"steps.request.outputs.operation == '{OPERATION}'" in workflow
     assert f"trusted-main/scripts/operator/actions/{OPERATION}.sh" in workflow
+    assert "ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS" in workflow
     assert f"{OPERATION})" in dispatch
     assert f"exec bash scripts/operator/actions/{OPERATION}.sh" in dispatch
 
@@ -91,17 +92,32 @@ def test_version_requires_exact_expected_release_not_http_success_or_substring()
     assert matches("x" * 4097 + "1.0.122") is False
 
 
-def test_proxy_inspection_failure_is_explicit_and_fail_closed():
+def test_multi_proxy_topology_is_inspected_and_route_can_exist_in_any_candidate():
     source = ACTION.read_text(encoding="utf-8")
-    inspection = source.split('nginx_result = run(["docker", "exec"', 1)[1].split(
-        'receipt["proxy"] = proxy', 1
-    )[0]
-    assert 'proxy["inspection_succeeded"] = nginx_result.returncode == 0' in inspection
+    inspection = source.split("nginx_candidates =", 1)[1].split('receipt["proxy"] = proxy', 1)[0]
+    assert 'for candidate in nginx_candidates[:10]:' in inspection
+    assert 'run(["docker", "exec", candidate, "nginx", "-T"])' in inspection
+    assert 'route_found = route_found or item["route_present"]' in inspection
+    assert '"candidate_count": len(nginx_candidates)' in inspection
+    assert '"multi_proxy_topology_supported": True' in inspection
+    assert 'failures.append("proxy_container_missing")' in inspection
     assert 'failures.append("proxy_inspection_failed")' in inspection
-    assert "if nginx_result.returncode:" in inspection
-    assert "else:" in inspection
+    assert 'failures.append("octopus_route_missing")' in inspection
+    assert "proxy_container_not_unique" not in source
     assert "|| true" not in inspection
     assert "2>/dev/null" not in inspection
+
+
+def test_host_443_is_informational_when_public_tls_is_verified_separately():
+    source = ACTION.read_text(encoding="utf-8")
+    listener_block = source.split('listeners_result = run(["ss", "-H", "-lnt"])', 1)[1].split(
+        'docker_result = run(', 1
+    )[0]
+    assert '"required_origin_ports": [80, 43300]' in listener_block
+    assert '"host_tls_listener_required": False' in listener_block
+    assert '"tls_termination": "host" if 443 in ports else "external_or_container_edge"' in listener_block
+    assert 'all(port in ports for port in (80, 43300))' in listener_block
+    assert 'all(port in ports for port in (80, 443, 43300))' not in listener_block
 
 
 def test_served_certificate_is_independent_from_https_and_installed_certs():


### PR DESCRIPTION
Follow-up to #548 after running the audit against MevSpace.

The live read-only receipt proved Octopus itself is healthy on 127.0.0.1:43300 at release 1.0.122, DNS/public HTTP(S) are reachable, and the served wildcard certificate is valid. It also showed the production edge has two nginx layers (`public-auth-edge` plus the internal proxy) and no host-level 443 listener, so the prior audit stopped on topology assumptions rather than a service failure.

This PR:
- inspects all nginx/proxy candidates and accepts the Octopus route when it is proven in any inspected nginx layer
- still fails closed if a candidate cannot be inspected, no proxy exists, or no Octopus route is found
- treats host 443 as informational because public TLS is independently verified against the certificate actually served on `octopus.ed-finder.app:443`
- continues to require origin HTTP (80) and Octopus loopback (43300)
- records whether TLS is host-local or external/container-edge terminated
- restores backwards-compatible `ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || ED_NEW_OPERATOR_KNOWN_HOSTS` handling, matching the configured production environment
- adds regression tests for the multi-proxy topology, non-required host 443, and known-hosts compatibility

No production mutation is performed by the audit itself; it remains read-only, DB/env/private-key safe, and bounded.