### PR TITLE
Add hardened read-only Octopus edge status operation

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - host-status
+          - octopus-edge-status
           - recover-v3-runtime-contract
           - octopus-qdrant-healthcheck-repair
   push:
@@ -62,7 +63,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair) ;;
+            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -139,6 +140,25 @@ jobs:
               "$SSH_USER@$SSH_HOST" \
               'cd /opt/ed-finder && bash -s' \
               < trusted-main/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+
+      - name: Inspect Octopus edge status
+        if: steps.request.outputs.operation == 'octopus-edge-status'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'cd /opt/ed-finder && bash -s' \
+              < trusted-main/scripts/operator/actions/octopus-edge-status.sh
 
       - name: Recover retained V3 runtime contract
         if: steps.request.outputs.operation == 'recover-v3-runtime-contract'

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -22,6 +22,12 @@ Current scripts:
   broken `wget` healthcheck in Octopus v1.0.122's Qdrant Compose service,
   recreates only Qdrant, and starts/verifies the blocked web service. It does
   not read `.env`, access a database, or modify volumes.
+- `actions/octopus-edge-status.sh`: fail-closed, read-only status receipt for
+  Octopus v1.0.122 on `ed-finder-prod`. It reports the bounded edge listeners,
+  relevant containers, internal health/version, sanitized nginx routing, DNS,
+  public HTTP/HTTPS responses, and the certificate actually served for Octopus
+  SNI. It does not read environment or private-key files, access a database,
+  write files, or restart services.
 - `recover_v3_runtime_contract.py`: read-only helper for the allowlisted ed-new
   `recover-v3-runtime-contract` operation. It identifies the retained Phase 4C
   R5 Compose source root from container labels, rejects secret-like and unsafe

--- a/scripts/operator/actions/dispatch.sh
+++ b/scripts/operator/actions/dispatch.sh
@@ -23,6 +23,9 @@ case "$stage" in
   octopus-qdrant-healthcheck-repair)
     exec bash scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
     ;;
+  octopus-edge-status)
+    exec bash scripts/operator/actions/octopus-edge-status.sh
+    ;;
   latest-stage18j-summary)
     exec bash scripts/operator/actions/latest-artifact-summary.sh "stage-18j"
     ;;

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This action deliberately delegates all inspection to a fixed Python program:
+# no caller-controlled command, path, hostname, or container name is accepted.
+exec python3 - <<'PY'
+import hashlib
+import ipaddress
+import json
+import re
+import socket
+import subprocess
+import sys
+
+EXPECTED_HOST = "ed-finder-prod"
+EXPECTED_FQDN = "nb79a3d.mevnode.com"
+PUBLIC_NAME = "octopus.ed-finder.app"
+EXPECTED_VERSION = "1.0.122"
+MAX_RESPONSE = 4096
+
+
+def run(argv, *, stdin=None, timeout=15):
+    try:
+        return subprocess.run(argv, input=stdin, text=True, capture_output=True,
+                              timeout=timeout, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
+
+
+def bounded_get(url, *, insecure=False):
+    argv = ["curl", "--silent", "--show-error", "--location", "--max-time", "10",
+            "--max-filesize", str(MAX_RESPONSE), "--output", "-",
+            "--write-out", "\n%{http_code}"]
+    if insecure:
+        argv.append("--insecure")
+    result = run(argv + [url])
+    body, sep, code = result.stdout.rpartition("\n")
+    bounded = body[:MAX_RESPONSE]
+    return {
+        "inspection_succeeded": result.returncode == 0 and bool(sep),
+        "status_code": int(code) if sep and code.isdigit() else None,
+        "body_bytes": len(bounded.encode("utf-8")),
+        "body_sha256": hashlib.sha256(bounded.encode()).hexdigest() if sep else None,
+    }, bounded
+
+
+def version_matches(body):
+    if len(body.encode("utf-8")) > MAX_RESPONSE:
+        return False
+    try:
+        value = json.loads(body)
+    except json.JSONDecodeError:
+        value = body.strip()
+    candidates = []
+    if isinstance(value, str):
+        candidates.append(value)
+    elif isinstance(value, dict):
+        candidates.extend(str(value.get(key, "")) for key in ("version", "release", "tag"))
+    return any(re.search(r"(?:^|[^0-9])v?" + re.escape(EXPECTED_VERSION) + r"(?:$|[^0-9])", item)
+               for item in candidates)
+
+
+def parse_proxy_servers(config):
+    servers = []
+    current = None
+    depth = 0
+    for raw in config.splitlines():
+        line = raw.strip()
+        if re.fullmatch(r"server\s*\{", line):
+            if current is not None:
+                return []  # ambiguous nested server block
+            current = []
+            depth = 1
+            continue
+        if current is None:
+            continue
+        depth += line.count("{") - line.count("}")
+        match = re.fullmatch(r"(set\s+\$[A-Za-z_][A-Za-z0-9_]*\s+[^;\s]+|server_name\s+[^;]+|proxy_pass\s+[^;\s]+)\s*;", line)
+        if match:
+            current.append(match.group(1) + ";")
+        if depth == 0:
+            servers.append(current)
+            current = None
+    return servers if current is None else []
+
+
+def route_present(servers):
+    all_directives = []
+    all_resolved = []
+    found = False
+    for directives in servers:
+        all_directives.extend(directives)
+        present, resolved = route_present_in_server(directives)
+        all_resolved.extend(resolved)
+        found = found or present
+    return found, all_resolved[:20], all_directives[:100]
+
+
+def route_present_in_server(directives):
+    variables = {}
+    proxy_targets = []
+    names = []
+    for directive in directives:
+        if directive.startswith("set "):
+            _, variable, value = directive[:-1].split(None, 2)
+            variables[variable] = value
+        elif directive.startswith("proxy_pass "):
+            proxy_targets.append(directive[len("proxy_pass "):-1])
+        elif directive.startswith("server_name "):
+            names.extend(directive[len("server_name "):-1].split())
+    resolved = [variables.get(target, target) for target in proxy_targets]
+    target_ok = any(re.fullmatch(r"https?://octopus-web(?::3000)?(?:/.*)?", target) or
+                    re.fullmatch(r"https?://(?:127\.0\.0\.1|localhost):43300(?:/.*)?", target)
+                    for target in resolved)
+    return PUBLIC_NAME in names and target_ok, resolved[:20]
+
+
+receipt = {
+    "schema_version": "ed-finder/operator-operation-result/v1",
+    "operation": "octopus-edge-status",
+    "status": "stopped",
+    "read_only": True,
+    "db_access_performed": False,
+    "db_writes_performed": False,
+    "env_files_read": False,
+    "private_keys_read": False,
+    "service_changes_performed": False,
+    "filesystem_writes_performed": False,
+}
+failures = []
+
+host = socket.gethostname().split(".")[0]
+fqdn_result = run(["hostname", "-f"])
+fqdn = fqdn_result.stdout.strip()
+receipt["host"] = {"short": host, "fqdn": fqdn}
+if host != EXPECTED_HOST or fqdn_result.returncode or fqdn != EXPECTED_FQDN:
+    failures.append("unexpected_host_identity")
+if run(["pwd", "-P"]).stdout.strip() != "/opt/ed-finder":
+    failures.append("unexpected_working_directory")
+if failures:
+    receipt["failures"] = sorted(set(failures))
+    print(json.dumps(receipt, separators=(",", ":"), sort_keys=True))
+    sys.exit(1)
+
+listeners_result = run(["ss", "-H", "-lnt"])
+ports = set()
+if listeners_result.returncode == 0:
+    for line in listeners_result.stdout.splitlines():
+        match = re.search(r"\s(?:\[[^]]+\]|[^\s]+):(\d+)\s", line + " ")
+        if match:
+            ports.add(int(match.group(1)))
+receipt["listeners"] = {str(port): port in ports for port in (80, 443, 43300)}
+receipt["listeners"]["inspection_succeeded"] = listeners_result.returncode == 0
+if listeners_result.returncode:
+    failures.append("listener_inspection_failed")
+elif not all(port in ports for port in (80, 443, 43300)):
+    failures.append("required_listener_missing")
+
+docker_result = run(["docker", "ps", "--format", "{{.Names}}\t{{.Image}}\t{{.Status}}"])
+containers = []
+if docker_result.returncode == 0:
+    for line in docker_result.stdout.splitlines():
+        fields = line.split("\t", 2)
+        if len(fields) == 3 and re.search(r"octopus|nginx|proxy", fields[0] + " " + fields[1], re.I):
+            containers.append(dict(zip(("name", "image", "status"), fields)))
+receipt["containers"] = {"inspection_succeeded": docker_result.returncode == 0,
+                         "items": containers[:20], "truncated": len(containers) > 20}
+if docker_result.returncode:
+    failures.append("container_inspection_failed")
+
+nginx_candidates = [item["name"] for item in containers
+                    if re.search(r"nginx|proxy", item["name"] + " " + item["image"], re.I)]
+proxy = {"inspection_succeeded": False, "route_present": False, "directives": [], "resolved_proxy_targets": []}
+if len(nginx_candidates) != 1:
+    failures.append("proxy_container_not_unique")
+else:
+    nginx_result = run(["docker", "exec", nginx_candidates[0], "nginx", "-T"])
+    proxy["inspection_succeeded"] = nginx_result.returncode == 0
+    if nginx_result.returncode:
+        failures.append("proxy_inspection_failed")
+    else:
+        servers = parse_proxy_servers(nginx_result.stdout)
+        proxy["route_present"], proxy["resolved_proxy_targets"], proxy["directives"] = route_present(servers)
+        if not proxy["route_present"]:
+            failures.append("octopus_route_missing")
+receipt["proxy"] = proxy
+
+health, _ = bounded_get("http://127.0.0.1:43300/api/health")
+version, version_body = bounded_get("http://127.0.0.1:43300/api/version")
+version["expected_release"] = EXPECTED_VERSION
+version["expected_release_present"] = version_matches(version_body)
+version["bounded_response"] = version_body[:MAX_RESPONSE]
+receipt["octopus_internal"] = {"health": health, "version": version}
+if health["status_code"] not in range(200, 400) or version["status_code"] not in range(200, 400):
+    failures.append("octopus_internal_http_failed")
+if not version["expected_release_present"]:
+    failures.append("unexpected_octopus_version")
+
+try:
+    dns_values = sorted({str(ipaddress.ip_address(item[4][0])) for item in
+                         socket.getaddrinfo(PUBLIC_NAME, 443, type=socket.SOCK_STREAM)})
+    dns_ok = bool(dns_values)
+except (OSError, ValueError):
+    dns_values, dns_ok = [], False
+receipt["dns"] = {"inspection_succeeded": dns_ok, "addresses": dns_values[:16]}
+if not dns_ok:
+    failures.append("dns_resolution_failed")
+
+http, _ = bounded_get("http://" + PUBLIC_NAME + "/")
+https, _ = bounded_get("https://" + PUBLIC_NAME + "/", insecure=True)
+https["tls_verification_bypassed_for_response_only"] = True
+receipt["public_http"] = {"http": http, "https": https}
+if not http["inspection_succeeded"] or not https["inspection_succeeded"]:
+    failures.append("public_http_inspection_failed")
+elif http["status_code"] not in range(200, 400) or https["status_code"] not in range(200, 400):
+    failures.append("public_http_status_failed")
+
+served = {"inspection_succeeded": False, "certificate_present": False, "hostname_valid": False,
+          "currently_valid": False, "served_certificate_valid": False, "names": [],
+          "installed_certificate_availability": "not_inspected"}
+handshake = run(["openssl", "s_client", "-connect", PUBLIC_NAME + ":443", "-servername", PUBLIC_NAME,
+                 "-verify_hostname", PUBLIC_NAME, "-verify_return_error", "-showcerts"], stdin="", timeout=15)
+cert_match = re.search(r"-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", handshake.stdout, re.S)
+if handshake.returncode != 0 or not cert_match:
+    failures.append("served_certificate_fetch_failed")
+else:
+    cert = cert_match.group(0) + "\n"
+    metadata = run(["openssl", "x509", "-noout", "-subject", "-issuer", "-dates", "-ext", "subjectAltName"], stdin=cert)
+    hostname_check = run(["openssl", "x509", "-noout", "-checkhost", PUBLIC_NAME], stdin=cert)
+    validity_check = run(["openssl", "x509", "-noout", "-checkend", "0"], stdin=cert)
+    served["inspection_succeeded"] = metadata.returncode == 0
+    served["certificate_present"] = metadata.returncode == 0
+    served["hostname_valid"] = hostname_check.returncode == 0
+    served["currently_valid"] = validity_check.returncode == 0
+    served["served_certificate_valid"] = (
+        handshake.returncode == 0 and served["certificate_present"] and
+        served["hostname_valid"] and served["currently_valid"]
+    )
+    served["names"] = sorted(set(re.findall(r"DNS:([^,\s]+)", metadata.stdout)))[:50]
+    dates = dict(re.findall(r"^(notBefore|notAfter)=(.*)$", metadata.stdout, re.M))
+    served.update(dates)
+    if not served["served_certificate_valid"]:
+        failures.append("served_certificate_invalid")
+receipt["served_certificate"] = served
+
+receipt["failures"] = sorted(set(failures))
+receipt["status"] = "success" if not failures else "stopped"
+print(json.dumps(receipt, separators=(",", ":"), sort_keys=True))
+sys.exit(0 if not failures else 1)
+PY

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Keep the operation contract machine-readable even if the Python runtime is absent.
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' '{"schema_version":"ed-finder/operator-operation-result/v1","operation":"octopus-edge-status","status":"stopped","read_only":true,"db_access_performed":false,"db_writes_performed":false,"env_files_read":false,"private_keys_read":false,"service_changes_performed":false,"filesystem_writes_performed":false,"failures":["python3_unavailable"]}'
+    exit 1
+fi
+
 # This action deliberately delegates all inspection to a fixed Python program:
 # no caller-controlled command, path, hostname, or container name is accepted.
 exec python3 - <<'PY'

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from pathlib import Path
 
@@ -26,6 +27,22 @@ def test_ed_new_workflow_and_dispatch_allowlist_dedicated_action():
     assert f"trusted-main/scripts/operator/actions/{OPERATION}.sh" in workflow
     assert f"{OPERATION})" in dispatch
     assert f"exec bash scripts/operator/actions/{OPERATION}.sh" in dispatch
+
+
+def test_missing_python_still_emits_structured_stopped_receipt():
+    result = subprocess.run(
+        ["/bin/bash", str(ACTION)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/definitely-missing"},
+    )
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "ed-finder/operator-operation-result/v1"
+    assert payload["operation"] == OPERATION
+    assert payload["status"] == "stopped"
+    assert payload["read_only"] is True
+    assert payload["failures"] == ["python3_unavailable"]
 
 
 def test_variable_docker_network_proxy_route_is_correlated_in_same_server():

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -1,0 +1,125 @@
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / "scripts/operator/actions/octopus-edge-status.sh"
+WORKFLOW = ROOT / ".github/workflows/chatgpt-ed-new-ops.yml"
+DISPATCH = ROOT / "scripts/operator/actions/dispatch.sh"
+OPERATION = "octopus-edge-status"
+
+
+def _python_functions():
+    source = ACTION.read_text(encoding="utf-8")
+    program = source.split("exec python3 - <<'PY'\n", 1)[1].rsplit("\nPY\n", 1)[0]
+    namespace = {}
+    exec(program.split("receipt = {", 1)[0], namespace)
+    return namespace
+
+
+def test_ed_new_workflow_and_dispatch_allowlist_dedicated_action():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    dispatch = DISPATCH.read_text(encoding="utf-8")
+    assert workflow.count(f"          - {OPERATION}\n") == 1
+    assert f"host-status|{OPERATION}|recover-v3-runtime-contract" in workflow
+    assert f"steps.request.outputs.operation == '{OPERATION}'" in workflow
+    assert f"trusted-main/scripts/operator/actions/{OPERATION}.sh" in workflow
+    assert f"{OPERATION})" in dispatch
+    assert f"exec bash scripts/operator/actions/{OPERATION}.sh" in dispatch
+
+
+def test_variable_docker_network_proxy_route_is_correlated_in_same_server():
+    functions = _python_functions()
+    config = """
+server {
+  listen 443 ssl;
+  server_name octopus.ed-finder.app;
+  set $octopus_upstream http://octopus-web:3000;
+  location / { proxy_pass $octopus_upstream; }
+  proxy_pass $octopus_upstream;
+  ssl_certificate_key /do/not/report/privkey.pem;
+}
+"""
+    servers = functions["parse_proxy_servers"](config)
+    present, resolved, emitted = functions["route_present"](servers)
+    assert present is True
+    assert resolved == ["http://octopus-web:3000"]
+    assert "43300" not in " ".join(emitted)
+    assert all(item.startswith(("set ", "server_name ", "proxy_pass ")) for item in emitted)
+    assert "privkey" not in " ".join(emitted)
+
+
+def test_proxy_variable_cannot_be_defined_in_an_unrelated_server():
+    functions = _python_functions()
+    config = """
+server {
+  server_name unrelated.example;
+  set $octopus_upstream http://octopus-web:3000;
+}
+server {
+  server_name octopus.ed-finder.app;
+  proxy_pass $octopus_upstream;
+}
+"""
+    present, _, _ = functions["route_present"](functions["parse_proxy_servers"](config))
+    assert present is False
+
+
+def test_version_requires_exact_expected_release_not_http_success_or_substring():
+    matches = _python_functions()["version_matches"]
+    assert matches('{"version":"1.0.122"}') is True
+    assert matches('{"release":"v1.0.122"}') is True
+    assert matches('{"version":"1.0.121"}') is False
+    assert matches('{"version":"11.0.1220"}') is False
+    assert matches("x" * 4097 + "1.0.122") is False
+
+
+def test_proxy_inspection_failure_is_explicit_and_fail_closed():
+    source = ACTION.read_text(encoding="utf-8")
+    inspection = source.split('nginx_result = run(["docker", "exec"', 1)[1].split(
+        'receipt["proxy"] = proxy', 1
+    )[0]
+    assert 'proxy["inspection_succeeded"] = nginx_result.returncode == 0' in inspection
+    assert 'failures.append("proxy_inspection_failed")' in inspection
+    assert "if nginx_result.returncode:" in inspection
+    assert "else:" in inspection
+    assert "|| true" not in inspection
+    assert "2>/dev/null" not in inspection
+
+
+def test_served_certificate_is_independent_from_https_and_installed_certs():
+    source = ACTION.read_text(encoding="utf-8")
+    assert '"tls_verification_bypassed_for_response_only"] = True' in source
+    assert '"installed_certificate_availability": "not_inspected"' in source
+    assert '"-servername", PUBLIC_NAME' in source
+    assert '"-verify_hostname", PUBLIC_NAME, "-verify_return_error"' in source
+    served_block = source.split('served = {', 1)[1].split('receipt["served_certificate"]', 1)[0]
+    assert "/etc/letsencrypt" not in served_block
+    assert "installed_certificate" not in served_block.replace(
+        '"installed_certificate_availability": "not_inspected"', ""
+    )
+    assert 'served["certificate_present"] = metadata.returncode == 0' in served_block
+    assert 'served["hostname_valid"] = hostname_check.returncode == 0' in served_block
+    assert 'served["currently_valid"] = validity_check.returncode == 0' in served_block
+
+
+def test_action_command_surface_is_read_only_secret_safe_and_bounded():
+    source = ACTION.read_text(encoding="utf-8")
+    assert 'EXPECTED_HOST = "ed-finder-prod"' in source
+    assert 'EXPECTED_FQDN = "nb79a3d.mevnode.com"' in source
+    assert "MAX_RESPONSE = 4096" in source
+    forbidden = (
+        ".env", "Config.Env", "POSTGRES", "psql", "mysql", "sqlite", "/root/.ssh",
+        "id_rsa", "privkey.pem", "docker restart", "compose up", "compose down",
+        "systemctl", "service restart", "shred", "chmod", "chown",
+    )
+    for value in forbidden:
+        assert value not in source
+    for safety_field in (
+        '"db_access_performed": False', '"db_writes_performed": False',
+        '"env_files_read": False', '"private_keys_read": False',
+        '"service_changes_performed": False', '"filesystem_writes_performed": False',
+    ):
+        assert safety_field in source
+    syntax = subprocess.run(["bash", "-n", str(ACTION)], capture_output=True, text=True)
+    assert syntax.returncode == 0, syntax.stderr


### PR DESCRIPTION
Closed as redundant. #548 already merged the corrected audit implementation, and #549 subsequently merged the production-topology fixes after a live MevSpace run. No code from this duplicate PR is needed.