### PR TITLE
Harden Octopus Qdrant healthcheck repair

### DIFF
--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -20,8 +20,10 @@ Current scripts:
   Hetzner-only commands.
 - `actions/octopus-qdrant-healthcheck-repair.sh`: narrowly repairs the known
   broken `wget` healthcheck in Octopus v1.0.122's Qdrant Compose service,
-  recreates only Qdrant, and starts/verifies the blocked web service. It does
-  not read `.env`, access a database, or modify volumes.
+  accepts the exact repaired state on a resumable rerun, recreates only Qdrant,
+  verifies the existing Postgres container is healthy without accessing it,
+  and starts/verifies web without managing its dependencies. It does not read
+  `.env`, access a database, or modify volumes.
 - `actions/octopus-edge-status.sh`: fail-closed, read-only status receipt for
   Octopus v1.0.122 on `ed-finder-prod`. It reports the bounded edge listeners,
   relevant containers, internal health/version, sanitized nginx routing, DNS,

--- a/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+++ b/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
@@ -5,10 +5,12 @@ OCTOPUS_DIR="/opt/octopus"
 COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"
 EXPECTED_HOST="ed-finder-prod"
 EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"
+EXPECTED_POSTGRES_IMAGE="postgres:17-alpine"
 BACKUP=""
 EDIT_COMMITTED=false
 QDRANT_RECREATED=false
 WEB_STARTED=false
+EXPECTED_HEALTHCHECK='test: ["CMD-SHELL", "while read -r _ local _ state _; do if [ $$state = 0A ]; then case $$local in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp; while read -r _ local _ state _; do if [ $$state = 0A ]; then case $$local in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp6; exit 1"]'
 
 receipt() {
   local status="$1" reason="$2"
@@ -55,14 +57,15 @@ command -v docker >/dev/null 2>&1 || stop "docker_missing"
 docker compose version >/dev/null 2>&1 || stop "docker_compose_missing"
 
 # Validate the rendered service identity without displaying interpolated values.
-read -r rendered_image rendered_web_image < <(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" config --format json \
-  | python3 -c 'import json,sys; d=json.load(sys.stdin).get("services",{}); print((d.get("qdrant",{}) or {}).get("image", ""), (d.get("web",{}) or {}).get("image", ""))') \
+read -r rendered_image rendered_web_image rendered_postgres_image < <(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" config --format json \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin).get("services",{}); print((d.get("qdrant",{}) or {}).get("image", ""), (d.get("web",{}) or {}).get("image", ""), (d.get("postgres",{}) or {}).get("image", ""))') \
   || stop "compose_render_failed"
 [ "$rendered_image" = "$EXPECTED_IMAGE" ] || stop "unexpected_qdrant_image"
 case "$rendered_web_image" in
   ghcr.io/octopusreview/octopus-selfhost:1.0.122) ;;
   *) stop "unexpected_octopus_web_image" ;;
 esac
+[ "$rendered_postgres_image" = "$EXPECTED_POSTGRES_IMAGE" ] || stop "unexpected_postgres_image"
 current_qdrant_id="$(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" ps -q qdrant)"
 [ -n "$current_qdrant_id" ] || stop "existing_qdrant_container_missing"
 current_qdrant_image="$(docker inspect --format '{{.Config.Image}}' "$current_qdrant_id" 2>/dev/null)" \
@@ -72,7 +75,7 @@ current_qdrant_image="$(docker inspect --format '{{.Config.Image}}' "$current_qd
 # The editor accepts exactly one qdrant healthcheck block and exactly the known
 # wget /readyz failure mode. It changes only healthcheck.test, preserving timing.
 replacement_file="$(mktemp "$OCTOPUS_DIR/.qdrant-healthcheck.XXXXXX")"
-if ! python3 - "$COMPOSE_FILE" "$replacement_file" <<'PY'
+if editor_state="$(python3 - "$COMPOSE_FILE" "$replacement_file" "$EXPECTED_HEALTHCHECK" <<'PY'
 from pathlib import Path
 import re
 import sys
@@ -118,35 +121,48 @@ test_index = tests[0]
 test_line = lines[test_index]
 expected = ('test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", '
             '"http://localhost:6333/readyz"]')
-if test_line.strip() != expected:
-    raise SystemExit("qdrant healthcheck is not the expected broken wget readiness check")
-if any("wget" in line for i, line in enumerate(lines) if i != test_index and start <= i < hend):
-    raise SystemExit("unexpected additional wget content in qdrant healthcheck")
-
 prefix = " " * (indent + 4)
-command = ('test: ["CMD-SHELL", "while read -r _ local _ state _; do if [ $$state = 0A ]; '
-           'then case $$local in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp; '
-           'while read -r _ local _ state _; do if [ $$state = 0A ]; then case $$local '
-           'in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp6; exit 1"]\n')
-lines[test_index] = prefix + command
+fixed = sys.argv[3]
+if test_line.strip() == expected:
+    if any("wget" in line for i, line in enumerate(lines) if i != test_index and start <= i < hend):
+        raise SystemExit("unexpected additional wget content in qdrant healthcheck")
+    lines[test_index] = prefix + fixed + "\n"
+    state = "patched"
+elif test_line.strip() == fixed:
+    state = "already_patched"
+else:
+    raise SystemExit("qdrant healthcheck is neither the exact broken nor fixed state")
+
 Path(sys.argv[2]).write_text("".join(lines), encoding="utf-8")
+print(state)
 PY
-then
+)"; then
+  case "$editor_state" in
+    patched|already_patched) ;;
+    *) rm -f -- "$replacement_file"; stop "unexpected_healthcheck_editor_result" ;;
+  esac
+else
   rm -f -- "$replacement_file"
-  stop "expected_broken_healthcheck_not_found"
+  stop "expected_healthcheck_state_not_found"
 fi
 
-timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-BACKUP="$COMPOSE_FILE.before-qdrant-healthcheck-repair.$timestamp"
-[ ! -e "$BACKUP" ] || { rm -f -- "$replacement_file"; stop "backup_already_exists"; }
-cp --preserve=mode,ownership,timestamps -- "$COMPOSE_FILE" "$BACKUP"
-chown --reference="$COMPOSE_FILE" "$replacement_file"
-chmod --reference="$COMPOSE_FILE" "$replacement_file"
-mv -- "$replacement_file" "$COMPOSE_FILE"
+if [ "$editor_state" = patched ]; then
+  timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  BACKUP="$COMPOSE_FILE.before-qdrant-healthcheck-repair.$timestamp"
+  [ ! -e "$BACKUP" ] || { rm -f -- "$replacement_file"; stop "backup_already_exists"; }
+  cp --preserve=mode,ownership,timestamps -- "$COMPOSE_FILE" "$BACKUP"
+  chown --reference="$COMPOSE_FILE" "$replacement_file"
+  chmod --reference="$COMPOSE_FILE" "$replacement_file"
+  mv -- "$replacement_file" "$COMPOSE_FILE"
+else
+  rm -f -- "$replacement_file"
+fi
 
 docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" config --quiet \
   || stop "edited_compose_validation_failed"
-EDIT_COMMITTED=true
+if [ "$editor_state" = patched ]; then
+  EDIT_COMMITTED=true
+fi
 
 docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" up -d --no-deps --force-recreate qdrant \
   >/dev/null || stop "qdrant_recreate_failed"
@@ -171,18 +187,38 @@ with urlopen("http://127.0.0.1:43333/readyz", timeout=5) as response:
         raise SystemExit(1)
 PY
 
-docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" up -d web >/dev/null \
+postgres_id="$(docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" ps -q postgres)"
+[ -n "$postgres_id" ] || stop "existing_postgres_container_missing"
+postgres_image="$(docker inspect --format '{{.Config.Image}}' "$postgres_id" 2>/dev/null)" \
+  || stop "existing_postgres_image_inspect_failed"
+[ "$postgres_image" = "$EXPECTED_POSTGRES_IMAGE" ] || stop "unexpected_running_postgres_image"
+postgres_health="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$postgres_id" 2>/dev/null)" \
+  || stop "existing_postgres_inspect_failed"
+[ "$postgres_health" = healthy ] || stop "existing_postgres_not_healthy"
+
+docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" up -d --no-deps web >/dev/null \
   || stop "web_start_failed"
 WEB_STARTED=true
 
 web_ready=false
 for _ in $(seq 1 60); do
   if python3 - <<'PY'
+import json
 from urllib.request import urlopen
-for path in ("/", "/api/health", "/api/version"):
+
+def version_matches(payload):
+    return isinstance(payload, dict) and payload.get("version") == "1.0.122"
+
+for path in ("/", "/api/health"):
     with urlopen("http://127.0.0.1:43300" + path, timeout=5) as response:
         if not 200 <= response.status < 400:
             raise SystemExit(1)
+with urlopen("http://127.0.0.1:43300/api/version", timeout=5) as response:
+    if response.status != 200:
+        raise SystemExit(1)
+    payload = json.loads(response.read(4096).decode("utf-8"))
+    if not version_matches(payload):
+        raise SystemExit(1)
 PY
   then web_ready=true; break; fi
   sleep 2

--- a/tests/test_octopus_qdrant_healthcheck_repair.py
+++ b/tests/test_octopus_qdrant_healthcheck_repair.py
@@ -1,18 +1,27 @@
+import re
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "chatgpt-ops.yml"
 DISPATCH = ROOT / "scripts" / "operator" / "actions" / "dispatch.sh"
 ACTION = ROOT / "scripts" / "operator" / "actions" / "octopus-qdrant-healthcheck-repair.sh"
 OPERATION = "octopus-qdrant-healthcheck-repair"
+BROKEN_HEALTHCHECK = ('test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", '
+                      '"http://localhost:6333/readyz"]')
+FIXED_HEALTHCHECK = ('test: ["CMD-SHELL", "while read -r _ local _ state _; do if [ $$state = 0A ]; '
+                     'then case $$local in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp; '
+                     'while read -r _ local _ state _; do if [ $$state = 0A ]; then case $$local '
+                     'in *:18BD) exit 0;; esac; fi; done < /proc/net/tcp6; exit 1"]')
 
 
 def _editor_source():
     source = ACTION.read_text(encoding="utf-8")
-    marker = 'if ! python3 - "$COMPOSE_FILE" "$replacement_file" <<\'PY\'\n'
-    return source.split(marker, 1)[1].split("\nPY\nthen", 1)[0]
+    marker = 'if editor_state="$(python3 - "$COMPOSE_FILE" "$replacement_file" "$EXPECTED_HEALTHCHECK" <<\'PY\'\n'
+    return source.split(marker, 1)[1].split("\nPY\n)\"; then", 1)[0]
 
 
 def _run_editor(tmp_path, healthcheck):
@@ -34,7 +43,7 @@ def _run_editor(tmp_path, healthcheck):
         encoding="utf-8",
     )
     result = subprocess.run(
-        [sys.executable, "-", str(compose), str(output)],
+        [sys.executable, "-", str(compose), str(output), FIXED_HEALTHCHECK],
         input=_editor_source(),
         text=True,
         capture_output=True,
@@ -61,33 +70,35 @@ def test_repair_action_has_fail_closed_scope_and_guards():
         'EXPECTED_HOST="ed-finder-prod"',
         'COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"',
         'EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"',
+        'EXPECTED_POSTGRES_IMAGE="postgres:17-alpine"',
         'ghcr.io/octopusreview/octopus-selfhost:1.0.122',
-        'test_line.strip() != expected',
+        'test_line.strip() == expected',
         '"CMD", "wget", "--no-verbose", "--tries=1", "--spider"',
         "*:18BD) exit 0",
         "cp --preserve=mode,ownership,timestamps",
         "config --quiet",
         "up -d --no-deps --force-recreate qdrant",
+        'ps -q postgres)',
+        'postgres_health" = healthy',
+        "up -d --no-deps web",
         "qdrant_health_timeout",
         "http://127.0.0.1:43333/readyz",
         "http://127.0.0.1:43300",
-        'for path in ("/", "/api/health", "/api/version")',
+        'payload.get("version") == "1.0.122"',
     )
     for guard in required:
         assert guard in source
 
     assert ".env" not in source
-    assert "POSTGRES" not in source
     assert "password" not in source.lower()
     assert '"db_access_performed": False' in source
     assert '"volume_configuration_modified": False' in source
 
 
 def test_editor_replaces_only_exact_broken_healthcheck(tmp_path):
-    broken = ('test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", '
-              '"http://localhost:6333/readyz"]')
-    result, compose, output = _run_editor(tmp_path, broken)
+    result, compose, output = _run_editor(tmp_path, BROKEN_HEALTHCHECK)
     assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "patched"
     before = compose.read_text(encoding="utf-8")
     after = output.read_text(encoding="utf-8")
     assert after.replace(after.split("      test:", 1)[1].split("\n", 1)[0],
@@ -97,10 +108,77 @@ def test_editor_replaces_only_exact_broken_healthcheck(tmp_path):
     assert "wget" not in after
 
 
-def test_editor_refuses_drifted_healthcheck(tmp_path):
-    result, _, output = _run_editor(
-        tmp_path,
-        'test: ["CMD", "wget", "--spider", "http://localhost:6333/readyz"]',
-    )
+def test_editor_accepts_exact_fixed_healthcheck_for_rerun(tmp_path):
+    result, compose, output = _run_editor(tmp_path, FIXED_HEALTHCHECK)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "already_patched"
+    assert output.read_text(encoding="utf-8") == compose.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("healthcheck", [
+    'test: ["CMD", "wget", "--spider", "http://localhost:6333/readyz"]',
+    BROKEN_HEALTHCHECK.replace("/readyz", "/healthz"),
+    FIXED_HEALTHCHECK.replace("*:18BD", "*:18BE", 1),
+    'test: ["CMD-SHELL", "exit 0"]',
+])
+def test_editor_refuses_unexpected_healthcheck_variants(tmp_path, healthcheck):
+    result, _, output = _run_editor(tmp_path, healthcheck)
     assert result.returncode != 0
     assert not output.exists()
+
+
+def test_edit_is_committed_only_after_compose_validation_succeeds():
+    source = ACTION.read_text(encoding="utf-8")
+    moved = source.index('mv -- "$replacement_file" "$COMPOSE_FILE"')
+    validation = source.index(
+        'docker compose --project-directory "$OCTOPUS_DIR" -f "$COMPOSE_FILE" config --quiet',
+        moved,
+    )
+    committed = source.index("EDIT_COMMITTED=true", validation)
+    assert moved < validation < committed
+
+    trap = source[source.index("on_exit() {"):source.index("trap on_exit EXIT")]
+    assert '[ "$rc" -ne 0 ] && [ "$EDIT_COMMITTED" = false ]' in trap
+    assert '[ -n "$BACKUP" ] && [ -f "$BACKUP" ]' in trap
+    assert 'cp --preserve=mode,ownership,timestamps -- "$BACKUP" "$COMPOSE_FILE"' in trap
+
+
+def test_web_start_is_dependency_free_after_read_only_postgres_healthcheck():
+    source = ACTION.read_text(encoding="utf-8")
+    postgres_ps = source.index('ps -q postgres)"')
+    postgres_inspect = source.index("postgres_health=", postgres_ps)
+    web_start = source.index("up -d --no-deps web")
+    assert postgres_ps < postgres_inspect < web_start
+    assert "up -d web" not in source
+
+
+def test_action_never_manages_or_mutates_postgres():
+    source = ACTION.read_text(encoding="utf-8")
+    forbidden = (
+        r"docker compose[^\n]*(?:up|restart|stop|rm|create)[^\n]*postgres",
+        r"docker compose[^\n]*exec[^\n]*postgres",
+        r"\bpsql\b",
+        r"\b(?:migrate|migration|schema)\b[^\n]*(?:apply|deploy|update|alter)",
+    )
+    for pattern in forbidden:
+        assert re.search(pattern, source, re.IGNORECASE) is None
+
+
+def test_version_probe_requires_exact_octopus_version():
+    source = ACTION.read_text(encoding="utf-8")
+    function_source = "def version_matches" + source.split("def version_matches", 1)[1].split("\n\n", 1)[0]
+    namespace = {}
+    exec(function_source, namespace)
+    version_matches = namespace["version_matches"]
+
+    assert version_matches({"version": "1.0.122", "buildId": "abc", "server": "selfhost",
+                            "selfHosted": True})
+    for payload in (
+        {"version": "1.0.121"},
+        {"version": "v1.0.122"},
+        {"release": "1.0.122"},
+        {"version": 1.0122},
+        [{"version": "1.0.122"}],
+        "1.0.122",
+    ):
+        assert not version_matches(payload)


### PR DESCRIPTION
## Summary
- harden the allowlisted `octopus-qdrant-healthcheck-repair` operator action
- preserve exact-state and image guards, narrow `--no-deps` service scope, and read-only Postgres verification
- keep compose rollback armed until `docker compose config --quiet` succeeds
- add regression coverage for rollback ordering and fail-closed behavior

## Safety
- no production access from Codex
- no arbitrary remote shell expansion
- no database, volume, migration, or `.env` mutations
- exact Octopus version `1.0.122` verification remains required
- unrelated containers remain out of scope

This PR is intentionally limited to the repair action, its tests, and operator documentation.