### PR TITLE
Correct Octopus production host identity guards

### DIFF
--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -25,7 +25,7 @@ Current scripts:
   and starts/verifies web without managing its dependencies. It does not read
   `.env`, access a database, or modify volumes.
 - `actions/octopus-edge-status.sh`: fail-closed, read-only status receipt for
-  Octopus v1.0.122 on `ed-finder-prod`. It reports the bounded edge listeners,
+  Octopus v1.0.122 on short host `ed-finder`. It reports the bounded edge listeners,
   relevant containers, internal health/version, sanitized nginx routing, DNS,
   public HTTP/HTTPS responses, and the certificate actually served for Octopus
   SNI. It does not read environment or private-key files, access a database,

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -18,7 +18,7 @@ import socket
 import subprocess
 import sys
 
-EXPECTED_HOST = "ed-finder-prod"
+EXPECTED_HOST = "ed-finder"
 EXPECTED_FQDN = "nb79a3d.mevnode.com"
 PUBLIC_NAME = "octopus.ed-finder.app"
 EXPECTED_VERSION = "1.0.122"
@@ -64,6 +64,11 @@ def version_matches(body):
         candidates.extend(str(value.get(key, "")) for key in ("version", "release", "tag"))
     return any(re.search(r"(?:^|[^0-9])v?" + re.escape(EXPECTED_VERSION) + r"(?:$|[^0-9])", item)
                for item in candidates)
+
+
+def host_identity_matches(short_host, fqdn, fqdn_returncode):
+    return (short_host == EXPECTED_HOST and fqdn_returncode == 0 and
+            fqdn == EXPECTED_FQDN)
 
 
 def parse_proxy_servers(config):
@@ -139,7 +144,7 @@ host = socket.gethostname().split(".")[0]
 fqdn_result = run(["hostname", "-f"])
 fqdn = fqdn_result.stdout.strip()
 receipt["host"] = {"short": host, "fqdn": fqdn}
-if host != EXPECTED_HOST or fqdn_result.returncode or fqdn != EXPECTED_FQDN:
+if not host_identity_matches(host, fqdn, fqdn_result.returncode):
     failures.append("unexpected_host_identity")
 if run(["pwd", "-P"]).stdout.strip() != "/opt/ed-finder":
     failures.append("unexpected_working_directory")

--- a/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+++ b/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 OCTOPUS_DIR="/opt/octopus"
 COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"
-EXPECTED_HOST="ed-finder-prod"
+EXPECTED_HOST="ed-finder"
 EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"
 EXPECTED_POSTGRES_IMAGE="postgres:17-alpine"
 BACKUP=""

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -140,7 +140,7 @@ def test_served_certificate_is_independent_from_https_and_installed_certs():
 
 def test_action_command_surface_is_read_only_secret_safe_and_bounded():
     source = ACTION.read_text(encoding="utf-8")
-    assert 'EXPECTED_HOST = "ed-finder-prod"' in source
+    assert 'EXPECTED_HOST = "ed-finder"' in source
     assert 'EXPECTED_FQDN = "nb79a3d.mevnode.com"' in source
     assert "MAX_RESPONSE = 4096" in source
     forbidden = (
@@ -158,3 +158,13 @@ def test_action_command_surface_is_read_only_secret_safe_and_bounded():
         assert safety_field in source
     syntax = subprocess.run(["bash", "-n", str(ACTION)], capture_output=True, text=True)
     assert syntax.returncode == 0, syntax.stderr
+
+
+def test_host_identity_accepts_only_exact_short_host_and_fqdn():
+    matches = _python_functions()["host_identity_matches"]
+
+    assert matches("ed-finder", "nb79a3d.mevnode.com", 0) is True
+    assert matches("ed-finder-prod", "nb79a3d.mevnode.com", 0) is False
+    assert matches("another-host", "nb79a3d.mevnode.com", 0) is False
+    assert matches("ed-finder", "another.example.com", 0) is False
+    assert matches("ed-finder", "nb79a3d.mevnode.com", 1) is False

--- a/tests/test_octopus_qdrant_healthcheck_repair.py
+++ b/tests/test_octopus_qdrant_healthcheck_repair.py
@@ -1,4 +1,3 @@
-import os
 import re
 import subprocess
 import sys
@@ -96,32 +95,15 @@ def test_repair_action_has_fail_closed_scope_and_guards():
     assert '"volume_configuration_modified": False' in source
 
 
-@pytest.mark.parametrize(
-    ("short_host", "expected_reason"),
-    [
-        ("ed-finder", "unexpected_working_directory"),
-        ("ed-finder-prod", "unexpected_host"),
-        ("another-host", "unexpected_host"),
-    ],
-)
-def test_repair_action_accepts_only_exact_production_short_host(
-    tmp_path, short_host, expected_reason
-):
-    hostname = tmp_path / "hostname"
-    hostname.write_text(f"#!/bin/sh\nprintf '%s\\n' '{short_host}'\n", encoding="utf-8")
-    hostname.chmod(0o755)
-    user_id = tmp_path / "id"
-    user_id.write_text("#!/bin/sh\nprintf '0\\n'\n", encoding="utf-8")
-    user_id.chmod(0o755)
-    env = os.environ.copy()
-    env["PATH"] = f"{tmp_path}:/usr/bin:/bin"
+def test_repair_action_uses_exact_non_destructive_production_host_guard():
+    source = ACTION.read_text(encoding="utf-8")
+    host_guard_lines = [line for line in source.splitlines() if "hostname -s" in line]
 
-    result = subprocess.run(
-        ["/bin/bash", str(ACTION)], capture_output=True, text=True, env=env, check=False
-    )
-
-    assert result.returncode == 1
-    assert f'"reason":"{expected_reason}"' in result.stderr
+    assert host_guard_lines == [
+        '[ "$(hostname -s)" = "$EXPECTED_HOST" ] || stop "unexpected_host"'
+    ]
+    assert 'EXPECTED_HOST="ed-finder"' in source
+    assert 'EXPECTED_HOST="ed-finder-prod"' not in source
 
 
 def test_editor_replaces_only_exact_broken_healthcheck(tmp_path):

--- a/tests/test_octopus_qdrant_healthcheck_repair.py
+++ b/tests/test_octopus_qdrant_healthcheck_repair.py
@@ -1,3 +1,4 @@
+import os
 import re
 import subprocess
 import sys
@@ -67,7 +68,7 @@ def test_dispatcher_uses_dedicated_repair_action():
 def test_repair_action_has_fail_closed_scope_and_guards():
     source = ACTION.read_text(encoding="utf-8")
     required = (
-        'EXPECTED_HOST="ed-finder-prod"',
+        'EXPECTED_HOST="ed-finder"',
         'COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"',
         'EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"',
         'EXPECTED_POSTGRES_IMAGE="postgres:17-alpine"',
@@ -93,6 +94,34 @@ def test_repair_action_has_fail_closed_scope_and_guards():
     assert "password" not in source.lower()
     assert '"db_access_performed": False' in source
     assert '"volume_configuration_modified": False' in source
+
+
+@pytest.mark.parametrize(
+    ("short_host", "expected_reason"),
+    [
+        ("ed-finder", "unexpected_working_directory"),
+        ("ed-finder-prod", "unexpected_host"),
+        ("another-host", "unexpected_host"),
+    ],
+)
+def test_repair_action_accepts_only_exact_production_short_host(
+    tmp_path, short_host, expected_reason
+):
+    hostname = tmp_path / "hostname"
+    hostname.write_text(f"#!/bin/sh\nprintf '%s\\n' '{short_host}'\n", encoding="utf-8")
+    hostname.chmod(0o755)
+    user_id = tmp_path / "id"
+    user_id.write_text("#!/bin/sh\nprintf '0\\n'\n", encoding="utf-8")
+    user_id.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:/usr/bin:/bin"
+
+    result = subprocess.run(
+        ["/bin/bash", str(ACTION)], capture_output=True, text=True, env=env, check=False
+    )
+
+    assert result.returncode == 1
+    assert f'"reason":"{expected_reason}"' in result.stderr
 
 
 def test_editor_replaces_only_exact_broken_healthcheck(tmp_path):


### PR DESCRIPTION
Narrow correction after the fail-closed Octopus repair proved the production short hostname is `ed-finder`, not `ed-finder-prod`.

Changes only the Octopus operator host identity guards, preserves the exact edge FQDN check, and adds focused regression coverage rejecting stale/other host identities. Existing Qdrant repair safeguards remain unchanged: exact images/version, exact broken-or-fixed healthcheck state, rollback/compose-validation ordering, `--no-deps` service scope, read-only Postgres health verification, and no DB/volume/migration/env mutation.

Codex worker validation: shell syntax passed, Python tests compile, manual host-guard checks passed, and `git diff --check` passed. Full repository CI/review remains required before merge.