### PR TITLE
Restore verified Octopus production host identity

### DIFF
--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -25,7 +25,7 @@ Current scripts:
   and starts/verifies web without managing its dependencies. It does not read
   `.env`, access a database, or modify volumes.
 - `actions/octopus-edge-status.sh`: fail-closed, read-only status receipt for
-  Octopus v1.0.122 on short host `ed-finder`. It reports the bounded edge listeners,
+  Octopus v1.0.122 on short host `ed-finder-prod`. It reports the bounded edge listeners,
   relevant containers, internal health/version, sanitized nginx routing, DNS,
   public HTTP/HTTPS responses, and the certificate actually served for Octopus
   SNI. It does not read environment or private-key files, access a database,

--- a/scripts/operator/actions/octopus-edge-status.sh
+++ b/scripts/operator/actions/octopus-edge-status.sh
@@ -18,7 +18,7 @@ import socket
 import subprocess
 import sys
 
-EXPECTED_HOST = "ed-finder"
+EXPECTED_HOST = "ed-finder-prod"
 EXPECTED_FQDN = "nb79a3d.mevnode.com"
 PUBLIC_NAME = "octopus.ed-finder.app"
 EXPECTED_VERSION = "1.0.122"

--- a/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+++ b/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 OCTOPUS_DIR="/opt/octopus"
 COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"
-EXPECTED_HOST="ed-finder"
+EXPECTED_HOST="ed-finder-prod"
 EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"
 EXPECTED_POSTGRES_IMAGE="postgres:17-alpine"
 BACKUP=""
@@ -48,7 +48,11 @@ on_exit() {
 }
 trap on_exit EXIT
 
-[ "$(hostname -s)" = "$EXPECTED_HOST" ] || stop "unexpected_host"
+host_identity_matches() {
+  [ "$1" = "$EXPECTED_HOST" ]
+}
+
+host_identity_matches "$(hostname -s)" || stop "unexpected_host"
 [ "$(id -u)" -eq 0 ] || stop "root_required"
 [ "$(pwd -P)" = "/opt/ed-finder" ] || stop "unexpected_working_directory"
 [ -d "$OCTOPUS_DIR" ] || stop "octopus_directory_missing"

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -140,7 +140,7 @@ def test_served_certificate_is_independent_from_https_and_installed_certs():
 
 def test_action_command_surface_is_read_only_secret_safe_and_bounded():
     source = ACTION.read_text(encoding="utf-8")
-    assert 'EXPECTED_HOST = "ed-finder"' in source
+    assert 'EXPECTED_HOST = "ed-finder-prod"' in source
     assert 'EXPECTED_FQDN = "nb79a3d.mevnode.com"' in source
     assert "MAX_RESPONSE = 4096" in source
     forbidden = (
@@ -163,8 +163,8 @@ def test_action_command_surface_is_read_only_secret_safe_and_bounded():
 def test_host_identity_accepts_only_exact_short_host_and_fqdn():
     matches = _python_functions()["host_identity_matches"]
 
-    assert matches("ed-finder", "nb79a3d.mevnode.com", 0) is True
-    assert matches("ed-finder-prod", "nb79a3d.mevnode.com", 0) is False
+    assert matches("ed-finder-prod", "nb79a3d.mevnode.com", 0) is True
+    assert matches("ed-finder", "nb79a3d.mevnode.com", 0) is False
     assert matches("another-host", "nb79a3d.mevnode.com", 0) is False
-    assert matches("ed-finder", "another.example.com", 0) is False
-    assert matches("ed-finder", "nb79a3d.mevnode.com", 1) is False
+    assert matches("ed-finder-prod", "another.example.com", 0) is False
+    assert matches("ed-finder-prod", "nb79a3d.mevnode.com", 1) is False

--- a/tests/test_octopus_qdrant_healthcheck_repair.py
+++ b/tests/test_octopus_qdrant_healthcheck_repair.py
@@ -67,7 +67,7 @@ def test_dispatcher_uses_dedicated_repair_action():
 def test_repair_action_has_fail_closed_scope_and_guards():
     source = ACTION.read_text(encoding="utf-8")
     required = (
-        'EXPECTED_HOST="ed-finder"',
+        'EXPECTED_HOST="ed-finder-prod"',
         'COMPOSE_FILE="$OCTOPUS_DIR/docker-compose.selfhost.yml"',
         'EXPECTED_IMAGE="qdrant/qdrant:v1.17.0"',
         'EXPECTED_POSTGRES_IMAGE="postgres:17-alpine"',
@@ -97,13 +97,45 @@ def test_repair_action_has_fail_closed_scope_and_guards():
 
 def test_repair_action_uses_exact_non_destructive_production_host_guard():
     source = ACTION.read_text(encoding="utf-8")
-    host_guard_lines = [line for line in source.splitlines() if "hostname -s" in line]
+    guard = source.split("host_identity_matches() {", 1)[1].split(
+        'host_identity_matches "$(hostname -s)" || stop "unexpected_host"', 1
+    )[0]
 
-    assert host_guard_lines == [
-        '[ "$(hostname -s)" = "$EXPECTED_HOST" ] || stop "unexpected_host"'
-    ]
-    assert 'EXPECTED_HOST="ed-finder"' in source
-    assert 'EXPECTED_HOST="ed-finder-prod"' not in source
+    assert '[ "$1" = "$EXPECTED_HOST" ]' in guard
+    assert 'EXPECTED_HOST="ed-finder-prod"' in source
+    assert 'EXPECTED_HOST="ed-finder"' not in source
+
+
+@pytest.mark.parametrize(
+    ("hostname", "accepted"),
+    (("ed-finder-prod", True), ("ed-finder", False), ("another-host", False)),
+)
+def test_repair_host_identity_contract_isolated_from_production_actions(hostname, accepted):
+    source = ACTION.read_text(encoding="utf-8")
+    function = source.split("host_identity_matches() {", 1)[1].split("}\n", 1)[0]
+    harness = (
+        'EXPECTED_HOST="ed-finder-prod"\n'
+        "host_identity_matches() {" + function + "}\n"
+        'host_identity_matches "$1"\n'
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", harness, "host-contract-test", hostname],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert (result.returncode == 0) is accepted
+    assert result.stdout == ""
+    assert result.stderr == ""
+
+
+def test_repair_host_guard_precedes_filesystem_and_docker_actions():
+    source = ACTION.read_text(encoding="utf-8")
+    host_guard = source.index('host_identity_matches "$(hostname -s)" || stop "unexpected_host"')
+
+    assert host_guard < source.index('[ -d "$OCTOPUS_DIR" ]')
+    assert host_guard < source.index("command -v docker")
 
 
 def test_editor_replaces_only_exact_broken_healthcheck(tmp_path):


### PR DESCRIPTION
Follow-up to #552 after the allowlisted MevSpace ed-new repair correctly failed closed on its host guard.

Read-only `host-status` evidence from the same pinned ed-new control plane confirms the production identity is short hostname `ed-finder-prod` with FQDN `nb79a3d.mevnode.com`. This PR restores that verified short hostname in the Octopus edge-status and Qdrant-healthcheck-repair contracts.

Safety properties are preserved: exact FQDN/version/image checks, structured fail-closed receipts, narrow Qdrant/web scope, read-only Postgres verification, and no DB/volume/migration/env mutation. The host regression test is isolated to the pure comparison helper and does not execute the production repair action, Docker, `/opt/octopus`, or any service/filesystem mutation.

Production was not modified by the Codex worker. Full repository CI and Codex Review are required before merge and before any production retry.