### PR TITLE
Add read-only Octopus edge topology detail probe

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -10,6 +10,7 @@ on:
         options:
           - host-status
           - octopus-edge-status
+          - octopus-edge-topology-detail
           - recover-v3-runtime-contract
           - octopus-qdrant-healthcheck-repair
   push:
@@ -63,7 +64,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair) ;;
+            host-status|octopus-edge-status|octopus-edge-topology-detail|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -159,6 +160,25 @@ jobs:
               "$SSH_USER@$SSH_HOST" \
               'cd /opt/ed-finder && bash -s' \
               < trusted-main/scripts/operator/actions/octopus-edge-status.sh
+
+      - name: Inspect exact Octopus edge topology detail
+        if: steps.request.outputs.operation == 'octopus-edge-topology-detail'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'cd /opt/ed-finder && bash -s' \
+              < trusted-main/scripts/operator/actions/octopus-edge-topology-detail.sh
 
       - name: Recover retained V3 runtime contract
         if: steps.request.outputs.operation == 'recover-v3-runtime-contract'

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -30,6 +30,11 @@ Current scripts:
   public HTTP/HTTPS responses, and the certificate actually served for Octopus
   SNI. It does not read environment or private-key files, access a database,
   write files, or restart services.
+- `actions/octopus-edge-topology-detail.sh`: parameterless, fail-closed,
+  read-only topology receipt for the two fixed live nginx containers. It emits
+  only allowlisted Docker metadata, nginx configuration origin paths and
+  sanitized routing directives, plus bounded internal Octopus health/version
+  evidence; it does not expose raw configuration, environment, or secrets.
 - `recover_v3_runtime_contract.py`: read-only helper for the allowlisted ed-new
   `recover-v3-runtime-contract` operation. It identifies the retained Phase 4C
   R5 Compose source root from container labels, rejects secret-like and unsafe

--- a/scripts/operator/actions/dispatch.sh
+++ b/scripts/operator/actions/dispatch.sh
@@ -26,6 +26,9 @@ case "$stage" in
   octopus-edge-status)
     exec bash scripts/operator/actions/octopus-edge-status.sh
     ;;
+  octopus-edge-topology-detail)
+    exec bash scripts/operator/actions/octopus-edge-topology-detail.sh
+    ;;
   latest-stage18j-summary)
     exec bash scripts/operator/actions/latest-artifact-summary.sh "stage-18j"
     ;;

--- a/scripts/operator/actions/octopus-edge-topology-detail.sh
+++ b/scripts/operator/actions/octopus-edge-topology-detail.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 0 ]; then
+    printf '%s\n' '{"schema_version":"ed-finder/operator-operation-result/v1","operation":"octopus-edge-topology-detail","status":"stopped","read_only":true,"db_access_performed":false,"db_writes_performed":false,"env_files_read":false,"private_keys_read":false,"service_changes_performed":false,"filesystem_writes_performed":false,"failures":["caller_parameters_not_allowed"]}'
+    exit 64
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' '{"schema_version":"ed-finder/operator-operation-result/v1","operation":"octopus-edge-topology-detail","status":"stopped","read_only":true,"db_access_performed":false,"db_writes_performed":false,"env_files_read":false,"private_keys_read":false,"service_changes_performed":false,"filesystem_writes_performed":false,"failures":["python3_unavailable"]}'
+    exit 1
+fi
+
+# All remote inputs are constants. The program requests only allowlisted Docker
+# metadata and reduces nginx -T output to origin paths and safe directives.
+exec python3 - <<'PY'
+import hashlib
+import json
+import re
+import socket
+import subprocess
+import sys
+
+OPERATION = "octopus-edge-topology-detail"
+EXPECTED_HOST = "ed-finder-prod"
+EXPECTED_FQDN = "nb79a3d.mevnode.com"
+EXPECTED_WORKDIR = "/opt/ed-finder"
+EXPECTED_VERSION = "1.0.122"
+EXPECTED_IMAGE = "nginx:1.28-alpine"
+CONTAINERS = ("edfinder-v3-public-auth-edge", "edfinder-v3-proxy")
+MAX_RESPONSE = 4096
+MAX_NGINX_OUTPUT = 1024 * 1024
+MAX_NGINX_ORIGINS = 128
+MAX_NGINX_DIRECTIVES = 512
+MAX_NGINX_FIELD = 2048
+INSPECT_FORMAT = json.dumps({
+    "name": "{{.Name}}",
+    "image": "{{.Config.Image}}",
+    "state": "{{.State.Status}}",
+    "network_mode": "{{.HostConfig.NetworkMode}}",
+    "networks": "{{json .NetworkSettings.Networks}}",
+    "ports": "{{json .NetworkSettings.Ports}}",
+    "mounts": "{{json .Mounts}}",
+}, separators=(",", ":"))
+
+
+def run(argv, *, timeout=15):
+    try:
+        return subprocess.run(argv, text=True, capture_output=True, timeout=timeout, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
+
+
+def stopped_receipt(failures, **fields):
+    receipt = {
+        "schema_version": "ed-finder/operator-operation-result/v1",
+        "operation": OPERATION,
+        "status": "stopped",
+        "read_only": True,
+        "db_access_performed": False,
+        "db_writes_performed": False,
+        "env_files_read": False,
+        "private_keys_read": False,
+        "service_changes_performed": False,
+        "filesystem_writes_performed": False,
+        **fields,
+        "failures": sorted(set(failures)),
+    }
+    return receipt
+
+
+def exact_version(body):
+    if len(body.encode("utf-8")) > MAX_RESPONSE:
+        return False
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(payload, dict) and payload.get("version") == EXPECTED_VERSION
+
+
+def bounded_get(url):
+    result = run(["curl", "--silent", "--show-error", "--max-time", "10",
+                  "--max-filesize", str(MAX_RESPONSE), "--output", "-",
+                  "--write-out", "\n%{http_code}", url])
+    body, separator, code = result.stdout.rpartition("\n")
+    body = body[:MAX_RESPONSE]
+    return ({
+        "inspection_succeeded": result.returncode == 0 and bool(separator),
+        "status_code": int(code) if separator and code.isdigit() else None,
+        "body_bytes": len(body.encode("utf-8")),
+        "body_sha256": hashlib.sha256(body.encode()).hexdigest() if separator else None,
+    }, body)
+
+
+def sanitized_nginx_metadata(config):
+    if len(config.encode("utf-8")) > MAX_NGINX_OUTPUT:
+        raise ValueError("nginx output exceeded limit")
+    origins = []
+    directives = []
+    current_origin = None
+    origin_pattern = re.compile(r"^# configuration file ([^:\r\n]+):$")
+    directive_pattern = re.compile(
+        r"^(listen|server_name|proxy_pass|include)\s+([^;\r\n]+);$"
+    )
+    for raw_line in config.splitlines():
+        line = raw_line.strip()
+        origin = origin_pattern.fullmatch(line)
+        if origin:
+            current_origin = origin.group(1)
+            if len(current_origin) > MAX_NGINX_FIELD:
+                raise ValueError("nginx origin exceeded limit")
+            if current_origin not in origins:
+                origins.append(current_origin)
+                if len(origins) > MAX_NGINX_ORIGINS:
+                    raise ValueError("too many nginx origins")
+            continue
+        directive = directive_pattern.fullmatch(line)
+        if directive:
+            if len(directive.group(2)) > MAX_NGINX_FIELD:
+                raise ValueError("nginx directive exceeded limit")
+            directives.append({
+                "origin": current_origin,
+                "name": directive.group(1),
+                "value": directive.group(2),
+            })
+            if len(directives) > MAX_NGINX_DIRECTIVES:
+                raise ValueError("too many nginx directives")
+    return {"configuration_file_origins": origins, "directives": directives}
+
+
+def decode_inspect(stdout, expected_name):
+    raw = json.loads(stdout)
+    networks = json.loads(raw["networks"] or "{}")
+    ports = json.loads(raw["ports"] or "{}")
+    mounts = json.loads(raw["mounts"] or "[]")
+    if (raw["name"] != "/" + expected_name or raw["state"] != "running"
+            or raw["image"] != EXPECTED_IMAGE):
+        raise ValueError("unexpected container identity, state, or image")
+    published_ports = {}
+    for container_port, bindings in ports.items():
+        if not isinstance(bindings, list):
+            continue
+        real_bindings = [
+            {"HostIp": binding["HostIp"], "HostPort": binding["HostPort"]}
+            for binding in bindings
+            if (isinstance(binding, dict)
+                and isinstance(binding.get("HostIp"), str)
+                and isinstance(binding.get("HostPort"), str)
+                and bool(binding["HostPort"]))
+        ]
+        if real_bindings:
+            published_ports[container_port] = real_bindings
+    return {
+        "name": expected_name,
+        "image": raw["image"],
+        "network_mode": raw["network_mode"],
+        "network_names": sorted(networks),
+        "published_ports": published_ports,
+        "mounts": [
+            {"source": item.get("Source"), "destination": item.get("Destination"),
+             "type": item.get("Type"), "rw": bool(item.get("RW"))}
+            for item in mounts if item.get("Type") in {"bind", "volume"}
+        ],
+    }
+
+
+def inspect_containers(names, runner=run):
+    items = []
+    failures = []
+    for name in names:
+        inspected = runner([
+            "docker", "inspect", "--type", "container", "--format", INSPECT_FORMAT, name
+        ])
+        if inspected.returncode != 0:
+            failures.append(f"container_missing:{name}")
+            continue
+        try:
+            items.append(decode_inspect(inspected.stdout, name))
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            failures.append(f"container_unexpected:{name}")
+    return items, failures
+
+
+def inspect_nginx(items, runner=run):
+    failures = []
+    for item in items:
+        name = item["name"]
+        nginx = runner(["docker", "exec", name, "nginx", "-T"])
+        if nginx.returncode != 0:
+            failures.append(f"nginx_inspection_failed:{name}")
+            continue
+        try:
+            item["nginx"] = sanitized_nginx_metadata(nginx.stdout)
+        except ValueError:
+            failures.append(f"nginx_inspection_unbounded:{name}")
+    return failures
+
+
+def inspect_topology(names, runner=run):
+    items, failures = inspect_containers(names, runner)
+    if failures:
+        return items, failures
+    failures.extend(inspect_nginx(items, runner))
+    return items, failures
+
+
+failures = []
+short_host = socket.gethostname().split(".")[0]
+fqdn_result = run(["hostname", "-f"])
+fqdn = fqdn_result.stdout.strip()
+pwd_result = run(["pwd", "-P"])
+workdir = pwd_result.stdout.strip()
+identity = {"short": short_host, "fqdn": fqdn, "working_directory": workdir}
+if short_host != EXPECTED_HOST or fqdn_result.returncode != 0 or fqdn != EXPECTED_FQDN:
+    failures.append("unexpected_host_identity")
+if pwd_result.returncode != 0 or workdir != EXPECTED_WORKDIR:
+    failures.append("unexpected_working_directory")
+if failures:
+    print(json.dumps(stopped_receipt(failures, host=identity), separators=(",", ":"), sort_keys=True))
+    sys.exit(1)
+
+container_receipts, container_failures = inspect_topology(CONTAINERS)
+failures.extend(container_failures)
+
+health, _ = bounded_get("http://127.0.0.1:43300/api/health")
+version, version_body = bounded_get("http://127.0.0.1:43300/api/version")
+version["expected_version"] = EXPECTED_VERSION
+version["exact_version_match"] = version["inspection_succeeded"] and exact_version(version_body)
+if health["status_code"] not in range(200, 300):
+    failures.append("octopus_health_failed")
+if version["status_code"] not in range(200, 300):
+    failures.append("octopus_version_http_failed")
+if not version["exact_version_match"]:
+    failures.append("unexpected_octopus_version")
+
+receipt = stopped_receipt(
+    failures,
+    host=identity,
+    expected_containers=list(CONTAINERS),
+    containers=container_receipts,
+    octopus_internal={"health": health, "version": version},
+)
+if not failures and [item["name"] for item in container_receipts] == list(CONTAINERS):
+    receipt["status"] = "completed"
+    receipt.pop("failures")
+print(json.dumps(receipt, separators=(",", ":"), sort_keys=True))
+sys.exit(0 if receipt["status"] == "completed" else 1)
+PY

--- a/tests/test_octopus_edge_status.py
+++ b/tests/test_octopus_edge_status.py
@@ -22,7 +22,7 @@ def test_ed_new_workflow_and_dispatch_allowlist_dedicated_action():
     workflow = WORKFLOW.read_text(encoding="utf-8")
     dispatch = DISPATCH.read_text(encoding="utf-8")
     assert workflow.count(f"          - {OPERATION}\n") == 1
-    assert f"host-status|{OPERATION}|recover-v3-runtime-contract" in workflow
+    assert f"host-status|{OPERATION}|octopus-edge-topology-detail|recover-v3-runtime-contract" in workflow
     assert f"steps.request.outputs.operation == '{OPERATION}'" in workflow
     assert f"trusted-main/scripts/operator/actions/{OPERATION}.sh" in workflow
     assert "ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS" in workflow

--- a/tests/test_octopus_edge_topology_detail.py
+++ b/tests/test_octopus_edge_topology_detail.py
@@ -1,0 +1,232 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / "scripts/operator/actions/octopus-edge-topology-detail.sh"
+WORKFLOW = ROOT / ".github/workflows/chatgpt-ed-new-ops.yml"
+DISPATCH = ROOT / "scripts/operator/actions/dispatch.sh"
+OPERATION = "octopus-edge-topology-detail"
+CONTAINERS = ("edfinder-v3-public-auth-edge", "edfinder-v3-proxy")
+
+
+def _python_functions():
+    source = ACTION.read_text(encoding="utf-8")
+    program = source.split("exec python3 - <<'PY'\n", 1)[1].rsplit("\nPY\n", 1)[0]
+    namespace = {}
+    exec(program.split("short_host = socket.gethostname()", 1)[0], namespace)
+    return namespace
+
+
+def test_workflow_and_fixed_dispatcher_allowlist_the_operation():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    dispatcher = DISPATCH.read_text(encoding="utf-8")
+    assert workflow.count(f"          - {OPERATION}\n") == 1
+    assert f"octopus-edge-status|{OPERATION}|recover-v3-runtime-contract" in workflow
+    assert f"steps.request.outputs.operation == '{OPERATION}'" in workflow
+    assert f"trusted-main/scripts/operator/actions/{OPERATION}.sh" in workflow
+    assert "ref: main" in workflow
+    assert "StrictHostKeyChecking=yes" in workflow
+    assert f"{OPERATION})" in dispatcher
+    assert f"exec bash scripts/operator/actions/{OPERATION}.sh" in dispatcher
+
+
+def test_action_has_no_parameters_and_uses_only_exact_container_names():
+    source = ACTION.read_text(encoding="utf-8")
+    assert 'if [ "$#" -ne 0 ]' in source
+    assert f'CONTAINERS = ("{CONTAINERS[0]}", "{CONTAINERS[1]}")' in source
+    assert '"docker", "inspect", "--type", "container", "--format", INSPECT_FORMAT, name' in source
+    assert '["docker", "exec", name, "nginx", "-T"]' in source
+    assert "docker ps" not in source
+    assert "docker container ls" not in source
+
+    result = subprocess.run(["bash", str(ACTION), "unexpected"], capture_output=True, text=True)
+    assert result.returncode == 64
+    assert json.loads(result.stdout)["failures"] == ["caller_parameters_not_allowed"]
+
+
+def test_docker_metadata_is_bounded_and_does_not_request_env_or_secrets():
+    source = ACTION.read_text(encoding="utf-8")
+    for required in (
+        '"image": "{{.Config.Image}}"',
+        '"network_mode": "{{.HostConfig.NetworkMode}}"',
+        '"networks": "{{json .NetworkSettings.Networks}}"',
+        '"ports": "{{json .NetworkSettings.Ports}}"',
+        '"mounts": "{{json .Mounts}}"',
+    ):
+        assert required in source
+    forbidden = (
+        "Config.Env", ".env", "printenv", "/proc/", "docker cp", "docker volume",
+        "psql", "postgres", "mysql", "sqlite", "redis-cli",
+        "privkey", "docker restart", "docker start", "docker stop", "compose up",
+        "compose down", "systemctl", "service restart", "chmod", "chown", "tee ",
+    )
+    lowered = source.lower()
+    for value in forbidden:
+        assert value.lower() not in lowered
+
+
+def test_inspect_decoder_emits_required_structure_and_fails_closed():
+    decode = _python_functions()["decode_inspect"]
+    raw = {
+        "name": "/edfinder-v3-proxy",
+        "image": "nginx:1.28-alpine",
+        "state": "running",
+        "network_mode": "bridge",
+        "networks": json.dumps({"edge": {"IPAddress": "172.20.0.2"}}),
+        "ports": json.dumps({
+            "443/tcp": [{"HostIp": "0.0.0.0", "HostPort": "443"}],
+            "80/tcp": None,
+            "8080/tcp": [],
+            "8443/tcp": [{"HostIp": "0.0.0.0", "HostPort": ""}],
+        }),
+        "mounts": json.dumps([
+            {"Source": "/opt/ed-finder/nginx.conf", "Destination": "/etc/nginx/nginx.conf", "Type": "bind", "RW": False},
+            {"Source": "cache", "Destination": "/cache", "Type": "volume", "RW": True},
+            {"Source": "/tmp", "Destination": "/tmp", "Type": "tmpfs", "RW": True},
+        ]),
+    }
+    result = decode(json.dumps(raw), "edfinder-v3-proxy")
+    assert result == {
+        "name": "edfinder-v3-proxy",
+        "image": "nginx:1.28-alpine",
+        "network_mode": "bridge",
+        "network_names": ["edge"],
+        "published_ports": {"443/tcp": [{"HostIp": "0.0.0.0", "HostPort": "443"}]},
+        "mounts": [
+            {"source": "/opt/ed-finder/nginx.conf", "destination": "/etc/nginx/nginx.conf", "type": "bind", "rw": False},
+            {"source": "cache", "destination": "/cache", "type": "volume", "rw": True},
+        ],
+    }
+    raw["name"] = "/lookalike-proxy"
+    try:
+        decode(json.dumps(raw), "edfinder-v3-proxy")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unexpected container identity was accepted")
+    raw["name"] = "/edfinder-v3-proxy"
+    raw["state"] = "exited"
+    try:
+        decode(json.dumps(raw), "edfinder-v3-proxy")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("non-running container was accepted")
+    raw["state"] = "running"
+    raw["image"] = "nginx:latest"
+    try:
+        decode(json.dumps(raw), "edfinder-v3-proxy")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unexpected container image was accepted")
+
+
+def test_image_mismatch_fails_before_any_nginx_exec():
+    namespace = _python_functions()
+    inspect_topology = namespace["inspect_topology"]
+    inspect_format = namespace["INSPECT_FORMAT"]
+    calls = []
+
+    def fake_run(argv):
+        calls.append(argv)
+        name = argv[-1]
+        image = "nginx:1.28-alpine" if name == CONTAINERS[0] else "nginx:latest"
+        payload = {
+            "name": f"/{name}",
+            "image": image,
+            "state": "running",
+            "network_mode": "bridge",
+            "networks": "{}",
+            "ports": "{}",
+            "mounts": "[]",
+        }
+        return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+
+    items, failures = inspect_topology(CONTAINERS, fake_run)
+    assert [item["name"] for item in items] == [CONTAINERS[0]]
+    assert failures == [f"container_unexpected:{CONTAINERS[1]}"]
+    assert calls == [
+        ["docker", "inspect", "--type", "container", "--format", inspect_format, name]
+        for name in CONTAINERS
+    ]
+    assert not any(call[:2] == ["docker", "exec"] for call in calls)
+
+
+def test_nginx_output_is_reduced_to_origins_and_four_safe_directives():
+    parse = _python_functions()["sanitized_nginx_metadata"]
+    config = """
+# configuration file /etc/nginx/nginx.conf:
+include /etc/nginx/conf.d/*.conf;
+# configuration file /etc/nginx/conf.d/octopus.conf:
+server {
+  listen 443 ssl;
+  server_name octopus.ed-finder.app;
+  proxy_pass http://127.0.0.1:43300;
+  ssl_certificate_key /run/secrets/octopus.key;
+  auth_basic_user_file /run/secrets/htpasswd;
+}
+"""
+    result = parse(config)
+    assert result["configuration_file_origins"] == [
+        "/etc/nginx/nginx.conf", "/etc/nginx/conf.d/octopus.conf"
+    ]
+    assert [item["name"] for item in result["directives"]] == [
+        "include", "listen", "server_name", "proxy_pass"
+    ]
+    serialized = json.dumps(result)
+    assert "octopus.key" not in serialized
+    assert "htpasswd" not in serialized
+
+
+def test_exact_octopus_version_accepts_only_exact_version_object():
+    exact = _python_functions()["exact_version"]
+    assert exact('{"version":"1.0.122"}') is True
+    rejected = (
+        '{"release":"1.0.122"}',
+        '{"tag":"1.0.122"}',
+        '"1.0.122"',
+        '1.0.122',
+        '{"version":"v1.0.122"}',
+        '{"version":"1.0.122-build1"}',
+        '{"version":"11.0.1220"}',
+        '{"version":"1.0.121"}',
+        '[{"version":"1.0.122"}]',
+        '{"version":null}',
+        '{"version":true}',
+        '{"version":122}',
+        '{"version":{"value":"1.0.122"}}',
+        '{"version":"1.0.122"',
+        '{"version":"1.0.122","padding":"' + ("é" * 4096) + '"}',
+    )
+    for payload in rejected:
+        assert exact(payload) is False, payload[:100]
+
+
+def test_version_receipt_requires_successful_bounded_fetch():
+    source = ACTION.read_text(encoding="utf-8")
+    assert (
+        'version["exact_version_match"] = version["inspection_succeeded"] '
+        'and exact_version(version_body)'
+    ) in source
+
+
+def test_host_workdir_fail_closed_and_receipt_safety_fields_are_present():
+    source = ACTION.read_text(encoding="utf-8")
+    assert 'EXPECTED_HOST = "ed-finder-prod"' in source
+    assert 'EXPECTED_FQDN = "nb79a3d.mevnode.com"' in source
+    assert 'EXPECTED_WORKDIR = "/opt/ed-finder"' in source
+    assert 'failures.append("unexpected_host_identity")' in source
+    assert 'failures.append("unexpected_working_directory")' in source
+    assert 'failures.append(f"container_missing:{name}")' in source
+    assert 'failures.append(f"container_unexpected:{name}")' in source
+    for field in (
+        '"db_access_performed": False', '"db_writes_performed": False',
+        '"env_files_read": False', '"private_keys_read": False',
+        '"service_changes_performed": False', '"filesystem_writes_performed": False',
+    ):
+        assert field in source
+    syntax = subprocess.run(["bash", "-n", str(ACTION)], capture_output=True, text=True)
+    assert syntax.returncode == 0, syntax.stderr


### PR DESCRIPTION
Adds a narrowly scoped read-only ed-new Ops operation, `octopus-edge-topology-detail`, needed to identify the live MevSpace nginx mount/config source before any bounded public-route install.

The probe is fixed-input and fail-closed: exact host `ed-finder-prod` / FQDN `nb79a3d.mevnode.com`, exact working directory `/opt/ed-finder`, exact containers `edfinder-v3-public-auth-edge` and `edfinder-v3-proxy`, exact nginx image `nginx:1.28-alpine`, and exact Octopus version object `{"version":"1.0.122"}`. It reports only image/network/published-port/mount metadata plus bounded sanitized nginx configuration origins and `listen`/`server_name`/`proxy_pass`/`include` directives.

It does not read Config.Env, env files, private keys, secrets, databases, or arbitrary volume contents, and performs no filesystem/service/container/network/nginx/DB/volume/migration/env mutation. `nginx -T` is only executed against the two exact validated nginx containers. Tests verify the read-only command surface, strict version gate, exact image gate before exec, true published-port filtering, bounded output, structured receipts, and trusted-main ed-new workflow/dispatcher wiring.

This PR does not install or change the public Octopus route. It only provides the production topology evidence needed to design that later write operation safely.