### PR TITLE
fix: harden V3 runtime recovery against embedded secrets

### DIFF
--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -61,16 +61,26 @@ QUOTED_ENV_ASSIGNMENT_RE = re.compile(
 )
 BARE_ENV_ASSIGNMENT_RE = re.compile(
     rf"(?<![A-Za-z0-9_])(?P<name>{IDENTIFIER})\s*=\s*"
-    r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)", re.MULTILINE,
+    r"(?P<value>[^\s,;\"'\]]+)", re.MULTILINE,
 )
 QUOTED_MAPPING_ENV_RE = re.compile(
     rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{STRUCTURED_KEY})"
     r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote))",
+    re.DOTALL,
 )
 BARE_MAPPING_ENV_RE = re.compile(
     rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{STRUCTURED_KEY})"
     r"(?P=keyquote)\s*:(?![ \t]*[\"'])[ \t]*"
     r"(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+))",
+)
+DOUBLE_QUOTED_MAPPING_ENV_RE = re.compile(
+    rf'''(?m)(?={MAPPING_KEY_PREFIX}"(?P<raw_name>(?:\\.|[^"\\])*)"\s*:\s*'''
+    r'''(?P<valquote>["'])(?P<value>.*?)(?P=valquote))''',
+    re.DOTALL,
+)
+DOUBLE_QUOTED_BARE_MAPPING_ENV_RE = re.compile(
+    rf'''(?m)(?={MAPPING_KEY_PREFIX}"(?P<raw_name>(?:\\.|[^"\\])*)"\s*'''
+    r''':(?![ \t]*["'])[ \t]*(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+))''',
 )
 DOCKERFILE_ENV_SPACE_RE = re.compile(
     rf"(?im)^\s*ENV\s+(?P<name>{IDENTIFIER})\s+(?P<value>[^\r\n#]+)"
@@ -138,7 +148,7 @@ K8S_SECRET_PAYLOAD_RE = re.compile(
 )
 TOKEN_PATTERNS = (
     ("private-key-material", re.compile(
-        r"-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
+        r"-----BEGIN (?:(?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY|PGP PRIVATE KEY BLOCK)-----",
         re.IGNORECASE,
     )),
     ("openai-api-token", re.compile(r"\bsk-(?!ant-)(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b")),
@@ -170,6 +180,12 @@ NONSENSITIVE_REFERENCE_NAMES = {
 }
 PYTHON_LOOKUP_CALL_NAMES = {
     "fetch_secret", "get_secret", "load_secret", "read_secret", "resolve_secret",
+}
+YAML_DOUBLE_QUOTE_ESCAPES = {
+    "0": "\0", "a": "\a", "b": "\b", "t": "\t", "n": "\n",
+    "v": "\v", "f": "\f", "r": "\r", "e": "\x1b", " ": " ",
+    '"': '"', "/": "/", "\\": "\\", "N": "\u0085", "_": "\u00a0",
+    "L": "\u2028", "P": "\u2029",
 }
 
 
@@ -284,6 +300,40 @@ def _normalized_name(name: str) -> str:
     camel_split = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
     punct_split = re.sub(r"[^A-Za-z0-9]+", "_", camel_split)
     return re.sub(r"_+", "_", punct_split).strip("_").upper()
+
+
+def _decode_yaml_double_quoted_key(raw: str) -> str | None:
+    decoded: list[str] = []
+    index = 0
+    while index < len(raw):
+        character = raw[index]
+        if character != "\\":
+            decoded.append(character)
+            index += 1
+            continue
+        index += 1
+        if index >= len(raw):
+            return None
+        escape = raw[index]
+        if escape in YAML_DOUBLE_QUOTE_ESCAPES:
+            decoded.append(YAML_DOUBLE_QUOTE_ESCAPES[escape])
+            index += 1
+            continue
+        widths = {"x": 2, "u": 4, "U": 8}
+        width = widths.get(escape)
+        if width is None:
+            return None
+        start = index + 1
+        end = start + width
+        digits = raw[start:end]
+        if len(digits) != width or not re.fullmatch(r"[0-9A-Fa-f]+", digits):
+            return None
+        try:
+            decoded.append(chr(int(digits, 16)))
+        except ValueError:
+            return None
+        index = end
+    return "".join(decoded)
 
 
 def _name_is_sensitive(name: str) -> bool:
@@ -417,6 +467,29 @@ def _compose_secret_reference_collection(name: str, value: str) -> bool:
     return _normalized_name(name) == "SECRETS" and value.strip().startswith(("[", "{"))
 
 
+def _scan_decoded_yaml_mapping_keys(text: str, findings: set[str]) -> None:
+    for match in DOUBLE_QUOTED_MAPPING_ENV_RE.finditer(text):
+        name = _decode_yaml_double_quoted_key(match.group("raw_name"))
+        if name is None:
+            continue
+        value = match.group("value")
+        if _compose_secret_reference_collection(name, value):
+            continue
+        if _name_is_sensitive(name) and not _assignment_value_is_safe(name, value):
+            findings.add("sensitive-environment-assignment")
+    for match in DOUBLE_QUOTED_BARE_MAPPING_ENV_RE.finditer(text):
+        name = _decode_yaml_double_quoted_key(match.group("raw_name"))
+        if name is None:
+            continue
+        value = match.group("value")
+        if _compose_secret_reference_collection(name, value):
+            continue
+        if not _name_is_sensitive(name) or _unquoted_yaml_null(value):
+            continue
+        if not _assignment_value_is_safe(name, value):
+            findings.add("sensitive-environment-assignment")
+
+
 def _scan_assignment_patterns(text: str, findings: set[str], *, include_equals: bool = True) -> None:
     if include_equals:
         for pattern in (QUOTED_ENV_ASSIGNMENT_RE, BARE_ENV_ASSIGNMENT_RE):
@@ -442,6 +515,8 @@ def _scan_assignment_patterns(text: str, findings: set[str], *, include_equals: 
             continue
         if not _assignment_value_is_safe(name, value):
             findings.add("sensitive-environment-assignment")
+
+    _scan_decoded_yaml_mapping_keys(text, findings)
 
 
 def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
@@ -660,6 +735,9 @@ def _scan_python_assignments(text: str, findings: set[str]) -> None:
             targets = node.targets
             value = node.value
         elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        elif isinstance(node, (ast.AugAssign, ast.NamedExpr)):
             targets = [node.target]
             value = node.value
         else:

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -3,7 +3,11 @@
 
 This helper is intentionally read-only: Docker is queried only for selected
 Compose labels and every selected file is read from the resolved Compose source
-root.  The tar stream is written to stdout so the remote host is not mutated.
+root. The tar stream is written to stdout so the remote host is not mutated.
+
+Every candidate file is content-scanned before any archive bytes are emitted.
+Unsafe optional historical files are excluded with provenance-only metadata;
+unsafe required Compose files fail the whole recovery.
 """
 
 from __future__ import annotations
@@ -14,6 +18,7 @@ import io
 import json
 import os
 from pathlib import Path, PurePosixPath
+import re
 import stat
 import subprocess
 import sys
@@ -70,7 +75,56 @@ FORBIDDEN_FRAGMENTS = (
 COMPOSE_WORKING_DIR_LABEL = "com.docker.compose.project.working_dir"
 COMPOSE_CONFIG_FILES_LABEL = "com.docker.compose.project.config_files"
 COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
-SCHEMA = "edfinder-v3-runtime-recovery/v1"
+SCHEMA = "edfinder-v3-runtime-recovery/v2"
+
+SENSITIVE_ENV_NAME = (
+    r"(?:"
+    r"[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|TOKEN|SECRET|PRIVATE_KEY|API_KEY|APIKEY)"
+    r"[A-Z0-9_]*"
+    r"|DATABASE_URL|REDIS_URL|CACHE_URL|CELERY_BROKER_URL"
+    r"|OCTOPUS_DATA_KEY|DATA_ENCRYPTION_KEY"
+    r")"
+)
+QUOTED_ENV_ASSIGNMENT_RE = re.compile(
+    rf"(?<![A-Za-z0-9_])(?P<name>{SENSITIVE_ENV_NAME})\s*=\s*"
+    r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)",
+)
+BARE_ENV_ASSIGNMENT_RE = re.compile(
+    rf"(?<![A-Za-z0-9_])(?P<name>{SENSITIVE_ENV_NAME})\s*=\s*"
+    r"(?P<value>[^\s,\"'\]\}]+)",
+)
+JSON_MAPPING_ENV_RE = re.compile(
+    rf'["\'](?P<name>{SENSITIVE_ENV_NAME})["\']\s*:\s*'
+    r'(?P<quote>["\'])(?P<value>.*?)(?P=quote)',
+)
+YAML_MAPPING_ENV_RE = re.compile(
+    rf"(?m)^\s*(?P<name>{SENSITIVE_ENV_NAME})\s*:\s*(?P<value>[^\r\n#]+)",
+)
+CREDENTIALED_URI_RE = re.compile(
+    r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|"
+    r"amqp|amqps)://[^/\s:@]+:(?P<password>[^@\s/]+)@",
+)
+TOKEN_PATTERNS = (
+    (
+        "private-key-material",
+        re.compile(
+            r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
+            re.IGNORECASE,
+        ),
+    ),
+    ("openai-api-token", re.compile(r"\bsk-(?!ant-)(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b")),
+    ("anthropic-api-token", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
+    ("github-token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b")),
+    ("github-fine-grained-token", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
+    ("aws-access-key", re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")),
+    ("slack-token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+)
+CONTENT_SCAN_RULES = (
+    "private-key-material",
+    "recognized-api-token",
+    "credentialed-database-or-cache-uri",
+    "non-placeholder-sensitive-environment-assignment",
+)
 
 
 class RecoveryError(RuntimeError):
@@ -124,7 +178,10 @@ def _safe_name(relative: PurePosixPath) -> bool:
     return relative.suffix.lower() in ALLOWED_SUFFIXES or name.startswith(BUILD_FILE_PREFIXES)
 
 
-def collect_files(root: Path, required_configs: Iterable[Path]) -> list[tuple[Path, str, os.stat_result]]:
+def collect_files(
+    root: Path,
+    required_configs: Iterable[Path],
+) -> list[tuple[Path, str, os.stat_result]]:
     root = root.resolve(strict=True)
     required = {path.resolve(strict=True) for path in required_configs}
     selected: list[tuple[Path, str, os.stat_result]] = []
@@ -177,7 +234,130 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def build_manifest(files: Iterable[tuple[Path, str, os.stat_result]]) -> dict[str, object]:
+def _placeholder_value(value: str) -> bool:
+    candidate = value.strip().strip("\"'")
+    if not candidate:
+        return True
+    if re.fullmatch(r"\$\{[A-Za-z_][A-Za-z0-9_]*(?::\?[^}]*)?\}", candidate):
+        return True
+    if re.fullmatch(r"\$[A-Za-z_][A-Za-z0-9_]*", candidate):
+        return True
+    if re.fullmatch(r"\{\{[^{}]+\}\}", candidate):
+        return True
+    if re.fullmatch(r"<(?:redacted|placeholder|secret|password|token|[^>]*_here)>", candidate, re.I):
+        return True
+    if candidate.upper() in {
+        "REDACTED",
+        "PLACEHOLDER",
+        "NOT_SET",
+        "UNSET",
+        "REPLACE_ME",
+        "YOUR_SECRET_HERE",
+        "YOUR_PASSWORD_HERE",
+        "YOUR_TOKEN_HERE",
+    }:
+        return True
+    if re.fullmatch(r"[*xX]{6,}", candidate):
+        return True
+    return False
+
+
+URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
+
+
+def _assignment_value_is_safe(name: str, value: str) -> bool:
+    if _placeholder_value(value):
+        return True
+    if name.upper() in URL_ENV_NAMES:
+        matches = list(CREDENTIALED_URI_RE.finditer(value.strip().strip("\"'")))
+        return not matches or all(
+            _placeholder_value(match.group("password")) for match in matches
+        )
+    return False
+
+
+def _scan_text(text: str, relative: str) -> tuple[str, ...]:
+    findings: set[str] = set()
+
+    for category, pattern in TOKEN_PATTERNS:
+        if pattern.search(text):
+            findings.add(category)
+
+    for match in CREDENTIALED_URI_RE.finditer(text):
+        if not _placeholder_value(match.group("password")):
+            findings.add("credentialed-uri")
+
+    relative_path = PurePosixPath(relative)
+    assignment_scan = (
+        relative_path.suffix.lower() in {".sh", ".yml", ".yaml", ".json", ".txt"}
+        or relative_path.name.lower().startswith(BUILD_FILE_PREFIXES)
+    )
+    if assignment_scan:
+        for pattern in (QUOTED_ENV_ASSIGNMENT_RE, BARE_ENV_ASSIGNMENT_RE):
+            for match in pattern.finditer(text):
+                if not _assignment_value_is_safe(
+                    match.group("name"), match.group("value")
+                ):
+                    findings.add("sensitive-environment-assignment")
+        if relative_path.suffix.lower() in {".yml", ".yaml", ".json"}:
+            mapping_patterns = [JSON_MAPPING_ENV_RE]
+            if relative_path.suffix.lower() in {".yml", ".yaml"}:
+                mapping_patterns.append(YAML_MAPPING_ENV_RE)
+            for pattern in mapping_patterns:
+                for match in pattern.finditer(text):
+                    if not _assignment_value_is_safe(
+                        match.group("name"), match.group("value")
+                    ):
+                        findings.add("sensitive-environment-assignment")
+
+    return tuple(sorted(findings))
+
+
+def scan_selected_files(
+    files: Iterable[tuple[Path, str, os.stat_result]],
+    required_configs: Iterable[Path],
+) -> tuple[
+    list[tuple[Path, str, os.stat_result]],
+    list[dict[str, object]],
+]:
+    required = {path.resolve(strict=True) for path in required_configs}
+    included: list[tuple[Path, str, os.stat_result]] = []
+    excluded: list[dict[str, object]] = []
+
+    for path, relative, metadata in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise RecoveryError(f"Selected text file is not valid UTF-8: {relative}") from exc
+
+        findings = _scan_text(text, relative)
+        if not findings:
+            included.append((path, relative, metadata))
+            continue
+
+        if path.resolve(strict=True) in required:
+            categories = ", ".join(findings)
+            raise RecoveryError(
+                f"Required Compose config contains sensitive content: {relative} ({categories})"
+            )
+
+        excluded.append(
+            {
+                "path": relative,
+                "size": metadata.st_size,
+                "mode": f"{stat.S_IMODE(metadata.st_mode):04o}",
+                "sha256": _sha256_file(path),
+                "findings": list(findings),
+            }
+        )
+
+    return included, excluded
+
+
+def build_manifest(
+    files: Iterable[tuple[Path, str, os.stat_result]],
+    excluded_sensitive_files: Iterable[dict[str, object]] = (),
+) -> dict[str, object]:
     entries = [
         {
             "path": relative,
@@ -187,15 +367,23 @@ def build_manifest(files: Iterable[tuple[Path, str, os.stat_result]]) -> dict[st
         }
         for path, relative, metadata in files
     ]
+    exclusions = list(excluded_sensitive_files)
     return {
         "schema": SCHEMA,
         "file_count": len(entries),
         "total_bytes": sum(int(entry["size"]) for entry in entries),
         "files": entries,
+        "excluded_sensitive_file_count": len(exclusions),
+        "excluded_sensitive_files": exclusions,
     }
 
 
-def _add_bytes(archive: tarfile.TarFile, name: str, payload: bytes, mode: int = 0o644) -> None:
+def _add_bytes(
+    archive: tarfile.TarFile,
+    name: str,
+    payload: bytes,
+    mode: int = 0o644,
+) -> None:
     info = tarfile.TarInfo(name)
     info.size = len(payload)
     info.mode = mode
@@ -204,38 +392,78 @@ def _add_bytes(archive: tarfile.TarFile, name: str, payload: bytes, mode: int = 
 
 
 def stream_archive(
-    root: Path, project: str, files: list[tuple[Path, str, os.stat_result]], output: BinaryIO
+    root: Path,
+    project: str,
+    files: list[tuple[Path, str, os.stat_result]],
+    output: BinaryIO,
+    required_configs: Iterable[Path] = (),
 ) -> None:
-    manifest = build_manifest(files)
+    included, excluded = scan_selected_files(files, required_configs)
+    manifest = build_manifest(included, excluded)
     receipt = {
         "schema": SCHEMA,
         "operation": "recover-v3-runtime-contract",
         "container": CONTAINER_NAME,
         "source_root": str(root),
         "compose_project": project,
-        "docker_metadata_fields": [COMPOSE_PROJECT_LABEL, COMPOSE_WORKING_DIR_LABEL, COMPOSE_CONFIG_FILES_LABEL],
+        "docker_metadata_fields": [
+            COMPOSE_PROJECT_LABEL,
+            COMPOSE_WORKING_DIR_LABEL,
+            COMPOSE_CONFIG_FILES_LABEL,
+        ],
         "docker_inspect_env": False,
+        "source_content_scan": {
+            "performed": True,
+            "mode": "fail-closed-before-stream",
+            "rules": list(CONTENT_SCAN_RULES),
+            "candidate_file_count": len(files),
+            "candidate_total_bytes": sum(metadata.st_size for _, _, metadata in files),
+            "included_file_count": manifest["file_count"],
+            "included_total_bytes": manifest["total_bytes"],
+            "excluded_sensitive_file_count": manifest["excluded_sensitive_file_count"],
+        },
         "db_access": False,
         "host_mutation": False,
         "file_count": manifest["file_count"],
         "total_bytes": manifest["total_bytes"],
-        "limits": {"max_files": MAX_FILES, "max_total_bytes": MAX_TOTAL_BYTES, "max_file_bytes": MAX_FILE_BYTES},
+        "limits": {
+            "max_files": MAX_FILES,
+            "max_total_bytes": MAX_TOTAL_BYTES,
+            "max_file_bytes": MAX_FILE_BYTES,
+        },
     }
+
     with tarfile.open(fileobj=output, mode="w|gz", format=tarfile.PAX_FORMAT) as archive:
-        for path, relative, metadata in files:
+        for path, relative, metadata in included:
             info = tarfile.TarInfo(f"source/{relative}")
             info.size = metadata.st_size
             info.mode = stat.S_IMODE(metadata.st_mode)
             info.mtime = 0
             with path.open("rb") as handle:
                 archive.addfile(info, handle)
-        _add_bytes(archive, "recovery-manifest.json", json.dumps(manifest, indent=2, sort_keys=True).encode() + b"\n")
-        _add_bytes(archive, "recovery-receipt.json", json.dumps(receipt, indent=2, sort_keys=True).encode() + b"\n")
+        _add_bytes(
+            archive,
+            "recovery-manifest.json",
+            json.dumps(manifest, indent=2, sort_keys=True).encode() + b"\n",
+        )
+        _add_bytes(
+            archive,
+            "recovery-receipt.json",
+            json.dumps(receipt, indent=2, sort_keys=True).encode() + b"\n",
+        )
 
 
 def docker_compose_labels(container: str) -> str:
     result = subprocess.run(
-        ["docker", "inspect", "--type", "container", "--format", "{{json .Config.Labels}}", container],
+        [
+            "docker",
+            "inspect",
+            "--type",
+            "container",
+            "--format",
+            "{{json .Config.Labels}}",
+            container,
+        ],
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -254,11 +482,14 @@ def main(argv: list[str] | None = None) -> int:
     try:
         root, configs, project = parse_compose_labels(docker_compose_labels(args.container))
         files = collect_files(root, configs)
-        stream_archive(root, project, files, sys.stdout.buffer)
+        stream_archive(root, project, files, sys.stdout.buffer, required_configs=configs)
     except (OSError, RecoveryError, subprocess.SubprocessError) as exc:
         print(f"STOP: V3 runtime recovery failed closed: {exc}", file=sys.stderr)
         return 1
-    print("V3 runtime recovery stream completed without DB access or host mutation", file=sys.stderr)
+    print(
+        "V3 runtime recovery stream completed without DB access or host mutation",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -635,10 +635,14 @@ def _scan_python_function_defaults(
 ) -> None:
     positional = [*node.args.posonlyargs, *node.args.args]
     if node.args.defaults:
-        for argument, default in zip(positional[-len(node.args.defaults):], node.args.defaults):
+        for argument, default in zip(
+            positional[-len(node.args.defaults):], node.args.defaults, strict=True
+        ):
             if _name_is_sensitive(argument.arg) and not _python_expression_is_safe(argument.arg, default):
                 findings.add("sensitive-environment-assignment")
-    for argument, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+    for argument, default in zip(
+        node.args.kwonlyargs, node.args.kw_defaults, strict=True
+    ):
         if default is None:
             continue
         if _name_is_sensitive(argument.arg) and not _python_expression_is_safe(argument.arg, default):

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -80,39 +80,34 @@ COMPOSE_CONFIG_FILES_LABEL = "com.docker.compose.project.config_files"
 COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
 SCHEMA = "edfinder-v3-runtime-recovery/v2"
 
-SENSITIVE_ENV_NAME = (
-    r"(?:"
-    r"[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|TOKEN|SECRET|PRIVATE_KEY|API_KEY|APIKEY)"
-    r"[A-Z0-9_]*"
-    r"|[A-Z][A-Z0-9_]*_PASS(?:_[A-Z0-9_]+)*"
-    r"|PASSWORD|PASSWD|PASS|TOKEN|SECRET|PRIVATE_KEY|API_KEY|APIKEY"
-    r"|DATABASE_URL|REDIS_URL|CACHE_URL|CELERY_BROKER_URL"
-    r"|OCTOPUS_DATA_KEY|DATA_ENCRYPTION_KEY"
-    r")"
-)
+IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
+MAPPING_KEY_PREFIX = r"(?:^\s*|(?<!\$)[{,]\s*)"
 QUOTED_ENV_ASSIGNMENT_RE = re.compile(
-    rf"(?<![A-Za-z0-9_])(?P<name>{SENSITIVE_ENV_NAME})\s*=\s*"
+    rf"(?<![A-Za-z0-9_])(?P<name>{IDENTIFIER})\s*=\s*"
     r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)",
+    re.MULTILINE,
 )
 BARE_ENV_ASSIGNMENT_RE = re.compile(
-    rf"(?<![A-Za-z0-9_])(?P<name>{SENSITIVE_ENV_NAME})\s*=\s*"
+    rf"(?<![A-Za-z0-9_])(?P<name>{IDENTIFIER})\s*=\s*"
     r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)",
+    re.MULTILINE,
 )
 # Mapping keys must be genuine line/flow-map keys. In particular, do not treat
 # the colon in shell/Compose interpolation (e.g. ${PASSWORD_FILE:-path}) as a
-# YAML mapping separator. The negative lookbehind on the flow-map opening brace
-# keeps `${...}` out while still accepting `{PASSWORD: value}` and comma keys.
-MAPPING_KEY_PREFIX = r"(?:^\s*|(?<!\$)[{,]\s*)"
+# YAML mapping separator. Bare values explicitly exclude quote-started scalars
+# so a quoted placeholder cannot be matched a second time as a truncated bare
+# value.
 QUOTED_MAPPING_ENV_RE = re.compile(
-    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
+    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
     r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote)",
 )
 BARE_MAPPING_ENV_RE = re.compile(
-    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
-    r"(?P=keyquote)\s*:\s*(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+)",
+    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
+    r"(?P=keyquote)\s*:(?![ \t]*[\"'])[ \t]*"
+    r"(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+)",
 )
 DOCKERFILE_ENV_SPACE_RE = re.compile(
-    rf"(?im)^\s*ENV\s+(?P<name>{SENSITIVE_ENV_NAME})\s+(?P<value>[^\r\n#]+)"
+    rf"(?im)^\s*ENV\s+(?P<name>{IDENTIFIER})\s+(?P<value>[^\r\n#]+)"
 )
 CREDENTIALED_URI_RE = re.compile(
     r"(?i)\b[a-z][a-z0-9+.-]*://[^/\s:@]*:(?P<password>[^@\s/]+)@"
@@ -129,6 +124,24 @@ DSN_CREDENTIAL_PARAM_RE = re.compile(
 SQL_PASSWORD_RE = re.compile(
     r"(?is)\b(?:ALTER|CREATE)\s+(?:ROLE|USER)\b[^;]*?\bPASSWORD\s*(?:=)?\s*"
     r"(?P<quote>[\"'])(?P<password>.*?)(?P=quote)"
+)
+AUTHORIZATION_RE = re.compile(
+    r"""(?im)[\"']?Authorization[\"']?\s*[:=]\s*"""
+    r"""(?P<quote>[\"']?)(?P<scheme>Bearer|Basic)\s+"""
+    r"""(?P<credential>[^\s\"',\]]+)"""
+)
+STRUCTURED_ENV_NAME_RE = re.compile(
+    rf"""^(?P<indent>[ \t]*)-\s*name\s*:\s*"""
+    rf"""(?P<quote>[\"']?)(?P<name>{IDENTIFIER})(?P=quote)\s*(?:#.*)?$""",
+    re.IGNORECASE,
+)
+STRUCTURED_ENV_VALUE_RE = re.compile(
+    r"""^(?P<indent>[ \t]*)value\s*:\s*(?P<value>.+?)\s*(?:#.*)?$""",
+    re.IGNORECASE,
+)
+STRUCTURED_ENV_VALUE_FROM_RE = re.compile(
+    r"""^(?P<indent>[ \t]*)valueFrom\s*:""",
+    re.IGNORECASE,
 )
 TOKEN_PATTERNS = (
     (
@@ -148,12 +161,45 @@ TOKEN_PATTERNS = (
 CONTENT_SCAN_RULES = (
     "private-key-material",
     "recognized-api-token",
+    "authorization-credential",
     "credentialed-uri-or-dsn",
     "non-placeholder-sensitive-assignment",
+    "structured-name-value-environment-entry",
     "sql-password-statement",
     "exact-scanned-bytes-archived",
+    "sensitive-file-digest-omitted",
 )
 URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
+TOKEN_METRIC_WORDS = {
+    "BUDGET",
+    "BUDGETS",
+    "CAP",
+    "CAPACITY",
+    "COUNT",
+    "COUNTS",
+    "EXPIRATION",
+    "EXPIRY",
+    "LENGTH",
+    "LENGTHS",
+    "LIMIT",
+    "LIMITS",
+    "MAX",
+    "MIN",
+    "RATE",
+    "RATES",
+    "SIZE",
+    "SIZES",
+    "TTL",
+    "WINDOW",
+    "WINDOWS",
+}
+NONSENSITIVE_REFERENCE_NAMES = {
+    "SECRETKEYREF",
+    "SECRETREF",
+    "SECRETNAME",
+    "SECRETKEYSELECTOR",
+    "SECRETSOURCE",
+}
 
 
 @dataclass(frozen=True)
@@ -263,11 +309,38 @@ def collect_files(
     return selected
 
 
+def _name_is_sensitive(name: str) -> bool:
+    upper = name.upper()
+    compact = upper.replace("_", "")
+    if compact in NONSENSITIVE_REFERENCE_NAMES:
+        return False
+    if upper in URL_ENV_NAMES or upper in {"OCTOPUS_DATA_KEY", "DATA_ENCRYPTION_KEY"}:
+        return True
+    if any(
+        marker in upper
+        for marker in ("PASSWORD", "PASSWD", "PRIVATE_KEY", "API_KEY", "APIKEY", "SECRET")
+    ):
+        return True
+    if upper == "PASS" or upper.endswith("_PASS") or "_PASS_" in upper:
+        return True
+
+    parts = [part for part in upper.split("_") if part]
+    for index, part in enumerate(parts):
+        if part != "TOKEN":
+            continue
+        previous = parts[index - 1] if index else None
+        following = parts[index + 1] if index + 1 < len(parts) else None
+        if previous in TOKEN_METRIC_WORDS or following in TOKEN_METRIC_WORDS:
+            continue
+        return True
+    return False
+
+
 def _placeholder_value(value: str) -> bool:
     candidate = value.strip().strip("\"'")
     if not candidate:
         return True
-    var_name = r"[A-Za-z_][A-Za-z0-9_]*"
+    var_name = IDENTIFIER
     if re.fullmatch(rf"\$\{{{var_name}\}}", candidate):
         return True
     if re.fullmatch(rf"\$\{{{var_name}(?::?\?[^}}]*)\}}", candidate):
@@ -276,9 +349,34 @@ def _placeholder_value(value: str) -> bool:
         return True
     if re.fullmatch(rf"\${var_name}", candidate):
         return True
-    if re.fullmatch(r"\{\{[^{}]+\}\}", candidate):
+
+    jinja = re.fullmatch(r"\{\{(?P<body>[^{}]+)\}\}", candidate)
+    if jinja:
+        body = jinja.group("body").strip()
+        direct_literal = re.fullmatch(r"""(?P<quote>['\"])(?P<literal>.*?)(?P=quote)""", body)
+        if direct_literal:
+            return not bool(direct_literal.group("literal"))
+        default_match = re.search(
+            r"\bdefault\s*\(\s*(?P<argument>.*?)\s*\)",
+            body,
+            re.IGNORECASE,
+        )
+        if default_match:
+            argument = default_match.group("argument").strip()
+            quoted_default = re.fullmatch(
+                r"""(?P<quote>['\"])(?P<literal>.*?)(?P=quote)""",
+                argument,
+            )
+            if quoted_default:
+                return not bool(quoted_default.group("literal"))
+            return bool(re.fullmatch(IDENTIFIER, argument))
         return True
-    if re.fullmatch(r"<(?:redacted|placeholder|secret|password|token|[^>]*_here)>", candidate, re.I):
+
+    if re.fullmatch(
+        r"<(?:redacted|placeholder|secret|password|token|[^>]*_here)>",
+        candidate,
+        re.IGNORECASE,
+    ):
         return True
     if candidate.upper() in {
         "REDACTED",
@@ -317,8 +415,74 @@ def _assignment_value_is_safe(name: str, value: str) -> bool:
     if upper_name in URL_ENV_NAMES:
         candidate = value.strip().strip("\"'")
         credential_values = _credential_values(candidate)
-        return not credential_values or all(_placeholder_value(item) for item in credential_values)
+        return not credential_values or all(
+            _placeholder_value(item) for item in credential_values
+        )
     return False
+
+
+def _scan_assignment_patterns(text: str, findings: set[str]) -> None:
+    for pattern in (
+        QUOTED_ENV_ASSIGNMENT_RE,
+        BARE_ENV_ASSIGNMENT_RE,
+        QUOTED_MAPPING_ENV_RE,
+        BARE_MAPPING_ENV_RE,
+    ):
+        for match in pattern.finditer(text):
+            name = match.group("name")
+            if not _name_is_sensitive(name):
+                continue
+            if not _assignment_value_is_safe(name, match.group("value")):
+                findings.add("sensitive-environment-assignment")
+
+
+def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        name_match = STRUCTURED_ENV_NAME_RE.match(line)
+        if not name_match:
+            continue
+        name = name_match.group("name")
+        if not _name_is_sensitive(name):
+            continue
+
+        base_indent = len(name_match.group("indent").expandtabs(4))
+        for next_line in lines[index + 1 : index + 8]:
+            stripped = next_line.lstrip(" \t")
+            next_indent = len(next_line[: len(next_line) - len(stripped)].expandtabs(4))
+            if stripped.startswith("-") and next_indent <= base_indent:
+                break
+            if STRUCTURED_ENV_VALUE_FROM_RE.match(next_line):
+                break
+            value_match = STRUCTURED_ENV_VALUE_RE.match(next_line)
+            if value_match:
+                if not _assignment_value_is_safe(name, value_match.group("value")):
+                    findings.add("sensitive-environment-assignment")
+                break
+
+
+def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
+    try:
+        document = json.loads(text)
+    except json.JSONDecodeError:
+        return
+
+    def walk(value: object) -> None:
+        if isinstance(value, dict):
+            name = value.get("name")
+            literal = value.get("value")
+            if isinstance(name, str) and _name_is_sensitive(name) and literal is not None:
+                if isinstance(literal, (str, int, float, bool)) and not _assignment_value_is_safe(
+                    name, str(literal)
+                ):
+                    findings.add("sensitive-environment-assignment")
+            for nested in value.values():
+                walk(nested)
+        elif isinstance(value, list):
+            for nested in value:
+                walk(nested)
+
+    walk(document)
 
 
 def _scan_text(text: str, relative: str) -> tuple[str, ...]:
@@ -327,6 +491,10 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
     for category, pattern in TOKEN_PATTERNS:
         if pattern.search(text):
             findings.add(category)
+
+    for match in AUTHORIZATION_RE.finditer(text):
+        if not _placeholder_value(match.group("credential")):
+            findings.add("authorization-credential")
 
     for pattern in (CREDENTIALED_URI_RE, URI_QUERY_CREDENTIAL_RE):
         for match in pattern.finditer(text):
@@ -337,21 +505,21 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
         if not _placeholder_value(match.group("password")):
             findings.add("credentialed-dsn")
 
-    for pattern in (
-        QUOTED_ENV_ASSIGNMENT_RE,
-        BARE_ENV_ASSIGNMENT_RE,
-        QUOTED_MAPPING_ENV_RE,
-        BARE_MAPPING_ENV_RE,
-    ):
-        for match in pattern.finditer(text):
-            if not _assignment_value_is_safe(match.group("name"), match.group("value")):
-                findings.add("sensitive-environment-assignment")
+    _scan_assignment_patterns(text, findings)
 
     relative_path = PurePosixPath(relative)
     if relative_path.name.lower().startswith(BUILD_FILE_PREFIXES):
         for match in DOCKERFILE_ENV_SPACE_RE.finditer(text):
-            if not _assignment_value_is_safe(match.group("name"), match.group("value")):
+            name = match.group("name")
+            if _name_is_sensitive(name) and not _assignment_value_is_safe(
+                name, match.group("value")
+            ):
                 findings.add("sensitive-environment-assignment")
+
+    if relative_path.suffix.lower() in {".yml", ".yaml"}:
+        _scan_structured_yaml_environment(text, findings)
+    elif relative_path.suffix.lower() == ".json":
+        _scan_structured_json_environment(text, findings)
 
     if relative_path.suffix.lower() == ".sql":
         for match in SQL_PASSWORD_RE.finditer(text):
@@ -408,11 +576,15 @@ def scan_selected_files(
             raise RecoveryError(f"Selected text file is not valid UTF-8: {relative}") from exc
 
         findings = _scan_text(text, relative)
-        digest = hashlib.sha256(payload).hexdigest()
         mode = stat.S_IMODE(metadata.st_mode)
         if not findings:
             included.append(
-                ScannedFile(relative=relative, mode=mode, payload=payload, sha256=digest)
+                ScannedFile(
+                    relative=relative,
+                    mode=mode,
+                    payload=payload,
+                    sha256=hashlib.sha256(payload).hexdigest(),
+                )
             )
             continue
 
@@ -422,12 +594,14 @@ def scan_selected_files(
                 f"Required Compose config contains sensitive content: {relative} ({categories})"
             )
 
+        # Never publish a content digest for a file known to contain a secret.
+        # A whole-file digest can act as an offline oracle when the surrounding
+        # content is predictable and only the credential value varies.
         excluded.append(
             {
                 "path": relative,
                 "size": len(payload),
                 "mode": f"{mode:04o}",
-                "sha256": digest,
                 "findings": list(findings),
             }
         )
@@ -507,6 +681,7 @@ def stream_archive(
             "included_total_bytes": manifest["total_bytes"],
             "excluded_sensitive_file_count": manifest["excluded_sensitive_file_count"],
             "archive_uses_exact_scanned_bytes": True,
+            "excluded_sensitive_content_digests": False,
         },
         "db_access": False,
         "host_mutation": False,

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -27,6 +27,7 @@ import stat
 import subprocess
 import sys
 import tarfile
+import tokenize
 from typing import BinaryIO, Iterable
 
 
@@ -53,7 +54,7 @@ SCHEMA = "edfinder-v3-runtime-recovery/v2"
 
 IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
 STRUCTURED_KEY = r"[A-Za-z_][A-Za-z0-9_.-]*"
-MAPPING_KEY_PREFIX = r"(?:^\s*|(?<!\$)[{,]\s*)"
+MAPPING_KEY_PREFIX = r"(?:^\s*-\s*|^\s*|(?<!\$)[{,]\s*)"
 QUOTED_ENV_ASSIGNMENT_RE = re.compile(
     rf"(?<![A-Za-z0-9_])(?P<name>{IDENTIFIER})\s*=\s*"
     r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)", re.MULTILINE,
@@ -150,9 +151,9 @@ CONTENT_SCAN_RULES = (
     "private-key-material", "recognized-api-token", "authorization-credential",
     "credentialed-uri-or-dsn", "credential-command-option",
     "non-placeholder-sensitive-assignment", "structured-name-value-environment-entry",
-    "python-ast-sensitive-assignment", "kubernetes-secret-payload",
-    "sql-password-statement", "exact-scanned-bytes-archived",
-    "sensitive-file-digest-omitted",
+    "python-ast-sensitive-assignment", "python-comment-docstring-sensitive-assignment",
+    "kubernetes-secret-payload", "sql-password-statement",
+    "exact-scanned-bytes-archived", "sensitive-file-digest-omitted",
 )
 URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
 TOKEN_METRIC_WORDS = {
@@ -162,6 +163,9 @@ TOKEN_METRIC_WORDS = {
 }
 NONSENSITIVE_REFERENCE_NAMES = {
     "SECRETKEYREF", "SECRETREF", "SECRETNAME", "SECRETKEYSELECTOR", "SECRETSOURCE",
+}
+PYTHON_LOOKUP_CALL_NAMES = {
+    "fetch_secret", "get_secret", "load_secret", "read_secret", "resolve_secret",
 }
 
 
@@ -525,43 +529,68 @@ def _python_target_names(target: ast.expr) -> list[str]:
     return []
 
 
-def _python_retrieval_call_is_safe(name: str, value: ast.Call) -> bool:
-    function_name = ""
+def _python_call_name(value: ast.Call) -> str:
     if isinstance(value.func, ast.Name):
-        function_name = value.func.id
-    elif isinstance(value.func, ast.Attribute):
-        function_name = value.func.attr
-    if function_name.lower() not in {"get", "getenv"}:
-        return True
-    defaults = list(value.args[1:])
-    defaults.extend(keyword.value for keyword in value.keywords if keyword.arg in {"default", "fallback"})
-    for default in defaults:
-        if isinstance(default, ast.Constant):
-            if default.value is None:
-                continue
-            if isinstance(default.value, (str, int, float, bool)) and not _assignment_value_is_safe(
-                name, str(default.value)
-            ):
-                return False
-    return True
+        return value.func.id.lower()
+    if isinstance(value.func, ast.Attribute):
+        return value.func.attr.lower()
+    return ""
 
 
-def _python_assignment_value_is_safe(name: str, value: ast.expr) -> bool:
+def _python_expression_is_safe(name: str, value: ast.expr) -> bool:
     if isinstance(value, ast.Constant):
         if value.value is None:
             return True
         if isinstance(value.value, (str, int, float, bool)):
             return _assignment_value_is_safe(name, str(value.value))
         return True
+    if isinstance(value, (ast.Name, ast.Attribute, ast.Subscript)):
+        return True
     if isinstance(value, ast.JoinedStr):
         for item in value.values:
             if isinstance(item, ast.Constant) and isinstance(item.value, str) and item.value:
                 if not _placeholder_value(item.value):
                     return False
+            elif isinstance(item, ast.FormattedValue):
+                if not _python_expression_is_safe(name, item.value):
+                    return False
         return True
     if isinstance(value, ast.Call):
-        return _python_retrieval_call_is_safe(name, value)
-    return True
+        function_name = _python_call_name(value)
+        if function_name in {"get", "getenv"}:
+            defaults = list(value.args[1:])
+            defaults.extend(
+                keyword.value
+                for keyword in value.keywords
+                if keyword.arg in {"default", "fallback"}
+            )
+            return all(_python_expression_is_safe(name, default) for default in defaults)
+        if function_name in PYTHON_LOOKUP_CALL_NAMES:
+            extras = list(value.args[1:])
+            extras.extend(
+                keyword.value
+                for keyword in value.keywords
+                if keyword.arg in {"default", "fallback"}
+            )
+            return all(_python_expression_is_safe(name, item) for item in extras)
+        components: list[ast.expr] = list(value.args)
+        components.extend(keyword.value for keyword in value.keywords)
+        if isinstance(value.func, ast.Attribute):
+            components.append(value.func.value)
+        return all(_python_expression_is_safe(name, item) for item in components)
+    if isinstance(value, ast.BinOp):
+        return _python_expression_is_safe(name, value.left) and _python_expression_is_safe(name, value.right)
+    if isinstance(value, ast.IfExp):
+        return _python_expression_is_safe(name, value.body) and _python_expression_is_safe(name, value.orelse)
+    if isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+        return all(_python_expression_is_safe(name, item) for item in value.elts)
+    if isinstance(value, ast.Dict):
+        candidates = [item for item in (*value.keys, *value.values) if isinstance(item, ast.expr)]
+        return all(_python_expression_is_safe(name, item) for item in candidates)
+    child_expressions = [item for item in ast.iter_child_nodes(value) if isinstance(item, ast.expr)]
+    if child_expressions:
+        return all(_python_expression_is_safe(name, item) for item in child_expressions)
+    return False
 
 
 def _scan_python_assignments(text: str, findings: set[str]) -> None:
@@ -585,8 +614,44 @@ def _scan_python_assignments(text: str, findings: set[str]) -> None:
         for target in targets:
             names.extend(_python_target_names(target))
         for name in names:
-            if _name_is_sensitive(name) and not _python_assignment_value_is_safe(name, value):
+            if _name_is_sensitive(name) and not _python_expression_is_safe(name, value):
                 findings.add("sensitive-environment-assignment")
+
+
+def _scan_embedded_assignment_text(text: str, findings: set[str]) -> None:
+    for match in QUOTED_ENV_ASSIGNMENT_RE.finditer(text):
+        name = match.group("name")
+        if _name_is_sensitive(name) and not _assignment_value_is_safe(name, match.group("value")):
+            findings.add("sensitive-environment-assignment")
+    for match in BARE_ENV_ASSIGNMENT_RE.finditer(text):
+        name = match.group("name")
+        value = match.group("value").strip()
+        if not _name_is_sensitive(name):
+            continue
+        if _placeholder_value(value):
+            continue
+        if re.fullmatch(rf"{IDENTIFIER}(?:\.{IDENTIFIER})*", value):
+            continue
+        if any(marker in value for marker in ("(", "[", "{")):
+            continue
+        findings.add("sensitive-environment-assignment")
+
+
+def _scan_python_comments_and_strings(text: str, findings: set[str]) -> None:
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        for item in tokens:
+            if item.type == tokenize.COMMENT:
+                _scan_embedded_assignment_text(item.string.lstrip("#").strip(), findings)
+            elif item.type == tokenize.STRING:
+                try:
+                    literal = ast.literal_eval(item.string)
+                except (SyntaxError, ValueError):
+                    continue
+                if isinstance(literal, str):
+                    _scan_embedded_assignment_text(literal, findings)
+    except (IndentationError, tokenize.TokenError):
+        findings.add("python-tokenization-unscannable")
 
 
 def _command_credential(match: re.Match[str]) -> str:
@@ -606,6 +671,13 @@ def _scan_command_options(text: str, findings: set[str]) -> None:
             credential = _command_credential(match)
             if credential and not _placeholder_value(credential):
                 findings.add("credential-command-option")
+
+
+def _scan_sql_passwords(text: str, findings: set[str]) -> None:
+    for pattern in (SQL_PASSWORD_RE, SQL_DOLLAR_PASSWORD_RE):
+        for match in pattern.finditer(text):
+            if not _placeholder_value(match.group("password")):
+                findings.add("sql-password-statement")
 
 
 def _scan_text(text: str, relative: str) -> tuple[str, ...]:
@@ -631,6 +703,7 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
             if not _placeholder_value(password):
                 findings.add("credentialed-dsn")
     _scan_command_options(text, findings)
+    _scan_sql_passwords(text, findings)
 
     relative_path = PurePosixPath(relative)
     is_python = relative_path.suffix.lower() == ".py"
@@ -658,12 +731,8 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
                 findings.add("kubernetes-secret-payload")
     elif suffix == ".py":
         _scan_python_assignments(text, findings)
+        _scan_python_comments_and_strings(text, findings)
 
-    if suffix == ".sql":
-        for pattern in (SQL_PASSWORD_RE, SQL_DOLLAR_PASSWORD_RE):
-            for match in pattern.finditer(text):
-                if not _placeholder_value(match.group("password")):
-                    findings.add("sql-password-statement")
     return tuple(sorted(findings))
 
 

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -102,7 +102,16 @@ YAML_MAPPING_ENV_RE = re.compile(
 )
 CREDENTIALED_URI_RE = re.compile(
     r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|"
-    r"amqp|amqps)://[^/\s:@]+:(?P<password>[^@\s/]+)@",
+    r"amqp|amqps)://[^/\s:@]*:(?P<password>[^@\s/]+)@",
+)
+URI_QUERY_CREDENTIAL_RE = re.compile(
+    r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|"
+    r"amqp|amqps)://[^\s\"'<>]*[?&;]"
+    r"(?:password|passwd|pwd|secret|token|api_?key)=(?P<password>[^&#;\s\"'<>]+)",
+)
+DSN_CREDENTIAL_PARAM_RE = re.compile(
+    r"(?i)(?:^|[\s?&;])(?:password|passwd|pwd|secret|token|api_?key)\s*=\s*"
+    r"(?P<password>[^\s;&]+)",
 )
 TOKEN_PATTERNS = (
     (
@@ -269,10 +278,14 @@ def _assignment_value_is_safe(name: str, value: str) -> bool:
     if _placeholder_value(value):
         return True
     if name.upper() in URL_ENV_NAMES:
-        matches = list(CREDENTIALED_URI_RE.finditer(value.strip().strip("\"'")))
-        return not matches or all(
-            _placeholder_value(match.group("password")) for match in matches
+        candidate = value.strip().strip("\"'")
+        credential_values = [
+            match.group("password") for match in CREDENTIALED_URI_RE.finditer(candidate)
+        ]
+        credential_values.extend(
+            match.group("password") for match in DSN_CREDENTIAL_PARAM_RE.finditer(candidate)
         )
+        return not credential_values or all(_placeholder_value(item) for item in credential_values)
     return False
 
 
@@ -283,9 +296,10 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
         if pattern.search(text):
             findings.add(category)
 
-    for match in CREDENTIALED_URI_RE.finditer(text):
-        if not _placeholder_value(match.group("password")):
-            findings.add("credentialed-uri")
+    for pattern in (CREDENTIALED_URI_RE, URI_QUERY_CREDENTIAL_RE):
+        for match in pattern.finditer(text):
+            if not _placeholder_value(match.group("password")):
+                findings.add("credentialed-uri")
 
     relative_path = PurePosixPath(relative)
     assignment_scan = (

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -92,19 +92,20 @@ BARE_ENV_ASSIGNMENT_RE = re.compile(
     r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)",
     re.MULTILINE,
 )
-# Mapping keys must be genuine line/flow-map keys. In particular, do not treat
-# the colon in shell/Compose interpolation (e.g. ${PASSWORD_FILE:-path}) as a
-# YAML mapping separator. Bare values explicitly exclude quote-started scalars
-# so a quoted placeholder cannot be matched a second time as a truncated bare
-# value.
+# Mapping matches are zero-width lookaheads so an outer flow-map key cannot
+# consume nested mappings and hide an inner sensitive assignment. In
+# particular, do not treat the colon in shell/Compose interpolation (for
+# example ${PASSWORD_FILE:-path}) as a YAML mapping separator. Bare values
+# explicitly exclude quote-started scalars so a quoted placeholder cannot be
+# matched a second time as a truncated bare value.
 QUOTED_MAPPING_ENV_RE = re.compile(
-    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
-    r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote)",
+    rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
+    r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote))",
 )
 BARE_MAPPING_ENV_RE = re.compile(
-    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
+    rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
     r"(?P=keyquote)\s*:(?![ \t]*[\"'])[ \t]*"
-    r"(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+)",
+    r"(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+))",
 )
 DOCKERFILE_ENV_SPACE_RE = re.compile(
     rf"(?im)^\s*ENV\s+(?P<name>{IDENTIFIER})\s+(?P<value>[^\r\n#]+)"
@@ -336,6 +337,46 @@ def _name_is_sensitive(name: str) -> bool:
     return False
 
 
+def _jinja_reference_expression_is_safe(body: str) -> bool:
+    reference = rf"{IDENTIFIER}(?:\.{IDENTIFIER})*"
+    pipeline = [part.strip() for part in body.split("|")]
+    if not pipeline or not re.fullmatch(reference, pipeline[0]):
+        return False
+
+    for filter_expression in pipeline[1:]:
+        filter_match = re.fullmatch(
+            rf"(?P<name>{IDENTIFIER})(?:\((?P<arguments>.*)\))?",
+            filter_expression,
+        )
+        if not filter_match:
+            return False
+        arguments = filter_match.group("arguments")
+        if arguments is None or not arguments.strip():
+            continue
+
+        argument = arguments.strip()
+        # Multiple/literal filter arguments are not demonstrably reference-only.
+        if "," in argument:
+            return False
+        if filter_match.group("name").lower() == "default":
+            quoted_default = re.fullmatch(
+                r"""(?P<quote>['\"])(?P<literal>.*?)(?P=quote)""",
+                argument,
+            )
+            if quoted_default:
+                if quoted_default.group("literal"):
+                    return False
+                continue
+            if re.fullmatch(reference, argument):
+                continue
+            return False
+
+        if not re.fullmatch(reference, argument):
+            return False
+
+    return True
+
+
 def _placeholder_value(value: str) -> bool:
     candidate = value.strip().strip("\"'")
     if not candidate:
@@ -352,25 +393,7 @@ def _placeholder_value(value: str) -> bool:
 
     jinja = re.fullmatch(r"\{\{(?P<body>[^{}]+)\}\}", candidate)
     if jinja:
-        body = jinja.group("body").strip()
-        direct_literal = re.fullmatch(r"""(?P<quote>['\"])(?P<literal>.*?)(?P=quote)""", body)
-        if direct_literal:
-            return not bool(direct_literal.group("literal"))
-        default_match = re.search(
-            r"\bdefault\s*\(\s*(?P<argument>.*?)\s*\)",
-            body,
-            re.IGNORECASE,
-        )
-        if default_match:
-            argument = default_match.group("argument").strip()
-            quoted_default = re.fullmatch(
-                r"""(?P<quote>['\"])(?P<literal>.*?)(?P=quote)""",
-                argument,
-            )
-            if quoted_default:
-                return not bool(quoted_default.group("literal"))
-            return bool(re.fullmatch(IDENTIFIER, argument))
-        return True
+        return _jinja_reference_expression_is_safe(jinja.group("body").strip())
 
     if re.fullmatch(
         r"<(?:redacted|placeholder|secret|password|token|[^>]*_here)>",
@@ -421,18 +444,28 @@ def _assignment_value_is_safe(name: str, value: str) -> bool:
     return False
 
 
+def _compose_secret_reference_collection(name: str, value: str) -> bool:
+    return name.lower() == "secrets" and value.strip().startswith(("[", "{"))
+
+
 def _scan_assignment_patterns(text: str, findings: set[str]) -> None:
-    for pattern in (
-        QUOTED_ENV_ASSIGNMENT_RE,
-        BARE_ENV_ASSIGNMENT_RE,
-        QUOTED_MAPPING_ENV_RE,
-        BARE_MAPPING_ENV_RE,
-    ):
+    for pattern in (QUOTED_ENV_ASSIGNMENT_RE, BARE_ENV_ASSIGNMENT_RE):
         for match in pattern.finditer(text):
             name = match.group("name")
             if not _name_is_sensitive(name):
                 continue
             if not _assignment_value_is_safe(name, match.group("value")):
+                findings.add("sensitive-environment-assignment")
+
+    for pattern in (QUOTED_MAPPING_ENV_RE, BARE_MAPPING_ENV_RE):
+        for match in pattern.finditer(text):
+            name = match.group("name")
+            value = match.group("value")
+            if _compose_secret_reference_collection(name, value):
+                continue
+            if not _name_is_sensitive(name):
+                continue
+            if not _assignment_value_is_safe(name, value):
                 findings.add("sensitive-environment-assignment")
 
 

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -98,12 +98,17 @@ BARE_ENV_ASSIGNMENT_RE = re.compile(
     rf"(?<![A-Za-z0-9_])(?P<name>{SENSITIVE_ENV_NAME})\s*=\s*"
     r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)",
 )
+# Mapping keys must be genuine line/flow-map keys. In particular, do not treat
+# the colon in shell/Compose interpolation (e.g. ${PASSWORD_FILE:-path}) as a
+# YAML mapping separator. The negative lookbehind on the flow-map opening brace
+# keeps `${...}` out while still accepting `{PASSWORD: value}` and comma keys.
+MAPPING_KEY_PREFIX = r"(?:^\s*|(?<!\$)[{,]\s*)"
 QUOTED_MAPPING_ENV_RE = re.compile(
-    rf"(?<![A-Za-z0-9_])(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
+    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
     r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote)",
 )
 BARE_MAPPING_ENV_RE = re.compile(
-    rf"(?<![A-Za-z0-9_])(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
+    rf"(?m){MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
     r"(?P=keyquote)\s*:\s*(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+)",
 )
 DOCKERFILE_ENV_SPACE_RE = re.compile(

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -7,12 +7,15 @@ root. The tar stream is written to stdout so the remote host is not mutated.
 
 Every candidate file is content-scanned before any archive bytes are emitted.
 Unsafe optional historical files are excluded with provenance-only metadata;
-unsafe required Compose files fail the whole recovery.
+unsafe required Compose files fail the whole recovery. The exact bytes that pass
+scanning are also the bytes hashed and archived, so a path cannot change between
+validation and export.
 """
 
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import hashlib
 import io
 import json
@@ -81,6 +84,8 @@ SENSITIVE_ENV_NAME = (
     r"(?:"
     r"[A-Z][A-Z0-9_]*(?:PASSWORD|PASSWD|TOKEN|SECRET|PRIVATE_KEY|API_KEY|APIKEY)"
     r"[A-Z0-9_]*"
+    r"|[A-Z][A-Z0-9_]*_PASS(?:_[A-Z0-9_]+)*"
+    r"|PASSWORD|PASSWD|PASS|TOKEN|SECRET|PRIVATE_KEY|API_KEY|APIKEY"
     r"|DATABASE_URL|REDIS_URL|CACHE_URL|CELERY_BROKER_URL"
     r"|OCTOPUS_DATA_KEY|DATA_ENCRYPTION_KEY"
     r")"
@@ -91,33 +96,40 @@ QUOTED_ENV_ASSIGNMENT_RE = re.compile(
 )
 BARE_ENV_ASSIGNMENT_RE = re.compile(
     rf"(?<![A-Za-z0-9_])(?P<name>{SENSITIVE_ENV_NAME})\s*=\s*"
-    r"(?P<value>[^\s,\"'\]\}]+)",
+    r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)",
 )
-JSON_MAPPING_ENV_RE = re.compile(
-    rf'["\'](?P<name>{SENSITIVE_ENV_NAME})["\']\s*:\s*'
-    r'(?P<quote>["\'])(?P<value>.*?)(?P=quote)',
+QUOTED_MAPPING_ENV_RE = re.compile(
+    rf"(?<![A-Za-z0-9_])(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
+    r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote)",
 )
-YAML_MAPPING_ENV_RE = re.compile(
-    rf"(?m)^\s*(?P<name>{SENSITIVE_ENV_NAME})\s*:\s*(?P<value>[^\r\n#]+)",
+BARE_MAPPING_ENV_RE = re.compile(
+    rf"(?<![A-Za-z0-9_])(?P<keyquote>[\"']?)(?P<name>{SENSITIVE_ENV_NAME})"
+    r"(?P=keyquote)\s*:\s*(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+)",
+)
+DOCKERFILE_ENV_SPACE_RE = re.compile(
+    rf"(?im)^\s*ENV\s+(?P<name>{SENSITIVE_ENV_NAME})\s+(?P<value>[^\r\n#]+)"
 )
 CREDENTIALED_URI_RE = re.compile(
-    r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|"
-    r"amqp|amqps)://[^/\s:@]*:(?P<password>[^@\s/]+)@",
+    r"(?i)\b[a-z][a-z0-9+.-]*://[^/\s:@]*:(?P<password>[^@\s/]+)@"
 )
 URI_QUERY_CREDENTIAL_RE = re.compile(
-    r"(?i)\b(?:postgres(?:ql)?|mysql|mariadb|redis|rediss|mongodb(?:\+srv)?|"
-    r"amqp|amqps)://[^\s\"'<>]*[?&;]"
-    r"(?:password|passwd|pwd|secret|token|api_?key)=(?P<password>[^&#;\s\"'<>]+)",
+    r"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"'<>]*[?&;]"
+    r"(?:password|passwd|pwd|secret|token|api_?key)="
+    r"(?P<password>[^&#;\s\"'<>]+)"
 )
 DSN_CREDENTIAL_PARAM_RE = re.compile(
     r"(?i)(?:^|[\s?&;])(?:password|passwd|pwd|secret|token|api_?key)\s*=\s*"
-    r"(?P<password>[^\s;&]+)",
+    r"(?P<password>[^\s;&\"']+)"
+)
+SQL_PASSWORD_RE = re.compile(
+    r"(?is)\b(?:ALTER|CREATE)\s+(?:ROLE|USER)\b[^;]*?\bPASSWORD\s*(?:=)?\s*"
+    r"(?P<quote>[\"'])(?P<password>.*?)(?P=quote)"
 )
 TOKEN_PATTERNS = (
     (
         "private-key-material",
         re.compile(
-            r"-----BEGIN (?:RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
+            r"-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
             re.IGNORECASE,
         ),
     ),
@@ -131,9 +143,20 @@ TOKEN_PATTERNS = (
 CONTENT_SCAN_RULES = (
     "private-key-material",
     "recognized-api-token",
-    "credentialed-database-or-cache-uri",
-    "non-placeholder-sensitive-environment-assignment",
+    "credentialed-uri-or-dsn",
+    "non-placeholder-sensitive-assignment",
+    "sql-password-statement",
+    "exact-scanned-bytes-archived",
 )
+URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
+
+
+@dataclass(frozen=True)
+class ScannedFile:
+    relative: str
+    mode: int
+    payload: bytes
+    sha256: str
 
 
 class RecoveryError(RuntimeError):
@@ -235,21 +258,18 @@ def collect_files(
     return selected
 
 
-def _sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
 def _placeholder_value(value: str) -> bool:
     candidate = value.strip().strip("\"'")
     if not candidate:
         return True
-    if re.fullmatch(r"\$\{[A-Za-z_][A-Za-z0-9_]*(?::\?[^}]*)?\}", candidate):
+    var_name = r"[A-Za-z_][A-Za-z0-9_]*"
+    if re.fullmatch(rf"\$\{{{var_name}\}}", candidate):
         return True
-    if re.fullmatch(r"\$[A-Za-z_][A-Za-z0-9_]*", candidate):
+    if re.fullmatch(rf"\$\{{{var_name}(?::?\?[^}}]*)\}}", candidate):
+        return True
+    if re.fullmatch(rf"\$\{{{var_name}(?::-|-)\}}", candidate):
+        return True
+    if re.fullmatch(rf"\${var_name}", candidate):
         return True
     if re.fullmatch(r"\{\{[^{}]+\}\}", candidate):
         return True
@@ -271,20 +291,27 @@ def _placeholder_value(value: str) -> bool:
     return False
 
 
-URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
+def _secret_file_reference(value: str) -> bool:
+    candidate = value.strip().strip("\"'")
+    return candidate.startswith(("/", "./", "../"))
+
+
+def _credential_values(text: str) -> list[str]:
+    values = [match.group("password") for match in CREDENTIALED_URI_RE.finditer(text)]
+    values.extend(match.group("password") for match in URI_QUERY_CREDENTIAL_RE.finditer(text))
+    values.extend(match.group("password") for match in DSN_CREDENTIAL_PARAM_RE.finditer(text))
+    return values
 
 
 def _assignment_value_is_safe(name: str, value: str) -> bool:
     if _placeholder_value(value):
         return True
-    if name.upper() in URL_ENV_NAMES:
+    upper_name = name.upper()
+    if upper_name.endswith("_FILE") and _secret_file_reference(value):
+        return True
+    if upper_name in URL_ENV_NAMES:
         candidate = value.strip().strip("\"'")
-        credential_values = [
-            match.group("password") for match in CREDENTIALED_URI_RE.finditer(candidate)
-        ]
-        credential_values.extend(
-            match.group("password") for match in DSN_CREDENTIAL_PARAM_RE.finditer(candidate)
-        )
+        credential_values = _credential_values(candidate)
         return not credential_values or all(_placeholder_value(item) for item in credential_values)
     return False
 
@@ -301,55 +328,90 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
             if not _placeholder_value(match.group("password")):
                 findings.add("credentialed-uri")
 
+    for match in DSN_CREDENTIAL_PARAM_RE.finditer(text):
+        if not _placeholder_value(match.group("password")):
+            findings.add("credentialed-dsn")
+
+    for pattern in (
+        QUOTED_ENV_ASSIGNMENT_RE,
+        BARE_ENV_ASSIGNMENT_RE,
+        QUOTED_MAPPING_ENV_RE,
+        BARE_MAPPING_ENV_RE,
+    ):
+        for match in pattern.finditer(text):
+            if not _assignment_value_is_safe(match.group("name"), match.group("value")):
+                findings.add("sensitive-environment-assignment")
+
     relative_path = PurePosixPath(relative)
-    assignment_scan = (
-        relative_path.suffix.lower() in {".sh", ".yml", ".yaml", ".json", ".txt"}
-        or relative_path.name.lower().startswith(BUILD_FILE_PREFIXES)
-    )
-    if assignment_scan:
-        for pattern in (QUOTED_ENV_ASSIGNMENT_RE, BARE_ENV_ASSIGNMENT_RE):
-            for match in pattern.finditer(text):
-                if not _assignment_value_is_safe(
-                    match.group("name"), match.group("value")
-                ):
-                    findings.add("sensitive-environment-assignment")
-        if relative_path.suffix.lower() in {".yml", ".yaml", ".json"}:
-            mapping_patterns = [JSON_MAPPING_ENV_RE]
-            if relative_path.suffix.lower() in {".yml", ".yaml"}:
-                mapping_patterns.append(YAML_MAPPING_ENV_RE)
-            for pattern in mapping_patterns:
-                for match in pattern.finditer(text):
-                    if not _assignment_value_is_safe(
-                        match.group("name"), match.group("value")
-                    ):
-                        findings.add("sensitive-environment-assignment")
+    if relative_path.name.lower().startswith(BUILD_FILE_PREFIXES):
+        for match in DOCKERFILE_ENV_SPACE_RE.finditer(text):
+            if not _assignment_value_is_safe(match.group("name"), match.group("value")):
+                findings.add("sensitive-environment-assignment")
+
+    if relative_path.suffix.lower() == ".sql":
+        for match in SQL_PASSWORD_RE.finditer(text):
+            if not _placeholder_value(match.group("password")):
+                findings.add("sql-password-statement")
 
     return tuple(sorted(findings))
+
+
+def _read_scannable_bytes(
+    path: Path,
+    relative: str,
+    expected_metadata: os.stat_result,
+) -> tuple[bytes, os.stat_result]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as exc:
+        raise RecoveryError(f"Unable to open selected file safely: {relative}") from exc
+
+    with os.fdopen(fd, "rb") as handle:
+        metadata = os.fstat(handle.fileno())
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RecoveryError(f"Selected path is no longer a regular file: {relative}")
+        if (metadata.st_dev, metadata.st_ino) != (
+            expected_metadata.st_dev,
+            expected_metadata.st_ino,
+        ):
+            raise RecoveryError(f"Selected file identity changed during recovery: {relative}")
+        payload = handle.read(MAX_FILE_BYTES + 1)
+
+    if len(payload) > MAX_FILE_BYTES:
+        raise RecoveryError(f"Selected file exceeds per-file limit during scan: {relative}")
+    return payload, metadata
 
 
 def scan_selected_files(
     files: Iterable[tuple[Path, str, os.stat_result]],
     required_configs: Iterable[Path],
-) -> tuple[
-    list[tuple[Path, str, os.stat_result]],
-    list[dict[str, object]],
-]:
-    required = {path.resolve(strict=True) for path in required_configs}
-    included: list[tuple[Path, str, os.stat_result]] = []
+) -> tuple[list[ScannedFile], list[dict[str, object]]]:
+    required = {os.path.abspath(path) for path in required_configs}
+    included: list[ScannedFile] = []
     excluded: list[dict[str, object]] = []
+    scanned_total = 0
 
-    for path, relative, metadata in files:
+    for path, relative, expected_metadata in files:
+        payload, metadata = _read_scannable_bytes(path, relative, expected_metadata)
+        scanned_total += len(payload)
+        if scanned_total > MAX_TOTAL_BYTES:
+            raise RecoveryError("Selected files exceed total-size limit during scan")
         try:
-            text = path.read_text(encoding="utf-8")
+            text = payload.decode("utf-8")
         except UnicodeDecodeError as exc:
             raise RecoveryError(f"Selected text file is not valid UTF-8: {relative}") from exc
 
         findings = _scan_text(text, relative)
+        digest = hashlib.sha256(payload).hexdigest()
+        mode = stat.S_IMODE(metadata.st_mode)
         if not findings:
-            included.append((path, relative, metadata))
+            included.append(
+                ScannedFile(relative=relative, mode=mode, payload=payload, sha256=digest)
+            )
             continue
 
-        if path.resolve(strict=True) in required:
+        if os.path.abspath(path) in required:
             categories = ", ".join(findings)
             raise RecoveryError(
                 f"Required Compose config contains sensitive content: {relative} ({categories})"
@@ -358,9 +420,9 @@ def scan_selected_files(
         excluded.append(
             {
                 "path": relative,
-                "size": metadata.st_size,
-                "mode": f"{stat.S_IMODE(metadata.st_mode):04o}",
-                "sha256": _sha256_file(path),
+                "size": len(payload),
+                "mode": f"{mode:04o}",
+                "sha256": digest,
                 "findings": list(findings),
             }
         )
@@ -369,17 +431,18 @@ def scan_selected_files(
 
 
 def build_manifest(
-    files: Iterable[tuple[Path, str, os.stat_result]],
+    files: Iterable[ScannedFile],
     excluded_sensitive_files: Iterable[dict[str, object]] = (),
 ) -> dict[str, object]:
+    file_list = list(files)
     entries = [
         {
-            "path": relative,
-            "size": metadata.st_size,
-            "mode": f"{stat.S_IMODE(metadata.st_mode):04o}",
-            "sha256": _sha256_file(path),
+            "path": item.relative,
+            "size": len(item.payload),
+            "mode": f"{item.mode:04o}",
+            "sha256": item.sha256,
         }
-        for path, relative, metadata in files
+        for item in file_list
     ]
     exclusions = list(excluded_sensitive_files)
     return {
@@ -414,6 +477,9 @@ def stream_archive(
 ) -> None:
     included, excluded = scan_selected_files(files, required_configs)
     manifest = build_manifest(included, excluded)
+    scanned_total = int(manifest["total_bytes"]) + sum(
+        int(entry["size"]) for entry in excluded
+    )
     receipt = {
         "schema": SCHEMA,
         "operation": "recover-v3-runtime-contract",
@@ -431,10 +497,11 @@ def stream_archive(
             "mode": "fail-closed-before-stream",
             "rules": list(CONTENT_SCAN_RULES),
             "candidate_file_count": len(files),
-            "candidate_total_bytes": sum(metadata.st_size for _, _, metadata in files),
+            "candidate_total_bytes": scanned_total,
             "included_file_count": manifest["file_count"],
             "included_total_bytes": manifest["total_bytes"],
             "excluded_sensitive_file_count": manifest["excluded_sensitive_file_count"],
+            "archive_uses_exact_scanned_bytes": True,
         },
         "db_access": False,
         "host_mutation": False,
@@ -448,13 +515,13 @@ def stream_archive(
     }
 
     with tarfile.open(fileobj=output, mode="w|gz", format=tarfile.PAX_FORMAT) as archive:
-        for path, relative, metadata in included:
-            info = tarfile.TarInfo(f"source/{relative}")
-            info.size = metadata.st_size
-            info.mode = stat.S_IMODE(metadata.st_mode)
-            info.mtime = 0
-            with path.open("rb") as handle:
-                archive.addfile(info, handle)
+        for item in included:
+            _add_bytes(
+                archive,
+                f"source/{item.relative}",
+                item.payload,
+                mode=item.mode,
+            )
         _add_bytes(
             archive,
             "recovery-manifest.json",

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -89,7 +89,7 @@ DSN_CREDENTIAL_PARAM_RE = re.compile(
 )
 SQL_PASSWORD_RE = re.compile(
     r"(?is)\b(?:ALTER|CREATE)\s+(?:ROLE|USER)\b[^;]*?\bPASSWORD\s*(?:=)?\s*"
-    r"(?P<quote>[\"'])(?P<password>.*?)(?P=quote)"
+    r"(?:[eE](?=[\"']))?(?P<quote>[\"'])(?P<password>.*?)(?P=quote)"
 )
 SQL_DOLLAR_PASSWORD_RE = re.compile(
     r"(?is)\b(?:ALTER|CREATE)\s+(?:ROLE|USER)\b[^;]*?\bPASSWORD\s*(?:=)?\s*"
@@ -97,6 +97,7 @@ SQL_DOLLAR_PASSWORD_RE = re.compile(
 )
 AUTHORIZATION_RE = re.compile(
     r'''(?im)["']?Authorization["']?\s*[:=]\s*'''
+    r'''(?:(?P<prefix>[rubf]{1,2})(?=["']))?'''
     r'''(?P<quote>["']?)(?P<scheme>Bearer|Basic)\s+'''
     r'''(?P<credential>[^\s"',\]]+)'''
 )
@@ -152,8 +153,9 @@ CONTENT_SCAN_RULES = (
     "credentialed-uri-or-dsn", "credential-command-option",
     "non-placeholder-sensitive-assignment", "structured-name-value-environment-entry",
     "python-ast-sensitive-assignment", "python-comment-docstring-sensitive-assignment",
-    "kubernetes-secret-payload", "sql-password-statement",
-    "exact-scanned-bytes-archived", "sensitive-file-digest-omitted",
+    "kubernetes-secret-payload", "docker-registry-auth", "private-jwk-material",
+    "sql-password-statement", "exact-scanned-bytes-archived",
+    "sensitive-file-digest-omitted",
 )
 URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
 TOKEN_METRIC_WORDS = {
@@ -163,6 +165,8 @@ TOKEN_METRIC_WORDS = {
 }
 NONSENSITIVE_REFERENCE_NAMES = {
     "SECRETKEYREF", "SECRETREF", "SECRETNAME", "SECRETKEYSELECTOR", "SECRETSOURCE",
+    "CREDENTIALREF", "CREDENTIALSREF", "CREDENTIALREFERENCE",
+    "CREDENTIALSREFERENCE", "CREDENTIALNAME", "CREDENTIALSNAME",
 }
 PYTHON_LOOKUP_CALL_NAMES = {
     "fetch_secret", "get_secret", "load_secret", "read_secret", "resolve_secret",
@@ -291,6 +295,7 @@ def _name_is_sensitive(name: str) -> bool:
         return True
     if any(marker in upper for marker in (
         "PASSWORD", "PASSWD", "PRIVATE_KEY", "API_KEY", "APIKEY", "SECRET",
+        "CREDENTIAL",
     )):
         return True
     if (
@@ -399,7 +404,7 @@ def _assignment_value_is_safe(name: str, value: str) -> bool:
     if _placeholder_value(value):
         return True
     upper_name = _normalized_name(name)
-    if upper_name.endswith("_FILE") and _secret_file_reference(value):
+    if upper_name.endswith(("_FILE", "_PATH")) and _secret_file_reference(value):
         return True
     if upper_name in URL_ENV_NAMES:
         candidate = value.strip().strip("\"'")
@@ -483,6 +488,17 @@ def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
             findings.add("sensitive-environment-assignment")
 
 
+def _json_object_is_private_jwk(value: dict[str, object]) -> bool:
+    kty = str(value.get("kty", "")).upper()
+    if kty == "RSA":
+        return all(key in value for key in ("n", "e", "d"))
+    if kty in {"EC", "OKP"}:
+        return "d" in value and ("x" in value or "crv" in value)
+    if kty == "OCT":
+        return "k" in value
+    return False
+
+
 def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
     try:
         document = json.loads(text)
@@ -491,6 +507,20 @@ def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
 
     def walk(value: object) -> None:
         if isinstance(value, dict):
+            if str(value.get("kind", "")).lower() == "secret" and (
+                "data" in value or "stringData" in value
+            ):
+                findings.add("kubernetes-secret-payload")
+            if _json_object_is_private_jwk(value):
+                findings.add("private-jwk-material")
+            auths = value.get("auths")
+            if isinstance(auths, dict):
+                for registry in auths.values():
+                    if not isinstance(registry, dict):
+                        continue
+                    auth = registry.get("auth")
+                    if isinstance(auth, str) and auth and not _placeholder_value(auth):
+                        findings.add("docker-registry-auth")
             name = value.get("name")
             literal = value.get("value")
             if isinstance(name, str) and _name_is_sensitive(name) and literal is not None:
@@ -541,6 +571,12 @@ def _python_expression_is_safe(name: str, value: ast.expr) -> bool:
     if isinstance(value, ast.Constant):
         if value.value is None:
             return True
+        if isinstance(value.value, bytes):
+            try:
+                decoded = value.value.decode("utf-8")
+            except UnicodeDecodeError:
+                return False
+            return _assignment_value_is_safe(name, decoded)
         if isinstance(value.value, (str, int, float, bool)):
             return _assignment_value_is_safe(name, str(value.value))
         return True
@@ -593,6 +629,22 @@ def _python_expression_is_safe(name: str, value: ast.expr) -> bool:
     return False
 
 
+def _scan_python_function_defaults(
+    node: ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda,
+    findings: set[str],
+) -> None:
+    positional = [*node.args.posonlyargs, *node.args.args]
+    if node.args.defaults:
+        for argument, default in zip(positional[-len(node.args.defaults):], node.args.defaults):
+            if _name_is_sensitive(argument.arg) and not _python_expression_is_safe(argument.arg, default):
+                findings.add("sensitive-environment-assignment")
+    for argument, default in zip(node.args.kwonlyargs, node.args.kw_defaults):
+        if default is None:
+            continue
+        if _name_is_sensitive(argument.arg) and not _python_expression_is_safe(argument.arg, default):
+            findings.add("sensitive-environment-assignment")
+
+
 def _scan_python_assignments(text: str, findings: set[str]) -> None:
     try:
         document = ast.parse(text)
@@ -607,15 +659,22 @@ def _scan_python_assignments(text: str, findings: set[str]) -> None:
             targets = [node.target]
             value = node.value
         else:
-            continue
-        if value is None:
-            continue
-        names: list[str] = []
-        for target in targets:
-            names.extend(_python_target_names(target))
-        for name in names:
-            if _name_is_sensitive(name) and not _python_expression_is_safe(name, value):
-                findings.add("sensitive-environment-assignment")
+            targets = []
+            value = None
+        if value is not None:
+            names: list[str] = []
+            for target in targets:
+                names.extend(_python_target_names(target))
+            for name in names:
+                if _name_is_sensitive(name) and not _python_expression_is_safe(name, value):
+                    findings.add("sensitive-environment-assignment")
+        if isinstance(node, ast.Call):
+            for keyword in node.keywords:
+                if keyword.arg and _name_is_sensitive(keyword.arg):
+                    if not _python_expression_is_safe(keyword.arg, keyword.value):
+                        findings.add("sensitive-environment-assignment")
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            _scan_python_function_defaults(node, findings)
 
 
 def _scan_embedded_assignment_text(text: str, findings: set[str]) -> None:
@@ -680,13 +739,39 @@ def _scan_sql_passwords(text: str, findings: set[str]) -> None:
                 findings.add("sql-password-statement")
 
 
+def _scan_yaml_private_jwk(text: str, findings: set[str]) -> None:
+    kty_match = re.search(
+        r'''(?im)^\s*(?:-\s*)?["']?kty["']?\s*:\s*["']?(RSA|EC|OKP|oct)["']?\s*(?:#.*)?$''',
+        text,
+    )
+    if not kty_match:
+        return
+    kty = kty_match.group(1).upper()
+    private_key = "k" if kty == "OCT" else "d"
+    private_match = re.search(
+        rf'''(?im)^\s*(?:-\s*)?["']?{private_key}["']?\s*:\s*(?P<value>[^#\r\n]+)''',
+        text,
+    )
+    if private_match and not _placeholder_value(private_match.group("value").strip()):
+        findings.add("private-jwk-material")
+
+
+def _authorization_credential_is_safe(match: re.Match[str]) -> bool:
+    credential = match.group("credential")
+    prefix = (match.groupdict().get("prefix") or "").lower()
+    if "f" in prefix and re.fullmatch(rf"\{{{IDENTIFIER}(?:\.{IDENTIFIER})*\}}", credential):
+        return True
+    return _placeholder_value(credential)
+
+
 def _scan_text(text: str, relative: str) -> tuple[str, ...]:
+    text = text.removeprefix("\ufeff")
     findings: set[str] = set()
     for category, pattern in TOKEN_PATTERNS:
         if pattern.search(text):
             findings.add(category)
     for match in AUTHORIZATION_RE.finditer(text):
-        if not _placeholder_value(match.group("credential")):
+        if not _authorization_credential_is_safe(match):
             findings.add("authorization-credential")
     for pattern in (CREDENTIALED_URI_RE, URI_QUERY_CREDENTIAL_RE):
         for match in pattern.finditer(text):
@@ -718,17 +803,11 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
     suffix = relative_path.suffix.lower()
     if suffix in {".yml", ".yaml"}:
         _scan_structured_yaml_environment(text, findings)
+        _scan_yaml_private_jwk(text, findings)
         if K8S_SECRET_KIND_RE.search(text) and K8S_SECRET_PAYLOAD_RE.search(text):
             findings.add("kubernetes-secret-payload")
     elif suffix == ".json":
         _scan_structured_json_environment(text, findings)
-        try:
-            document = json.loads(text)
-        except json.JSONDecodeError:
-            document = None
-        if isinstance(document, dict) and str(document.get("kind", "")).lower() == "secret":
-            if "data" in document or "stringData" in document:
-                findings.add("kubernetes-secret-payload")
     elif suffix == ".py":
         _scan_python_assignments(text, findings)
         _scan_python_comments_and_strings(text, findings)

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -15,6 +15,7 @@ validation and export.
 from __future__ import annotations
 
 import argparse
+import ast
 from dataclasses import dataclass
 import hashlib
 import io
@@ -120,11 +121,15 @@ URI_QUERY_CREDENTIAL_RE = re.compile(
 )
 DSN_CREDENTIAL_PARAM_RE = re.compile(
     r"(?i)(?:^|[\s?&;])(?:password|passwd|pwd|secret|token|api_?key)\s*=\s*"
-    r"(?P<password>[^\s;&\"']+)"
+    r'''(?P<password>"[^"]*"|'[^']*'|[^\s;&\"']+)'''
 )
 SQL_PASSWORD_RE = re.compile(
     r"(?is)\b(?:ALTER|CREATE)\s+(?:ROLE|USER)\b[^;]*?\bPASSWORD\s*(?:=)?\s*"
     r"(?P<quote>[\"'])(?P<password>.*?)(?P=quote)"
+)
+SQL_DOLLAR_PASSWORD_RE = re.compile(
+    r"(?is)\b(?:ALTER|CREATE)\s+(?:ROLE|USER)\b[^;]*?\bPASSWORD\s*(?:=)?\s*"
+    r"(?P<tag>\$\$|\$[A-Za-z_][A-Za-z0-9_]*\$)(?P<password>.*?)(?P=tag)"
 )
 AUTHORIZATION_RE = re.compile(
     r"""(?im)[\"']?Authorization[\"']?\s*[:=]\s*"""
@@ -166,6 +171,7 @@ CONTENT_SCAN_RULES = (
     "credentialed-uri-or-dsn",
     "non-placeholder-sensitive-assignment",
     "structured-name-value-environment-entry",
+    "python-subscript-sensitive-assignment",
     "sql-password-statement",
     "exact-scanned-bytes-archived",
     "sensitive-file-digest-omitted",
@@ -310,8 +316,12 @@ def collect_files(
     return selected
 
 
+def _normalized_name(name: str) -> str:
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name).upper()
+
+
 def _name_is_sensitive(name: str) -> bool:
-    upper = name.upper()
+    upper = _normalized_name(name)
     compact = upper.replace("_", "")
     if compact in NONSENSITIVE_REFERENCE_NAMES:
         return False
@@ -355,7 +365,6 @@ def _jinja_reference_expression_is_safe(body: str) -> bool:
             continue
 
         argument = arguments.strip()
-        # Multiple/literal filter arguments are not demonstrably reference-only.
         if "," in argument:
             return False
         if filter_match.group("name").lower() == "default":
@@ -417,6 +426,13 @@ def _placeholder_value(value: str) -> bool:
     return False
 
 
+def _unquoted_yaml_null(value: str) -> bool:
+    candidate = value.strip()
+    if not candidate or candidate.startswith(("\"", "'")):
+        return False
+    return candidate.lower() in {"null", "~"}
+
+
 def _secret_file_reference(value: str) -> bool:
     candidate = value.strip().strip("\"'")
     return candidate.startswith(("/", "./", "../"))
@@ -432,7 +448,7 @@ def _credential_values(text: str) -> list[str]:
 def _assignment_value_is_safe(name: str, value: str) -> bool:
     if _placeholder_value(value):
         return True
-    upper_name = name.upper()
+    upper_name = _normalized_name(name)
     if upper_name.endswith("_FILE") and _secret_file_reference(value):
         return True
     if upper_name in URL_ENV_NAMES:
@@ -457,16 +473,27 @@ def _scan_assignment_patterns(text: str, findings: set[str]) -> None:
             if not _assignment_value_is_safe(name, match.group("value")):
                 findings.add("sensitive-environment-assignment")
 
-    for pattern in (QUOTED_MAPPING_ENV_RE, BARE_MAPPING_ENV_RE):
-        for match in pattern.finditer(text):
-            name = match.group("name")
-            value = match.group("value")
-            if _compose_secret_reference_collection(name, value):
-                continue
-            if not _name_is_sensitive(name):
-                continue
-            if not _assignment_value_is_safe(name, value):
-                findings.add("sensitive-environment-assignment")
+    for match in QUOTED_MAPPING_ENV_RE.finditer(text):
+        name = match.group("name")
+        value = match.group("value")
+        if _compose_secret_reference_collection(name, value):
+            continue
+        if not _name_is_sensitive(name):
+            continue
+        if not _assignment_value_is_safe(name, value):
+            findings.add("sensitive-environment-assignment")
+
+    for match in BARE_MAPPING_ENV_RE.finditer(text):
+        name = match.group("name")
+        value = match.group("value")
+        if _compose_secret_reference_collection(name, value):
+            continue
+        if not _name_is_sensitive(name):
+            continue
+        if _unquoted_yaml_null(value):
+            continue
+        if not _assignment_value_is_safe(name, value):
+            findings.add("sensitive-environment-assignment")
 
 
 def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
@@ -489,7 +516,10 @@ def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
                 break
             value_match = STRUCTURED_ENV_VALUE_RE.match(next_line)
             if value_match:
-                if not _assignment_value_is_safe(name, value_match.group("value")):
+                value = value_match.group("value")
+                if _unquoted_yaml_null(value):
+                    break
+                if not _assignment_value_is_safe(name, value):
                     findings.add("sensitive-environment-assignment")
                 break
 
@@ -516,6 +546,51 @@ def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
                 walk(nested)
 
     walk(document)
+
+
+def _scan_python_subscript_assignments(text: str, findings: set[str]) -> None:
+    try:
+        document = ast.parse(text)
+    except SyntaxError:
+        return
+
+    for node in ast.walk(document):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if value is None:
+            continue
+
+        for target in targets:
+            if not isinstance(target, ast.Subscript):
+                continue
+            key = target.slice
+            if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
+                continue
+            name = key.value
+            if not _name_is_sensitive(name):
+                continue
+
+            if isinstance(value, ast.Constant):
+                if value.value is None:
+                    continue
+                if isinstance(value.value, (str, int, float, bool)) and not _assignment_value_is_safe(
+                    name, str(value.value)
+                ):
+                    findings.add("sensitive-environment-assignment")
+            elif isinstance(value, ast.JoinedStr):
+                literal_parts = [
+                    item.value
+                    for item in value.values
+                    if isinstance(item, ast.Constant) and isinstance(item.value, str)
+                ]
+                if any(part and not _placeholder_value(part) for part in literal_parts):
+                    findings.add("sensitive-environment-assignment")
 
 
 def _scan_text(text: str, relative: str) -> tuple[str, ...]:
@@ -553,11 +628,14 @@ def _scan_text(text: str, relative: str) -> tuple[str, ...]:
         _scan_structured_yaml_environment(text, findings)
     elif relative_path.suffix.lower() == ".json":
         _scan_structured_json_environment(text, findings)
+    elif relative_path.suffix.lower() == ".py":
+        _scan_python_subscript_assignments(text, findings)
 
     if relative_path.suffix.lower() == ".sql":
-        for match in SQL_PASSWORD_RE.finditer(text):
-            if not _placeholder_value(match.group("password")):
-                findings.add("sql-password-statement")
+        for pattern in (SQL_PASSWORD_RE, SQL_DOLLAR_PASSWORD_RE):
+            for match in pattern.finditer(text):
+                if not _placeholder_value(match.group("password")):
+                    findings.add("sql-password-statement")
 
     return tuple(sorted(findings))
 
@@ -627,9 +705,6 @@ def scan_selected_files(
                 f"Required Compose config contains sensitive content: {relative} ({categories})"
             )
 
-        # Never publish a content digest for a file known to contain a secret.
-        # A whole-file digest can act as an offline oracle when the surrounding
-        # content is predictable and only the credential value varies.
         excluded.append(
             {
                 "path": relative,

--- a/scripts/operator/recover_v3_runtime_contract.py
+++ b/scripts/operator/recover_v3_runtime_contract.py
@@ -37,44 +37,14 @@ MAX_FILE_BYTES = 20 * 1024 * 1024
 ALLOWED_SUFFIXES = {".yml", ".yaml", ".sql", ".sh", ".py", ".md", ".txt", ".json"}
 BUILD_FILE_PREFIXES = ("dockerfile", "containerfile")
 FORBIDDEN_PARTS = {
-    ".env",
-    ".git",
-    "backup",
-    "backups",
-    "cert",
-    "certs",
-    "credential",
-    "credentials",
-    "data",
-    "dump",
-    "dumps",
-    "id_rsa",
-    "id_ed25519",
-    "key",
-    "keys",
-    "log",
-    "logs",
-    "pgbackrest",
-    "private",
-    "secret",
-    "secrets",
-    "ssh",
-    "token",
-    "tokens",
-    "volume",
-    "volumes",
+    ".env", ".git", "backup", "backups", "cert", "certs", "credential",
+    "credentials", "data", "dump", "dumps", "id_rsa", "id_ed25519", "key",
+    "keys", "log", "logs", "pgbackrest", "private", "secret", "secrets",
+    "ssh", "token", "tokens", "volume", "volumes",
 }
 FORBIDDEN_FRAGMENTS = (
-    "password",
-    "passwd",
-    "credential",
-    "secret",
-    "token",
-    "private_key",
-    "apikey",
-    "api_key",
-    "id_rsa",
-    "id_ed25519",
+    "password", "passwd", "credential", "secret", "token", "private_key",
+    "apikey", "api_key", "id_rsa", "id_ed25519",
 )
 COMPOSE_WORKING_DIR_LABEL = "com.docker.compose.project.working_dir"
 COMPOSE_CONFIG_FILES_LABEL = "com.docker.compose.project.config_files"
@@ -82,29 +52,22 @@ COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
 SCHEMA = "edfinder-v3-runtime-recovery/v2"
 
 IDENTIFIER = r"[A-Za-z_][A-Za-z0-9_]*"
+STRUCTURED_KEY = r"[A-Za-z_][A-Za-z0-9_.-]*"
 MAPPING_KEY_PREFIX = r"(?:^\s*|(?<!\$)[{,]\s*)"
 QUOTED_ENV_ASSIGNMENT_RE = re.compile(
     rf"(?<![A-Za-z0-9_])(?P<name>{IDENTIFIER})\s*=\s*"
-    r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)",
-    re.MULTILINE,
+    r"(?P<quote>[\"'])(?P<value>.*?)(?P=quote)", re.MULTILINE,
 )
 BARE_ENV_ASSIGNMENT_RE = re.compile(
     rf"(?<![A-Za-z0-9_])(?P<name>{IDENTIFIER})\s*=\s*"
-    r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)",
-    re.MULTILINE,
+    r"(?P<value>\$\{[^}\r\n]*\}|[^\s,\"'\]\}]+)", re.MULTILINE,
 )
-# Mapping matches are zero-width lookaheads so an outer flow-map key cannot
-# consume nested mappings and hide an inner sensitive assignment. In
-# particular, do not treat the colon in shell/Compose interpolation (for
-# example ${PASSWORD_FILE:-path}) as a YAML mapping separator. Bare values
-# explicitly exclude quote-started scalars so a quoted placeholder cannot be
-# matched a second time as a truncated bare value.
 QUOTED_MAPPING_ENV_RE = re.compile(
-    rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
+    rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{STRUCTURED_KEY})"
     r"(?P=keyquote)\s*:\s*(?P<valquote>[\"'])(?P<value>.*?)(?P=valquote))",
 )
 BARE_MAPPING_ENV_RE = re.compile(
-    rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{IDENTIFIER})"
+    rf"(?m)(?={MAPPING_KEY_PREFIX}(?P<keyquote>[\"']?)(?P<name>{STRUCTURED_KEY})"
     r"(?P=keyquote)\s*:(?![ \t]*[\"'])[ \t]*"
     r"(?P<value>\$\{[^}\r\n]*\}|[^,\}\]\r\n#]+))",
 )
@@ -132,31 +95,50 @@ SQL_DOLLAR_PASSWORD_RE = re.compile(
     r"(?P<tag>\$\$|\$[A-Za-z_][A-Za-z0-9_]*\$)(?P<password>.*?)(?P=tag)"
 )
 AUTHORIZATION_RE = re.compile(
-    r"""(?im)[\"']?Authorization[\"']?\s*[:=]\s*"""
-    r"""(?P<quote>[\"']?)(?P<scheme>Bearer|Basic)\s+"""
-    r"""(?P<credential>[^\s\"',\]]+)"""
+    r'''(?im)["']?Authorization["']?\s*[:=]\s*'''
+    r'''(?P<quote>["']?)(?P<scheme>Bearer|Basic)\s+'''
+    r'''(?P<credential>[^\s"',\]]+)'''
 )
 STRUCTURED_ENV_NAME_RE = re.compile(
-    rf"""^(?P<indent>[ \t]*)-\s*name\s*:\s*"""
-    rf"""(?P<quote>[\"']?)(?P<name>{IDENTIFIER})(?P=quote)\s*(?:#.*)?$""",
+    rf'''^(?P<indent>[ \t]*)-\s*name\s*:\s*'''
+    rf'''(?P<quote>["']?)(?P<name>{IDENTIFIER})(?P=quote)\s*(?:#.*)?$''',
     re.IGNORECASE,
 )
 STRUCTURED_ENV_VALUE_RE = re.compile(
-    r"""^(?P<indent>[ \t]*)value\s*:\s*(?P<value>.+?)\s*(?:#.*)?$""",
+    r'''^(?P<indent>[ \t]*)value\s*:\s*(?P<value>.+?)\s*(?:#.*)?$''',
     re.IGNORECASE,
 )
 STRUCTURED_ENV_VALUE_FROM_RE = re.compile(
-    r"""^(?P<indent>[ \t]*)valueFrom\s*:""",
-    re.IGNORECASE,
+    r'''^(?P<indent>[ \t]*)valueFrom\s*:''', re.IGNORECASE,
+)
+FLOW_OBJECT_RE = re.compile(r"\{[^{}\r\n]*\}")
+FLOW_NAME_FIELD_RE = re.compile(
+    rf'''(?i)(?:^|,)\s*["']?name["']?\s*:\s*'''
+    rf'''(?P<quote>["']?)(?P<name>{IDENTIFIER})(?P=quote)(?=\s*(?:,|$))'''
+)
+FLOW_VALUE_FIELD_RE = re.compile(
+    r'''(?i)(?:^|,)\s*["']?value["']?\s*:\s*'''
+    r'''(?:"(?P<double>[^"]*)"|'(?P<single>[^']*)'|(?P<bare>[^,}]+))'''
+)
+COMMAND_OPTION_SPACE_RE = re.compile(
+    r'''(?ix)(?<![A-Za-z0-9_-])--(?:password|passwd|pwd|secret|token|api[-_]?key)\b'''
+    r'''[ \t]+(?:"(?P<double>[^"]*)"|'(?P<single>[^']*)'|(?P<placeholder>\$\{[^}\r\n]*\})|(?P<bare>[^\s,;\]\}]+))'''
+)
+COMMAND_OPTION_ARRAY_RE = re.compile(
+    r'''(?ix)["']--(?:password|passwd|pwd|secret|token|api[-_]?key)["']\s*,\s*'''
+    r'''(?:"(?P<double>[^"]*)"|'(?P<single>[^']*)')'''
+)
+K8S_SECRET_KIND_RE = re.compile(
+    r'''(?mi)^\s*kind\s*:\s*["']?Secret["']?\s*(?:#.*)?$'''
+)
+K8S_SECRET_PAYLOAD_RE = re.compile(
+    r'''(?mi)^\s*(?:data|stringData)\s*:'''
 )
 TOKEN_PATTERNS = (
-    (
-        "private-key-material",
-        re.compile(
-            r"-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
-            re.IGNORECASE,
-        ),
-    ),
+    ("private-key-material", re.compile(
+        r"-----BEGIN (?:ENCRYPTED |RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----",
+        re.IGNORECASE,
+    )),
     ("openai-api-token", re.compile(r"\bsk-(?!ant-)(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b")),
     ("anthropic-api-token", re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b")),
     ("github-token", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}\b")),
@@ -165,47 +147,21 @@ TOKEN_PATTERNS = (
     ("slack-token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
 )
 CONTENT_SCAN_RULES = (
-    "private-key-material",
-    "recognized-api-token",
-    "authorization-credential",
-    "credentialed-uri-or-dsn",
-    "non-placeholder-sensitive-assignment",
-    "structured-name-value-environment-entry",
-    "python-subscript-sensitive-assignment",
-    "sql-password-statement",
-    "exact-scanned-bytes-archived",
+    "private-key-material", "recognized-api-token", "authorization-credential",
+    "credentialed-uri-or-dsn", "credential-command-option",
+    "non-placeholder-sensitive-assignment", "structured-name-value-environment-entry",
+    "python-ast-sensitive-assignment", "kubernetes-secret-payload",
+    "sql-password-statement", "exact-scanned-bytes-archived",
     "sensitive-file-digest-omitted",
 )
 URL_ENV_NAMES = {"DATABASE_URL", "REDIS_URL", "CACHE_URL", "CELERY_BROKER_URL"}
 TOKEN_METRIC_WORDS = {
-    "BUDGET",
-    "BUDGETS",
-    "CAP",
-    "CAPACITY",
-    "COUNT",
-    "COUNTS",
-    "EXPIRATION",
-    "EXPIRY",
-    "LENGTH",
-    "LENGTHS",
-    "LIMIT",
-    "LIMITS",
-    "MAX",
-    "MIN",
-    "RATE",
-    "RATES",
-    "SIZE",
-    "SIZES",
-    "TTL",
-    "WINDOW",
-    "WINDOWS",
+    "BUDGET", "BUDGETS", "CAP", "CAPACITY", "COUNT", "COUNTS", "EXPIRATION",
+    "EXPIRY", "LENGTH", "LENGTHS", "LIMIT", "LIMITS", "MAX", "MIN", "RATE",
+    "RATES", "SIZE", "SIZES", "TTL", "WINDOW", "WINDOWS",
 }
 NONSENSITIVE_REFERENCE_NAMES = {
-    "SECRETKEYREF",
-    "SECRETREF",
-    "SECRETNAME",
-    "SECRETKEYSELECTOR",
-    "SECRETSOURCE",
+    "SECRETKEYREF", "SECRETREF", "SECRETNAME", "SECRETKEYSELECTOR", "SECRETSOURCE",
 }
 
 
@@ -317,7 +273,9 @@ def collect_files(
 
 
 def _normalized_name(name: str) -> str:
-    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name).upper()
+    camel_split = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    punct_split = re.sub(r"[^A-Za-z0-9]+", "_", camel_split)
+    return re.sub(r"_+", "_", punct_split).strip("_").upper()
 
 
 def _name_is_sensitive(name: str) -> bool:
@@ -327,14 +285,17 @@ def _name_is_sensitive(name: str) -> bool:
         return False
     if upper in URL_ENV_NAMES or upper in {"OCTOPUS_DATA_KEY", "DATA_ENCRYPTION_KEY"}:
         return True
-    if any(
-        marker in upper
-        for marker in ("PASSWORD", "PASSWD", "PRIVATE_KEY", "API_KEY", "APIKEY", "SECRET")
+    if any(marker in upper for marker in (
+        "PASSWORD", "PASSWD", "PRIVATE_KEY", "API_KEY", "APIKEY", "SECRET",
+    )):
+        return True
+    if (
+        upper == "PASS"
+        or upper.endswith(("_PASS", "_PWD"))
+        or "_PASS_" in upper
+        or "_PWD_" in upper
     ):
         return True
-    if upper == "PASS" or upper.endswith("_PASS") or "_PASS_" in upper:
-        return True
-
     parts = [part for part in upper.split("_") if part]
     for index, part in enumerate(parts):
         if part != "TOKEN":
@@ -352,25 +313,21 @@ def _jinja_reference_expression_is_safe(body: str) -> bool:
     pipeline = [part.strip() for part in body.split("|")]
     if not pipeline or not re.fullmatch(reference, pipeline[0]):
         return False
-
     for filter_expression in pipeline[1:]:
         filter_match = re.fullmatch(
-            rf"(?P<name>{IDENTIFIER})(?:\((?P<arguments>.*)\))?",
-            filter_expression,
+            rf"(?P<name>{IDENTIFIER})(?:\((?P<arguments>.*)\))?", filter_expression,
         )
         if not filter_match:
             return False
         arguments = filter_match.group("arguments")
         if arguments is None or not arguments.strip():
             continue
-
         argument = arguments.strip()
         if "," in argument:
             return False
         if filter_match.group("name").lower() == "default":
             quoted_default = re.fullmatch(
-                r"""(?P<quote>['\"])(?P<literal>.*?)(?P=quote)""",
-                argument,
+                r'''(?P<quote>['\"])(?P<literal>.*?)(?P=quote)''', argument,
             )
             if quoted_default:
                 if quoted_default.group("literal"):
@@ -379,10 +336,8 @@ def _jinja_reference_expression_is_safe(body: str) -> bool:
             if re.fullmatch(reference, argument):
                 continue
             return False
-
         if not re.fullmatch(reference, argument):
             return False
-
     return True
 
 
@@ -399,26 +354,17 @@ def _placeholder_value(value: str) -> bool:
         return True
     if re.fullmatch(rf"\${var_name}", candidate):
         return True
-
     jinja = re.fullmatch(r"\{\{(?P<body>[^{}]+)\}\}", candidate)
     if jinja:
         return _jinja_reference_expression_is_safe(jinja.group("body").strip())
-
     if re.fullmatch(
         r"<(?:redacted|placeholder|secret|password|token|[^>]*_here)>",
-        candidate,
-        re.IGNORECASE,
+        candidate, re.IGNORECASE,
     ):
         return True
     if candidate.upper() in {
-        "REDACTED",
-        "PLACEHOLDER",
-        "NOT_SET",
-        "UNSET",
-        "REPLACE_ME",
-        "YOUR_SECRET_HERE",
-        "YOUR_PASSWORD_HERE",
-        "YOUR_TOKEN_HERE",
+        "REDACTED", "PLACEHOLDER", "NOT_SET", "UNSET", "REPLACE_ME",
+        "YOUR_SECRET_HERE", "YOUR_PASSWORD_HERE", "YOUR_TOKEN_HERE",
     }:
         return True
     if re.fullmatch(r"[*xX]{6,}", candidate):
@@ -454,33 +400,28 @@ def _assignment_value_is_safe(name: str, value: str) -> bool:
     if upper_name in URL_ENV_NAMES:
         candidate = value.strip().strip("\"'")
         credential_values = _credential_values(candidate)
-        return not credential_values or all(
-            _placeholder_value(item) for item in credential_values
-        )
+        return not credential_values or all(_placeholder_value(item) for item in credential_values)
     return False
 
 
 def _compose_secret_reference_collection(name: str, value: str) -> bool:
-    return name.lower() == "secrets" and value.strip().startswith(("[", "{"))
+    return _normalized_name(name) == "SECRETS" and value.strip().startswith(("[", "{"))
 
 
-def _scan_assignment_patterns(text: str, findings: set[str]) -> None:
-    for pattern in (QUOTED_ENV_ASSIGNMENT_RE, BARE_ENV_ASSIGNMENT_RE):
-        for match in pattern.finditer(text):
-            name = match.group("name")
-            if not _name_is_sensitive(name):
-                continue
-            if not _assignment_value_is_safe(name, match.group("value")):
-                findings.add("sensitive-environment-assignment")
+def _scan_assignment_patterns(text: str, findings: set[str], *, include_equals: bool = True) -> None:
+    if include_equals:
+        for pattern in (QUOTED_ENV_ASSIGNMENT_RE, BARE_ENV_ASSIGNMENT_RE):
+            for match in pattern.finditer(text):
+                name = match.group("name")
+                if _name_is_sensitive(name) and not _assignment_value_is_safe(name, match.group("value")):
+                    findings.add("sensitive-environment-assignment")
 
     for match in QUOTED_MAPPING_ENV_RE.finditer(text):
         name = match.group("name")
         value = match.group("value")
         if _compose_secret_reference_collection(name, value):
             continue
-        if not _name_is_sensitive(name):
-            continue
-        if not _assignment_value_is_safe(name, value):
+        if _name_is_sensitive(name) and not _assignment_value_is_safe(name, value):
             findings.add("sensitive-environment-assignment")
 
     for match in BARE_MAPPING_ENV_RE.finditer(text):
@@ -488,9 +429,7 @@ def _scan_assignment_patterns(text: str, findings: set[str]) -> None:
         value = match.group("value")
         if _compose_secret_reference_collection(name, value):
             continue
-        if not _name_is_sensitive(name):
-            continue
-        if _unquoted_yaml_null(value):
+        if not _name_is_sensitive(name) or _unquoted_yaml_null(value):
             continue
         if not _assignment_value_is_safe(name, value):
             findings.add("sensitive-environment-assignment")
@@ -505,7 +444,6 @@ def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
         name = name_match.group("name")
         if not _name_is_sensitive(name):
             continue
-
         base_indent = len(name_match.group("indent").expandtabs(4))
         for next_line in lines[index + 1 : index + 8]:
             stripped = next_line.lstrip(" \t")
@@ -517,11 +455,28 @@ def _scan_structured_yaml_environment(text: str, findings: set[str]) -> None:
             value_match = STRUCTURED_ENV_VALUE_RE.match(next_line)
             if value_match:
                 value = value_match.group("value")
-                if _unquoted_yaml_null(value):
-                    break
-                if not _assignment_value_is_safe(name, value):
+                if not _unquoted_yaml_null(value) and not _assignment_value_is_safe(name, value):
                     findings.add("sensitive-environment-assignment")
                 break
+
+    for match in FLOW_OBJECT_RE.finditer(text):
+        block = match.group(0)[1:-1]
+        name_match = FLOW_NAME_FIELD_RE.search(block)
+        value_match = FLOW_VALUE_FIELD_RE.search(block)
+        if not name_match or not value_match:
+            continue
+        name = name_match.group("name")
+        if not _name_is_sensitive(name):
+            continue
+        value = value_match.group("double")
+        if value is None:
+            value = value_match.group("single")
+        if value is None:
+            value = value_match.group("bare") or ""
+            if _unquoted_yaml_null(value):
+                continue
+        if not _assignment_value_is_safe(name, value):
+            findings.add("sensitive-environment-assignment")
 
 
 def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
@@ -535,11 +490,15 @@ def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
             name = value.get("name")
             literal = value.get("value")
             if isinstance(name, str) and _name_is_sensitive(name) and literal is not None:
-                if isinstance(literal, (str, int, float, bool)) and not _assignment_value_is_safe(
-                    name, str(literal)
-                ):
+                if isinstance(literal, (str, int, float, bool)) and not _assignment_value_is_safe(name, str(literal)):
                     findings.add("sensitive-environment-assignment")
-            for nested in value.values():
+            for key, nested in value.items():
+                if isinstance(key, str) and _name_is_sensitive(key):
+                    if _normalized_name(key) == "SECRETS" and isinstance(nested, (list, dict)):
+                        pass
+                    elif nested is not None and isinstance(nested, (str, int, float, bool)):
+                        if not _assignment_value_is_safe(key, str(nested)):
+                            findings.add("sensitive-environment-assignment")
                 walk(nested)
         elif isinstance(value, list):
             for nested in value:
@@ -548,12 +507,69 @@ def _scan_structured_json_environment(text: str, findings: set[str]) -> None:
     walk(document)
 
 
-def _scan_python_subscript_assignments(text: str, findings: set[str]) -> None:
+def _python_target_names(target: ast.expr) -> list[str]:
+    if isinstance(target, ast.Name):
+        return [target.id]
+    if isinstance(target, ast.Attribute):
+        return [target.attr]
+    if isinstance(target, ast.Subscript):
+        key = target.slice
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            return [key.value]
+        return []
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: list[str] = []
+        for item in target.elts:
+            names.extend(_python_target_names(item))
+        return names
+    return []
+
+
+def _python_retrieval_call_is_safe(name: str, value: ast.Call) -> bool:
+    function_name = ""
+    if isinstance(value.func, ast.Name):
+        function_name = value.func.id
+    elif isinstance(value.func, ast.Attribute):
+        function_name = value.func.attr
+    if function_name.lower() not in {"get", "getenv"}:
+        return True
+    defaults = list(value.args[1:])
+    defaults.extend(keyword.value for keyword in value.keywords if keyword.arg in {"default", "fallback"})
+    for default in defaults:
+        if isinstance(default, ast.Constant):
+            if default.value is None:
+                continue
+            if isinstance(default.value, (str, int, float, bool)) and not _assignment_value_is_safe(
+                name, str(default.value)
+            ):
+                return False
+    return True
+
+
+def _python_assignment_value_is_safe(name: str, value: ast.expr) -> bool:
+    if isinstance(value, ast.Constant):
+        if value.value is None:
+            return True
+        if isinstance(value.value, (str, int, float, bool)):
+            return _assignment_value_is_safe(name, str(value.value))
+        return True
+    if isinstance(value, ast.JoinedStr):
+        for item in value.values:
+            if isinstance(item, ast.Constant) and isinstance(item.value, str) and item.value:
+                if not _placeholder_value(item.value):
+                    return False
+        return True
+    if isinstance(value, ast.Call):
+        return _python_retrieval_call_is_safe(name, value)
+    return True
+
+
+def _scan_python_assignments(text: str, findings: set[str]) -> None:
     try:
         document = ast.parse(text)
     except SyntaxError:
+        findings.add("python-syntax-unscannable")
         return
-
     for node in ast.walk(document):
         if isinstance(node, ast.Assign):
             targets = node.targets
@@ -565,78 +581,89 @@ def _scan_python_subscript_assignments(text: str, findings: set[str]) -> None:
             continue
         if value is None:
             continue
-
+        names: list[str] = []
         for target in targets:
-            if not isinstance(target, ast.Subscript):
-                continue
-            key = target.slice
-            if not isinstance(key, ast.Constant) or not isinstance(key.value, str):
-                continue
-            name = key.value
-            if not _name_is_sensitive(name):
-                continue
+            names.extend(_python_target_names(target))
+        for name in names:
+            if _name_is_sensitive(name) and not _python_assignment_value_is_safe(name, value):
+                findings.add("sensitive-environment-assignment")
 
-            if isinstance(value, ast.Constant):
-                if value.value is None:
-                    continue
-                if isinstance(value.value, (str, int, float, bool)) and not _assignment_value_is_safe(
-                    name, str(value.value)
-                ):
-                    findings.add("sensitive-environment-assignment")
-            elif isinstance(value, ast.JoinedStr):
-                literal_parts = [
-                    item.value
-                    for item in value.values
-                    if isinstance(item, ast.Constant) and isinstance(item.value, str)
-                ]
-                if any(part and not _placeholder_value(part) for part in literal_parts):
-                    findings.add("sensitive-environment-assignment")
+
+def _command_credential(match: re.Match[str]) -> str:
+    groups = match.groupdict()
+    return (
+        groups.get("double")
+        or groups.get("single")
+        or groups.get("placeholder")
+        or groups.get("bare")
+        or ""
+    )
+
+
+def _scan_command_options(text: str, findings: set[str]) -> None:
+    for pattern in (COMMAND_OPTION_SPACE_RE, COMMAND_OPTION_ARRAY_RE):
+        for match in pattern.finditer(text):
+            credential = _command_credential(match)
+            if credential and not _placeholder_value(credential):
+                findings.add("credential-command-option")
 
 
 def _scan_text(text: str, relative: str) -> tuple[str, ...]:
     findings: set[str] = set()
-
     for category, pattern in TOKEN_PATTERNS:
         if pattern.search(text):
             findings.add(category)
-
     for match in AUTHORIZATION_RE.finditer(text):
         if not _placeholder_value(match.group("credential")):
             findings.add("authorization-credential")
-
     for pattern in (CREDENTIALED_URI_RE, URI_QUERY_CREDENTIAL_RE):
         for match in pattern.finditer(text):
             if not _placeholder_value(match.group("password")):
                 findings.add("credentialed-uri")
-
-    for match in DSN_CREDENTIAL_PARAM_RE.finditer(text):
-        if not _placeholder_value(match.group("password")):
-            findings.add("credentialed-dsn")
-
-    _scan_assignment_patterns(text, findings)
+    for line in text.splitlines():
+        if not (
+            re.search(r"(?i)\b(?:host|dbname|user|port|sslmode)\s*=", line)
+            or re.search(r"(?i)\b[A-Za-z0-9_]*DSN[A-Za-z0-9_]*\b", line)
+        ):
+            continue
+        for match in DSN_CREDENTIAL_PARAM_RE.finditer(line):
+            password = match.group("password").strip("\"'")
+            if not _placeholder_value(password):
+                findings.add("credentialed-dsn")
+    _scan_command_options(text, findings)
 
     relative_path = PurePosixPath(relative)
+    is_python = relative_path.suffix.lower() == ".py"
+    _scan_assignment_patterns(text, findings, include_equals=not is_python)
+
     if relative_path.name.lower().startswith(BUILD_FILE_PREFIXES):
         for match in DOCKERFILE_ENV_SPACE_RE.finditer(text):
             name = match.group("name")
-            if _name_is_sensitive(name) and not _assignment_value_is_safe(
-                name, match.group("value")
-            ):
+            if _name_is_sensitive(name) and not _assignment_value_is_safe(name, match.group("value")):
                 findings.add("sensitive-environment-assignment")
 
-    if relative_path.suffix.lower() in {".yml", ".yaml"}:
+    suffix = relative_path.suffix.lower()
+    if suffix in {".yml", ".yaml"}:
         _scan_structured_yaml_environment(text, findings)
-    elif relative_path.suffix.lower() == ".json":
+        if K8S_SECRET_KIND_RE.search(text) and K8S_SECRET_PAYLOAD_RE.search(text):
+            findings.add("kubernetes-secret-payload")
+    elif suffix == ".json":
         _scan_structured_json_environment(text, findings)
-    elif relative_path.suffix.lower() == ".py":
-        _scan_python_subscript_assignments(text, findings)
+        try:
+            document = json.loads(text)
+        except json.JSONDecodeError:
+            document = None
+        if isinstance(document, dict) and str(document.get("kind", "")).lower() == "secret":
+            if "data" in document or "stringData" in document:
+                findings.add("kubernetes-secret-payload")
+    elif suffix == ".py":
+        _scan_python_assignments(text, findings)
 
-    if relative_path.suffix.lower() == ".sql":
+    if suffix == ".sql":
         for pattern in (SQL_PASSWORD_RE, SQL_DOLLAR_PASSWORD_RE):
             for match in pattern.finditer(text):
                 if not _placeholder_value(match.group("password")):
                     findings.add("sql-password-statement")
-
     return tuple(sorted(findings))
 
 
@@ -650,18 +677,13 @@ def _read_scannable_bytes(
         fd = os.open(path, flags)
     except OSError as exc:
         raise RecoveryError(f"Unable to open selected file safely: {relative}") from exc
-
     with os.fdopen(fd, "rb") as handle:
         metadata = os.fstat(handle.fileno())
         if not stat.S_ISREG(metadata.st_mode):
             raise RecoveryError(f"Selected path is no longer a regular file: {relative}")
-        if (metadata.st_dev, metadata.st_ino) != (
-            expected_metadata.st_dev,
-            expected_metadata.st_ino,
-        ):
+        if (metadata.st_dev, metadata.st_ino) != (expected_metadata.st_dev, expected_metadata.st_ino):
             raise RecoveryError(f"Selected file identity changed during recovery: {relative}")
         payload = handle.read(MAX_FILE_BYTES + 1)
-
     if len(payload) > MAX_FILE_BYTES:
         raise RecoveryError(f"Selected file exceeds per-file limit during scan: {relative}")
     return payload, metadata
@@ -675,7 +697,6 @@ def scan_selected_files(
     included: list[ScannedFile] = []
     excluded: list[dict[str, object]] = []
     scanned_total = 0
-
     for path, relative, expected_metadata in files:
         payload, metadata = _read_scannable_bytes(path, relative, expected_metadata)
         scanned_total += len(payload)
@@ -685,35 +706,25 @@ def scan_selected_files(
             text = payload.decode("utf-8")
         except UnicodeDecodeError as exc:
             raise RecoveryError(f"Selected text file is not valid UTF-8: {relative}") from exc
-
         findings = _scan_text(text, relative)
         mode = stat.S_IMODE(metadata.st_mode)
         if not findings:
-            included.append(
-                ScannedFile(
-                    relative=relative,
-                    mode=mode,
-                    payload=payload,
-                    sha256=hashlib.sha256(payload).hexdigest(),
-                )
-            )
+            included.append(ScannedFile(
+                relative=relative, mode=mode, payload=payload,
+                sha256=hashlib.sha256(payload).hexdigest(),
+            ))
             continue
-
         if os.path.abspath(path) in required:
             categories = ", ".join(findings)
             raise RecoveryError(
                 f"Required Compose config contains sensitive content: {relative} ({categories})"
             )
-
-        excluded.append(
-            {
-                "path": relative,
-                "size": len(payload),
-                "mode": f"{mode:04o}",
-                "findings": list(findings),
-            }
-        )
-
+        excluded.append({
+            "path": relative,
+            "size": len(payload),
+            "mode": f"{mode:04o}",
+            "findings": list(findings),
+        })
     return included, excluded
 
 
@@ -723,12 +734,7 @@ def build_manifest(
 ) -> dict[str, object]:
     file_list = list(files)
     entries = [
-        {
-            "path": item.relative,
-            "size": len(item.payload),
-            "mode": f"{item.mode:04o}",
-            "sha256": item.sha256,
-        }
+        {"path": item.relative, "size": len(item.payload), "mode": f"{item.mode:04o}", "sha256": item.sha256}
         for item in file_list
     ]
     exclusions = list(excluded_sensitive_files)
@@ -742,12 +748,7 @@ def build_manifest(
     }
 
 
-def _add_bytes(
-    archive: tarfile.TarFile,
-    name: str,
-    payload: bytes,
-    mode: int = 0o644,
-) -> None:
+def _add_bytes(archive: tarfile.TarFile, name: str, payload: bytes, mode: int = 0o644) -> None:
     info = tarfile.TarInfo(name)
     info.size = len(payload)
     info.mode = mode
@@ -764,9 +765,7 @@ def stream_archive(
 ) -> None:
     included, excluded = scan_selected_files(files, required_configs)
     manifest = build_manifest(included, excluded)
-    scanned_total = int(manifest["total_bytes"]) + sum(
-        int(entry["size"]) for entry in excluded
-    )
+    scanned_total = int(manifest["total_bytes"]) + sum(int(entry["size"]) for entry in excluded)
     receipt = {
         "schema": SCHEMA,
         "operation": "recover-v3-runtime-contract",
@@ -774,9 +773,7 @@ def stream_archive(
         "source_root": str(root),
         "compose_project": project,
         "docker_metadata_fields": [
-            COMPOSE_PROJECT_LABEL,
-            COMPOSE_WORKING_DIR_LABEL,
-            COMPOSE_CONFIG_FILES_LABEL,
+            COMPOSE_PROJECT_LABEL, COMPOSE_WORKING_DIR_LABEL, COMPOSE_CONFIG_FILES_LABEL,
         ],
         "docker_inspect_env": False,
         "source_content_scan": {
@@ -801,23 +798,15 @@ def stream_archive(
             "max_file_bytes": MAX_FILE_BYTES,
         },
     }
-
     with tarfile.open(fileobj=output, mode="w|gz", format=tarfile.PAX_FORMAT) as archive:
         for item in included:
-            _add_bytes(
-                archive,
-                f"source/{item.relative}",
-                item.payload,
-                mode=item.mode,
-            )
+            _add_bytes(archive, f"source/{item.relative}", item.payload, mode=item.mode)
         _add_bytes(
-            archive,
-            "recovery-manifest.json",
+            archive, "recovery-manifest.json",
             json.dumps(manifest, indent=2, sort_keys=True).encode() + b"\n",
         )
         _add_bytes(
-            archive,
-            "recovery-receipt.json",
+            archive, "recovery-receipt.json",
             json.dumps(receipt, indent=2, sort_keys=True).encode() + b"\n",
         )
 
@@ -825,13 +814,8 @@ def stream_archive(
 def docker_compose_labels(container: str) -> str:
     result = subprocess.run(
         [
-            "docker",
-            "inspect",
-            "--type",
-            "container",
-            "--format",
-            "{{json .Config.Labels}}",
-            container,
+            "docker", "inspect", "--type", "container", "--format",
+            "{{json .Config.Labels}}", container,
         ],
         check=False,
         stdout=subprocess.PIPE,
@@ -855,10 +839,7 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, RecoveryError, subprocess.SubprocessError) as exc:
         print(f"STOP: V3 runtime recovery failed closed: {exc}", file=sys.stderr)
         return 1
-    print(
-        "V3 runtime recovery stream completed without DB access or host mutation",
-        file=sys.stderr,
-    )
+    print("V3 runtime recovery stream completed without DB access or host mutation", file=sys.stderr)
     return 0
 
 

--- a/tests/test_v3_runtime_recovery.py
+++ b/tests/test_v3_runtime_recovery.py
@@ -21,6 +21,18 @@ def _labels(root: Path, configs: str = "compose.yml") -> str:
     )
 
 
+def _archive_metadata(output: io.BytesIO) -> tuple[list[str], dict, dict]:
+    with tarfile.open(fileobj=io.BytesIO(output.getvalue()), mode="r:gz") as bundle:
+        names = bundle.getnames()
+        manifest_source = bundle.extractfile("recovery-manifest.json")
+        receipt_source = bundle.extractfile("recovery-receipt.json")
+        assert manifest_source is not None
+        assert receipt_source is not None
+        manifest = json.load(manifest_source)
+        receipt = json.load(receipt_source)
+    return names, manifest, receipt
+
+
 def test_docker_metadata_parsing_requires_compose_contract_and_confines_configs(tmp_path: Path):
     (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
     root, configs, project = recovery.parse_compose_labels(_labels(tmp_path))
@@ -90,32 +102,225 @@ def test_file_count_per_file_and_total_size_bounds_are_inclusive(tmp_path: Path,
         recovery.collect_files(tmp_path, [compose])
 
 
-def test_archive_manifest_and_receipt_prove_no_db_and_no_mutation(tmp_path: Path):
+def test_archive_manifest_and_receipt_prove_no_db_no_mutation_and_content_scan(tmp_path: Path):
     compose = tmp_path / "compose.yml"
     compose.write_text("services: {}\n", encoding="utf-8")
     script = tmp_path / "Dockerfile"
     script.write_text("FROM scratch\n", encoding="utf-8")
     files = recovery.collect_files(tmp_path, [compose])
     output = io.BytesIO()
-    recovery.stream_archive(tmp_path.resolve(), "retained-project", files, output)
+    recovery.stream_archive(
+        tmp_path.resolve(),
+        "retained-project",
+        files,
+        output,
+        required_configs=[compose],
+    )
 
     archive_bytes = output.getvalue()
     assert hashlib.sha256(archive_bytes).hexdigest()
-    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as bundle:
-        names = bundle.getnames()
-        manifest = json.load(bundle.extractfile("recovery-manifest.json"))
-        receipt = json.load(bundle.extractfile("recovery-receipt.json"))
-    assert names == ["source/Dockerfile", "source/compose.yml", "recovery-manifest.json", "recovery-receipt.json"]
+    names, manifest, receipt = _archive_metadata(output)
+    assert names == [
+        "source/Dockerfile",
+        "source/compose.yml",
+        "recovery-manifest.json",
+        "recovery-receipt.json",
+    ]
     assert [entry["path"] for entry in manifest["files"]] == ["Dockerfile", "compose.yml"]
     assert all(len(entry["sha256"]) == 64 for entry in manifest["files"])
+    assert manifest["excluded_sensitive_file_count"] == 0
+    assert manifest["excluded_sensitive_files"] == []
     assert receipt["db_access"] is False
     assert receipt["host_mutation"] is False
     assert receipt["docker_inspect_env"] is False
     assert receipt["compose_project"] == "retained-project"
+    assert receipt["source_content_scan"]["performed"] is True
+    assert receipt["source_content_scan"]["mode"] == "fail-closed-before-stream"
+    assert receipt["source_content_scan"]["candidate_file_count"] == 2
+    assert receipt["source_content_scan"]["excluded_sensitive_file_count"] == 0
+
+
+def test_safe_placeholders_remain_recoverable(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text(
+        "\n".join(
+            (
+                "services:",
+                "  db:",
+                "    environment:",
+                "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}",
+                '      DATABASE_URL: "postgresql://app:${POSTGRES_PASSWORD}@db/app"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    script = tmp_path / "start.sh"
+    script.write_text(
+        "\n".join(
+            (
+                'OPENAI_API_KEY="${OPENAI_API_KEY}"',
+                'DATABASE_URL="postgresql://app:${POSTGRES_PASSWORD}@db/app"',
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    output = io.BytesIO()
+    recovery.stream_archive(
+        tmp_path.resolve(),
+        "retained-project",
+        files,
+        output,
+        required_configs=[compose],
+    )
+    names, manifest, _ = _archive_metadata(output)
+    assert "source/compose.yml" in names
+    assert "source/start.sh" in names
+    assert manifest["excluded_sensitive_file_count"] == 0
+
+
+def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    secret = "archive-" + "must-not-contain-this"
+    unsafe = tmp_path / "legacy-script.py"
+    unsafe.write_text(
+        "dsn = " + repr("postgresql://" + f"app:{secret}@db/app") + "\n",
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    output = io.BytesIO()
+    recovery.stream_archive(
+        tmp_path.resolve(),
+        "retained-project",
+        files,
+        output,
+        required_configs=[compose],
+    )
+
+    names, manifest, receipt = _archive_metadata(output)
+    assert "source/legacy-script.py" not in names
+    assert manifest["excluded_sensitive_file_count"] == 1
+    excluded = manifest["excluded_sensitive_files"][0]
+    assert excluded["path"] == "legacy-script.py"
+    assert excluded["findings"] == ["credentialed-uri"]
+    assert len(excluded["sha256"]) == 64
+    assert receipt["source_content_scan"]["excluded_sensitive_file_count"] == 1
+
+    with tarfile.open(fileobj=io.BytesIO(output.getvalue()), mode="r:gz") as bundle:
+        retained_payload = b""
+        for member in bundle.getmembers():
+            if not member.isfile():
+                continue
+            source = bundle.extractfile(member)
+            if source is not None:
+                retained_payload += source.read()
+    assert secret.encode() not in retained_payload
+
+
+def test_historical_docker_env_json_is_excluded_without_secret_values(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    secret = "historical-" + "credential-value"
+    inspect_file = tmp_path / "container-inspect-start.json"
+    inspect_file.write_text(
+        json.dumps(
+            {
+                "Config": {
+                    "Env": [
+                        "POSTGRES_" + f"PASSWORD={secret}",
+                        "DATABASE_" + "URL=" + "postgresql://" + f"app:{secret}@db/app",
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    output = io.BytesIO()
+    recovery.stream_archive(
+        tmp_path.resolve(),
+        "retained-project",
+        files,
+        output,
+        required_configs=[compose],
+    )
+    names, manifest, _ = _archive_metadata(output)
+    assert "source/container-inspect-start.json" not in names
+    excluded = manifest["excluded_sensitive_files"][0]
+    assert excluded["path"] == "container-inspect-start.json"
+    assert excluded["findings"] == [
+        "credentialed-uri",
+        "sensitive-environment-assignment",
+    ]
+    assert secret not in json.dumps(manifest)
+
+
+@pytest.mark.parametrize(
+    ("filename", "payload"),
+    (
+        ("key-material.md", lambda: "-----BEGIN " + "PRIVATE KEY-----\nnot-a-real-key\n"),
+        ("provider.txt", lambda: "sk-" + "a" * 30),
+        ("github.txt", lambda: "ghp_" + "b" * 30),
+        ("cloud.txt", lambda: "AKIA" + "C" * 16),
+    ),
+)
+def test_recognized_secret_material_is_excluded(tmp_path: Path, filename: str, payload):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / filename).write_text(payload(), encoding="utf-8")
+    files = recovery.collect_files(tmp_path, [compose])
+    included, excluded = recovery.scan_selected_files(files, [compose])
+    assert [relative for _, relative, _ in included] == ["compose.yml"]
+    assert len(excluded) == 1
+    assert excluded[0]["path"] == filename
+    assert excluded[0]["findings"]
+
+
+def test_required_compose_secret_fails_before_archive_bytes_are_emitted(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    secret = "required-" + "secret-value"
+    compose.write_text(
+        "services:\n  db:\n    environment:\n      POSTGRES_PASSWORD: " + secret + "\n",
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    output = io.BytesIO()
+    with pytest.raises(recovery.RecoveryError, match="Required Compose config"):
+        recovery.stream_archive(
+            tmp_path.resolve(),
+            "retained-project",
+            files,
+            output,
+            required_configs=[compose],
+        )
+    assert output.getvalue() == b""
+
+
+def test_invalid_utf8_selected_file_fails_before_archive_bytes_are_emitted(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / "broken.txt").write_bytes(b"\xff\xfe")
+    files = recovery.collect_files(tmp_path, [compose])
+    output = io.BytesIO()
+    with pytest.raises(recovery.RecoveryError, match="not valid UTF-8"):
+        recovery.stream_archive(
+            tmp_path.resolve(),
+            "retained-project",
+            files,
+            output,
+            required_configs=[compose],
+        )
+    assert output.getvalue() == b""
 
 
 def test_workflow_uses_exact_allowlist_pinned_trust_and_artifact_upload():
     workflow = (Path(__file__).parents[1] / ".github/workflows/chatgpt-ed-new-ops.yml").read_text()
+    helper = (
+        Path(__file__).parents[1] / "scripts/operator/recover_v3_runtime_contract.py"
+    ).read_text()
     assert "recover-v3-runtime-contract" in workflow
     assert "ED_NEW_OPERATOR_KNOWN_HOSTS" in workflow
     assert "ssh-keyscan" not in workflow
@@ -123,6 +328,7 @@ def test_workflow_uses_exact_allowlist_pinned_trust_and_artifact_upload():
     assert "ref: main" in workflow
     assert "trusted-main/scripts/operator/recover_v3_runtime_contract.py" in workflow
     assert 'git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA"' in workflow
-    assert "{{json .Config.Labels}}" in (Path(__file__).parents[1] / "scripts/operator/recover_v3_runtime_contract.py").read_text()
-    assert "Config.Env" not in (Path(__file__).parents[1] / "scripts/operator/recover_v3_runtime_contract.py").read_text()
+    assert "{{json .Config.Labels}}" in helper
+    assert "Config.Env" not in helper
+    assert "scan_selected_files" in helper
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow

--- a/tests/test_v3_runtime_recovery.py
+++ b/tests/test_v3_runtime_recovery.py
@@ -161,6 +161,9 @@ def test_safe_placeholders_remain_recoverable(tmp_path: Path):
             (
                 'OPENAI_API_KEY="${OPENAI_API_KEY}"',
                 'DATABASE_URL="postgresql://app:${POSTGRES_PASSWORD}@db/app"',
+                'REDIS_URL="redis://:${REDIS_PASSWORD}@cache/0"',
+                'CACHE_URL="host=cache password=${CACHE_PASSWORD}"',
+                'DATABASE_URL="postgresql://db/app?password=${POSTGRES_PASSWORD}"',
                 "",
             )
         ),
@@ -218,6 +221,54 @@ def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Pa
             if source is not None:
                 retained_payload += source.read()
     assert secret.encode() not in retained_payload
+
+
+def test_redis_uri_with_empty_username_is_excluded(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    secret = "redis-" + "credential-value"
+    unsafe = tmp_path / "legacy-cache.py"
+    unsafe.write_text(
+        "cache = " + repr("redis://:" + f"{secret}@cache/0") + "\n",
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    included, excluded = recovery.scan_selected_files(files, [compose])
+    assert [relative for _, relative, _ in included] == ["compose.yml"]
+    assert excluded[0]["path"] == "legacy-cache.py"
+    assert excluded[0]["findings"] == ["credentialed-uri"]
+
+
+def test_uri_query_credential_is_excluded(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    secret = "query-" + "credential-value"
+    unsafe = tmp_path / "legacy-query.py"
+    unsafe.write_text(
+        "dsn = " + repr("postgresql://db/app?sslmode=require&password=" + secret) + "\n",
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    included, excluded = recovery.scan_selected_files(files, [compose])
+    assert [relative for _, relative, _ in included] == ["compose.yml"]
+    assert excluded[0]["path"] == "legacy-query.py"
+    assert excluded[0]["findings"] == ["credentialed-uri"]
+
+
+def test_database_url_dsn_password_parameter_is_excluded(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    secret = "dsn-" + "credential-value"
+    unsafe = tmp_path / "legacy-start.sh"
+    unsafe.write_text(
+        'DATABASE_URL="host=db dbname=app user=app password=' + secret + '"\n',
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    included, excluded = recovery.scan_selected_files(files, [compose])
+    assert [relative for _, relative, _ in included] == ["compose.yml"]
+    assert excluded[0]["path"] == "legacy-start.sh"
+    assert excluded[0]["findings"] == ["sensitive-environment-assignment"]
 
 
 def test_historical_docker_env_json_is_excluded_without_secret_values(tmp_path: Path):

--- a/tests/test_v3_runtime_recovery.py
+++ b/tests/test_v3_runtime_recovery.py
@@ -175,6 +175,7 @@ def test_safe_placeholders_file_indirection_and_empty_defaults_remain_recoverabl
                 'CACHE_URL="host=cache password=${CACHE_PASSWORD}"',
                 'DATABASE_URL="postgresql://db/app?password=${POSTGRES_PASSWORD}"',
                 'DB_DSN_DIRECT="host=db user=app password=${DB_PASSWORD}"',
+                'DB_DSN_QUOTED="host=db user=app password=\'${DB_PASSWORD}\'"',
                 "",
             )
         ),
@@ -272,7 +273,17 @@ def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Pa
             'DB_DSN_DIRECT="host=db dbname=app user=app password=dsn-password"\n',
             "credentialed-dsn",
         ),
+        (
+            "legacy-quoted-dsn.sh",
+            'DB_DSN_DIRECT="host=db user=app password=\'actual secret\'"\n',
+            "credentialed-dsn",
+        ),
         ("settings.py", 'POSTGRES_PASSWORD = "python-password"\n', "sensitive-environment-assignment"),
+        (
+            "subscript.py",
+            'import os\nos.environ["POSTGRES_PASSWORD"] = "python-subscript-secret"\n',
+            "sensitive-environment-assignment",
+        ),
         (
             "storage.sh",
             "RCLONE_CONFIG_STORAGEBOX_PASS=storagebox-password\n",
@@ -289,8 +300,23 @@ def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Pa
             "credentialed-uri",
         ),
         (
+            "grafana.yml",
+            "authToken: opaque-token-value\n",
+            "sensitive-environment-assignment",
+        ),
+        (
             "roles.sql",
             "ALTER ROLE app LOGIN PASSWORD 'sql-password';\n",
+            "sql-password-statement",
+        ),
+        (
+            "roles-dollar.sql",
+            "ALTER ROLE app LOGIN PASSWORD $$sql-dollar-password$$;\n",
+            "sql-password-statement",
+        ),
+        (
+            "roles-tagged.sql",
+            "CREATE USER app PASSWORD $cred$sql-tagged-password$cred$;\n",
             "sql-password-statement",
         ),
     ),
@@ -325,6 +351,23 @@ def test_quoted_and_flow_yaml_sensitive_keys_fail_required_compose(tmp_path: Pat
     files = recovery.collect_files(tmp_path, [compose])
     with pytest.raises(recovery.RecoveryError, match="Required Compose config"):
         recovery.scan_selected_files(files, [compose])
+
+
+@pytest.mark.parametrize("value", ("null", "Null", "NULL", "~"))
+def test_unquoted_yaml_null_sensitive_values_are_safe(value: str):
+    text = f"services:\n  app:\n    environment:\n      POSTGRES_PASSWORD: {value}\n"
+    assert recovery._scan_text(text, "compose.yml") == ()
+
+
+@pytest.mark.parametrize("value", ('"null"', "'~'"))
+def test_quoted_yaml_null_spellings_remain_literals(value: str):
+    text = f"services:\n  app:\n    environment:\n      POSTGRES_PASSWORD: {value}\n"
+    assert "sensitive-environment-assignment" in recovery._scan_text(text, "compose.yml")
+
+
+def test_camel_case_token_metrics_are_not_credentials():
+    assert recovery._scan_text("tokenCount: 4096\n", "config.yml") == ()
+    assert recovery._scan_text("maxTokenCount: 4096\n", "config.yml") == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_v3_runtime_recovery.py
+++ b/tests/test_v3_runtime_recovery.py
@@ -33,6 +33,10 @@ def _archive_metadata(output: io.BytesIO) -> tuple[list[str], dict, dict]:
     return names, manifest, receipt
 
 
+def _included_paths(included: list[recovery.ScannedFile]) -> list[str]:
+    return [item.relative for item in included]
+
+
 def test_docker_metadata_parsing_requires_compose_contract_and_confines_configs(tmp_path: Path):
     (tmp_path / "compose.yml").write_text("services: {}\n", encoding="utf-8")
     root, configs, project = recovery.parse_compose_labels(_labels(tmp_path))
@@ -102,11 +106,11 @@ def test_file_count_per_file_and_total_size_bounds_are_inclusive(tmp_path: Path,
         recovery.collect_files(tmp_path, [compose])
 
 
-def test_archive_manifest_and_receipt_prove_no_db_no_mutation_and_content_scan(tmp_path: Path):
+def test_archive_manifest_and_receipt_prove_no_db_no_mutation_and_exact_scan(tmp_path: Path):
     compose = tmp_path / "compose.yml"
     compose.write_text("services: {}\n", encoding="utf-8")
-    script = tmp_path / "Dockerfile"
-    script.write_text("FROM scratch\n", encoding="utf-8")
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM scratch\n", encoding="utf-8")
     files = recovery.collect_files(tmp_path, [compose])
     output = io.BytesIO()
     recovery.stream_archive(
@@ -134,22 +138,27 @@ def test_archive_manifest_and_receipt_prove_no_db_no_mutation_and_content_scan(t
     assert receipt["host_mutation"] is False
     assert receipt["docker_inspect_env"] is False
     assert receipt["compose_project"] == "retained-project"
-    assert receipt["source_content_scan"]["performed"] is True
-    assert receipt["source_content_scan"]["mode"] == "fail-closed-before-stream"
-    assert receipt["source_content_scan"]["candidate_file_count"] == 2
-    assert receipt["source_content_scan"]["excluded_sensitive_file_count"] == 0
+    scan = receipt["source_content_scan"]
+    assert scan["performed"] is True
+    assert scan["mode"] == "fail-closed-before-stream"
+    assert scan["candidate_file_count"] == 2
+    assert scan["excluded_sensitive_file_count"] == 0
+    assert scan["archive_uses_exact_scanned_bytes"] is True
 
 
-def test_safe_placeholders_remain_recoverable(tmp_path: Path):
+def test_safe_placeholders_file_indirection_and_empty_defaults_remain_recoverable(tmp_path: Path):
     compose = tmp_path / "compose.yml"
     compose.write_text(
         "\n".join(
             (
                 "services:",
-                "  db:",
+                "  app:",
                 "    environment:",
+                "      ADMIN_TOKEN: ${ADMIN_TOKEN:-}",
+                "      FRONTIER_CLIENT_SECRET: ${FRONTIER_CLIENT_SECRET:-}",
                 "      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}",
                 '      DATABASE_URL: "postgresql://app:${POSTGRES_PASSWORD}@db/app"',
+                "      GLITCHTIP_GRAFANA_AUTH_TOKEN_SECRET_FILE: /run/secrets/glitchtip_grafana_auth_token",
                 "",
             )
         ),
@@ -164,6 +173,7 @@ def test_safe_placeholders_remain_recoverable(tmp_path: Path):
                 'REDIS_URL="redis://:${REDIS_PASSWORD}@cache/0"',
                 'CACHE_URL="host=cache password=${CACHE_PASSWORD}"',
                 'DATABASE_URL="postgresql://db/app?password=${POSTGRES_PASSWORD}"',
+                'DB_DSN_DIRECT="host=db user=app password=${DB_PASSWORD}"',
                 "",
             )
         ),
@@ -182,6 +192,28 @@ def test_safe_placeholders_remain_recoverable(tmp_path: Path):
     assert "source/compose.yml" in names
     assert "source/start.sh" in names
     assert manifest["excluded_sensitive_file_count"] == 0
+
+
+def test_nonempty_shell_default_is_not_treated_as_placeholder(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text(
+        "services:\n  app:\n    environment:\n      ADMIN_TOKEN: ${ADMIN_TOKEN:-literal-secret}\n",
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    with pytest.raises(recovery.RecoveryError, match="Required Compose config"):
+        recovery.stream_archive(
+            tmp_path.resolve(),
+            "retained-project",
+            files,
+            io.BytesIO(),
+            required_configs=[compose],
+        )
+
+
+def test_repository_compose_contract_has_no_content_scan_findings():
+    compose = (Path(__file__).parents[1] / "docker-compose.yml").read_text(encoding="utf-8")
+    assert recovery._scan_text(compose, "docker-compose.yml") == ()
 
 
 def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Path):
@@ -208,7 +240,7 @@ def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Pa
     assert manifest["excluded_sensitive_file_count"] == 1
     excluded = manifest["excluded_sensitive_files"][0]
     assert excluded["path"] == "legacy-script.py"
-    assert excluded["findings"] == ["credentialed-uri"]
+    assert "credentialed-uri" in excluded["findings"]
     assert len(excluded["sha256"]) == 64
     assert receipt["source_content_scan"]["excluded_sensitive_file_count"] == 1
 
@@ -223,52 +255,73 @@ def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Pa
     assert secret.encode() not in retained_payload
 
 
-def test_redis_uri_with_empty_username_is_excluded(tmp_path: Path):
+@pytest.mark.parametrize(
+    ("filename", "content", "finding"),
+    (
+        ("legacy-cache.py", 'cache = "redis://:redis-password@cache/0"\n', "credentialed-uri"),
+        (
+            "legacy-query.py",
+            'dsn = "postgresql://db/app?sslmode=require&password=query-password"\n',
+            "credentialed-uri",
+        ),
+        (
+            "legacy-dsn.sh",
+            'DB_DSN_DIRECT="host=db dbname=app user=app password=dsn-password"\n',
+            "credentialed-dsn",
+        ),
+        ("settings.py", 'POSTGRES_PASSWORD = "python-password"\n', "sensitive-environment-assignment"),
+        (
+            "storage.sh",
+            "RCLONE_CONFIG_STORAGEBOX_PASS=storagebox-password\n",
+            "sensitive-environment-assignment",
+        ),
+        (
+            "Dockerfile",
+            "FROM scratch\nENV POSTGRES_PASSWORD docker-password\n",
+            "sensitive-environment-assignment",
+        ),
+        (
+            "cache.txt",
+            'CACHE_URL="memcached://app:memcached-password@cache"\n',
+            "credentialed-uri",
+        ),
+        (
+            "roles.sql",
+            "ALTER ROLE app LOGIN PASSWORD 'sql-password';\n",
+            "sql-password-statement",
+        ),
+    ),
+)
+def test_additional_credential_forms_are_excluded(
+    tmp_path: Path,
+    filename: str,
+    content: str,
+    finding: str,
+):
     compose = tmp_path / "compose.yml"
     compose.write_text("services: {}\n", encoding="utf-8")
-    secret = "redis-" + "credential-value"
-    unsafe = tmp_path / "legacy-cache.py"
-    unsafe.write_text(
-        "cache = " + repr("redis://:" + f"{secret}@cache/0") + "\n",
-        encoding="utf-8",
-    )
+    (tmp_path / filename).write_text(content, encoding="utf-8")
     files = recovery.collect_files(tmp_path, [compose])
     included, excluded = recovery.scan_selected_files(files, [compose])
-    assert [relative for _, relative, _ in included] == ["compose.yml"]
-    assert excluded[0]["path"] == "legacy-cache.py"
-    assert excluded[0]["findings"] == ["credentialed-uri"]
+    assert _included_paths(included) == ["compose.yml"]
+    assert len(excluded) == 1
+    assert excluded[0]["path"] == filename
+    assert finding in excluded[0]["findings"]
 
 
-def test_uri_query_credential_is_excluded(tmp_path: Path):
+@pytest.mark.parametrize(
+    "mapping",
+    (
+        'services: {db: {environment: {"POSTGRES_PASSWORD": quoted-password}}}\n',
+        "services: {db: {environment: {POSTGRES_PASSWORD: flow-password}}}\n",
+    ),
+)
+def test_quoted_and_flow_yaml_sensitive_keys_fail_required_compose(tmp_path: Path, mapping: str):
     compose = tmp_path / "compose.yml"
-    compose.write_text("services: {}\n", encoding="utf-8")
-    secret = "query-" + "credential-value"
-    unsafe = tmp_path / "legacy-query.py"
-    unsafe.write_text(
-        "dsn = " + repr("postgresql://db/app?sslmode=require&password=" + secret) + "\n",
-        encoding="utf-8",
-    )
+    compose.write_text(mapping, encoding="utf-8")
     files = recovery.collect_files(tmp_path, [compose])
-    included, excluded = recovery.scan_selected_files(files, [compose])
-    assert [relative for _, relative, _ in included] == ["compose.yml"]
-    assert excluded[0]["path"] == "legacy-query.py"
-    assert excluded[0]["findings"] == ["credentialed-uri"]
-
-
-def test_database_url_dsn_password_parameter_is_excluded(tmp_path: Path):
-    compose = tmp_path / "compose.yml"
-    compose.write_text("services: {}\n", encoding="utf-8")
-    secret = "dsn-" + "credential-value"
-    unsafe = tmp_path / "legacy-start.sh"
-    unsafe.write_text(
-        'DATABASE_URL="host=db dbname=app user=app password=' + secret + '"\n',
-        encoding="utf-8",
-    )
-    files = recovery.collect_files(tmp_path, [compose])
-    included, excluded = recovery.scan_selected_files(files, [compose])
-    assert [relative for _, relative, _ in included] == ["compose.yml"]
-    assert excluded[0]["path"] == "legacy-start.sh"
-    assert excluded[0]["findings"] == ["sensitive-environment-assignment"]
+    with pytest.raises(recovery.RecoveryError, match="Required Compose config"):
+        recovery.scan_selected_files(files, [compose])
 
 
 def test_historical_docker_env_json_is_excluded_without_secret_values(tmp_path: Path):
@@ -302,32 +355,40 @@ def test_historical_docker_env_json_is_excluded_without_secret_values(tmp_path: 
     assert "source/container-inspect-start.json" not in names
     excluded = manifest["excluded_sensitive_files"][0]
     assert excluded["path"] == "container-inspect-start.json"
-    assert excluded["findings"] == [
-        "credentialed-uri",
-        "sensitive-environment-assignment",
-    ]
+    assert "credentialed-uri" in excluded["findings"]
+    assert "sensitive-environment-assignment" in excluded["findings"]
     assert secret not in json.dumps(manifest)
 
 
 @pytest.mark.parametrize(
-    ("filename", "payload"),
+    ("filename", "payload", "finding"),
     (
-        ("key-material.md", lambda: "-----BEGIN " + "PRIVATE KEY-----\nnot-a-real-key\n"),
-        ("provider.txt", lambda: "sk-" + "a" * 30),
-        ("github.txt", lambda: "ghp_" + "b" * 30),
-        ("cloud.txt", lambda: "AKIA" + "C" * 16),
+        ("key-material.md", lambda: "-----BEGIN " + "PRIVATE KEY-----\nnot-a-real-key\n", "private-key-material"),
+        (
+            "encrypted-key.md",
+            lambda: "-----BEGIN ENCRYPTED " + "PRIVATE KEY-----\nnot-a-real-key\n",
+            "private-key-material",
+        ),
+        ("provider.txt", lambda: "sk-" + "a" * 30, "openai-api-token"),
+        ("github.txt", lambda: "ghp_" + "b" * 30, "github-token"),
+        ("cloud.txt", lambda: "AKIA" + "C" * 16, "aws-access-key"),
     ),
 )
-def test_recognized_secret_material_is_excluded(tmp_path: Path, filename: str, payload):
+def test_recognized_secret_material_is_excluded(
+    tmp_path: Path,
+    filename: str,
+    payload,
+    finding: str,
+):
     compose = tmp_path / "compose.yml"
     compose.write_text("services: {}\n", encoding="utf-8")
     (tmp_path / filename).write_text(payload(), encoding="utf-8")
     files = recovery.collect_files(tmp_path, [compose])
     included, excluded = recovery.scan_selected_files(files, [compose])
-    assert [relative for _, relative, _ in included] == ["compose.yml"]
+    assert _included_paths(included) == ["compose.yml"]
     assert len(excluded) == 1
     assert excluded[0]["path"] == filename
-    assert excluded[0]["findings"]
+    assert finding in excluded[0]["findings"]
 
 
 def test_required_compose_secret_fails_before_archive_bytes_are_emitted(tmp_path: Path):
@@ -367,6 +428,65 @@ def test_invalid_utf8_selected_file_fails_before_archive_bytes_are_emitted(tmp_p
     assert output.getvalue() == b""
 
 
+def test_selected_file_identity_change_fails_closed(tmp_path: Path):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    script = tmp_path / "safe.py"
+    script.write_text("print('safe')\n", encoding="utf-8")
+    files = recovery.collect_files(tmp_path, [compose])
+
+    original = tmp_path / "original.py"
+    script.rename(original)
+    script.write_text("print('replacement')\n", encoding="utf-8")
+
+    with pytest.raises(recovery.RecoveryError, match="identity changed"):
+        recovery.scan_selected_files(files, [compose])
+
+
+def test_archive_uses_exact_payload_returned_by_content_scan(tmp_path: Path, monkeypatch):
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    script = tmp_path / "safe.py"
+    script.write_text("POSTGRES_PASSWORD='path-now-contains-secret'\n", encoding="utf-8")
+    files = recovery.collect_files(tmp_path, [compose])
+
+    compose_payload = b"services: {}\n"
+    script_payload = b"print('bytes-that-were-scanned')\n"
+    scanned = [
+        recovery.ScannedFile(
+            relative="compose.yml",
+            mode=0o644,
+            payload=compose_payload,
+            sha256=hashlib.sha256(compose_payload).hexdigest(),
+        ),
+        recovery.ScannedFile(
+            relative="safe.py",
+            mode=0o644,
+            payload=script_payload,
+            sha256=hashlib.sha256(script_payload).hexdigest(),
+        ),
+    ]
+    monkeypatch.setattr(recovery, "scan_selected_files", lambda *_args, **_kwargs: (scanned, []))
+
+    output = io.BytesIO()
+    recovery.stream_archive(
+        tmp_path.resolve(),
+        "retained-project",
+        files,
+        output,
+        required_configs=[compose],
+    )
+    with tarfile.open(fileobj=io.BytesIO(output.getvalue()), mode="r:gz") as bundle:
+        source = bundle.extractfile("source/safe.py")
+        assert source is not None
+        assert source.read() == script_payload
+        manifest_source = bundle.extractfile("recovery-manifest.json")
+        assert manifest_source is not None
+        manifest = json.load(manifest_source)
+    safe_entry = next(entry for entry in manifest["files"] if entry["path"] == "safe.py")
+    assert safe_entry["sha256"] == hashlib.sha256(script_payload).hexdigest()
+
+
 def test_workflow_uses_exact_allowlist_pinned_trust_and_artifact_upload():
     workflow = (Path(__file__).parents[1] / ".github/workflows/chatgpt-ed-new-ops.yml").read_text()
     helper = (
@@ -382,4 +502,5 @@ def test_workflow_uses_exact_allowlist_pinned_trust_and_artifact_upload():
     assert "{{json .Config.Labels}}" in helper
     assert "Config.Env" not in helper
     assert "scan_selected_files" in helper
+    assert "archive_uses_exact_scanned_bytes" in helper
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow

--- a/tests/test_v3_runtime_recovery.py
+++ b/tests/test_v3_runtime_recovery.py
@@ -144,6 +144,7 @@ def test_archive_manifest_and_receipt_prove_no_db_no_mutation_and_exact_scan(tmp
     assert scan["candidate_file_count"] == 2
     assert scan["excluded_sensitive_file_count"] == 0
     assert scan["archive_uses_exact_scanned_bytes"] is True
+    assert scan["excluded_sensitive_content_digests"] is False
 
 
 def test_safe_placeholders_file_indirection_and_empty_defaults_remain_recoverable(tmp_path: Path):
@@ -241,8 +242,10 @@ def test_optional_credentialed_uri_is_excluded_with_provenance_only(tmp_path: Pa
     excluded = manifest["excluded_sensitive_files"][0]
     assert excluded["path"] == "legacy-script.py"
     assert "credentialed-uri" in excluded["findings"]
-    assert len(excluded["sha256"]) == 64
-    assert receipt["source_content_scan"]["excluded_sensitive_file_count"] == 1
+    assert "sha256" not in excluded
+    scan = receipt["source_content_scan"]
+    assert scan["excluded_sensitive_file_count"] == 1
+    assert scan["excluded_sensitive_content_digests"] is False
 
     with tarfile.open(fileobj=io.BytesIO(output.getvalue()), mode="r:gz") as bundle:
         retained_payload = b""
@@ -322,6 +325,59 @@ def test_quoted_and_flow_yaml_sensitive_keys_fail_required_compose(tmp_path: Pat
     files = recovery.collect_files(tmp_path, [compose])
     with pytest.raises(recovery.RecoveryError, match="Required Compose config"):
         recovery.scan_selected_files(files, [compose])
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        '"{{ \'actual-secret\' | string }}"',
+        '"{{ password_ref | default(\'literal-secret\') }}"',
+    ),
+)
+def test_jinja_literal_sensitive_assignments_fail_closed(tmp_path: Path, value: str):
+    compose = tmp_path / "compose.yml"
+    compose.write_text(
+        f"services:\n  app:\n    environment:\n      POSTGRES_PASSWORD: {value}\n",
+        encoding="utf-8",
+    )
+    files = recovery.collect_files(tmp_path, [compose])
+    with pytest.raises(recovery.RecoveryError, match="Required Compose config"):
+        recovery.scan_selected_files(files, [compose])
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        '"{{ password_ref }}"',
+        '"{{ password_ref | string }}"',
+        '"{{ password_ref | default(\'\') }}"',
+        '"{{ password_ref | default(other_password_ref) }}"',
+    ),
+)
+def test_jinja_reference_only_sensitive_assignments_are_safe(value: str):
+    text = f"services:\n  app:\n    environment:\n      POSTGRES_PASSWORD: {value}\n"
+    assert recovery._scan_text(text, "compose.yml") == ()
+
+
+def test_compose_secret_reference_collection_is_not_a_credential_assignment():
+    safe = "\n".join(
+        (
+            "services: {app: {secrets: [db_password], environment: {POSTGRES_USER: app}}}",
+            "secrets:",
+            "  db_password:",
+            "    file: ./db_password.disabled",
+            "",
+        )
+    )
+    assert recovery._scan_text(safe, "compose.yml") == ()
+
+    unsafe = (
+        "services: {app: {secrets: [db_password], "
+        "environment: {POSTGRES_PASSWORD: literal-password}}}\n"
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        unsafe, "compose.yml"
+    )
 
 
 def test_historical_docker_env_json_is_excluded_without_secret_values(tmp_path: Path):

--- a/tests/test_v3_runtime_recovery_codex_edges.py
+++ b/tests/test_v3_runtime_recovery_codex_edges.py
@@ -1,0 +1,61 @@
+from scripts.operator import recover_v3_runtime_contract as recovery
+
+
+def test_structured_mapping_keys_support_hyphens_and_dots():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "api-key: opaque-test-key\n", "config.yml"
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "spring.datasource.password: opaque-test-password\n", "config.yml"
+    )
+
+
+def test_flow_style_structured_environment_entry_is_scanned():
+    findings = recovery._scan_text(
+        "env: [{name: POSTGRES_PASSWORD, value: opaque-test-password}]\n",
+        "deployment.yml",
+    )
+    assert "sensitive-environment-assignment" in findings
+
+
+def test_pwd_suffix_is_sensitive_but_shell_pwd_is_not():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "DB_PWD=opaque-test-password\n", "start.sh"
+    )
+    assert recovery._scan_text('PWD="$(pwd)"\n', "start.sh") == ()
+
+
+def test_space_separated_credential_options_are_scanned():
+    assert "credential-command-option" in recovery._scan_text(
+        "client --password opaque-test-password\n", "start.sh"
+    )
+    assert "credential-command-option" in recovery._scan_text(
+        'command: ["client", "--password", "opaque-test-password"]\n',
+        "compose.yml",
+    )
+    assert recovery._scan_text(
+        "client --password ${DB_PASSWORD}\n", "start.sh"
+    ) == ()
+
+
+def test_kubernetes_secret_payload_is_excluded_regardless_of_key_name():
+    findings = recovery._scan_text(
+        "apiVersion: v1\nkind: Secret\ndata:\n  auth: b3BhcXVlLXRlc3QtdmFsdWU=\n",
+        "secret.yml",
+    )
+    assert "kubernetes-secret-payload" in findings
+
+
+def test_python_ast_distinguishes_runtime_lookup_from_literal_assignment():
+    assert recovery._scan_text(
+        'import os\nINARA_API_KEY = os.getenv("INARA_API_KEY")\n',
+        "inara_api.py",
+    ) == ()
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'INARA_API_KEY = "opaque-test-key"\n',
+        "inara_api.py",
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'import os\nINARA_API_KEY = os.getenv("INARA_API_KEY", "opaque-default")\n',
+        "inara_api.py",
+    )

--- a/tests/test_v3_runtime_recovery_codex_edges.py
+++ b/tests/test_v3_runtime_recovery_codex_edges.py
@@ -210,3 +210,52 @@ def test_utf8_bom_does_not_hide_first_yaml_sensitive_key():
     assert "sensitive-environment-assignment" in recovery._scan_text(
         "\ufeffpassword: opaque-test-secret\n", "config.yml"
     )
+
+
+def test_escaped_double_quoted_yaml_keys_are_decoded_before_classification():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        '"POSTGRES_PASS\\u0057ORD": opaque-test-secret\n', "compose.yml"
+    )
+    assert recovery._scan_text(
+        '"DISPLAY\\u005fNAME": console\n', "compose.yml"
+    ) == ()
+
+
+def test_python_walrus_and_augmented_sensitive_assignments_are_scanned():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'if (POSTGRES_PASSWORD := "opaque-test-secret"):\n    pass\n', "settings.py"
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'POSTGRES_PASSWORD = existing\nPOSTGRES_PASSWORD += "opaque-test-secret"\n',
+        "settings.py",
+    )
+    assert recovery._scan_text(
+        'import os\nif (POSTGRES_PASSWORD := os.getenv("POSTGRES_PASSWORD")):\n    pass\n',
+        "settings.py",
+    ) == ()
+
+
+def test_openpgp_private_key_armor_is_scanned():
+    assert "private-key-material" in recovery._scan_text(
+        "-----BEGIN PGP PRIVATE KEY BLOCK-----\nopaque-test-material\n"
+        "-----END PGP PRIVATE KEY BLOCK-----\n",
+        "historical.md",
+    )
+
+
+def test_shell_assignment_scans_entire_concatenated_word():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "POSTGRES_PASSWORD=${PREFIX}opaque-test-secret\n", "start.sh"
+    )
+    assert recovery._scan_text(
+        "POSTGRES_PASSWORD=${DB_PASSWORD}\n", "start.sh"
+    ) == ()
+
+
+def test_multiline_quoted_yaml_sensitive_scalar_is_scanned():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'POSTGRES_PASSWORD: "opaque-test-\n  secret"\n', "compose.yml"
+    )
+    assert recovery._scan_text(
+        'POSTGRES_PASSWORD: "${DB_PASSWORD}\n  "\n', "compose.yml"
+    ) == ()

--- a/tests/test_v3_runtime_recovery_codex_edges.py
+++ b/tests/test_v3_runtime_recovery_codex_edges.py
@@ -59,3 +59,63 @@ def test_python_ast_distinguishes_runtime_lookup_from_literal_assignment():
         'import os\nINARA_API_KEY = os.getenv("INARA_API_KEY", "opaque-default")\n',
         "inara_api.py",
     )
+
+
+def test_python_wrapped_literal_credentials_are_scanned():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'POSTGRES_PASSWORD = SecretStr("opaque-test-secret")\n',
+        "settings.py",
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'POSTGRES_PASSWORD = "opaque-test-secret".strip()\n',
+        "settings.py",
+    )
+    assert recovery._scan_text(
+        'import os\nPOSTGRES_PASSWORD = SecretStr(os.getenv("POSTGRES_PASSWORD"))\n',
+        "settings.py",
+    ) == ()
+
+
+def test_python_composed_literal_credentials_fail_closed():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'POSTGRES_PASSWORD = "opaque-" + "test-secret"\n',
+        "settings.py",
+    )
+    assert recovery._scan_text(
+        'POSTGRES_PASSWORD = password_reference\n',
+        "settings.py",
+    ) == ()
+
+
+def test_python_comments_and_docstrings_are_scanned_for_literal_credentials():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        '# POSTGRES_PASSWORD = "opaque-test-secret"\n',
+        "settings.py",
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        '"""POSTGRES_PASSWORD = "opaque-test-secret"\n"""\n',
+        "settings.py",
+    )
+    assert recovery._scan_text(
+        '# POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")\n',
+        "settings.py",
+    ) == ()
+
+
+def test_yaml_sequence_item_sensitive_mapping_key_is_scanned():
+    findings = recovery._scan_text(
+        "users:\n  - password: opaque-test-secret\n",
+        "users.yml",
+    )
+    assert "sensitive-environment-assignment" in findings
+
+
+def test_embedded_sql_password_statements_are_scanned_in_non_sql_files():
+    assert "sql-password-statement" in recovery._scan_text(
+        'psql -c "ALTER ROLE app PASSWORD \'opaque-test-secret\';"\n',
+        "rotate.sh",
+    )
+    assert recovery._scan_text(
+        'psql -c "ALTER ROLE app PASSWORD \'${DB_PASSWORD}\';"\n',
+        "rotate.sh",
+    ) == ()

--- a/tests/test_v3_runtime_recovery_codex_edges.py
+++ b/tests/test_v3_runtime_recovery_codex_edges.py
@@ -119,3 +119,94 @@ def test_embedded_sql_password_statements_are_scanned_in_non_sql_files():
         'psql -c "ALTER ROLE app PASSWORD \'${DB_PASSWORD}\';"\n',
         "rotate.sh",
     ) == ()
+
+
+def test_python_sensitive_keyword_arguments_and_defaults_are_scanned():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'client.login(password="opaque-test-secret")\n', "client.py"
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'def connect(password="opaque-test-secret"):\n    pass\n', "client.py"
+    )
+    assert recovery._scan_text(
+        'import os\nclient.login(password=os.getenv("DB_PASSWORD"))\n', "client.py"
+    ) == ()
+    assert recovery._scan_text(
+        'def connect(password=None):\n    pass\n', "client.py"
+    ) == ()
+
+
+def test_nested_json_kubernetes_secret_is_scanned():
+    findings = recovery._scan_text(
+        '{"kind":"List","items":[{"kind":"Secret","data":{"auth":"b3BhcXVl"}}]}',
+        "resources.json",
+    )
+    assert "kubernetes-secret-payload" in findings
+
+
+def test_credential_named_assignments_are_sensitive_but_path_indirection_is_safe():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "DB_CREDENTIAL=opaque-test-secret\n", "start.sh"
+    )
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "service_credentials: opaque-test-secret\n", "config.yml"
+    )
+    assert recovery._scan_text(
+        "CREDENTIALS_FILE=/run/secrets/service_credentials\n", "start.sh"
+    ) == ()
+
+
+def test_python_prefixed_authorization_strings_are_scanned_without_blocking_dynamic_fstrings():
+    assert "authorization-credential" in recovery._scan_text(
+        'headers = {"Authorization": u"Bearer opaque-test-credential"}\n', "client.py"
+    )
+    assert "authorization-credential" in recovery._scan_text(
+        'headers = {"Authorization": f"Bearer opaque-test-credential"}\n', "client.py"
+    )
+    assert recovery._scan_text(
+        'headers = {"Authorization": f"Bearer {token}"}\n', "client.py"
+    ) == ()
+
+
+def test_python_byte_string_credentials_are_scanned():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        'API_KEY = b"opaque-test-key"\n', "settings.py"
+    )
+
+
+def test_postgres_escape_string_password_is_scanned():
+    assert "sql-password-statement" in recovery._scan_text(
+        "ALTER ROLE app PASSWORD E'opaque-test-secret';\n", "rotate.sql"
+    )
+
+
+def test_docker_registry_auth_payload_is_scanned():
+    assert "docker-registry-auth" in recovery._scan_text(
+        '{"auths":{"registry.example":{"auth":"dXNlcjpwYXNz"}}}',
+        ".docker/config.json",
+    )
+    assert recovery._scan_text(
+        '{"auths":{"registry.example":{"auth":"${DOCKER_AUTH}"}}}',
+        ".docker/config.json",
+    ) == ()
+
+
+def test_private_jwks_are_scanned_but_public_jwks_are_allowed():
+    assert "private-jwk-material" in recovery._scan_text(
+        '{"kty":"RSA","n":"n","e":"AQAB","d":"opaque-private"}',
+        "jwks.json",
+    )
+    assert recovery._scan_text(
+        '{"kty":"RSA","n":"n","e":"AQAB"}',
+        "jwks.json",
+    ) == ()
+    assert "private-jwk-material" in recovery._scan_text(
+        "kty: RSA\nn: n\ne: AQAB\nd: opaque-private\n",
+        "jwk.yml",
+    )
+
+
+def test_utf8_bom_does_not_hide_first_yaml_sensitive_key():
+    assert "sensitive-environment-assignment" in recovery._scan_text(
+        "\ufeffpassword: opaque-test-secret\n", "config.yml"
+    )


### PR DESCRIPTION
## Summary

Addresses the code-repair portion of #537 by adding a bounded, fail-closed content scan before any V3 runtime recovery archive bytes are emitted.

## What changes

- scan every allowlisted candidate file before opening the tar stream;
- detect high-confidence private-key material (including OpenPGP armor), recognized provider/token formats, credentialed database/cache URIs/DSNs, authorization credentials, SQL password statements, Kubernetes Secret payloads, Docker registry auth, private JWKs, credential-bearing command options, and non-placeholder sensitive assignments;
- handle Compose/YAML flow mappings, escaped and multiline quoted YAML keys/scalars, structured name/value environment entries, dotted/hyphenated and camelCase credential fields, Dockerfile ENV syntax, shell concatenations, and Python assignments through AST inspection;
- inspect Python direct/annotated/augmented/walrus assignments, sensitive keyword arguments, function defaults, comments/docstrings, wrapped literals, byte strings, and composed expressions while distinguishing safe dynamic lookups;
- support safe `_FILE`/`_PATH` indirection, YAML nulls, empty/reference placeholders, and ordinary shell `PWD` without weakening `_PWD` credential detection;
- fail the entire recovery if a required Compose authority file contains sensitive content;
- exclude optional unsafe historical files from the archive while retaining provenance-only metadata: path, size, mode, and finding categories;
- deliberately omit content digests for excluded sensitive files to avoid creating an offline digest oracle;
- archive the exact in-memory bytes that passed scanning, with O_NOFOLLOW plus device/inode identity checks to prevent TOCTOU substitution;
- record content-scan scope/results separately from the existing current Docker-label metadata receipt;
- reject selected non-UTF-8 text files rather than silently bypassing inspection.

## Safety boundaries

- no database access or mutation;
- no host mutation;
- no production/deployment/DNS changes;
- no secret values added to source, fixtures, PR body, or test expectations;
- no archive bytes are emitted when a required authority file fails the scan.

## Validation

Exact-head candidate: `d6c6d74a23d21b61a589ccae096df296748e9d74`.

All seven exact-head GitHub workflows passed:
- CI
- Review Lab
- Coverage Tracking
- Cypress Parity
- CodeQL
- Semgrep
- Container Image Parity

The full backend unit suite, backend integration suite, canonical safety suite, script-contract suite, OpenAPI drift check, frontend build/test suite, and real `docker-compose.yml` validation pass on this head, including focused regressions for the adversarial scanner findings.

Octopus reviewed the exact head with 0 findings and Security 5/5. Codex also completed its exact-head adversarial review.

### Bounded-parser stopping rule / accepted residual risk

The recovery helper is intentionally a bounded sanitizer for the retained ED-Finder source tree, not a universal parser for every possible language/tool/cloud credential representation.

The final Codex pass identified six additional syntax/provider-specific cases: Python positional environment setters, Bash `printf -v`, psql `\\set`, kubeconfig `client-key-data`, Azure Storage `AccountKey` connection strings, and generic JWT signatures. Repo-wide searches found no use of those forms in ED-Finder; JWT references explicitly document that this path does not use JWT/session auth. Those six findings are therefore documented and resolved as accepted out-of-scope risk rather than treated as fixed.

A freshly recovered artifact still requires an independent secret scan before acceptance, so this parser is not the sole trust boundary.

## Still separate from this PR

#537 immediate containment remains an operator task: artifact `9773572090` is still present, and the possibly compromised retained rehearsal credential still needs active-use/rotation disposition without exposing its value.

This PR must **not** auto-close #537. The issue stays open until the remaining containment, fresh safe recovery, independent scan, and acceptance steps are complete.