### PR TITLE
Stage 27A: remove final stale lane ambiguity

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -179,9 +179,10 @@ Stage 25 has exactly one primary objective:
 8. Use the external adversarial audit as an execution-order correction, not as
    a parallel roadmap: preserve the now-closed ratings, migration, backup, and
    CI foundations before opening new product lanes like accounts.
-9. Incubate only the safe slices of the next two opportunity lanes:
-   `B-1` nearest-colonised proximity in Inspect, then `A-1` journal import as
-   staging/evidence ingestion only, with no new canonical write shortcut.
+9. Preserve the already-shipped bounded `B-1` nearest-colonised proximity and
+   `A-1` journal staging/evidence capabilities without expanding either from
+   its old lane. Any spatial or Commander History follow-on is governed only
+   by the Stage 27 programme and authorization table below.
 
 ## Audit Response
 


### PR DESCRIPTION
## Summary
- preserve the already-shipped bounded B-1 proximity and A-1 journal staging capabilities
- remove wording that could still be read as authorizing the old lanes to expand independently
- make explicit that any spatial / Commander History follow-on is governed by the Stage 27 programme and authorization table

## Scope
Documentation/governance only. No runtime, dependency, database, production, V2, deployment, or map behavior changes.

## Validation
- Codex worker mandatory strict state-resolution gate: PASS
- `git diff --check`: PASS
- focused governance assertion bodies: PASS (28/28 via the worker's in-memory pytest marker shim because pytest was not installed in that worker venv)

Official protected-branch CI remains the acceptance gate for this PR.