### PR TITLE
Fix Octopus review footer with system-derived PR head SHA

### DIFF
--- a/.github/workflows/octopus-review-head-normalizer.yml
+++ b/.github/workflows/octopus-review-head-normalizer.yml
@@ -1,0 +1,42 @@
+name: Octopus review head normalizer
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: octopus-review-head-${{ github.event.issue.number }}-${{ github.event.comment.id }}
+  cancel-in-progress: true
+
+jobs:
+  normalize:
+    name: Normalize Octopus reviewed head
+    if: >-
+      github.event.issue.pull_request &&
+      github.event.comment.user.login == 'octopus-fc8f7111f1[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Replace model-derived footer with exact PR head
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/normalize_octopus_review_head.py \
+            --event "$EVENT_PATH" \
+            --repository "$REPOSITORY"

--- a/scripts/ci/normalize_octopus_review_head.py
+++ b/scripts/ci/normalize_octopus_review_head.py
@@ -9,13 +9,12 @@ text; GitHub's pull-request API is the authority for the current head SHA.
 from __future__ import annotations
 
 import argparse
+from http.client import HTTPException, HTTPSConnection
 import json
 import os
 from pathlib import Path
 import re
 import sys
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
 
 
 OCTOPUS_LOGIN = "octopus-fc8f7111f1[bot]"
@@ -23,7 +22,8 @@ OCTOPUS_HEADING = "## 🐙 Octopus Review"
 FOOTER_RE = re.compile(r"(?mi)^Last reviewed commit:\s*.*(?:\r?\n)?")
 CHECKLIST_RE = re.compile(r"(?m)^### Checklist\s*$")
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-API_ROOT = "https://api.github.com"
+API_HOST = "api.github.com"
+MAX_RESPONSE_BYTES = 1_000_000
 
 
 class NormalizerError(RuntimeError):
@@ -47,25 +47,42 @@ def normalize_review_body(body: str, head_sha: str) -> str:
     return f"{cleaned}\n\n{footer}\n"
 
 
-def _api_json(method: str, path: str, token: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+def _api_json(
+    method: str,
+    path: str,
+    token: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Call only the fixed GitHub API host with a validated absolute API path."""
+    if method not in {"GET", "PATCH"}:
+        raise NormalizerError("unsupported GitHub API method")
+    if not path.startswith("/repos/") or ".." in path or "?" in path or "#" in path:
+        raise NormalizerError("GitHub API path is invalid")
+
     data = None if payload is None else json.dumps(payload).encode("utf-8")
-    request = Request(
-        f"{API_ROOT}{path}",
-        data=data,
-        method=method,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "ed-finder-octopus-head-normalizer",
-            "Content-Type": "application/json",
-        },
-    )
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "ed-finder-octopus-head-normalizer",
+    }
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+
+    connection = HTTPSConnection(API_HOST, timeout=20)
     try:
-        with urlopen(request, timeout=20) as response:
-            raw = response.read(1_000_000)
-    except (HTTPError, URLError, TimeoutError) as exc:
+        connection.request(method, path, body=data, headers=headers)
+        response = connection.getresponse()
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+        if response.status < 200 or response.status >= 300:
+            raise NormalizerError(f"GitHub API request failed: {method} {path}")
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raise NormalizerError("GitHub API response exceeded size limit")
+    except (HTTPException, OSError, TimeoutError) as exc:
         raise NormalizerError(f"GitHub API request failed: {method} {path}") from exc
+    finally:
+        connection.close()
+
     try:
         decoded = json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/scripts/ci/normalize_octopus_review_head.py
+++ b/scripts/ci/normalize_octopus_review_head.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Normalize the Octopus review footer to the system-derived PR head SHA.
+
+This runs only from the default-branch issue_comment workflow for the exact
+Octopus GitHub App bot. The LLM-generated footer is treated as untrusted display
+text; GitHub's pull-request API is the authority for the current head SHA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+OCTOPUS_LOGIN = "octopus-fc8f7111f1[bot]"
+OCTOPUS_HEADING = "## 🐙 Octopus Review"
+FOOTER_RE = re.compile(r"(?mi)^Last reviewed commit:\s*.*(?:\r?\n)?")
+CHECKLIST_RE = re.compile(r"(?m)^### Checklist\s*$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+API_ROOT = "https://api.github.com"
+
+
+class NormalizerError(RuntimeError):
+    """The event or GitHub response did not satisfy the fail-closed contract."""
+
+
+def normalize_review_body(body: str, head_sha: str) -> str:
+    """Return one exact, system-derived reviewed-commit footer."""
+    if not SHA_RE.fullmatch(head_sha):
+        raise NormalizerError("head SHA must be exactly 40 lowercase hexadecimal characters")
+    if OCTOPUS_HEADING not in body:
+        raise NormalizerError("comment is not an Octopus review body")
+
+    cleaned = FOOTER_RE.sub("", body).rstrip()
+    footer = f"Last reviewed commit: {head_sha}"
+    checklist = CHECKLIST_RE.search(cleaned)
+    if checklist:
+        before = cleaned[: checklist.start()].rstrip()
+        after = cleaned[checklist.start() :].lstrip()
+        return f"{before}\n\n{footer}\n\n{after}\n"
+    return f"{cleaned}\n\n{footer}\n"
+
+
+def _api_json(method: str, path: str, token: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = Request(
+        f"{API_ROOT}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "ed-finder-octopus-head-normalizer",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=20) as response:
+            raw = response.read(1_000_000)
+    except (HTTPError, URLError, TimeoutError) as exc:
+        raise NormalizerError(f"GitHub API request failed: {method} {path}") from exc
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise NormalizerError("GitHub API response was not JSON") from exc
+    if not isinstance(decoded, dict):
+        raise NormalizerError("GitHub API response was not an object")
+    return decoded
+
+
+def process_event(event: dict[str, object], repository: str, token: str) -> str:
+    """Normalize one qualifying event; return a short outcome label."""
+    action = event.get("action")
+    if action not in {"created", "edited"}:
+        return "ignored-action"
+
+    issue = event.get("issue")
+    comment = event.get("comment")
+    if not isinstance(issue, dict) or not isinstance(comment, dict):
+        return "ignored-shape"
+    if not isinstance(issue.get("pull_request"), dict):
+        return "ignored-non-pr"
+
+    user = comment.get("user")
+    if not isinstance(user, dict) or user.get("login") != OCTOPUS_LOGIN:
+        return "ignored-author"
+
+    body = comment.get("body")
+    comment_id = comment.get("id")
+    pr_number = issue.get("number")
+    if not isinstance(body, str) or OCTOPUS_HEADING not in body:
+        return "ignored-body"
+    if not isinstance(comment_id, int) or not isinstance(pr_number, int):
+        raise NormalizerError("qualifying event is missing numeric comment/PR identity")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise NormalizerError("repository identity is invalid")
+    if not token:
+        raise NormalizerError("GitHub token is missing")
+
+    pr = _api_json("GET", f"/repos/{repository}/pulls/{pr_number}", token)
+    head = pr.get("head")
+    if not isinstance(head, dict):
+        raise NormalizerError("pull request response is missing head metadata")
+    head_sha = head.get("sha")
+    if not isinstance(head_sha, str) or not SHA_RE.fullmatch(head_sha):
+        raise NormalizerError("pull request response has an invalid head SHA")
+
+    normalized = normalize_review_body(body, head_sha)
+    if normalized == body:
+        return "already-current"
+
+    _api_json(
+        "PATCH",
+        f"/repos/{repository}/issues/comments/{comment_id}",
+        token,
+        {"body": normalized},
+    )
+    return "updated"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--repository", required=True)
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    try:
+        event = json.loads(Path(args.event).read_text(encoding="utf-8"))
+        if not isinstance(event, dict):
+            raise NormalizerError("event payload was not an object")
+        outcome = process_event(event, args.repository, token)
+    except (OSError, json.JSONDecodeError, NormalizerError) as exc:
+        print(f"STOP: {exc}", file=sys.stderr)
+        return 1
+    print(f"OCTOPUS_HEAD_NORMALIZER={outcome}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_octopus_review_head_normalizer.py
+++ b/tests/test_octopus_review_head_normalizer.py
@@ -1,0 +1,96 @@
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/ci/normalize_octopus_review_head.py"
+WORKFLOW = ROOT / ".github/workflows/octopus-review-head-normalizer.yml"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("octopus_head_normalizer", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalizer_replaces_bogus_footer_with_exact_full_sha():
+    module = _module()
+    sha = "a" * 40
+    body = "## 🐙 Octopus Review\n\nSummary\n\nLast reviewed commit: abc1234\n\n### Checklist\n- [x] done\n"
+    normalized = module.normalize_review_body(body, sha)
+    assert normalized.count("Last reviewed commit:") == 1
+    assert f"Last reviewed commit: {sha}" in normalized
+    assert "abc1234" not in normalized
+    assert normalized.index(f"Last reviewed commit: {sha}") < normalized.index("### Checklist")
+
+
+def test_normalizer_inserts_footer_when_model_omits_it():
+    module = _module()
+    sha = "b" * 40
+    body = "## 🐙 Octopus Review\n\nSummary\n\n### Checklist\n- [x] done\n"
+    normalized = module.normalize_review_body(body, sha)
+    assert normalized.count("Last reviewed commit:") == 1
+    assert f"Last reviewed commit: {sha}" in normalized
+
+
+def test_normalizer_collapses_multiple_model_footers():
+    module = _module()
+    sha = "c" * 40
+    body = (
+        "## 🐙 Octopus Review\n\n"
+        "Last reviewed commit: deadbeef\n"
+        "Text\n"
+        "Last reviewed commit: cafebabe\n"
+    )
+    normalized = module.normalize_review_body(body, sha)
+    assert normalized.count("Last reviewed commit:") == 1
+    assert normalized.rstrip().endswith(f"Last reviewed commit: {sha}")
+
+
+def test_normalizer_rejects_non_octopus_body_and_bad_sha():
+    module = _module()
+    for body, sha in [
+        ("ordinary comment", "a" * 40),
+        ("## 🐙 Octopus Review\n", "abc1234"),
+        ("## 🐙 Octopus Review\n", "A" * 40),
+    ]:
+        try:
+            module.normalize_review_body(body, sha)
+        except module.NormalizerError:
+            pass
+        else:
+            raise AssertionError("unsafe input was accepted")
+
+
+def test_workflow_is_default_branch_event_postprocessor_with_minimal_permissions():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    data = yaml.safe_load(source)
+    assert "pull_request_target" not in source
+    assert "issue_comment:" in source
+    assert "types: [created, edited]" in source
+    assert "octopus-fc8f7111f1[bot]" in source
+    assert "ref: main" in source
+    assert "persist-credentials: false" in source
+    assert "issues: write" in source
+    assert "pull-requests: read" in source
+    assert "contents: read" in source
+    assert "contents: write" not in source
+    assert "pull-requests: write" not in source
+    assert "normalize_octopus_review_head.py" in source
+    assert isinstance(data, dict)
+
+
+def test_script_never_takes_comment_body_or_token_as_shell_arguments():
+    source = SCRIPT.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "GITHUB_TOKEN" in source
+    assert "--body" not in workflow
+    assert "github.event.comment.body" not in workflow
+    assert "github.event.comment.body" not in source
+    assert "PATCH" in source
+    assert "/issues/comments/" in source
+    assert "/pulls/" in source


### PR DESCRIPTION
Fixes #558 for ED-Finder without trusting the LLM-generated footer. A default-branch `issue_comment` postprocessor runs only for the exact Octopus GitHub App bot, fetches the current PR head SHA from GitHub, replaces any model-generated `Last reviewed commit:` line with exactly one full 40-character system-derived SHA, and updates the existing comment only when needed. It uses only `contents: read`, `pull-requests: read`, and `issues: write`; no merge/deploy/database authority is added. Focused tests cover bogus/missing/duplicate footer handling, invalid inputs, default-branch event wiring, and minimal permissions.