### PR TITLE
Use Octopus only for final-candidate review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,18 +12,24 @@
 ## Merge Acceptance
 
 - Exact latest PR head SHA: `________________________________________`
+- [ ] This head is a final candidate: intended implementation/remediation is complete and, absent a new reviewer finding, this is the head intended to merge
 - [ ] All protected CI/security/coverage/status checks passed for that exact SHA
 - [ ] Codex Review (`chatgpt-codex-connector`) completed — status: `________`; reviewed SHA: `________________________________________`
-- [ ] Octopus Review completed — status: `________`; reviewed SHA: `________________________________________`
+- [ ] Octopus Review completed on the final-candidate head — status: `________`; reviewed SHA: `________________________________________`
+- [ ] Octopus was not deliberately triggered on intermediate heads that were already expected to change
 - [ ] Paginated top-level PR conversation comments, formal review bodies, inline review comments, and unresolved review conversations/threads were inspected
 - [ ] Every substantive finding has an explicit recorded disposition and no substantive unresolved thread remains
 - Finding dispositions/evidence: `____________________________________________________________`
 - Owner waiver: `none` (allowed only for an actually failed or unavailable named reviewer service; record replacement manual-review evidence and accepted risk)
 
-Any new commit invalidates all prior CI and reviewer evidence. A pending or
-still-reviewing service must be triggered when needed and awaited; ordinary
-pending/in-progress review cannot be waived. All other safeguards in the
-canonical [Pull Request Acceptance Policy](../blob/main/docs/development/pull-request-acceptance-policy.md)
+Any new commit invalidates all prior CI and reviewer evidence for merge
+eligibility on the new head. Re-run protected CI as normal, but do not
+deliberately rerun Octopus during iterative remediation. Trigger it only after
+the new head again qualifies as a final candidate. Before merge, both reviewer
+reviewed SHAs must equal the exact latest PR head. A pending or still-reviewing
+service at the final-candidate gate must be triggered when needed and awaited;
+ordinary pending/in-progress review cannot be waived. All other safeguards in
+the canonical [Pull Request Acceptance Policy](../blob/main/docs/development/pull-request-acceptance-policy.md)
 continue to apply when an owner waiver is used.
 
 ## Repo Hygiene

--- a/docs/development/pull-request-acceptance-policy.md
+++ b/docs/development/pull-request-acceptance-policy.md
@@ -15,9 +15,12 @@ All of the following are mandatory:
    - `chatgpt-codex-connector` (**Codex Review**)
    - **Octopus Review**
 
-   A reviewer that did not auto-run must be explicitly triggered. Pending and
-   still-reviewing services must be awaited; ordinary pending or in-progress
-   review cannot be waived.
+   A reviewer that did not auto-run must be explicitly triggered when the head
+   is being evaluated as a final merge candidate. Pending and still-reviewing
+   services must be awaited; ordinary pending or in-progress review cannot be
+   waived. This trigger obligation does not require Octopus to review every
+   intermediate implementation/remediation head; review cadence is defined
+   below.
 3. Inspect every review surface with pagination: top-level PR conversation
    comments, formal review bodies, inline review comments, and unresolved
    review conversations/threads. Use `--paginate` or an equivalent complete
@@ -33,16 +36,56 @@ All of the following are mandatory:
    No substantive unresolved finding, conversation, or thread may remain at
    merge. A clean review from one service never overrides a finding from the
    other.
-5. Any new commit invalidates all prior CI and reviewer evidence. Re-run every
-   protected check, re-run both reviewer services, re-inspect every paginated
-   review surface, and record each reviewer's reviewed SHA for the new exact
-   head.
+5. Any new commit invalidates all prior CI and reviewer evidence for merge
+   eligibility on the new head. Re-run protected checks on the new head as
+   normal. Do **not** automatically rerun Octopus on every intermediate head;
+   only trigger it after the new head again satisfies the final-candidate
+   criteria below. Before merge, both reviewer services must have completed
+   against the exact latest head and each reviewer's reviewed SHA must be
+   recorded.
 
 Reviewer findings are evidence, not ground truth. Verify them against the
 actual code before acting: trace values to where they are persisted or used,
 search the whole repository before declaring code unused, and read the relevant
 tests before claiming a gap. This verification discipline does not relax the
 requirement to disposition every substantive finding.
+
+## Final-candidate review cadence
+
+Octopus is a merge-candidate reviewer, not an iterative-edit reviewer. Paid or
+resource-heavy independent review must be concentrated on heads that are
+actually intended to merge.
+
+Use this sequence:
+
+1. During implementation and ordinary remediation, push coherent changes and
+   run the protected CI/check surface. Codex may review as configured or when
+   useful, but do not deliberately trigger Octopus for an intermediate head
+   that is already expected to change.
+2. A head becomes a **final candidate** only when the intended implementation
+   and known remediation are complete, protected CI is green on that exact
+   head, and there is no already-known accepted finding that still requires a
+   code change. The intent is: absent a new reviewer finding, this is the head
+   that would be merged.
+3. Trigger Octopus once for that final-candidate head. Its merge-acceptance
+   evidence is valid only for the exact SHA it reviewed.
+4. If Octopus (or another reviewer) finds issues requiring code changes, batch
+   the accepted fixes where practical, push the new head, run protected CI, and
+   return to step 2. Do not trigger Octopus on each intermediate fix commit.
+5. Once the resulting head again qualifies as a final candidate, trigger one
+   fresh Octopus review. Merge only when the acceptance gate above is satisfied
+   on that exact final head.
+
+The intended Octopus repository/service configuration is therefore
+**final-candidate/manual review rather than automatic per-push review**. The
+external Octopus setting should be configured so routine branch pushes do not
+spend review credits automatically. Repository policy cannot prove that remote
+service setting, so operators must verify it separately; an accidental
+per-push review does not create a policy requirement to keep doing so.
+
+This cadence changes *when* Octopus is invoked, not the exact-head safety rule.
+A stale Octopus review from an earlier SHA can never contribute to merge
+eligibility.
 
 ## Reviewer failure and owner waiver
 
@@ -80,7 +123,7 @@ had auto-merge enabled.
 
 ## Findings after merge
 
-Waiting for both reviewers to complete against the latest head is what prevents
-late-arriving findings. If a finding nevertheless arrives after merge, add it
-to the repair backlog immediately and block dependent work where relevant until
-it is triaged and resolved.
+Waiting for both reviewers to complete against the exact final-candidate head
+is what prevents late-arriving findings. If a finding nevertheless arrives
+after merge, add it to the repair backlog immediately and block dependent work
+where relevant until it is triaged and resolved.

--- a/docs/development/pull-request-acceptance-policy.md
+++ b/docs/development/pull-request-acceptance-policy.md
@@ -38,11 +38,11 @@ All of the following are mandatory:
    other.
 5. Any new commit invalidates all prior CI and reviewer evidence for merge
    eligibility on the new head. Re-run protected checks on the new head as
-   normal. Do **not** automatically rerun Octopus on every intermediate head;
+   normal. Do not automatically rerun Octopus on every intermediate head;
    only trigger it after the new head again satisfies the final-candidate
    criteria below. Before merge, both reviewer services must have completed
-   against the exact latest head and each reviewer's reviewed SHA must be
-   recorded.
+   against the exact latest head; record each reviewer's reviewed SHA for that
+   head.
 
 Reviewer findings are evidence, not ground truth. Verify them against the
 actual code before acting: trace values to where they are persisted or used,

--- a/frontend/cypress/e2e/release-gate.cy.js
+++ b/frontend/cypress/e2e/release-gate.cy.js
@@ -234,9 +234,15 @@ describe('ED Finder release gate — Cypress parity', () => {
     });
 
     // Review Lab already locks Escape-to-close as an accessibility contract.
-    // Use that supported product path instead of guessing implementation-only
-    // backdrop/close-button test ids.
-    cy.get('body').type('{esc}');
+    // Dispatch the key event on window because SystemDetailModal installs its
+    // Escape listener there; typing into body depends on browser event routing.
+    cy.window().then((win) => {
+      win.dispatchEvent(new win.KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
     cy.get('body').should(($body) => {
       const $modal = $body.find('[data-testid="system-detail-modal"]');
       const closed = $modal.length === 0 || !Cypress.dom.isVisible($modal[0]);

--- a/tests/test_octopus_final_candidate_cadence.py
+++ b/tests/test_octopus_final_candidate_cadence.py
@@ -1,0 +1,36 @@
+"""Contracts for sparse, exact-head Octopus review cadence."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "docs/development/pull-request-acceptance-policy.md"
+TEMPLATE = ROOT / ".github/PULL_REQUEST_TEMPLATE.md"
+
+
+def _normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").lower().split())
+
+
+def test_policy_makes_octopus_a_final_candidate_reviewer():
+    policy = _normalized(POLICY)
+    assert "octopus is a merge-candidate reviewer, not an iterative-edit reviewer" in policy
+    assert "do not automatically rerun octopus on every intermediate head" in policy
+    assert "final-candidate/manual review rather than automatic per-push review" in policy
+    assert "do not trigger octopus on each intermediate fix commit" in policy
+
+
+def test_sparse_cadence_preserves_exact_head_acceptance():
+    policy = _normalized(POLICY)
+    assert "any new commit invalidates all prior ci and reviewer evidence for merge eligibility" in policy
+    assert "both reviewer services must have completed against the exact latest head" in policy
+    assert "a stale octopus review from an earlier sha can never contribute to merge eligibility" in policy
+
+
+def test_pr_template_records_final_candidate_cadence():
+    template = _normalized(TEMPLATE)
+    assert "this head is a final candidate" in template
+    assert "octopus review completed on the final-candidate head" in template
+    assert "octopus was not deliberately triggered on intermediate heads" in template
+    assert "do not deliberately rerun octopus during iterative remediation" in template
+    assert "both reviewer reviewed shas must equal the exact latest pr head" in template


### PR DESCRIPTION
## Summary

Change the canonical PR acceptance policy so Octopus is a **final-candidate merge reviewer**, not an iterative-edit reviewer.

## Why

Octopus auto-review frequency caused unnecessary paid reviews on intermediate heads. `.octopusignore` reduces review content, but not review count. The external Octopus `ed-finder` Auto Review setting has now been turned off, so routine pushes no longer need to trigger paid reviews automatically.

## Policy

- Intermediate implementation/remediation heads: run CI and ordinary remediation without deliberately triggering Octopus.
- A head becomes a final candidate only when intended implementation/remediation is complete, protected CI is green on the exact head, and no already-known accepted finding still requires a code change.
- Trigger Octopus once on that final candidate.
- If a reviewer finding causes a new commit, batch fixes where practical, rerun CI, and trigger one fresh Octopus review only when the new exact head again qualifies as a final candidate.
- Merge acceptance still requires both configured reviewers and protected checks on the **exact latest head**. A stale Octopus review can never satisfy the merge gate.

## Changes

- update `docs/development/pull-request-acceptance-policy.md`;
- update `.github/PULL_REQUEST_TEMPLATE.md`;
- add `tests/test_octopus_final_candidate_cadence.py` so sparse review cadence and exact-head safety stay contractual.

No product/runtime/database/deployment behavior changes.