### PR TITLE
test: guard Stage 27A production coverage audit pack

### DIFF
--- a/docs/colonisation-redesign/stage-27a-production-data-coverage-queries.sql
+++ b/docs/colonisation-redesign/stage-27a-production-data-coverage-queries.sql
@@ -1,6 +1,8 @@
 -- Stage 27A SELECT-only V3 data-coverage audit pack.
 -- Run only through an already-authorized read-only operator path.
--- This file performs no writes, DDL, locks, settings changes, or function calls.
+-- This file performs no writes, DDL, locks, settings changes, or unsafe function calls.
+-- Every statement has an explicit result-row LIMIT so a later authorized production
+-- run cannot accidentally materialize an unbounded detail set in the client.
 -- Report the database identity/time separately through the authorized wrapper;
 -- never add credentials to this file or command history.
 
@@ -11,7 +13,8 @@ SELECT
   COUNT(*) FILTER (WHERE main_star_type IS NOT NULL) AS with_main_star_type,
   MIN(updated_at) AS oldest_updated_at,
   MAX(updated_at) AS newest_updated_at
-FROM systems;
+FROM systems
+LIMIT 1;
 
 -- 2. Body population and physical/stellar properties.
 SELECT
@@ -36,7 +39,8 @@ SELECT
   COUNT(*) FILTER (WHERE absolute_magnitude IS NOT NULL) AS with_absolute_magnitude,
   MIN(updated_at) AS oldest_updated_at,
   MAX(updated_at) AS newest_updated_at
-FROM bodies;
+FROM bodies
+LIMIT 1;
 
 -- 3. Orbital descriptor coverage. Epoch is absent from the current schema.
 SELECT
@@ -55,7 +59,8 @@ SELECT
       AND ascending_node IS NOT NULL AND arg_of_periapsis IS NOT NULL
       AND mean_anomaly IS NOT NULL
   ) AS with_all_stored_orbital_elements
-FROM bodies;
+FROM bodies
+LIMIT 1;
 
 -- 4. Ring bands, association/provenance, and multiple-band population.
 SELECT association_status, source, confidence,
@@ -67,7 +72,8 @@ SELECT association_status, source, confidence,
        MAX(updated_at) AS newest_updated_at
 FROM body_rings
 GROUP BY association_status, source, confidence
-ORDER BY association_status, source, confidence;
+ORDER BY association_status, source, confidence
+LIMIT 200;
 
 SELECT COUNT(*) AS bodies_with_multiple_ring_rows
 FROM (
@@ -76,7 +82,8 @@ FROM (
   WHERE body_id IS NOT NULL AND association_status = 'local_matched'
   GROUP BY system_id64, body_id
   HAVING COUNT(*) > 1
-) AS multi;
+) AS multi
+LIMIT 1;
 
 -- 5. Station data and body association. Missing links stay missing.
 SELECT
@@ -88,26 +95,30 @@ SELECT
   COUNT(*) FILTER (WHERE has_market OR has_shipyard OR has_outfitting OR has_refuel OR has_repair OR has_rearm) AS with_selected_service,
   MIN(updated_at) AS oldest_updated_at,
   MAX(updated_at) AS newest_updated_at
-FROM stations;
+FROM stations
+LIMIT 1;
 
 SELECT association_status, lane, association_confidence, association_source,
        COUNT(*) AS links,
        COUNT(*) FILTER (WHERE body_id IS NOT NULL) AS with_body_id
 FROM station_body_links
 GROUP BY association_status, lane, association_confidence, association_source
-ORDER BY association_status, lane, association_confidence, association_source;
+ORDER BY association_status, lane, association_confidence, association_source
+LIMIT 200;
 
 -- 6. Defensive identity checks. Non-zero rows are unresolved audit findings;
 -- do not auto-repair or name-match them.
 SELECT COUNT(*) AS cross_system_station_body_links
 FROM station_body_links l
 JOIN bodies b ON b.id = l.body_id
-WHERE l.system_id64 <> b.system_id64;
+WHERE l.system_id64 <> b.system_id64
+LIMIT 1;
 
 SELECT COUNT(*) AS cross_system_ring_body_links
 FROM body_rings r
 JOIN bodies b ON b.id = r.body_id
-WHERE r.system_id64 <> b.system_id64;
+WHERE r.system_id64 <> b.system_id64
+LIMIT 1;
 
 -- 7. Personal exploration population by source/type without exposing sync keys.
 SELECT source, event_type, COUNT(*) AS facts,
@@ -118,7 +129,8 @@ SELECT source, event_type, COUNT(*) AS facts,
        MAX(observed_at) AS last_observed_at
 FROM exploration_facts
 GROUP BY source, event_type
-ORDER BY source, event_type;
+ORDER BY source, event_type
+LIMIT 200;
 
 SELECT
   COUNT(*) AS body_completeness_rows,
@@ -128,11 +140,13 @@ SELECT
   COUNT(*) FILTER (WHERE dss_state = 'mapped') AS mapped,
   COUNT(*) FILTER (WHERE first_discovered) AS first_discovered,
   COUNT(*) FILTER (WHERE first_mapped) AS first_mapped
-FROM exploration_body_completeness;
+FROM exploration_body_completeness
+LIMIT 1;
 
 SELECT
   (SELECT COUNT(*) FROM exploration_visits) AS visits,
   (SELECT COUNT(*) FROM exploration_expedition_routes) AS route_legs,
   (SELECT COUNT(*) FROM exobiology_organisms) AS organism_rows,
   (SELECT COUNT(*) FROM exobiology_sales) AS exobiology_sale_rows,
-  (SELECT COUNT(*) FROM codex_observations) AS codex_rows;
+  (SELECT COUNT(*) FROM codex_observations) AS codex_rows
+LIMIT 1;

--- a/docs/colonisation-redesign/stage-27a-production-data-coverage-queries.sql
+++ b/docs/colonisation-redesign/stage-27a-production-data-coverage-queries.sql
@@ -1,7 +1,7 @@
 -- Stage 27A SELECT-only V3 data-coverage audit pack.
 -- Run only through an already-authorized read-only operator path.
 -- This file performs no writes, DDL, locks, settings changes, or unsafe function calls.
--- Every statement has an explicit result-row LIMIT so a later authorized production
+-- Every statement has an explicit outer result-row LIMIT so a later authorized production
 -- run cannot accidentally materialize an unbounded detail set in the client.
 -- Report the database identity/time separately through the authorized wrapper;
 -- never add credentials to this file or command history.
@@ -98,13 +98,34 @@ SELECT
 FROM stations
 LIMIT 1;
 
-SELECT association_status, lane, association_confidence, association_source,
-       COUNT(*) AS links,
-       COUNT(*) FILTER (WHERE body_id IS NOT NULL) AS with_body_id
-FROM station_body_links
-GROUP BY association_status, lane, association_confidence, association_source
-ORDER BY association_status, lane, association_confidence, association_source
-LIMIT 200;
+-- The station-link dimensions are all constrained by the schema, but their
+-- legitimate Cartesian product can exceed the client row cap. Preserve every
+-- observed group inside one bounded result row instead of silently dropping
+-- groups after an arbitrary LIMIT.
+SELECT
+  COUNT(*) AS association_groups,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'association_status', association_status,
+        'lane', lane,
+        'association_confidence', association_confidence,
+        'association_source', association_source,
+        'links', links,
+        'with_body_id', with_body_id
+      )
+      ORDER BY association_status, lane, association_confidence, association_source
+    ),
+    '[]'::jsonb
+  ) AS groups
+FROM (
+  SELECT association_status, lane, association_confidence, association_source,
+         COUNT(*) AS links,
+         COUNT(*) FILTER (WHERE body_id IS NOT NULL) AS with_body_id
+  FROM station_body_links
+  GROUP BY association_status, lane, association_confidence, association_source
+) AS grouped_station_links
+LIMIT 1;
 
 -- 6. Defensive identity checks. Non-zero rows are unresolved audit findings;
 -- do not auto-repair or name-match them.

--- a/docs/colonisation-redesign/stage-27a-production-data-coverage-queries.sql
+++ b/docs/colonisation-redesign/stage-27a-production-data-coverage-queries.sql
@@ -63,17 +63,47 @@ FROM bodies
 LIMIT 1;
 
 -- 4. Ring bands, association/provenance, and multiple-band population.
-SELECT association_status, source, confidence,
-       COUNT(*) AS ring_rows,
-       COUNT(*) FILTER (WHERE ring_class IS NOT NULL) AS with_class,
-       COUNT(*) FILTER (WHERE inner_radius IS NOT NULL AND outer_radius IS NOT NULL) AS with_radii,
-       COUNT(DISTINCT (system_id64, body_id)) FILTER (WHERE body_id IS NOT NULL) AS associated_bodies,
-       MIN(updated_at) AS oldest_updated_at,
-       MAX(updated_at) AS newest_updated_at
-FROM body_rings
-GROUP BY association_status, source, confidence
-ORDER BY association_status, source, confidence
-LIMIT 200;
+-- `source` and `confidence` are free-form text, so report the full group count
+-- plus an ordered sample capped at 200 groups. `omitted_groups` accounts for
+-- every group outside the bounded payload instead of silently dropping them.
+SELECT
+  COUNT(*) AS provenance_groups,
+  COUNT(*) FILTER (WHERE group_rank > 200) AS omitted_groups,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'association_status', association_status,
+        'source', source,
+        'confidence', confidence,
+        'ring_rows', ring_rows,
+        'with_class', with_class,
+        'with_radii', with_radii,
+        'associated_bodies', associated_bodies,
+        'oldest_updated_at', oldest_updated_at,
+        'newest_updated_at', newest_updated_at
+      )
+      ORDER BY group_rank
+    ) FILTER (WHERE group_rank <= 200),
+    '[]'::jsonb
+  ) AS sampled_groups
+FROM (
+  SELECT grouped_ring_provenance.*,
+         ROW_NUMBER() OVER (
+           ORDER BY association_status, source, confidence
+         ) AS group_rank
+  FROM (
+    SELECT association_status, source, confidence,
+           COUNT(*) AS ring_rows,
+           COUNT(*) FILTER (WHERE ring_class IS NOT NULL) AS with_class,
+           COUNT(*) FILTER (WHERE inner_radius IS NOT NULL AND outer_radius IS NOT NULL) AS with_radii,
+           COUNT(DISTINCT (system_id64, body_id)) FILTER (WHERE body_id IS NOT NULL) AS associated_bodies,
+           MIN(updated_at) AS oldest_updated_at,
+           MAX(updated_at) AS newest_updated_at
+    FROM body_rings
+    GROUP BY association_status, source, confidence
+  ) AS grouped_ring_provenance
+) AS ranked_ring_provenance
+LIMIT 1;
 
 SELECT COUNT(*) AS bodies_with_multiple_ring_rows
 FROM (
@@ -142,16 +172,42 @@ WHERE r.system_id64 <> b.system_id64
 LIMIT 1;
 
 -- 7. Personal exploration population by source/type without exposing sync keys.
-SELECT source, event_type, COUNT(*) AS facts,
-       COUNT(DISTINCT system_id64) AS systems,
-       COUNT(*) FILTER (WHERE body_id IS NOT NULL) AS with_body_id,
-       COUNT(*) FILTER (WHERE body_id IS NULL AND body_name IS NOT NULL) AS name_only_body,
-       MIN(observed_at) AS first_observed_at,
-       MAX(observed_at) AS last_observed_at
-FROM exploration_facts
-GROUP BY source, event_type
-ORDER BY source, event_type
-LIMIT 200;
+-- `source` and `event_type` are not a schema-bounded enumeration, so retain a
+-- bounded 200-group payload while separately counting every omitted group.
+SELECT
+  COUNT(*) AS event_groups,
+  COUNT(*) FILTER (WHERE group_rank > 200) AS omitted_groups,
+  COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'source', source,
+        'event_type', event_type,
+        'facts', facts,
+        'systems', systems,
+        'with_body_id', with_body_id,
+        'name_only_body', name_only_body,
+        'first_observed_at', first_observed_at,
+        'last_observed_at', last_observed_at
+      )
+      ORDER BY group_rank
+    ) FILTER (WHERE group_rank <= 200),
+    '[]'::jsonb
+  ) AS sampled_groups
+FROM (
+  SELECT grouped_exploration.*,
+         ROW_NUMBER() OVER (ORDER BY source, event_type) AS group_rank
+  FROM (
+    SELECT source, event_type, COUNT(*) AS facts,
+           COUNT(DISTINCT system_id64) AS systems,
+           COUNT(*) FILTER (WHERE body_id IS NOT NULL) AS with_body_id,
+           COUNT(*) FILTER (WHERE body_id IS NULL AND body_name IS NOT NULL) AS name_only_body,
+           MIN(observed_at) AS first_observed_at,
+           MAX(observed_at) AS last_observed_at
+    FROM exploration_facts
+    GROUP BY source, event_type
+  ) AS grouped_exploration
+) AS ranked_exploration
+LIMIT 1;
 
 SELECT
   COUNT(*) AS body_completeness_rows,

--- a/tests/integration/test_stage27a_production_data_coverage_pack.py
+++ b/tests/integration/test_stage27a_production_data_coverage_pack.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 import psycopg2
@@ -14,6 +15,7 @@ COVERAGE_PACK = (
     / 'colonisation-redesign'
     / 'stage-27a-production-data-coverage-queries.sql'
 )
+MAX_RESULT_ROWS = 200
 
 
 def _statements() -> list[str]:
@@ -24,6 +26,12 @@ def _statements() -> list[str]:
             lines.append(line)
     sql = '\n'.join(lines)
     return [part.strip() for part in sql.split(';') if part.strip()]
+
+
+def _statement_limit(statement: str) -> int:
+    limits = re.findall(r'\bLIMIT\s+(\d+)\b', statement, flags=re.IGNORECASE)
+    assert len(limits) == 1
+    return int(limits[0])
 
 
 @pytest.mark.db
@@ -39,12 +47,15 @@ def test_stage27a_coverage_pack_executes_against_current_migrated_schema_read_on
             assert cur.fetchone() == ('on',)
 
             for index, statement in enumerate(statements, start=1):
+                limit = _statement_limit(statement)
+                assert 1 <= limit <= MAX_RESULT_ROWS
                 try:
                     cur.execute(statement)
-                    cur.fetchall()
+                    rows = cur.fetchall()
+                    assert len(rows) <= limit
                 except Exception as exc:
                     raise AssertionError(
-                        f'Stage 27A coverage statement {index} no longer matches the migrated schema'
+                        f'Stage 27A coverage statement {index} no longer matches the migrated schema or result bound'
                     ) from exc
     finally:
         conn.rollback()

--- a/tests/integration/test_stage27a_production_data_coverage_pack.py
+++ b/tests/integration/test_stage27a_production_data_coverage_pack.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COVERAGE_PACK = (
+    ROOT
+    / 'docs'
+    / 'colonisation-redesign'
+    / 'stage-27a-production-data-coverage-queries.sql'
+)
+
+
+def _statements() -> list[str]:
+    lines = []
+    for raw_line in COVERAGE_PACK.read_text(encoding='utf-8').splitlines():
+        line = raw_line.split('--', 1)[0]
+        if line.strip():
+            lines.append(line)
+    sql = '\n'.join(lines)
+    return [part.strip() for part in sql.split(';') if part.strip()]
+
+
+@pytest.mark.db
+def test_stage27a_coverage_pack_executes_against_current_migrated_schema_read_only():
+    statements = _statements()
+    assert len(statements) == 12
+
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    try:
+        conn.set_session(readonly=True, autocommit=False)
+        with conn.cursor() as cur:
+            cur.execute('SHOW transaction_read_only')
+            assert cur.fetchone() == ('on',)
+
+            for index, statement in enumerate(statements, start=1):
+                try:
+                    cur.execute(statement)
+                    cur.fetchall()
+                except Exception as exc:
+                    raise AssertionError(
+                        f'Stage 27A coverage statement {index} no longer matches the migrated schema'
+                    ) from exc
+    finally:
+        conn.rollback()
+        conn.close()

--- a/tests/integration/test_stage27a_production_data_coverage_pack.py
+++ b/tests/integration/test_stage27a_production_data_coverage_pack.py
@@ -31,7 +31,10 @@ def _statements() -> list[str]:
 def _statement_limit(statement: str) -> int:
     limits = re.findall(r'\bLIMIT\s+(\d+)\b', statement, flags=re.IGNORECASE)
     assert len(limits) == 1
-    return int(limits[0])
+    outer = re.search(r'\bLIMIT\s+(\d+)\s*$', statement, flags=re.IGNORECASE)
+    assert outer is not None
+    assert outer.group(1) == limits[0]
+    return int(outer.group(1))
 
 
 @pytest.mark.db
@@ -57,6 +60,67 @@ def test_stage27a_coverage_pack_executes_against_current_migrated_schema_read_on
                     raise AssertionError(
                         f'Stage 27A coverage statement {index} no longer matches the migrated schema or result bound'
                     ) from exc
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.db
+def test_stage27a_identity_drift_queries_detect_cross_system_fixtures_read_only():
+    """Exercise the actual drift statements, not only their predicate text.
+
+    Temporary tables shadow the canonical names only for this connection. They
+    let the test construct deliberately impossible cross-system rows without
+    weakening the real station/body write guards or persisting fixture data.
+    After the fixture transaction commits, the audit statements themselves run
+    in a read-only transaction exactly as the production coverage pack must.
+    """
+    statements = _statements()
+    station_drift = statements[7]
+    ring_drift = statements[8]
+
+    conn = psycopg2.connect(os.environ['DATABASE_URL'])
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                'CREATE TEMP TABLE bodies ('
+                'id BIGINT PRIMARY KEY, system_id64 BIGINT NOT NULL'
+                ') ON COMMIT PRESERVE ROWS'
+            )
+            cur.execute(
+                'CREATE TEMP TABLE station_body_links ('
+                'system_id64 BIGINT NOT NULL, body_id BIGINT'
+                ') ON COMMIT PRESERVE ROWS'
+            )
+            cur.execute(
+                'CREATE TEMP TABLE body_rings ('
+                'system_id64 BIGINT NOT NULL, body_id BIGINT'
+                ') ON COMMIT PRESERVE ROWS'
+            )
+            cur.execute(
+                'INSERT INTO bodies (id, system_id64) VALUES '
+                '(9001, 2002), (9002, 1001)'
+            )
+            cur.execute(
+                'INSERT INTO station_body_links (system_id64, body_id) VALUES '
+                '(1001, 9001), (1001, 9002)'
+            )
+            cur.execute(
+                'INSERT INTO body_rings (system_id64, body_id) VALUES '
+                '(1001, 9001), (1001, 9002)'
+            )
+        conn.commit()
+
+        conn.set_session(readonly=True, autocommit=False)
+        with conn.cursor() as cur:
+            cur.execute('SHOW transaction_read_only')
+            assert cur.fetchone() == ('on',)
+
+            cur.execute(station_drift)
+            assert cur.fetchone() == (1,)
+
+            cur.execute(ring_drift)
+            assert cur.fetchone() == (1,)
     finally:
         conn.rollback()
         conn.close()

--- a/tests/test_stage27a_production_data_coverage_pack.py
+++ b/tests/test_stage27a_production_data_coverage_pack.py
@@ -32,12 +32,28 @@ FORBIDDEN_PATTERNS = (
     r'\bDO\s+\$\$',
     r'\bCOPY\b',
     r'\bFOR\s+(UPDATE|SHARE)\b',
-    # SELECT can still cause session side effects through functions. Block the
-    # whole PostgreSQL advisory-lock family plus function-based settings changes.
+    # Defense in depth for known PostgreSQL side-effect families.
     r'\bpg_(?:try_)?advisory_[a-z_]*\s*\(',
     r'\bset_config\s*\(',
     r'refresh_map_mviews\s*\(',
 )
+# Function-like syntax in the pack is deliberately tiny. SQL structural words
+# that can appear immediately before '(' are included here too; any other
+# identifier-call surface (for example pg_notify()) fails closed.
+SAFE_CALL_TOKENS = {
+    'count',
+    'min',
+    'max',
+    'coalesce',
+    'jsonb_agg',
+    'jsonb_build_object',
+    'row_number',
+    'filter',
+    'distinct',
+    'from',
+    'over',
+}
+CALL_TOKEN_RE = re.compile(r'\b([A-Za-z_][A-Za-z0-9_]*)\s*\(')
 
 
 def _raw_sql() -> str:
@@ -71,9 +87,12 @@ def _statement_limit(statement: str) -> int:
     return int(outer.group(1))
 
 
-def _assert_no_forbidden_patterns(statement: str) -> None:
+def _assert_safe_select_surface(statement: str) -> None:
     for pattern in FORBIDDEN_PATTERNS:
         assert re.search(pattern, statement, flags=re.IGNORECASE) is None, pattern
+    call_tokens = {match.group(1).lower() for match in CALL_TOKEN_RE.finditer(statement)}
+    unknown = sorted(call_tokens - SAFE_CALL_TOKENS)
+    assert not unknown, f'coverage statement uses non-allowlisted call surface: {unknown}'
 
 
 def test_stage27a_coverage_pack_is_bounded_select_only_sql():
@@ -85,7 +104,7 @@ def test_stage27a_coverage_pack_is_bounded_select_only_sql():
     for statement in statements:
         limit = _statement_limit(statement)
         assert 1 <= limit <= MAX_RESULT_ROWS
-        _assert_no_forbidden_patterns(statement)
+        _assert_safe_select_surface(statement)
 
 
 def test_stage27a_limit_guard_rejects_nested_only_bounds():
@@ -102,11 +121,23 @@ def test_stage27a_select_guard_blocks_function_side_effects():
         "SELECT set_config('statement_timeout', '0', false) LIMIT 1",
         'SELECT pg_try_advisory_lock(1) LIMIT 1',
         'SELECT pg_try_advisory_xact_lock_shared(1) LIMIT 1',
+        "SELECT pg_notify('audit', 'payload') LIMIT 1",
     ):
-        assert any(
-            re.search(pattern, malicious, flags=re.IGNORECASE)
-            for pattern in FORBIDDEN_PATTERNS
-        ), malicious
+        with pytest.raises(AssertionError):
+            _assert_safe_select_surface(malicious)
+
+
+def test_stage27a_ring_breakdown_accounts_for_every_group_with_bounded_payload():
+    ring_breakdown = _statements()[3]
+
+    assert _statement_limit(ring_breakdown) == 1
+    assert 'COUNT(*) AS provenance_groups' in ring_breakdown
+    assert 'COUNT(*) FILTER (WHERE group_rank > 200) AS omitted_groups' in ring_breakdown
+    assert 'ROW_NUMBER() OVER (' in ring_breakdown
+    assert ') FILTER (WHERE group_rank <= 200)' in ring_breakdown
+    assert 'jsonb_agg(' in ring_breakdown
+    assert 'GROUP BY association_status, source, confidence' in ring_breakdown
+    assert 'LIMIT 200' not in ring_breakdown
 
 
 def test_stage27a_station_association_breakdown_preserves_every_group():
@@ -117,6 +148,19 @@ def test_stage27a_station_association_breakdown_preserves_every_group():
     assert 'jsonb_agg(' in station_breakdown
     assert 'GROUP BY association_status, lane, association_confidence, association_source' in station_breakdown
     assert 'LIMIT 200' not in station_breakdown
+
+
+def test_stage27a_exploration_breakdown_accounts_for_every_group_with_bounded_payload():
+    exploration_breakdown = _statements()[9]
+
+    assert _statement_limit(exploration_breakdown) == 1
+    assert 'COUNT(*) AS event_groups' in exploration_breakdown
+    assert 'COUNT(*) FILTER (WHERE group_rank > 200) AS omitted_groups' in exploration_breakdown
+    assert 'ROW_NUMBER() OVER (ORDER BY source, event_type)' in exploration_breakdown
+    assert ') FILTER (WHERE group_rank <= 200)' in exploration_breakdown
+    assert 'jsonb_agg(' in exploration_breakdown
+    assert 'GROUP BY source, event_type' in exploration_breakdown
+    assert 'LIMIT 200' not in exploration_breakdown
 
 
 def test_stage27a_coverage_pack_does_not_expose_credentials_or_commander_keys():

--- a/tests/test_stage27a_production_data_coverage_pack.py
+++ b/tests/test_stage27a_production_data_coverage_pack.py
@@ -11,11 +11,16 @@ COVERAGE_PACK = (
     / 'colonisation-redesign'
     / 'stage-27a-production-data-coverage-queries.sql'
 )
+MAX_RESULT_ROWS = 200
+
+
+def _raw_sql() -> str:
+    return COVERAGE_PACK.read_text(encoding='utf-8')
 
 
 def _sql_without_line_comments() -> str:
     lines = []
-    for raw_line in COVERAGE_PACK.read_text(encoding='utf-8').splitlines():
+    for raw_line in _raw_sql().splitlines():
         line = raw_line.split('--', 1)[0]
         if line.strip():
             lines.append(line)
@@ -26,11 +31,21 @@ def _statements() -> list[str]:
     return [part.strip() for part in _sql_without_line_comments().split(';') if part.strip()]
 
 
+def _statement_limit(statement: str) -> int:
+    limits = re.findall(r'\bLIMIT\s+(\d+)\b', statement, flags=re.IGNORECASE)
+    assert len(limits) == 1, f'every coverage statement must have exactly one literal LIMIT: {statement}'
+    return int(limits[0])
+
+
 def test_stage27a_coverage_pack_is_bounded_select_only_sql():
     statements = _statements()
 
     assert len(statements) == 12
     assert all(statement.upper().startswith('SELECT') for statement in statements)
+
+    for statement in statements:
+        limit = _statement_limit(statement)
+        assert 1 <= limit <= MAX_RESULT_ROWS
 
     sql = _sql_without_line_comments()
     forbidden_patterns = (
@@ -51,7 +66,9 @@ def test_stage27a_coverage_pack_is_bounded_select_only_sql():
         r'\bDO\s+\$\$',
         r'\bCOPY\b',
         r'\bFOR\s+(UPDATE|SHARE)\b',
-        r'pg_advisory_(xact_)?lock',
+        # Block the entire PostgreSQL advisory-lock family, including
+        # pg_try_advisory_lock*, xact/shared variants, and unlock helpers.
+        r'\bpg_(?:try_)?advisory_[a-z_]*\s*\(',
         r'refresh_map_mviews\s*\(',
     )
     for pattern in forbidden_patterns:
@@ -59,7 +76,9 @@ def test_stage27a_coverage_pack_is_bounded_select_only_sql():
 
 
 def test_stage27a_coverage_pack_does_not_expose_credentials_or_commander_keys():
-    sql = _sql_without_line_comments().lower()
+    # Scan the complete checked-in file, comments included. Commented examples
+    # are still repository disclosure and must not be able to hide credentials.
+    sql = _raw_sql().lower()
 
     for forbidden in (
         'password',

--- a/tests/test_stage27a_production_data_coverage_pack.py
+++ b/tests/test_stage27a_production_data_coverage_pack.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COVERAGE_PACK = (
+    ROOT
+    / 'docs'
+    / 'colonisation-redesign'
+    / 'stage-27a-production-data-coverage-queries.sql'
+)
+
+
+def _sql_without_line_comments() -> str:
+    lines = []
+    for raw_line in COVERAGE_PACK.read_text(encoding='utf-8').splitlines():
+        line = raw_line.split('--', 1)[0]
+        if line.strip():
+            lines.append(line)
+    return '\n'.join(lines)
+
+
+def _statements() -> list[str]:
+    return [part.strip() for part in _sql_without_line_comments().split(';') if part.strip()]
+
+
+def test_stage27a_coverage_pack_is_bounded_select_only_sql():
+    statements = _statements()
+
+    assert len(statements) == 12
+    assert all(statement.upper().startswith('SELECT') for statement in statements)
+
+    sql = _sql_without_line_comments()
+    forbidden_patterns = (
+        r'\bINSERT\b',
+        r'\bUPDATE\b',
+        r'\bDELETE\b',
+        r'\bMERGE\b',
+        r'\bCREATE\b',
+        r'\bALTER\b',
+        r'\bDROP\b',
+        r'\bTRUNCATE\b',
+        r'\bGRANT\b',
+        r'\bREVOKE\b',
+        r'\bSET\b',
+        r'\bRESET\b',
+        r'\bLOCK\b',
+        r'\bCALL\b',
+        r'\bDO\s+\$\$',
+        r'\bCOPY\b',
+        r'\bFOR\s+(UPDATE|SHARE)\b',
+        r'pg_advisory_(xact_)?lock',
+        r'refresh_map_mviews\s*\(',
+    )
+    for pattern in forbidden_patterns:
+        assert re.search(pattern, sql, flags=re.IGNORECASE) is None, pattern
+
+
+def test_stage27a_coverage_pack_does_not_expose_credentials_or_commander_keys():
+    sql = _sql_without_line_comments().lower()
+
+    for forbidden in (
+        'password',
+        'postgresql://',
+        'postgres://',
+        'database_url',
+        'admin_token',
+        'frontier_client_secret',
+        'sync_key',
+    ):
+        assert forbidden not in sql
+
+
+def test_stage27a_coverage_pack_keeps_identity_drift_checks_explicit():
+    sql = _sql_without_line_comments()
+
+    assert 'cross_system_station_body_links' in sql
+    assert 'l.system_id64 <> b.system_id64' in sql
+    assert 'cross_system_ring_body_links' in sql
+    assert 'r.system_id64 <> b.system_id64' in sql
+    assert "association_status = 'local_matched'" in sql

--- a/tests/test_stage27a_production_data_coverage_pack.py
+++ b/tests/test_stage27a_production_data_coverage_pack.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 COVERAGE_PACK = (
@@ -12,6 +14,30 @@ COVERAGE_PACK = (
     / 'stage-27a-production-data-coverage-queries.sql'
 )
 MAX_RESULT_ROWS = 200
+FORBIDDEN_PATTERNS = (
+    r'\bINSERT\b',
+    r'\bUPDATE\b',
+    r'\bDELETE\b',
+    r'\bMERGE\b',
+    r'\bCREATE\b',
+    r'\bALTER\b',
+    r'\bDROP\b',
+    r'\bTRUNCATE\b',
+    r'\bGRANT\b',
+    r'\bREVOKE\b',
+    r'\bSET\b',
+    r'\bRESET\b',
+    r'\bLOCK\b',
+    r'\bCALL\b',
+    r'\bDO\s+\$\$',
+    r'\bCOPY\b',
+    r'\bFOR\s+(UPDATE|SHARE)\b',
+    # SELECT can still cause session side effects through functions. Block the
+    # whole PostgreSQL advisory-lock family plus function-based settings changes.
+    r'\bpg_(?:try_)?advisory_[a-z_]*\s*\(',
+    r'\bset_config\s*\(',
+    r'refresh_map_mviews\s*\(',
+)
 
 
 def _raw_sql() -> str:
@@ -33,8 +59,21 @@ def _statements() -> list[str]:
 
 def _statement_limit(statement: str) -> int:
     limits = re.findall(r'\bLIMIT\s+(\d+)\b', statement, flags=re.IGNORECASE)
-    assert len(limits) == 1, f'every coverage statement must have exactly one literal LIMIT: {statement}'
-    return int(limits[0])
+    assert len(limits) == 1, (
+        f'every coverage statement must have exactly one literal LIMIT: {statement}'
+    )
+    outer = re.search(r'\bLIMIT\s+(\d+)\s*$', statement, flags=re.IGNORECASE)
+    assert outer is not None, (
+        'the sole result bound must apply to the outer SELECT, not only to a nested query: '
+        f'{statement}'
+    )
+    assert outer.group(1) == limits[0]
+    return int(outer.group(1))
+
+
+def _assert_no_forbidden_patterns(statement: str) -> None:
+    for pattern in FORBIDDEN_PATTERNS:
+        assert re.search(pattern, statement, flags=re.IGNORECASE) is None, pattern
 
 
 def test_stage27a_coverage_pack_is_bounded_select_only_sql():
@@ -46,33 +85,38 @@ def test_stage27a_coverage_pack_is_bounded_select_only_sql():
     for statement in statements:
         limit = _statement_limit(statement)
         assert 1 <= limit <= MAX_RESULT_ROWS
+        _assert_no_forbidden_patterns(statement)
 
-    sql = _sql_without_line_comments()
-    forbidden_patterns = (
-        r'\bINSERT\b',
-        r'\bUPDATE\b',
-        r'\bDELETE\b',
-        r'\bMERGE\b',
-        r'\bCREATE\b',
-        r'\bALTER\b',
-        r'\bDROP\b',
-        r'\bTRUNCATE\b',
-        r'\bGRANT\b',
-        r'\bREVOKE\b',
-        r'\bSET\b',
-        r'\bRESET\b',
-        r'\bLOCK\b',
-        r'\bCALL\b',
-        r'\bDO\s+\$\$',
-        r'\bCOPY\b',
-        r'\bFOR\s+(UPDATE|SHARE)\b',
-        # Block the entire PostgreSQL advisory-lock family, including
-        # pg_try_advisory_lock*, xact/shared variants, and unlock helpers.
-        r'\bpg_(?:try_)?advisory_[a-z_]*\s*\(',
-        r'refresh_map_mviews\s*\(',
+
+def test_stage27a_limit_guard_rejects_nested_only_bounds():
+    malicious = (
+        'SELECT * FROM exploration_facts '
+        'WHERE EXISTS (SELECT 1 LIMIT 200)'
     )
-    for pattern in forbidden_patterns:
-        assert re.search(pattern, sql, flags=re.IGNORECASE) is None, pattern
+    with pytest.raises(AssertionError, match='outer SELECT'):
+        _statement_limit(malicious)
+
+
+def test_stage27a_select_guard_blocks_function_side_effects():
+    for malicious in (
+        "SELECT set_config('statement_timeout', '0', false) LIMIT 1",
+        'SELECT pg_try_advisory_lock(1) LIMIT 1',
+        'SELECT pg_try_advisory_xact_lock_shared(1) LIMIT 1',
+    ):
+        assert any(
+            re.search(pattern, malicious, flags=re.IGNORECASE)
+            for pattern in FORBIDDEN_PATTERNS
+        ), malicious
+
+
+def test_stage27a_station_association_breakdown_preserves_every_group():
+    station_breakdown = _statements()[6]
+
+    assert _statement_limit(station_breakdown) == 1
+    assert 'COUNT(*) AS association_groups' in station_breakdown
+    assert 'jsonb_agg(' in station_breakdown
+    assert 'GROUP BY association_status, lane, association_confidence, association_source' in station_breakdown
+    assert 'LIMIT 200' not in station_breakdown
 
 
 def test_stage27a_coverage_pack_does_not_expose_credentials_or_commander_keys():


### PR DESCRIPTION
## Summary

Harden the authorised Stage 27A SELECT-only production data-coverage pack without accessing production or expanding Stage 27 scope.

## Changes

- add a unit contract that requires the Stage 27A coverage SQL to remain exactly 12 SELECT statements;
- reject DML, DDL, lock/settings/call surfaces, advisory locks, refresh helpers, credentials and commander sync keys from the pack;
- preserve explicit station/body and ring/body cross-system identity drift checks;
- add a disposable-Postgres integration test that executes every coverage statement against the current fully migrated schema inside a read-only transaction.

## Why

`stage-27a-system-map-data-readiness.md` correctly leaves real production population as `UNKNOWN_COVERAGE` because there is no already-authorised V3 read-only production path. We should not weaken that boundary. These tests make the pack ready and schema-current for the day an authorised read-only path exists, without touching production now.

## Scope boundary

Stage 27A audit/contract work only. No Babylon/runtime implementation, no production map change, no Stage 27B work, no production database access, no writes, no deployment.