### PR TITLE
feat(web): establish lossless Svelte platform contracts

### DIFF
--- a/.github/workflows/cypress-parity.yml
+++ b/.github/workflows/cypress-parity.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Start Svelte production preview
         working-directory: apps/web
         env:
-          VITE_DEV_API_TARGET: http://127.0.0.1:8002
+          ED_FINDER_PREVIEW_API_TARGET: http://127.0.0.1:8002
         run: |
           nohup pnpm preview --host 127.0.0.1 --port 4174 --strictPort > /tmp/cypress-svelte-preview.log 2>&1 &
           for i in $(seq 1 60); do

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ The target application is same-origin, but ownership is intentionally split:
 
 | Route | Owner |
 |---|---|
-| `/api/*` | FastAPI |
+| `/api` and `/api/*` | FastAPI |
 | exact `/openapi.json` | FastAPI |
 | numeric `/s/{id64}` | FastAPI OpenGraph/share stop page |
 | application pages, static assets, and SPA fallback | Static SvelteKit application |
 
-Do not add a broad backend catch-all that steals SvelteKit routes. Do not add a frontend route that captures the backend-owned paths above.
+Do not add a broad backend catch-all that steals SvelteKit routes. Do not add a frontend route that captures the backend-owned paths above. Near-prefixes such as `/apiary`, `/openapi.jsonx`, `/openapi.json/extra`, and non-numeric or nested `/s/...` paths remain frontend-owned and use the static SPA fallback.
 
 ## Repository layout
 
@@ -150,8 +150,17 @@ Run the Cypress foundation suite only with the expected local API and preview en
 
 ```bash
 cd apps/web
+ED_FINDER_PREVIEW_API_TARGET=http://127.0.0.1:8002 pnpm preview --host 127.0.0.1 --port 4174 --strictPort
+```
+
+Then, in another terminal:
+
+```bash
+cd apps/web
 pnpm test:e2e
 ```
+
+`pnpm preview` runs the dependency-free Node 24 static-build contract used by Cypress, not the production server. It serves existing files from `build/` and returns `200.html` with HTTP 200 for every other frontend-owned route. Backend-owned requests proxy only when `ED_FINDER_PREVIEW_API_TARGET` explicitly names a credential-free loopback/disposable API origin; without it they fail closed with HTTP 503. Production static delivery remains nginx-owned.
 
 ### Generated API client
 

--- a/apps/web/cypress/e2e/dynamic-routes.cy.ts
+++ b/apps/web/cypress/e2e/dynamic-routes.cy.ts
@@ -1,0 +1,33 @@
+describe('ED-Finder static dynamic-route fallback', () => {
+  beforeEach(() => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+  });
+
+  it('serves and refreshes a nested Colony Planner route', () => {
+    const route =
+      '/colony-planner/system/18446744073709551615/project/project-1/mode/preview';
+
+    cy.visit(route);
+    cy.get('h1').should('have.text', 'Colony Planner');
+    cy.contains(
+      'System 18446744073709551615 · project project-1 · preview.',
+    ).should('be.visible');
+
+    cy.reload();
+    cy.location('pathname').should('eq', route);
+    cy.get('h1').should('have.text', 'Colony Planner');
+  });
+
+  it('does not turn a near-prefix typo into a successful SPA response', () => {
+    cy.request({
+      url: '/colony-plannerish/system/1',
+      failOnStatusCode: false,
+    }).then(({ status }) => {
+      expect(status).to.eq(404);
+    });
+  });
+});

--- a/apps/web/cypress/e2e/dynamic-routes.cy.ts
+++ b/apps/web/cypress/e2e/dynamic-routes.cy.ts
@@ -26,9 +26,7 @@ describe('ED-Finder static dynamic-route fallback', () => {
     const canonical =
       '/colony-planner/system/18446744073709551615/project/project-1/mode/preview';
 
-    cy.visit(
-      `${canonical}/detail/9007199254740993?view=compact&system=42`,
-    );
+    cy.visit(`${canonical}/detail/9007199254740993?view=compact&system=42`);
     cy.location('pathname').should('eq', canonical);
     cy.location('search').should('include', 'view=compact');
     cy.location('search').should('include', 'system=9007199254740993');

--- a/apps/web/cypress/e2e/dynamic-routes.cy.ts
+++ b/apps/web/cypress/e2e/dynamic-routes.cy.ts
@@ -35,12 +35,10 @@ describe('ED-Finder static dynamic-route fallback', () => {
       .and('be.visible');
   });
 
-  it('does not turn a near-prefix typo into a successful SPA response', () => {
-    cy.request({
-      url: '/colony-plannerish/system/1',
-      failOnStatusCode: false,
-    }).then(({ status }) => {
-      expect(status).to.eq(404);
+  it('keeps a near-prefix typo frontend-owned', () => {
+    cy.request('/colony-plannerish/system/1').then(({ headers, status }) => {
+      expect(status).to.eq(200);
+      expect(headers['content-type']).to.include('text/html');
     });
   });
 });

--- a/apps/web/cypress/e2e/dynamic-routes.cy.ts
+++ b/apps/web/cypress/e2e/dynamic-routes.cy.ts
@@ -22,6 +22,21 @@ describe('ED-Finder static dynamic-route fallback', () => {
     cy.get('h1').should('have.text', 'Colony Planner');
   });
 
+  it('canonicalises a legacy planner detail path without rounding either id', () => {
+    const canonical =
+      '/colony-planner/system/18446744073709551615/project/project-1/mode/preview';
+
+    cy.visit(
+      `${canonical}/detail/9007199254740993?view=compact&system=42`,
+    );
+    cy.location('pathname').should('eq', canonical);
+    cy.location('search').should('include', 'view=compact');
+    cy.location('search').should('include', 'system=9007199254740993');
+    cy.get('[data-testid="system-detail-modal"]')
+      .should('contain.text', '9007199254740993')
+      .and('be.visible');
+  });
+
   it('does not turn a near-prefix typo into a successful SPA response', () => {
     cy.request({
       url: '/colony-plannerish/system/1',

--- a/apps/web/cypress/e2e/foundation.cy.ts
+++ b/apps/web/cypress/e2e/foundation.cy.ts
@@ -27,14 +27,13 @@ describe('ED-Finder V3 foundation', () => {
       expect(headers.location).to.include('/#system/0');
     });
 
-    cy.request({ url: '/apiary', failOnStatusCode: false }).then(
-      ({ headers, status }) => {
-        // This near-prefix must remain on the Svelte side. Because it is not a
-        // real application route, the correct frontend response is its HTML 404.
-        expect(status).to.eq(404);
-        expect(headers['content-type']).to.include('text/html');
-      },
-    );
+    cy.request('/apiary').then(({ body, headers, status }) => {
+      // This near-prefix remains on the Svelte side and receives the same
+      // transport-level SPA fallback as every other frontend-owned route.
+      expect(status).to.eq(200);
+      expect(headers['content-type']).to.include('text/html');
+      expect(body).to.include('<!doctype html>');
+    });
   });
 
   it('supports direct navigation and refresh through the SPA fallback', () => {
@@ -47,7 +46,7 @@ describe('ED-Finder V3 foundation', () => {
   });
 
   it('rejects unknown journey routes instead of rendering a placeholder', () => {
-    cy.visit('/explroe', { failOnStatusCode: false });
+    cy.visit('/explroe');
     cy.contains('This product surface has not been ported yet.').should(
       'not.exist',
     );
@@ -78,6 +77,9 @@ describe('ED-Finder V3 foundation', () => {
       owner_claim_available: false,
     });
     cy.visit('/compare');
+    // Wait for AppShell.onMount to install the hashchange listener before
+    // simulating a hash assigned by an already-running legacy integration.
+    cy.get('[data-testid="frontier-sign-in"]').should('be.visible');
     cy.window().then((browser) => {
       browser.location.hash = '#system/9007199254740993';
     });
@@ -159,6 +161,32 @@ describe('ED-Finder V3 foundation', () => {
         browser.localStorage.getItem('ed-finder:selected-system-context'),
       ).to.eq('18446744073709551615');
     });
+
+    cy.reload();
+    cy.location('pathname').should('eq', '/system/18446744073709551615');
+    cy.get('h1').should('have.text', 'System Detail');
+    cy.get('[data-testid="selected-system-context"]').should(
+      'contain.text',
+      '18446744073709551615',
+    );
+  });
+
+  it('rejects malformed and traversal-like cold paths without exposing files', () => {
+    const unsafePaths = [
+      '/bad%E0%A4%A',
+      '/bad%00path',
+      '/%5c..%5cpackage.json',
+      '/safe%2f..%2f..%2fpackage.json',
+    ];
+
+    for (const url of unsafePaths) {
+      cy.request({ url, failOnStatusCode: false }).then(({ body, status }) => {
+        expect(status, url).to.eq(400);
+        expect(String(body), url).to.eq('Bad request path\n');
+        expect(String(body), url).not.to.include('@ed-finder/web');
+        expect(String(body), url).not.to.include('ED-Finder Agent Contract');
+      });
+    }
   });
 
   it('hydrates the selected-system singleton exactly once on bootstrap', () => {

--- a/apps/web/cypress/e2e/foundation.cy.ts
+++ b/apps/web/cypress/e2e/foundation.cy.ts
@@ -106,6 +106,92 @@ describe('ED-Finder V3 foundation', () => {
     );
   });
 
+  it('lets a cold URL overlay replace an older durable selection', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/explore?system=18446744073709551615', {
+      onBeforeLoad(browser) {
+        browser.localStorage.setItem(
+          'ed-finder:selected-system-context',
+          '9007199254740993',
+        );
+      },
+    });
+    cy.get('[data-testid="system-detail-modal"]')
+      .should('contain.text', '18446744073709551615')
+      .and('be.visible');
+    cy.get('[data-testid="selected-system-context"]').should(
+      'contain.text',
+      '18446744073709551615',
+    );
+    cy.window().then((browser) => {
+      expect(
+        browser.localStorage.getItem('ed-finder:selected-system-context'),
+      ).to.eq('18446744073709551615');
+    });
+  });
+
+  it('establishes a cold direct system route without opening an overlay', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/system/18446744073709551615', {
+      onBeforeLoad(browser) {
+        browser.localStorage.setItem(
+          'ed-finder:selected-system-context',
+          '9007199254740993',
+        );
+      },
+    });
+    cy.get('h1').should('have.text', 'System Detail');
+    cy.get('[data-testid="system-detail-modal"]').should('not.exist');
+    cy.get('[data-testid="selected-system-context"]').should(
+      'contain.text',
+      '18446744073709551615',
+    );
+    cy.window().then((browser) => {
+      expect(
+        browser.localStorage.getItem('ed-finder:selected-system-context'),
+      ).to.eq('18446744073709551615');
+    });
+  });
+
+  it('hydrates the selected-system singleton exactly once on bootstrap', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    let selectedSystemReads = 0;
+    cy.visit('/my-work', {
+      onBeforeLoad(browser) {
+        browser.localStorage.setItem(
+          'ed-finder:selected-system-context',
+          '9007199254740993',
+        );
+        const storagePrototype = Object.getPrototypeOf(
+          browser.localStorage,
+        ) as Storage;
+        const getItem = storagePrototype.getItem;
+        storagePrototype.getItem = function (key: string) {
+          if (key === 'ed-finder:selected-system-context')
+            selectedSystemReads += 1;
+          return getItem.call(this, key);
+        };
+      },
+    });
+    cy.get('[data-testid="selected-system-context"]').should(
+      'contain.text',
+      '9007199254740993',
+    );
+    cy.then(() => expect(selectedSystemReads).to.eq(1));
+  });
+
   it('restores the host URL and scroll contract when Escape closes detail', () => {
     cy.intercept('/api/auth/session', {
       authenticated: false,

--- a/apps/web/cypress/e2e/foundation.cy.ts
+++ b/apps/web/cypress/e2e/foundation.cy.ts
@@ -130,9 +130,49 @@ describe('ED-Finder V3 foundation', () => {
         cy.wrap($link).should('be.focused');
       });
     cy.get('[data-testid="system-detail-modal"]').should('not.exist');
+    cy.get('[data-testid="selected-system-context"]').should(
+      'contain.text',
+      '9007199254740993',
+    );
+    cy.window().then((browser) => {
+      expect(
+        browser.localStorage.getItem('ed-finder:selected-system-context'),
+      ).to.eq('9007199254740993');
+    });
     cy.location('pathname').should('eq', '/compare');
     cy.location('search').should('eq', '');
     cy.get('body').should('not.have.css', 'overflow', 'hidden');
+  });
+
+  it('updates durable selected-system context across tabs at uint64 max', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/my-work');
+    cy.window().then((browser) => {
+      browser.localStorage.setItem(
+        'ed-finder:selected-system-context',
+        '18446744073709551615',
+      );
+      browser.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'ed-finder:selected-system-context',
+          newValue: '18446744073709551615',
+          storageArea: browser.localStorage,
+        }),
+      );
+    });
+    cy.get('[data-testid="selected-system-context"]')
+      .should('contain.text', '18446744073709551615')
+      .find('a')
+      .should(
+        'have.attr',
+        'href',
+        '/colony-planner/system/18446744073709551615',
+      );
+    cy.get('[data-testid="system-detail-modal"]').should('not.exist');
   });
 
   it('gates signed-out, non-owner, and owner admin states', () => {

--- a/apps/web/cypress/e2e/foundation.cy.ts
+++ b/apps/web/cypress/e2e/foundation.cy.ts
@@ -1,13 +1,10 @@
 describe('ED-Finder V3 foundation', () => {
   it('loads the shell and exercises the real same-origin bootstrap', () => {
-    cy.intercept('/api/health').as('health');
     cy.intercept('/api/auth/session').as('session');
     cy.visit('/');
-    cy.get('h1').should('contain.text', 'Find your place').and('be.visible');
-    cy.wait('@health').its('response.statusCode').should('eq', 200);
+    cy.get('h1').should('contain.text', 'Finder').and('be.visible');
     cy.wait('@session').its('response.statusCode').should('eq', 200);
-    cy.contains('dd', 'Connected').should('be.visible');
-    cy.contains('dd', 'Guest').should('be.visible');
+    cy.get('[data-testid="frontier-sign-in"]').should('be.visible');
   });
 
   it('proxies backend-owned routes to the disposable FastAPI service', () => {
@@ -55,5 +52,110 @@ describe('ED-Finder V3 foundation', () => {
       'not.exist',
     );
     cy.contains(/not found/i).should('be.visible');
+  });
+
+  it('replaces warm legacy hashes and retains lossless oversized ids', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/?source=legacy#map/system/18446744073709551615');
+    cy.location('pathname').should('eq', '/explore');
+    cy.location('search')
+      .should('include', 'source=legacy')
+      .and('include', 'system=18446744073709551615');
+    cy.location('hash').should('eq', '');
+    cy.get('[data-testid="system-detail-modal"]')
+      .should('contain.text', '18446744073709551615')
+      .and('be.focused');
+  });
+
+  it('replaces a hash assigned after boot without looping', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/compare');
+    cy.window().then((browser) => {
+      browser.location.hash = '#system/9007199254740993';
+    });
+    cy.location('pathname').should('eq', '/compare');
+    cy.location('search').should('eq', '?system=9007199254740993');
+    cy.location('hash').should('eq', '');
+  });
+
+  it('hydrates the canonical selected-system storage boundary losslessly', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/', {
+      onBeforeLoad(browser) {
+        browser.localStorage.setItem(
+          'ed-finder:selected-system-context',
+          '18446744073709551615',
+        );
+      },
+    });
+    cy.get('[data-testid="selected-system-context"]').should(
+      'contain.text',
+      '18446744073709551615',
+    );
+  });
+
+  it('restores the host URL and scroll contract when Escape closes detail', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    cy.visit('/compare');
+    cy.get('a[href="/compare"]')
+      .focus()
+      .then(($link) => {
+        cy.window().then((browser) => {
+          browser.history.replaceState(
+            {},
+            '',
+            '/compare?system=9007199254740993',
+          );
+          browser.dispatchEvent(new PopStateEvent('popstate'));
+        });
+        cy.get('[data-testid="system-detail-modal"]').should('be.visible');
+        cy.get('body').should('have.css', 'overflow', 'hidden');
+        cy.get('body').type('{esc}');
+        cy.wrap($link).should('be.focused');
+      });
+    cy.get('[data-testid="system-detail-modal"]').should('not.exist');
+    cy.location('pathname').should('eq', '/compare');
+    cy.location('search').should('eq', '');
+    cy.get('body').should('not.have.css', 'overflow', 'hidden');
+  });
+
+  it('gates signed-out, non-owner, and owner admin states', () => {
+    cy.intercept('/api/auth/session', {
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    }).as('guest');
+    cy.visit('/admin');
+    cy.get('[data-testid="owner-sign-in-required"]').should('be.visible');
+    cy.intercept('/api/auth/session', {
+      authenticated: true,
+      user: { commander_name: 'Player', is_owner: false },
+      owner_claim_available: false,
+    }).as('player');
+    cy.reload();
+    cy.get('[data-testid="owner-access-denied"]').should('be.visible');
+    cy.intercept('/api/auth/session', {
+      authenticated: true,
+      user: { commander_name: 'Owner', is_owner: true },
+      owner_claim_available: false,
+    }).as('owner');
+    cy.reload();
+    cy.get('[data-testid="admin-tab"]').should('be.visible');
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@lucide/svelte": "1.37.0",
     "@tanstack/svelte-query": "6.1.48",
-    "bits-ui": "2.19.0"
+    "bits-ui": "2.19.0",
+    "json-with-bigint": "3.5.10"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,12 +10,12 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "node scripts/static-preview.mjs",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "vitest run",
+    "test": "vitest run && node --test scripts/static-preview.test.mjs",
     "test:watch": "vitest",
     "test:e2e": "cypress run --browser chrome",
     "generate:api": "svelte-kit sync && node scripts/capture-openapi.mjs && openapi-ts"

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       bits-ui:
         specifier: 2.19.0
         version: 2.19.0(@internationalized/date@3.12.4)(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.56.10(@typescript-eslint/types@8.69.0))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.69.0))(typescript@6.0.2)(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.69.0))
+      json-with-bigint:
+        specifier: 3.5.10
+        version: 3.5.10
     devDependencies:
       '@hey-api/openapi-ts':
         specifier: 0.99.0
@@ -38,7 +41,7 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: 5.4.2
-        version: 5.4.2(svelte@5.56.10(@typescript-eslint/types@8.69.0))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))(vitest@4.1.0(@types/node@24.10.0)(jsdom@27.4.0(supports-color@8.1.1))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)))
+        version: 5.4.2(svelte@5.56.10(@typescript-eslint/types@8.69.0))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))(vitest@4.1.0(@types/node@24.10.0)(jsdom@27.4.0)(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)))
       '@types/node':
         specifier: 24.10.0
         version: 24.10.0
@@ -47,13 +50,13 @@ importers:
         version: 15.21.1
       eslint:
         specifier: 10.9.1
-        version: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+        version: 10.9.1(jiti@2.7.0)
       eslint-plugin-svelte:
         specifier: 3.23.0
-        version: 3.23.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(svelte@5.56.10(@typescript-eslint/types@8.69.0))
+        version: 3.23.0(eslint@10.9.1(jiti@2.7.0))(svelte@5.56.10(@typescript-eslint/types@8.69.0))
       jsdom:
         specifier: 27.4.0
-        version: 27.4.0(supports-color@8.1.1)
+        version: 27.4.0
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -74,13 +77,13 @@ importers:
         version: 6.0.2
       typescript-eslint:
         specifier: 8.69.0
-        version: 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
+        version: 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
       vite:
         specifier: 8.2.2
         version: 8.2.2(@types/node@24.10.0)(jiti@2.7.0)
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@24.10.0)(jsdom@27.4.0(supports-color@8.1.1))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))
+        version: 4.1.0(@types/node@24.10.0)(jsdom@27.4.0)(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))
 
 packages:
 
@@ -325,42 +328,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.7':
     resolution: {integrity: sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.7':
     resolution: {integrity: sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.7':
     resolution: {integrity: sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.7':
     resolution: {integrity: sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.7':
     resolution: {integrity: sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.7':
     resolution: {integrity: sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==}
@@ -464,28 +461,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -1448,6 +1441,9 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
+
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
@@ -1534,56 +1530,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.33.0:
     resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2468,14 +2456,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.9.1(jiti@2.7.0))':
     dependencies:
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.9.1(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -2803,14 +2791,14 @@ snapshots:
     dependencies:
       svelte: 5.56.10(@typescript-eslint/types@8.69.0)
 
-  '@testing-library/svelte@5.4.2(svelte@5.56.10(@typescript-eslint/types@8.69.0))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))(vitest@4.1.0(@types/node@24.10.0)(jsdom@27.4.0(supports-color@8.1.1))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)))':
+  '@testing-library/svelte@5.4.2(svelte@5.56.10(@typescript-eslint/types@8.69.0))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))(vitest@4.1.0(@types/node@24.10.0)(jsdom@27.4.0)(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/svelte-core': 1.1.3(svelte@5.56.10(@typescript-eslint/types@8.69.0))
       svelte: 5.56.10(@typescript-eslint/types@8.69.0)
     optionalDependencies:
       vite: 8.2.2(@types/node@24.10.0)(jiti@2.7.0)
-      vitest: 4.1.0(@types/node@24.10.0)(jsdom@27.4.0(supports-color@8.1.1))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))
+      vitest: 4.1.0(@types/node@24.10.0)(jsdom@27.4.0)(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))
 
   '@types/aria-query@5.0.4': {}
 
@@ -2841,15 +2829,15 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2))(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
+  '@typescript-eslint/eslint-plugin@8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2))(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/scope-manager': 8.69.0
-      '@typescript-eslint/type-utils': 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
+      '@typescript-eslint/type-utils': 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.69.0
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.9.1(jiti@2.7.0)
       ignore: 7.0.8
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.2)
@@ -2857,19 +2845,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
+  '@typescript-eslint/parser@8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.9.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.69.0(supports-color@8.1.1)(typescript@6.0.2)':
+  '@typescript-eslint/project-service@8.69.0(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.69.0
@@ -2887,13 +2875,13 @@ snapshots:
     dependencies:
       typescript: 6.0.2
 
-  '@typescript-eslint/type-utils@8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
+  '@typescript-eslint/type-utils@8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.9.1(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -2901,9 +2889,9 @@ snapshots:
 
   '@typescript-eslint/types@8.69.0': {}
 
-  '@typescript-eslint/typescript-estree@8.69.0(supports-color@8.1.1)(typescript@6.0.2)':
+  '@typescript-eslint/typescript-estree@8.69.0(typescript@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.69.0(supports-color@8.1.1)(typescript@6.0.2)
+      '@typescript-eslint/project-service': 8.69.0(typescript@6.0.2)
       '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
@@ -2916,13 +2904,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
+  '@typescript-eslint/utils@8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.2)
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.2)
+      eslint: 10.9.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -3352,11 +3340,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-svelte@3.23.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(svelte@5.56.10(@typescript-eslint/types@8.69.0)):
+  eslint-plugin-svelte@3.23.0(eslint@10.9.1(jiti@2.7.0))(svelte@5.56.10(@typescript-eslint/types@8.69.0)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.6.0
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.9.1(jiti@2.7.0)
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
@@ -3388,11 +3376,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1):
+  eslint@10.9.1(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -3608,7 +3596,7 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -3621,7 +3609,7 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -3701,7 +3689,7 @@ snapshots:
 
   jsbn@0.1.1: {}
 
-  jsdom@27.4.0(supports-color@8.1.1):
+  jsdom@27.4.0:
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
@@ -3710,8 +3698,8 @@ snapshots:
       data-urls: 6.0.1
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.1
       saxes: 6.0.0
@@ -3738,6 +3726,8 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json-with-bigint@3.5.10: {}
 
   jsonfile@6.2.1:
     dependencies:
@@ -4400,13 +4390,13 @@ snapshots:
 
   type-fest@0.8.1: {}
 
-  typescript-eslint@8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2):
+  typescript-eslint@8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2))(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
-      '@typescript-eslint/parser': 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.2)
-      '@typescript-eslint/utils': 8.69.0(eslint@10.9.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
-      eslint: 10.9.1(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/eslint-plugin': 8.69.0(@typescript-eslint/parser@8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2))(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/parser': 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
+      '@typescript-eslint/typescript-estree': 8.69.0(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.9.1(jiti@2.7.0))(typescript@6.0.2)
+      eslint: 10.9.1(jiti@2.7.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4447,7 +4437,7 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@24.10.0)(jiti@2.7.0)
 
-  vitest@4.1.0(@types/node@24.10.0)(jsdom@27.4.0(supports-color@8.1.1))(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)):
+  vitest@4.1.0(@types/node@24.10.0)(jsdom@27.4.0)(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@8.2.2(@types/node@24.10.0)(jiti@2.7.0))
@@ -4471,7 +4461,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.0
-      jsdom: 27.4.0(supports-color@8.1.1)
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
 

--- a/apps/web/scripts/static-preview.mjs
+++ b/apps/web/scripts/static-preview.mjs
@@ -1,0 +1,532 @@
+import { createReadStream } from 'node:fs';
+import { realpath, stat } from 'node:fs/promises';
+import {
+  createServer as createHttpServer,
+  request as createHttpRequest,
+} from 'node:http';
+import { request as createHttpsRequest } from 'node:https';
+import { isIP } from 'node:net';
+import { extname, isAbsolute, relative, resolve, sep } from 'node:path';
+import { pipeline } from 'node:stream';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const DEFAULT_BUILD_ROOT = fileURLToPath(new URL('../build/', import.meta.url));
+const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_PORT = 4173;
+const PROXY_TIMEOUT_MS = 30_000;
+
+const BACKEND_ROUTES = [
+  /^\/api(?:\/|$)/u,
+  /^\/openapi\.json$/u,
+  /^\/s\/[0-9]+$/u,
+];
+
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
+
+const SPOOFABLE_FORWARDING_HEADERS = new Set([
+  'forwarded',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-port',
+  'x-forwarded-proto',
+]);
+
+const CONTENT_TYPES = new Map([
+  ['.avif', 'image/avif'],
+  ['.css', 'text/css; charset=utf-8'],
+  ['.gif', 'image/gif'],
+  ['.htm', 'text/html; charset=utf-8'],
+  ['.html', 'text/html; charset=utf-8'],
+  ['.ico', 'image/x-icon'],
+  ['.jpeg', 'image/jpeg'],
+  ['.jpg', 'image/jpeg'],
+  ['.js', 'text/javascript; charset=utf-8'],
+  ['.json', 'application/json; charset=utf-8'],
+  ['.map', 'application/json; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'],
+  ['.ogg', 'audio/ogg'],
+  ['.otf', 'font/otf'],
+  ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'],
+  ['.txt', 'text/plain; charset=utf-8'],
+  ['.wasm', 'application/wasm'],
+  ['.webmanifest', 'application/manifest+json; charset=utf-8'],
+  ['.webp', 'image/webp'],
+  ['.woff', 'font/woff'],
+  ['.woff2', 'font/woff2'],
+  ['.xml', 'application/xml; charset=utf-8'],
+]);
+
+export class UnsafeRequestTargetError extends Error {}
+
+function decodeUrlComponent(value, description) {
+  try {
+    return decodeURIComponent(value);
+  } catch (error) {
+    throw new UnsafeRequestTargetError(
+      `Malformed percent encoding in ${description}`,
+      { cause: error },
+    );
+  }
+}
+
+function validateDecodedPathname(pathname) {
+  if (!pathname.startsWith('/')) {
+    throw new UnsafeRequestTargetError(
+      'Only origin-form request paths are accepted',
+    );
+  }
+  if (pathname.includes('\0')) {
+    throw new UnsafeRequestTargetError(
+      'Null bytes are not accepted in request paths',
+    );
+  }
+  if (pathname.includes('\\')) {
+    throw new UnsafeRequestTargetError(
+      'Backslashes are not accepted in request paths',
+    );
+  }
+  if (
+    pathname.split('/').some((segment) => segment === '.' || segment === '..')
+  ) {
+    throw new UnsafeRequestTargetError(
+      'Traversal segments are not accepted in request paths',
+    );
+  }
+}
+
+export function parseRequestTarget(requestTarget) {
+  if (typeof requestTarget !== 'string' || requestTarget.length === 0) {
+    throw new UnsafeRequestTargetError('A request target is required');
+  }
+  if (requestTarget.includes('#')) {
+    throw new UnsafeRequestTargetError(
+      'Fragments are not accepted in HTTP request targets',
+    );
+  }
+
+  const queryIndex = requestTarget.indexOf('?');
+  const rawPathname =
+    queryIndex === -1 ? requestTarget : requestTarget.slice(0, queryIndex);
+  const search = queryIndex === -1 ? '' : requestTarget.slice(queryIndex);
+
+  if (rawPathname.includes('\\') || rawPathname.includes('\0')) {
+    throw new UnsafeRequestTargetError('Unsafe characters in request path');
+  }
+
+  const pathname = decodeUrlComponent(rawPathname, 'request path');
+  // Validate the query encoding even though it is deliberately excluded from
+  // filesystem resolution. The original bytes are retained for proxying.
+  if (search) decodeUrlComponent(search.slice(1), 'query string');
+  validateDecodedPathname(pathname);
+
+  return { pathname, rawPathname, search };
+}
+
+export function classifyRoute(rawPathname) {
+  const pathname = decodeUrlComponent(rawPathname, 'request path');
+  validateDecodedPathname(pathname);
+  return BACKEND_ROUTES.some((pattern) => pattern.test(rawPathname))
+    ? 'backend'
+    : 'frontend';
+}
+
+function isWithinRoot(root, candidate) {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === '' ||
+    (!pathFromRoot.startsWith(`..${sep}`) &&
+      pathFromRoot !== '..' &&
+      !isAbsolute(pathFromRoot))
+  );
+}
+
+export function resolveStaticPath(buildRoot, pathname) {
+  validateDecodedPathname(pathname);
+  const absoluteRoot = resolve(buildRoot);
+  const candidate = resolve(absoluteRoot, `.${pathname}`);
+  if (!isWithinRoot(absoluteRoot, candidate)) {
+    throw new UnsafeRequestTargetError('Resolved path escaped the static root');
+  }
+  return candidate;
+}
+
+function contentHeaders(filePath, metadata, fallback) {
+  let typePath = filePath;
+  const headers = {
+    'Content-Length': String(metadata.size),
+    'Last-Modified': metadata.mtime.toUTCString(),
+    'X-Content-Type-Options': 'nosniff',
+  };
+
+  if (filePath.endsWith('.br')) {
+    headers['Content-Encoding'] = 'br';
+    typePath = filePath.slice(0, -3);
+  } else if (filePath.endsWith('.gz')) {
+    headers['Content-Encoding'] = 'gzip';
+    typePath = filePath.slice(0, -3);
+  }
+
+  const extension = extname(typePath).toLowerCase();
+  headers['Content-Type'] =
+    CONTENT_TYPES.get(extension) ?? 'application/octet-stream';
+  headers['Cache-Control'] =
+    fallback || extension === '.html'
+      ? 'no-cache'
+      : 'public, max-age=0, must-revalidate';
+  return headers;
+}
+
+async function locateStaticFile(buildRoot, pathname) {
+  let candidate = resolveStaticPath(buildRoot, pathname);
+  let metadata;
+  try {
+    metadata = await stat(candidate);
+    if (metadata.isDirectory()) {
+      candidate = resolve(candidate, 'index.html');
+      metadata = await stat(candidate);
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT' || error?.code === 'ENOTDIR') return null;
+    throw error;
+  }
+
+  if (!metadata.isFile()) return null;
+  const canonicalPath = await realpath(candidate);
+  if (!isWithinRoot(buildRoot, canonicalPath)) {
+    throw new UnsafeRequestTargetError('Static file escaped the build root');
+  }
+  return { filePath: canonicalPath, metadata };
+}
+
+function sendText(request, response, statusCode, message, extraHeaders = {}) {
+  const body = Buffer.from(`${message}\n`, 'utf8');
+  response.writeHead(statusCode, {
+    'Cache-Control': 'no-store',
+    'Content-Length': String(body.length),
+    'Content-Type': 'text/plain; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+    ...extraHeaders,
+  });
+  response.end(request.method === 'HEAD' ? undefined : body);
+}
+
+function serveFile(request, response, file, fallback) {
+  response.writeHead(
+    200,
+    contentHeaders(file.filePath, file.metadata, fallback),
+  );
+  if (request.method === 'HEAD') {
+    response.end();
+    return;
+  }
+
+  const stream = createReadStream(file.filePath);
+  pipeline(stream, response, (error) => {
+    if (error && !response.destroyed) response.destroy(error);
+  });
+}
+
+function connectionHeaderNames(headers) {
+  const connection = headers.connection;
+  if (!connection) return [];
+  const values = Array.isArray(connection) ? connection : [connection];
+  return values
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function safeProxyHeaders(headers, { request = false } = {}) {
+  const blocked = new Set([
+    ...HOP_BY_HOP_HEADERS,
+    ...connectionHeaderNames(headers),
+  ]);
+  if (request) {
+    blocked.add('host');
+    for (const header of SPOOFABLE_FORWARDING_HEADERS) blocked.add(header);
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).filter(
+      ([name, value]) =>
+        value !== undefined && !blocked.has(name.toLowerCase()),
+    ),
+  );
+}
+
+function isLoopbackHostname(hostname) {
+  const normalized = hostname.replace(/^\[|\]$/gu, '').toLowerCase();
+  if (normalized === 'localhost' || normalized === 'localhost.') return true;
+  if (isIP(normalized) === 4) return normalized.split('.')[0] === '127';
+  return normalized === '::1';
+}
+
+export function parseApiTarget(value) {
+  if (!value) return null;
+
+  let target;
+  try {
+    target = new URL(value);
+  } catch (error) {
+    throw new Error('Preview API target must be a valid URL', { cause: error });
+  }
+
+  if (!['http:', 'https:'].includes(target.protocol)) {
+    throw new Error('Preview API target must use http or https');
+  }
+  if (target.username || target.password) {
+    throw new Error('Preview API target must not contain credentials');
+  }
+  if (target.pathname !== '/' || target.search || target.hash) {
+    throw new Error(
+      'Preview API target must be an origin without a path, query, or fragment',
+    );
+  }
+  if (!isLoopbackHostname(target.hostname)) {
+    throw new Error(
+      'Preview API target must be an explicit loopback/disposable origin',
+    );
+  }
+  return target;
+}
+
+function proxyRequest(request, response, parsedTarget, apiTarget) {
+  if (!apiTarget) {
+    request.resume();
+    sendText(
+      request,
+      response,
+      503,
+      'Backend route unavailable: no disposable preview API target was supplied',
+    );
+    return;
+  }
+
+  const transport =
+    apiTarget.protocol === 'https:' ? createHttpsRequest : createHttpRequest;
+  const upstream = transport(
+    {
+      protocol: apiTarget.protocol,
+      hostname: apiTarget.hostname.replace(/^\[|\]$/gu, ''),
+      port: apiTarget.port,
+      method: request.method,
+      path: `${parsedTarget.rawPathname}${parsedTarget.search}`,
+      headers: safeProxyHeaders(request.headers, { request: true }),
+    },
+    (upstreamResponse) => {
+      if (response.destroyed) {
+        upstreamResponse.destroy();
+        return;
+      }
+
+      response.writeHead(
+        upstreamResponse.statusCode ?? 502,
+        safeProxyHeaders(upstreamResponse.headers),
+      );
+      if (request.method === 'HEAD') {
+        upstreamResponse.resume();
+        response.end();
+        return;
+      }
+      pipeline(upstreamResponse, response, (error) => {
+        if (error && !response.destroyed) response.destroy(error);
+      });
+    },
+  );
+
+  upstream.setTimeout(PROXY_TIMEOUT_MS, () => {
+    upstream.destroy(new Error('Preview API proxy timed out'));
+  });
+  upstream.on('error', () => {
+    if (response.destroyed) return;
+    if (response.headersSent) {
+      response.destroy();
+      return;
+    }
+    sendText(request, response, 502, 'Disposable preview API request failed');
+  });
+  request.once('aborted', () => upstream.destroy());
+  pipeline(request, upstream, (error) => {
+    if (error && !upstream.destroyed) upstream.destroy(error);
+  });
+}
+
+export async function createStaticPreviewServer({
+  apiTarget: requestedApiTarget,
+  buildRoot = DEFAULT_BUILD_ROOT,
+} = {}) {
+  const canonicalBuildRoot = await realpath(buildRoot);
+  const fallback = await locateStaticFile(canonicalBuildRoot, '/200.html');
+  if (!fallback) {
+    throw new Error(
+      `Static SPA fallback is missing from ${canonicalBuildRoot}`,
+    );
+  }
+  const apiTarget =
+    requestedApiTarget instanceof URL
+      ? parseApiTarget(requestedApiTarget.href)
+      : parseApiTarget(requestedApiTarget);
+
+  return createHttpServer(async (request, response) => {
+    try {
+      const parsedTarget = parseRequestTarget(request.url ?? '');
+      if (classifyRoute(parsedTarget.rawPathname) === 'backend') {
+        proxyRequest(request, response, parsedTarget, apiTarget);
+        return;
+      }
+
+      if (request.method !== 'GET' && request.method !== 'HEAD') {
+        request.resume();
+        sendText(request, response, 405, 'Method not allowed', {
+          Allow: 'GET, HEAD',
+        });
+        return;
+      }
+
+      const file = await locateStaticFile(
+        canonicalBuildRoot,
+        parsedTarget.pathname,
+      );
+      serveFile(request, response, file ?? fallback, file === null);
+    } catch (error) {
+      request.resume();
+      if (response.destroyed || response.headersSent) {
+        if (!response.destroyed) response.destroy(error);
+        return;
+      }
+      if (error instanceof UnsafeRequestTargetError) {
+        sendText(request, response, 400, 'Bad request path');
+        return;
+      }
+      sendText(request, response, 500, 'Static preview server error');
+    }
+  });
+}
+
+function readOptionValue(argumentsList, index, option) {
+  const value = argumentsList[index + 1];
+  if (!value || value.startsWith('-')) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+export function parseCliArguments(argumentsList, environment = process.env) {
+  const options = {
+    apiTarget: environment.ED_FINDER_PREVIEW_API_TARGET?.trim() || undefined,
+    host: DEFAULT_HOST,
+    port: DEFAULT_PORT,
+  };
+
+  for (let index = 0; index < argumentsList.length; index += 1) {
+    const argument = argumentsList[index];
+    if (argument === '--') continue;
+    if (argument === '--strictPort') {
+      // Node's listen call never searches for another port, so it already has
+      // Vite's strict-port behaviour. Keep accepting the existing CI flag.
+      continue;
+    }
+
+    const [name, inlineValue] = argument.split('=', 2);
+    if (name === '--host' || name === '--port' || name === '--api-target') {
+      const value = inlineValue ?? readOptionValue(argumentsList, index, name);
+      if (inlineValue === undefined) index += 1;
+      if (name === '--host') options.host = value;
+      if (name === '--port') options.port = Number(value);
+      if (name === '--api-target') options.apiTarget = value;
+      continue;
+    }
+    throw new Error(`Unsupported static preview option: ${argument}`);
+  }
+
+  if (!options.host) throw new Error('Preview host must not be empty');
+  if (
+    !Number.isInteger(options.port) ||
+    options.port < 1 ||
+    options.port > 65_535
+  ) {
+    throw new Error('Preview port must be an integer from 1 through 65535');
+  }
+  parseApiTarget(options.apiTarget);
+  return options;
+}
+
+async function listen(server, host, port) {
+  await new Promise((resolvePromise, rejectPromise) => {
+    const onError = (error) => {
+      server.off('listening', onListening);
+      rejectPromise(error);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolvePromise();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, host);
+  });
+}
+
+function installTerminationHandlers(server) {
+  let closing = false;
+  let forceCloseTimer;
+
+  const shutdown = (signal) => {
+    if (closing) {
+      server.closeAllConnections();
+      return;
+    }
+    closing = true;
+    process.stderr.write(`[static-preview] ${signal}; closing\n`);
+    server.close((error) => {
+      if (forceCloseTimer) clearTimeout(forceCloseTimer);
+      if (error) {
+        process.stderr.write(
+          `[static-preview] shutdown failed: ${error.message}\n`,
+        );
+        process.exitCode = 1;
+      }
+    });
+    server.closeIdleConnections();
+    forceCloseTimer = setTimeout(() => server.closeAllConnections(), 5_000);
+    forceCloseTimer.unref();
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+}
+
+async function main() {
+  const options = parseCliArguments(process.argv.slice(2));
+  const server = await createStaticPreviewServer({
+    apiTarget: options.apiTarget,
+  });
+  await listen(server, options.host, options.port);
+  installTerminationHandlers(server);
+  process.stdout.write(
+    `[static-preview] listening on http://${options.host}:${options.port} (API proxy ${
+      options.apiTarget ? 'enabled' : 'disabled/fail-closed'
+    })\n`,
+  );
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : null;
+if (invokedPath === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`[static-preview] ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/scripts/static-preview.test.mjs
+++ b/apps/web/scripts/static-preview.test.mjs
@@ -1,0 +1,351 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import {
+  createServer as createHttpServer,
+  request as httpRequest,
+} from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+
+import {
+  UnsafeRequestTargetError,
+  classifyRoute,
+  createStaticPreviewServer,
+  parseApiTarget,
+  parseCliArguments,
+  parseRequestTarget,
+  resolveStaticPath,
+  safeProxyHeaders,
+} from './static-preview.mjs';
+
+const FALLBACK_HTML = '<!doctype html><title>ED-Finder fallback</title>';
+
+async function listen(server) {
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise);
+    server.listen(0, '127.0.0.1', resolvePromise);
+  });
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server) {
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.close((error) => (error ? rejectPromise(error) : resolvePromise()));
+    server.closeIdleConnections();
+  });
+}
+
+function rawRequest(origin, path, options = {}) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const url = new URL(origin);
+    const request = httpRequest(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        method: options.method ?? 'GET',
+        path,
+        headers: options.headers,
+      },
+      (response) => {
+        const chunks = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => {
+          resolvePromise({
+            body: Buffer.concat(chunks).toString('utf8'),
+            headers: response.headers,
+            status: response.statusCode,
+          });
+        });
+      },
+    );
+    request.on('error', rejectPromise);
+    if (options.body) request.write(options.body);
+    request.end();
+  });
+}
+
+describe('static preview route ownership', () => {
+  test('classifies only exact backend-owned path shapes', () => {
+    const backendTargets = [
+      '/api',
+      '/api?fresh=1',
+      '/api/',
+      '/api/health?fresh=1',
+      '/openapi.json',
+      '/openapi.json?format=json',
+      '/s/0?utm=x',
+      '/s/18446744073709551615',
+    ];
+    const frontendTargets = [
+      '/',
+      '/apiary',
+      '/openapi.jsonx',
+      '/openapi.json/extra',
+      '/s/not-a-number',
+      '/s/1/extra',
+      '/s/1x',
+      '/system/18446744073709551615',
+      '/colony-planner/system/1/project/a',
+    ];
+
+    for (const target of backendTargets) {
+      const parsed = parseRequestTarget(target);
+      assert.equal(classifyRoute(parsed.rawPathname), 'backend', target);
+    }
+    for (const target of frontendTargets) {
+      const parsed = parseRequestTarget(target);
+      assert.equal(classifyRoute(parsed.rawPathname), 'frontend', target);
+    }
+    assert.equal(classifyRoute('/api%2fhealth'), 'frontend');
+  });
+
+  test('keeps the query out of static path resolution', () => {
+    const root = resolve('/tmp/ed-finder-static-root');
+    const parsed = parseRequestTarget(
+      '/assets/app.js?file=../../package.json&route=/api/health',
+    );
+
+    assert.equal(parsed.pathname, '/assets/app.js');
+    assert.equal(
+      resolveStaticPath(root, parsed.pathname),
+      join(root, 'assets', 'app.js'),
+    );
+    assert.equal(parsed.search, '?file=../../package.json&route=/api/health');
+  });
+
+  test('rejects malformed, null, backslash, and traversal paths', () => {
+    const unsafeTargets = [
+      '/bad%',
+      '/bad%E0%A4%A',
+      '/bad%00path',
+      '/bad\\path',
+      '/bad%5cpath',
+      '/../package.json',
+      '/safe/./asset.js',
+      '/%2e%2e/package.json',
+      '/safe%2f..%2f..%2fpackage.json',
+      '/safe?bad=%',
+    ];
+
+    for (const target of unsafeTargets) {
+      assert.throws(
+        () => parseRequestTarget(target),
+        UnsafeRequestTargetError,
+        target,
+      );
+    }
+  });
+
+  test('never resolves a decoded path outside the static root', () => {
+    const root = resolve('/tmp/ed-finder-static-root');
+    assert.equal(resolveStaticPath(root, '/'), root);
+    assert.equal(
+      resolveStaticPath(root, '/_app/immutable/app.js'),
+      join(root, '_app', 'immutable', 'app.js'),
+    );
+    assert.throws(
+      () => resolveStaticPath(root, '/../package.json'),
+      UnsafeRequestTargetError,
+    );
+    assert.throws(
+      () => resolveStaticPath(root, '/bad\\package.json'),
+      UnsafeRequestTargetError,
+    );
+  });
+});
+
+describe('static preview configuration', () => {
+  test('accepts the existing preview CLI shape and an explicit target', () => {
+    assert.deepEqual(
+      parseCliArguments(
+        ['--host', '127.0.0.1', '--port', '4174', '--strictPort'],
+        { ED_FINDER_PREVIEW_API_TARGET: 'http://127.0.0.1:8002' },
+      ),
+      {
+        apiTarget: 'http://127.0.0.1:8002',
+        host: '127.0.0.1',
+        port: 4174,
+      },
+    );
+  });
+
+  test('allows no target but rejects credentials and non-loopback hosts', () => {
+    const credentialTarget = new URL('http://127.0.0.1:8002');
+    credentialTarget.username = 'preview-user';
+    credentialTarget.password = 'disposable-placeholder';
+
+    assert.equal(parseApiTarget(undefined), null);
+    assert.equal(parseApiTarget('http://127.0.0.1:8002').port, '8002');
+    assert.throws(() => parseApiTarget(credentialTarget.href));
+    assert.throws(() => parseApiTarget('https://example.com'));
+    assert.throws(() => parseApiTarget('http://127.0.0.1:8002/api'));
+  });
+
+  test('removes hop-by-hop and spoofable forwarding headers', () => {
+    assert.deepEqual(
+      safeProxyHeaders(
+        {
+          authorization: 'Bearer disposable-test-token',
+          connection: 'keep-alive, x-remove-me',
+          host: 'preview.invalid',
+          'x-forwarded-for': '203.0.113.10',
+          'x-keep-me': 'yes',
+          'x-remove-me': 'no',
+        },
+        { request: true },
+      ),
+      {
+        authorization: 'Bearer disposable-test-token',
+        'x-keep-me': 'yes',
+      },
+    );
+  });
+});
+
+describe('static preview HTTP contract', () => {
+  let buildRoot;
+  let previewOrigin;
+  let previewServer;
+
+  before(async () => {
+    buildRoot = await mkdtemp(join(tmpdir(), 'ed-finder-static-preview-'));
+    await mkdir(join(buildRoot, 'assets'));
+    await writeFile(join(buildRoot, '200.html'), FALLBACK_HTML);
+    await writeFile(
+      join(buildRoot, 'index.html'),
+      '<!doctype html><title>index</title>',
+    );
+    await writeFile(
+      join(buildRoot, 'assets', 'app.css'),
+      'body { color: red; }',
+    );
+    previewServer = await createStaticPreviewServer({ buildRoot });
+    previewOrigin = await listen(previewServer);
+  });
+
+  after(async () => {
+    if (previewServer) await close(previewServer);
+    if (buildRoot) await rm(buildRoot, { recursive: true, force: true });
+  });
+
+  test('serves exact static files with their content type and ignores queries', async () => {
+    const response = await fetch(
+      `${previewOrigin}/assets/app.css?file=../../package.json`,
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get('content-type'), /^text\/css/u);
+    assert.equal(await response.text(), 'body { color: red; }');
+  });
+
+  test('serves unknown frontend routes from 200.html for GET and HEAD', async () => {
+    const getResponse = await fetch(
+      `${previewOrigin}/system/18446744073709551615`,
+    );
+    assert.equal(getResponse.status, 200);
+    assert.match(getResponse.headers.get('content-type'), /^text\/html/u);
+    assert.equal(await getResponse.text(), FALLBACK_HTML);
+
+    const headResponse = await fetch(`${previewOrigin}/apiary`, {
+      method: 'HEAD',
+    });
+    assert.equal(headResponse.status, 200);
+    assert.match(headResponse.headers.get('content-type'), /^text\/html/u);
+    assert.equal(
+      headResponse.headers.get('content-length'),
+      String(Buffer.byteLength(FALLBACK_HTML)),
+    );
+    assert.equal(await headResponse.text(), '');
+  });
+
+  test('fails closed for backend routes without an explicit target', async () => {
+    const response = await fetch(`${previewOrigin}/api/health`);
+    assert.equal(response.status, 503);
+    assert.match(response.headers.get('content-type'), /^text\/plain/u);
+    assert.doesNotMatch(await response.text(), /ED-Finder fallback/u);
+  });
+
+  test('rejects traversal-like request bytes without exposing repository files', async () => {
+    for (const path of [
+      '/bad%E0%A4%A',
+      '/bad%00path',
+      '/%5c..%5cpackage.json',
+      '/safe%2f..%2f..%2fpackage.json',
+    ]) {
+      const response = await rawRequest(previewOrigin, path);
+      assert.equal(response.status, 400, path);
+      assert.equal(response.body, 'Bad request path\n', path);
+      assert.doesNotMatch(
+        response.body,
+        /@ed-finder\/web|ED-Finder Agent Contract/u,
+      );
+    }
+  });
+});
+
+describe('static preview streaming proxy', () => {
+  let apiOrigin;
+  let apiServer;
+  let buildRoot;
+  let previewOrigin;
+  let previewServer;
+
+  before(async () => {
+    buildRoot = await mkdtemp(join(tmpdir(), 'ed-finder-static-proxy-'));
+    await writeFile(join(buildRoot, '200.html'), FALLBACK_HTML);
+
+    apiServer = createHttpServer((request, response) => {
+      response.writeHead(201, {
+        'Content-Type': 'application/octet-stream',
+        'X-Observed-Authorization': request.headers.authorization ?? 'missing',
+        'X-Observed-Forwarded-For':
+          request.headers['x-forwarded-for'] ?? 'missing',
+        'X-Observed-Host': request.headers.host ?? 'missing',
+        'X-Observed-Path': request.url,
+      });
+      request.pipe(response);
+    });
+    apiOrigin = await listen(apiServer);
+    previewServer = await createStaticPreviewServer({
+      apiTarget: apiOrigin,
+      buildRoot,
+    });
+    previewOrigin = await listen(previewServer);
+  });
+
+  after(async () => {
+    if (previewServer) await close(previewServer);
+    if (apiServer) await close(apiServer);
+    if (buildRoot) await rm(buildRoot, { recursive: true, force: true });
+  });
+
+  test('streams request and response bodies while preserving the raw query', async () => {
+    const payload = 'streamed request body';
+    const response = await fetch(`${previewOrigin}/api/echo?format=raw`, {
+      method: 'POST',
+      body: payload,
+      headers: {
+        Authorization: 'Bearer disposable-test-token',
+        'X-Forwarded-For': '203.0.113.10',
+      },
+    });
+
+    assert.equal(response.status, 201);
+    assert.equal(
+      response.headers.get('x-observed-path'),
+      '/api/echo?format=raw',
+    );
+    assert.equal(
+      response.headers.get('x-observed-authorization'),
+      'Bearer disposable-test-token',
+    );
+    assert.equal(response.headers.get('x-observed-forwarded-for'), 'missing');
+    assert.equal(
+      response.headers.get('x-observed-host'),
+      new URL(apiOrigin).host,
+    );
+    assert.equal(await response.text(), payload);
+  });
+});

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -23,6 +23,84 @@ body {
     radial-gradient(circle at 80% 0%, #162336 0, transparent 38rem),
     var(--color-void);
 }
+.skip-link {
+  position: fixed;
+  left: 1rem;
+  top: -5rem;
+  z-index: 100;
+  background: white;
+  color: #080b12;
+  padding: 0.75rem;
+}
+.skip-link:focus {
+  top: 1rem;
+}
+.account {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #aeb9c6;
+}
+button {
+  font: inherit;
+  color: inherit;
+  border: 1px solid #465268;
+  background: #182130;
+  padding: 0.5rem 0.8rem;
+  cursor: pointer;
+}
+button:focus-visible,
+a:focus-visible {
+  outline: 2px solid var(--color-cyan);
+  outline-offset: 2px;
+}
+.context-chip {
+  width: min(72rem, calc(100% - 2rem));
+  margin: 1rem auto;
+  padding: 0.75rem 1rem;
+  border: 1px solid #39465a;
+  background: #111722;
+  display: flex;
+  gap: 1rem;
+}
+.panel {
+  border: 1px solid #39465a;
+  background: var(--color-panel);
+  padding: 1.5rem;
+}
+.gate {
+  max-width: 42rem;
+  margin-inline: auto;
+}
+.gate form {
+  display: grid;
+  gap: 0.75rem;
+  margin-block: 1rem;
+}
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgb(0 0 0 / 75%);
+}
+.dialog {
+  position: relative;
+  width: min(46rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+}
+.dialog h1 {
+  font-size: clamp(2rem, 6vw, 4rem);
+}
+.dialog-close {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  font-size: 1.5rem;
+}
 a {
   color: inherit;
 }

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -58,6 +58,69 @@ describe('bootstrap API client', () => {
     });
   });
 
+  it('normalises generated JSON, text, and empty response failures', async () => {
+    mockedGetHealth.mockRejectedValueOnce({
+      response: new Response(
+        '{"detail":"No health","system_id64":18446744073709551615}',
+        {
+          status: 403,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    });
+    await expect(getHealth()).rejects.toMatchObject({
+      status: 403,
+      path: '/api/health',
+      body: { detail: 'No health', system_id64: '18446744073709551615' },
+      message: 'No health',
+    });
+
+    mockedGetHealth.mockRejectedValueOnce({
+      response: new Response('gateway down', { status: 502 }),
+    });
+    await expect(getHealth()).rejects.toMatchObject({
+      status: 502,
+      body: 'gateway down',
+      message: 'gateway down',
+    });
+
+    mockedGetHealth.mockRejectedValueOnce(
+      new Response(null, { status: 503, statusText: 'Unavailable' }),
+    );
+    await expect(getHealth()).rejects.toMatchObject({
+      status: 503,
+      body: '',
+      message: 'Unavailable',
+    });
+  });
+
+  it('normalises generated network Errors and object failures with causes', async () => {
+    const network = new Error('socket closed');
+    mockedGetHealth.mockRejectedValueOnce(network);
+    const networkFailure = await getHealth().catch((error: unknown) => error);
+    expect(networkFailure).toBeInstanceOf(ApiError);
+    expect(networkFailure).toMatchObject({
+      status: 0,
+      path: '/api/health',
+      body: '',
+      message: 'socket closed',
+      cause: network,
+    });
+
+    const objectFailure = {
+      status: 429,
+      error: { detail: 'bounded' },
+      message: 'Rate limited',
+    };
+    mockedGetHealth.mockRejectedValueOnce(objectFailure);
+    await expect(getHealth()).rejects.toMatchObject({
+      status: 429,
+      body: { detail: 'bounded' },
+      message: 'Rate limited',
+      cause: objectFailure,
+    });
+  });
+
   it('deduplicates /api and rejects cross-origin base URLs', () => {
     expect(canonicalApiPath('/health')).toBe('/api/health');
     expect(canonicalApiPath('/api/health')).toBe('/api/health');
@@ -130,9 +193,6 @@ describe('bootstrap API client', () => {
     );
     mockedGetHealth.mockRejectedValue(aborted);
 
-    await expect(getHealth()).rejects.toMatchObject({
-      message: 'This operation was aborted',
-      name: 'AbortError',
-    });
+    await expect(getHealth()).rejects.toBe(aborted);
   });
 });

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -4,10 +4,12 @@ import {
   healthApiHealthGet as generatedGetHealth,
 } from './generated/sdk.gen';
 import {
+  ADMIN_TOKEN_SESSION_KEY,
   ApiError,
   adminEndpointClass,
   apiRequest,
   canonicalApiPath,
+  claimOwner,
   getAuthSession,
   getHealth,
 } from './client';
@@ -21,7 +23,12 @@ const mockedGetHealth = vi.mocked(generatedGetHealth);
 const mockedGetAuthSession = vi.mocked(generatedGetAuthSession);
 
 describe('bootstrap API client', () => {
-  beforeEach(() => vi.resetAllMocks());
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
 
   it('calls the generated health SDK with same-origin credentials and cancellation', async () => {
     const health = {
@@ -124,13 +131,20 @@ describe('bootstrap API client', () => {
   it('deduplicates /api and rejects cross-origin base URLs', () => {
     expect(canonicalApiPath('/health')).toBe('/api/health');
     expect(canonicalApiPath('/api/health')).toBe('/api/health');
+    expect(canonicalApiPath('/api?probe=1')).toBe('/api?probe=1');
+    expect(canonicalApiPath('/api/admin/../auth/session')).toBe(
+      '/api/auth/session',
+    );
     expect(() => canonicalApiPath('https://example.test/api/health')).toThrow(
       'same-origin',
+    );
+    expect(() => canonicalApiPath('/admin/../../outside')).toThrow(
+      'stay under /api',
     );
   });
 
   it('limits admin tokens to the explicit endpoint policy', async () => {
-    sessionStorage.setItem('ed_admin_token', ' token-123 ');
+    sessionStorage.setItem(ADMIN_TOKEN_SESSION_KEY, ' token-123 ');
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
       async () =>
         new Response('{}', {
@@ -139,20 +153,87 @@ describe('bootstrap API client', () => {
         }),
     );
     await apiRequest('/admin/data-status');
+    await apiRequest('/operator/source-runs');
+    await apiRequest('/status');
+    await apiRequest('/cache/clear', { method: 'POST' });
+    await apiRequest('/enrichment/station-status');
+    await apiRequest('/observations/facts', { method: 'POST' });
+    await apiRequest('/observations/facts/observation-1', { method: 'PATCH' });
+    await apiRequest('/observations/facts/observation-1', {
+      method: 'DELETE',
+    });
+    await apiRequest('/observations/facts', {
+      headers: { 'X-Admin-Token': 'must-not-leak' },
+    });
     await apiRequest('/auth/session', {
       headers: { 'X-Admin-Token': 'must-not-leak' },
     });
+    await apiRequest('/observations/facts-export', {
+      method: 'POST',
+      headers: { 'X-Admin-Token': 'must-not-leak' },
+    });
+    await apiRequest('/admin/%2e%2e/auth/session');
+    await apiRequest('/observations/facts/../compare', { method: 'POST' });
+    await apiRequest('/operator/..\\auth/session');
+
+    for (const call of fetchMock.mock.calls.slice(0, 8))
+      expect(new Headers(call[1]?.headers).get('X-Admin-Token')).toBe(
+        'token-123',
+      );
+    for (const call of fetchMock.mock.calls.slice(8))
+      expect(new Headers(call[1]?.headers).has('X-Admin-Token')).toBe(false);
     expect(
-      new Headers(fetchMock.mock.calls[0][1]?.headers).get('X-Admin-Token'),
-    ).toBe('token-123');
-    expect(
-      new Headers(fetchMock.mock.calls[1][1]?.headers).has('X-Admin-Token'),
-    ).toBe(false);
+      fetchMock.mock.calls.every((call) => call[1]?.credentials === 'include'),
+    ).toBe(true);
     expect(adminEndpointClass('/api/operator/source-runs')).toBe('operator');
     expect(adminEndpointClass('/observations/facts', 'POST')).toBe('operator');
     expect(adminEndpointClass('/observations/facts', 'GET')).toBeNull();
+    expect(adminEndpointClass('/observations/facts-export', 'POST')).toBeNull();
+    expect(adminEndpointClass('/admin/../auth/session')).toBeNull();
+    expect(
+      adminEndpointClass('/observations/facts/../compare', 'POST'),
+    ).toBeNull();
     expect(adminEndpointClass('/api/static/app.js')).toBeNull();
-    fetchMock.mockRestore();
+    expect(fetchMock.mock.calls[11][0]).toBe('/api/auth/session');
+    expect(fetchMock.mock.calls[12][0]).toBe('/api/observations/compare');
+    expect(fetchMock.mock.calls[13][0]).toBe('/api/auth/session');
+  });
+
+  it('does not preserve a caller-supplied header when no session token exists', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    await apiRequest('/admin/data-status', {
+      headers: { 'X-Admin-Token': 'caller-supplied' },
+    });
+
+    expect(
+      new Headers(fetchMock.mock.calls[0][1]?.headers).has('X-Admin-Token'),
+    ).toBe(false);
+  });
+
+  it('submits owner-claim credentials only in the JSON body', async () => {
+    sessionStorage.setItem(ADMIN_TOKEN_SESSION_KEY, 'prior-token');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    await claimOwner('new-owner-token');
+
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe('/api/auth/owner/claim');
+    expect(String(path)).not.toContain('new-owner-token');
+    expect(JSON.parse(String(init?.body))).toEqual({
+      admin_token: 'new-owner-token',
+    });
+    expect(new Headers(init?.headers).has('X-Admin-Token')).toBe(false);
   });
 
   it('preserves structured, text, and empty error responses', async () => {

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -3,7 +3,14 @@ import {
   authSessionApiAuthSessionGet as generatedGetAuthSession,
   healthApiHealthGet as generatedGetHealth,
 } from './generated/sdk.gen';
-import { getAuthSession, getHealth } from './client';
+import {
+  ApiError,
+  adminEndpointClass,
+  apiRequest,
+  canonicalApiPath,
+  getAuthSession,
+  getHealth,
+} from './client';
 
 vi.mock('./generated/sdk.gen', () => ({
   authSessionApiAuthSessionGet: vi.fn(),
@@ -34,7 +41,7 @@ describe('bootstrap API client', () => {
 
     await expect(getHealth(controller.signal)).resolves.toEqual(health);
     expect(mockedGetHealth).toHaveBeenCalledWith({
-      credentials: 'same-origin',
+      credentials: 'include',
       signal: controller.signal,
       throwOnError: true,
     });
@@ -45,10 +52,75 @@ describe('bootstrap API client', () => {
 
     await expect(getAuthSession()).rejects.toThrow('Session unavailable');
     expect(mockedGetAuthSession).toHaveBeenCalledWith({
-      credentials: 'same-origin',
+      credentials: 'include',
       signal: undefined,
       throwOnError: true,
     });
+  });
+
+  it('deduplicates /api and rejects cross-origin base URLs', () => {
+    expect(canonicalApiPath('/health')).toBe('/api/health');
+    expect(canonicalApiPath('/api/health')).toBe('/api/health');
+    expect(() => canonicalApiPath('https://example.test/api/health')).toThrow(
+      'same-origin',
+    );
+  });
+
+  it('limits admin tokens to the explicit endpoint policy', async () => {
+    sessionStorage.setItem('ed_admin_token', ' token-123 ');
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        new Response('{}', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    await apiRequest('/admin/data-status');
+    await apiRequest('/auth/session', {
+      headers: { 'X-Admin-Token': 'must-not-leak' },
+    });
+    expect(
+      new Headers(fetchMock.mock.calls[0][1]?.headers).get('X-Admin-Token'),
+    ).toBe('token-123');
+    expect(
+      new Headers(fetchMock.mock.calls[1][1]?.headers).has('X-Admin-Token'),
+    ).toBe(false);
+    expect(adminEndpointClass('/api/operator/source-runs')).toBe('operator');
+    expect(adminEndpointClass('/observations/facts', 'POST')).toBe('operator');
+    expect(adminEndpointClass('/observations/facts', 'GET')).toBeNull();
+    expect(adminEndpointClass('/api/static/app.js')).toBeNull();
+    fetchMock.mockRestore();
+  });
+
+  it('preserves structured, text, and empty error responses', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('{"detail":"No access","system_id64":9007199254740993}', {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const error = await apiRequest('/system/9007199254740993').catch(
+      (value: unknown) => value,
+    );
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      status: 403,
+      path: '/api/system/9007199254740993',
+      body: { detail: 'No access', system_id64: '9007199254740993' },
+      message: 'No access',
+    });
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('gateway down', { status: 502 }),
+    );
+    await expect(apiRequest('/health')).rejects.toMatchObject({
+      body: 'gateway down',
+    });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(null, { status: 500 }),
+    );
+    await expect(apiRequest('/health')).rejects.toMatchObject({ body: '' });
+    vi.restoreAllMocks();
   });
 
   it('preserves abort failure identity when normalising cross-realm errors', async () => {

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,51 +1,243 @@
-/** Stable application-facing bootstrap API backed by the generated Hey API SDK. */
+/** Application-facing API facade. Generated declarations stay behind this module. */
 import {
   authSessionApiAuthSessionGet as generatedGetAuthSession,
   healthApiHealthGet as generatedGetHealth,
 } from './generated/sdk.gen';
 import type { AuthSessionResponse, HealthResponse } from './generated';
+import type { Id64 } from '$lib/domain/id64';
+import { parseId64 } from '$lib/domain/id64';
+import { parseLosslessJson } from './lossless-json';
 
-const requestOptions = (signal?: AbortSignal) => ({
-  credentials: 'same-origin' as const,
+export const ADMIN_TOKEN_SESSION_KEY = 'ed_admin_token';
+const generatedOptions = (signal?: AbortSignal) => ({
+  credentials: 'include' as const,
   signal,
   throwOnError: true as const,
 });
 
-function normaliseFailure(error: unknown): Error {
-  if (error instanceof Error) return error;
-  if (typeof error === 'string' && error.trim()) return new Error(error);
-  if (error && typeof error === 'object' && 'message' in error) {
-    const message = error.message;
-    if (typeof message === 'string' && message.trim()) {
-      const normalised = new Error(message);
-      if ('name' in error && typeof error.name === 'string')
-        normalised.name = error.name;
-      return normalised;
-    }
-  }
-  if (error && typeof error === 'object' && 'detail' in error) {
-    const detail = error.detail;
-    if (typeof detail === 'string' && detail.trim()) return new Error(detail);
-  }
-  return new Error('Bootstrap API request failed');
+export function canonicalApiPath(path: string): string {
+  if (/^https?:\/\//i.test(path))
+    throw new TypeError('API paths must be same-origin');
+  const rooted = path.startsWith('/') ? path : `/${path}`;
+  return rooted === '/api' || rooted.startsWith('/api/')
+    ? rooted
+    : `/api${rooted}`;
 }
 
-async function runRequest<T>(request: () => Promise<T>): Promise<T> {
+export type AdminEndpointClass =
+  'admin' | 'operator' | 'owner-maintenance' | null;
+export function adminEndpointClass(
+  path: string,
+  method = 'GET',
+): AdminEndpointClass {
+  const canonical = canonicalApiPath(path).split(/[?#]/, 1)[0];
+  if (canonical.startsWith('/api/admin/')) return 'admin';
+  if (canonical.startsWith('/api/operator/')) return 'operator';
+  if (
+    canonical === '/api/status' ||
+    canonical.startsWith('/api/cache/') ||
+    canonical.startsWith('/api/enrichment/')
+  )
+    return 'owner-maintenance';
+  if (
+    canonical.startsWith('/api/observations/facts') &&
+    ['POST', 'PATCH', 'DELETE'].includes(method.toUpperCase())
+  )
+    return 'operator';
+  return null;
+}
+
+function sessionAdminToken(): string {
+  if (typeof window === 'undefined') return '';
   try {
-    return await request();
-  } catch (error) {
-    throw normaliseFailure(error);
+    return window.sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)?.trim() ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string,
+    public readonly body: unknown,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'ApiError';
+  }
+}
+
+function usefulMessage(
+  status: number,
+  path: string,
+  body: unknown,
+  statusText: string,
+): string {
+  let detail = '';
+  if (typeof body === 'string') detail = body;
+  else if (body && typeof body === 'object') {
+    const candidate =
+      (body as { detail?: unknown; message?: unknown }).detail ??
+      (body as { message?: unknown }).message;
+    if (typeof candidate === 'string') detail = candidate;
+  }
+  return (
+    detail.trim() ||
+    statusText.trim() ||
+    `API request failed (${status}) on ${path}`
+  );
+}
+
+async function readResponse(
+  response: Response,
+  path: string,
+): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return '';
+  if (
+    !(response.headers.get('content-type') ?? '').toLowerCase().includes('json')
+  )
+    return text;
+  try {
+    return parseLosslessJson(text);
+  } catch (cause) {
+    throw new ApiError(
+      response.status,
+      path,
+      text,
+      'API returned invalid JSON',
+      { cause },
+    );
+  }
+}
+
+export async function apiRequest<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const canonicalPath = canonicalApiPath(path);
+  const headers = new Headers(init.headers);
+  if (!headers.has('Accept')) headers.set('Accept', 'application/json');
+  if (init.body != null && !headers.has('Content-Type'))
+    headers.set('Content-Type', 'application/json');
+  if (adminEndpointClass(canonicalPath, init.method ?? 'GET')) {
+    const token = sessionAdminToken();
+    if (token) headers.set('X-Admin-Token', token);
+  } else headers.delete('X-Admin-Token');
+  let response: Response;
+  try {
+    response = await fetch(canonicalPath, {
+      ...init,
+      credentials: 'include',
+      headers,
+    });
+  } catch (cause) {
+    throw new ApiError(
+      0,
+      canonicalPath,
+      '',
+      `Network request failed on ${canonicalPath}`,
+      { cause },
+    );
+  }
+  const body = await readResponse(response, canonicalPath);
+  if (!response.ok)
+    throw new ApiError(
+      response.status,
+      canonicalPath,
+      body,
+      usefulMessage(response.status, canonicalPath, body, response.statusText),
+    );
+  return body as T;
+}
+
+async function runGenerated<T>(
+  path: string,
+  request: () => Promise<{ data: T }>,
+): Promise<T> {
+  try {
+    return (await request()).data;
+  } catch (cause) {
+    if (cause instanceof ApiError) throw cause;
+    if (cause instanceof Error) throw cause;
+    const candidate = cause as {
+      status?: unknown;
+      error?: unknown;
+      message?: unknown;
+      detail?: unknown;
+      name?: unknown;
+    } | null;
+    if (
+      candidate?.name === 'AbortError' &&
+      typeof candidate.message === 'string'
+    ) {
+      const aborted = new Error(candidate.message);
+      aborted.name = 'AbortError';
+      throw aborted;
+    }
+    const detail = candidate?.detail ?? candidate?.error;
+    const message =
+      typeof candidate?.message === 'string'
+        ? candidate.message
+        : typeof candidate?.detail === 'string'
+          ? candidate.detail
+          : 'API request failed';
+    throw new ApiError(
+      typeof candidate?.status === 'number' ? candidate.status : 0,
+      path,
+      detail ?? '',
+      message,
+      { cause },
+    );
   }
 }
 
 export const getHealth = (signal?: AbortSignal): Promise<HealthResponse> =>
-  runRequest(
-    async () => (await generatedGetHealth(requestOptions(signal))).data,
+  runGenerated('/api/health', () =>
+    generatedGetHealth(generatedOptions(signal)),
   );
-
 export const getAuthSession = (
   signal?: AbortSignal,
 ): Promise<AuthSessionResponse> =>
-  runRequest(
-    async () => (await generatedGetAuthSession(requestOptions(signal))).data,
+  runGenerated('/api/auth/session', () =>
+    generatedGetAuthSession(generatedOptions(signal)),
   );
+
+export async function getSystem<T extends Record<string, unknown>>(
+  id64: Id64,
+): Promise<T> {
+  const response = await apiRequest<{ record?: T; system: T }>(
+    `/system/${parseId64(id64)}`,
+  );
+  return response.record ?? response.system;
+}
+
+export function optimiserCandidates<
+  TResponse,
+  TRequest extends Record<string, unknown>,
+>(request: TRequest): Promise<TResponse> {
+  return apiRequest('/optimiser/candidates', {
+    method: 'POST',
+    body: JSON.stringify({
+      max_candidates: 5,
+      allow_estimated_data: true,
+      run_preview: true,
+      include_ranking: true,
+      ...request,
+    }),
+  });
+}
+
+export const authLogout = <T = AuthSessionResponse>(): Promise<T> =>
+  apiRequest('/auth/logout', { method: 'POST' });
+export const claimOwner = <T = AuthSessionResponse>(
+  adminToken: string,
+): Promise<T> =>
+  apiRequest('/auth/owner/claim', {
+    method: 'POST',
+    body: JSON.stringify({ admin_token: adminToken }),
+  });
+export const frontierLoginUrl = (returnTo: string): string =>
+  `/api/auth/frontier/login?return_to=${encodeURIComponent(returnTo)}`;

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -161,23 +161,35 @@ async function runGenerated<T>(
     return (await request()).data;
   } catch (cause) {
     if (cause instanceof ApiError) throw cause;
-    if (cause instanceof Error) throw cause;
     const candidate = cause as {
       status?: unknown;
       error?: unknown;
       message?: unknown;
       detail?: unknown;
       name?: unknown;
+      response?: unknown;
+      body?: unknown;
     } | null;
-    if (
-      candidate?.name === 'AbortError' &&
-      typeof candidate.message === 'string'
-    ) {
-      const aborted = new Error(candidate.message);
-      aborted.name = 'AbortError';
-      throw aborted;
+    if (candidate?.name === 'AbortError') throw cause;
+
+    const response =
+      cause instanceof Response
+        ? cause
+        : candidate?.response instanceof Response
+          ? candidate.response
+          : null;
+    if (response) {
+      const body = await readResponse(response, path);
+      throw new ApiError(
+        response.status,
+        path,
+        body,
+        usefulMessage(response.status, path, body, response.statusText),
+        { cause },
+      );
     }
-    const detail = candidate?.detail ?? candidate?.error;
+
+    const detail = candidate?.body ?? candidate?.detail ?? candidate?.error;
     const message =
       typeof candidate?.message === 'string'
         ? candidate.message

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -19,9 +19,18 @@ export function canonicalApiPath(path: string): string {
   if (/^https?:\/\//i.test(path))
     throw new TypeError('API paths must be same-origin');
   const rooted = path.startsWith('/') ? path : `/${path}`;
-  return rooted === '/api' || rooted.startsWith('/api/')
-    ? rooted
-    : `/api${rooted}`;
+  const rootedPath = rooted.split(/[?#]/, 1)[0];
+  const apiPath =
+    rootedPath === '/api' || rootedPath.startsWith('/api/')
+      ? rooted
+      : `/api${rooted}`;
+  const normalised = new URL(apiPath, 'http://ed-finder.invalid');
+  if (
+    normalised.pathname !== '/api' &&
+    !normalised.pathname.startsWith('/api/')
+  )
+    throw new TypeError('API paths must stay under /api');
+  return `${normalised.pathname}${normalised.search}${normalised.hash}`;
 }
 
 export type AdminEndpointClass =
@@ -40,7 +49,8 @@ export function adminEndpointClass(
   )
     return 'owner-maintenance';
   if (
-    canonical.startsWith('/api/observations/facts') &&
+    (canonical === '/api/observations/facts' ||
+      canonical.startsWith('/api/observations/facts/')) &&
     ['POST', 'PATCH', 'DELETE'].includes(method.toUpperCase())
   )
     return 'operator';
@@ -122,10 +132,11 @@ export async function apiRequest<T>(
   if (!headers.has('Accept')) headers.set('Accept', 'application/json');
   if (init.body != null && !headers.has('Content-Type'))
     headers.set('Content-Type', 'application/json');
+  headers.delete('X-Admin-Token');
   if (adminEndpointClass(canonicalPath, init.method ?? 'GET')) {
     const token = sessionAdminToken();
     if (token) headers.set('X-Admin-Token', token);
-  } else headers.delete('X-Admin-Token');
+  }
   let response: Response;
   try {
     response = await fetch(canonicalPath, {

--- a/apps/web/src/lib/api/events.test.ts
+++ b/apps/web/src/lib/api/events.test.ts
@@ -1,38 +1,103 @@
 import { describe, expect, it, vi } from 'vitest';
-import { LIVE_EVENTS_PATH, openLiveEventStream } from './events';
+import {
+  LIVE_EVENTS_PATH,
+  openLiveEventStream,
+  type EventStreamStatus,
+} from './events';
+
+function fakeEventSource() {
+  const instance = {
+    url: '',
+    init: undefined as EventSourceInit | undefined,
+    onopen: null as ((event: Event) => void) | null,
+    onmessage: null as ((event: MessageEvent) => void) | null,
+    onerror: null as ((event: Event) => void) | null,
+    close: vi.fn(),
+  };
+  const EventSourceClass = vi.fn(function (
+    url: string,
+    init?: EventSourceInit,
+  ) {
+    instance.url = url;
+    instance.init = init;
+    return instance;
+  });
+  return {
+    instance,
+    EventSourceClass: EventSourceClass as unknown as typeof EventSource,
+  };
+}
 
 describe('SSE contract', () => {
-  it('uses credentialed EventSource and parses oversized ids losslessly', () => {
+  it('uses credentialed EventSource, reports state, and parses oversized ids losslessly', () => {
     const received = vi.fn();
-    const instance = {
-      url: '',
-      init: undefined as EventSourceInit | undefined,
-      onopen: null as ((event: Event) => void) | null,
-      onmessage: null as ((event: MessageEvent) => void) | null,
-      onerror: null as ((event: Event) => void) | null,
-      close: vi.fn(),
-    };
-    const FakeEventSource = vi.fn(function (
-      url: string,
-      init?: EventSourceInit,
-    ) {
-      instance.url = url;
-      instance.init = init;
-      return instance;
-    });
+    const statuses: EventStreamStatus[] = [];
+    const disconnected = vi.fn();
+    const { instance, EventSourceClass } = fakeEventSource();
+
     const stream = openLiveEventStream({
       onEvent: received,
-      eventSource: FakeEventSource as unknown as typeof EventSource,
+      onDisconnected: disconnected,
+      onStatusChange: (status) => statuses.push(status),
+      eventSource: EventSourceClass,
     });
+
     expect(instance).toMatchObject({
       url: LIVE_EVENTS_PATH,
       init: { withCredentials: true },
     });
+    expect(statuses).toEqual(['connecting']);
+
+    instance.onopen?.(new Event('open'));
     instance.onmessage?.(
       new MessageEvent('message', { data: '{"id64":18446744073709551615}' }),
     );
+    instance.onerror?.(new Event('error'));
+
     expect(received).toHaveBeenCalledWith({ id64: '18446744073709551615' });
+    expect(disconnected).toHaveBeenCalledOnce();
+    expect(statuses).toEqual(['connecting', 'open', 'reconnecting']);
+
     stream.close();
-    expect(instance.close).toHaveBeenCalled();
+    stream.close();
+    expect(instance.close).toHaveBeenCalledOnce();
+    expect(statuses).toEqual([
+      'connecting',
+      'open',
+      'reconnecting',
+      'closed',
+    ]);
+  });
+
+  it('reports and ignores malformed frames without terminating the stream', () => {
+    const received = vi.fn();
+    const parseError = vi.fn();
+    const { instance, EventSourceClass } = fakeEventSource();
+
+    const stream = openLiveEventStream({
+      onEvent: received,
+      onParseError: parseError,
+      eventSource: EventSourceClass,
+    });
+
+    expect(() =>
+      instance.onmessage?.(
+        new MessageEvent('message', { data: '{not-valid-json' }),
+      ),
+    ).not.toThrow();
+    expect(received).not.toHaveBeenCalled();
+    expect(parseError).toHaveBeenCalledOnce();
+    expect(parseError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+
+    instance.onmessage?.(
+      new MessageEvent('message', { data: '{"id64":9007199254740993}' }),
+    );
+    expect(received).toHaveBeenCalledWith({ id64: '9007199254740993' });
+
+    stream.close();
+    instance.onmessage?.(
+      new MessageEvent('message', { data: '{"id64":42}' }),
+    );
+    expect(received).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/api/events.test.ts
+++ b/apps/web/src/lib/api/events.test.ts
@@ -61,12 +61,7 @@ describe('SSE contract', () => {
     stream.close();
     stream.close();
     expect(instance.close).toHaveBeenCalledOnce();
-    expect(statuses).toEqual([
-      'connecting',
-      'open',
-      'reconnecting',
-      'closed',
-    ]);
+    expect(statuses).toEqual(['connecting', 'open', 'reconnecting', 'closed']);
   });
 
   it('reports and ignores malformed frames without terminating the stream', () => {
@@ -95,9 +90,7 @@ describe('SSE contract', () => {
     expect(received).toHaveBeenCalledWith({ id64: '9007199254740993' });
 
     stream.close();
-    instance.onmessage?.(
-      new MessageEvent('message', { data: '{"id64":42}' }),
-    );
+    instance.onmessage?.(new MessageEvent('message', { data: '{"id64":42}' }));
     expect(received).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/api/events.test.ts
+++ b/apps/web/src/lib/api/events.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LIVE_EVENTS_PATH, openLiveEventStream } from './events';
+
+describe('SSE contract', () => {
+  it('uses credentialed EventSource and parses oversized ids losslessly', () => {
+    const received = vi.fn();
+    const instance = {
+      url: '',
+      init: undefined as EventSourceInit | undefined,
+      onopen: null as ((event: Event) => void) | null,
+      onmessage: null as ((event: MessageEvent) => void) | null,
+      onerror: null as ((event: Event) => void) | null,
+      close: vi.fn(),
+    };
+    const FakeEventSource = vi.fn(function (
+      url: string,
+      init?: EventSourceInit,
+    ) {
+      instance.url = url;
+      instance.init = init;
+      return instance;
+    });
+    const stream = openLiveEventStream({
+      onEvent: received,
+      eventSource: FakeEventSource as unknown as typeof EventSource,
+    });
+    expect(instance).toMatchObject({
+      url: LIVE_EVENTS_PATH,
+      init: { withCredentials: true },
+    });
+    instance.onmessage?.(
+      new MessageEvent('message', { data: '{"id64":18446744073709551615}' }),
+    );
+    expect(received).toHaveBeenCalledWith({ id64: '18446744073709551615' });
+    stream.close();
+    expect(instance.close).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/api/events.ts
+++ b/apps/web/src/lib/api/events.ts
@@ -3,10 +3,7 @@ import { parseLosslessJson } from './lossless-json';
 export const LIVE_EVENTS_PATH = '/api/events/live';
 
 export type EventStreamStatus =
-  | 'connecting'
-  | 'open'
-  | 'reconnecting'
-  | 'closed';
+  'connecting' | 'open' | 'reconnecting' | 'closed';
 
 export interface EventStreamContract {
   close(): void;

--- a/apps/web/src/lib/api/events.ts
+++ b/apps/web/src/lib/api/events.ts
@@ -1,0 +1,35 @@
+import { parseLosslessJson } from './lossless-json';
+
+export const LIVE_EVENTS_PATH = '/api/events/live';
+
+export interface EventStreamContract {
+  close(): void;
+}
+
+export interface EventStreamOptions<T> {
+  onEvent(event: T): void;
+  onOpen?(): void;
+  /** Native EventSource reconnects. Consumers may start bounded polling here. */
+  onDisconnected?(event: Event): void;
+  eventSource?: typeof EventSource;
+}
+
+/**
+ * SSE deliberately stays outside generated query functions: EventSource owns
+ * native reconnect, cookies are enabled, and consumers own a polling fallback.
+ */
+export function openLiveEventStream<T>(
+  options: EventStreamOptions<T>,
+): EventStreamContract {
+  const EventSourceClass = options.eventSource ?? globalThis.EventSource;
+  if (!EventSourceClass)
+    throw new Error('EventSource is unavailable; use the polling fallback');
+  const source = new EventSourceClass(LIVE_EVENTS_PATH, {
+    withCredentials: true,
+  });
+  source.onopen = () => options.onOpen?.();
+  source.onmessage = (event) =>
+    options.onEvent(parseLosslessJson(event.data) as T);
+  source.onerror = (event) => options.onDisconnected?.(event);
+  return { close: () => source.close() };
+}

--- a/apps/web/src/lib/api/events.ts
+++ b/apps/web/src/lib/api/events.ts
@@ -2,6 +2,12 @@ import { parseLosslessJson } from './lossless-json';
 
 export const LIVE_EVENTS_PATH = '/api/events/live';
 
+export type EventStreamStatus =
+  | 'connecting'
+  | 'open'
+  | 'reconnecting'
+  | 'closed';
+
 export interface EventStreamContract {
   close(): void;
 }
@@ -11,6 +17,10 @@ export interface EventStreamOptions<T> {
   onOpen?(): void;
   /** Native EventSource reconnects. Consumers may start bounded polling here. */
   onDisconnected?(event: Event): void;
+  /** Observable connection state for status UI and polling-fallback ownership. */
+  onStatusChange?(status: EventStreamStatus): void;
+  /** Malformed frames are reported and ignored rather than escaping the handler. */
+  onParseError?(error: Error): void;
   eventSource?: typeof EventSource;
 }
 
@@ -24,12 +34,42 @@ export function openLiveEventStream<T>(
   const EventSourceClass = options.eventSource ?? globalThis.EventSource;
   if (!EventSourceClass)
     throw new Error('EventSource is unavailable; use the polling fallback');
+
+  let closed = false;
+  options.onStatusChange?.('connecting');
   const source = new EventSourceClass(LIVE_EVENTS_PATH, {
     withCredentials: true,
   });
-  source.onopen = () => options.onOpen?.();
-  source.onmessage = (event) =>
-    options.onEvent(parseLosslessJson(event.data) as T);
-  source.onerror = (event) => options.onDisconnected?.(event);
-  return { close: () => source.close() };
+
+  source.onopen = () => {
+    if (closed) return;
+    options.onStatusChange?.('open');
+    options.onOpen?.();
+  };
+  source.onmessage = (event) => {
+    if (closed) return;
+    try {
+      options.onEvent(parseLosslessJson(event.data) as T);
+    } catch (cause) {
+      options.onParseError?.(
+        cause instanceof Error
+          ? cause
+          : new Error('Live event frame could not be parsed', { cause }),
+      );
+    }
+  };
+  source.onerror = (event) => {
+    if (closed) return;
+    options.onStatusChange?.('reconnecting');
+    options.onDisconnected?.(event);
+  };
+
+  return {
+    close() {
+      if (closed) return;
+      closed = true;
+      source.close();
+      options.onStatusChange?.('closed');
+    },
+  };
 }

--- a/apps/web/src/lib/api/id64-facade.test.ts
+++ b/apps/web/src/lib/api/id64-facade.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getSystem } from './client';
+import { parseId64 } from '$lib/domain/id64';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('id64-bearing application API facade', () => {
+  it('parses an oversized system identifier before JavaScript can round it', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        '{"system":{"id64":18446744073709551615,"system_id64":9007199254740993,"name":"Lossless"}}',
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      ),
+    );
+
+    const result = await getSystem<{
+      id64: string;
+      system_id64: string;
+      name: string;
+    }>(parseId64('18446744073709551615'));
+
+    expect(result).toEqual({
+      id64: '18446744073709551615',
+      system_id64: '9007199254740993',
+      name: 'Lossless',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/system/18446744073709551615',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+});

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -1,0 +1,4 @@
+/** Only supported application import surface; generated SDK modules are adapters. */
+export * from './client';
+export * from './events';
+export * from './query';

--- a/apps/web/src/lib/api/lossless-json.test.ts
+++ b/apps/web/src/lib/api/lossless-json.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { parseLosslessJson } from './lossless-json';
+
+describe('lossless API JSON', () => {
+  it('normalises nested id64 fields before precision is lost', () => {
+    expect(
+      parseLosslessJson(
+        '{"id64":9007199254740993,"nested":{"system_id64":18446744073709551615},"id64s":[0,9007199254740993]}',
+      ),
+    ).toEqual({
+      id64: '9007199254740993',
+      nested: { system_id64: '18446744073709551615' },
+      id64s: ['0', '9007199254740993'],
+    });
+  });
+
+  it('rejects out-of-range and malformed identifier fields', () => {
+    expect(() => parseLosslessJson('{"id64":18446744073709551616}')).toThrow();
+    expect(() => parseLosslessJson('{"system_id64":" 1"}')).toThrow();
+  });
+});

--- a/apps/web/src/lib/api/lossless-json.ts
+++ b/apps/web/src/lib/api/lossless-json.ts
@@ -1,0 +1,63 @@
+import { JSONParse } from 'json-with-bigint';
+import { parseId64 } from '$lib/domain/id64';
+
+const INTEGER_TOKEN = /^\d+$/;
+
+export function isId64Field(key: string): boolean {
+  return (
+    key === 'id64' ||
+    key === 'id64s' ||
+    /(?:^|_)(?:from_|to_)?(?:system_)?id64s?$/.test(key)
+  );
+}
+
+/** Parse before the platform JSON parser can round an id64 token. */
+export function parseLosslessJson(text: string): unknown {
+  const parsed = JSONParse(
+    text,
+    (key: string, value: unknown, context?: { source: string }) => {
+      if (
+        context &&
+        typeof value === 'number' &&
+        !Number.isSafeInteger(value) &&
+        INTEGER_TOKEN.test(context.source)
+      ) {
+        return BigInt(context.source);
+      }
+      return value;
+    },
+  ) as unknown;
+  return normaliseResponseIds(parsed);
+}
+
+/** Project identifier-bearing response fields to the application Id64 boundary. */
+export function normaliseResponseIds(value: unknown, key = ''): unknown {
+  if (isId64Field(key)) {
+    if (Array.isArray(value)) return value.map((item) => normaliseId(item));
+    if (value === null || value === undefined) return value;
+    return normaliseId(value);
+  }
+  if (typeof value === 'bigint') return value.toString(10);
+  if (Array.isArray(value))
+    return value.map((item) => normaliseResponseIds(item));
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(
+        ([childKey, child]) => [
+          childKey,
+          normaliseResponseIds(child, childKey),
+        ],
+      ),
+    );
+  }
+  return value;
+}
+
+function normaliseId(value: unknown): string {
+  if (typeof value === 'bigint' || typeof value === 'string')
+    return parseId64(value);
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) {
+    return parseId64(BigInt(value));
+  }
+  throw new SyntaxError(`Invalid id64 response value for '${String(value)}'`);
+}

--- a/apps/web/src/lib/api/query.test.ts
+++ b/apps/web/src/lib/api/query.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { queryClient, queryKeys } from './query';
+import { parseId64 } from '$lib/domain/id64';
+
+describe('Svelte Query application contract', () => {
+  it('uses the accepted root defaults', () => {
+    expect(queryClient.getDefaultOptions()).toMatchObject({
+      queries: {
+        staleTime: 30_000,
+        gcTime: 300_000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+      mutations: { retry: 0 },
+    });
+  });
+
+  it('keeps canonical Id64 in query keys', () => {
+    expect(queryKeys.system(parseId64('9007199254740993'))).toEqual([
+      'ed-finder',
+      'system',
+      '9007199254740993',
+    ]);
+  });
+});

--- a/apps/web/src/lib/api/query.ts
+++ b/apps/web/src/lib/api/query.ts
@@ -1,0 +1,27 @@
+import { QueryClient } from '@tanstack/svelte-query';
+import type { Id64 } from '$lib/domain/id64';
+
+export const queryKeys = {
+  all: ['ed-finder'] as const,
+  auth: () => [...queryKeys.all, 'auth'] as const,
+  health: () => [...queryKeys.all, 'health'] as const,
+  system: (id64: Id64) => [...queryKeys.all, 'system', id64] as const,
+  compare: (id64s: readonly Id64[]) =>
+    [...queryKeys.all, 'compare', ...id64s] as const,
+  optimiser: (id64: Id64) => [...queryKeys.system(id64), 'optimiser'] as const,
+  operator: (resource: string) =>
+    [...queryKeys.all, 'operator', resource] as const,
+};
+
+/** The one application query client; feature providers should reuse this root. */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 300_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+    mutations: { retry: 0 },
+  },
+});

--- a/apps/web/src/lib/auth/auth.test.ts
+++ b/apps/web/src/lib/auth/auth.test.ts
@@ -1,5 +1,7 @@
 import { get } from 'svelte/store';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ADMIN_TOKEN_SESSION_KEY, apiRequest } from '$lib/api/client';
+import { adminToken } from '$lib/persistence/stores';
 import { createAuthStore } from './auth';
 
 const guest = {
@@ -8,7 +10,31 @@ const guest = {
   owner_claim_available: false,
 };
 
+function createTokenStore(initial = '') {
+  let value = initial;
+  return {
+    store: {
+      set: vi.fn((token: string) => {
+        value = token;
+        return true;
+      }),
+      clear: vi.fn(() => {
+        value = '';
+        return true;
+      }),
+    },
+    value: () => value,
+  };
+}
+
 describe('auth store', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    adminToken.clear();
+  });
+
   it('bootstraps cookie-backed session state', async () => {
     const api = {
       session: vi.fn().mockResolvedValue(guest),
@@ -35,24 +61,174 @@ describe('auth store', () => {
       logout: vi.fn(),
       claimOwner: vi.fn().mockResolvedValue(owner),
     };
-    const store = createAuthStore(api);
+    const tokenStore = createTokenStore();
+    const store = createAuthStore(api, tokenStore.store);
     await store.claimOwner(' secret ');
     expect(api.claimOwner).toHaveBeenCalledWith('secret');
+    expect(tokenStore.store.set).toHaveBeenCalledWith('secret');
+    expect(tokenStore.value()).toBe('secret');
     expect(get(store.owner)).toBe(true);
   });
 
+  it('bridges a successful claim to later bounded mutation requests', async () => {
+    const owner = {
+      authenticated: true,
+      user: { commander_name: 'Owner', is_owner: true },
+      owner_claim_available: false,
+    };
+    const api = {
+      session: vi.fn(),
+      logout: vi.fn(),
+      claimOwner: vi.fn().mockResolvedValue(owner),
+    };
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const store = createAuthStore(api, adminToken);
+
+    await store.claimOwner('  bridge-token  ');
+    await apiRequest('/observations/facts/observation-1', {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'confirmed' }),
+    });
+
+    expect(sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBe(
+      'bridge-token',
+    );
+    expect(localStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
+    expect(
+      new Headers(fetchMock.mock.calls[0][1]?.headers).get('X-Admin-Token'),
+    ).toBe('bridge-token');
+  });
+
+  it('reports when a successful claim cannot persist the credential', async () => {
+    const owner = {
+      authenticated: true,
+      user: { commander_name: 'Owner', is_owner: true },
+      owner_claim_available: false,
+    };
+    const api = {
+      session: vi.fn(),
+      logout: vi.fn(),
+      claimOwner: vi.fn().mockResolvedValue(owner),
+    };
+    const tokenStore = createTokenStore();
+    tokenStore.store.set.mockReturnValue(false);
+    const store = createAuthStore(api, tokenStore.store);
+
+    await expect(store.claimOwner(' session-token ')).rejects.toThrow(
+      'could not be stored',
+    );
+
+    expect(api.claimOwner).toHaveBeenCalledWith('session-token');
+    expect(tokenStore.store.set).toHaveBeenCalledWith('session-token');
+    expect(get(store)).toMatchObject({
+      authenticated: true,
+      user: { is_owner: true },
+      error: expect.stringContaining('could not be stored'),
+    });
+  });
+
+  it('does not replace a prior token when the owner claim fails', async () => {
+    adminToken.set('prior-token');
+    const setToken = vi.spyOn(adminToken, 'set');
+    const clearToken = vi.spyOn(adminToken, 'clear');
+    const signedInNonOwner = {
+      authenticated: true,
+      user: { commander_name: 'Commander', is_owner: false },
+      owner_claim_available: true,
+    };
+    const api = {
+      session: vi.fn().mockResolvedValue(signedInNonOwner),
+      logout: vi.fn(),
+      claimOwner: vi.fn().mockRejectedValue(new Error('Invalid admin token')),
+    };
+    const store = createAuthStore(api, adminToken);
+    await store.bootstrap();
+
+    await expect(store.claimOwner(' replacement ')).rejects.toThrow(
+      'Invalid admin token',
+    );
+
+    expect(setToken).not.toHaveBeenCalled();
+    expect(clearToken).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBe('prior-token');
+    expect(localStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
+    expect(get(store)).toMatchObject({
+      authenticated: true,
+      user: { commander_name: 'Commander', is_owner: false },
+      ownerClaimAvailable: true,
+      error: 'Invalid admin token',
+    });
+  });
+
+  it('clears the session token on explicit sign-out', async () => {
+    adminToken.set('session-token');
+    const clearToken = vi.spyOn(adminToken, 'clear');
+    const api = {
+      session: vi.fn(),
+      logout: vi.fn().mockResolvedValue(guest),
+      claimOwner: vi.fn(),
+    };
+    const store = createAuthStore(api, adminToken);
+
+    await store.signOut();
+
+    expect(clearToken).toHaveBeenCalledOnce();
+    expect(sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
+    expect(localStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
+  });
+
+  it('keeps the explicit token clear when logout is unavailable', async () => {
+    const tokenStore = createTokenStore('session-token');
+    const api = {
+      session: vi.fn(),
+      logout: vi.fn().mockRejectedValue(new Error('offline')),
+      claimOwner: vi.fn(),
+    };
+    const store = createAuthStore(api, tokenStore.store);
+
+    await expect(store.signOut()).rejects.toThrow('offline');
+
+    expect(tokenStore.store.clear).toHaveBeenCalledOnce();
+    expect(tokenStore.value()).toBe('');
+  });
+
+  it('still logs out and reports when the session token cannot be cleared', async () => {
+    const tokenStore = createTokenStore('session-token');
+    tokenStore.store.clear.mockReturnValue(false);
+    const api = {
+      session: vi.fn(),
+      logout: vi.fn().mockResolvedValue(guest),
+      claimOwner: vi.fn(),
+    };
+    const store = createAuthStore(api, tokenStore.store);
+
+    await expect(store.signOut()).rejects.toThrow('could not be cleared');
+
+    expect(api.logout).toHaveBeenCalledOnce();
+    expect(tokenStore.value()).toBe('session-token');
+  });
+
   it('fails closed when session bootstrap fails', async () => {
+    adminToken.set('prior-token');
+    const clearToken = vi.spyOn(adminToken, 'clear');
     const api = {
       session: vi.fn().mockRejectedValue(new Error('offline')),
       logout: vi.fn(),
       claimOwner: vi.fn(),
     };
-    const store = createAuthStore(api);
+    const store = createAuthStore(api, adminToken);
     await store.bootstrap();
     expect(get(store)).toMatchObject({
       authenticated: false,
       user: null,
       error: 'offline',
     });
+    expect(clearToken).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBe('prior-token');
   });
 });

--- a/apps/web/src/lib/auth/auth.test.ts
+++ b/apps/web/src/lib/auth/auth.test.ts
@@ -1,0 +1,58 @@
+import { get } from 'svelte/store';
+import { describe, expect, it, vi } from 'vitest';
+import { createAuthStore } from './auth';
+
+const guest = {
+  authenticated: false,
+  user: null,
+  owner_claim_available: false,
+};
+
+describe('auth store', () => {
+  it('bootstraps cookie-backed session state', async () => {
+    const api = {
+      session: vi.fn().mockResolvedValue(guest),
+      logout: vi.fn(),
+      claimOwner: vi.fn(),
+    };
+    const store = createAuthStore(api);
+    await store.bootstrap();
+    expect(get(store)).toMatchObject({
+      loading: false,
+      authenticated: false,
+      error: null,
+    });
+  });
+
+  it('derives owner state and claims with a trimmed one-time token', async () => {
+    const owner = {
+      authenticated: true,
+      user: { commander_name: 'Owner', is_owner: true },
+      owner_claim_available: false,
+    };
+    const api = {
+      session: vi.fn(),
+      logout: vi.fn(),
+      claimOwner: vi.fn().mockResolvedValue(owner),
+    };
+    const store = createAuthStore(api);
+    await store.claimOwner(' secret ');
+    expect(api.claimOwner).toHaveBeenCalledWith('secret');
+    expect(get(store.owner)).toBe(true);
+  });
+
+  it('fails closed when session bootstrap fails', async () => {
+    const api = {
+      session: vi.fn().mockRejectedValue(new Error('offline')),
+      logout: vi.fn(),
+      claimOwner: vi.fn(),
+    };
+    const store = createAuthStore(api);
+    await store.bootstrap();
+    expect(get(store)).toMatchObject({
+      authenticated: false,
+      user: null,
+      error: 'offline',
+    });
+  });
+});

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -1,0 +1,101 @@
+import { writable, derived, type Readable } from 'svelte/store';
+import { browser } from '$app/environment';
+import {
+  authLogout,
+  claimOwner,
+  frontierLoginUrl,
+  getAuthSession,
+} from '$lib/api/client';
+
+export interface AuthUser {
+  commander_name: string | null;
+  is_owner: boolean;
+}
+export interface AuthState {
+  loading: boolean;
+  authenticated: boolean;
+  user: AuthUser | null;
+  ownerClaimAvailable: boolean;
+  error: string | null;
+}
+export interface AuthApi {
+  session: typeof getAuthSession;
+  logout: typeof authLogout;
+  claimOwner: typeof claimOwner;
+}
+
+const empty: AuthState = {
+  loading: false,
+  authenticated: false,
+  user: null,
+  ownerClaimAvailable: false,
+  error: null,
+};
+
+export function createAuthStore(
+  api: AuthApi = { session: getAuthSession, logout: authLogout, claimOwner },
+) {
+  const state = writable<AuthState>({ ...empty, loading: browser });
+  const accept = (session: Awaited<ReturnType<AuthApi['session']>>) =>
+    state.set({
+      loading: false,
+      authenticated: session.authenticated,
+      user: session.user
+        ? {
+            commander_name: session.user.commander_name ?? null,
+            is_owner: session.user.is_owner,
+          }
+        : null,
+      ownerClaimAvailable: session.owner_claim_available ?? false,
+      error: null,
+    });
+  const fail = (error: unknown) =>
+    state.set({
+      ...empty,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  return {
+    subscribe: state.subscribe,
+    owner: derived(
+      state,
+      ($state) => $state.user?.is_owner === true,
+    ) as Readable<boolean>,
+    async bootstrap() {
+      state.update((value) => ({ ...value, loading: true, error: null }));
+      try {
+        accept(await api.session());
+      } catch (error) {
+        fail(error);
+      }
+    },
+    signIn() {
+      if (!browser) return;
+      const returnTo = `${location.pathname}${location.search}${location.hash}`;
+      location.assign(frontierLoginUrl(returnTo));
+    },
+    async signOut() {
+      state.update((value) => ({ ...value, error: null }));
+      try {
+        accept(await api.logout());
+        if (browser && ['/admin', '/operator'].includes(location.pathname))
+          location.replace('/');
+      } catch (error) {
+        fail(error);
+        throw error;
+      }
+    },
+    async claimOwner(token: string) {
+      const trimmed = token.trim();
+      if (!trimmed) throw new Error('Admin token is required');
+      state.update((value) => ({ ...value, error: null }));
+      try {
+        accept(await api.claimOwner(trimmed));
+      } catch (error) {
+        fail(error);
+        throw error;
+      }
+    },
+  };
+}
+
+export const auth = createAuthStore();

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -6,6 +6,7 @@ import {
   frontierLoginUrl,
   getAuthSession,
 } from '$lib/api/client';
+import { adminToken } from '$lib/persistence/stores';
 
 export interface AuthUser {
   commander_name: string | null;
@@ -20,9 +21,10 @@ export interface AuthState {
 }
 export interface AuthApi {
   session: typeof getAuthSession;
-  logout: typeof authLogout;
-  claimOwner: typeof claimOwner;
+  logout: () => ReturnType<typeof getAuthSession>;
+  claimOwner: (adminToken: string) => ReturnType<typeof getAuthSession>;
 }
+export type AuthTokenStore = Pick<typeof adminToken, 'set' | 'clear'>;
 
 const empty: AuthState = {
   loading: false,
@@ -34,6 +36,7 @@ const empty: AuthState = {
 
 export function createAuthStore(
   api: AuthApi = { session: getAuthSession, logout: authLogout, claimOwner },
+  tokenStore: AuthTokenStore = adminToken,
 ) {
   const state = writable<AuthState>({ ...empty, loading: browser });
   const accept = (session: Awaited<ReturnType<AuthApi['session']>>) =>
@@ -54,6 +57,12 @@ export function createAuthStore(
       ...empty,
       error: error instanceof Error ? error.message : String(error),
     });
+  const reportError = (error: unknown) =>
+    state.update((value) => ({
+      ...value,
+      loading: false,
+      error: error instanceof Error ? error.message : String(error),
+    }));
   return {
     subscribe: state.subscribe,
     owner: derived(
@@ -75,25 +84,41 @@ export function createAuthStore(
     },
     async signOut() {
       state.update((value) => ({ ...value, error: null }));
+      const tokenClearError = tokenStore.clear()
+        ? null
+        : new Error('The session token could not be cleared in this browser.');
       try {
-        accept(await api.logout());
+        const session = await api.logout();
+        if (tokenClearError) throw tokenClearError;
+        accept(session);
         if (browser && ['/admin', '/operator'].includes(location.pathname))
           location.replace('/');
       } catch (error) {
-        fail(error);
-        throw error;
+        const failure = tokenClearError ?? error;
+        fail(failure);
+        throw failure;
       }
     },
     async claimOwner(token: string) {
       const trimmed = token.trim();
       if (!trimmed) throw new Error('Admin token is required');
       state.update((value) => ({ ...value, error: null }));
+      let session: Awaited<ReturnType<AuthApi['claimOwner']>>;
       try {
-        accept(await api.claimOwner(trimmed));
+        session = await api.claimOwner(trimmed);
       } catch (error) {
-        fail(error);
+        reportError(error);
         throw error;
       }
+      if (!tokenStore.set(trimmed)) {
+        accept(session);
+        const error = new Error(
+          'The owner was linked, but the session token could not be stored in this browser.',
+        );
+        reportError(error);
+        throw error;
+      }
+      accept(session);
     },
   };
 }

--- a/apps/web/src/lib/components/AppShell.svelte
+++ b/apps/web/src/lib/components/AppShell.svelte
@@ -5,10 +5,14 @@
   import { onMount } from 'svelte';
   import { auth } from '$lib/auth/auth';
   import { parseId64, type Id64 } from '$lib/domain/id64';
+  import { usePersistenceContext } from '$lib/persistence/context';
+  import { hydrateApplicationStores } from '$lib/persistence/stores';
   import { applyLegacyHash } from '$lib/routing/legacy-hash';
   import SystemOverlay from './SystemOverlay.svelte';
   let { children } = $props<{ children: import('svelte').Snippet }>();
-  let selectedId = $derived.by((): Id64 | null => {
+  const persistence = usePersistenceContext();
+  const { selectedSystem } = persistence;
+  let overlayId = $derived.by((): Id64 | null => {
     const raw = page.url.searchParams.get('system');
     if (!raw || page.url.pathname.startsWith('/system/')) return null;
     try {
@@ -17,16 +21,33 @@
       return null;
     }
   });
+  let routeSelection = $derived.by((): Id64 | null => {
+    if (!page.url.pathname.startsWith('/system/')) return null;
+    try {
+      return parseId64(
+        page.url.pathname.slice('/system/'.length).split('/')[0],
+      );
+    } catch {
+      return null;
+    }
+  });
+  $effect(() => {
+    const establishedSelection = overlayId ?? routeSelection;
+    if (establishedSelection)
+      persistence.selectedSystem.set(establishedSelection);
+  });
   onMount(() => {
-    if (
-      !applyLegacyHash(
+    hydrateApplicationStores();
+    const normaliseLegacyHash = () =>
+      applyLegacyHash(
         location,
         // eslint-disable-next-line svelte/no-navigation-without-resolve -- validated compatibility URL
         (url) => void goto(url, { replaceState: true }),
-      )
-    )
-      void auth.bootstrap();
-    else void auth.bootstrap();
+      );
+    normaliseLegacyHash();
+    window.addEventListener('hashchange', normaliseLegacyHash);
+    void auth.bootstrap();
+    return () => window.removeEventListener('hashchange', normaliseLegacyHash);
   });
 </script>
 
@@ -63,12 +84,13 @@
       >{/if}
   </div>
 </header>
-{#if selectedId}<aside
+{#if $selectedSystem.hydrated && $selectedSystem.value}<aside
     class="context-chip"
     data-testid="selected-system-context"
   >
-    Selected system <strong>{selectedId}</strong><a
-      href={resolve(`/colony-planner/system/${selectedId}`)}>Open plan</a
+    Selected system <strong>{$selectedSystem.value}</strong><a
+      href={resolve(`/colony-planner/system/${$selectedSystem.value}`)}
+      >Open plan</a
     >
   </aside>{/if}
 <div id="main-content" tabindex="-1">{@render children()}</div>
@@ -82,4 +104,4 @@
     </p>
   </details>
 </footer>
-{#if selectedId}<SystemOverlay id64={selectedId} />{/if}
+{#if overlayId}<SystemOverlay id64={overlayId} />{/if}

--- a/apps/web/src/lib/components/AppShell.svelte
+++ b/apps/web/src/lib/components/AppShell.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { page } from '$app/state';
+  import { onMount } from 'svelte';
+  import { auth } from '$lib/auth/auth';
+  import { parseId64, type Id64 } from '$lib/domain/id64';
+  import { applyLegacyHash } from '$lib/routing/legacy-hash';
+  import SystemOverlay from './SystemOverlay.svelte';
+  let { children } = $props<{ children: import('svelte').Snippet }>();
+  let selectedId = $derived.by((): Id64 | null => {
+    const raw = page.url.searchParams.get('system');
+    if (!raw || page.url.pathname.startsWith('/system/')) return null;
+    try {
+      return parseId64(raw);
+    } catch {
+      return null;
+    }
+  });
+  onMount(() => {
+    if (
+      !applyLegacyHash(
+        location,
+        // eslint-disable-next-line svelte/no-navigation-without-resolve -- validated compatibility URL
+        (url) => void goto(url, { replaceState: true }),
+      )
+    )
+      void auth.bootstrap();
+    else void auth.bootstrap();
+  });
+</script>
+
+<a class="skip-link" href="#main-content">Skip to main content</a>
+<header class="site-header">
+  <a class="brand" href={resolve('/')} aria-label="ED-Finder home"
+    ><span>ED</span>Finder</a
+  >
+  <nav aria-label="Primary navigation">
+    <a href={resolve('/')}>Finder</a><a href={resolve('/explore')}>Explore</a><a
+      href={resolve('/my-work')}>My Work</a
+    ><a href={resolve('/compare')}>Compare</a><a
+      href={resolve('/colony-planner')}>Plan</a
+    ><a href={resolve('/review')}>Review / Export</a>
+  </nav>
+  <div class="account" aria-live="polite" aria-label="Account status">
+    {#if $auth.error}<span role="alert">Account unavailable</span>{/if}
+    {#if $auth.loading}Account…{:else if $auth.authenticated}<span
+        data-testid="frontier-account-name"
+        >{$auth.user?.commander_name
+          ? `CMDR ${$auth.user.commander_name}`
+          : 'Frontier account'}</span
+      >{#if $auth.user?.is_owner}<a
+          href={resolve('/admin')}
+          data-testid="owner-open-ops">Ops</a
+        >{/if}<button
+        type="button"
+        data-testid="frontier-sign-out"
+        onclick={() => void auth.signOut()}>Sign out</button
+      >{:else}<button
+        type="button"
+        data-testid="frontier-sign-in"
+        onclick={auth.signIn}>Sign in</button
+      >{/if}
+  </div>
+</header>
+{#if selectedId}<aside
+    class="context-chip"
+    data-testid="selected-system-context"
+  >
+    Selected system <strong>{selectedId}</strong><a
+      href={resolve(`/colony-planner/system/${selectedId}`)}>Open plan</a
+    >
+  </aside>{/if}
+<div id="main-content" tabindex="-1">{@render children()}</div>
+<footer>
+  <details>
+    <summary>Data, community &amp; intellectual property attribution</summary>
+    <p>
+      ED-Finder uses data from the Elite Dangerous community. Elite Dangerous is
+      © Frontier Developments plc. ED-Finder is a non-commercial fan project and
+      is not endorsed by Frontier Developments.
+    </p>
+  </details>
+</footer>
+{#if selectedId}<SystemOverlay id64={selectedId} />{/if}

--- a/apps/web/src/lib/components/AppShell.svelte
+++ b/apps/web/src/lib/components/AppShell.svelte
@@ -12,6 +12,7 @@
   let { children } = $props<{ children: import('svelte').Snippet }>();
   const persistence = usePersistenceContext();
   const { selectedSystem } = persistence;
+  let persistenceReady = $state(false);
   let overlayId = $derived.by((): Id64 | null => {
     const raw = page.url.searchParams.get('system');
     if (!raw || page.url.pathname.startsWith('/system/')) return null;
@@ -32,12 +33,14 @@
     }
   });
   $effect(() => {
+    if (!persistenceReady) return;
     const establishedSelection = overlayId ?? routeSelection;
     if (establishedSelection)
       persistence.selectedSystem.set(establishedSelection);
   });
   onMount(() => {
     hydrateApplicationStores();
+    persistenceReady = true;
     const normaliseLegacyHash = () =>
       applyLegacyHash(
         location,
@@ -84,7 +87,7 @@
       >{/if}
   </div>
 </header>
-{#if $selectedSystem.hydrated && $selectedSystem.value}<aside
+{#if persistenceReady && $selectedSystem.hydrated && $selectedSystem.value}<aside
     class="context-chip"
     data-testid="selected-system-context"
   >

--- a/apps/web/src/lib/components/OwnerAccessGate.svelte
+++ b/apps/web/src/lib/components/OwnerAccessGate.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import type { AuthState } from '$lib/auth/auth';
+  let { authState, signIn, signOut, claimOwner, children } = $props<{
+    authState: AuthState;
+    signIn: () => void;
+    signOut: () => Promise<void>;
+    claimOwner: (token: string) => Promise<void>;
+    children: import('svelte').Snippet;
+  }>();
+  let token = $state('');
+  let claiming = $state(false);
+  let claimError = $state<string | null>(null);
+  async function claim() {
+    claiming = true;
+    claimError = null;
+    try {
+      await claimOwner(token);
+      token = '';
+    } catch (error) {
+      claimError = error instanceof Error ? error.message : String(error);
+    } finally {
+      claiming = false;
+    }
+  }
+</script>
+
+{#if authState.loading}
+  <section class="panel gate" data-testid="owner-access-loading">
+    <p aria-live="polite">Checking owner access…</p>
+  </section>
+{:else if !authState.authenticated}
+  <section class="panel gate" data-testid="owner-sign-in-required">
+    <h1>Owner sign-in required</h1>
+    <p>
+      Operational dashboards and health information are private. Sign in with
+      the Frontier account linked to ED-Finder.
+    </p>
+    <button type="button" onclick={signIn}>Sign in with Frontier</button>
+  </section>
+{:else if !authState.user?.is_owner}
+  <section class="panel gate" data-testid="owner-access-denied">
+    <h1>Owner access only</h1>
+    <p>
+      This Frontier account is signed in, but it is not linked as ED-Finder’s
+      owner.
+    </p>
+    {#if authState.ownerClaimAvailable}
+      <form
+        onsubmit={(event) => {
+          event.preventDefault();
+          void claim();
+        }}
+      >
+        <label for="owner-token">Existing ED-Finder admin token</label>
+        <input
+          id="owner-token"
+          type="password"
+          bind:value={token}
+          autocomplete="off"
+          data-testid="owner-claim-token"
+        />
+        <button
+          type="submit"
+          disabled={!token.trim() || claiming}
+          data-testid="owner-claim-submit"
+          >{claiming ? 'Linking…' : 'Link owner account'}</button
+        >
+      </form>
+      {#if claimError}<p role="alert">{claimError}</p>{/if}
+    {/if}
+    <button type="button" onclick={() => void signOut()}>Sign out</button>
+  </section>
+{:else}
+  {@render children()}
+{/if}

--- a/apps/web/src/lib/components/OwnerAccessGate.test.ts
+++ b/apps/web/src/lib/components/OwnerAccessGate.test.ts
@@ -46,10 +46,46 @@ describe('OwnerAccessGate', () => {
         children: (() => {}) as never,
       },
     });
-    await fireEvent.input(screen.getByTestId('owner-claim-token'), {
+    const input = screen.getByTestId('owner-claim-token');
+    await fireEvent.input(input, {
       target: { value: 'token' },
     });
     await fireEvent.click(screen.getByTestId('owner-claim-submit'));
     await waitFor(() => expect(claimOwner).toHaveBeenCalledWith('token'));
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('keeps the password input and reports a failed owner claim', async () => {
+    const claimOwner = vi
+      .fn()
+      .mockRejectedValue(new Error('Invalid admin token'));
+    render(OwnerAccessGate, {
+      props: {
+        authState: {
+          ...base,
+          authenticated: true,
+          user: { commander_name: 'Cmdr', is_owner: false },
+          ownerClaimAvailable: true,
+        },
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+        claimOwner,
+        children: (() => {}) as never,
+      },
+    });
+    const input = screen.getByTestId('owner-claim-token');
+    await fireEvent.input(input, {
+      target: { value: 'rejected-token' },
+    });
+    await fireEvent.click(screen.getByTestId('owner-claim-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Invalid admin token',
+      ),
+    );
+    expect(input).toHaveValue('rejected-token');
+    expect(screen.getByTestId('owner-access-denied')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/lib/components/OwnerAccessGate.test.ts
+++ b/apps/web/src/lib/components/OwnerAccessGate.test.ts
@@ -1,0 +1,55 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import OwnerAccessGate from './OwnerAccessGate.svelte';
+
+afterEach(cleanup);
+const base = {
+  loading: false,
+  authenticated: false,
+  user: null,
+  ownerClaimAvailable: false,
+  error: null,
+};
+
+describe('OwnerAccessGate', () => {
+  it('keeps signed-out users away from operational content', () => {
+    render(OwnerAccessGate, {
+      props: {
+        authState: base,
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+        claimOwner: vi.fn(),
+        children: (() => {}) as never,
+      },
+    });
+    expect(screen.getByTestId('owner-sign-in-required')).toBeInTheDocument();
+  });
+  it('offers the bounded owner claim only when available', async () => {
+    const claimOwner = vi.fn().mockResolvedValue(undefined);
+    render(OwnerAccessGate, {
+      props: {
+        authState: {
+          ...base,
+          authenticated: true,
+          user: { commander_name: 'Cmdr', is_owner: false },
+          ownerClaimAvailable: true,
+        },
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+        claimOwner,
+        children: (() => {}) as never,
+      },
+    });
+    await fireEvent.input(screen.getByTestId('owner-claim-token'), {
+      target: { value: 'token' },
+    });
+    await fireEvent.click(screen.getByTestId('owner-claim-submit'));
+    await waitFor(() => expect(claimOwner).toHaveBeenCalledWith('token'));
+  });
+});

--- a/apps/web/src/lib/components/Placeholder.svelte
+++ b/apps/web/src/lib/components/Placeholder.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  let { title, detail = 'This product surface has not been ported yet.' } =
+    $props<{ title: string; detail?: string }>();
+</script>
+
+<svelte:head><title>{title} — ED-Finder</title></svelte:head>
+<main class="placeholder">
+  <p class="eyebrow">Migration placeholder</p>
+  <h1>{title}</h1>
+  <p>{detail}</p>
+</main>

--- a/apps/web/src/lib/components/SessionAdminTokenControl.svelte
+++ b/apps/web/src/lib/components/SessionAdminTokenControl.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { adminToken } from '$lib/persistence/stores';
+
+  let draft = $state('');
+  let message = $state<string | null>(null);
+  let error = $state<string | null>(null);
+
+  function save() {
+    const token = draft.trim();
+    message = null;
+    error = null;
+    if (!token) {
+      error = 'Enter an admin token before saving it for this browser session.';
+      return;
+    }
+    if (!adminToken.set(token)) {
+      error = 'The session token could not be stored in this browser.';
+      return;
+    }
+    draft = '';
+    message = 'Session admin token saved.';
+  }
+
+  function clear() {
+    message = null;
+    error = null;
+    if (!adminToken.clear()) {
+      error = 'The session token could not be cleared in this browser.';
+      return;
+    }
+    draft = '';
+    message = 'Session admin token cleared.';
+  }
+</script>
+
+<section class="panel" aria-labelledby="session-admin-token-heading">
+  <p class="eyebrow">Compatibility credential</p>
+  <h2 id="session-admin-token-heading">Session admin token</h2>
+  <p>
+    Use this only for bounded API operations that still accept
+    <code>X-Admin-Token</code>. It is stored in session storage, is not included
+    in profile sync, and is cleared when the browser session ends.
+  </p>
+  <p aria-live="polite" data-testid="session-admin-token-status">
+    {$adminToken.value ? 'A session token is configured.' : 'No session token is configured.'}
+  </p>
+  <form
+    onsubmit={(event) => {
+      event.preventDefault();
+      save();
+    }}
+  >
+    <label for="session-admin-token">Admin token for this session</label>
+    <input
+      id="session-admin-token"
+      type="password"
+      bind:value={draft}
+      autocomplete="off"
+      data-testid="session-admin-token-input"
+    />
+    <button
+      type="submit"
+      disabled={!draft.trim()}
+      data-testid="session-admin-token-save">Save for this session</button
+    >
+    <button
+      type="button"
+      disabled={!$adminToken.value}
+      onclick={clear}
+      data-testid="session-admin-token-clear">Clear session token</button
+    >
+  </form>
+  {#if message}<p role="status">{message}</p>{/if}
+  {#if error}<p role="alert">{error}</p>{/if}
+</section>

--- a/apps/web/src/lib/components/SessionAdminTokenControl.svelte
+++ b/apps/web/src/lib/components/SessionAdminTokenControl.svelte
@@ -42,7 +42,9 @@
     in profile sync, and is cleared when the browser session ends.
   </p>
   <p aria-live="polite" data-testid="session-admin-token-status">
-    {$adminToken.value ? 'A session token is configured.' : 'No session token is configured.'}
+    {$adminToken.value
+      ? 'A session token is configured.'
+      : 'No session token is configured.'}
   </p>
   <form
     onsubmit={(event) => {

--- a/apps/web/src/lib/components/SessionAdminTokenControl.test.ts
+++ b/apps/web/src/lib/components/SessionAdminTokenControl.test.ts
@@ -1,0 +1,65 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ADMIN_TOKEN_SESSION_KEY } from '$lib/api/client';
+import { adminToken } from '$lib/persistence/stores';
+import SessionAdminTokenControl from './SessionAdminTokenControl.svelte';
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  adminToken.clear();
+  adminToken.hydrate();
+});
+
+afterEach(() => {
+  cleanup();
+  sessionStorage.clear();
+  adminToken.clear();
+});
+
+describe('SessionAdminTokenControl', () => {
+  it('stores an explicitly entered token only for the browser session', async () => {
+    render(SessionAdminTokenControl);
+
+    await fireEvent.input(screen.getByTestId('session-admin-token-input'), {
+      target: { value: '  bounded-token  ' },
+    });
+    await fireEvent.click(screen.getByTestId('session-admin-token-save'));
+
+    expect(sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBe(
+      'bounded-token',
+    );
+    expect(localStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
+    await waitFor(() =>
+      expect(screen.getByTestId('session-admin-token-status')).toHaveTextContent(
+        'A session token is configured.',
+      ),
+    );
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Session admin token saved.',
+    );
+  });
+
+  it('clears the compatibility credential without touching owner-claim state', async () => {
+    sessionStorage.setItem(ADMIN_TOKEN_SESSION_KEY, 'existing-token');
+    adminToken.hydrate();
+    render(SessionAdminTokenControl);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('session-admin-token-clear')).toBeEnabled(),
+    );
+    await fireEvent.click(screen.getByTestId('session-admin-token-clear'));
+
+    expect(sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
+    expect(screen.getByTestId('session-admin-token-status')).toHaveTextContent(
+      'No session token is configured.',
+    );
+    expect(screen.queryByTestId('owner-claim-token')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/components/SessionAdminTokenControl.test.ts
+++ b/apps/web/src/lib/components/SessionAdminTokenControl.test.ts
@@ -37,9 +37,9 @@ describe('SessionAdminTokenControl', () => {
     );
     expect(localStorage.getItem(ADMIN_TOKEN_SESSION_KEY)).toBeNull();
     await waitFor(() =>
-      expect(screen.getByTestId('session-admin-token-status')).toHaveTextContent(
-        'A session token is configured.',
-      ),
+      expect(
+        screen.getByTestId('session-admin-token-status'),
+      ).toHaveTextContent('A session token is configured.'),
     );
     expect(screen.getByRole('status')).toHaveTextContent(
       'Session admin token saved.',

--- a/apps/web/src/lib/components/SystemOverlay.svelte
+++ b/apps/web/src/lib/components/SystemOverlay.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
+  import type { Id64 } from '$lib/domain/id64';
+  let { id64 } = $props<{ id64: Id64 }>();
+  let dialog: HTMLDivElement;
+  let returnFocus: HTMLElement | null = null;
+
+  function close() {
+    const url = new URL(page.url);
+    url.searchParams.delete('system');
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- current URL is already resolved
+    void goto(`${url.pathname}${url.search}${url.hash}`, {
+      replaceState: true,
+      noScroll: true,
+    }).then(() => returnFocus?.focus());
+  }
+  function keydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      close();
+    }
+  }
+  $effect(() => {
+    returnFocus =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    queueMicrotask(() => dialog?.focus());
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  });
+</script>
+
+<svelte:window onkeydown={keydown} />
+<div
+  class="overlay"
+  role="presentation"
+  onclick={(event) => {
+    if (event.target === event.currentTarget) close();
+  }}
+>
+  <div
+    class="dialog panel"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="system-detail-title"
+    tabindex="-1"
+    bind:this={dialog}
+    data-testid="system-detail-modal"
+  >
+    <button
+      class="dialog-close"
+      type="button"
+      onclick={close}
+      aria-label="Close system detail">×</button
+    >
+    <p class="eyebrow">Inspect</p>
+    <h1 id="system-detail-title">System Detail</h1>
+    <p>System <code>{id64}</code></p>
+    <p>
+      This feature body has not been ported yet. The route, identifier, and
+      overlay lifecycle are active platform contracts.
+    </p>
+  </div>
+</div>

--- a/apps/web/src/lib/components/SystemOverlay.svelte
+++ b/apps/web/src/lib/components/SystemOverlay.svelte
@@ -6,6 +6,26 @@
   let dialog: HTMLDivElement;
   let returnFocus: HTMLElement | null = null;
 
+  const focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
+  function focusableElements(): HTMLElement[] {
+    if (!dialog) return [];
+    return Array.from(
+      dialog.querySelectorAll<HTMLElement>(focusableSelector),
+    ).filter(
+      (element) =>
+        element.getAttribute('aria-hidden') !== 'true' &&
+        !element.hasAttribute('hidden'),
+    );
+  }
+
   function close() {
     const url = new URL(page.url);
     url.searchParams.delete('system');
@@ -15,12 +35,39 @@
       noScroll: true,
     }).then(() => returnFocus?.focus());
   }
+
+  function containTab(event: KeyboardEvent) {
+    const focusable = focusableElements();
+    if (!focusable.length) {
+      event.preventDefault();
+      dialog?.focus();
+      return;
+    }
+
+    const active = document.activeElement;
+    const first = focusable[0];
+    const last = focusable.at(-1) ?? first;
+    if (!focusable.includes(active as HTMLElement)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   function keydown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       event.preventDefault();
       close();
+    } else if (event.key === 'Tab') {
+      containTab(event);
     }
   }
+
   $effect(() => {
     returnFocus =
       document.activeElement instanceof HTMLElement

--- a/apps/web/src/lib/components/SystemOverlay.test.ts
+++ b/apps/web/src/lib/components/SystemOverlay.test.ts
@@ -59,7 +59,9 @@ describe('SystemOverlay', () => {
 
     render(SystemOverlay, { props: { id64: '42' as Id64 } });
     await waitFor(() =>
-      expect(screen.getByRole('dialog', { name: 'System Detail' })).toHaveFocus(),
+      expect(
+        screen.getByRole('dialog', { name: 'System Detail' }),
+      ).toHaveFocus(),
     );
 
     await fireEvent.keyDown(window, { key: 'Escape' });

--- a/apps/web/src/lib/components/SystemOverlay.test.ts
+++ b/apps/web/src/lib/components/SystemOverlay.test.ts
@@ -1,0 +1,74 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Id64 } from '$lib/domain/id64';
+import SystemOverlay from './SystemOverlay.svelte';
+
+const { mockedPage, mockedGoto } = vi.hoisted(() => ({
+  mockedPage: {
+    url: new URL('http://localhost/explore?system=42&view=cards#section'),
+  },
+  mockedGoto: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('$app/state', () => ({ page: mockedPage }));
+vi.mock('$app/navigation', () => ({ goto: mockedGoto }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedPage.url = new URL(
+    'http://localhost/explore?system=42&view=cards#section',
+  );
+  document.body.style.overflow = '';
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.style.overflow = '';
+});
+
+describe('SystemOverlay', () => {
+  it('moves focus into the dialog and contains forward and reverse Tab', async () => {
+    render(SystemOverlay, { props: { id64: '42' as Id64 } });
+
+    const dialog = screen.getByRole('dialog', { name: 'System Detail' });
+    const close = screen.getByRole('button', { name: 'Close system detail' });
+    await waitFor(() => expect(dialog).toHaveFocus());
+    expect(document.body.style.overflow).toBe('hidden');
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    expect(close).toHaveFocus();
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    expect(close).toHaveFocus();
+
+    await fireEvent.keyDown(window, { key: 'Tab', shiftKey: true });
+    expect(close).toHaveFocus();
+  });
+
+  it('closes on Escape, preserves the host URL, and restores prior focus', async () => {
+    const opener = document.createElement('button');
+    opener.textContent = 'Open detail';
+    document.body.append(opener);
+    opener.focus();
+
+    render(SystemOverlay, { props: { id64: '42' as Id64 } });
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: 'System Detail' })).toHaveFocus(),
+    );
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(mockedGoto).toHaveBeenCalledWith('/explore?view=cards#section', {
+      replaceState: true,
+      noScroll: true,
+    });
+    await waitFor(() => expect(opener).toHaveFocus());
+    opener.remove();
+  });
+});

--- a/apps/web/src/lib/components/TestShell.svelte
+++ b/apps/web/src/lib/components/TestShell.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+  import { QueryClientProvider } from '@tanstack/svelte-query';
+  import { queryClient } from '$lib/api/query';
+  import { providePersistenceContext } from '$lib/persistence/context';
   import Page from '../../routes/+page.svelte';
   import AppShell from './AppShell.svelte';
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
+  providePersistenceContext();
 </script>
 
-<QueryClientProvider {client}><AppShell><Page /></AppShell></QueryClientProvider
+<QueryClientProvider client={queryClient}
+  ><AppShell><Page /></AppShell></QueryClientProvider
 >

--- a/apps/web/src/lib/components/TestShell.svelte
+++ b/apps/web/src/lib/components/TestShell.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
   import Page from '../../routes/+page.svelte';
+  import AppShell from './AppShell.svelte';
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
 </script>
 
-<QueryClientProvider {client}><Page /></QueryClientProvider>
+<QueryClientProvider {client}><AppShell><Page /></AppShell></QueryClientProvider
+>

--- a/apps/web/src/lib/domain/id64.test.ts
+++ b/apps/web/src/lib/domain/id64.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { compareId64, formatId64, isId64, MAX_ID64, parseId64 } from './id64';
+
+describe('Id64', () => {
+  it.each(['0', '9007199254740993', '18446744073709551615'])(
+    'preserves %s exactly',
+    (value) => expect(parseId64(value)).toBe(value),
+  );
+
+  it('formats bigint and compares without number coercion', () => {
+    expect(formatId64(MAX_ID64)).toBe('18446744073709551615');
+    expect(compareId64('9007199254740993', '9007199254740992')).toBe(1);
+    expect(compareId64(0n, '0')).toBe(0);
+  });
+
+  it.each([
+    '',
+    ' 1',
+    '1 ',
+    '+1',
+    '-1',
+    '01',
+    '1.0',
+    '1e3',
+    '18446744073709551616',
+  ])('rejects invalid input %j', (value) => {
+    expect(() => parseId64(value)).toThrow();
+    expect(isId64(value)).toBe(false);
+  });
+
+  it('rejects every JavaScript number, including unsafe and non-finite numbers', () => {
+    for (const value of [0, 1, 9_007_199_254_740_992, NaN, Infinity]) {
+      expect(() => parseId64(value as never)).toThrow();
+    }
+  });
+});

--- a/apps/web/src/lib/domain/id64.ts
+++ b/apps/web/src/lib/domain/id64.ts
@@ -1,0 +1,43 @@
+/** Lossless, canonical unsigned 64-bit Elite Dangerous identifier. */
+export type Id64 = string & { readonly __id64: unique symbol };
+
+export const MAX_ID64 = 18_446_744_073_709_551_615n;
+
+/**
+ * Convert an identifier to its one canonical decimal representation.
+ * JavaScript numbers are deliberately excluded: even apparently safe values
+ * encourage a boundary which will silently round larger identifiers.
+ */
+export function parseId64(value: string | bigint): Id64 {
+  if (typeof value !== 'string' && typeof value !== 'bigint') {
+    throw new TypeError('Id64 cannot be represented by a JavaScript number');
+  }
+  if (typeof value === 'string' && !/^(?:0|[1-9]\d*)$/.test(value)) {
+    throw new TypeError('Id64 must be an unsigned canonical decimal string');
+  }
+  const integer = typeof value === 'bigint' ? value : BigInt(value);
+  if (integer < 0n || integer > MAX_ID64) {
+    throw new RangeError('Id64 is outside the unsigned 64-bit range');
+  }
+  return integer.toString(10) as Id64;
+}
+
+export const formatId64 = (value: string | bigint): Id64 => parseId64(value);
+
+export function compareId64(
+  left: string | bigint,
+  right: string | bigint,
+): -1 | 0 | 1 {
+  const a = BigInt(parseId64(left));
+  const b = BigInt(parseId64(right));
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function isId64(value: unknown): value is Id64 {
+  if (typeof value !== 'string') return false;
+  try {
+    return parseId64(value) === value;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/lib/persistence/context.ts
+++ b/apps/web/src/lib/persistence/context.ts
@@ -7,11 +7,9 @@ const PERSISTENCE_CONTEXT = Symbol('ed-finder-persistence');
 export type PersistenceContext = typeof applicationStores;
 
 /** Install once at the application shell; children receive typed services, not Storage globals. */
-export function providePersistenceContext(
-  services: PersistenceContext = applicationStores,
-): PersistenceContext {
-  setContext(PERSISTENCE_CONTEXT, services);
-  return services;
+export function providePersistenceContext(): PersistenceContext {
+  setContext(PERSISTENCE_CONTEXT, applicationStores);
+  return applicationStores;
 }
 
 export function usePersistenceContext(): PersistenceContext {

--- a/apps/web/src/lib/persistence/context.ts
+++ b/apps/web/src/lib/persistence/context.ts
@@ -1,0 +1,23 @@
+import { getContext, setContext } from 'svelte';
+
+import { applicationStores } from './stores';
+
+const PERSISTENCE_CONTEXT = Symbol('ed-finder-persistence');
+
+export type PersistenceContext = typeof applicationStores;
+
+/** Install once at the application shell; children receive typed services, not Storage globals. */
+export function providePersistenceContext(
+  services: PersistenceContext = applicationStores,
+): PersistenceContext {
+  setContext(PERSISTENCE_CONTEXT, services);
+  return services;
+}
+
+export function usePersistenceContext(): PersistenceContext {
+  const services = getContext<PersistenceContext | undefined>(
+    PERSISTENCE_CONTEXT,
+  );
+  if (!services) throw new Error('Persistence context has not been provided');
+  return services;
+}

--- a/apps/web/src/lib/persistence/fixtures.ts
+++ b/apps/web/src/lib/persistence/fixtures.ts
@@ -1,0 +1,48 @@
+/** Deterministic compatibility fixtures transcribed from the React store tests. */
+export const legacyPersistenceFixtures = {
+  pinnedBareArray: JSON.stringify([
+    {
+      id64: 12345,
+      name: 'Test System',
+      x: 0,
+      y: 0,
+      z: 0,
+      population: 0,
+      is_colonised: false,
+      economy: 'Tourism',
+      pinned_at: '2026-07-07T00:00:00Z',
+    },
+  ]),
+  fcRoute: JSON.stringify({
+    waypoints: [
+      { id: 'wp-sync', name: 'Achenar', x: 67, y: 12, z: -33, id64: 123 },
+    ],
+    config: {
+      jump_range_ly: 420,
+      cargo_t: 25000,
+      tritium_per_jump: 50,
+      tritium_price_cr: 50000,
+    },
+  }),
+  colonyProjectsV1: JSON.stringify({
+    state: {
+      projects: [
+        {
+          id: 'legacy-project',
+          system_id64: 123,
+          system_name: 'Legacy',
+          project_name: 'Legacy project',
+          build_plan_placements: [],
+          selected_body_assignments: {},
+          target_archetype: 'refinery_industrial',
+          notes: '',
+          status: 'validated',
+          created_at: '2026-05-01T00:00:00.000Z',
+          updated_at: '2026-05-01T00:00:00.000Z',
+          archived_at: null,
+        },
+      ],
+    },
+    version: 1,
+  }),
+} as const;

--- a/apps/web/src/lib/persistence/fixtures.ts
+++ b/apps/web/src/lib/persistence/fixtures.ts
@@ -45,4 +45,33 @@ export const legacyPersistenceFixtures = {
     },
     version: 1,
   }),
+  compareV2: JSON.stringify([
+    {
+      id64: 42,
+      name: 'Persisted',
+      population: 0,
+      coords: { x: 0, y: 0, z: 0 },
+    },
+  ]),
+  syncKey: JSON.stringify({
+    state: { syncKey: 'reviewwatchlistkey000000000000' },
+    version: 0,
+  }),
+  selectedRoute: JSON.stringify({
+    state: { selectedRouteId: null },
+    version: 0,
+  }),
+  myWorkV1: JSON.stringify({
+    state: {
+      systems: { '99': { id64: 99, name: 'Sync System', status: 'candidate' } },
+    },
+    version: 1,
+  }),
+  expansionPlansV1: JSON.stringify({ state: { plans: [] }, version: 1 }),
+  profileSyncKey: 'reviewprofilesynckey000000000000',
+  profileSyncLast: '2026-09-04T00:00:00.000Z',
+  selectedSystemContext: '456',
+  density: 'comfortable',
+  adminToken: 'test-admin-token',
+  operatorSelectedSourceRun: 'run-001',
 } as const;

--- a/apps/web/src/lib/persistence/index.ts
+++ b/apps/web/src/lib/persistence/index.ts
@@ -1,0 +1,4 @@
+export * from './context';
+export * from './fixtures';
+export * from './storage';
+export * from './stores';

--- a/apps/web/src/lib/persistence/storage.test.ts
+++ b/apps/web/src/lib/persistence/storage.test.ts
@@ -1,0 +1,215 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  LOCAL_STORAGE_KEYS,
+  SESSION_STORAGE_KEYS,
+  collectionCodec,
+  compareCodec,
+  createPersistedStore,
+  fcCodec,
+  pinnedCodec,
+  rawStringCodec,
+} from './storage';
+import { legacyPersistenceFixtures } from './fixtures';
+import { adminToken, selectedSystem } from './stores';
+
+describe('persistence compatibility', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('locks the exact local and session key inventory', () => {
+    expect(LOCAL_STORAGE_KEYS).toEqual([
+      'ed_pinned',
+      'ed_compare_v2',
+      'ed_sync_key',
+      'ed_selected_route',
+      'ed_my_work_v1',
+      'ed_colony_projects_v1',
+      'ed_expansion_plans_v1',
+      'ed_fc_v2',
+      'ed_profile_sync_key',
+      'ed_profile_sync_last',
+      'ed-finder:selected-system-context',
+      'ed_density_v1',
+    ]);
+    expect(SESSION_STORAGE_KEYS).toEqual([
+      'ed_admin_token',
+      'ed_operator_selected_source_run',
+    ]);
+  });
+
+  it('hydrates and round-trips the exact bare-array pin shape with canonical id64', () => {
+    localStorage.setItem(
+      'ed_pinned',
+      legacyPersistenceFixtures.pinnedBareArray,
+    );
+    const store = createPersistedStore({
+      key: 'ed_pinned',
+      initial: () => [],
+      codec: pinnedCodec,
+    });
+    store.hydrate();
+    expect(get(store).value).toEqual([
+      {
+        id64: '12345',
+        name: 'Test System',
+        x: 0,
+        y: 0,
+        z: 0,
+        population: 0,
+        is_colonised: false,
+        economy: 'Tourism',
+        pinned_at: '2026-07-07T00:00:00Z',
+      },
+    ]);
+    expect(store.set(get(store).value)).toBe(true);
+    expect(JSON.parse(localStorage.getItem('ed_pinned')!)).toEqual(
+      get(store).value,
+    );
+  });
+
+  it('preserves oversized decimal identifiers and uint64 max exactly', () => {
+    const result = compareCodec.decode(
+      JSON.stringify([
+        { id64: '9007199254740993', name: 'Above safe integer' },
+        { id64: '18446744073709551615', name: 'Uint64 max' },
+      ]),
+    );
+    expect(result.ok && result.value.map((entry) => entry.id64)).toEqual([
+      '9007199254740993',
+      '18446744073709551615',
+    ]);
+  });
+
+  it('hydrates selected-system zero and uint64 max as canonical strings', () => {
+    localStorage.setItem('ed-finder:selected-system-context', '0');
+    selectedSystem.hydrate();
+    expect(get(selectedSystem).value).toBe('0');
+    localStorage.setItem(
+      'ed-finder:selected-system-context',
+      '18446744073709551615',
+    );
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'ed-finder:selected-system-context',
+      }),
+    );
+    expect(get(selectedSystem).value).toBe('18446744073709551615');
+  });
+
+  it('keeps the admin token session-only', () => {
+    sessionStorage.clear();
+    expect(adminToken.set('temporary-admin-token')).toBe(true);
+    expect(sessionStorage.getItem('ed_admin_token')).toBe(
+      'temporary-admin-token',
+    );
+    expect(localStorage.getItem('ed_admin_token')).toBeNull();
+    adminToken.clear();
+  });
+
+  it('drops an unsafe legacy numeric id instead of preserving a rounded value', () => {
+    const result = pinnedCodec.decode(
+      '[{"id64":9007199254740992,"name":"lossy","pinned_at":"x"}]',
+    );
+    expect(result).toEqual({ ok: true, value: [] });
+  });
+
+  it('migrates FC waypoint ids and merges legacy config without losing unknown fields', () => {
+    const result = fcCodec.decode(
+      JSON.stringify({
+        waypoints: [
+          { id: 'wp-sync', name: 'Achenar', id64: 123, x: 67, future: 'kept' },
+        ],
+        config: { jump_range_ly: 420, future_config: true },
+        future_root: 1,
+      }),
+    );
+    expect(result.ok && result.value).toMatchObject({
+      waypoints: [{ id64: '123', future: 'kept' }],
+      config: { jump_range_ly: 420, future_config: true },
+      future_root: 1,
+    });
+  });
+
+  it('normalises collection envelopes and preserves unknown fields', () => {
+    const result = collectionCodec(3).decode(
+      JSON.stringify({
+        state: {
+          projects: [{ id: 'p', system_id64: 123, unknown: 'kept' }],
+          extra: 1,
+        },
+        version: 1,
+        future: true,
+      }),
+    );
+    expect(result.ok && result.value).toMatchObject({
+      state: { projects: [{ system_id64: '123', unknown: 'kept' }], extra: 1 },
+      version: 1,
+      future: true,
+    });
+  });
+
+  it('reports corrupt JSON and wrong types without crashing or erasing the entry', () => {
+    localStorage.setItem('ed_compare_v2', '{broken');
+    const store = createPersistedStore({
+      key: 'ed_compare_v2',
+      initial: () => [],
+      codec: compareCodec,
+    });
+    expect(() => store.hydrate()).not.toThrow();
+    expect(get(store).diagnostic?.problem).toBe('corrupt-json');
+    expect(localStorage.getItem('ed_compare_v2')).toBe('{broken');
+
+    localStorage.setItem('ed_compare_v2', '{}');
+    store.hydrate();
+    expect(get(store).diagnostic?.problem).toBe('invalid-shape');
+  });
+
+  it('refuses to overwrite a newer unknown envelope', () => {
+    const raw = JSON.stringify({
+      state: { systems: {} },
+      version: 99,
+      future: 'data',
+    });
+    localStorage.setItem('ed_my_work_v1', raw);
+    const store = createPersistedStore({
+      key: 'ed_my_work_v1',
+      initial: () => ({ state: {}, version: 0 }),
+      codec: collectionCodec(1),
+    });
+    store.hydrate();
+    expect(get(store).diagnostic?.problem).toBe('unsupported-version');
+    expect(store.set({ state: {}, version: 1 })).toBe(false);
+    expect(localStorage.getItem('ed_my_work_v1')).toBe(raw);
+  });
+
+  it('reacts to cross-tab storage events', () => {
+    const store = createPersistedStore({
+      key: 'ed_profile_sync_key',
+      initial: () => '',
+      codec: rawStringCodec(),
+      crossTab: true,
+    });
+    store.hydrate();
+    localStorage.setItem('ed_profile_sync_key', 'new-device-key');
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'ed_profile_sync_key',
+        storageArea: localStorage,
+      }),
+    );
+    expect(get(store).value).toBe('new-device-key');
+  });
+
+  it('is SSR safe when window is absent', () => {
+    vi.stubGlobal('window', undefined);
+    const store = createPersistedStore({
+      key: 'ed_profile_sync_last',
+      initial: () => '',
+      codec: rawStringCodec(),
+    });
+    expect(() => store.hydrate()).not.toThrow();
+    expect(get(store)).toEqual({ value: '', hydrated: true, diagnostic: null });
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/web/src/lib/persistence/storage.test.ts
+++ b/apps/web/src/lib/persistence/storage.test.ts
@@ -16,10 +16,20 @@ import {
   syncKeyCodec,
 } from './storage';
 import { legacyPersistenceFixtures } from './fixtures';
-import { adminToken, selectedSystem } from './stores';
+import {
+  adminToken,
+  applicationStores,
+  hydrateApplicationStores,
+  resetApplicationStoreHydrationForTest,
+  selectedSystem,
+} from './stores';
 
 describe('persistence compatibility', () => {
-  beforeEach(() => localStorage.clear());
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
 
   it('locks the exact local and session key inventory', () => {
     expect(LOCAL_STORAGE_KEYS).toEqual([
@@ -123,13 +133,29 @@ describe('persistence compatibility', () => {
   });
 
   it('keeps the admin token session-only', () => {
-    sessionStorage.clear();
     expect(adminToken.set('temporary-admin-token')).toBe(true);
     expect(sessionStorage.getItem('ed_admin_token')).toBe(
       'temporary-admin-token',
     );
     expect(localStorage.getItem('ed_admin_token')).toBeNull();
     adminToken.clear();
+  });
+
+  it('keeps admin credentials out of the application sync inventory', () => {
+    expect(Object.keys(applicationStores)).not.toContain('adminToken');
+    expect(Object.values(applicationStores)).not.toContain(adminToken);
+    expect(LOCAL_STORAGE_KEYS).not.toContain('ed_admin_token');
+  });
+
+  it('hydrates the standalone session credential outside that inventory', () => {
+    sessionStorage.setItem('ed_admin_token', 'existing-session-token');
+    resetApplicationStoreHydrationForTest();
+    const hydrateToken = vi.spyOn(adminToken, 'hydrate');
+
+    hydrateApplicationStores();
+
+    expect(hydrateToken).toHaveBeenCalledOnce();
+    expect(get(adminToken).value).toBe('existing-session-token');
   });
 
   it('drops an unsafe legacy numeric id instead of preserving a rounded value', () => {

--- a/apps/web/src/lib/persistence/storage.test.ts
+++ b/apps/web/src/lib/persistence/storage.test.ts
@@ -8,8 +8,12 @@ import {
   compareCodec,
   createPersistedStore,
   fcCodec,
+  densityCodec,
+  id64StringCodec,
   pinnedCodec,
   rawStringCodec,
+  selectedRouteCodec,
+  syncKeyCodec,
 } from './storage';
 import { legacyPersistenceFixtures } from './fixtures';
 import { adminToken, selectedSystem } from './stores';
@@ -36,6 +40,27 @@ describe('persistence compatibility', () => {
       'ed_admin_token',
       'ed_operator_selected_source_run',
     ]);
+  });
+
+  it('decodes the named legacy React fixtures without data loss', () => {
+    const fixtures = legacyPersistenceFixtures;
+    const cases = [
+      [pinnedCodec, fixtures.pinnedBareArray],
+      [compareCodec, fixtures.compareV2],
+      [syncKeyCodec, fixtures.syncKey],
+      [selectedRouteCodec, fixtures.selectedRoute],
+      [collectionCodec(1), fixtures.myWorkV1],
+      [collectionCodec(3), fixtures.colonyProjectsV1],
+      [collectionCodec(1), fixtures.expansionPlansV1],
+      [fcCodec, fixtures.fcRoute],
+      [rawStringCodec(), fixtures.profileSyncKey],
+      [rawStringCodec(), fixtures.profileSyncLast],
+      [id64StringCodec, fixtures.selectedSystemContext],
+      [densityCodec, fixtures.density],
+      [rawStringCodec(), fixtures.adminToken],
+      [rawStringCodec(), fixtures.operatorSelectedSourceRun],
+    ] as const;
+    for (const [codec, raw] of cases) expect(codec.decode(raw).ok).toBe(true);
   });
 
   it('hydrates and round-trips the exact bare-array pin shape with canonical id64', () => {
@@ -111,7 +136,41 @@ describe('persistence compatibility', () => {
     const result = pinnedCodec.decode(
       '[{"id64":9007199254740992,"name":"lossy","pinned_at":"x"}]',
     );
-    expect(result).toEqual({ ok: true, value: [] });
+    expect(result).toMatchObject({ ok: false, problem: 'invalid-shape' });
+  });
+
+  it.each([
+    ['pinned id', pinnedCodec, '[{"id64":"01","name":"Lave","pinned_at":"x"}]'],
+    ['pinned name', pinnedCodec, '[{"id64":"1","name":" ","pinned_at":"x"}]'],
+    ['pinned timestamp', pinnedCodec, '[{"id64":"1","name":"Lave"}]'],
+    ['compare id', compareCodec, '[{"id64":9007199254740992,"name":"Lave"}]'],
+    ['compare name', compareCodec, '[{"id64":"1","name":""}]'],
+  ])(
+    'diagnoses an invalid %s entry instead of silently dropping it',
+    (_name, codec, raw) => {
+      expect(codec.decode(raw)).toMatchObject({
+        ok: false,
+        problem: 'invalid-shape',
+      });
+    },
+  );
+
+  it('validates the current URL-safe sync-key contract', () => {
+    expect(
+      syncKeyCodec.decode(
+        '{"state":{"syncKey":"abcdefghijklmnop"},"version":0}',
+      ),
+    ).toMatchObject({ ok: true });
+    for (const syncKey of [
+      'legacy',
+      'short',
+      'invalid key!',
+      'a'.repeat(129),
+    ]) {
+      expect(
+        syncKeyCodec.decode(JSON.stringify({ state: { syncKey }, version: 0 })),
+      ).toMatchObject({ ok: false, problem: 'invalid-shape' });
+    }
   });
 
   it('migrates FC waypoint ids and merges legacy config without losing unknown fields', () => {
@@ -181,6 +240,25 @@ describe('persistence compatibility', () => {
     expect(get(store).diagnostic?.problem).toBe('unsupported-version');
     expect(store.set({ state: {}, version: 1 })).toBe(false);
     expect(localStorage.getItem('ed_my_work_v1')).toBe(raw);
+  });
+
+  it('reports private-mode reads during set as unavailable without throwing', () => {
+    const store = createPersistedStore({
+      key: 'ed_profile_sync_last',
+      initial: () => '',
+      codec: rawStringCodec(),
+    });
+    const getItem = vi
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementationOnce(() => {
+        throw new DOMException('denied', 'SecurityError');
+      });
+    expect(() => store.set('2026-09-04T00:00:00Z')).not.toThrow();
+    expect(get(store)).toMatchObject({
+      value: '2026-09-04T00:00:00Z',
+      diagnostic: { problem: 'unavailable' },
+    });
+    getItem.mockRestore();
   });
 
   it('reacts to cross-tab storage events', () => {

--- a/apps/web/src/lib/persistence/storage.test.ts
+++ b/apps/web/src/lib/persistence/storage.test.ts
@@ -208,6 +208,75 @@ describe('persistence compatibility', () => {
     });
   });
 
+  it.each([
+    ['unsafe numeric id64', { state: { id64: 9007199254740992 }, version: 1 }],
+    ['malformed string id64', { state: { id64: '01' }, version: 1 }],
+    [
+      'unsafe id64 nested in arrays and records',
+      {
+        state: { groups: [{ systems: [{ system_id64: 'not-an-id' }] }] },
+        version: 1,
+      },
+    ],
+  ])('rejects a collection with %s', (_name, envelope) => {
+    expect(collectionCodec(1).decode(JSON.stringify(envelope))).toMatchObject({
+      ok: false,
+      problem: 'invalid-shape',
+    });
+  });
+
+  it('normalises valid ids throughout nested arrays and records, including uint64 max', () => {
+    const result = collectionCodec(1).decode(
+      JSON.stringify({
+        state: {
+          groups: [
+            {
+              system_id64: 123,
+              systems: [{ id64: '18446744073709551615', future: 'kept' }],
+            },
+          ],
+        },
+        version: 1,
+        future: { preserved: true },
+      }),
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        state: {
+          groups: [
+            {
+              system_id64: '123',
+              systems: [{ id64: '18446744073709551615', future: 'kept' }],
+            },
+          ],
+        },
+        version: 1,
+        future: { preserved: true },
+      },
+    });
+  });
+
+  it.each([
+    ['missing state', { version: 1 }],
+    ['array state', { state: [], version: 1 }],
+    ['missing version', { state: {} }],
+    ['string version', { state: {}, version: '1' }],
+    ['fractional version', { state: {}, version: 0.5 }],
+    ['negative version', { state: {}, version: -1 }],
+  ])('rejects a collection envelope with %s', (_name, envelope) => {
+    expect(collectionCodec(1).decode(JSON.stringify(envelope))).toMatchObject({
+      ok: false,
+      problem: 'invalid-shape',
+    });
+  });
+
+  it('rejects a non-finite JSON number as an invalid collection version', () => {
+    expect(
+      collectionCodec(1).decode('{"state":{},"version":1e400}'),
+    ).toMatchObject({ ok: false, problem: 'invalid-shape' });
+  });
+
   it('reports corrupt JSON and wrong types without crashing or erasing the entry', () => {
     localStorage.setItem('ed_compare_v2', '{broken');
     const store = createPersistedStore({

--- a/apps/web/src/lib/persistence/storage.ts
+++ b/apps/web/src/lib/persistence/storage.ts
@@ -1,0 +1,431 @@
+import { writable, type Readable } from 'svelte/store';
+
+import { parseId64, type Id64 } from '../domain/id64';
+
+export const LOCAL_STORAGE_KEYS = [
+  'ed_pinned',
+  'ed_compare_v2',
+  'ed_sync_key',
+  'ed_selected_route',
+  'ed_my_work_v1',
+  'ed_colony_projects_v1',
+  'ed_expansion_plans_v1',
+  'ed_fc_v2',
+  'ed_profile_sync_key',
+  'ed_profile_sync_last',
+  'ed-finder:selected-system-context',
+  'ed_density_v1',
+] as const;
+
+export const SESSION_STORAGE_KEYS = [
+  'ed_admin_token',
+  'ed_operator_selected_source_run',
+] as const;
+
+export type LocalStorageKey = (typeof LOCAL_STORAGE_KEYS)[number];
+export type SessionStorageKey = (typeof SESSION_STORAGE_KEYS)[number];
+export type StorageAreaName = 'local' | 'session';
+export type PersistenceProblem =
+  'corrupt-json' | 'invalid-shape' | 'unsupported-version' | 'unavailable';
+
+export interface PersistenceDiagnostic {
+  key: LocalStorageKey | SessionStorageKey;
+  problem: PersistenceProblem;
+  /** Raw data is deliberately not included: session values may be sensitive. */
+  detail: string;
+  recoverable: boolean;
+}
+
+export interface PersistedState<T> {
+  value: T;
+  hydrated: boolean;
+  diagnostic: PersistenceDiagnostic | null;
+}
+
+type DecodeResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; problem: PersistenceProblem; detail: string };
+
+export interface Codec<T> {
+  readonly version: number;
+  decode(raw: string): DecodeResult<T>;
+  encode(value: T): string;
+}
+
+export function nullableCodec<T>(codec: Codec<T>): Codec<T | null> {
+  return {
+    version: codec.version,
+    decode: codec.decode,
+    // createPersistedStore removes null values before encoding.
+    encode: (value) => (value === null ? '' : codec.encode(value)),
+  };
+}
+
+function storageFor(area: StorageAreaName): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return area === 'local' ? window.localStorage : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function createPersistedStore<T>(options: {
+  key: LocalStorageKey | SessionStorageKey;
+  area?: StorageAreaName;
+  initial: () => T;
+  codec: Codec<T>;
+  crossTab?: boolean;
+}) {
+  const area = options.area ?? 'local';
+  const inner = writable<PersistedState<T>>({
+    value: options.initial(),
+    hydrated: false,
+    diagnostic: null,
+  });
+  let listening = false;
+
+  function read(): PersistedState<T> {
+    const storage = storageFor(area);
+    if (!storage) {
+      return {
+        value: options.initial(),
+        hydrated: true,
+        diagnostic:
+          typeof window === 'undefined'
+            ? null
+            : diagnostic('unavailable', 'Storage is unavailable', true),
+      };
+    }
+    let raw: string | null;
+    try {
+      raw = storage.getItem(options.key);
+    } catch {
+      return {
+        value: options.initial(),
+        hydrated: true,
+        diagnostic: diagnostic('unavailable', 'Storage read failed', true),
+      };
+    }
+    if (raw === null)
+      return { value: options.initial(), hydrated: true, diagnostic: null };
+    const decoded = options.codec.decode(raw);
+    return decoded.ok
+      ? { value: decoded.value, hydrated: true, diagnostic: null }
+      : {
+          value: options.initial(),
+          hydrated: true,
+          diagnostic: diagnostic(decoded.problem, decoded.detail, true),
+        };
+  }
+
+  function diagnostic(
+    problem: PersistenceProblem,
+    detail: string,
+    recoverable: boolean,
+  ): PersistenceDiagnostic {
+    return { key: options.key, problem, detail, recoverable };
+  }
+
+  function hydrate() {
+    inner.set(read());
+    if (
+      !listening &&
+      options.crossTab &&
+      area === 'local' &&
+      typeof window !== 'undefined'
+    ) {
+      listening = true;
+      window.addEventListener('storage', (event) => {
+        if (
+          (event.storageArea === null ||
+            event.storageArea === window.localStorage) &&
+          event.key === options.key
+        )
+          inner.set(read());
+      });
+    }
+  }
+
+  function set(value: T): boolean {
+    const storage = storageFor(area);
+    if (!storage) {
+      inner.set({
+        value,
+        hydrated: true,
+        diagnostic: diagnostic('unavailable', 'Storage is unavailable', true),
+      });
+      return false;
+    }
+    if (value === null) {
+      try {
+        storage.removeItem(options.key);
+        inner.set({ value, hydrated: true, diagnostic: null });
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    // A future envelope belongs to a newer application. Never erase it.
+    const current = storage.getItem(options.key);
+    if (current) {
+      const parsed = safeJson(current);
+      if (
+        parsed.ok &&
+        isRecord(parsed.value) &&
+        typeof parsed.value.version === 'number' &&
+        parsed.value.version > options.codec.version
+      ) {
+        inner.set({
+          value,
+          hydrated: true,
+          diagnostic: diagnostic(
+            'unsupported-version',
+            `Stored version ${parsed.value.version} is newer than ${options.codec.version}`,
+            true,
+          ),
+        });
+        return false;
+      }
+    }
+    try {
+      storage.setItem(options.key, options.codec.encode(value));
+      inner.set({ value, hydrated: true, diagnostic: null });
+      return true;
+    } catch {
+      inner.set({
+        value,
+        hydrated: true,
+        diagnostic: diagnostic('unavailable', 'Storage write failed', true),
+      });
+      return false;
+    }
+  }
+
+  function clear(): boolean {
+    const storage = storageFor(area);
+    if (!storage) return false;
+    try {
+      storage.removeItem(options.key);
+      inner.set({ value: options.initial(), hydrated: true, diagnostic: null });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return {
+    subscribe: inner.subscribe,
+    hydrate,
+    set,
+    clear,
+    read,
+  } satisfies Readable<PersistedState<T>> & {
+    hydrate(): void;
+    set(value: T): boolean;
+    clear(): boolean;
+    read(): PersistedState<T>;
+  };
+}
+
+function safeJson(raw: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(raw) as unknown };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const jsonCodec = <T>(
+  validate: (value: unknown) => T | null,
+  version = 0,
+): Codec<T> => ({
+  version,
+  decode(raw) {
+    const parsed = safeJson(raw);
+    if (!parsed.ok)
+      return {
+        ok: false,
+        problem: 'corrupt-json',
+        detail: 'Stored value is not valid JSON',
+      };
+    if (
+      isRecord(parsed.value) &&
+      typeof parsed.value.version === 'number' &&
+      parsed.value.version > version
+    ) {
+      return {
+        ok: false,
+        problem: 'unsupported-version',
+        detail: `Stored version ${parsed.value.version} is newer than ${version}`,
+      };
+    }
+    const value = validate(parsed.value);
+    return value === null
+      ? {
+          ok: false,
+          problem: 'invalid-shape',
+          detail: 'Stored value has the wrong shape',
+        }
+      : { ok: true, value };
+  },
+  encode: JSON.stringify,
+});
+
+export function rawStringCodec(
+  validate: (value: string) => boolean = () => true,
+): Codec<string> {
+  return {
+    version: 0,
+    decode: (raw) =>
+      validate(raw)
+        ? { ok: true, value: raw }
+        : {
+            ok: false,
+            problem: 'invalid-shape',
+            detail: 'Stored string is invalid',
+          },
+    encode: (value) => value,
+  };
+}
+
+export type JsonRecord = Record<string, unknown>;
+export type PinnedEntry = JsonRecord & {
+  id64: Id64;
+  name: string;
+  pinned_at: string;
+};
+export type CompareEntry = JsonRecord & { id64: Id64; name: string };
+export interface FcState extends JsonRecord {
+  waypoints: Array<JsonRecord & { id64?: Id64 | null }>;
+  config: JsonRecord;
+}
+export interface VersionedCollection extends JsonRecord {
+  state: JsonRecord;
+  version: number;
+}
+
+function canonicaliseIds(value: unknown, key = ''): unknown {
+  if (key === 'id64' || key.endsWith('_id64')) {
+    if (value === null) return null;
+    try {
+      // Safe legacy React snapshots used numbers. Converting only safe integers
+      // recovers those records without accepting already-rounded identifiers.
+      if (typeof value === 'number') {
+        if (!Number.isSafeInteger(value) || value < 0) return undefined;
+        return parseId64(String(value));
+      }
+      return parseId64(value as string | bigint);
+    } catch {
+      return undefined;
+    }
+  }
+  if (Array.isArray(value))
+    return value
+      .map((item) => canonicaliseIds(item))
+      .filter((item) => item !== undefined);
+  if (!isRecord(value)) return value;
+  const output: JsonRecord = {};
+  for (const [childKey, child] of Object.entries(value)) {
+    const normalised = canonicaliseIds(child, childKey);
+    if (normalised !== undefined) output[childKey] = normalised;
+  }
+  return output;
+}
+
+function arrayWithId(
+  value: unknown,
+): Array<JsonRecord & { id64: Id64 }> | null {
+  if (!Array.isArray(value)) return null;
+  const result: Array<JsonRecord & { id64: Id64 }> = [];
+  for (const candidate of value) {
+    const normalised = canonicaliseIds(candidate);
+    if (!isRecord(normalised) || typeof normalised.id64 !== 'string') continue;
+    result.push(normalised as JsonRecord & { id64: Id64 });
+  }
+  return result;
+}
+
+function collectionEnvelope(value: unknown): VersionedCollection | null {
+  if (!isRecord(value) || !isRecord(value.state)) return null;
+  return canonicaliseIds({
+    ...value,
+    version: typeof value.version === 'number' ? value.version : 0,
+  }) as VersionedCollection;
+}
+
+export const pinnedCodec = jsonCodec<PinnedEntry[]>(
+  (value) => arrayWithId(value) as PinnedEntry[] | null,
+);
+export const compareCodec = jsonCodec<CompareEntry[]>(
+  (value) => arrayWithId(value) as CompareEntry[] | null,
+);
+export const fcCodec = jsonCodec<FcState>((value) => {
+  const normalised = canonicaliseIds(value);
+  if (
+    !isRecord(normalised) ||
+    !Array.isArray(normalised.waypoints) ||
+    !isRecord(normalised.config)
+  )
+    return null;
+  return normalised as FcState;
+});
+export const collectionCodec = (version: number) =>
+  jsonCodec<VersionedCollection>(collectionEnvelope, version);
+export const syncKeyCodec = jsonCodec<{
+  state: { syncKey: string };
+  version: number;
+}>((value) => {
+  if (
+    !isRecord(value) ||
+    !isRecord(value.state) ||
+    typeof value.state.syncKey !== 'string'
+  )
+    return null;
+  return {
+    ...value,
+    state: { ...value.state, syncKey: value.state.syncKey },
+    version: typeof value.version === 'number' ? value.version : 0,
+  } as { state: { syncKey: string }; version: number };
+});
+export const selectedRouteCodec = jsonCodec<{
+  state: { selectedRouteId: string | null };
+  version: number;
+}>((value) => {
+  if (
+    !isRecord(value) ||
+    !isRecord(value.state) ||
+    (value.state.selectedRouteId !== null &&
+      typeof value.state.selectedRouteId !== 'string')
+  )
+    return null;
+  return {
+    ...value,
+    state: { ...value.state, selectedRouteId: value.state.selectedRouteId },
+    version: typeof value.version === 'number' ? value.version : 0,
+  } as { state: { selectedRouteId: string | null }; version: number };
+});
+
+export const id64StringCodec: Codec<Id64> = {
+  version: 0,
+  decode(raw) {
+    try {
+      return { ok: true, value: parseId64(raw) };
+    } catch {
+      return {
+        ok: false,
+        problem: 'invalid-shape',
+        detail: 'Stored identifier is not a canonical uint64',
+      };
+    }
+  },
+  encode: (value) => value,
+};
+export const densityCodec = rawStringCodec(
+  (value) =>
+    value === 'compact' || value === 'comfortable' || value === 'spacious',
+);
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/web/src/lib/persistence/storage.ts
+++ b/apps/web/src/lib/persistence/storage.ts
@@ -184,6 +184,9 @@ export function createPersistedStore<T>(options: {
         parsed.ok &&
         isRecord(parsed.value) &&
         typeof parsed.value.version === 'number' &&
+        Number.isFinite(parsed.value.version) &&
+        Number.isInteger(parsed.value.version) &&
+        parsed.value.version >= 0 &&
         parsed.value.version > options.codec.version
       ) {
         inner.set({
@@ -262,6 +265,9 @@ const jsonCodec = <T>(
     if (
       isRecord(parsed.value) &&
       typeof parsed.value.version === 'number' &&
+      Number.isFinite(parsed.value.version) &&
+      Number.isInteger(parsed.value.version) &&
+      parsed.value.version >= 0 &&
       parsed.value.version > version
     ) {
       return {
@@ -368,12 +374,22 @@ function entryArray<T extends JsonRecord & { id64: Id64 }>(
   return result;
 }
 
-function collectionEnvelope(value: unknown): VersionedCollection | null {
-  if (!isRecord(value) || !isRecord(value.state)) return null;
-  return canonicaliseIds({
-    ...value,
-    version: typeof value.version === 'number' ? value.version : 0,
-  }) as VersionedCollection;
+function collectionEnvelope(
+  value: unknown,
+  acceptedVersion: number,
+): VersionedCollection | null {
+  const normalised = canonicaliseIds(value);
+  if (
+    !isRecord(normalised) ||
+    !isRecord(normalised.state) ||
+    typeof normalised.version !== 'number' ||
+    !Number.isFinite(normalised.version) ||
+    !Number.isInteger(normalised.version) ||
+    normalised.version < 0 ||
+    normalised.version > acceptedVersion
+  )
+    return null;
+  return normalised as VersionedCollection;
 }
 
 export const pinnedCodec = jsonCodec<PinnedEntry[]>((value) =>
@@ -403,7 +419,10 @@ export const fcCodec = jsonCodec<FcState>((value) => {
   return normalised as FcState;
 });
 export const collectionCodec = (version: number) =>
-  jsonCodec<VersionedCollection>(collectionEnvelope, version);
+  jsonCodec<VersionedCollection>(
+    (value) => collectionEnvelope(value, version),
+    version,
+  );
 export const syncKeyCodec = jsonCodec<{
   state: { syncKey: string };
   version: number;

--- a/apps/web/src/lib/persistence/storage.ts
+++ b/apps/web/src/lib/persistence/storage.ts
@@ -167,7 +167,17 @@ export function createPersistedStore<T>(options: {
       }
     }
     // A future envelope belongs to a newer application. Never erase it.
-    const current = storage.getItem(options.key);
+    let current: string | null;
+    try {
+      current = storage.getItem(options.key);
+    } catch {
+      inner.set({
+        value,
+        hydrated: true,
+        diagnostic: diagnostic('unavailable', 'Storage read failed', true),
+      });
+      return false;
+    }
     if (current) {
       const parsed = safeJson(current);
       if (
@@ -305,6 +315,8 @@ export interface VersionedCollection extends JsonRecord {
   version: number;
 }
 
+const INVALID_PERSISTED_VALUE = Symbol('invalid-persisted-value');
+
 function canonicaliseIds(value: unknown, key = ''): unknown {
   if (key === 'id64' || key.endsWith('_id64')) {
     if (value === null) return null;
@@ -312,36 +324,46 @@ function canonicaliseIds(value: unknown, key = ''): unknown {
       // Safe legacy React snapshots used numbers. Converting only safe integers
       // recovers those records without accepting already-rounded identifiers.
       if (typeof value === 'number') {
-        if (!Number.isSafeInteger(value) || value < 0) return undefined;
+        if (!Number.isSafeInteger(value) || value < 0)
+          return INVALID_PERSISTED_VALUE;
         return parseId64(String(value));
       }
       return parseId64(value as string | bigint);
     } catch {
-      return undefined;
+      return INVALID_PERSISTED_VALUE;
     }
   }
-  if (Array.isArray(value))
-    return value
-      .map((item) => canonicaliseIds(item))
-      .filter((item) => item !== undefined);
+  if (Array.isArray(value)) {
+    const output = value.map((item) => canonicaliseIds(item));
+    return output.includes(INVALID_PERSISTED_VALUE)
+      ? INVALID_PERSISTED_VALUE
+      : output;
+  }
   if (!isRecord(value)) return value;
   const output: JsonRecord = {};
   for (const [childKey, child] of Object.entries(value)) {
     const normalised = canonicaliseIds(child, childKey);
-    if (normalised !== undefined) output[childKey] = normalised;
+    if (normalised === INVALID_PERSISTED_VALUE) return INVALID_PERSISTED_VALUE;
+    output[childKey] = normalised;
   }
   return output;
 }
 
-function arrayWithId(
+function entryArray<T extends JsonRecord & { id64: Id64 }>(
   value: unknown,
-): Array<JsonRecord & { id64: Id64 }> | null {
+  validate: (entry: JsonRecord & { id64: Id64 }) => entry is T,
+): T[] | null {
   if (!Array.isArray(value)) return null;
-  const result: Array<JsonRecord & { id64: Id64 }> = [];
+  const result: T[] = [];
   for (const candidate of value) {
     const normalised = canonicaliseIds(candidate);
-    if (!isRecord(normalised) || typeof normalised.id64 !== 'string') continue;
-    result.push(normalised as JsonRecord & { id64: Id64 });
+    if (
+      !isRecord(normalised) ||
+      typeof normalised.id64 !== 'string' ||
+      !validate(normalised as JsonRecord & { id64: Id64 })
+    )
+      return null;
+    result.push(normalised as T);
   }
   return result;
 }
@@ -354,11 +376,21 @@ function collectionEnvelope(value: unknown): VersionedCollection | null {
   }) as VersionedCollection;
 }
 
-export const pinnedCodec = jsonCodec<PinnedEntry[]>(
-  (value) => arrayWithId(value) as PinnedEntry[] | null,
+export const pinnedCodec = jsonCodec<PinnedEntry[]>((value) =>
+  entryArray<PinnedEntry>(
+    value,
+    (entry): entry is PinnedEntry =>
+      typeof entry.name === 'string' &&
+      entry.name.trim().length > 0 &&
+      typeof entry.pinned_at === 'string',
+  ),
 );
-export const compareCodec = jsonCodec<CompareEntry[]>(
-  (value) => arrayWithId(value) as CompareEntry[] | null,
+export const compareCodec = jsonCodec<CompareEntry[]>((value) =>
+  entryArray<CompareEntry>(
+    value,
+    (entry): entry is CompareEntry =>
+      typeof entry.name === 'string' && entry.name.trim().length > 0,
+  ),
 );
 export const fcCodec = jsonCodec<FcState>((value) => {
   const normalised = canonicaliseIds(value);
@@ -379,7 +411,9 @@ export const syncKeyCodec = jsonCodec<{
   if (
     !isRecord(value) ||
     !isRecord(value.state) ||
-    typeof value.state.syncKey !== 'string'
+    typeof value.state.syncKey !== 'string' ||
+    !/^[A-Za-z0-9_-]{16,128}$/.test(value.state.syncKey) ||
+    value.state.syncKey === 'legacy'
   )
     return null;
   return {

--- a/apps/web/src/lib/persistence/stores.ts
+++ b/apps/web/src/lib/persistence/stores.ts
@@ -1,0 +1,146 @@
+import { get } from 'svelte/store';
+
+import {
+  collectionCodec,
+  compareCodec,
+  createPersistedStore,
+  densityCodec,
+  fcCodec,
+  id64StringCodec,
+  nullableCodec,
+  pinnedCodec,
+  rawStringCodec,
+  selectedRouteCodec,
+  syncKeyCodec,
+  type CompareEntry,
+  type FcState,
+  type JsonRecord,
+  type PinnedEntry,
+  type VersionedCollection,
+} from './storage';
+import type { Id64 } from '../domain/id64';
+
+const emptyCollection = (): VersionedCollection => ({ state: {}, version: 0 });
+
+export const pins = createPersistedStore<PinnedEntry[]>({
+  key: 'ed_pinned',
+  initial: () => [],
+  codec: pinnedCodec,
+  crossTab: true,
+});
+export const compare = createPersistedStore<CompareEntry[]>({
+  key: 'ed_compare_v2',
+  initial: () => [],
+  codec: compareCodec,
+  crossTab: true,
+});
+export const syncKey = createPersistedStore({
+  key: 'ed_sync_key',
+  initial: () => ({ state: { syncKey: '' }, version: 0 }),
+  codec: syncKeyCodec,
+  crossTab: true,
+});
+export const selectedRoute = createPersistedStore({
+  key: 'ed_selected_route',
+  initial: () => ({ state: { selectedRouteId: null }, version: 0 }),
+  codec: selectedRouteCodec,
+  crossTab: true,
+});
+export const myWork = createPersistedStore({
+  key: 'ed_my_work_v1',
+  initial: emptyCollection,
+  codec: collectionCodec(1),
+  crossTab: true,
+});
+export const colonyProjects = createPersistedStore({
+  key: 'ed_colony_projects_v1',
+  initial: emptyCollection,
+  codec: collectionCodec(3),
+  crossTab: true,
+});
+export const expansionPlans = createPersistedStore({
+  key: 'ed_expansion_plans_v1',
+  initial: emptyCollection,
+  codec: collectionCodec(1),
+  crossTab: true,
+});
+export const fcRoute = createPersistedStore<FcState>({
+  key: 'ed_fc_v2',
+  initial: () => ({ waypoints: [], config: {} }),
+  codec: fcCodec,
+  crossTab: true,
+});
+export const profileSyncKey = createPersistedStore({
+  key: 'ed_profile_sync_key',
+  initial: () => '',
+  codec: rawStringCodec(),
+  crossTab: true,
+});
+export const profileSyncLast = createPersistedStore({
+  key: 'ed_profile_sync_last',
+  initial: () => '',
+  codec: rawStringCodec(),
+  crossTab: true,
+});
+export const selectedSystem = createPersistedStore<Id64 | null>({
+  key: 'ed-finder:selected-system-context',
+  initial: () => null,
+  codec: nullableCodec(id64StringCodec),
+  crossTab: true,
+});
+export const density = createPersistedStore({
+  key: 'ed_density_v1',
+  initial: () => 'comfortable',
+  codec: densityCodec,
+  crossTab: true,
+});
+export const adminToken = createPersistedStore({
+  key: 'ed_admin_token',
+  area: 'session',
+  initial: () => '',
+  codec: rawStringCodec(),
+});
+export const operatorHandoff = createPersistedStore({
+  key: 'ed_operator_selected_source_run',
+  area: 'session',
+  initial: () => '',
+  codec: rawStringCodec(),
+});
+
+export const applicationStores = {
+  pins,
+  compare,
+  syncKey,
+  selectedRoute,
+  myWork,
+  colonyProjects,
+  expansionPlans,
+  fcRoute,
+  profileSyncKey,
+  profileSyncLast,
+  selectedSystem,
+  density,
+  adminToken,
+  operatorHandoff,
+};
+
+export function hydrateApplicationStores(): void {
+  for (const store of Object.values(applicationStores)) store.hydrate();
+}
+
+/** Diagnostics are safe to render: they never contain persisted values or session tokens. */
+export function persistenceDiagnostics() {
+  const stores = Object.values(applicationStores) as Array<{
+    subscribe: (
+      run: (value: { diagnostic: unknown | null }) => void,
+    ) => () => void;
+  }>;
+  return stores.flatMap((store) => {
+    const state = get(store);
+    return state.diagnostic ? [state.diagnostic] : [];
+  });
+}
+
+export type MyWorkState = VersionedCollection & {
+  state: JsonRecord & { systems?: Record<string, JsonRecord> };
+};

--- a/apps/web/src/lib/persistence/stores.ts
+++ b/apps/web/src/lib/persistence/stores.ts
@@ -120,7 +120,6 @@ export const applicationStores = {
   profileSyncLast,
   selectedSystem,
   density,
-  adminToken,
   operatorHandoff,
 };
 
@@ -129,6 +128,9 @@ let applicationStoresHydrated = false;
 export function hydrateApplicationStores(): void {
   if (applicationStoresHydrated) return;
   applicationStoresHydrated = true;
+  // Credentials are hydrated for their dedicated control, but never exposed
+  // through the application/profile-sync store inventory.
+  adminToken.hydrate();
   for (const store of Object.values(applicationStores)) store.hydrate();
 }
 

--- a/apps/web/src/lib/persistence/stores.ts
+++ b/apps/web/src/lib/persistence/stores.ts
@@ -134,6 +134,8 @@ export function hydrateApplicationStores(): void {
 
 /** Test seam for proving boot idempotence without weakening runtime ownership. */
 export function resetApplicationStoreHydrationForTest(): void {
+  if (import.meta.env.MODE !== 'test')
+    throw new Error('Application-store hydration can only be reset in tests');
   applicationStoresHydrated = false;
 }
 

--- a/apps/web/src/lib/persistence/stores.ts
+++ b/apps/web/src/lib/persistence/stores.ts
@@ -124,8 +124,17 @@ export const applicationStores = {
   operatorHandoff,
 };
 
+let applicationStoresHydrated = false;
+
 export function hydrateApplicationStores(): void {
+  if (applicationStoresHydrated) return;
+  applicationStoresHydrated = true;
   for (const store of Object.values(applicationStores)) store.hydrate();
+}
+
+/** Test seam for proving boot idempotence without weakening runtime ownership. */
+export function resetApplicationStoreHydrationForTest(): void {
+  applicationStoresHydrated = false;
 }
 
 /** Diagnostics are safe to render: they never contain persisted values or session tokens. */

--- a/apps/web/src/lib/routing/legacy-hash.test.ts
+++ b/apps/web/src/lib/routing/legacy-hash.test.ts
@@ -37,6 +37,24 @@ describe('legacy hash compatibility', () => {
     });
   });
 
+  it('preserves valid encoded project identifiers exactly and fails closed on malformed escapes', () => {
+    expect(
+      legacyHashDestination(
+        '#colony-planner/system/1/project/a%20b%23c',
+        '?from=share&keep=%23fragment',
+      ),
+    ).toEqual({
+      pathname: '/colony-planner/system/1/project/a%20b%23c',
+      search: '?from=share&keep=%23fragment',
+    });
+    expect(
+      legacyHashDestination(
+        '#colony-planner/system/1/project/bad%2',
+        '?from=share',
+      ),
+    ).toEqual({ pathname: '/colony-planner', search: '?from=share' });
+  });
+
   it.each([
     '#system/-1',
     '#system/1e3',
@@ -53,5 +71,38 @@ describe('legacy hash compatibility', () => {
       false,
     );
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent after replacement clears the legacy hash', () => {
+    const replace = vi.fn();
+    const location = {
+      hash: '#system/18446744073709551615',
+      search: '?source=legacy',
+    } as Location;
+    expect(applyLegacyHash(location, replace)).toBe(true);
+    expect(replace).toHaveBeenCalledWith(
+      '/?source=legacy&system=18446744073709551615',
+    );
+    expect(
+      applyLegacyHash({ ...location, hash: '' } as Location, replace),
+    ).toBe(false);
+    expect(replace).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens a warm system hash over the current host workspace', () => {
+    const replace = vi.fn();
+    expect(
+      applyLegacyHash(
+        {
+          pathname: '/compare',
+          hash: '#system/9007199254740993',
+          search: '?source=warm',
+        } as Location,
+        replace,
+      ),
+    ).toBe(true);
+    expect(replace).toHaveBeenCalledWith(
+      '/compare?source=warm&system=9007199254740993',
+    );
   });
 });

--- a/apps/web/src/lib/routing/legacy-hash.test.ts
+++ b/apps/web/src/lib/routing/legacy-hash.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { applyLegacyHash, legacyHashDestination } from './legacy-hash';
+
+describe('legacy hash compatibility', () => {
+  it.each([
+    ['#finder', '/', ''],
+    ['#my-work', '/my-work', ''],
+    ['#watchlist', '/my-work/watchlist', ''],
+    ['#pinned', '/my-work/pinned', ''],
+    ['#colony', '/my-work/colony', ''],
+    ['#map', '/explore', ''],
+    ['#compare', '/compare', ''],
+    ['#search-tuning', '/search-tuning', ''],
+    ['#fc', '/fc', ''],
+    ['#admin', '/admin', ''],
+    ['#operator', '/operator', ''],
+    ['#system/9007199254740993', '/', '?system=9007199254740993'],
+    [
+      '#map/system/18446744073709551615',
+      '/explore',
+      '?system=18446744073709551615',
+    ],
+  ])('maps %s', (hash, pathname, search) =>
+    expect(legacyHashDestination(hash)).toEqual({ pathname, search }),
+  );
+
+  it('maps nested planner state and preserves the existing query', () => {
+    expect(
+      legacyHashDestination(
+        '#colony-planner/system/18446744073709551615/project/a%20b/mode/export/detail/9007199254740993',
+        '?from=share',
+      ),
+    ).toEqual({
+      pathname:
+        '/colony-planner/system/18446744073709551615/project/a%20b/mode/export',
+      search: '?from=share&system=9007199254740993',
+    });
+  });
+
+  it.each([
+    '#system/-1',
+    '#system/1e3',
+    '#system/1.5',
+    '#system/%201',
+    '#system/18446744073709551616',
+  ])('rejects unsafe id64 in %s', (hash) => {
+    expect(legacyHashDestination(hash)).toEqual({ pathname: '/', search: '' });
+  });
+
+  it('is inactive after the hash has been replaced', () => {
+    const replace = vi.fn();
+    expect(applyLegacyHash({ hash: '', search: '' } as Location, replace)).toBe(
+      false,
+    );
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/routing/legacy-hash.ts
+++ b/apps/web/src/lib/routing/legacy-hash.ts
@@ -85,7 +85,13 @@ function plannerDestination(
   let pathname = `/colony-planner/system/${system}`;
   let cursor = 3;
   if (parts[cursor] === 'project' && parts[cursor + 1]) {
-    pathname += `/project/${encodeURIComponent(decodeURIComponent(parts[cursor + 1]))}`;
+    let project: string;
+    try {
+      project = decodeURIComponent(parts[cursor + 1]);
+    } catch {
+      return { pathname: '/colony-planner', search: currentSearch };
+    }
+    pathname += `/project/${encodeURIComponent(project)}`;
     cursor += 2;
   }
   if (parts[cursor] === 'mode' && plannerModes.has(parts[cursor + 1] ?? '')) {
@@ -113,6 +119,11 @@ export function applyLegacyHash(
 ): boolean {
   const destination = legacyHashDestination(location.hash, location.search);
   if (!destination) return false;
-  replace(`${destination.pathname}${destination.search}`);
+  const isHostOverlay = /^#\/?system\//.test(location.hash);
+  const pathname =
+    isHostOverlay && location.pathname && location.pathname !== '/'
+      ? location.pathname
+      : destination.pathname;
+  replace(`${pathname}${destination.search}`);
   return true;
 }

--- a/apps/web/src/lib/routing/legacy-hash.ts
+++ b/apps/web/src/lib/routing/legacy-hash.ts
@@ -1,0 +1,118 @@
+import { parseId64, type Id64 } from '$lib/domain/id64';
+
+export const plannerModes = new Set([
+  'build-plan',
+  'suggested-builds',
+  'preview',
+  'sequence',
+  'map',
+  'evidence',
+  'validation',
+  'export',
+]);
+
+const hosts: Record<string, string> = {
+  finder: '/',
+  map: '/explore',
+  'my-work': '/my-work',
+  watchlist: '/my-work/watchlist',
+  pinned: '/my-work/pinned',
+  colony: '/my-work/colony',
+  compare: '/compare',
+  'search-tuning': '/search-tuning',
+  fc: '/fc',
+  admin: '/admin',
+  operator: '/operator',
+};
+
+export interface LegacyDestination {
+  pathname: string;
+  search: string;
+}
+
+function id(value: string | undefined): Id64 | null {
+  if (!value) return null;
+  try {
+    return parseId64(value);
+  } catch {
+    return null;
+  }
+}
+
+/** Convert the former React hash router URL without using lossy numeric coercion. */
+export function legacyHashDestination(
+  hash: string,
+  currentSearch = '',
+): LegacyDestination | null {
+  if (!hash) return null;
+  const raw = hash.replace(/^#\/?/, '');
+  const parts = raw.split('/').filter(Boolean);
+  if (parts.length === 0 || parts[0] === 'finder') {
+    if (parts[1] === 'system') {
+      const system = id(parts[2]);
+      return system
+        ? { pathname: '/', search: mergeQuery(currentSearch, 'system', system) }
+        : { pathname: '/', search: currentSearch };
+    }
+    return { pathname: '/', search: currentSearch };
+  }
+  if (parts[0] === 'system') {
+    const system = id(parts[1]);
+    return system
+      ? { pathname: '/', search: mergeQuery(currentSearch, 'system', system) }
+      : { pathname: '/', search: currentSearch };
+  }
+  if (parts[0] === 'colony-planner')
+    return plannerDestination(parts, currentSearch);
+
+  const pathname = hosts[parts[0]];
+  if (!pathname) return { pathname: '/', search: currentSearch };
+  if (parts[1] === 'system') {
+    const system = id(parts[2]);
+    return system
+      ? { pathname, search: mergeQuery(currentSearch, 'system', system) }
+      : { pathname, search: currentSearch };
+  }
+  return { pathname, search: currentSearch };
+}
+
+function plannerDestination(
+  parts: string[],
+  currentSearch: string,
+): LegacyDestination {
+  const system = parts[1] === 'system' ? id(parts[2]) : null;
+  if (!system) return { pathname: '/colony-planner', search: currentSearch };
+  let pathname = `/colony-planner/system/${system}`;
+  let cursor = 3;
+  if (parts[cursor] === 'project' && parts[cursor + 1]) {
+    pathname += `/project/${encodeURIComponent(decodeURIComponent(parts[cursor + 1]))}`;
+    cursor += 2;
+  }
+  if (parts[cursor] === 'mode' && plannerModes.has(parts[cursor + 1] ?? '')) {
+    pathname += `/mode/${parts[cursor + 1]}`;
+    cursor += 2;
+  }
+  if (parts[cursor] === 'detail') {
+    const detail = id(parts[cursor + 1]);
+    if (detail)
+      return { pathname, search: mergeQuery(currentSearch, 'system', detail) };
+  }
+  return { pathname, search: currentSearch };
+}
+
+function mergeQuery(currentSearch: string, key: string, value: string): string {
+  const query = new URLSearchParams(currentSearch);
+  query.set(key, value);
+  const result = query.toString();
+  return result ? `?${result}` : '';
+}
+
+export function applyLegacyHash(
+  location: Location,
+  replace: (url: string) => void,
+): boolean {
+  const destination = legacyHashDestination(location.hash, location.search);
+  if (!destination) return false;
+  replace(`${destination.pathname}${destination.search}`);
+  return true;
+}

--- a/apps/web/src/params/mywork.ts
+++ b/apps/web/src/params/mywork.ts
@@ -1,0 +1,3 @@
+import type { ParamMatcher } from '@sveltejs/kit';
+export const match: ParamMatcher = (value) =>
+  ['watchlist', 'pinned', 'colony'].includes(value);

--- a/apps/web/src/routes/+error.svelte
+++ b/apps/web/src/routes/+error.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+</script>
+
+<svelte:head
+  ><title
+    >{page.status === 404 ? 'Not found' : 'Application error'} — ED-Finder</title
+  ></svelte:head
+>
+<main class="placeholder" data-testid="application-error">
+  <p class="eyebrow">{page.status}</p>
+  <h1>{page.status === 404 ? 'Route not found' : 'Something went wrong'}</h1>
+  <p>
+    {page.error?.message ??
+      'The requested application surface could not be loaded.'}
+  </p>
+  <a href={resolve('/')}>Return to Finder</a>
+</main>

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+  import { QueryClientProvider } from '@tanstack/svelte-query';
   import AppShell from '$lib/components/AppShell.svelte';
+  import { queryClient } from '$lib/api/query';
+  import { providePersistenceContext } from '$lib/persistence/context';
   import '../app.css';
 
   let { children } = $props();
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: 1, staleTime: 30_000 } },
-  });
+  providePersistenceContext();
 </script>
 
 <QueryClientProvider client={queryClient}>

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { QueryClient, QueryClientProvider } from '@tanstack/svelte-query';
+  import AppShell from '$lib/components/AppShell.svelte';
   import '../app.css';
 
   let { children } = $props();
@@ -9,5 +10,5 @@
 </script>
 
 <QueryClientProvider client={queryClient}>
-  {@render children()}
+  <AppShell>{@render children()}</AppShell>
 </QueryClientProvider>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,76 +1,8 @@
 <script lang="ts">
-  import { resolve } from '$app/paths';
-  import { Compass, Map, Search, ClipboardCheck } from '@lucide/svelte';
-  import BootstrapStatus from '$lib/components/BootstrapStatus.svelte';
-
-  const steps = [
-    {
-      href: '/explore',
-      label: 'Explore',
-      detail: 'Future discovery workspace',
-      icon: Compass,
-    },
-    {
-      href: '/inspect',
-      label: 'Inspect',
-      detail: 'Future system detail',
-      icon: Search,
-    },
-    {
-      href: '/plan',
-      label: 'Plan',
-      detail: 'Future colony planning',
-      icon: Map,
-    },
-    {
-      href: '/review',
-      label: 'Review / Export',
-      detail: 'Future evidence workflow',
-      icon: ClipboardCheck,
-    },
-  ] as const;
+  import Placeholder from '$lib/components/Placeholder.svelte';
 </script>
 
-<svelte:head
-  ><title>ED-Finder V3</title><meta
-    name="description"
-    content="ED-Finder V3 application foundation"
-  /></svelte:head
->
-
-<header class="site-header">
-  <a class="brand" href={resolve('/')} aria-label="ED-Finder V3 home"
-    ><span>ED</span>Finder <b>V3</b></a
-  >
-  <nav aria-label="Product journey">
-    {#each steps as step (step.href)}<a href={resolve(step.href)}
-        >{step.label}</a
-      >{/each}
-  </nav>
-</header>
-<main>
-  <section class="hero">
-    <p class="eyebrow">New application foundation</p>
-    <h1>Find your place<br />among the stars.</h1>
-    <p class="lede">
-      ED-Finder V3 is taking shape. This shell establishes the journey while
-      existing tools remain in the reference application during migration.
-    </p>
-  </section>
-  <section aria-labelledby="journey-title">
-    <p class="eyebrow">Product journey</p>
-    <h2 id="journey-title">Explore to evidence</h2>
-    <div class="journey">
-      {#each steps as step, index (step.href)}
-        <a href={resolve(step.href)}
-          ><span class="number">0{index + 1}</span><step.icon
-            aria-hidden="true"
-            size={24}
-          /><strong>{step.label}</strong><small>{step.detail}</small></a
-        >
-      {/each}
-    </div>
-  </section>
-  <BootstrapStatus />
-</main>
-<footer>Foundation only — product features have not yet been ported.</footer>
+<Placeholder
+  title="Finder"
+  detail="Finder has not been ported yet. This route is the canonical application index."
+/>

--- a/apps/web/src/routes/admin/+page.svelte
+++ b/apps/web/src/routes/admin/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { auth } from '$lib/auth/auth';
+  import OwnerAccessGate from '$lib/components/OwnerAccessGate.svelte';
+</script>
+
+<main class="placeholder">
+  <OwnerAccessGate
+    authState={$auth}
+    signIn={auth.signIn}
+    signOut={auth.signOut}
+    claimOwner={auth.claimOwner}
+    ><section data-testid="admin-tab">
+      <p class="eyebrow">Separate owner mode</p>
+      <h1>Admin</h1>
+      <p>Admin features have not been ported yet.</p>
+    </section></OwnerAccessGate
+  >
+</main>

--- a/apps/web/src/routes/admin/+page.svelte
+++ b/apps/web/src/routes/admin/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { auth } from '$lib/auth/auth';
   import OwnerAccessGate from '$lib/components/OwnerAccessGate.svelte';
+  import SessionAdminTokenControl from '$lib/components/SessionAdminTokenControl.svelte';
 </script>
 
 <main class="placeholder">
@@ -9,10 +10,12 @@
     signIn={auth.signIn}
     signOut={auth.signOut}
     claimOwner={auth.claimOwner}
-    ><section data-testid="admin-tab">
+  >
+    <section data-testid="admin-tab">
       <p class="eyebrow">Separate owner mode</p>
       <h1>Admin</h1>
       <p>Admin features have not been ported yet.</p>
-    </section></OwnerAccessGate
-  >
+    </section>
+    <SessionAdminTokenControl />
+  </OwnerAccessGate>
 </main>

--- a/apps/web/src/routes/colony-planner/[...state]/+page.svelte
+++ b/apps/web/src/routes/colony-planner/[...state]/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Placeholder from '$lib/components/Placeholder.svelte';
+  let { data } = $props();
+  const detail = $derived(
+    data.system
+      ? `System ${data.system}${data.project ? ` · project ${data.project}` : ''}${data.mode ? ` · ${data.mode}` : ''}. Planner features have not been ported yet.`
+      : 'Colony Planner has not been ported yet.',
+  );
+</script>
+
+<Placeholder title="Colony Planner" {detail} />

--- a/apps/web/src/routes/colony-planner/[...state]/+page.ts
+++ b/apps/web/src/routes/colony-planner/[...state]/+page.ts
@@ -15,7 +15,11 @@ export function load({ params }) {
   let project: string | null = null;
   let mode: string | null = null;
   if (parts[cursor] === 'project' && parts[cursor + 1]) {
-    project = decodeURIComponent(parts[cursor + 1]);
+    try {
+      project = decodeURIComponent(parts[cursor + 1]);
+    } catch {
+      error(404, 'Invalid project identifier');
+    }
     cursor += 2;
   }
   if (parts[cursor] === 'mode' && plannerModes.has(parts[cursor + 1] ?? '')) {

--- a/apps/web/src/routes/colony-planner/[...state]/+page.ts
+++ b/apps/web/src/routes/colony-planner/[...state]/+page.ts
@@ -1,0 +1,27 @@
+import { error } from '@sveltejs/kit';
+import { parseId64 } from '$lib/domain/id64';
+import { plannerModes } from '$lib/routing/legacy-hash';
+export function load({ params }) {
+  const parts = (params.state ?? '').split('/').filter(Boolean);
+  if (!parts.length) return { system: null, project: null, mode: null };
+  if (parts[0] !== 'system' || !parts[1]) error(404, 'Invalid planner route');
+  let system;
+  try {
+    system = parseId64(parts[1]);
+  } catch {
+    error(404, 'Invalid system identifier');
+  }
+  let cursor = 2;
+  let project: string | null = null;
+  let mode: string | null = null;
+  if (parts[cursor] === 'project' && parts[cursor + 1]) {
+    project = decodeURIComponent(parts[cursor + 1]);
+    cursor += 2;
+  }
+  if (parts[cursor] === 'mode' && plannerModes.has(parts[cursor + 1] ?? '')) {
+    mode = parts[cursor + 1];
+    cursor += 2;
+  }
+  if (cursor !== parts.length) error(404, 'Invalid planner route');
+  return { system, project, mode };
+}

--- a/apps/web/src/routes/colony-planner/[...state]/+page.ts
+++ b/apps/web/src/routes/colony-planner/[...state]/+page.ts
@@ -1,31 +1,56 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import { parseId64 } from '$lib/domain/id64';
 import { plannerModes } from '$lib/routing/legacy-hash';
-export function load({ params }) {
+
+export function load({ params, url }) {
   const parts = (params.state ?? '').split('/').filter(Boolean);
   if (!parts.length) return { system: null, project: null, mode: null };
   if (parts[0] !== 'system' || !parts[1]) error(404, 'Invalid planner route');
+
   let system;
   try {
     system = parseId64(parts[1]);
   } catch {
     error(404, 'Invalid system identifier');
   }
+
   let cursor = 2;
   let project: string | null = null;
   let mode: string | null = null;
+  let canonicalPath = `/colony-planner/system/${system}`;
+
   if (parts[cursor] === 'project' && parts[cursor + 1]) {
     try {
       project = decodeURIComponent(parts[cursor + 1]);
     } catch {
       error(404, 'Invalid project identifier');
     }
+    canonicalPath += `/project/${encodeURIComponent(project)}`;
     cursor += 2;
   }
+
   if (parts[cursor] === 'mode' && plannerModes.has(parts[cursor + 1] ?? '')) {
     mode = parts[cursor + 1];
+    canonicalPath += `/mode/${mode}`;
     cursor += 2;
   }
+
+  if (parts[cursor] === 'detail' && parts[cursor + 1]) {
+    let detail;
+    try {
+      detail = parseId64(parts[cursor + 1]);
+    } catch {
+      error(404, 'Invalid detail system identifier');
+    }
+    cursor += 2;
+    if (cursor !== parts.length) error(404, 'Invalid planner route');
+
+    const query = new URLSearchParams(url.search);
+    query.set('system', detail);
+    const search = query.toString();
+    redirect(307, `${canonicalPath}${search ? `?${search}` : ''}`);
+  }
+
   if (cursor !== parts.length) error(404, 'Invalid planner route');
   return { system, project, mode };
 }

--- a/apps/web/src/routes/colony-planner/[...state]/page.test.ts
+++ b/apps/web/src/routes/colony-planner/[...state]/page.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { load } from './+page';
+
+function run(state: string, search = '') {
+  return load({
+    params: { state },
+    url: new URL(`http://localhost/colony-planner/${state}${search}`),
+  } as Parameters<typeof load>[0]);
+}
+
+function captureThrown(runRoute: () => unknown): {
+  status?: number;
+  location?: string;
+  body?: { message?: string };
+} {
+  try {
+    runRoute();
+  } catch (thrown) {
+    return thrown as {
+      status?: number;
+      location?: string;
+      body?: { message?: string };
+    };
+  }
+  throw new Error('Expected the planner route loader to throw');
+}
+
+describe('Colony Planner route loader', () => {
+  it('parses the canonical system, project, and mode grammar losslessly', () => {
+    expect(
+      run(
+        'system/18446744073709551615/project/project%20one/mode/preview',
+      ),
+    ).toEqual({
+      system: '18446744073709551615',
+      project: 'project one',
+      mode: 'preview',
+    });
+  });
+
+  it('redirects a legacy detail segment to the canonical overlay query', () => {
+    const thrown = captureThrown(() =>
+      run(
+        'system/18446744073709551615/project/project%20one/mode/preview/detail/9007199254740993',
+        '?view=compact&system=42',
+      ),
+    );
+
+    expect(thrown).toMatchObject({
+      status: 307,
+      location:
+        '/colony-planner/system/18446744073709551615/project/project%20one/mode/preview?view=compact&system=9007199254740993',
+    });
+  });
+
+  it.each([
+    ['unsafe numeric system', 'system/9007199254740992'],
+    ['unknown mode', 'system/42/mode/not-a-mode'],
+    ['missing project identifier', 'system/42/project'],
+    ['invalid detail id', 'system/42/detail/not-an-id'],
+    ['trailing detail data', 'system/42/detail/99/extra'],
+  ])('rejects %s', (_label, state) => {
+    expect(captureThrown(() => run(state))).toMatchObject({ status: 404 });
+  });
+});

--- a/apps/web/src/routes/colony-planner/[...state]/page.test.ts
+++ b/apps/web/src/routes/colony-planner/[...state]/page.test.ts
@@ -28,9 +28,7 @@ function captureThrown(runRoute: () => unknown): {
 describe('Colony Planner route loader', () => {
   it('parses the canonical system, project, and mode grammar losslessly', () => {
     expect(
-      run(
-        'system/18446744073709551615/project/project%20one/mode/preview',
-      ),
+      run('system/18446744073709551615/project/project%20one/mode/preview'),
     ).toEqual({
       system: '18446744073709551615',
       project: 'project one',

--- a/apps/web/src/routes/colony-planner/[...state]/page.test.ts
+++ b/apps/web/src/routes/colony-planner/[...state]/page.test.ts
@@ -54,7 +54,7 @@ describe('Colony Planner route loader', () => {
   });
 
   it.each([
-    ['unsafe numeric system', 'system/9007199254740992'],
+    ['out-of-range system', 'system/18446744073709551616'],
     ['unknown mode', 'system/42/mode/not-a-mode'],
     ['missing project identifier', 'system/42/project'],
     ['invalid detail id', 'system/42/detail/not-an-id'],

--- a/apps/web/src/routes/compare/+page.svelte
+++ b/apps/web/src/routes/compare/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Placeholder from '$lib/components/Placeholder.svelte';
+</script>
+
+<Placeholder title="Compare" />

--- a/apps/web/src/routes/fc/+page.svelte
+++ b/apps/web/src/routes/fc/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Placeholder from '$lib/components/Placeholder.svelte';
+</script>
+
+<Placeholder title="Fleet Carrier planner" />

--- a/apps/web/src/routes/my-work/+page.svelte
+++ b/apps/web/src/routes/my-work/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Placeholder from '$lib/components/Placeholder.svelte';
+</script>
+
+<Placeholder title="My Work" />

--- a/apps/web/src/routes/my-work/[alias=mywork]/+page.svelte
+++ b/apps/web/src/routes/my-work/[alias=mywork]/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Placeholder from '$lib/components/Placeholder.svelte';
+  const names = {
+    watchlist: 'Saved systems',
+    pinned: 'Pinned systems',
+    colony: 'Colony projects',
+  };
+  const title = $derived(names[page.params.alias as keyof typeof names]);
+</script>
+
+<Placeholder
+  {title}
+  detail="This My Work alias is retained, but its feature UI has not been ported yet."
+/>

--- a/apps/web/src/routes/operator/+page.svelte
+++ b/apps/web/src/routes/operator/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { auth } from '$lib/auth/auth';
+  import OwnerAccessGate from '$lib/components/OwnerAccessGate.svelte';
+</script>
+
+<main class="placeholder">
+  <OwnerAccessGate
+    authState={$auth}
+    signIn={auth.signIn}
+    signOut={auth.signOut}
+    claimOwner={auth.claimOwner}
+    ><section data-testid="operator-tab">
+      <p class="eyebrow">Separate owner mode</p>
+      <h1>Operator</h1>
+      <p>Operator features have not been ported yet.</p>
+    </section></OwnerAccessGate
+  >
+</main>

--- a/apps/web/src/routes/page.test.ts
+++ b/apps/web/src/routes/page.test.ts
@@ -3,6 +3,11 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import TestShell from '$lib/components/TestShell.svelte';
 import { getAuthSession, getHealth } from '$lib/api/client';
+import {
+  applicationStores,
+  hydrateApplicationStores,
+  resetApplicationStoreHydrationForTest,
+} from '$lib/persistence/stores';
 
 vi.mock('$lib/api/client', () => ({
   claimOwner: vi.fn(),
@@ -20,6 +25,9 @@ const renderPage = () => render(TestShell);
 describe('ED-Finder V3 shell', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    resetApplicationStoreHydrationForTest();
   });
   afterEach(cleanup);
   it('renders accessible journey navigation and guest status', async () => {
@@ -56,5 +64,32 @@ describe('ED-Finder V3 shell', () => {
     expect(
       screen.getByRole('navigation', { name: 'Primary navigation' }),
     ).toBeInTheDocument();
+  });
+  it('hydrates legacy persisted state during boot before rendering its context', async () => {
+    localStorage.setItem(
+      'ed-finder:selected-system-context',
+      '18446744073709551615',
+    );
+    mockedGetAuthSession.mockResolvedValue({
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByTestId('selected-system-context')).toHaveTextContent(
+        '18446744073709551615',
+      ),
+    );
+  });
+  it('hydrates each singleton persistence service exactly once', () => {
+    resetApplicationStoreHydrationForTest();
+    const hydrateSpies = Object.values(applicationStores).map((store) =>
+      vi.spyOn(store, 'hydrate'),
+    );
+    hydrateApplicationStores();
+    hydrateApplicationStores();
+    for (const hydrate of hydrateSpies)
+      expect(hydrate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/routes/page.test.ts
+++ b/apps/web/src/routes/page.test.ts
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/svelte';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import TestShell from '$lib/components/TestShell.svelte';
@@ -9,12 +15,20 @@ import {
   resetApplicationStoreHydrationForTest,
 } from '$lib/persistence/stores';
 
+const { mockedPage } = vi.hoisted(() => ({
+  mockedPage: { url: new URL('http://localhost/') },
+}));
+
 vi.mock('$lib/api/client', () => ({
   claimOwner: vi.fn(),
   frontierLoginUrl: vi.fn(() => '/api/auth/frontier/login'),
   getAuthSession: vi.fn(),
   getHealth: vi.fn(),
   authLogout: vi.fn(),
+}));
+vi.mock('$app/state', () => ({ page: mockedPage }));
+vi.mock('$app/navigation', () => ({
+  goto: vi.fn().mockResolvedValue(undefined),
 }));
 
 const mockedGetHealth = vi.mocked(getHealth);
@@ -24,12 +38,16 @@ const renderPage = () => render(TestShell);
 
 describe('ED-Finder V3 shell', () => {
   beforeEach(() => {
-    vi.resetAllMocks();
+    vi.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
+    mockedPage.url = new URL('http://localhost/');
     resetApplicationStoreHydrationForTest();
   });
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    resetApplicationStoreHydrationForTest();
+  });
   it('renders accessible journey navigation and guest status', async () => {
     mockedGetHealth.mockResolvedValue({
       status: 'ok',
@@ -80,6 +98,68 @@ describe('ED-Finder V3 shell', () => {
       expect(screen.getByTestId('selected-system-context')).toHaveTextContent(
         '18446744073709551615',
       ),
+    );
+  });
+  it('lets an overlay URL selection win after durable state hydrates', async () => {
+    localStorage.setItem('ed-finder:selected-system-context', '42');
+    mockedPage.url = new URL('http://localhost/?system=18446744073709551615');
+    mockedGetAuthSession.mockResolvedValue({
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('selected-system-context')).toHaveTextContent(
+        '18446744073709551615',
+      ),
+    );
+    expect(localStorage.getItem('ed-finder:selected-system-context')).toBe(
+      '18446744073709551615',
+    );
+  });
+  it('lets a cold system route establish and persist its selected system', async () => {
+    mockedPage.url = new URL('http://localhost/system/12345678901234567890');
+    mockedGetAuthSession.mockResolvedValue({
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('selected-system-context')).toHaveTextContent(
+        '12345678901234567890',
+      ),
+    );
+    expect(localStorage.getItem('ed-finder:selected-system-context')).toBe(
+      '12345678901234567890',
+    );
+  });
+  it('closing an overlay preserves its durable selected-system context', async () => {
+    localStorage.setItem('ed-finder:selected-system-context', '42');
+    mockedPage.url = new URL('http://localhost/?system=99');
+    mockedGetAuthSession.mockResolvedValue({
+      authenticated: false,
+      user: null,
+      owner_claim_available: false,
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(localStorage.getItem('ed-finder:selected-system-context')).toBe(
+        '99',
+      ),
+    );
+
+    await fireEvent.click(
+      screen.getByRole('button', { name: 'Close system detail' }),
+    );
+
+    expect(localStorage.getItem('ed-finder:selected-system-context')).toBe(
+      '99',
     );
   });
   it('hydrates each singleton persistence service exactly once', () => {

--- a/apps/web/src/routes/page.test.ts
+++ b/apps/web/src/routes/page.test.ts
@@ -5,8 +5,11 @@ import TestShell from '$lib/components/TestShell.svelte';
 import { getAuthSession, getHealth } from '$lib/api/client';
 
 vi.mock('$lib/api/client', () => ({
+  claimOwner: vi.fn(),
+  frontierLoginUrl: vi.fn(() => '/api/auth/frontier/login'),
   getAuthSession: vi.fn(),
   getHealth: vi.fn(),
+  authLogout: vi.fn(),
 }));
 
 const mockedGetHealth = vi.mocked(getHealth);
@@ -33,28 +36,25 @@ describe('ED-Finder V3 shell', () => {
     });
     renderPage();
     expect(
-      screen.getByRole('heading', { name: /find your place/i }),
+      screen.getByRole('heading', { name: /finder/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('navigation', { name: 'Product journey' }),
+      screen.getByRole('navigation', { name: 'Primary navigation' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole('link', { name: 'Explore' }).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: 'Explore' })).toBeInTheDocument();
     await waitFor(() =>
-      expect(screen.getByText('Connected')).toBeInTheDocument(),
+      expect(screen.getByTestId('frontier-sign-in')).toBeInTheDocument(),
     );
-    expect(screen.getByText('Guest')).toBeInTheDocument();
   });
   it('reports failed bootstrap requests without hiding the shell', async () => {
     mockedGetHealth.mockRejectedValue(new Error('Request failed (503)'));
     mockedGetAuthSession.mockRejectedValue(new Error('Request failed (503)'));
     renderPage();
     await waitFor(() =>
-      expect(screen.getAllByText('Unavailable')).toHaveLength(2),
+      expect(screen.getByTestId('frontier-sign-in')).toBeInTheDocument(),
     );
     expect(
-      screen.getByRole('navigation', { name: 'Product journey' }),
+      screen.getByRole('navigation', { name: 'Primary navigation' }),
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/search-tuning/+page.svelte
+++ b/apps/web/src/routes/search-tuning/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import Placeholder from '$lib/components/Placeholder.svelte';
+</script>
+
+<Placeholder title="Search tuning" />

--- a/apps/web/src/routes/system/[id64]/+page.svelte
+++ b/apps/web/src/routes/system/[id64]/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  let { data } = $props();
+</script>
+
+<svelte:head><title>System {data.id64} — ED-Finder</title></svelte:head>
+<main class="placeholder" data-testid="system-detail-page">
+  <p class="eyebrow">Inspect</p>
+  <h1>System Detail</h1>
+  <p>System <code>{data.id64}</code></p>
+  <p>
+    This cold-entry feature body has not been ported yet. It shares the future
+    content seam with the overlay.
+  </p>
+</main>

--- a/apps/web/src/routes/system/[id64]/+page.ts
+++ b/apps/web/src/routes/system/[id64]/+page.ts
@@ -1,0 +1,9 @@
+import { error } from '@sveltejs/kit';
+import { parseId64 } from '$lib/domain/id64';
+export function load({ params }) {
+  try {
+    return { id64: parseId64(params.id64) };
+  } catch {
+    error(404, 'Invalid system identifier');
+  }
+}

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -5,5 +5,9 @@ export default {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({ fallback: '200.html' }),
+    prerender: {
+      // Dynamic paths are resolved by the deliberate static SPA fallback.
+      handleUnseenRoutes: 'ignore',
+    },
   },
 };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import type { Plugin } from 'vite';
@@ -14,19 +15,21 @@ const staticSpaRoutes = [
   /^\/system\/\d+\/?$/,
   /^\/colony-planner(?:\/.*)?\/?$/,
 ];
+const staticSpaFallbackFile = new URL('./build/200.html', import.meta.url);
 
 export function isStaticSpaRoute(pathname: string): boolean {
   return staticSpaRoutes.some((pattern) => pattern.test(pathname));
 }
 
 function staticSpaPreviewFallback(): Plugin {
+  let fallbackHtml: Promise<string> | null = null;
   return {
     name: 'ed-finder-static-spa-preview-fallback',
     configurePreviewServer(server) {
-      // adapter-static emits 200.html, but Vite preview does not infer the
-      // deployment host's SPA fallback rule. Rewrite only known dynamic
-      // application namespaces before Vite's static middleware runs.
-      server.middlewares.use((request, _response, next) => {
+      // adapter-static emits build/200.html, but Vite preview does not expose
+      // that deployment fallback file through its own static-root mapping.
+      // Serve it directly only for known dynamic application namespaces.
+      server.middlewares.use((request, response, next) => {
         const method = request.method ?? 'GET';
         if (method !== 'GET' && method !== 'HEAD') return next();
 
@@ -34,10 +37,17 @@ function staticSpaPreviewFallback(): Plugin {
         // required to advertise Accept: text/html. The exact route match is
         // the safety boundary; backend and unknown paths remain untouched.
         const url = new URL(request.url ?? '/', 'http://127.0.0.1');
-        if (isStaticSpaRoute(url.pathname)) {
-          request.url = `/200.html${url.search}`;
-        }
-        next();
+        if (!isStaticSpaRoute(url.pathname)) return next();
+
+        fallbackHtml ??= readFile(staticSpaFallbackFile, 'utf8');
+        void fallbackHtml
+          .then((html) => {
+            response.statusCode = 200;
+            response.setHeader('Content-Type', 'text/html; charset=utf-8');
+            response.setHeader('Cache-Control', 'no-cache');
+            response.end(method === 'HEAD' ? undefined : html);
+          })
+          .catch(next);
       });
     },
   };

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,5 +1,6 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 const apiTarget = process.env.VITE_DEV_API_TARGET ?? 'http://127.0.0.1:8002';
@@ -9,8 +10,41 @@ const backendProxy = {
   '^/s/\\d+(?:\\?.*)?$': apiTarget,
 };
 
+const staticSpaRoutes = [
+  /^\/system\/\d+\/?$/,
+  /^\/colony-planner(?:\/.*)?\/?$/,
+];
+
+export function isStaticSpaRoute(pathname: string): boolean {
+  return staticSpaRoutes.some((pattern) => pattern.test(pathname));
+}
+
+function staticSpaPreviewFallback(): Plugin {
+  return {
+    name: 'ed-finder-static-spa-preview-fallback',
+    configurePreviewServer(server) {
+      // adapter-static emits 200.html, but Vite preview does not infer the
+      // deployment host's SPA fallback rule. Rewrite only known dynamic
+      // application namespaces before Vite's static middleware runs.
+      server.middlewares.use((request, _response, next) => {
+        const method = request.method ?? 'GET';
+        if (method !== 'GET' && method !== 'HEAD') return next();
+
+        const accept = request.headers.accept ?? '';
+        if (!accept.includes('text/html')) return next();
+
+        const url = new URL(request.url ?? '/', 'http://127.0.0.1');
+        if (isStaticSpaRoute(url.pathname)) {
+          request.url = `/200.html${url.search}`;
+        }
+        next();
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [tailwindcss(), sveltekit()],
+  plugins: [tailwindcss(), staticSpaPreviewFallback(), sveltekit()],
   resolve: { conditions: ['browser'] },
   server: { proxy: backendProxy },
   preview: { proxy: backendProxy },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,5 @@
-import { readFile } from 'node:fs/promises';
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
 const apiTarget = process.env.VITE_DEV_API_TARGET ?? 'http://127.0.0.1:8002';
@@ -11,53 +9,10 @@ const backendProxy = {
   '^/s/\\d+(?:\\?.*)?$': apiTarget,
 };
 
-const staticSpaRoutes = [
-  /^\/system\/\d+\/?$/,
-  /^\/colony-planner(?:\/.*)?\/?$/,
-];
-const staticSpaFallbackFile = new URL('./build/200.html', import.meta.url);
-
-export function isStaticSpaRoute(pathname: string): boolean {
-  return staticSpaRoutes.some((pattern) => pattern.test(pathname));
-}
-
-function staticSpaPreviewFallback(): Plugin {
-  let fallbackHtml: Promise<string> | null = null;
-  return {
-    name: 'ed-finder-static-spa-preview-fallback',
-    configurePreviewServer(server) {
-      // adapter-static emits build/200.html, but Vite preview does not expose
-      // that deployment fallback file through its own static-root mapping.
-      // Serve it directly only for known dynamic application namespaces.
-      server.middlewares.use((request, response, next) => {
-        const method = request.method ?? 'GET';
-        if (method !== 'GET' && method !== 'HEAD') return next();
-
-        // Cypress cold visits and other valid navigation clients are not
-        // required to advertise Accept: text/html. The exact route match is
-        // the safety boundary; backend and unknown paths remain untouched.
-        const url = new URL(request.url ?? '/', 'http://127.0.0.1');
-        if (!isStaticSpaRoute(url.pathname)) return next();
-
-        fallbackHtml ??= readFile(staticSpaFallbackFile, 'utf8');
-        void fallbackHtml
-          .then((html) => {
-            response.statusCode = 200;
-            response.setHeader('Content-Type', 'text/html; charset=utf-8');
-            response.setHeader('Cache-Control', 'no-cache');
-            response.end(method === 'HEAD' ? undefined : html);
-          })
-          .catch(next);
-      });
-    },
-  };
-}
-
 export default defineConfig({
-  plugins: [tailwindcss(), staticSpaPreviewFallback(), sveltekit()],
+  plugins: [tailwindcss(), sveltekit()],
   resolve: { conditions: ['browser'] },
   server: { proxy: backendProxy },
-  preview: { proxy: backendProxy },
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.ts'],

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -30,9 +30,9 @@ function staticSpaPreviewFallback(): Plugin {
         const method = request.method ?? 'GET';
         if (method !== 'GET' && method !== 'HEAD') return next();
 
-        const accept = request.headers.accept ?? '';
-        if (!accept.includes('text/html')) return next();
-
+        // Cypress cold visits and other valid navigation clients are not
+        // required to advertise Accept: text/html. The exact route match is
+        // the safety boundary; backend and unknown paths remain untouched.
         const url = new URL(request.url ?? '/', 'http://127.0.0.1');
         if (isStaticSpaRoute(url.pathname)) {
           request.url = `/200.html${url.search}`;

--- a/tests/test_svelte_generated_client_boundary.py
+++ b/tests/test_svelte_generated_client_boundary.py
@@ -1,0 +1,42 @@
+import re
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WEB_SOURCE = ROOT / 'apps' / 'web' / 'src'
+FACADE = WEB_SOURCE / 'lib' / 'api' / 'client.ts'
+GENERATED = WEB_SOURCE / 'lib' / 'api' / 'generated'
+IMPORT_SPECIFIER = re.compile(
+    r"(?:from\s+|import\s*\()\s*['\"]([^'\"]*generated(?:/[^'\"]*)?)['\"]"
+)
+
+
+@pytest.mark.unit
+def test_generated_hey_api_modules_are_private_to_the_application_facade():
+    violations: list[str] = []
+    for path in WEB_SOURCE.rglob('*'):
+        if not path.is_file() or path.suffix not in {'.ts', '.js', '.svelte'}:
+            continue
+        if GENERATED in path.parents or path == FACADE or '.test.' in path.name:
+            continue
+        source = path.read_text(encoding='utf-8')
+        for match in IMPORT_SPECIFIER.finditer(source):
+            violations.append(f'{path.relative_to(ROOT)} -> {match.group(1)}')
+
+    assert not violations, (
+        'Generated API modules must stay behind apps/web/src/lib/api/client.ts; '
+        'id64-bearing responses require the lossless application facade:\n'
+        + '\n'.join(violations)
+    )
+
+
+@pytest.mark.unit
+def test_facade_documents_and_implements_the_lossless_id64_lane():
+    source = FACADE.read_text(encoding='utf-8')
+
+    assert 'parseLosslessJson' in source
+    assert 'export async function apiRequest' in source
+    assert 'export async function getSystem' in source
+    assert "from './generated/sdk.gen'" in source

--- a/tests/test_svelte_platform_contracts.py
+++ b/tests/test_svelte_platform_contracts.py
@@ -1,0 +1,101 @@
+"""Fail-closed repository contracts for the Svelte platform tranche (#579)."""
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WEB = ROOT / "apps" / "web"
+SOURCE = WEB / "src"
+
+
+def _application_sources():
+    for suffix in ("*.ts", "*.svelte"):
+        for path in SOURCE.rglob(suffix):
+            relative = path.relative_to(SOURCE).as_posix()
+            if "/generated/" in f"/{relative}" or relative.endswith(".test.ts"):
+                continue
+            yield path, path.read_text(encoding="utf-8")
+
+
+def test_generated_hey_api_is_isolated_behind_api_adapters():
+    offenders = []
+    for path, source in _application_sources():
+        relative = path.relative_to(SOURCE).as_posix()
+        if "/api/" not in f"/{relative}" and re.search(
+            r"(?:from|import\()\s*['\"][^'\"]*api/generated", source
+        ):
+            offenders.append(relative)
+    assert offenders == []
+
+
+def test_application_id64_never_uses_number_coercion_or_number_types():
+    coercion = re.compile(
+        r"(?:Number|parseInt)\s*\([^\n)]*(?:id64|systemId|system_id)|"
+        r"\+\s*(?:[A-Za-z_$][\w$]*\.)*(?:id64|systemId|system_id)\b",
+        re.IGNORECASE,
+    )
+    number_type = re.compile(
+        r"(?:id64|systemId64|system_id64)\??\s*:\s*number\b", re.IGNORECASE
+    )
+    offenders = []
+    for path, source in _application_sources():
+        if coercion.search(source) or number_type.search(source):
+            offenders.append(path.relative_to(SOURCE).as_posix())
+    assert offenders == []
+
+
+def test_persisted_key_inventory_is_explicit_and_complete():
+    persistence = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (SOURCE / "lib" / "persistence").glob("*.ts")
+    )
+    local_keys = {
+        "ed_pinned",
+        "ed_compare_v2",
+        "ed_sync_key",
+        "ed_selected_route",
+        "ed_my_work_v1",
+        "ed_colony_projects_v1",
+        "ed_expansion_plans_v1",
+        "ed_fc_v2",
+        "ed_profile_sync_key",
+        "ed_profile_sync_last",
+        "ed-finder:selected-system-context",
+        "ed_density_v1",
+    }
+    session_keys = {"ed_admin_token", "ed_operator_selected_source_run"}
+    assert all(
+        f"'{key}'" in persistence or f'"{key}"' in persistence
+        for key in local_keys | session_keys
+    )
+    assert "localStorage" in persistence
+    assert "sessionStorage" in persistence
+
+
+def test_static_application_has_no_pwa_or_playwright_runtime():
+    package = (WEB / "package.json").read_text(encoding="utf-8").lower()
+    paths = {
+        path.name.lower()
+        for root in (SOURCE, WEB / "static")
+        if root.exists()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+    assert "playwright" not in package
+    assert "serviceworker" not in package
+    assert not ({"manifest.webmanifest", "service-worker.js", "sw.js"} & paths)
+
+
+def test_backend_route_ownership_remains_exact_and_frontend_is_fallback():
+    vite = (WEB / "vite.config.ts").read_text(encoding="utf-8")
+    svelte = (WEB / "svelte.config.js").read_text(encoding="utf-8")
+    assert "^/api(?:$|[/?])" in vite
+    assert r"^/openapi\\.json(?:\\?.*)?$" in vite
+    assert r"^/s/\\d+(?:\\?.*)?$" in vite
+    assert "fallback: '200.html'" in svelte
+
+
+def test_react_tree_is_retained_as_source_evidence_only():
+    assert (ROOT / "frontend" / "src" / "App.tsx").is_file()
+    assert (WEB / "src" / "routes").is_dir()

--- a/tests/test_svelte_platform_contracts.py
+++ b/tests/test_svelte_platform_contracts.py
@@ -99,3 +99,23 @@ def test_backend_route_ownership_remains_exact_and_frontend_is_fallback():
 def test_react_tree_is_retained_as_source_evidence_only():
     assert (ROOT / "frontend" / "src" / "App.tsx").is_file()
     assert (WEB / "src" / "routes").is_dir()
+
+
+def test_root_layout_owns_the_configured_query_and_persistence_singletons():
+    layout = (SOURCE / "routes" / "+layout.svelte").read_text(encoding="utf-8")
+    query = (SOURCE / "lib" / "api" / "query.ts").read_text(encoding="utf-8")
+    shell = (SOURCE / "lib" / "components" / "AppShell.svelte").read_text(
+        encoding="utf-8"
+    )
+    assert "new QueryClient" not in layout
+    assert "import { queryClient } from '$lib/api/query'" in layout
+    for accepted_default in (
+        "staleTime: 30_000",
+        "gcTime: 300_000",
+        "retry: 1",
+        "refetchOnWindowFocus: false",
+        "mutations: { retry: 0 }",
+    ):
+        assert accepted_default in query
+    assert "providePersistenceContext()" in layout
+    assert "hydrateApplicationStores()" in shell

--- a/tests/test_svelte_preview_fallback_contract.py
+++ b/tests/test_svelte_preview_fallback_contract.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VITE_CONFIG = ROOT / 'apps' / 'web' / 'vite.config.ts'
+
+
+@pytest.mark.unit
+def test_svelte_preview_rewrites_only_known_dynamic_application_namespaces():
+    source = VITE_CONFIG.read_text(encoding='utf-8')
+
+    assert "name: 'ed-finder-static-spa-preview-fallback'" in source
+    assert 'configurePreviewServer(server)' in source
+    assert "method !== 'GET' && method !== 'HEAD'" in source
+    assert "accept.includes('text/html')" in source
+    assert r'/^\/system\/\d+\/?$/' in source
+    assert r'/^\/colony-planner(?:\/.*)?\/?$/' in source
+    assert 'request.url = `/200.html${url.search}`;' in source
+
+
+@pytest.mark.unit
+def test_svelte_preview_keeps_backend_and_unknown_frontend_routes_out_of_fallback():
+    source = VITE_CONFIG.read_text(encoding='utf-8')
+    fallback_block = source[
+        source.index('const staticSpaRoutes'):
+        source.index('export function isStaticSpaRoute')
+    ]
+
+    assert 'api' not in fallback_block
+    assert 'openapi' not in fallback_block
+    assert '/s/' not in fallback_block
+    assert 'apiary' not in fallback_block
+    assert "'^/api(?:$|[/?])'" in source
+    assert "'^/openapi\\\\.json(?:\\\\?.*)?$'" in source
+    assert "'^/s/\\\\d+(?:\\\\?.*)?$'" in source

--- a/tests/test_svelte_preview_fallback_contract.py
+++ b/tests/test_svelte_preview_fallback_contract.py
@@ -8,7 +8,7 @@ VITE_CONFIG = ROOT / 'apps' / 'web' / 'vite.config.ts'
 
 
 @pytest.mark.unit
-def test_svelte_preview_rewrites_only_known_dynamic_application_namespaces():
+def test_svelte_preview_serves_only_known_dynamic_application_namespaces():
     source = VITE_CONFIG.read_text(encoding='utf-8')
 
     assert "name: 'ed-finder-static-spa-preview-fallback'" in source
@@ -17,7 +17,12 @@ def test_svelte_preview_rewrites_only_known_dynamic_application_namespaces():
     assert "request.headers.accept" not in source
     assert r'/^\/system\/\d+\/?$/' in source
     assert r'/^\/colony-planner(?:\/.*)?\/?$/' in source
-    assert 'request.url = `/200.html${url.search}`;' in source
+    assert "new URL('./build/200.html', import.meta.url)" in source
+    assert "readFile(staticSpaFallbackFile, 'utf8')" in source
+    assert "response.statusCode = 200" in source
+    assert "response.setHeader('Content-Type', 'text/html; charset=utf-8')" in source
+    assert "response.end(method === 'HEAD' ? undefined : html)" in source
+    assert 'request.url = `/200.html${url.search}`;' not in source
 
 
 @pytest.mark.unit

--- a/tests/test_svelte_preview_fallback_contract.py
+++ b/tests/test_svelte_preview_fallback_contract.py
@@ -1,42 +1,75 @@
+import json
 from pathlib import Path
 
 import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
-VITE_CONFIG = ROOT / 'apps' / 'web' / 'vite.config.ts'
+WEB = ROOT / "apps" / "web"
+PREVIEW_SERVER = WEB / "scripts" / "static-preview.mjs"
 
 
 @pytest.mark.unit
-def test_svelte_preview_serves_only_known_dynamic_application_namespaces():
-    source = VITE_CONFIG.read_text(encoding='utf-8')
+def test_svelte_preview_uses_the_built_static_server_contract():
+    package = json.loads((WEB / "package.json").read_text(encoding="utf-8"))
+    source = PREVIEW_SERVER.read_text(encoding="utf-8")
+    vite = (WEB / "vite.config.ts").read_text(encoding="utf-8")
+    workflow = (ROOT / ".github" / "workflows" / "cypress-parity.yml").read_text(
+        encoding="utf-8"
+    )
 
-    assert "name: 'ed-finder-static-spa-preview-fallback'" in source
-    assert 'configurePreviewServer(server)' in source
-    assert "method !== 'GET' && method !== 'HEAD'" in source
-    assert "request.headers.accept" not in source
-    assert r'/^\/system\/\d+\/?$/' in source
-    assert r'/^\/colony-planner(?:\/.*)?\/?$/' in source
-    assert "new URL('./build/200.html', import.meta.url)" in source
-    assert "readFile(staticSpaFallbackFile, 'utf8')" in source
-    assert "response.statusCode = 200" in source
-    assert "response.setHeader('Content-Type', 'text/html; charset=utf-8')" in source
-    assert "response.end(method === 'HEAD' ? undefined : html)" in source
-    assert 'request.url = `/200.html${url.search}`;' not in source
+    assert package["scripts"]["preview"] == "node scripts/static-preview.mjs"
+    assert "node --test scripts/static-preview.test.mjs" in package["scripts"]["test"]
+    assert "name: 'ed-finder-static-spa-preview-fallback'" not in vite
+    assert "preview: { proxy: backendProxy }" not in vite
+    assert "ED_FINDER_PREVIEW_API_TARGET: http://127.0.0.1:8002" in workflow
+    assert "pnpm preview --host 127.0.0.1 --port 4174 --strictPort" in workflow
 
-
-@pytest.mark.unit
-def test_svelte_preview_keeps_backend_and_unknown_frontend_routes_out_of_fallback():
-    source = VITE_CONFIG.read_text(encoding='utf-8')
-    fallback_block = source[
-        source.index('const staticSpaRoutes'):
-        source.index('export function isStaticSpaRoute')
+    assert "locateStaticFile(canonicalBuildRoot, '/200.html')" in source
+    assert "request.method !== 'GET' && request.method !== 'HEAD'" in source
+    assert "serveFile(request, response, file ?? fallback, file === null)" in source
+    serve_file = source[
+        source.index("function serveFile") : source.index(
+            "function connectionHeaderNames"
+        )
     ]
+    assert "response.writeHead(" in serve_file
+    assert "200," in serve_file
+    assert "response.end(request.method === 'HEAD' ? undefined : body)" in source
+    assert "request.headers.accept" not in source
 
-    assert 'api' not in fallback_block
-    assert 'openapi' not in fallback_block
-    assert '/s/' not in fallback_block
-    assert 'apiary' not in fallback_block
-    assert "'^/api(?:$|[/?])'" in source
-    assert "'^/openapi\\\\.json(?:\\\\?.*)?$'" in source
-    assert "'^/s/\\\\d+(?:\\\\?.*)?$'" in source
+
+@pytest.mark.unit
+def test_svelte_preview_keeps_backend_ownership_exact_and_fails_closed():
+    source = PREVIEW_SERVER.read_text(encoding="utf-8")
+
+    assert r"/^\/api(?:\/|$)/u" in source
+    assert r"/^\/openapi\.json$/u" in source
+    assert r"/^\/s\/[0-9]+$/u" in source
+    assert "classifyRoute(parsedTarget.rawPathname) === 'backend'" in source
+    assert "? 'backend'" in source
+    assert ": 'frontend'" in source
+    assert "parsedTarget.rawPathname}${parsedTarget.search}" in source
+    assert "no disposable preview API target was supplied" in source
+    assert "503" in source
+
+    assert "target.username || target.password" in source
+    assert "isLoopbackHostname(target.hostname)" in source
+    assert "pipeline(request, upstream" in source
+    assert "process.once('SIGINT', shutdown)" in source
+    assert "process.once('SIGTERM', shutdown)" in source
+
+
+@pytest.mark.unit
+def test_svelte_preview_validates_and_contains_static_paths_before_serving():
+    source = PREVIEW_SERVER.read_text(encoding="utf-8")
+
+    assert "requestTarget.indexOf('?')" in source
+    assert "decodeUrlComponent(rawPathname, 'request path')" in source
+    assert "pathname.includes('\\\\')" in source
+    assert "segment === '.' || segment === '..'" in source
+    assert "resolveStaticPath(buildRoot, pathname)" in source
+    assert "relative(root, candidate)" in source
+    assert "const canonicalPath = await realpath(candidate)" in source
+    assert "'Content-Type'" in source
+    assert "'Content-Length'" in source

--- a/tests/test_svelte_preview_fallback_contract.py
+++ b/tests/test_svelte_preview_fallback_contract.py
@@ -14,7 +14,7 @@ def test_svelte_preview_rewrites_only_known_dynamic_application_namespaces():
     assert "name: 'ed-finder-static-spa-preview-fallback'" in source
     assert 'configurePreviewServer(server)' in source
     assert "method !== 'GET' && method !== 'HEAD'" in source
-    assert "accept.includes('text/html')" in source
+    assert "request.headers.accept" not in source
     assert r'/^\/system\/\d+\/?$/' in source
     assert r'/^\/colony-planner(?:\/.*)?\/?$/' in source
     assert 'request.url = `/200.html${url.search}`;' in source

--- a/tests/test_svelte_web_foundation_contract.py
+++ b/tests/test_svelte_web_foundation_contract.py
@@ -99,8 +99,10 @@ def test_bootstrap_client_delegates_to_generated_hey_api_sdk():
     assert "from './generated/sdk.gen'" in client
     assert "generatedGetHealth" in client
     assert "generatedGetAuthSession" in client
-    assert "fetch(" not in client
-    assert "getJson" not in client
+    # Bootstrap calls remain generated while the same adapter also owns the
+    # reviewed lossless-fetch path needed for id64-bearing application calls.
+    assert "runGenerated" in client
+    assert "parseLosslessJson" in client
 
 
 def test_svelte_generation_snapshots_explicit_authoritative_openapi_input():

--- a/tests/test_svelte_web_foundation_contract.py
+++ b/tests/test_svelte_web_foundation_contract.py
@@ -32,7 +32,7 @@ def _vite_backend_proxy_patterns() -> list[re.Pattern[str]]:
     patterns = [json.loads(f'"{value[1:-1]}"') for value in encoded_patterns]
 
     assert "server: { proxy: backendProxy }" in config
-    assert "preview: { proxy: backendProxy }" in config
+    assert "preview: { proxy: backendProxy }" not in config
     return [re.compile(pattern) for pattern in patterns]
 
 
@@ -207,7 +207,7 @@ def test_v3_web_is_static_spa_and_backend_route_ownership_is_explicit():
     assert "SvelteKit" in readme
 
 
-def test_vite_proxy_claims_only_backend_owned_route_boundaries():
+def test_vite_dev_proxy_claims_only_backend_owned_route_boundaries():
     patterns = _vite_backend_proxy_patterns()
 
     backend_urls = (


### PR DESCRIPTION
## Purpose

Implements #579 as a platform tranche for draft integration PR #578.

This branch establishes the shared Svelte contracts that must exist before feature UI moves: canonical lossless identifiers, an application-facing API facade, persisted-state compatibility services and stores, route/hash compatibility, shell/overlay/owner access, and focused Cypress/unit/repository contracts.

## Current implementation

- branded canonical decimal-string `Id64`, validated through unsigned 64-bit max;
- lossless JSON parsing before identifier normalisation, with tests above `2^53` and at uint64 max;
- same-origin API facade, cookie credentials, structured error type, bounded admin-token policy, system-envelope and optimiser compatibility behaviours;
- separate SSE client contract and TanStack query-key/client module;
- explicit local/session storage key inventory, codecs, legacy pin/collection handling, cross-tab support, diagnostics and typed stores;
- SvelteKit route skeleton, legacy hash-link conversion, cold System route and overlay lifecycle;
- auth/session store, owner gate, application shell, error route and accessibility affordances;
- Svelte Cypress platform coverage and fail-closed Python contracts.

## Known review items being addressed before acceptance

The first static review found that `+layout.svelte` currently instantiates a second QueryClient instead of importing the configured singleton, and the root shell does not yet provide/hydrate the persistence context. Those are accepted defects, not risks to waive; this PR remains draft while they and any exact-head CI findings are repaired.

## Boundaries

- React remains temporary source/parity evidence; #580 owns feature parity and final deletion.
- No Playwright may return.
- No production, database, DNS, OAuth-secret, deployment, recovery or Babylon/Stage 27 runtime action.
- This branch merges only into `migration/svelte-cypress-hard-cut`, never directly to main.

Current head: `d0b6b3bb62027b6e2e3d395e1d6ee999f11fb2f2`