### PR TITLE
ci: remove deprecated Node 20 action runtime

### DIFF
--- a/.github/workflows/cypress-parity.yml
+++ b/.github/workflows/cypress-parity.yml
@@ -145,7 +145,7 @@ jobs:
           exit 1
 
       - name: Restore Cypress binary cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0, Node 24
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-15.21.1

--- a/tests/test_ci_dependency_contract.py
+++ b/tests/test_ci_dependency_contract.py
@@ -40,3 +40,18 @@ def test_confirmed_target_or_skip_is_pytest8_safe_for_module_level_smokes():
     helper = _read('tests', 'helpers', 'db_isolation.py')
 
     assert 'allow_module_level=True' in helper
+
+
+def test_cypress_cache_action_targets_node24_without_unsafe_opt_out():
+    workflow = _read('.github', 'workflows', 'cypress-parity.yml')
+    all_workflows = '\n'.join(
+        path.read_text(encoding='utf-8')
+        for path in sorted((ROOT / '.github' / 'workflows').glob('*.y*ml'))
+    )
+
+    assert (
+        'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 '
+        '# v6.1.0, Node 24'
+    ) in workflow
+    assert 'actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809' not in all_workflows
+    assert 'ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION' not in all_workflows


### PR DESCRIPTION
## Summary

Remove the remaining GitHub Actions JavaScript runtime deprecation from the Cypress gate.

- replace the direct `actions/cache` v4.2.4 pin, which declares `node20`, with immutable `actions/cache` v6.1.0 SHA `55cc8345863c7cc4c66a329aec7e433d2d1c52a9`, which declares `node24`;
- retain the same Cypress binary cache path and key;
- add a repository contract that rejects the old Node 20 cache SHA and the insecure `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` opt-out.

## Audit result

The current pins for `actions/checkout` v7, `actions/setup-node` v7, `actions/setup-python` v7, `actions/upload-artifact` v7, `actions/download-artifact` v7, `dorny/paths-filter` v4, `docker/setup-buildx-action` v4, and the pinned CodeQL v4 action all declare `node24` (or are composite actions). The direct `actions/cache` v4 pin was the actionable warning observed in the exact Cypress workflow log.

## Safety

Workflow dependency maintenance only. No product, production, deployment, database, host, secret, or recovery action.