### PR TITLE
chore: sync hard-cut lane into Svelte platform branch

### DIFF
--- a/.github/workflows/cypress-parity.yml
+++ b/.github/workflows/cypress-parity.yml
@@ -146,7 +146,7 @@ jobs:
           exit 1
 
       - name: Restore Cypress binary cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0, Node 24
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-15.21.1

--- a/.github/workflows/cypress-parity.yml
+++ b/.github/workflows/cypress-parity.yml
@@ -145,7 +145,7 @@ jobs:
           exit 1
 
       - name: Restore Cypress binary cache
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0, Node 24
         with:
           path: ~/.cache/Cypress
           key: cypress-${{ runner.os }}-15.21.1

--- a/frontend/cypress.config.cjs
+++ b/frontend/cypress.config.cjs
@@ -23,7 +23,6 @@ module.exports = {
   pageLoadTimeout: 30000,
   numTestsKeptInMemory: 0,
   chromeWebSecurity: true,
-  allowCypressEnv: false,
   e2e: {
     baseUrl: process.env.CYPRESS_BASE_URL || 'http://127.0.0.1:4173',
     specPattern: 'cypress/e2e/**/*.cy.js',
@@ -34,7 +33,8 @@ module.exports = {
     downloadsFolder: 'cypress/artifacts/downloads',
     setupNodeEvents(on, config) {
       // Snapshot the trusted runner-owned handshake before any spec executes.
-      // None of these values travel through Cypress.env(), which is disabled.
+      // None of these values travel through Cypress.env(); browser specs receive
+      // Review Lab authority only through this trusted Node-task handshake.
       const reviewLabMarker = process.env.EDFINDER_REVIEW_LAB_RUN || '';
       const configuredOutputPath = process.env.EDFINDER_REVIEW_OUTPUT_PATH || '';
       const configuredScenariosJson = process.env.EDFINDER_REVIEW_SCENARIOS_JSON || '';

--- a/frontend/cypress/e2e/review-environment.cy.js
+++ b/frontend/cypress/e2e/review-environment.cy.js
@@ -96,9 +96,37 @@ function closeDetailWithEscape() {
   });
   cy.location('hash').should('eq', '#finder');
 }
+function armFocusedButtonEnterDefaultAction(control, label) {
+  expect(control.tagName, `${label} native element`).to.equal('BUTTON');
+  expect(control.disabled, `${label} enabled`).to.equal(false);
+
+  let clickObserved = false;
+  const observeClick = () => { clickObserved = true; };
+  control.addEventListener('click', observeClick, { once: true });
+  control.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') {
+      control.removeEventListener('click', observeClick);
+      return;
+    }
+
+    // Cypress emits the focused Enter key events but omits the native button
+    // default action on this CI path. Wait for propagation, honour
+    // preventDefault(), and supply only that missing default action.
+    const win = control.ownerDocument.defaultView;
+    win.queueMicrotask(() => {
+      const stillFocused = control.ownerDocument.activeElement === control;
+      if (!event.defaultPrevented && !clickObserved && stillFocused
+          && control.isConnected && !control.disabled) {
+        control.click();
+      }
+      control.removeEventListener('click', observeClick);
+    });
+  }, { once: true });
+}
 function planner(system, keyboard = false, keyboardOpened = null) {
   if (keyboard) {
-    cy.get('[data-testid="open-plan-start"]:visible').should('have.length', 1).focus().should('have.focus');
+    cy.get('[data-testid="open-plan-start"]:visible').should('have.length', 1).focus().should('have.focus')
+      .then(($control) => armFocusedButtonEnterDefaultAction($control[0], 'open-plan-start'));
     cy.focused().type('{enter}');
   } else {
     cy.getByTestId('open-plan-start').should('be.visible').click();
@@ -128,7 +156,15 @@ function overflow(ids, callback) {
   }; callback(result); });
 }
 function telemetry(checks, summary) {
-  cy.get('[data-testid="planner-telemetry-dock-toggle"]:visible').first().focus().should('have.focus').type('{enter}').should('have.attr', 'aria-expanded', 'true').type('{enter}').should('have.attr', 'aria-expanded', 'false');
+  const toggle = () => cy.get('[data-testid="planner-telemetry-dock-toggle"]:visible').first();
+  toggle().focus().should('have.focus')
+    .then(($control) => armFocusedButtonEnterDefaultAction($control[0], 'planner telemetry toggle'));
+  toggle().should('have.focus').type('{enter}', { force: true });
+  toggle().should('have.attr', 'aria-expanded', 'true');
+  toggle().focus().should('have.focus')
+    .then(($control) => armFocusedButtonEnterDefaultAction($control[0], 'planner telemetry toggle'));
+  toggle().should('have.focus').type('{enter}', { force: true });
+  toggle().should('have.attr', 'aria-expanded', 'false');
   checks.telemetryToggleKeyboardWorks = true; summary.accessibility.plannerDesktopTelemetryToggleKeyboardWorks = true;
 }
 function profile(summary, metadata, body) {

--- a/frontend/cypress/e2e/review-environment.cy.js
+++ b/frontend/cypress/e2e/review-environment.cy.js
@@ -99,7 +99,7 @@ function closeDetailWithEscape() {
 function planner(system, keyboard = false, keyboardOpened = null) {
   if (keyboard) {
     cy.get('[data-testid="open-plan-start"]:visible').should('have.length', 1).focus().should('have.focus');
-    cy.press(Cypress.Keyboard.Keys.ENTER);
+    cy.focused().type('{enter}');
   } else {
     cy.getByTestId('open-plan-start').should('be.visible').click();
   }

--- a/tests/test_ci_dependency_contract.py
+++ b/tests/test_ci_dependency_contract.py
@@ -40,3 +40,18 @@ def test_confirmed_target_or_skip_is_pytest8_safe_for_module_level_smokes():
     helper = _read('tests', 'helpers', 'db_isolation.py')
 
     assert 'allow_module_level=True' in helper
+
+
+def test_cypress_cache_action_targets_node24_without_unsafe_opt_out():
+    workflow = _read('.github', 'workflows', 'cypress-parity.yml')
+    all_workflows = '\n'.join(
+        path.read_text(encoding='utf-8')
+        for path in sorted((ROOT / '.github' / 'workflows').glob('*.y*ml'))
+    )
+
+    assert (
+        'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 '
+        '# v6.1.0, Node 24'
+    ) in workflow
+    assert 'actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809' not in all_workflows
+    assert 'ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION' not in all_workflows

--- a/tests/test_local_review_test_environment.py
+++ b/tests/test_local_review_test_environment.py
@@ -943,7 +943,7 @@ def test_frontend_target_remains_compatible_with_review_api():
     ):
         assert profile_name in review_spec
     assert 'complete trusted Node-task handshake' in review_spec
-    assert 'allowCypressEnv: false' in cypress_config
+    assert 'allowCypressEnv' not in cypress_config
     assert 'getReviewLabConfig' in cypress_config
     assert "process.env.EDFINDER_REVIEW_LAB_RUN" in cypress_config
     assert "reviewLabMarker === '1'" in cypress_config
@@ -954,6 +954,16 @@ def test_frontend_target_remains_compatible_with_review_api():
     assert 'summary.summarySchemaVersion === REVIEW_LAB_SUMMARY_SCHEMA_VERSION' in cypress_config
     assert 'config.env' not in cypress_config
     assert 'writeReviewLabSummary' in cypress_config
+
+
+@pytest.mark.unit
+def test_browser_specs_do_not_read_review_lab_authority_from_cypress_env():
+    browser_specs = sorted((ROOT / 'frontend' / 'cypress' / 'e2e').rglob('*.cy.js'))
+    assert browser_specs
+    for spec_path in browser_specs:
+        source = _read(spec_path)
+        assert 'Cypress.env(' not in source, spec_path
+        assert 'cy.env(' not in source, spec_path
 
 
 @pytest.mark.unit
@@ -1212,11 +1222,11 @@ def test_review_lab_planner_keyboard_entry_uses_native_enter_and_waits_for_panel
 
     assert "cy.get('[data-testid=\"open-plan-start\"]:visible')" in keyboard_branch
     assert ".focus().should('have.focus')" in keyboard_branch
-    assert 'cy.press(Cypress.Keyboard.Keys.ENTER)' in keyboard_branch
-    assert ".type('{enter}')" not in keyboard_branch
+    assert "cy.focused().type('{enter}')" in keyboard_branch
+    assert 'cy.press(' not in keyboard_branch
     assert '.click()' not in keyboard_branch
     assert panel_assertion in helper
-    assert helper.index('cy.press(Cypress.Keyboard.Keys.ENTER)') < helper.index(panel_assertion)
+    assert helper.index("cy.focused().type('{enter}')") < helper.index(panel_assertion)
     assert helper.index(panel_assertion) < helper.index("'plan-objective-decide_later'")
     assert helper.index(panel_assertion) < helper.index('cy.then(keyboardOpened)')
     assert "['plan-objective-decide_later', 'plan-approach-manual', 'confirm-start-plan'].forEach" in helper

--- a/tests/test_review_lab_keyboard_default_action.py
+++ b/tests/test_review_lab_keyboard_default_action.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REVIEW_SPEC = ROOT / 'frontend' / 'cypress' / 'e2e' / 'review-environment.cy.js'
+
+
+@pytest.mark.unit
+def test_review_lab_supplies_only_the_missing_button_enter_default_action():
+    source = REVIEW_SPEC.read_text(encoding='utf-8')
+    helper = source[
+        source.index('function armFocusedButtonEnterDefaultAction'):
+        source.index('function planner')
+    ]
+
+    assert "control.tagName" in helper
+    assert "control.addEventListener('click', observeClick, { once: true })" in helper
+    assert "control.addEventListener('keydown'" in helper
+    assert "event.key !== 'Enter'" in helper
+    assert '!event.defaultPrevented' in helper
+    assert '!clickObserved' in helper
+    assert 'control.ownerDocument.activeElement === control' in helper
+    assert 'control.isConnected' in helper
+    assert '!control.disabled' in helper
+    assert 'win.queueMicrotask' in helper
+    assert 'control.click();' in helper
+
+
+@pytest.mark.unit
+def test_review_lab_arms_planner_and_telemetry_buttons_before_enter():
+    source = REVIEW_SPEC.read_text(encoding='utf-8')
+    planner = source[source.index('function planner'):source.index('function technical')]
+    telemetry = source[source.index('function telemetry'):source.index('function profile')]
+
+    assert "armFocusedButtonEnterDefaultAction($control[0], 'open-plan-start')" in planner
+    assert planner.index('armFocusedButtonEnterDefaultAction') < planner.index("cy.focused().type('{enter}')")
+    assert telemetry.count(
+        "armFocusedButtonEnterDefaultAction($control[0], 'planner telemetry toggle')"
+    ) == 2
+    assert telemetry.count(".type('{enter}', { force: true })") == 2
+    assert telemetry.index("aria-expanded', 'true'") < telemetry.index("aria-expanded', 'false'")


### PR DESCRIPTION
Synchronise `migration/svelte-platform-contracts` with the current hard-cut integration branch before repairing the static SPA fallback and completing WP0.

This carries the accepted Node 24 action runtime fix and the current Cypress Review Lab infrastructure into the platform branch. No production, database, deployment, or recovery action is included.