### PR TITLE
fix(ci): repair Codex version sanitiser bootstrap

### DIFF
--- a/.github/workflows/codex-laptop.yml
+++ b/.github/workflows/codex-laptop.yml
@@ -181,7 +181,7 @@ jobs:
               exit 69
             }
           done
-          version="$(codex --version | head -n 1 | tr -cd '[:alnum:]._- ')"
+          version="$(codex --version | head -n 1 | tr -cd '[:alnum:]. _-')"
           [ -n "$version" ] || {
             echo "::error::Unable to obtain a sanitised Codex CLI version."
             exit 69


### PR DESCRIPTION
## Purpose

Restores the newly pinned Codex worker after its first fail-closed run exposed a shell portability defect in the CLI-version sanitiser.

## Change

Moves the literal hyphen to the end of the `tr` allowlist used to sanitise `codex --version`. This prevents GNU `tr` from interpreting `_ -` as a reversed range while preserving the same allowed output characters.

## Scope

Exactly one line in `.github/workflows/codex-laptop.yml`; no product, test, dependency, branch-policy, production, database, DNS, secret, deployment, recovery or live-data change.

## Provenance note

This is a control-plane bootstrap exception: the broken line prevented every pinned Codex invocation from starting, so Codex could not author its own launcher repair. After this lands, Codex will add the regression contract and perform all subsequent repository coding.