### PR TITLE
fix(frontend): merge WP1 CI and CodeQL hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,7 @@ jobs:
             src/lib/api/index.ts \
             src/lib/api/core.ts \
             src/lib/format.ts \
+            src/types/api.gen.ts \
             src/types/api.ts \
             src/components/NavBar.tsx \
             src/components/ResultCard.tsx \

--- a/frontend/knip.json
+++ b/frontend/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/App.tsx", "map-foundation/main.tsx"],
+  "entry": ["src/App.tsx", "map-foundation/main.tsx", "src/types/api.gen.ts"],
   "project": ["src/**/*.{ts,tsx}"],
   "ignore": [
     "src/components/ui/**",

--- a/packages/api-client/src/core.test.ts
+++ b/packages/api-client/src/core.test.ts
@@ -32,7 +32,29 @@ describe('API transport', () => {
     expect(resolveApiUrl('/systems/42')).toBe(
       'https://api.example.test/custom/systems/42',
     );
+  });
+
+  it('preserves empty, root, all-slash, normal, absolute, and undefined base behavior', async () => {
+    const { configureApiBase } = await loadCore();
+
+    expect(configureApiBase('')).toBe('');
+    expect(configureApiBase('/')).toBe('');
+    expect(configureApiBase('////')).toBe('');
+    expect(configureApiBase('/custom')).toBe('/custom');
+    expect(configureApiBase('/custom///')).toBe('/custom');
+    expect(configureApiBase('https://api.example.test/')).toBe(
+      'https://api.example.test',
+    );
     expect(configureApiBase(undefined)).toBe('/api');
+  });
+
+  it('removes a very long repeated-slash suffix without truncating the base', async () => {
+    const { configureApiBase } = await loadCore();
+    const base = 'https://api.example.test/custom';
+    const trailingSlashes = '/'.repeat(100_000);
+
+    expect(configureApiBase(`${base}${trailingSlashes}`)).toBe(base);
+    expect(configureApiBase(trailingSlashes)).toBe('');
   });
 
   it('does not duplicate an explicit /api path when the base already ends in /api', async () => {

--- a/packages/api-client/src/core.ts
+++ b/packages/api-client/src/core.ts
@@ -16,7 +16,18 @@ export let API_BASE = DEFAULT_API_BASE;
 
 /** Configure the shared transport without coupling it to Vite or a UI framework. */
 export function configureApiBase(base: string | undefined): string {
-  API_BASE = base?.replace(/\/+$/, '') ?? DEFAULT_API_BASE;
+  if (base === undefined) {
+    API_BASE = DEFAULT_API_BASE;
+    return API_BASE;
+  }
+
+  // The base is caller-controlled, so scan it once instead of using a regex.
+  let end = base.length;
+  while (end > 0 && base[end - 1] === '/') {
+    end -= 1;
+  }
+
+  API_BASE = end === base.length ? base : base.slice(0, end);
   return API_BASE;
 }
 

--- a/tests/test_svelte_web_foundation_contract.py
+++ b/tests/test_svelte_web_foundation_contract.py
@@ -194,6 +194,27 @@ def test_openapi_drift_lane_generates_both_clients_from_the_running_api():
     assert "packages/api-client/src/generated/api.gen.ts" in react_generator
 
 
+def test_legacy_generated_api_compatibility_shim_stays_public():
+    compatibility_entry = "src/types/api.gen.ts"
+    frontend = ROOT / "frontend"
+    knip = _package_json(frontend / "knip.json")
+    shim = _read("frontend", *compatibility_entry.split("/"))
+    generator = _read("frontend", "scripts", "types-gen.mjs")
+    workflow = _read(".github", "workflows", "ci.yml")
+    v2_job = workflow.split("  v2:\n", 1)[1].split("  web:\n", 1)[0]
+    source_presence = v2_job.split(
+        "- name: Verify required source files are present\n", 1
+    )[1].split("- name: Install dependencies\n", 1)[0]
+
+    assert compatibility_entry in knip["entry"]
+    assert shim == "export * from '../../../packages/api-client/src/generated/api.gen';\n"
+    assert (
+        "const output = path.resolve(repoRoot, "
+        "'packages/api-client/src/generated/api.gen.ts');"
+    ) in generator
+    assert compatibility_entry in source_presence
+
+
 def test_legacy_react_frontend_remains_temporary_source_evidence():
     legacy_package = _package_json(ROOT / "frontend" / "package.json")
     readme = _read("README.md")


### PR DESCRIPTION
## Purpose

Integrate the disjoint CI/security repair branch into the active WP1 shared-core branch without rewriting either implementation commit.

## Changes

- replace the uncontrolled trailing-slash regular expression with a linear-time loop and adversarial long-input tests;
- register the required generated frontend compatibility shim as an explicit Knip entry;
- lock the generated-type authority and compatibility path with a repository contract test.

## Validation

- shared packages: 309 tests passed across 42 files;
- React TypeScript check passed;
- `yarn knip --files` passed;
- focused OpenAPI/source-presence/application-stack contracts: 62 passed;
- `git diff --check` passed.

This PR is only an ancestry-preserving integration into `migration/svelte-shared-core`; it does not target the main integration branch directly.