### PR TITLE
feat(web): complete Svelte persistence and profile-sync parity

### DIFF
--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -8,6 +8,8 @@ import {
   claimOwner,
   getAuthSession,
   getHealth,
+  pullProfileSync,
+  pushProfileSync,
 } from './client';
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}) =>
@@ -185,6 +187,62 @@ describe('bootstrap API client', () => {
     expect(fetchMock.mock.calls[2]?.[1]?.body).toBe(
       JSON.stringify({ admin_token: 'one-time-owner-link-secret' }),
     );
+  });
+
+  it('uses the same-origin facade for profile pull/push without an admin header', async () => {
+    sessionStorage.setItem('ed_admin_token', 'must-not-leak');
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        jsonResponse({ blob: {}, updated_at: 'pull-time', blob_bytes: 2 }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ updated_at: 'push-time', blob_bytes: 42 }),
+      );
+
+    await pullProfileSync('profile-key-1234567890');
+    await pushProfileSync('profile-key-1234567890', {
+      version: 1,
+      exported_at: 'now',
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      '/api/profile/sync/profile-key-1234567890',
+    );
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      '/api/profile/sync/profile-key-1234567890',
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: 'PUT',
+      body: JSON.stringify({ blob: { version: 1, exported_at: 'now' } }),
+    });
+    for (const [, init] of fetchMock.mock.calls)
+      expect(new Headers(init?.headers).has('X-Admin-Token')).toBe(false);
+  });
+
+  it('preserves the profile endpoint problem body on a 413 response', async () => {
+    const problem = {
+      type: 'about:blank',
+      title: 'Profile blob too large',
+      status: 413,
+      detail: 'Profile blob too large: 1048577 bytes (max 1048576).',
+      instance: '/api/profile/sync/profile-key-1234567890',
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(problem, {
+        status: 413,
+        headers: { 'content-type': 'application/problem+json' },
+      }),
+    );
+
+    await expect(
+      pushProfileSync('profile-key-1234567890', { oversized: true }),
+    ).rejects.toMatchObject({
+      status: 413,
+      path: '/api/profile/sync/profile-key-1234567890',
+      body: problem,
+      message: problem.detail,
+    });
   });
 
   it('preserves structured, text, and empty error responses', async () => {

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -2,9 +2,13 @@
 import type { AuthSessionResponse, HealthResponse } from './generated';
 import type { Id64 } from '$lib/domain/id64';
 import { parseId64 } from '$lib/domain/id64';
+import {
+  ADMIN_TOKEN_SESSION_KEY,
+  readSessionStorageValue,
+} from '$lib/persistence/storage';
 import { parseLosslessJson } from './lossless-json';
 
-export const ADMIN_TOKEN_SESSION_KEY = 'ed_admin_token';
+export { ADMIN_TOKEN_SESSION_KEY } from '$lib/persistence/storage';
 
 export function canonicalApiPath(path: string): string {
   if (/^https?:\/\//i.test(path))
@@ -202,12 +206,7 @@ export function adminEndpointClass(
 }
 
 function sessionAdminToken(): string {
-  if (typeof window === 'undefined') return '';
-  try {
-    return window.sessionStorage.getItem(ADMIN_TOKEN_SESSION_KEY)?.trim() ?? '';
-  } catch {
-    return '';
-  }
+  return readSessionStorageValue(ADMIN_TOKEN_SESSION_KEY)?.trim() ?? '';
 }
 
 export class ApiError extends Error {
@@ -345,6 +344,36 @@ export function optimiserCandidates<
       include_ranking: true,
       ...request,
     }),
+  });
+}
+
+export interface ProfileSyncPullResponse<TBlob> {
+  blob: TBlob;
+  updated_at: string;
+  blob_bytes: number;
+}
+
+export interface ProfileSyncPushResponse {
+  updated_at: string;
+  blob_bytes: number;
+}
+
+export function pullProfileSync<TBlob>(
+  syncKey: string,
+  signal?: AbortSignal,
+): Promise<ProfileSyncPullResponse<TBlob>> {
+  return apiRequest(`/profile/sync/${encodeURIComponent(syncKey)}`, { signal });
+}
+
+export function pushProfileSync<TBlob>(
+  syncKey: string,
+  blob: TBlob,
+  signal?: AbortSignal,
+): Promise<ProfileSyncPushResponse> {
+  return apiRequest(`/profile/sync/${encodeURIComponent(syncKey)}`, {
+    method: 'PUT',
+    body: JSON.stringify({ blob }),
+    signal,
   });
 }
 

--- a/apps/web/src/lib/persistence/fixtures.ts
+++ b/apps/web/src/lib/persistence/fixtures.ts
@@ -53,6 +53,22 @@ export const legacyPersistenceFixtures = {
       coords: { x: 0, y: 0, z: 0 },
     },
   ]),
+  legacyColonyV2: JSON.stringify([
+    {
+      id: 'legacy-colony',
+      name: 'Legacy Colony',
+      phase: 'planning',
+      target_population: null,
+      notes: 'Opaque compatibility record',
+      id64: 42,
+      x: 0,
+      y: 0,
+      z: 0,
+      current_population: null,
+      claimed_at: '2026-05-01T00:00:00.000Z',
+      updated_at: '2026-05-01T00:00:00.000Z',
+    },
+  ]),
   syncKey: JSON.stringify({
     state: { syncKey: 'reviewwatchlistkey000000000000' },
     version: 0,

--- a/apps/web/src/lib/persistence/index.ts
+++ b/apps/web/src/lib/persistence/index.ts
@@ -1,4 +1,5 @@
 export * from './context';
 export * from './fixtures';
+export * from './profile-sync';
 export * from './storage';
 export * from './stores';

--- a/apps/web/src/lib/persistence/profile-sync.test.ts
+++ b/apps/web/src/lib/persistence/profile-sync.test.ts
@@ -1,0 +1,367 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '$lib/api/client';
+import { parseId64 } from '$lib/domain/id64';
+import {
+  PROFILE_SYNC_KEYS,
+  PROFILE_SYNC_SECURITY_DENYLIST,
+  applyProfileBlob,
+  createProfileSyncCommandService,
+  gatherProfileBlob,
+  type ProfileSyncTransport,
+} from './profile-sync';
+import { PERSISTENCE_KEYS } from './storage';
+import {
+  colonyProjects,
+  compare,
+  expansionPlans,
+  fcRoute,
+  legacyColonyPassthrough,
+  myWork,
+  pins,
+  profileSyncLast,
+} from './stores';
+
+const VALID_KEY = 'profile-sync-key-1234567890';
+const EXPORTED_AT = '2026-09-05T10:00:00.000Z';
+
+const emptyTransport = (): ProfileSyncTransport => ({
+  pull: async () => {
+    throw new Error('Unexpected pull');
+  },
+  push: async () => {
+    throw new Error('Unexpected push');
+  },
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+  for (const store of [
+    pins,
+    compare,
+    fcRoute,
+    myWork,
+    colonyProjects,
+    expansionPlans,
+    legacyColonyPassthrough,
+    profileSyncLast,
+  ])
+    store.clear();
+});
+
+describe('profile sync persistence helpers', () => {
+  it('gathers only the closed compatibility allowlist and explicit metadata', () => {
+    localStorage.setItem(
+      PERSISTENCE_KEYS.pins,
+      JSON.stringify([{ id64: 42, name: 'Pin', pinned_at: EXPORTED_AT }]),
+    );
+    localStorage.setItem(
+      PERSISTENCE_KEYS.compare,
+      JSON.stringify([{ id64: 43, name: 'Compare' }]),
+    );
+    localStorage.setItem(
+      PERSISTENCE_KEYS.legacyColony,
+      JSON.stringify([{ arbitrary: { future: true }, id64: 44 }]),
+    );
+    localStorage.setItem(
+      PERSISTENCE_KEYS.fcRoute,
+      JSON.stringify({ waypoints: [], config: { jump_range_ly: 400 } }),
+    );
+    localStorage.setItem(
+      PERSISTENCE_KEYS.myWork,
+      JSON.stringify({ state: { systems: {} }, version: 1 }),
+    );
+    localStorage.setItem(
+      PERSISTENCE_KEYS.colonyProjects,
+      JSON.stringify({ state: { projects: {} }, version: 3 }),
+    );
+    localStorage.setItem(
+      PERSISTENCE_KEYS.expansionPlans,
+      JSON.stringify({ state: { plans: {} }, version: 1 }),
+    );
+
+    // Even maliciously copied credential/session values are outside the
+    // closed profile allowlist.
+    localStorage.setItem(
+      PERSISTENCE_KEYS.syncKey,
+      JSON.stringify({ state: { syncKey: 'watch-list-key-1234' }, version: 0 }),
+    );
+    localStorage.setItem(PERSISTENCE_KEYS.adminToken, 'must-not-sync');
+    localStorage.setItem(PERSISTENCE_KEYS.operatorHandoff, 'must-not-sync');
+    localStorage.setItem(PERSISTENCE_KEYS.profileSyncKey, VALID_KEY);
+    localStorage.setItem(PERSISTENCE_KEYS.profileSyncLast, EXPORTED_AT);
+    localStorage.setItem(PERSISTENCE_KEYS.density, 'compact');
+
+    const blob = gatherProfileBlob(undefined, EXPORTED_AT);
+
+    expect(Object.keys(blob).sort()).toEqual(
+      ['version', 'exported_at', ...PROFILE_SYNC_KEYS].sort(),
+    );
+    expect(blob.ed_pinned).toEqual([
+      { id64: '42', name: 'Pin', pinned_at: EXPORTED_AT },
+    ]);
+    expect(blob.ed_colony_v2).toEqual([
+      { arbitrary: { future: true }, id64: '44' },
+    ]);
+    expect(PROFILE_SYNC_SECURITY_DENYLIST).toEqual([
+      PERSISTENCE_KEYS.adminToken,
+      PERSISTENCE_KEYS.operatorHandoff,
+      PERSISTENCE_KEYS.syncKey,
+    ]);
+    for (const denied of PROFILE_SYNC_SECURITY_DENYLIST)
+      expect(blob).not.toHaveProperty(denied);
+  });
+
+  it('omits absent and corrupt values instead of exporting in-memory defaults', () => {
+    localStorage.setItem(PERSISTENCE_KEYS.compare, '{broken');
+    expect(gatherProfileBlob(undefined, EXPORTED_AT)).toEqual({
+      version: 1,
+      exported_at: EXPORTED_AT,
+    });
+  });
+
+  it('applies a key-level merge without clearing missing or null datasets', () => {
+    pins.set([
+      {
+        id64: parseId64('42'),
+        name: 'Local pin',
+        pinned_at: EXPORTED_AT,
+      },
+    ]);
+
+    const receipt = applyProfileBlob({
+      version: 1,
+      exported_at: EXPORTED_AT,
+      ed_pinned: null,
+      ed_compare_v2: [{ id64: '43', name: 'Pulled compare' }],
+    });
+
+    expect(receipt).toEqual({
+      applied: [PERSISTENCE_KEYS.compare],
+      rejected: [],
+    });
+    expect(get(pins).value[0]?.name).toBe('Local pin');
+    expect(get(compare).value).toEqual([
+      { id64: '43', name: 'Pulled compare' },
+    ]);
+  });
+
+  it('round-trips the unowned legacy colony payload as opaque JSON', () => {
+    const first = [
+      {
+        arbitrary: ['kept', { nested: true }],
+        id64: '18446744073709551615',
+      },
+    ];
+    expect(legacyColonyPassthrough.setFromJsonValue(first)).toBe(true);
+    expect(gatherProfileBlob(undefined, EXPORTED_AT).ed_colony_v2).toEqual(
+      first,
+    );
+
+    const second = { future_shape: { remains: 'opaque' } };
+    expect(
+      applyProfileBlob({
+        version: 1,
+        exported_at: EXPORTED_AT,
+        ed_colony_v2: second,
+      }),
+    ).toEqual({
+      applied: [PERSISTENCE_KEYS.legacyColony],
+      rejected: [],
+    });
+    expect(legacyColonyPassthrough.readStored().state.value).toEqual(second);
+  });
+});
+
+describe('profile sync command service', () => {
+  it('is explicit and performs no command during construction', () => {
+    const transport = {
+      pull: vi.fn(emptyTransport().pull),
+      push: vi.fn(emptyTransport().push),
+    };
+    createProfileSyncCommandService({ transport });
+    expect(transport.pull).not.toHaveBeenCalled();
+    expect(transport.push).not.toHaveBeenCalled();
+  });
+
+  it('fans a successful pull into every current Svelte store without synthetic events', async () => {
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
+    const transport: ProfileSyncTransport = {
+      pull: async () => ({
+        blob: {
+          version: 1,
+          exported_at: EXPORTED_AT,
+          ed_pinned: [
+            { id64: '42', name: 'Pulled pin', pinned_at: EXPORTED_AT },
+          ],
+          ed_compare_v2: [{ id64: '43', name: 'Pulled compare' }],
+          ed_colony_v2: [{ id64: '44', arbitrary: true }],
+          ed_fc_v2: {
+            waypoints: [{ id: 'wp', name: 'Achenar', id64: '45' }],
+            config: { jump_range_ly: 420 },
+          },
+          ed_my_work_v1: {
+            state: {
+              systems: { remote: { id64: '46', name: 'Saved system' } },
+            },
+            version: 1,
+          },
+          ed_colony_projects_v1: {
+            state: {
+              projects: {
+                project: {
+                  id: 'project',
+                  system_id64: '47',
+                  build_plan_placements: [],
+                },
+              },
+            },
+            version: 3,
+          },
+          ed_expansion_plans_v1: {
+            state: {
+              plans: {
+                plan: {
+                  id: 'plan',
+                  anchor_system_id64: '48',
+                  slots: [{ slot_index: 0, system_id64: '49' }],
+                },
+              },
+            },
+            version: 1,
+          },
+        },
+        updated_at: '2026-09-05T11:00:00+00:00',
+        blob_bytes: 512,
+      }),
+      push: emptyTransport().push,
+    };
+    const service = createProfileSyncCommandService({ transport });
+
+    await expect(service.pull(VALID_KEY)).resolves.toMatchObject({
+      kind: 'pulled',
+      apply: { applied: PROFILE_SYNC_KEYS, rejected: [] },
+    });
+
+    expect(get(pins).value[0]?.id64).toBe('42');
+    expect(get(compare).value[0]?.id64).toBe('43');
+    expect(legacyColonyPassthrough.readStored().state.value).toEqual([
+      { id64: '44', arbitrary: true },
+    ]);
+    expect(get(fcRoute).value).toMatchObject({
+      waypoints: [{ id64: '45' }],
+      config: { jump_range_ly: 420, cargo_t: 25_000 },
+    });
+    expect(get(myWork).value.state.systems['46']?.name).toBe('Saved system');
+    expect(get(colonyProjects).value.state.projects.project?.system_id64).toBe(
+      '47',
+    );
+    expect(
+      get(expansionPlans).value.state.plans.plan?.slots[0]?.system_id64,
+    ).toBe('49');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('records the exact successful push receipt as a raw local value', async () => {
+    pins.set([
+      {
+        id64: parseId64('18446744073709551615'),
+        name: 'Max pin',
+        pinned_at: EXPORTED_AT,
+      },
+    ]);
+    const push = vi.fn(async () => ({
+      updated_at: '2026-09-05T12:00:00+00:00',
+      blob_bytes: 1024,
+    }));
+    const service = createProfileSyncCommandService({
+      transport: { pull: emptyTransport().pull, push },
+      now: () => EXPORTED_AT,
+    });
+
+    const result = await service.push(VALID_KEY);
+
+    expect(push).toHaveBeenCalledWith(
+      VALID_KEY,
+      expect.objectContaining({
+        version: 1,
+        exported_at: EXPORTED_AT,
+        ed_pinned: [expect.objectContaining({ id64: '18446744073709551615' })],
+      }),
+      undefined,
+    );
+    expect(result).toMatchObject({
+      kind: 'pushed',
+      receipt_recorded: true,
+      updated_at: '2026-09-05T12:00:00+00:00',
+    });
+    expect(localStorage.getItem(PERSISTENCE_KEYS.profileSyncLast)).toBe(
+      '2026-09-05T12:00:00+00:00',
+    );
+    expect(get(profileSyncLast).value).toBe('2026-09-05T12:00:00+00:00');
+  });
+
+  it('treats a 404 pull as an empty slot without clearing local data', async () => {
+    pins.set([
+      {
+        id64: parseId64('42'),
+        name: 'Keep me',
+        pinned_at: EXPORTED_AT,
+      },
+    ]);
+    const missing = new ApiError(
+      404,
+      `/api/profile/sync/${VALID_KEY}`,
+      { detail: 'No profile slot for sync_key (run a Push first)' },
+      'No profile slot for sync_key (run a Push first)',
+    );
+    const service = createProfileSyncCommandService({
+      transport: {
+        pull: async () => {
+          throw missing;
+        },
+        push: emptyTransport().push,
+      },
+    });
+
+    await expect(service.pull(VALID_KEY)).resolves.toEqual({
+      kind: 'empty',
+      apply: { applied: [], rejected: [] },
+    });
+    expect(get(pins).value[0]?.name).toBe('Keep me');
+  });
+
+  it('preserves a structured 413 error and does not record a push receipt', async () => {
+    const body = {
+      type: 'about:blank',
+      title: 'Profile blob too large',
+      status: 413,
+      detail: 'Profile blob too large: 1048577 bytes (max 1048576).',
+      instance: `/api/profile/sync/${VALID_KEY}`,
+    };
+    const oversized = new ApiError(
+      413,
+      `/api/profile/sync/${VALID_KEY}`,
+      body,
+      body.detail,
+    );
+    const service = createProfileSyncCommandService({
+      transport: {
+        pull: emptyTransport().pull,
+        push: async () => {
+          throw oversized;
+        },
+      },
+      now: () => EXPORTED_AT,
+    });
+
+    const error = await service
+      .push(VALID_KEY)
+      .catch((reason: unknown) => reason);
+    expect(error).toBe(oversized);
+    expect(error).toMatchObject({ status: 413, body });
+    expect(localStorage.getItem(PERSISTENCE_KEYS.profileSyncLast)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/persistence/profile-sync.ts
+++ b/apps/web/src/lib/persistence/profile-sync.ts
@@ -1,0 +1,250 @@
+import {
+  pullProfileSync,
+  pushProfileSync,
+  type ProfileSyncPullResponse,
+  type ProfileSyncPushResponse,
+} from '$lib/api/client';
+import {
+  PERSISTENCE_KEYS,
+  SYNC_KEY_PATTERN,
+  type LocalStorageKey,
+  type PersistedStore,
+} from './storage';
+import {
+  colonyProjects,
+  compare,
+  expansionPlans,
+  fcRoute,
+  legacyColonyPassthrough,
+  myWork,
+  pins,
+  profileSyncLast,
+} from './stores';
+
+/** Closed compatibility allowlist inherited from the React profile blob. */
+export const PROFILE_SYNC_KEYS = [
+  PERSISTENCE_KEYS.pins,
+  PERSISTENCE_KEYS.compare,
+  PERSISTENCE_KEYS.legacyColony,
+  PERSISTENCE_KEYS.fcRoute,
+  PERSISTENCE_KEYS.myWork,
+  PERSISTENCE_KEYS.colonyProjects,
+  PERSISTENCE_KEYS.expansionPlans,
+] as const satisfies readonly LocalStorageKey[];
+
+export type ProfileSyncKey = (typeof PROFILE_SYNC_KEYS)[number];
+
+/** Credentials and session handoffs which must never enter a profile blob. */
+export const PROFILE_SYNC_SECURITY_DENYLIST = [
+  PERSISTENCE_KEYS.adminToken,
+  PERSISTENCE_KEYS.operatorHandoff,
+  PERSISTENCE_KEYS.syncKey,
+] as const;
+
+export type ProfileBlob = {
+  version: 1;
+  exported_at: string;
+} & Partial<Record<ProfileSyncKey, unknown>>;
+
+export interface ProfileSyncValue {
+  present: boolean;
+  value?: unknown;
+}
+
+/** Plain dependency boundary keeps gather/apply and commands framework-neutral. */
+export interface ProfileSyncPersistence {
+  read(key: ProfileSyncKey): ProfileSyncValue;
+  apply(key: ProfileSyncKey, value: unknown): boolean;
+  recordPush(updatedAt: string): boolean;
+}
+
+interface ProfileStoreBinding {
+  read(): ProfileSyncValue;
+  apply(value: unknown): boolean;
+}
+
+function bindStore<T>(store: PersistedStore<T>): ProfileStoreBinding {
+  return {
+    read() {
+      const stored = store.readStored();
+      if (
+        !stored.present ||
+        stored.state.diagnostic !== null ||
+        stored.state.value === null
+      )
+        return { present: false };
+      return { present: true, value: stored.state.value };
+    },
+    apply: (value) => store.setFromJsonValue(value),
+  };
+}
+
+const browserBindings: Record<ProfileSyncKey, ProfileStoreBinding> = {
+  [PERSISTENCE_KEYS.pins]: bindStore(pins),
+  [PERSISTENCE_KEYS.compare]: bindStore(compare),
+  [PERSISTENCE_KEYS.legacyColony]: bindStore(legacyColonyPassthrough),
+  [PERSISTENCE_KEYS.fcRoute]: bindStore(fcRoute),
+  [PERSISTENCE_KEYS.myWork]: bindStore(myWork),
+  [PERSISTENCE_KEYS.colonyProjects]: bindStore(colonyProjects),
+  [PERSISTENCE_KEYS.expansionPlans]: bindStore(expansionPlans),
+};
+
+export const browserProfileSyncPersistence: ProfileSyncPersistence = {
+  read: (key) => browserBindings[key].read(),
+  apply: (key, value) => browserBindings[key].apply(value),
+  recordPush: (updatedAt) => profileSyncLast.set(updatedAt),
+};
+
+export function gatherProfileBlob(
+  persistence: ProfileSyncPersistence = browserProfileSyncPersistence,
+  exportedAt = new Date().toISOString(),
+): ProfileBlob {
+  const blob: Record<string, unknown> = {
+    version: 1,
+    exported_at: exportedAt,
+  };
+  for (const key of PROFILE_SYNC_KEYS) {
+    const entry = persistence.read(key);
+    if (entry.present && entry.value !== undefined && entry.value !== null)
+      blob[key] = entry.value;
+  }
+  return blob as ProfileBlob;
+}
+
+export interface ProfileApplyReceipt {
+  applied: ProfileSyncKey[];
+  rejected: ProfileSyncKey[];
+}
+
+/**
+ * Apply only present, non-null allowlisted datasets. This is a key-level
+ * merge: a present dataset replaces that local dataset, while missing keys do
+ * not clear state. Store setters provide same-tab fan-out; no synthetic
+ * StorageEvent is dispatched.
+ */
+export function applyProfileBlob(
+  blob: unknown,
+  persistence: ProfileSyncPersistence = browserProfileSyncPersistence,
+): ProfileApplyReceipt {
+  const receipt: ProfileApplyReceipt = { applied: [], rejected: [] };
+  if (blob === null || typeof blob !== 'object' || Array.isArray(blob))
+    return receipt;
+  const record = blob as Record<string, unknown>;
+  for (const key of PROFILE_SYNC_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    const value = record[key];
+    if (value === undefined || value === null) continue;
+    if (persistence.apply(key, value)) receipt.applied.push(key);
+    else receipt.rejected.push(key);
+  }
+  return receipt;
+}
+
+export interface ProfileSyncTransport {
+  pull(
+    syncKey: string,
+    signal?: AbortSignal,
+  ): Promise<ProfileSyncPullResponse<unknown>>;
+  push(
+    syncKey: string,
+    blob: ProfileBlob,
+    signal?: AbortSignal,
+  ): Promise<ProfileSyncPushResponse>;
+}
+
+const browserTransport: ProfileSyncTransport = {
+  pull: (syncKey, signal) => pullProfileSync(syncKey, signal),
+  push: (syncKey, blob, signal) => pushProfileSync(syncKey, blob, signal),
+};
+
+export type ProfilePullResult =
+  | {
+      kind: 'pulled';
+      updated_at: string;
+      blob_bytes: number;
+      apply: ProfileApplyReceipt;
+    }
+  | { kind: 'empty'; apply: ProfileApplyReceipt };
+
+export interface ProfilePushResult {
+  kind: 'pushed';
+  updated_at: string;
+  blob_bytes: number;
+  receipt_recorded: boolean;
+  blob: ProfileBlob;
+}
+
+export interface ProfileSyncCommandService {
+  pull(syncKey: string, signal?: AbortSignal): Promise<ProfilePullResult>;
+  push(syncKey: string, signal?: AbortSignal): Promise<ProfilePushResult>;
+}
+
+function validateProfileSyncKey(syncKey: string): void {
+  if (!SYNC_KEY_PATTERN.test(syncKey))
+    throw new TypeError(
+      'Profile sync key must be 16-128 URL-safe alphanumeric characters',
+    );
+}
+
+function errorStatus(error: unknown): number | null {
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'status' in error &&
+    typeof error.status === 'number'
+  )
+    return error.status;
+  return null;
+}
+
+/**
+ * Manual command service. Construction has no network calls or subscriptions;
+ * pull and push happen only when their explicit methods are invoked.
+ */
+export function createProfileSyncCommandService(
+  options: {
+    persistence?: ProfileSyncPersistence;
+    transport?: ProfileSyncTransport;
+    now?: () => string;
+  } = {},
+): ProfileSyncCommandService {
+  const persistence = options.persistence ?? browserProfileSyncPersistence;
+  const transport = options.transport ?? browserTransport;
+  const now = options.now ?? (() => new Date().toISOString());
+
+  return {
+    async pull(syncKey, signal) {
+      validateProfileSyncKey(syncKey);
+      try {
+        const response = await transport.pull(syncKey, signal);
+        return {
+          kind: 'pulled',
+          updated_at: response.updated_at,
+          blob_bytes: response.blob_bytes,
+          apply: applyProfileBlob(response.blob, persistence),
+        };
+      } catch (error) {
+        if (errorStatus(error) === 404)
+          return {
+            kind: 'empty',
+            apply: { applied: [], rejected: [] },
+          };
+        throw error;
+      }
+    },
+    async push(syncKey, signal) {
+      validateProfileSyncKey(syncKey);
+      const blob = gatherProfileBlob(persistence, now());
+      const response = await transport.push(syncKey, blob, signal);
+      return {
+        kind: 'pushed',
+        updated_at: response.updated_at,
+        blob_bytes: response.blob_bytes,
+        receipt_recorded: persistence.recordPush(response.updated_at),
+        blob,
+      };
+    },
+  };
+}
+
+export const profileSyncCommands = createProfileSyncCommandService();

--- a/apps/web/src/lib/persistence/storage.test.ts
+++ b/apps/web/src/lib/persistence/storage.test.ts
@@ -1,30 +1,59 @@
 import { get } from 'svelte/store';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseId64 } from '$lib/domain/id64';
 
 import {
+  DEFAULT_FC_CONFIG,
   LOCAL_STORAGE_KEYS,
+  PERSISTENCE_KEYS,
   SESSION_STORAGE_KEYS,
+  colonyProjectsCodec,
   collectionCodec,
   compareCodec,
   createPersistedStore,
-  fcCodec,
   densityCodec,
+  expansionPlansCodec,
+  fcCodec,
   id64StringCodec,
+  myWorkCodec,
+  normalisePlanRecord,
+  opaqueJsonCodec,
   pinnedCodec,
+  profileSyncKeyCodec,
   rawStringCodec,
+  replaceExpansionPlanSlotSystem,
   selectedRouteCodec,
   syncKeyCodec,
+  type ExpansionPlanRecord,
 } from './storage';
 import { legacyPersistenceFixtures } from './fixtures';
-import { adminToken, selectedSystem } from './stores';
+import {
+  adminToken,
+  colonyProjects,
+  compare,
+  density,
+  expansionPlans,
+  fcRoute,
+  myWork,
+  operatorHandoff,
+  profileSyncKey,
+  profileSyncLast,
+  selectedSystem,
+} from './stores';
 
 describe('persistence compatibility', () => {
   beforeEach(() => localStorage.clear());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
 
   it('locks the exact local and session key inventory', () => {
     expect(LOCAL_STORAGE_KEYS).toEqual([
       'ed_pinned',
       'ed_compare_v2',
+      'ed_colony_v2',
       'ed_sync_key',
       'ed_selected_route',
       'ed_my_work_v1',
@@ -42,18 +71,34 @@ describe('persistence compatibility', () => {
     ]);
   });
 
+  it('uses the exact current collection envelopes for empty state', () => {
+    myWork.hydrate();
+    colonyProjects.hydrate();
+    expansionPlans.hydrate();
+    expect(get(myWork).value).toEqual({ state: { systems: {} }, version: 1 });
+    expect(get(colonyProjects).value).toEqual({
+      state: { projects: {} },
+      version: 3,
+    });
+    expect(get(expansionPlans).value).toEqual({
+      state: { plans: {} },
+      version: 1,
+    });
+  });
+
   it('decodes the named legacy React fixtures without data loss', () => {
     const fixtures = legacyPersistenceFixtures;
     const cases = [
       [pinnedCodec, fixtures.pinnedBareArray],
       [compareCodec, fixtures.compareV2],
+      [opaqueJsonCodec, fixtures.legacyColonyV2],
       [syncKeyCodec, fixtures.syncKey],
       [selectedRouteCodec, fixtures.selectedRoute],
-      [collectionCodec(1), fixtures.myWorkV1],
-      [collectionCodec(3), fixtures.colonyProjectsV1],
-      [collectionCodec(1), fixtures.expansionPlansV1],
+      [myWorkCodec, fixtures.myWorkV1],
+      [colonyProjectsCodec, fixtures.colonyProjectsV1],
+      [expansionPlansCodec, fixtures.expansionPlansV1],
       [fcCodec, fixtures.fcRoute],
-      [rawStringCodec(), fixtures.profileSyncKey],
+      [profileSyncKeyCodec, fixtures.profileSyncKey],
       [rawStringCodec(), fixtures.profileSyncLast],
       [id64StringCodec, fixtures.selectedSystemContext],
       [densityCodec, fixtures.density],
@@ -93,6 +138,28 @@ describe('persistence compatibility', () => {
     );
   });
 
+  it('hydrates and round-trips Compare as a bare array, never an envelope', () => {
+    localStorage.setItem('ed_compare_v2', legacyPersistenceFixtures.compareV2);
+    const store = createPersistedStore({
+      key: PERSISTENCE_KEYS.compare,
+      initial: () => [],
+      codec: compareCodec,
+    });
+    store.hydrate();
+    expect(get(store).value).toEqual([
+      {
+        id64: '42',
+        name: 'Persisted',
+        population: 0,
+        coords: { x: 0, y: 0, z: 0 },
+      },
+    ]);
+    expect(store.set(get(store).value)).toBe(true);
+    const persisted = JSON.parse(localStorage.getItem('ed_compare_v2')!);
+    expect(Array.isArray(persisted)).toBe(true);
+    expect(persisted).toEqual(get(store).value);
+  });
+
   it('preserves oversized decimal identifiers and uint64 max exactly', () => {
     const result = compareCodec.decode(
       JSON.stringify([
@@ -130,6 +197,27 @@ describe('persistence compatibility', () => {
     );
     expect(localStorage.getItem('ed_admin_token')).toBeNull();
     adminToken.clear();
+  });
+
+  it('keeps the operator handoff session-only', () => {
+    sessionStorage.clear();
+    expect(operatorHandoff.set('run-001')).toBe(true);
+    expect(sessionStorage.getItem(PERSISTENCE_KEYS.operatorHandoff)).toBe(
+      'run-001',
+    );
+    expect(localStorage.getItem(PERSISTENCE_KEYS.operatorHandoff)).toBeNull();
+    operatorHandoff.clear();
+  });
+
+  it('stores the profile key and last-push receipt as raw strings', () => {
+    expect(profileSyncKey.set('profile-sync-key-1234567890')).toBe(true);
+    expect(profileSyncLast.set('2026-09-05T12:00:00+00:00')).toBe(true);
+    expect(localStorage.getItem(PERSISTENCE_KEYS.profileSyncKey)).toBe(
+      'profile-sync-key-1234567890',
+    );
+    expect(localStorage.getItem(PERSISTENCE_KEYS.profileSyncLast)).toBe(
+      '2026-09-05T12:00:00+00:00',
+    );
   });
 
   it('drops an unsafe legacy numeric id instead of preserving a rounded value', () => {
@@ -185,8 +273,19 @@ describe('persistence compatibility', () => {
     );
     expect(result.ok && result.value).toMatchObject({
       waypoints: [{ id64: '123', future: 'kept' }],
-      config: { jump_range_ly: 420, future_config: true },
+      config: {
+        ...DEFAULT_FC_CONFIG,
+        jump_range_ly: 420,
+        future_config: true,
+      },
       future_root: 1,
+    });
+  });
+
+  it('backfills the complete FC config when a legacy snapshot omits it', () => {
+    expect(fcCodec.decode('{"waypoints":[]}')).toEqual({
+      ok: true,
+      value: { waypoints: [], config: DEFAULT_FC_CONFIG },
     });
   });
 
@@ -210,6 +309,10 @@ describe('persistence compatibility', () => {
 
   it.each([
     ['unsafe numeric id64', { state: { id64: 9007199254740992 }, version: 1 }],
+    [
+      'unsafe numeric id64 list',
+      { state: { related_id64s: [9007199254740992] }, version: 1 },
+    ],
     ['malformed string id64', { state: { id64: '01' }, version: 1 }],
     [
       'unsafe id64 nested in arrays and records',
@@ -229,6 +332,7 @@ describe('persistence compatibility', () => {
     const result = collectionCodec(1).decode(
       JSON.stringify({
         state: {
+          related_id64s: [0, '18446744073709551615'],
           groups: [
             {
               system_id64: 123,
@@ -244,6 +348,7 @@ describe('persistence compatibility', () => {
       ok: true,
       value: {
         state: {
+          related_id64s: ['0', '18446744073709551615'],
           groups: [
             {
               system_id64: '123',
@@ -254,6 +359,249 @@ describe('persistence compatibility', () => {
         version: 1,
         future: { preserved: true },
       },
+    });
+  });
+
+  it('normalises My Work records and drops corrupt or unsafe legacy entries', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-05T12:00:00.000Z'));
+    const result = myWorkCodec.decode(
+      JSON.stringify({
+        state: {
+          systems: {
+            wrongKey: {
+              id64: 42,
+              name: '  Normalised  ',
+              labels: ['favourite', 'invalid', 'favourite', 'ready_to_plan'],
+              is_colonised: 1,
+            },
+            max: {
+              id64: '18446744073709551615',
+              name: '',
+              labels: null,
+              updated_at: '2026-09-04T00:00:00Z',
+            },
+            lossy: { id64: 9007199254740992, name: 'drop me' },
+            corrupt: 'drop me too',
+          },
+        },
+        version: 1,
+      }),
+    );
+    vi.useRealTimers();
+
+    expect(result.ok && result.value).toEqual({
+      state: {
+        systems: {
+          '42': {
+            id64: '42',
+            name: 'Normalised',
+            labels: ['favourite', 'ready_to_plan'],
+            is_colonised: true,
+            x: null,
+            y: null,
+            z: null,
+            population: null,
+            explicit_colonised_at: null,
+            updated_at: '2026-09-05T12:00:00.000Z',
+          },
+          '18446744073709551615': {
+            id64: '18446744073709551615',
+            name: 'System 18446744073709551615',
+            labels: [],
+            updated_at: '2026-09-04T00:00:00Z',
+            x: null,
+            y: null,
+            z: null,
+            population: null,
+            is_colonised: false,
+            explicit_colonised_at: null,
+          },
+        },
+      },
+      version: 1,
+    });
+  });
+
+  it('migrates legacy colony arrays to the current collection version', () => {
+    const result = colonyProjectsCodec.decode(
+      legacyPersistenceFixtures.colonyProjectsV1,
+    );
+    expect(result.ok && result.value).toMatchObject({
+      version: 3,
+      state: {
+        projects: {
+          'legacy-project': {
+            system_id64: '123',
+            status: 'draft',
+            declared_roles: [],
+            objective: null,
+            start_approach: null,
+            created_from: null,
+          },
+        },
+      },
+    });
+  });
+
+  it('recovers corrupt expansion collections and records without unsafe selectors', () => {
+    expect(expansionPlansCodec.decode('{broken')).toMatchObject({
+      ok: false,
+      problem: 'corrupt-json',
+    });
+    expect(
+      expansionPlansCodec.decode(
+        JSON.stringify({ state: { plans: 'not-an-object' }, version: 1 }),
+      ),
+    ).toEqual({
+      ok: true,
+      value: { state: { plans: {} }, version: 1 },
+    });
+
+    const result = expansionPlansCodec.decode(
+      JSON.stringify({
+        state: {
+          plans: {
+            nullRecord: null,
+            textRecord: 'bad',
+            unsafe: {
+              id: 'unsafe',
+              anchor_system_id64: 9007199254740992,
+              slots: [],
+            },
+            valid: {
+              id: 'plan-max',
+              anchor_system_id64: '18446744073709551615',
+              archived_at: null,
+              future: 'kept',
+              slots: [
+                null,
+                {
+                  slot_index: 0,
+                  system_id64: 84,
+                  system_name: 'First Target',
+                  economies: ['Refinery'],
+                  scores: { refinery: 80 },
+                  distance_from_anchor_ly: 12,
+                  colony_project_id: 'project-1',
+                  future_slot: true,
+                },
+                { slot_index: 1, system_id64: 'bad-id' },
+              ],
+            },
+          },
+        },
+        version: 1,
+      }),
+    );
+
+    expect(result.ok && result.value).toMatchObject({
+      state: {
+        plans: {
+          'plan-max': {
+            anchor_system_id64: '18446744073709551615',
+            future: 'kept',
+            slots: [
+              {
+                slot_index: 0,
+                system_id64: '84',
+                colony_project_id: 'project-1',
+                future_slot: true,
+              },
+            ],
+          },
+        },
+      },
+      version: 1,
+    });
+    const plans = result.ok ? Object.values(result.value.state.plans) : [];
+    expect(() =>
+      plans.filter((plan) =>
+        plan.slots.some((slot) => slot.system_id64 === '84'),
+      ),
+    ).not.toThrow();
+    expect(normalisePlanRecord([null, 'bad'])).toEqual({});
+  });
+
+  it('preserves slot data and clears only the replaced system project link', () => {
+    const plan: ExpansionPlanRecord = {
+      id: 'plan-1',
+      anchor_system_id64: parseId64('42'),
+      archived_at: null,
+      plan_name: 'Refinery loop',
+      slots: [
+        {
+          slot_index: 0,
+          system_id64: parseId64('84'),
+          system_name: 'First Target',
+          economies: ['Refinery'],
+          scores: { refinery: 80 },
+          distance_from_anchor_ly: 12,
+          colony_project_id: 'project-1',
+          future_slot: 'kept',
+        },
+        {
+          slot_index: 1,
+          system_id64: parseId64('85'),
+          colony_project_id: 'project-2',
+        },
+      ],
+    };
+    const updated = replaceExpansionPlanSlotSystem(
+      plan,
+      0,
+      {
+        system_id64: parseId64('126'),
+        system_name: 'Replacement Target',
+        scores: { refinery: 92 },
+        distance_from_anchor_ly: 18,
+      },
+      '2026-09-05T12:00:00Z',
+    );
+
+    expect(updated.slots[0]).toMatchObject({
+      system_id64: '126',
+      system_name: 'Replacement Target',
+      colony_project_id: null,
+      economies: ['Refinery'],
+      future_slot: 'kept',
+    });
+    expect(updated.slots[1]).toBe(plan.slots[1]);
+    expect(updated.slots[1].colony_project_id).toBe('project-2');
+    expect(updated.updated_at).toBe('2026-09-05T12:00:00Z');
+  });
+
+  it('rewrites a valid expansion legacy snapshot through its one-time migration path', () => {
+    localStorage.setItem(
+      PERSISTENCE_KEYS.expansionPlans,
+      JSON.stringify({
+        state: {
+          plans: [
+            {
+              id: 'legacy-plan',
+              anchor_system_id64: 42,
+              slots: [{ slot_index: 0, system_id64: 84 }],
+            },
+          ],
+        },
+        version: 0,
+      }),
+    );
+
+    expansionPlans.hydrate();
+
+    expect(
+      JSON.parse(localStorage.getItem(PERSISTENCE_KEYS.expansionPlans)!),
+    ).toMatchObject({
+      state: {
+        plans: {
+          'legacy-plan': {
+            anchor_system_id64: '42',
+            slots: [{ system_id64: '84', colony_project_id: null }],
+          },
+        },
+      },
+      version: 1,
     });
   });
 
@@ -346,6 +694,95 @@ describe('persistence compatibility', () => {
       }),
     );
     expect(get(store).value).toBe('new-device-key');
+  });
+
+  it('installs one guarded listener and never writes in response to an event', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const store = createPersistedStore({
+      key: PERSISTENCE_KEYS.profileSyncLast,
+      initial: () => '',
+      codec: rawStringCodec(),
+      crossTab: true,
+    });
+    store.hydrate();
+    store.hydrate();
+    expect(
+      addEventListener.mock.calls.filter(([event]) => event === 'storage'),
+    ).toHaveLength(1);
+
+    localStorage.setItem(PERSISTENCE_KEYS.profileSyncLast, 'remote-value');
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: PERSISTENCE_KEYS.profileSyncLast,
+        storageArea: localStorage,
+      }),
+    );
+    expect(get(store).value).toBe('remote-value');
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it('enables cross-tab reads only for local application stores', () => {
+    expect(compare.crossTab).toBe(true);
+    expect(fcRoute.crossTab).toBe(true);
+    expect(adminToken.area).toBe('session');
+    expect(adminToken.crossTab).toBe(false);
+  });
+
+  it('updates Compare from a guarded native cross-tab event', () => {
+    compare.hydrate();
+    localStorage.setItem(
+      PERSISTENCE_KEYS.compare,
+      JSON.stringify([{ id64: '18446744073709551615', name: 'Remote max' }]),
+    );
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: PERSISTENCE_KEYS.compare,
+        storageArea: localStorage,
+      }),
+    );
+    expect(get(compare).value).toEqual([
+      { id64: '18446744073709551615', name: 'Remote max' },
+    ]);
+  });
+
+  it('updates FC state cross-tab and backfills remote legacy config', () => {
+    fcRoute.hydrate();
+    localStorage.setItem(
+      PERSISTENCE_KEYS.fcRoute,
+      JSON.stringify({
+        waypoints: [
+          {
+            id: 'wp-remote',
+            name: 'Achenar',
+            x: 67,
+            y: 12,
+            z: -33,
+            id64: 123,
+          },
+        ],
+        config: { jump_range_ly: 420 },
+      }),
+    );
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: PERSISTENCE_KEYS.fcRoute,
+        storageArea: localStorage,
+      }),
+    );
+    expect(get(fcRoute).value).toMatchObject({
+      waypoints: [{ id64: '123', name: 'Achenar' }],
+      config: { ...DEFAULT_FC_CONFIG, jump_range_ly: 420 },
+    });
+  });
+
+  it('defaults and writes the raw density preference', () => {
+    density.hydrate();
+    expect(get(density).value).toBe('comfortable');
+    expect(localStorage.getItem(PERSISTENCE_KEYS.density)).toBe('comfortable');
+
+    expect(density.set('spacious')).toBe(true);
+    expect(localStorage.getItem(PERSISTENCE_KEYS.density)).toBe('spacious');
   });
 
   it('is SSR safe when window is absent', () => {

--- a/apps/web/src/lib/persistence/storage.ts
+++ b/apps/web/src/lib/persistence/storage.ts
@@ -2,25 +2,50 @@ import { writable, type Readable } from 'svelte/store';
 
 import { parseId64, type Id64 } from '../domain/id64';
 
+/**
+ * The one browser-storage key authority for the Svelte application. Runtime
+ * consumers import these names instead of redeclaring string keys.
+ */
+export const PERSISTENCE_KEYS = {
+  pins: 'ed_pinned',
+  compare: 'ed_compare_v2',
+  legacyColony: 'ed_colony_v2',
+  syncKey: 'ed_sync_key',
+  selectedRoute: 'ed_selected_route',
+  myWork: 'ed_my_work_v1',
+  colonyProjects: 'ed_colony_projects_v1',
+  expansionPlans: 'ed_expansion_plans_v1',
+  fcRoute: 'ed_fc_v2',
+  profileSyncKey: 'ed_profile_sync_key',
+  profileSyncLast: 'ed_profile_sync_last',
+  selectedSystem: 'ed-finder:selected-system-context',
+  density: 'ed_density_v1',
+  adminToken: 'ed_admin_token',
+  operatorHandoff: 'ed_operator_selected_source_run',
+} as const;
+
 export const LOCAL_STORAGE_KEYS = [
-  'ed_pinned',
-  'ed_compare_v2',
-  'ed_sync_key',
-  'ed_selected_route',
-  'ed_my_work_v1',
-  'ed_colony_projects_v1',
-  'ed_expansion_plans_v1',
-  'ed_fc_v2',
-  'ed_profile_sync_key',
-  'ed_profile_sync_last',
-  'ed-finder:selected-system-context',
-  'ed_density_v1',
+  PERSISTENCE_KEYS.pins,
+  PERSISTENCE_KEYS.compare,
+  PERSISTENCE_KEYS.legacyColony,
+  PERSISTENCE_KEYS.syncKey,
+  PERSISTENCE_KEYS.selectedRoute,
+  PERSISTENCE_KEYS.myWork,
+  PERSISTENCE_KEYS.colonyProjects,
+  PERSISTENCE_KEYS.expansionPlans,
+  PERSISTENCE_KEYS.fcRoute,
+  PERSISTENCE_KEYS.profileSyncKey,
+  PERSISTENCE_KEYS.profileSyncLast,
+  PERSISTENCE_KEYS.selectedSystem,
+  PERSISTENCE_KEYS.density,
 ] as const;
 
 export const SESSION_STORAGE_KEYS = [
-  'ed_admin_token',
-  'ed_operator_selected_source_run',
+  PERSISTENCE_KEYS.adminToken,
+  PERSISTENCE_KEYS.operatorHandoff,
 ] as const;
+
+export const ADMIN_TOKEN_SESSION_KEY = PERSISTENCE_KEYS.adminToken;
 
 export type LocalStorageKey = (typeof LOCAL_STORAGE_KEYS)[number];
 export type SessionStorageKey = (typeof SESSION_STORAGE_KEYS)[number];
@@ -42,6 +67,15 @@ export interface PersistedState<T> {
   diagnostic: PersistenceDiagnostic | null;
 }
 
+export interface StoredPersistedState<T> {
+  present: boolean;
+  state: PersistedState<T>;
+}
+
+type InspectedPersistedState<T> = StoredPersistedState<T> & {
+  raw: string | null;
+};
+
 type DecodeResult<T> =
   | { ok: true; value: T }
   | { ok: false; problem: PersistenceProblem; detail: string };
@@ -51,6 +85,29 @@ export interface Codec<T> {
   decode(raw: string): DecodeResult<T>;
   encode(value: T): string;
 }
+
+export interface PersistedStore<T> extends Readable<PersistedState<T>> {
+  readonly key: LocalStorageKey | SessionStorageKey;
+  readonly area: StorageAreaName;
+  readonly crossTab: boolean;
+  hydrate(): void;
+  set(value: T): boolean;
+  setFromJsonValue(value: unknown): boolean;
+  clear(): boolean;
+  read(): PersistedState<T>;
+  readStored(): StoredPersistedState<T>;
+}
+
+type PersistedStoreOptions<T> = {
+  initial: () => T;
+  codec: Codec<T>;
+  crossTab?: boolean;
+  persistInitial?: boolean;
+  migrateOnHydrate?: boolean;
+} & (
+  | { key: LocalStorageKey; area?: 'local' }
+  | { key: SessionStorageKey; area: 'session' }
+);
 
 export function nullableCodec<T>(codec: Codec<T>): Codec<T | null> {
   return {
@@ -70,13 +127,9 @@ function storageFor(area: StorageAreaName): Storage | null {
   }
 }
 
-export function createPersistedStore<T>(options: {
-  key: LocalStorageKey | SessionStorageKey;
-  area?: StorageAreaName;
-  initial: () => T;
-  codec: Codec<T>;
-  crossTab?: boolean;
-}) {
+export function createPersistedStore<T>(
+  options: PersistedStoreOptions<T>,
+): PersistedStore<T> {
   const area = options.area ?? 'local';
   const inner = writable<PersistedState<T>>({
     value: options.initial(),
@@ -85,16 +138,20 @@ export function createPersistedStore<T>(options: {
   });
   let listening = false;
 
-  function read(): PersistedState<T> {
+  function inspectStored(): InspectedPersistedState<T> {
     const storage = storageFor(area);
     if (!storage) {
       return {
-        value: options.initial(),
-        hydrated: true,
-        diagnostic:
-          typeof window === 'undefined'
-            ? null
-            : diagnostic('unavailable', 'Storage is unavailable', true),
+        present: false,
+        raw: null,
+        state: {
+          value: options.initial(),
+          hydrated: true,
+          diagnostic:
+            typeof window === 'undefined'
+              ? null
+              : diagnostic('unavailable', 'Storage is unavailable', true),
+        },
       };
     }
     let raw: string | null;
@@ -102,21 +159,46 @@ export function createPersistedStore<T>(options: {
       raw = storage.getItem(options.key);
     } catch {
       return {
-        value: options.initial(),
-        hydrated: true,
-        diagnostic: diagnostic('unavailable', 'Storage read failed', true),
+        present: false,
+        raw: null,
+        state: {
+          value: options.initial(),
+          hydrated: true,
+          diagnostic: diagnostic('unavailable', 'Storage read failed', true),
+        },
       };
     }
     if (raw === null)
-      return { value: options.initial(), hydrated: true, diagnostic: null };
-    const decoded = options.codec.decode(raw);
-    return decoded.ok
-      ? { value: decoded.value, hydrated: true, diagnostic: null }
-      : {
+      return {
+        present: false,
+        raw: null,
+        state: {
           value: options.initial(),
           hydrated: true,
-          diagnostic: diagnostic(decoded.problem, decoded.detail, true),
-        };
+          diagnostic: null,
+        },
+      };
+    const decoded = options.codec.decode(raw);
+    return {
+      present: true,
+      raw,
+      state: decoded.ok
+        ? { value: decoded.value, hydrated: true, diagnostic: null }
+        : {
+            value: options.initial(),
+            hydrated: true,
+            diagnostic: diagnostic(decoded.problem, decoded.detail, true),
+          },
+    };
+  }
+
+  function readStored(): StoredPersistedState<T> {
+    const { present, state } = inspectStored();
+    return { present, state };
+  }
+
+  function read(): PersistedState<T> {
+    return inspectStored().state;
   }
 
   function diagnostic(
@@ -128,7 +210,23 @@ export function createPersistedStore<T>(options: {
   }
 
   function hydrate() {
-    inner.set(read());
+    const stored = inspectStored();
+    inner.set(stored.state);
+    if (
+      options.persistInitial &&
+      !stored.present &&
+      stored.state.diagnostic === null
+    ) {
+      set(stored.state.value);
+    }
+    if (
+      options.migrateOnHydrate &&
+      stored.present &&
+      stored.state.diagnostic === null &&
+      options.codec.encode(stored.state.value) !== stored.raw
+    ) {
+      set(stored.state.value);
+    }
     if (
       !listening &&
       options.crossTab &&
@@ -137,14 +235,26 @@ export function createPersistedStore<T>(options: {
     ) {
       listening = true;
       window.addEventListener('storage', (event) => {
+        const local = storageFor('local');
         if (
-          (event.storageArea === null ||
-            event.storageArea === window.localStorage) &&
+          (event.storageArea === null || event.storageArea === local) &&
           event.key === options.key
         )
           inner.set(read());
       });
     }
+  }
+
+  function setFromJsonValue(value: unknown): boolean {
+    let raw: string | undefined;
+    try {
+      raw = JSON.stringify(value);
+    } catch {
+      return false;
+    }
+    if (raw === undefined) return false;
+    const decoded = options.codec.decode(raw);
+    return decoded.ok ? set(decoded.value) : false;
   }
 
   function set(value: T): boolean {
@@ -189,8 +299,9 @@ export function createPersistedStore<T>(options: {
         parsed.value.version >= 0 &&
         parsed.value.version > options.codec.version
       ) {
+        const existing = read();
         inner.set({
-          value,
+          value: existing.value,
           hydrated: true,
           diagnostic: diagnostic(
             'unsupported-version',
@@ -228,17 +339,28 @@ export function createPersistedStore<T>(options: {
   }
 
   return {
+    key: options.key,
+    area,
+    crossTab: Boolean(options.crossTab && area === 'local'),
     subscribe: inner.subscribe,
     hydrate,
     set,
+    setFromJsonValue,
     clear,
     read,
-  } satisfies Readable<PersistedState<T>> & {
-    hydrate(): void;
-    set(value: T): boolean;
-    clear(): boolean;
-    read(): PersistedState<T>;
+    readStored,
   };
+}
+
+/** Read a session-only raw value without letting API code own Storage access. */
+export function readSessionStorageValue(key: SessionStorageKey): string | null {
+  const storage = storageFor('session');
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
 }
 
 function safeJson(raw: string): { ok: true; value: unknown } | { ok: false } {
@@ -312,32 +434,112 @@ export type PinnedEntry = JsonRecord & {
   pinned_at: string;
 };
 export type CompareEntry = JsonRecord & { id64: Id64; name: string };
+
+export const DEFAULT_FC_CONFIG = {
+  jump_range_ly: 500,
+  cargo_t: 25_000,
+  tritium_per_jump: 50,
+  tritium_price_cr: 50_000,
+} as const;
+
+export interface FcConfig extends JsonRecord {
+  jump_range_ly: number;
+  cargo_t: number;
+  tritium_per_jump: number;
+  tritium_price_cr: number;
+}
+
 export interface FcState extends JsonRecord {
   waypoints: Array<JsonRecord & { id64?: Id64 | null }>;
-  config: JsonRecord;
+  config: FcConfig;
 }
+
 export interface VersionedCollection extends JsonRecord {
   state: JsonRecord;
   version: number;
 }
 
+export type SavedSystemLabel = 'considering' | 'favourite' | 'ready_to_plan';
+
+export interface MyWorkSystemRecord extends JsonRecord {
+  id64: Id64;
+  name: string;
+  x: number | null;
+  y: number | null;
+  z: number | null;
+  population: number | null;
+  is_colonised: boolean;
+  labels: SavedSystemLabel[];
+  explicit_colonised_at: string | null;
+  updated_at: string;
+}
+
+export interface MyWorkCollection extends VersionedCollection {
+  state: JsonRecord & { systems: Record<string, MyWorkSystemRecord> };
+  version: 1;
+}
+
+export interface ColonyProjectRecord extends JsonRecord {
+  id: string;
+  system_id64: Id64;
+  build_plan_placements: JsonRecord[];
+  selected_body_assignments: JsonRecord;
+  declared_roles: JsonRecord[];
+  status: 'draft' | 'ready_to_build' | 'building' | 'established';
+  archived_at: string | null;
+}
+
+export interface ColonyProjectCollection extends VersionedCollection {
+  state: JsonRecord & { projects: Record<string, ColonyProjectRecord> };
+  version: 3;
+}
+
+export interface ExpansionPlanSlot extends JsonRecord {
+  slot_index: number;
+  system_id64: Id64;
+  colony_project_id: string | null;
+}
+
+export interface ExpansionPlanRecord extends JsonRecord {
+  id: string;
+  anchor_system_id64: Id64;
+  slots: ExpansionPlanSlot[];
+  archived_at: string | null;
+}
+
+export interface ExpansionPlanCollection extends VersionedCollection {
+  state: JsonRecord & { plans: Record<string, ExpansionPlanRecord> };
+  version: 1;
+}
+
 const INVALID_PERSISTED_VALUE = Symbol('invalid-persisted-value');
+
+function canonicaliseId(value: unknown): Id64 | typeof INVALID_PERSISTED_VALUE {
+  try {
+    // Safe legacy React snapshots used numbers. Converting only safe integers
+    // recovers those records without accepting already-rounded identifiers.
+    if (typeof value === 'number') {
+      if (!Number.isSafeInteger(value) || value < 0)
+        return INVALID_PERSISTED_VALUE;
+      return parseId64(String(value));
+    }
+    return parseId64(value as string | bigint);
+  } catch {
+    return INVALID_PERSISTED_VALUE;
+  }
+}
 
 function canonicaliseIds(value: unknown, key = ''): unknown {
   if (key === 'id64' || key.endsWith('_id64')) {
     if (value === null) return null;
-    try {
-      // Safe legacy React snapshots used numbers. Converting only safe integers
-      // recovers those records without accepting already-rounded identifiers.
-      if (typeof value === 'number') {
-        if (!Number.isSafeInteger(value) || value < 0)
-          return INVALID_PERSISTED_VALUE;
-        return parseId64(String(value));
-      }
-      return parseId64(value as string | bigint);
-    } catch {
-      return INVALID_PERSISTED_VALUE;
-    }
+    return canonicaliseId(value);
+  }
+  if (key === 'id64s' || key.endsWith('_id64s')) {
+    if (!Array.isArray(value)) return INVALID_PERSISTED_VALUE;
+    const ids = value.map(canonicaliseId);
+    return ids.includes(INVALID_PERSISTED_VALUE)
+      ? INVALID_PERSISTED_VALUE
+      : ids;
   }
   if (Array.isArray(value)) {
     const output = value.map((item) => canonicaliseIds(item));
@@ -392,6 +594,297 @@ function collectionEnvelope(
   return normalised as VersionedCollection;
 }
 
+function isSupportedCollectionEnvelope(
+  value: unknown,
+  acceptedVersion: number,
+): value is JsonRecord & { state: JsonRecord; version: number } {
+  return (
+    isRecord(value) &&
+    isRecord(value.state) &&
+    typeof value.version === 'number' &&
+    Number.isFinite(value.version) &&
+    Number.isInteger(value.version) &&
+    value.version >= 0 &&
+    value.version <= acceptedVersion
+  );
+}
+
+function normaliseCollectionEnvelope<T extends VersionedCollection>(
+  value: unknown,
+  collectionKey: string,
+  version: number,
+  normaliseCollection: (collection: unknown) => JsonRecord,
+): T | null {
+  if (!isSupportedCollectionEnvelope(value, version)) return null;
+
+  // Canonicalise every field outside the record collection as one unit. Bad
+  // records are recovered independently below, while an unsafe identifier in
+  // envelope metadata still fails closed.
+  const canonical = canonicaliseIds({
+    ...value,
+    state: { ...value.state, [collectionKey]: {} },
+  });
+  if (!isRecord(canonical) || !isRecord(canonical.state)) return null;
+  canonical.state[collectionKey] = normaliseCollection(
+    value.state[collectionKey],
+  );
+  canonical.version = version;
+  return canonical as T;
+}
+
+function normaliseLabels(value: unknown): SavedSystemLabel[] {
+  if (!Array.isArray(value)) return [];
+  const labels = new Set<SavedSystemLabel>();
+  for (const candidate of value) {
+    if (
+      candidate === 'considering' ||
+      candidate === 'favourite' ||
+      candidate === 'ready_to_plan'
+    )
+      labels.add(candidate);
+  }
+  return [...labels];
+}
+
+function finiteNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function finiteNumberOrDefault(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function normaliseFcConfig(value: unknown): FcConfig {
+  const config = isRecord(value) ? value : {};
+  return {
+    ...config,
+    jump_range_ly: finiteNumberOrDefault(
+      config.jump_range_ly,
+      DEFAULT_FC_CONFIG.jump_range_ly,
+    ),
+    cargo_t: finiteNumberOrDefault(config.cargo_t, DEFAULT_FC_CONFIG.cargo_t),
+    tritium_per_jump: finiteNumberOrDefault(
+      config.tritium_per_jump,
+      DEFAULT_FC_CONFIG.tritium_per_jump,
+    ),
+    tritium_price_cr: finiteNumberOrDefault(
+      config.tritium_price_cr,
+      DEFAULT_FC_CONFIG.tritium_price_cr,
+    ),
+  };
+}
+
+/** React-compatible My Work recovery with the lossless Id64 policy applied. */
+export function normaliseMyWorkRecord(
+  value: unknown,
+  fallbackUpdatedAt = new Date().toISOString(),
+): Record<string, MyWorkSystemRecord> {
+  const candidates = Array.isArray(value)
+    ? value
+    : isRecord(value)
+      ? Object.values(value)
+      : [];
+  const systems: Record<string, MyWorkSystemRecord> = {};
+  for (const candidate of candidates) {
+    const normalised = canonicaliseIds(candidate);
+    if (!isRecord(normalised) || typeof normalised.id64 !== 'string') continue;
+    const id64 = normalised.id64 as Id64;
+    systems[id64] = {
+      ...normalised,
+      id64,
+      name:
+        typeof normalised.name === 'string' && normalised.name.trim()
+          ? normalised.name.trim()
+          : `System ${id64}`,
+      x: finiteNumberOrNull(normalised.x),
+      y: finiteNumberOrNull(normalised.y),
+      z: finiteNumberOrNull(normalised.z),
+      population: finiteNumberOrNull(normalised.population),
+      is_colonised: Boolean(normalised.is_colonised),
+      labels: normaliseLabels(normalised.labels),
+      explicit_colonised_at:
+        typeof normalised.explicit_colonised_at === 'string'
+          ? normalised.explicit_colonised_at
+          : null,
+      updated_at:
+        typeof normalised.updated_at === 'string' && normalised.updated_at
+          ? normalised.updated_at
+          : fallbackUpdatedAt,
+    };
+  }
+  return systems;
+}
+
+function normalisePlacements(value: unknown): JsonRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((placement, index) => {
+    if (!isRecord(placement)) return [];
+    if (
+      typeof placement.facility_template_id !== 'string' ||
+      !placement.facility_template_id.trim()
+    )
+      return [];
+    return [
+      {
+        facility_template_id: placement.facility_template_id,
+        local_body_id:
+          placement.local_body_id === null ||
+          placement.local_body_id === undefined
+            ? null
+            : String(placement.local_body_id),
+        is_primary_port: Boolean(placement.is_primary_port),
+        build_order:
+          typeof placement.build_order === 'number' &&
+          Number.isFinite(placement.build_order)
+            ? placement.build_order
+            : index + 1,
+      },
+    ];
+  });
+}
+
+function normaliseColonyStatus(value: unknown): ColonyProjectRecord['status'] {
+  return value === 'ready_to_build' ||
+    value === 'building' ||
+    value === 'established'
+    ? value
+    : 'draft';
+}
+
+export function normaliseColonyProjectRecord(
+  value: unknown,
+): Record<string, ColonyProjectRecord> {
+  const candidates = Array.isArray(value)
+    ? value
+    : isRecord(value)
+      ? Object.values(value)
+      : [];
+  const projects: Record<string, ColonyProjectRecord> = {};
+  for (const candidate of candidates) {
+    const normalised = canonicaliseIds(candidate);
+    if (
+      !isRecord(normalised) ||
+      typeof normalised.id !== 'string' ||
+      !normalised.id ||
+      typeof normalised.system_id64 !== 'string'
+    )
+      continue;
+    projects[normalised.id] = {
+      ...normalised,
+      id: normalised.id,
+      system_id64: normalised.system_id64 as Id64,
+      build_plan_placements: normalisePlacements(
+        normalised.build_plan_placements,
+      ),
+      selected_body_assignments: isRecord(normalised.selected_body_assignments)
+        ? normalised.selected_body_assignments
+        : {},
+      declared_roles: Array.isArray(normalised.declared_roles)
+        ? normalised.declared_roles.filter(isRecord)
+        : [],
+      objective: normalised.objective ?? null,
+      start_approach: normalised.start_approach ?? null,
+      created_from: normalised.created_from ?? null,
+      status: normaliseColonyStatus(normalised.status),
+      archived_at:
+        typeof normalised.archived_at === 'string'
+          ? normalised.archived_at
+          : null,
+    };
+  }
+  return projects;
+}
+
+function normalisePlanSlot(value: unknown): ExpansionPlanSlot | null {
+  const normalised = canonicaliseIds(value);
+  if (
+    !isRecord(normalised) ||
+    typeof normalised.slot_index !== 'number' ||
+    !Number.isFinite(normalised.slot_index) ||
+    !Number.isInteger(normalised.slot_index) ||
+    typeof normalised.system_id64 !== 'string'
+  )
+    return null;
+  return {
+    ...normalised,
+    slot_index: normalised.slot_index,
+    system_id64: normalised.system_id64 as Id64,
+    colony_project_id:
+      typeof normalised.colony_project_id === 'string'
+        ? normalised.colony_project_id
+        : null,
+  };
+}
+
+/**
+ * Recover expansion plans record-by-record so malformed profile data cannot
+ * make selectors call `.some`/`.find` on a non-array. Valid slots and unknown
+ * forward-compatible fields survive migration.
+ */
+export function normalisePlanRecord(
+  value: unknown,
+): Record<string, ExpansionPlanRecord> {
+  const candidates = Array.isArray(value)
+    ? value
+    : isRecord(value)
+      ? Object.values(value)
+      : [];
+  const plans: Record<string, ExpansionPlanRecord> = {};
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue;
+    const { slots: candidateSlots, ...candidateWithoutSlots } = candidate;
+    const normalised = canonicaliseIds(candidateWithoutSlots);
+    if (
+      !isRecord(normalised) ||
+      typeof normalised.id !== 'string' ||
+      !normalised.id ||
+      typeof normalised.anchor_system_id64 !== 'string'
+    )
+      continue;
+    const slots = Array.isArray(candidateSlots)
+      ? candidateSlots
+          .map(normalisePlanSlot)
+          .filter((slot): slot is ExpansionPlanSlot => slot !== null)
+      : [];
+    plans[normalised.id] = {
+      ...normalised,
+      id: normalised.id,
+      anchor_system_id64: normalised.anchor_system_id64 as Id64,
+      slots,
+      archived_at:
+        typeof normalised.archived_at === 'string'
+          ? normalised.archived_at
+          : null,
+    };
+  }
+  return plans;
+}
+
+export interface ExpansionPlanSlotSystemUpdate extends JsonRecord {
+  system_id64: Id64;
+  system_name: string;
+  scores: Record<string, number>;
+  distance_from_anchor_ly: number | null;
+}
+
+/** Immutable slot replacement; changing a system invalidates only its old project link. */
+export function replaceExpansionPlanSlotSystem(
+  plan: ExpansionPlanRecord,
+  slotIndex: number,
+  system: ExpansionPlanSlotSystemUpdate,
+  updatedAt = new Date().toISOString(),
+): ExpansionPlanRecord {
+  return {
+    ...plan,
+    slots: plan.slots.map((slot) =>
+      slot.slot_index === slotIndex
+        ? { ...slot, ...system, colony_project_id: null }
+        : slot,
+    ),
+    updated_at: updatedAt,
+  };
+}
+
 export const pinnedCodec = jsonCodec<PinnedEntry[]>((value) =>
   entryArray<PinnedEntry>(
     value,
@@ -410,19 +903,101 @@ export const compareCodec = jsonCodec<CompareEntry[]>((value) =>
 );
 export const fcCodec = jsonCodec<FcState>((value) => {
   const normalised = canonicaliseIds(value);
-  if (
-    !isRecord(normalised) ||
-    !Array.isArray(normalised.waypoints) ||
-    !isRecord(normalised.config)
-  )
-    return null;
-  return normalised as FcState;
+  if (!isRecord(normalised)) return null;
+  return {
+    ...normalised,
+    waypoints: Array.isArray(normalised.waypoints)
+      ? normalised.waypoints.filter(isRecord)
+      : [],
+    config: normaliseFcConfig(normalised.config),
+  };
 });
 export const collectionCodec = (version: number) =>
   jsonCodec<VersionedCollection>(
     (value) => collectionEnvelope(value, version),
     version,
   );
+
+export const myWorkCodec = jsonCodec<MyWorkCollection>(
+  (value) =>
+    normaliseCollectionEnvelope<MyWorkCollection>(
+      value,
+      'systems',
+      1,
+      (systems) => normaliseMyWorkRecord(systems),
+    ),
+  1,
+);
+
+export const colonyProjectsCodec = jsonCodec<ColonyProjectCollection>(
+  (value) =>
+    normaliseCollectionEnvelope<ColonyProjectCollection>(
+      value,
+      'projects',
+      3,
+      (projects) => normaliseColonyProjectRecord(projects),
+    ),
+  3,
+);
+
+export const expansionPlansCodec = jsonCodec<ExpansionPlanCollection>(
+  (value) =>
+    normaliseCollectionEnvelope<ExpansionPlanCollection>(
+      value,
+      'plans',
+      1,
+      (plans) => normalisePlanRecord(plans),
+    ),
+  1,
+);
+
+export const opaqueJsonCodec: Codec<unknown> = {
+  version: 0,
+  decode(raw) {
+    const parsed = safeJson(raw);
+    if (!parsed.ok)
+      return {
+        ok: false,
+        problem: 'corrupt-json',
+        detail: 'Stored value is not valid JSON',
+      };
+    const normalised = canonicaliseIds(parsed.value);
+    return normalised === INVALID_PERSISTED_VALUE
+      ? {
+          ok: false,
+          problem: 'invalid-shape',
+          detail: 'Stored value contains an unsafe identifier',
+        }
+      : { ok: true, value: normalised };
+  },
+  encode(value) {
+    const raw = JSON.stringify(value);
+    if (raw === undefined)
+      throw new TypeError('Value is not JSON serialisable');
+    return raw;
+  },
+};
+
+export const SYNC_KEY_PATTERN = /^[A-Za-z0-9_-]{16,128}$/;
+const SYNC_KEY_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+export function generateSyncKey(length = 32): string {
+  if (!Number.isInteger(length) || length < 16 || length > 128)
+    throw new RangeError('Sync-key length must be an integer from 16 to 128');
+  const bytes = new Uint8Array(length);
+  if (typeof crypto !== 'undefined' && 'getRandomValues' in crypto) {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let index = 0; index < length; index += 1)
+      bytes[index] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(
+    bytes,
+    (byte) => SYNC_KEY_ALPHABET[byte % SYNC_KEY_ALPHABET.length],
+  ).join('');
+}
+
 export const syncKeyCodec = jsonCodec<{
   state: { syncKey: string };
   version: number;
@@ -430,17 +1005,22 @@ export const syncKeyCodec = jsonCodec<{
   if (
     !isRecord(value) ||
     !isRecord(value.state) ||
+    value.version !== 0 ||
     typeof value.state.syncKey !== 'string' ||
-    !/^[A-Za-z0-9_-]{16,128}$/.test(value.state.syncKey) ||
+    !SYNC_KEY_PATTERN.test(value.state.syncKey) ||
     value.state.syncKey === 'legacy'
   )
     return null;
   return {
     ...value,
     state: { ...value.state, syncKey: value.state.syncKey },
-    version: typeof value.version === 'number' ? value.version : 0,
+    version: 0,
   } as { state: { syncKey: string }; version: number };
 });
+
+export const profileSyncKeyCodec = rawStringCodec((value) =>
+  SYNC_KEY_PATTERN.test(value),
+);
 export const selectedRouteCodec = jsonCodec<{
   state: { selectedRouteId: string | null };
   version: number;
@@ -448,6 +1028,7 @@ export const selectedRouteCodec = jsonCodec<{
   if (
     !isRecord(value) ||
     !isRecord(value.state) ||
+    value.version !== 0 ||
     (value.state.selectedRouteId !== null &&
       typeof value.state.selectedRouteId !== 'string')
   )
@@ -455,7 +1036,7 @@ export const selectedRouteCodec = jsonCodec<{
   return {
     ...value,
     state: { ...value.state, selectedRouteId: value.state.selectedRouteId },
-    version: typeof value.version === 'number' ? value.version : 0,
+    version: 0,
   } as { state: { selectedRouteId: string | null }; version: number };
 });
 

--- a/apps/web/src/lib/persistence/stores.ts
+++ b/apps/web/src/lib/persistence/stores.ts
@@ -1,110 +1,140 @@
 import { get } from 'svelte/store';
 
 import {
-  collectionCodec,
+  DEFAULT_FC_CONFIG,
+  PERSISTENCE_KEYS,
+  colonyProjectsCodec,
   compareCodec,
   createPersistedStore,
   densityCodec,
+  expansionPlansCodec,
   fcCodec,
+  generateSyncKey,
   id64StringCodec,
+  myWorkCodec,
   nullableCodec,
+  opaqueJsonCodec,
   pinnedCodec,
+  profileSyncKeyCodec,
   rawStringCodec,
   selectedRouteCodec,
   syncKeyCodec,
+  type ColonyProjectCollection,
   type CompareEntry,
+  type ExpansionPlanCollection,
   type FcState,
-  type JsonRecord,
+  type MyWorkCollection,
   type PinnedEntry,
-  type VersionedCollection,
 } from './storage';
 import type { Id64 } from '../domain/id64';
 
-const emptyCollection = (): VersionedCollection => ({ state: {}, version: 0 });
+/**
+ * Active local stores use one native-storage-event listener per singleton.
+ * Same-tab callers use `.set`; listeners only re-read and never write, so
+ * profile imports do not need synthetic events and cannot form feedback loops.
+ */
+export const CROSS_TAB_POLICY = 'guarded-native-storage-event' as const;
+const CROSS_TAB = true;
+const initialSyncKey = generateSyncKey();
 
 export const pins = createPersistedStore<PinnedEntry[]>({
-  key: 'ed_pinned',
+  key: PERSISTENCE_KEYS.pins,
   initial: () => [],
   codec: pinnedCodec,
-  crossTab: true,
+  crossTab: CROSS_TAB,
+  migrateOnHydrate: true,
 });
 export const compare = createPersistedStore<CompareEntry[]>({
-  key: 'ed_compare_v2',
+  key: PERSISTENCE_KEYS.compare,
   initial: () => [],
   codec: compareCodec,
-  crossTab: true,
+  crossTab: CROSS_TAB,
+  migrateOnHydrate: true,
 });
 export const syncKey = createPersistedStore({
-  key: 'ed_sync_key',
-  initial: () => ({ state: { syncKey: '' }, version: 0 }),
+  key: PERSISTENCE_KEYS.syncKey,
+  initial: () => ({ state: { syncKey: initialSyncKey }, version: 0 }),
   codec: syncKeyCodec,
-  crossTab: true,
+  crossTab: CROSS_TAB,
+  persistInitial: true,
 });
 export const selectedRoute = createPersistedStore({
-  key: 'ed_selected_route',
+  key: PERSISTENCE_KEYS.selectedRoute,
   initial: () => ({ state: { selectedRouteId: null }, version: 0 }),
   codec: selectedRouteCodec,
-  crossTab: true,
+  crossTab: CROSS_TAB,
 });
-export const myWork = createPersistedStore({
-  key: 'ed_my_work_v1',
-  initial: emptyCollection,
-  codec: collectionCodec(1),
-  crossTab: true,
+export const myWork = createPersistedStore<MyWorkCollection>({
+  key: PERSISTENCE_KEYS.myWork,
+  initial: () => ({ state: { systems: {} }, version: 1 }),
+  codec: myWorkCodec,
+  crossTab: CROSS_TAB,
+  migrateOnHydrate: true,
 });
-export const colonyProjects = createPersistedStore({
-  key: 'ed_colony_projects_v1',
-  initial: emptyCollection,
-  codec: collectionCodec(3),
-  crossTab: true,
+export const colonyProjects = createPersistedStore<ColonyProjectCollection>({
+  key: PERSISTENCE_KEYS.colonyProjects,
+  initial: () => ({ state: { projects: {} }, version: 3 }),
+  codec: colonyProjectsCodec,
+  crossTab: CROSS_TAB,
+  migrateOnHydrate: true,
 });
-export const expansionPlans = createPersistedStore({
-  key: 'ed_expansion_plans_v1',
-  initial: emptyCollection,
-  codec: collectionCodec(1),
-  crossTab: true,
+export const expansionPlans = createPersistedStore<ExpansionPlanCollection>({
+  key: PERSISTENCE_KEYS.expansionPlans,
+  initial: () => ({ state: { plans: {} }, version: 1 }),
+  codec: expansionPlansCodec,
+  crossTab: CROSS_TAB,
+  migrateOnHydrate: true,
 });
 export const fcRoute = createPersistedStore<FcState>({
-  key: 'ed_fc_v2',
-  initial: () => ({ waypoints: [], config: {} }),
+  key: PERSISTENCE_KEYS.fcRoute,
+  initial: () => ({ waypoints: [], config: { ...DEFAULT_FC_CONFIG } }),
   codec: fcCodec,
-  crossTab: true,
+  crossTab: CROSS_TAB,
+  migrateOnHydrate: true,
 });
 export const profileSyncKey = createPersistedStore({
-  key: 'ed_profile_sync_key',
+  key: PERSISTENCE_KEYS.profileSyncKey,
   initial: () => '',
-  codec: rawStringCodec(),
-  crossTab: true,
+  codec: profileSyncKeyCodec,
+  crossTab: CROSS_TAB,
 });
 export const profileSyncLast = createPersistedStore({
-  key: 'ed_profile_sync_last',
+  key: PERSISTENCE_KEYS.profileSyncLast,
   initial: () => '',
   codec: rawStringCodec(),
-  crossTab: true,
+  crossTab: CROSS_TAB,
 });
 export const selectedSystem = createPersistedStore<Id64 | null>({
-  key: 'ed-finder:selected-system-context',
+  key: PERSISTENCE_KEYS.selectedSystem,
   initial: () => null,
   codec: nullableCodec(id64StringCodec),
-  crossTab: true,
+  crossTab: CROSS_TAB,
 });
 export const density = createPersistedStore({
-  key: 'ed_density_v1',
+  key: PERSISTENCE_KEYS.density,
   initial: () => 'comfortable',
   codec: densityCodec,
-  crossTab: true,
+  crossTab: CROSS_TAB,
+  persistInitial: true,
 });
 export const adminToken = createPersistedStore({
-  key: 'ed_admin_token',
+  key: PERSISTENCE_KEYS.adminToken,
   area: 'session',
   initial: () => '',
   codec: rawStringCodec(),
 });
 export const operatorHandoff = createPersistedStore({
-  key: 'ed_operator_selected_source_run',
+  key: PERSISTENCE_KEYS.operatorHandoff,
   area: 'session',
   initial: () => '',
   codec: rawStringCodec(),
+});
+
+/** Opaque legacy profile payload; there is deliberately no active feature store. */
+export const legacyColonyPassthrough = createPersistedStore<unknown | null>({
+  key: PERSISTENCE_KEYS.legacyColony,
+  initial: () => null,
+  codec: nullableCodec(opaqueJsonCodec),
 });
 
 export const applicationStores = {
@@ -152,6 +182,4 @@ export function persistenceDiagnostics() {
   });
 }
 
-export type MyWorkState = VersionedCollection & {
-  state: JsonRecord & { systems?: Record<string, JsonRecord> };
-};
+export type MyWorkState = MyWorkCollection;

--- a/tests/test_svelte_platform_contracts.py
+++ b/tests/test_svelte_platform_contracts.py
@@ -97,6 +97,7 @@ def test_persisted_key_inventory_is_explicit_and_complete():
     local_keys = {
         "ed_pinned",
         "ed_compare_v2",
+        "ed_colony_v2",
         "ed_sync_key",
         "ed_selected_route",
         "ed_my_work_v1",
@@ -115,6 +116,60 @@ def test_persisted_key_inventory_is_explicit_and_complete():
     )
     assert "localStorage" in persistence
     assert "sessionStorage" in persistence
+
+
+def test_persistence_layer_is_the_only_runtime_browser_storage_owner():
+    storage_globals = re.compile(r"\b(?:localStorage|sessionStorage)\b")
+    storage_keys = re.compile(
+        r"ed_(?:pinned|compare_v2|colony_v2|sync_key|selected_route|"
+        r"my_work_v1|colony_projects_v1|expansion_plans_v1|fc_v2|"
+        r"profile_sync_key|profile_sync_last|density_v1|admin_token|"
+        r"operator_selected_source_run)|ed-finder:selected-system-context"
+    )
+    offenders = []
+    key_offenders = []
+    for path, source in _application_sources():
+        relative = path.relative_to(SOURCE).as_posix()
+        if relative.startswith("lib/persistence/"):
+            continue
+        if storage_globals.search(source):
+            offenders.append(relative)
+        if storage_keys.search(source):
+            key_offenders.append(relative)
+    assert offenders == []
+    assert key_offenders == []
+
+
+def test_profile_sync_is_closed_allowlist_without_synthetic_storage_events():
+    profile_sync = (
+        SOURCE / "lib" / "persistence" / "profile-sync.ts"
+    ).read_text(encoding="utf-8")
+    allowlist_match = re.search(
+        r"export const PROFILE_SYNC_KEYS = \[(.*?)\] as const", profile_sync, re.DOTALL
+    )
+    assert allowlist_match is not None
+    allowlist = set(re.findall(r"PERSISTENCE_KEYS\.([A-Za-z]+)", allowlist_match.group(1)))
+    assert allowlist == {
+        "pins",
+        "compare",
+        "legacyColony",
+        "fcRoute",
+        "myWork",
+        "colonyProjects",
+        "expansionPlans",
+    }
+    denylist_match = re.search(
+        r"export const PROFILE_SYNC_SECURITY_DENYLIST = \[(.*?)\] as const",
+        profile_sync,
+        re.DOTALL,
+    )
+    assert denylist_match is not None
+    denylist = set(
+        re.findall(r"PERSISTENCE_KEYS\.([A-Za-z]+)", denylist_match.group(1))
+    )
+    assert denylist == {"adminToken", "operatorHandoff", "syncKey"}
+    assert "new StorageEvent" not in profile_sync
+    assert ".dispatchEvent" not in profile_sync
 
 
 def test_static_application_has_no_pwa_or_playwright_runtime():


### PR DESCRIPTION
## Purpose

Integrate the completed persistence/profile-sync work packet into the Svelte platform lane after WP0 is accepted.

## Scope

- exact legacy storage-envelope decoding and canonical lossless Id64 handling;
- corrupt/unknown-envelope fail-closed behaviour;
- cross-tab persisted-store semantics;
- merge-not-replace profile pull and explicit push/gather commands;
- opaque legacy `ed_colony_v2` passthrough where required to avoid data loss;
- profile-sync exclusion of session-only security keys;
- focused API, storage, profile-sync and repository contract coverage.

## Sequencing

This PR is intentionally draft because it overlaps the active WP0 token/security integration in `client.ts` and persistence ownership. After WP0 lands, merge the then-current platform head into this branch, resolve conflicts without dropping either contract, rerun exact-head Svelte and repository checks, then review for merge.

No merge to `main`, production/deployment/database/OAuth-secret or Stage 27 work is included.