### PR TITLE
ops: add read-only V3 derived-data status

### DIFF
--- a/.github/workflows/v3-derived-data-status.yml
+++ b/.github/workflows/v3-derived-data-status.yml
@@ -1,0 +1,99 @@
+name: V3 derived-data status
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/prod-status-requests/20260905-v3-derived-data-status.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v3-derived-data-status
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Inspect V3 derived-data population
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 10
+    steps:
+      - name: Checkout status request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Validate exact one-purpose request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          expected='.github/prod-status-requests/20260905-v3-derived-data-status.json'
+          mapfile -t changed < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed[@]}" -eq 1 ] || { echo "Expected exactly one changed status request" >&2; exit 64; }
+          [ "${changed[0]}" = "$expected" ] || { echo "Unexpected status request path" >&2; exit 64; }
+          python3 - "$expected" <<'PY'
+          import json, pathlib, sys
+          value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding='utf-8'))
+          if value != {"operation": "v3-derived-data-status"}:
+              raise SystemExit("Request must be exactly v3-derived-data-status")
+          PY
+
+      - name: Checkout trusted operator implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare pinned SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" || { echo "Missing ED_NEW_OPERATOR_SSH_KEY" >&2; exit 1; }
+          test -n "$SSH_HOST" || { echo "Missing ED_NEW_OPERATOR_HOST" >&2; exit 1; }
+          test -n "$SSH_PORT" || { echo "Missing ED_NEW_OPERATOR_PORT" >&2; exit 1; }
+          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing pinned ed-new known-hosts secret" >&2; exit 1; }
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          if [ "$SSH_PORT" = "22" ]; then
+            lookup="$SSH_HOST"
+          else
+            lookup="[$SSH_HOST]:$SSH_PORT"
+          fi
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null || {
+            echo "Pinned known-host trust does not cover configured production host" >&2
+            exit 1
+          }
+
+      - name: Inspect derived-data state read-only
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'cd /opt/ed-finder && bash -s' \
+              < trusted-main/scripts/operator/actions/v3-derived-data-status.sh

--- a/scripts/operator/actions/v3-derived-data-status.sh
+++ b/scripts/operator/actions/v3-derived-data-status.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' '{"schema_version":"ed-finder/operator-operation-result/v1","operation":"v3-derived-data-status","status":"stopped","failures":["python3_unavailable"],"read_only":true,"direct_db_access_performed":false,"db_writes_performed":false,"env_files_read":false,"private_keys_read":false,"service_changes_performed":false,"filesystem_writes_performed":false}'
+    exit 1
+fi
+
+exec python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+from typing import Any
+
+EXPECTED_HOST = "ed-finder-prod"
+EXPECTED_FQDN = "nb79a3d.mevnode.com"
+POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+DB_USER = "edfinder"
+DB_NAME = "edfinder"
+STATEMENT_TIMEOUT_MS = 20_000
+PROCESS_TIMEOUT_SECONDS = 30
+
+RELATIONS = (
+    "systems",
+    "bodies",
+    "ratings",
+    "grid_cells",
+    "macro_grid",
+    "cluster_summary",
+    "system_slot_topology",
+    "system_archetype_scores",
+    "system_archetype_traits",
+    "system_regional_analysis",
+    "mv_archetype_rankings",
+    "mv_map_regions",
+    "mv_map_heatmap_200ly",
+    "mv_map_heatmap_500ly",
+    "mv_map_heatmap_1000ly",
+    "mv_map_timeline_month",
+)
+
+
+def run(argv: list[str], *, timeout: int = PROCESS_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(argv, text=True, capture_output=True, timeout=timeout, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
+
+
+def psql(sql: str, *, timeout: int = PROCESS_TIMEOUT_SECONDS) -> list[list[str]]:
+    # Every statement is hard-coded in this file. The explicit READ ONLY
+    # transaction is a second safety boundary on top of the operator workflow.
+    wrapped = (
+        "BEGIN READ ONLY; "
+        f"SET LOCAL statement_timeout = '{STATEMENT_TIMEOUT_MS}ms'; "
+        + sql.rstrip().rstrip(";")
+        + "; COMMIT;"
+    )
+    result = run(
+        [
+            "docker", "exec", POSTGRES_CONTAINER,
+            "psql", "-X", "-qAt", "-F", "\t", "-v", "ON_ERROR_STOP=1",
+            "-U", DB_USER, "-d", DB_NAME, "-c", wrapped,
+        ],
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        suffix = detail[-1][:240] if detail else f"exit_{result.returncode}"
+        raise RuntimeError(suffix)
+    rows: list[list[str]] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        rows.append(line.split("\t"))
+    return rows
+
+
+def as_int(value: str | None) -> int | None:
+    if value in (None, "", "\\N"):
+        return None
+    try:
+        return int(float(value))
+    except ValueError:
+        return None
+
+
+def as_float(value: str | None) -> float | None:
+    if value in (None, "", "\\N"):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+receipt: dict[str, Any] = {
+    "schema_version": "ed-finder/operator-operation-result/v1",
+    "operation": "v3-derived-data-status",
+    "status": "stopped",
+    "read_only": True,
+    "direct_db_access_performed": False,
+    "db_writes_performed": False,
+    "env_files_read": False,
+    "private_keys_read": False,
+    "service_changes_performed": False,
+    "filesystem_writes_performed": False,
+    "query_policy": {
+        "transaction": "READ ONLY",
+        "statement_timeout_ms": STATEMENT_TIMEOUT_MS,
+        "large_table_strategy": "catalog estimates plus small TABLESAMPLE probes",
+    },
+}
+failures: list[str] = []
+
+host = socket.gethostname().split(".")[0]
+fqdn_result = run(["hostname", "-f"])
+fqdn = fqdn_result.stdout.strip()
+receipt["host"] = {"short": host, "fqdn": fqdn}
+if host != EXPECTED_HOST or fqdn_result.returncode != 0 or fqdn != EXPECTED_FQDN:
+    failures.append("unexpected_host_identity")
+if run(["pwd", "-P"]).stdout.strip() != "/opt/ed-finder":
+    failures.append("unexpected_working_directory")
+if failures:
+    receipt["failures"] = sorted(set(failures))
+    print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    sys.exit(1)
+
+container = run(["docker", "inspect", "-f", "{{.State.Running}}", POSTGRES_CONTAINER])
+if container.returncode != 0 or container.stdout.strip() != "true":
+    failures.append("postgres_container_unavailable")
+    receipt["failures"] = sorted(set(failures))
+    print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    sys.exit(1)
+
+receipt["direct_db_access_performed"] = True
+
+try:
+    version_rows = psql(
+        "SELECT current_setting('server_version'), current_setting('server_version_num'), "
+        "pg_size_pretty(pg_database_size(current_database()))"
+    )
+    if version_rows:
+        receipt["postgres"] = {
+            "server_version": version_rows[0][0],
+            "server_version_num": as_int(version_rows[0][1]),
+            "database_size": version_rows[0][2],
+        }
+
+    relation_names = ",".join("'%s'" % name.replace("'", "''") for name in RELATIONS)
+    relation_rows = psql(
+        "SELECT c.relname, c.relkind, GREATEST(c.reltuples,0)::bigint, "
+        "pg_total_relation_size(c.oid)::bigint, "
+        "CASE WHEN c.relkind='m' THEN COALESCE(pm.ispopulated,false)::text ELSE '' END "
+        "FROM pg_class c "
+        "JOIN pg_namespace n ON n.oid=c.relnamespace "
+        "LEFT JOIN pg_matviews pm ON pm.schemaname=n.nspname AND pm.matviewname=c.relname "
+        "WHERE n.nspname='public' AND c.relname IN (" + relation_names + ") "
+        "ORDER BY c.relname"
+    )
+    relations: dict[str, Any] = {}
+    for row in relation_rows:
+        relations[row[0]] = {
+            "kind": row[1],
+            "estimated_rows": as_int(row[2]),
+            "total_bytes": as_int(row[3]),
+            "is_populated": None if row[4] == "" else row[4] == "true",
+        }
+    for name in RELATIONS:
+        relations.setdefault(name, {"missing": True})
+    receipt["relations"] = relations
+
+    stat_rows = psql(
+        "SELECT tablename, attname, null_frac::text, n_distinct::text, "
+        "COALESCE(most_common_vals::text,''), COALESCE(most_common_freqs::text,'') "
+        "FROM pg_stats WHERE schemaname='public' AND ("
+        "(tablename='systems' AND attname IN ('grid_cell_id','macro_grid_id','rating_dirty','cluster_dirty','has_body_data')) OR "
+        "(tablename='ratings' AND attname='rating_version') OR "
+        "(tablename='system_archetype_scores' AND attname='dirty')) "
+        "ORDER BY tablename, attname"
+    )
+    receipt["planner_statistics"] = [
+        {
+            "table": row[0],
+            "column": row[1],
+            "null_frac": as_float(row[2]),
+            "n_distinct": as_float(row[3]),
+            "most_common_vals": row[4] or None,
+            "most_common_freqs": row[5] or None,
+        }
+        for row in stat_rows
+    ]
+
+    # Samples are deliberately tiny and are used only to answer whether the
+    # post-import derived columns appear substantially populated. They are not
+    # accepted as exact integrity evidence.
+    system_sample = psql(
+        "SELECT COUNT(*)::bigint, "
+        "COUNT(*) FILTER (WHERE grid_cell_id IS NOT NULL)::bigint, "
+        "COUNT(*) FILTER (WHERE macro_grid_id IS NOT NULL)::bigint, "
+        "COUNT(*) FILTER (WHERE has_body_data)::bigint, "
+        "COUNT(*) FILTER (WHERE rating_dirty)::bigint, "
+        "COUNT(*) FILTER (WHERE cluster_dirty)::bigint "
+        "FROM systems TABLESAMPLE SYSTEM (0.01)"
+    )
+    if system_sample:
+        row = system_sample[0]
+        receipt["systems_sample"] = {
+            "sample_rows": as_int(row[0]),
+            "grid_cell_present": as_int(row[1]),
+            "macro_grid_present": as_int(row[2]),
+            "has_body_data": as_int(row[3]),
+            "rating_dirty": as_int(row[4]),
+            "cluster_dirty": as_int(row[5]),
+            "sample_percent": 0.01,
+        }
+
+    ratings_sample = psql(
+        "SELECT COUNT(*)::bigint, "
+        "COUNT(*) FILTER (WHERE rating_version='3.4')::bigint, "
+        "COUNT(*) FILTER (WHERE rating_version IS NULL)::bigint "
+        "FROM ratings TABLESAMPLE SYSTEM (0.05)"
+    )
+    if ratings_sample:
+        row = ratings_sample[0]
+        receipt["ratings_sample"] = {
+            "sample_rows": as_int(row[0]),
+            "rating_version_3_4": as_int(row[1]),
+            "rating_version_null": as_int(row[2]),
+            "sample_percent": 0.05,
+        }
+
+    archetype_sample = psql(
+        "SELECT COUNT(*)::bigint, COUNT(*) FILTER (WHERE dirty)::bigint "
+        "FROM system_archetype_scores TABLESAMPLE SYSTEM (0.1)"
+    ) if not relations.get("system_archetype_scores", {}).get("missing") else []
+    if archetype_sample:
+        receipt["archetype_sample"] = {
+            "sample_rows": as_int(archetype_sample[0][0]),
+            "dirty": as_int(archetype_sample[0][1]),
+            "sample_percent": 0.1,
+        }
+
+    app_meta_rows = psql(
+        "SELECT key, value, updated_at::text FROM app_meta "
+        "WHERE key IN ('last_nightly_update','nightly_update_started_at_epoch','nightly_update_completed_at_epoch') "
+        "ORDER BY key"
+    )
+    receipt["maintenance_markers"] = [
+        {"key": row[0], "value": row[1], "updated_at": row[2]}
+        for row in app_meta_rows
+    ]
+
+    stats_rows = psql(
+        "SELECT relname, last_analyze::text, last_autoanalyze::text, last_vacuum::text, last_autovacuum::text "
+        "FROM pg_stat_user_tables WHERE relname IN "
+        "('systems','bodies','ratings','cluster_summary','system_archetype_scores','system_regional_analysis') "
+        "ORDER BY relname"
+    )
+    receipt["table_maintenance"] = [
+        {
+            "table": row[0],
+            "last_analyze": row[1] or None,
+            "last_autoanalyze": row[2] or None,
+            "last_vacuum": row[3] or None,
+            "last_autovacuum": row[4] or None,
+        }
+        for row in stats_rows
+    ]
+except RuntimeError as exc:
+    failures.append("read_only_query_failed")
+    receipt["query_error"] = str(exc)
+
+receipt["failures"] = sorted(set(failures))
+receipt["status"] = "success" if not failures else "stopped"
+print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+sys.exit(0 if not failures else 1)
+PY

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -46,8 +46,10 @@ CHECKED_WORKFLOWS = (
     'container-image-parity.yml',
     'coverage.yml',
     'cypress-parity.yml',
+    'remove-ollama-production.yml',
     'review-lab.yml',
     'semgrep.yml',
+    'v3-derived-data-status.yml',
 )
 
 

--- a/tests/test_v3_derived_data_status.py
+++ b/tests/test_v3_derived_data_status.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / 'scripts' / 'operator' / 'actions' / 'v3-derived-data-status.sh'
+WORKFLOW = ROOT / '.github' / 'workflows' / 'v3-derived-data-status.yml'
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding='utf-8')
+
+
+def test_v3_derived_data_status_is_one_purpose_pinned_operator_path():
+    workflow = _read(WORKFLOW)
+
+    assert "20260905-v3-derived-data-status.json" in workflow
+    assert '{"operation": "v3-derived-data-status"}' in workflow
+    assert 'ref: main' in workflow
+    assert 'trusted-main/scripts/operator/actions/v3-derived-data-status.sh' in workflow
+    assert 'StrictHostKeyChecking=yes' in workflow
+    assert 'UserKnownHostsFile=~/.ssh/known_hosts' in workflow
+    assert 'environment: ed-new-operator' in workflow
+
+
+def test_v3_derived_data_status_is_host_locked_and_read_only():
+    source = _read(ACTION)
+
+    assert 'EXPECTED_HOST = "ed-finder-prod"' in source
+    assert 'EXPECTED_FQDN = "nb79a3d.mevnode.com"' in source
+    assert 'POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"' in source
+    assert 'BEGIN READ ONLY;' in source
+    assert 'statement_timeout' in source
+    assert '"read_only": True' in source
+    assert '"db_writes_performed": False' in source
+    assert '"env_files_read": False' in source
+    assert '"private_keys_read": False' in source
+    assert '"service_changes_performed": False' in source
+    assert '"filesystem_writes_performed": False' in source
+
+    for forbidden in (
+        '.env',
+        'docker restart',
+        'docker compose up',
+        'docker compose down',
+        'pg_dump',
+        'pg_restore',
+        'INSERT INTO',
+        'UPDATE systems',
+        'DELETE FROM',
+        'TRUNCATE',
+        'ALTER TABLE',
+        'CREATE TABLE',
+        'DROP TABLE',
+        'VACUUM',
+        'REINDEX',
+        'REFRESH MATERIALIZED VIEW',
+    ):
+        assert forbidden not in source
+
+
+def test_v3_derived_data_status_uses_bounded_estimates_and_samples():
+    source = _read(ACTION)
+
+    assert 'pg_class' in source
+    assert 'reltuples' in source
+    assert 'TABLESAMPLE SYSTEM (0.01)' in source
+    assert 'TABLESAMPLE SYSTEM (0.05)' in source
+    assert 'TABLESAMPLE SYSTEM (0.1)' in source
+    assert 'COUNT(*) FROM systems' not in source
+    assert 'COUNT(*) FROM ratings' not in source
+    for relation in (
+        'systems',
+        'ratings',
+        'cluster_summary',
+        'system_slot_topology',
+        'system_archetype_scores',
+        'system_regional_analysis',
+        'mv_archetype_rankings',
+    ):
+        assert relation in source
+
+
+def test_v3_derived_data_status_shell_syntax_is_valid():
+    result = subprocess.run(['bash', '-n', str(ACTION)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Adds a one-purpose, host-locked, read-only production inventory for the PostgreSQL 18 derived-data bootstrap state. It uses catalog estimates and tiny TABLESAMPLE probes rather than full-table counts, runs every query inside an explicit READ ONLY transaction with a 20s statement timeout, and performs no service/filesystem/DB mutation. This will let us establish whether grid, Ratings, clusters, topology/archetypes/regional analysis, and materialized views were ever populated before deciding how to redesign/run the V3 bootstrap builders.

No production execution is included in this PR; the status request is separate and can only use the trusted `main` implementation after merge.