### PR TITLE
ops: add first isolated V3 live checkpoint deploy path

### DIFF
--- a/.github/workflows/v3-application-live-checkpoint-preflight.yml
+++ b/.github/workflows/v3-application-live-checkpoint-preflight.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       deployment_mode:
-        description: Bootstrap requires proven app absence; upgrade requires the accepted prior release receipt
+        description: Bootstrap proves app absence; upgrade uses the durable accepted host receipt and manifest
         required: true
         default: bootstrap
         type: choice
@@ -14,10 +14,6 @@ on:
       release_run_id:
         description: Release workflow run containing the Contabo live-checkpoint candidate
         required: true
-        type: string
-      rollback_run_id:
-        description: Upgrade only - accepted prior release run containing the rollback manifest
-        required: false
         type: string
 
 permissions:
@@ -34,7 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     # This boundary is distinct from production credentials and routing.
     environment: v3-live-checkpoint
-    timeout-minutes: 15
+    # The operator bounds each command at 120 seconds and each candidate/rollback
+    # readiness window at 120 seconds. A worst-case upgrade, including host/runtime
+    # validation, four digest pull/inspect pairs, candidate apply/smoke, rollback
+    # apply/smoke, SSH transfer and receipt handling, remains below this job ceiling.
+    timeout-minutes: 75
     steps:
       - name: Checkout trusted operator implementation
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,15 +50,10 @@ jobs:
         env:
           DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE_RUN_ID: ${{ inputs.release_run_id }}
-          ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
         run: |
           set -euo pipefail
           [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || { echo "Candidate release run ID is invalid" >&2; exit 64; }
-          if [ "$DEPLOYMENT_MODE" = bootstrap ]; then
-            [ -z "$ROLLBACK_RUN_ID" ] || { echo "Bootstrap must not claim a prior release" >&2; exit 64; }
-          else
-            [[ "$ROLLBACK_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || { echo "Upgrade requires a valid rollback run ID" >&2; exit 64; }
-          fi
+          [[ "$DEPLOYMENT_MODE" = bootstrap || "$DEPLOYMENT_MODE" = upgrade ]] || { echo "Deployment mode is invalid" >&2; exit 64; }
       - name: Stop locally when target authority is incomplete
         shell: bash
         env:
@@ -83,35 +78,19 @@ jobs:
           path: ${{ runner.temp }}/candidate
           run-id: ${{ inputs.release_run_id }}
           github-token: ${{ github.token }}
-      - name: Download accepted rollback manifest
-        if: inputs.deployment_mode == 'upgrade'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: v3-application-release-manifest
-          path: ${{ runner.temp }}/rollback
-          run-id: ${{ inputs.rollback_run_id }}
-          github-token: ${{ github.token }}
-      - name: Verify downloaded artifact checksums
+      - name: Verify downloaded artifact checksum
         shell: bash
         env:
-          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE_DIR: ${{ runner.temp }}/candidate
-          ROLLBACK_DIR: ${{ runner.temp }}/rollback
         run: |
           set -euo pipefail
           (cd "$CANDIDATE_DIR" && sha256sum --check v3-application-release.json.sha256)
-          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
-            (cd "$ROLLBACK_DIR" && sha256sum --check v3-application-release.json.sha256)
-          fi
       - name: Authenticate release workflow run provenance
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE_RUN_ID: ${{ inputs.release_run_id }}
-          ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
           CANDIDATE: ${{ runner.temp }}/candidate/v3-application-release.json
-          ROLLBACK: ${{ runner.temp }}/rollback/v3-application-release.json
         run: |
           set -euo pipefail
           args=(
@@ -119,25 +98,14 @@ jobs:
             --candidate-run-id "$CANDIDATE_RUN_ID"
             --candidate-manifest "$CANDIDATE"
           )
-          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
-            args+=(--rollback-run-id "$ROLLBACK_RUN_ID" --rollback-manifest "$ROLLBACK")
-          fi
           GITHUB_TOKEN="$GH_TOKEN" python scripts/release/v3_release_run.py "${args[@]}"
-      - name: Verify candidate and conditional rollback manifests
+      - name: Verify candidate manifest
         shell: bash
         env:
-          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE: ${{ runner.temp }}/candidate/v3-application-release.json
-          ROLLBACK: ${{ runner.temp }}/rollback/v3-application-release.json
         run: |
           set -euo pipefail
           python scripts/release/v3_release_manifest.py verify "$CANDIDATE" --purpose deploy-candidate
-          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
-            python scripts/release/v3_release_manifest.py verify "$ROLLBACK" --purpose rollback-candidate
-            candidate_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git_sha"])' "$CANDIDATE")"
-            rollback_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git_sha"])' "$ROLLBACK")"
-            [ "$candidate_sha" != "$rollback_sha" ] || { echo "Candidate cannot be its own rollback" >&2; exit 64; }
-          fi
       - name: Prepare pinned Contabo live-checkpoint SSH trust boundary
         shell: bash
         env:
@@ -165,7 +133,6 @@ jobs:
       - name: Assemble source-free deployment bundle
         shell: bash
         env:
-          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           BUNDLE: ${{ runner.temp }}/v3-live-checkpoint-bundle
         run: |
           set -euo pipefail
@@ -175,16 +142,11 @@ jobs:
           install -m 700 scripts/operator/actions/v3-app-live-checkpoint-preflight.sh "$BUNDLE/scripts/operator/actions/"
           install -m 600 scripts/release/v3_release_manifest.py "$BUNDLE/scripts/release/"
           install -m 600 "$RUNNER_TEMP/candidate/v3-application-release.json" "$RUNNER_TEMP/candidate/v3-application-release.json.sha256" "$BUNDLE/artifacts/candidate/"
-          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
-            install -d -m 700 "$BUNDLE/artifacts/rollback"
-            install -m 600 "$RUNNER_TEMP/rollback/v3-application-release.json" "$RUNNER_TEMP/rollback/v3-application-release.json.sha256" "$BUNDLE/artifacts/rollback/"
-          fi
       - name: Run bounded Contabo deployment boundary
         shell: bash
         env:
           DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE_RUN_ID: ${{ inputs.release_run_id }}
-          ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
           SSH_HOST: ${{ secrets.V3_LIVE_CHECKPOINT_HOST }}
           SSH_PORT: ${{ secrets.V3_LIVE_CHECKPOINT_PORT }}
           SSH_USER: ${{ secrets.V3_LIVE_CHECKPOINT_USER }}
@@ -195,9 +157,6 @@ jobs:
           test -n "$SSH_USER" || { echo "Missing V3_LIVE_CHECKPOINT_USER" >&2; exit 1; }
           remote_receipt="$RECEIPT.remote"
           remote_args=(--mode "$DEPLOYMENT_MODE" --candidate-run-id "$CANDIDATE_RUN_ID" --candidate artifacts/candidate/v3-application-release.json --candidate-checksum artifacts/candidate/v3-application-release.json.sha256)
-          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
-            remote_args+=(--rollback-run-id "$ROLLBACK_RUN_ID" --rollback artifacts/rollback/v3-application-release.json --rollback-checksum artifacts/rollback/v3-application-release.json.sha256)
-          fi
           printf '%s\0' "${remote_args[@]}" > "$BUNDLE/arguments"
           set +e
           tar -C "$BUNDLE" -cf - . | ssh -i ~/.ssh/v3_live_checkpoint_key \

--- a/.github/workflows/v3-application-live-checkpoint-preflight.yml
+++ b/.github/workflows/v3-application-live-checkpoint-preflight.yml
@@ -1,15 +1,23 @@
-name: V3 application live-checkpoint deploy preflight
+name: V3 application live-checkpoint deploy
 
 on:
   workflow_dispatch:
     inputs:
+      deployment_mode:
+        description: Bootstrap requires proven app absence; upgrade requires the accepted prior release receipt
+        required: true
+        default: bootstrap
+        type: choice
+        options:
+          - bootstrap
+          - upgrade
       release_run_id:
         description: Release workflow run containing the Contabo live-checkpoint candidate
         required: true
         type: string
       rollback_run_id:
-        description: Accepted prior release run containing the rollback manifest
-        required: true
+        description: Upgrade only - accepted prior release run containing the rollback manifest
+        required: false
         type: string
 
 permissions:
@@ -21,13 +29,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  preflight:
-    name: Verify live-checkpoint candidate and stop before mutation
+  deploy:
+    name: Verify and apply the bounded live-checkpoint release
     runs-on: ubuntu-latest
-    # This boundary is intentionally distinct from the production operator
-    # environment and credentials. It grants no mutation authority by itself.
+    # This boundary is distinct from production credentials and routing.
     environment: v3-live-checkpoint
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout trusted operator implementation
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,6 +45,37 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
+      - name: Validate deployment mode before artifact access
+        shell: bash
+        env:
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+          CANDIDATE_RUN_ID: ${{ inputs.release_run_id }}
+          ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || { echo "Candidate release run ID is invalid" >&2; exit 64; }
+          if [ "$DEPLOYMENT_MODE" = bootstrap ]; then
+            [ -z "$ROLLBACK_RUN_ID" ] || { echo "Bootstrap must not claim a prior release" >&2; exit 64; }
+          else
+            [[ "$ROLLBACK_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || { echo "Upgrade requires a valid rollback run ID" >&2; exit 64; }
+          fi
+      - name: Stop locally when target authority is incomplete
+        shell: bash
+        env:
+          RECEIPT: ${{ runner.temp }}/v3-live-checkpoint-receipt.json
+        run: |
+          set -euo pipefail
+          gate_receipt="$RECEIPT.authority"
+          set +e
+          python scripts/operator/v3_checkpoint_deploy.py --authority-gate > "$gate_receipt"
+          gate_rc="$?"
+          set -e
+          cat "$gate_receipt"
+          if [ "$gate_rc" -ne 0 ]; then
+            mv "$gate_receipt" "$RECEIPT"
+            exit "$gate_rc"
+          fi
+          rm "$gate_receipt"
       - name: Download candidate release manifest
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
@@ -46,6 +84,7 @@ jobs:
           run-id: ${{ inputs.release_run_id }}
           github-token: ${{ github.token }}
       - name: Download accepted rollback manifest
+        if: inputs.deployment_mode == 'upgrade'
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: v3-application-release-manifest
@@ -55,40 +94,50 @@ jobs:
       - name: Verify downloaded artifact checksums
         shell: bash
         env:
-          CANDIDATE: ${{ runner.temp }}/candidate/v3-application-release.json
-          ROLLBACK: ${{ runner.temp }}/rollback/v3-application-release.json
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+          CANDIDATE_DIR: ${{ runner.temp }}/candidate
+          ROLLBACK_DIR: ${{ runner.temp }}/rollback
         run: |
           set -euo pipefail
-          (cd "$(dirname "$CANDIDATE")" && sha256sum --check v3-application-release.json.sha256)
-          (cd "$(dirname "$ROLLBACK")" && sha256sum --check v3-application-release.json.sha256)
+          (cd "$CANDIDATE_DIR" && sha256sum --check v3-application-release.json.sha256)
+          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
+            (cd "$ROLLBACK_DIR" && sha256sum --check v3-application-release.json.sha256)
+          fi
       - name: Authenticate release workflow run provenance
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE_RUN_ID: ${{ inputs.release_run_id }}
           ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
           CANDIDATE: ${{ runner.temp }}/candidate/v3-application-release.json
           ROLLBACK: ${{ runner.temp }}/rollback/v3-application-release.json
         run: |
           set -euo pipefail
-          GITHUB_TOKEN="$GH_TOKEN" python scripts/release/v3_release_run.py \
-            --repository "$GITHUB_REPOSITORY" \
-            --candidate-run-id "$CANDIDATE_RUN_ID" \
-            --candidate-manifest "$CANDIDATE" \
-            --rollback-run-id "$ROLLBACK_RUN_ID" \
-            --rollback-manifest "$ROLLBACK"
-      - name: Verify release and eligible rollback manifests
+          args=(
+            --repository "$GITHUB_REPOSITORY"
+            --candidate-run-id "$CANDIDATE_RUN_ID"
+            --candidate-manifest "$CANDIDATE"
+          )
+          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
+            args+=(--rollback-run-id "$ROLLBACK_RUN_ID" --rollback-manifest "$ROLLBACK")
+          fi
+          GITHUB_TOKEN="$GH_TOKEN" python scripts/release/v3_release_run.py "${args[@]}"
+      - name: Verify candidate and conditional rollback manifests
         shell: bash
         env:
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
           CANDIDATE: ${{ runner.temp }}/candidate/v3-application-release.json
           ROLLBACK: ${{ runner.temp }}/rollback/v3-application-release.json
         run: |
           set -euo pipefail
           python scripts/release/v3_release_manifest.py verify "$CANDIDATE" --purpose deploy-candidate
-          python scripts/release/v3_release_manifest.py verify "$ROLLBACK" --purpose rollback-candidate
-          candidate_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git_sha"])' "$CANDIDATE")"
-          rollback_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git_sha"])' "$ROLLBACK")"
-          [ "$candidate_sha" != "$rollback_sha" ] || { echo "Candidate cannot be its own rollback" >&2; exit 64; }
+          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
+            python scripts/release/v3_release_manifest.py verify "$ROLLBACK" --purpose rollback-candidate
+            candidate_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git_sha"])' "$CANDIDATE")"
+            rollback_sha="$(python -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["git_sha"])' "$ROLLBACK")"
+            [ "$candidate_sha" != "$rollback_sha" ] || { echo "Candidate cannot be its own rollback" >&2; exit 64; }
+          fi
       - name: Prepare pinned Contabo live-checkpoint SSH trust boundary
         shell: bash
         env:
@@ -100,7 +149,7 @@ jobs:
           set -euo pipefail
           test -n "$SSH_KEY" || { echo "Missing V3_LIVE_CHECKPOINT_SSH_KEY" >&2; exit 1; }
           test -n "$SSH_HOST" || { echo "Missing V3_LIVE_CHECKPOINT_HOST" >&2; exit 1; }
-          test -n "$SSH_PORT" || { echo "Missing V3_LIVE_CHECKPOINT_PORT" >&2; exit 1; }
+          [[ "$SSH_PORT" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$SSH_PORT" -le 65535 ] || { echo "Invalid V3_LIVE_CHECKPOINT_PORT" >&2; exit 1; }
           test -n "$SSH_KNOWN_HOSTS" || { echo "Missing pinned live-checkpoint known-hosts secret" >&2; exit 1; }
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
@@ -108,29 +157,86 @@ jobs:
           chmod 600 ~/.ssh/v3_live_checkpoint_key
           printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
-          if [ "$SSH_PORT" = "22" ]; then
-            known_host_lookup="$SSH_HOST"
-          else
-            known_host_lookup="[$SSH_HOST]:$SSH_PORT"
-          fi
+          if [ "$SSH_PORT" = "22" ]; then known_host_lookup="$SSH_HOST"; else known_host_lookup="[$SSH_HOST]:$SSH_PORT"; fi
           ssh-keygen -F "$known_host_lookup" -f ~/.ssh/known_hosts >/dev/null || {
             echo "Pinned known-host trust does not cover the configured host and port" >&2
             exit 1
           }
-      - name: Run deliberately stopped Contabo host/topology preflight
+      - name: Assemble source-free deployment bundle
         shell: bash
         env:
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+          BUNDLE: ${{ runner.temp }}/v3-live-checkpoint-bundle
+        run: |
+          set -euo pipefail
+          install -d -m 700 "$BUNDLE/deploy/v3-live-checkpoint" "$BUNDLE/scripts/operator/actions" "$BUNDLE/scripts/release" "$BUNDLE/artifacts/candidate"
+          install -m 600 deploy/v3-live-checkpoint/compose.yml deploy/v3-live-checkpoint/target-authority.json "$BUNDLE/deploy/v3-live-checkpoint/"
+          install -m 700 scripts/operator/v3_checkpoint_deploy.py "$BUNDLE/scripts/operator/"
+          install -m 700 scripts/operator/actions/v3-app-live-checkpoint-preflight.sh "$BUNDLE/scripts/operator/actions/"
+          install -m 600 scripts/release/v3_release_manifest.py "$BUNDLE/scripts/release/"
+          install -m 600 "$RUNNER_TEMP/candidate/v3-application-release.json" "$RUNNER_TEMP/candidate/v3-application-release.json.sha256" "$BUNDLE/artifacts/candidate/"
+          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
+            install -d -m 700 "$BUNDLE/artifacts/rollback"
+            install -m 600 "$RUNNER_TEMP/rollback/v3-application-release.json" "$RUNNER_TEMP/rollback/v3-application-release.json.sha256" "$BUNDLE/artifacts/rollback/"
+          fi
+      - name: Run bounded Contabo deployment boundary
+        shell: bash
+        env:
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+          CANDIDATE_RUN_ID: ${{ inputs.release_run_id }}
+          ROLLBACK_RUN_ID: ${{ inputs.rollback_run_id }}
           SSH_HOST: ${{ secrets.V3_LIVE_CHECKPOINT_HOST }}
           SSH_PORT: ${{ secrets.V3_LIVE_CHECKPOINT_PORT }}
           SSH_USER: ${{ secrets.V3_LIVE_CHECKPOINT_USER }}
+          BUNDLE: ${{ runner.temp }}/v3-live-checkpoint-bundle
+          RECEIPT: ${{ runner.temp }}/v3-live-checkpoint-receipt.json
         run: |
           set -euo pipefail
           test -n "$SSH_USER" || { echo "Missing V3_LIVE_CHECKPOINT_USER" >&2; exit 1; }
-          ssh -i ~/.ssh/v3_live_checkpoint_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'bash -s' \
-              < scripts/operator/actions/v3-app-live-checkpoint-preflight.sh
+          remote_receipt="$RECEIPT.remote"
+          remote_args=(--mode "$DEPLOYMENT_MODE" --candidate-run-id "$CANDIDATE_RUN_ID" --candidate artifacts/candidate/v3-application-release.json --candidate-checksum artifacts/candidate/v3-application-release.json.sha256)
+          if [ "$DEPLOYMENT_MODE" = upgrade ]; then
+            remote_args+=(--rollback-run-id "$ROLLBACK_RUN_ID" --rollback artifacts/rollback/v3-application-release.json --rollback-checksum artifacts/rollback/v3-application-release.json.sha256)
+          fi
+          printf '%s\0' "${remote_args[@]}" > "$BUNDLE/arguments"
+          set +e
+          tar -C "$BUNDLE" -cf - . | ssh -i ~/.ssh/v3_live_checkpoint_key \
+            -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'set -eu; umask 077; work="$(mktemp -d)"; trap '\''rm -rf -- "$work"'\'' EXIT HUP INT TERM; tar -xf - -C "$work"; cd "$work"; xargs -0 bash scripts/operator/actions/v3-app-live-checkpoint-preflight.sh < arguments' \
+            > "$remote_receipt"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+          if [ -s "$remote_receipt" ] && python -m json.tool "$remote_receipt" >/dev/null; then
+            mv "$remote_receipt" "$RECEIPT"
+            cat "$RECEIPT"
+          else
+            python - <<'PY' > "$RECEIPT"
+          import json
+          print(json.dumps({
+              "schema_version": "ed-finder/v3-live-checkpoint-deployment-receipt/v1",
+              "status": "stopped",
+              "failures": ["remote_transport_or_bundle_failed"],
+              "service_changes_performed": None,
+              "service_changes_may_have_been_performed": True,
+              "image_pulls_performed": None,
+              "image_pulls_may_have_been_performed": True,
+              "database_access_performed": None,
+              "database_access_may_have_been_performed": True,
+              "env_file_consumed_by_compose": None,
+              "env_file_may_have_been_consumed_by_compose": True,
+              "rollback_status": "unknown_require_durable_host_receipt_inspection",
+              "target_temporary_files_may_have_been_written": True,
+          }, sort_keys=True))
+          PY
+            cat "$RECEIPT"
+          fi
+          [ "${pipeline_status[0]}" -eq 0 ] && [ "${pipeline_status[1]}" -eq 0 ] || exit 78
+      - name: Upload sanitized deployment receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-live-checkpoint-deployment-receipt
+          path: ${{ runner.temp }}/v3-live-checkpoint-receipt.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/v3-application-live-checkpoint-preflight.yml
+++ b/.github/workflows/v3-application-live-checkpoint-preflight.yml
@@ -78,13 +78,6 @@ jobs:
           path: ${{ runner.temp }}/candidate
           run-id: ${{ inputs.release_run_id }}
           github-token: ${{ github.token }}
-      - name: Verify downloaded artifact checksum
-        shell: bash
-        env:
-          CANDIDATE_DIR: ${{ runner.temp }}/candidate
-        run: |
-          set -euo pipefail
-          (cd "$CANDIDATE_DIR" && sha256sum --check v3-application-release.json.sha256)
       - name: Authenticate release workflow run provenance
         shell: bash
         env:
@@ -99,6 +92,61 @@ jobs:
             --candidate-manifest "$CANDIDATE"
           )
           GITHUB_TOKEN="$GH_TOKEN" python scripts/release/v3_release_run.py "${args[@]}"
+      - name: Verify downloaded artifact checksum
+        shell: bash
+        env:
+          CANDIDATE_DIR: ${{ runner.temp }}/candidate
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import os
+          import re
+          import stat
+          import sys
+          from pathlib import Path
+
+          candidate_dir = Path(os.environ["CANDIDATE_DIR"])
+          manifest_basename = "v3-application-release.json"
+          manifest = candidate_dir / manifest_basename
+          checksum = candidate_dir / f"{manifest_basename}.sha256"
+
+          try:
+              for artifact in (manifest, checksum):
+                  metadata = artifact.lstat()
+                  if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                      raise OSError("candidate artifact is not a regular file")
+              checksum_bytes = checksum.read_bytes()
+          except OSError as exc:
+              print(
+                  f"Unable to read candidate checksum: {type(exc).__name__}",
+                  file=sys.stderr,
+              )
+              raise SystemExit(64) from exc
+
+          match = re.fullmatch(
+              rb"([0-9a-f]{64})  v3-application-release[.]json\n",
+              checksum_bytes,
+          )
+          if match is None:
+              print(
+                  "Candidate checksum must name only v3-application-release.json",
+                  file=sys.stderr,
+              )
+              raise SystemExit(64)
+
+          try:
+              digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+          except OSError as exc:
+              print(
+                  f"Unable to read candidate manifest: {type(exc).__name__}",
+                  file=sys.stderr,
+              )
+              raise SystemExit(64) from exc
+          if digest != match.group(1).decode("ascii"):
+              print("Candidate manifest checksum mismatch", file=sys.stderr)
+              raise SystemExit(64)
+          PY
       - name: Verify candidate manifest
         shell: bash
         env:

--- a/.github/workflows/v3-application-release.yml
+++ b/.github/workflows/v3-application-release.yml
@@ -21,6 +21,10 @@ on:
         description: Non-secret reviewed evidence identifier (required for proved compatibility)
         required: false
         type: string
+      reviewed_compatible_migration_sets:
+        description: Reviewed sha256 migration-set identities, one per line (backward-compatible only)
+        required: false
+        type: string
       rollback_eligible:
         description: Mark this release application-only rollback eligible
         required: true
@@ -43,6 +47,7 @@ jobs:
       git_sha: ${{ steps.source.outputs.git_sha }}
       backend_repository: ${{ steps.source.outputs.backend_repository }}
       web_repository: ${{ steps.source.outputs.web_repository }}
+      compatible_migration_sets: ${{ steps.compatibility.outputs.compatible_migration_sets }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -67,12 +72,57 @@ jobs:
           echo "git_sha=$actual_sha" >> "$GITHUB_OUTPUT"
           echo "backend_repository=ghcr.io/$repository/v3-backend" >> "$GITHUB_OUTPUT"
           echo "web_repository=ghcr.io/$repository/v3-web" >> "$GITHUB_OUTPUT"
+      - name: Normalize reviewed compatible migration identities
+        id: compatibility
+        shell: bash
+        env:
+          COMPATIBILITY: ${{ inputs.schema_compatibility }}
+          REVIEWED_COMPATIBLE_MIGRATION_SETS: ${{ inputs.reviewed_compatible_migration_sets }}
+        run: |
+          set -euo pipefail
+          normalized="$RUNNER_TEMP/reviewed-compatible-migration-sets.txt"
+          : > "$normalized"
+
+          if [ "$COMPATIBILITY" != "backward-compatible" ]; then
+            if [[ "$REVIEWED_COMPATIBLE_MIGRATION_SETS" =~ [^[:space:]] ]]; then
+              echo "reviewed compatible migration sets are accepted only for backward-compatible releases" >&2
+              exit 64
+            fi
+          else
+            if printf '%s' "$REVIEWED_COMPATIBLE_MIGRATION_SETS" | grep -Eiq \
+              '(password|passwd|secret|private[-_ ]?key|access[-_ ]?token|dsn|credential|[a-z][a-z0-9+.-]*://[^/@[:space:]:]+:[^/@[:space:]]+@)'; then
+              echo "reviewed compatible migration sets contain secret-like material" >&2
+              exit 64
+            fi
+
+            declare -A seen=()
+            while IFS= read -r identity || [ -n "$identity" ]; do
+              identity="${identity%$'\r'}"
+              identity="${identity#"${identity%%[![:space:]]*}"}"
+              identity="${identity%"${identity##*[![:space:]]}"}"
+              [ -n "$identity" ] || continue
+              [[ "$identity" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+                echo "each reviewed compatible migration set must be sha256:<64 lowercase hex>" >&2
+                exit 64
+              }
+              if [[ -v 'seen[$identity]' ]]; then
+                echo "reviewed compatible migration sets must not contain duplicates" >&2
+                exit 64
+              fi
+              seen["$identity"]=1
+              printf '%s\n' "$identity" >> "$normalized"
+            done <<< "$REVIEWED_COMPATIBLE_MIGRATION_SETS"
+            sort -o "$normalized" "$normalized"
+          fi
+
+          printf 'compatible_migration_sets=%s\n' "$(paste -sd ' ' "$normalized")" >> "$GITHUB_OUTPUT"
       - name: Validate manifest policy inputs before image publication
         shell: bash
         env:
           GIT_SHA: ${{ inputs.source_sha }}
           COMPATIBILITY: ${{ inputs.schema_compatibility }}
           COMPATIBILITY_EVIDENCE: ${{ inputs.compatibility_evidence }}
+          COMPATIBLE_MIGRATION_SETS: ${{ steps.compatibility.outputs.compatible_migration_sets }}
           ROLLBACK_ELIGIBLE: ${{ inputs.rollback_eligible }}
         run: |
           set -euo pipefail
@@ -86,6 +136,12 @@ jobs:
           )
           if [ -n "$COMPATIBILITY_EVIDENCE" ]; then
             args+=(--compatibility-evidence "$COMPATIBILITY_EVIDENCE")
+          fi
+          if [ "$COMPATIBILITY" = "backward-compatible" ]; then
+            read -ra compatible_migration_sets <<< "$COMPATIBLE_MIGRATION_SETS"
+            for identity in "${compatible_migration_sets[@]}"; do
+              args+=(--compatible-migration-set "$identity")
+            done
           fi
           if [ "$ROLLBACK_ELIGIBLE" = true ]; then
             args+=(--rollback-eligible --rollback-reason "Eligible only for the listed migration identities.")
@@ -190,6 +246,7 @@ jobs:
           WEB_IMAGE: ${{ needs.validate-source.outputs.web_repository }}@${{ needs.build-web.outputs.digest }}
           COMPATIBILITY: ${{ inputs.schema_compatibility }}
           COMPATIBILITY_EVIDENCE: ${{ inputs.compatibility_evidence }}
+          COMPATIBLE_MIGRATION_SETS: ${{ needs.validate-source.outputs.compatible_migration_sets }}
           ROLLBACK_ELIGIBLE: ${{ inputs.rollback_eligible }}
         run: |
           set -euo pipefail
@@ -203,6 +260,12 @@ jobs:
           )
           if [ -n "$COMPATIBILITY_EVIDENCE" ]; then
             args+=(--compatibility-evidence "$COMPATIBILITY_EVIDENCE")
+          fi
+          if [ "$COMPATIBILITY" = "backward-compatible" ]; then
+            read -ra compatible_migration_sets <<< "$COMPATIBLE_MIGRATION_SETS"
+            for identity in "${compatible_migration_sets[@]}"; do
+              args+=(--compatible-migration-set "$identity")
+            done
           fi
           if [ "$ROLLBACK_ELIGIBLE" = true ]; then
             args+=(--rollback-eligible --rollback-reason "Eligible only for the listed migration identities.")

--- a/.github/workflows/v3-application-release.yml
+++ b/.github/workflows/v3-application-release.yml
@@ -214,7 +214,7 @@ jobs:
             release/v3-application-release.json \
             --expected-git-sha "$GIT_SHA" \
             --verify-source-migrations
-          sha256sum release/v3-application-release.json > release/v3-application-release.json.sha256
+          (cd release && sha256sum v3-application-release.json > v3-application-release.json.sha256)
       - name: Upload immutable release manifest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,10 @@ Git history, removed workflows, old artifacts, and superseded design documents a
 
 ## Current programme
 
-The V3 application and One Spatial Platform programme is current. PR #601 is
-the single active application integration lane; at its currently known head it
-contains an Explore/Finder → fresh Babylon results → canonical Inspect slice.
-Because that work is an active PR, do not claim it has merged into `main`
-before repository state proves it.
+The V3 application and One Spatial Platform programme is current. PR #601's
+Explore/Finder → fresh Babylon results → canonical Inspect slice merged to
+`main` at `6d574a2908ebda146a2c271f8fb46a9e272ad12e`. The first non-production
+live-checkpoint exit path is now the bounded application release task.
 
 `apps/web/` is the sole target for new browser application work. Svelte/SvelteKit
 owns the application, domain orchestration, routes, panels, and accessible DOM;
@@ -62,9 +61,10 @@ environment. Hetzner/V2 is decommissioned.
 - Redis/cache state is disposable and rebuildable.
 - NATS/JetStream transport state is not canonical domain truth.
 - Production commands must come from current V3 runbooks/workflows that explicitly identify the target and safety boundary.
-- Contabo hosts exactly three self-hosted Codex runners. It is not production
-  and is not automatically a live-checkpoint destination; that destination is
-  a deployment decision with explicit capacity and isolation limits.
+- Contabo hosts exactly three self-hosted Codex runners. It is not production.
+  It is the selected first live-checkpoint target only through the isolated,
+  bounded application deployment authority; missing runtime/data/route facts
+  still stop mutation.
 - Ollama was experimental Octopus residue and has been removed from production;
   do not restore or document it as architecture.
 
@@ -123,9 +123,8 @@ Rules:
 
 New V3 application implementation lives under `apps/web/` and follows the locked Svelte 5/SvelteKit 2/TypeScript 6, Node 24 and pnpm 11 target in `docs/development/v3-application-stack-decision.md`. The checked-in frontend under `frontend/` still uses React, TypeScript and Vite; it remains migration/reference evidence with protected validation until deliberately retired after equivalent coverage exists.
 
-PR #601's known active head includes Finder, fresh Babylon results, and
-canonical Inspect integration. Treat that as active-PR state until merged, and
-keep new implementation in `apps/web/`.
+The merged #601 baseline includes Finder, fresh Babylon results, and canonical
+Inspect integration. Keep new implementation in `apps/web/`.
 
 The `apps/web/` static SPA owns application/static routes. FastAPI retains `/api/*`, exact `/openapi.json`, and numeric `/s/{id64}`; do not add a frontend route or backend catch-all that blurs that boundary.
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ retained migration and behavioural evidence, not the V3 target or an authority
 for current production. Stage 26's R3F selection remains an accurate historical
 decision.
 
-PR #601 is the single active V3 application integration lane. Its current known
-head, `12eebac48ca9286e0fd8c180cc5f552dc922d07e`, contains the real
-Explore/Finder → fresh Babylon results → canonical Inspect product slice and
-the Review Lab rebase onto `apps/web` + Babylon. Exact-head validation is still
-stabilising, so this is active-PR state rather than a green checkpoint or a
-claim that the implementation has merged into this `main`-based branch.
+PR #601's Explore/Finder → fresh Babylon results → canonical Inspect product
+slice and Review Lab rebase onto `apps/web` + Babylon merged to `main` at exact
+merge commit `6d574a2908ebda146a2c271f8fb46a9e272ad12e`.
+
+The current bounded exit task is the first non-production V3 live checkpoint;
+it is not a production promotion.
 
 ## Current authority
 
@@ -117,7 +117,8 @@ make state-check
 The root `docker-compose.yml` and retired V2 procedures do not describe V3
 production. Production or recovery work requires an explicitly current V3
 runbook and target. Contabo hosts exactly three self-hosted Codex runners; it is
-not production and is not automatically a live-checkpoint destination.
+not production. Its selected first live-checkpoint path remains isolated and
+fail-closed on the recorded missing runtime, data and route authorities.
 
 The repository currently has no executable PostgreSQL 18 recovery runbook.
 Stop rather than adapting V2 instructions or inventing host paths, credentials,

--- a/apps/api/src/config.py
+++ b/apps/api/src/config.py
@@ -84,6 +84,11 @@ class Settings(BaseSettings):
     # Set CORS_ORIGINS=https://ed-finder.app,https://www.ed-finder.app in .env
     cors_origins:       str  = '__unset__'
     expose_error_detail: bool = False
+    # Startup recovery for interrupted admin operations normally marks stale
+    # admin_job_runs as failed.  Keep that operational behaviour on by
+    # default; narrowly scoped read-only checkpoints can explicitly disable
+    # only this startup write while retaining the normal API surface.
+    admin_operation_startup_reap_enabled: bool = True
     # Optional error tracking (GlitchTip, Sentry-API-compatible). Blank
     # disables it entirely — sentry_sdk.init() below is only called when set.
     sentry_dsn:         Optional[str] = None

--- a/apps/api/src/main.py
+++ b/apps/api/src/main.py
@@ -85,6 +85,20 @@ _sse_pubsub_task: Optional[asyncio.Task] = None
 _eddn_simulation_ingest_task: Optional[asyncio.Task] = None
 
 
+async def _reap_stale_admin_runs_on_startup(pool: asyncpg.Pool) -> None:
+    """Run the normal admin-operation recovery unless explicitly disabled."""
+    if not settings.admin_operation_startup_reap_enabled:
+        log.info('Startup admin operation reaping disabled by configuration')
+        return
+
+    try:
+        reaped = await reap_stale_admin_operation_runs(pool)
+        if reaped:
+            log.warning('Reaped %d stale admin operation runs during startup', reaped)
+    except asyncpg.exceptions.UndefinedTableError:
+        log.warning('admin_job_runs table missing during startup reap; skipping stale admin run cleanup')
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     global _sse_pubsub_task, _eddn_simulation_ingest_task
@@ -177,12 +191,7 @@ async def lifespan(app: FastAPI):
         log.info('PostgreSQL read-only pool not configured; reusing primary pool')
     set_readonly_pool(readonly_pool)
 
-    try:
-        reaped = await reap_stale_admin_operation_runs(pool)
-        if reaped:
-            log.warning('Reaped %d stale admin operation runs during startup', reaped)
-    except asyncpg.exceptions.UndefinedTableError:
-        log.warning('admin_job_runs table missing during startup reap; skipping stale admin run cleanup')
+    await _reap_stale_admin_runs_on_startup(pool)
 
     redis = None
     try:

--- a/deploy/v3-live-checkpoint/compose.yml
+++ b/deploy/v3-live-checkpoint/compose.yml
@@ -1,0 +1,51 @@
+name: edfinder-v3-checkpoint
+
+# This project owns only the isolated V3 checkpoint application containers and
+# their private application network. PostgreSQL, Redis/Valkey, NATS, edge and
+# runner services are deliberately absent and can never become Compose deps.
+services:
+  api:
+    image: ${V3_CHECKPOINT_API_IMAGE:?digest-pinned API image is required}
+    container_name: edfinder-v3-checkpoint-api
+    restart: unless-stopped
+    env_file:
+      - ${V3_CHECKPOINT_API_ENV_FILE:?authorized external API env file is required}
+    environment:
+      BUILD_SHA: ${V3_CHECKPOINT_SOURCE_SHA:?exact source SHA is required}
+      EDDN_SIMULATION_INGEST_ENABLED: "false"
+      # Cache is optional for core Finder/Inspect correctness. No cache service
+      # is owned by this project, and an unavailable endpoint degrades safely.
+      REDIS_URL: redis://127.0.0.1:1/0
+    expose:
+      - "8000"
+    networks:
+      app:
+        aliases:
+          - api
+    cpus: "1.50"
+    mem_limit: 1536m
+    pids_limit: 256
+    security_opt:
+      - no-new-privileges:true
+
+  web:
+    image: ${V3_CHECKPOINT_WEB_IMAGE:?digest-pinned web image is required}
+    container_name: edfinder-v3-checkpoint-web
+    restart: unless-stopped
+    environment:
+      BUILD_SHA: ${V3_CHECKPOINT_SOURCE_SHA:?exact source SHA is required}
+      EDFINDER_API_UPSTREAM: api:8000
+    ports:
+      - ${V3_CHECKPOINT_ORIGIN_BIND:?reviewed loopback origin bind is required}:8080
+    networks:
+      - app
+    cpus: "0.50"
+    mem_limit: 512m
+    pids_limit: 128
+    security_opt:
+      - no-new-privileges:true
+
+networks:
+  app:
+    name: edfinder-v3-checkpoint-app
+    external: true

--- a/deploy/v3-live-checkpoint/compose.yml
+++ b/deploy/v3-live-checkpoint/compose.yml
@@ -13,6 +13,9 @@ services:
     environment:
       BUILD_SHA: ${V3_CHECKPOINT_SOURCE_SHA:?exact source SHA is required}
       EDDN_SIMULATION_INGEST_ENABLED: "false"
+      # This checkpoint is authorized for read-only DB access. Disable only
+      # the standard startup recovery UPDATE against admin_job_runs.
+      ADMIN_OPERATION_STARTUP_REAP_ENABLED: "false"
       # Cache is optional for core Finder/Inspect correctness. No cache service
       # is owned by this project, and an unavailable endpoint degrades safely.
       REDIS_URL: redis://127.0.0.1:1/0

--- a/deploy/v3-live-checkpoint/target-authority.json
+++ b/deploy/v3-live-checkpoint/target-authority.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "ed-finder/v3-live-checkpoint-target-authority/v1",
+  "status": "stopped",
+  "target": {
+    "provider": "contabo",
+    "classification": "live-checkpoint",
+    "production": false,
+    "hostname": "vmi3542235",
+    "fqdn": "vmi3542235.contaboserver.net",
+    "architecture": "x86_64"
+  },
+  "observed_at": "2026-09-06",
+  "observed_capacity": {
+    "logical_cpus": 8,
+    "cpu_model": "AMD EPYC Processor (with IBPB)",
+    "memory_total_kib": 24608576,
+    "memory_available_kib": 23340792,
+    "swap_total_kib": 0,
+    "root_bytes": 310911414272,
+    "root_available_bytes": 268809076736,
+    "root_filesystem": "ext4"
+  },
+  "observed_runtime": {
+    "container_runtime": null,
+    "compose": null,
+    "alternative_container_clis_present": [],
+    "container_names": [],
+    "docker_networks": [],
+    "docker_volumes": [],
+    "tcp_listeners": [
+      "0.0.0.0:22",
+      "[::]:22",
+      "127.0.0.53:53",
+      "127.0.0.54:53"
+    ],
+    "runner_services": [
+      "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker.service",
+      "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-2.service",
+      "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-3.service"
+    ],
+    "checkpoint_directories_found_under_opt_srv_var_lib": []
+  },
+  "application_contract": {
+    "compose_project": "edfinder-v3-checkpoint",
+    "compose_sha256": "200d8c3047e0f975435a98d5cf3dfb06b8478bd64d8e073767eeeb09a6136d81",
+    "services": {
+      "api": {
+        "container_name": "edfinder-v3-checkpoint-api",
+        "cpus": "1.50",
+        "memory": "1536m",
+        "pids": 256
+      },
+      "web": {
+        "container_name": "edfinder-v3-checkpoint-web",
+        "cpus": "0.50",
+        "memory": "512m",
+        "pids": 128
+      }
+    },
+    "network": "edfinder-v3-checkpoint-app",
+    "network_lifecycle": "externally-provisioned-persistent",
+    "named_volumes": [],
+    "resource_derivation": "The two app services are capped at 2.00 of 8 observed logical CPUs and 2048 MiB of 24032 MiB observed RAM so the three runner services retain 75% of CPU and more than 90% of nominal RAM."
+  },
+  "external_authority": {
+    "api_env_file": null,
+    "api_env_owner_uid": null,
+    "api_env_mode": null,
+    "database_source_authority": null,
+    "schema_identity_receipt": null,
+    "schema_identity_receipt_sha256": null,
+    "origin_bind": null,
+    "edge_route_authority": null,
+    "receipt_directory": null,
+    "receipt_owner_uid": null,
+    "receipt_mode": null,
+    "ghcr_pull_authority": null,
+    "docker_config_directory": null,
+    "docker_config_owner_uid": null,
+    "docker_config_mode": null,
+    "docker_context": null
+  },
+  "blockers": [
+    "container_runtime_and_compose_unavailable",
+    "authorized_checkpoint_database_source_missing",
+    "authorized_external_api_secret_file_missing",
+    "authoritative_schema_identity_receipt_missing",
+    "origin_loopback_port_and_listener_authority_missing",
+    "edge_route_and_network_wiring_authority_missing",
+    "durable_deployment_receipt_directory_missing",
+    "approved_ghcr_pull_authentication_authority_missing"
+  ]
+}

--- a/deploy/v3-live-checkpoint/target-authority.json
+++ b/deploy/v3-live-checkpoint/target-authority.json
@@ -42,7 +42,7 @@
   },
   "application_contract": {
     "compose_project": "edfinder-v3-checkpoint",
-    "compose_sha256": "200d8c3047e0f975435a98d5cf3dfb06b8478bd64d8e073767eeeb09a6136d81",
+    "compose_sha256": "f1a56dcd587a24e0513d12577c7af416d6e94f7f2ef5cc5f7d72e58a45386bcd",
     "services": {
       "api": {
         "container_name": "edfinder-v3-checkpoint-api",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,20 +27,18 @@ or override this set.
   new browser application work: Svelte/SvelteKit with a fresh Babylon renderer.
   React/R3F/Three is historical migration, behaviour, and parity evidence only;
   it is not the V3 target or current production authority.
-- **Active integration lane:** PR #601 is the single active V3 application
-  integration lane. Its current known head
-  `12eebac48ca9286e0fd8c180cc5f552dc922d07e` contains the real
-  Explore/Finder → fresh Babylon results → canonical Inspect slice and the
-  Review Lab rebase to `apps/web` + Babylon. Exact-head validation remains in
-  stabilization, so that is active-PR state rather than a green checkpoint or
-  a claim that the implementation has merged into this `main`-based branch.
+- **Merged application baseline:** PR #601's Explore/Finder → fresh Babylon
+  results → canonical Inspect slice and Review Lab rebase to `apps/web` +
+  Babylon merged at exact `main` commit
+  `6d574a2908ebda146a2c271f8fb46a9e272ad12e`.
 - **Historical renderer decision:** the equal Stage 26 bakeoff selected R3F and
   the subsequent Stage 26 work shipped. That result remains valuable history;
   it does not constrain the post-V2 V3 renderer target.
 - **Infrastructure separation:** Contabo is the host for exactly three
-  self-hosted Codex runners. It is not production. A live-checkpoint destination
-  remains a deployment decision; a prior read-only capacity audit established
-  only that a small isolated, bounded checkpoint might be feasible.
+  self-hosted Codex runners and the selected first live-checkpoint target. It
+  is not production. The checkpoint is limited to a persistent, isolated and
+  bounded two-service application namespace; current missing runtime, data and
+  route authority keeps mutation stopped.
 - **Inference:** Ollama was an Octopus experiment and has been removed from
   production. It is not part of the architecture.
 
@@ -62,16 +60,14 @@ evidence-interpretation, and Digital Twin owner.
 
 ## Execution order
 
-1. **Stabilize the active browser slice.** Complete review of PR #601's
-   Explore/Finder → Babylon results → Inspect journey, including typed
-   boundaries, accessibility, bounded data, Product E2E/Visual Acceptance, and
-   the separate Review Lab lane.
+1. **Exit the merged browser slice through a checkpoint.** Exercise the
+   accepted Explore/Finder → Babylon results → Inspect journey through the
+   bounded live-checkpoint path. That environment remains non-production.
 2. **Harden the V3 release.** Continue CPython 3.14/`uv`, immutable release
    provenance, same-origin route, health, migration compatibility, and rollback
    work without treating an application release as database recovery.
-3. **Merge, then choose checkpoint policy.** Accept the exact reviewed PR head
-   before any checkpoint/promotion decision. The destination and isolation
-   limits are deployment choices; Contabo is not a default.
+3. **Preserve the checkpoint boundary.** Keep Contabo non-production and its
+   persistent app-only namespace isolated from the three runner services.
 4. **Resolve search and data architecture in order.** Establish Search product
    and performance requirements, then choose the spatial index/grid/cluster
    design, then define the PostgreSQL 18 derived-data bootstrap.
@@ -89,7 +85,7 @@ evidence-interpretation, and Digital Twin owner.
 | Search and spatial data | Search requirements → spatial index/grid/cluster design → PG18 derived-data bootstrap. Current normal Finder uses raw `x/y/z` bounding and distance and does not establish `grid_cell_id` as a first-class accelerator. |
 | Scoring and judgement | Decide how Ratings v3.4 code/data dependencies relate to the intended archetype judgement layer. Do not trigger a full ratings/archetype rebuild from this roadmap. |
 | Derived-data bootstrap | Define sources, ordering, versioning, bounded resource use, rebuildability, verification, and rollback only after the preceding two gates. |
-| Live checkpoint | Choose destination, resource limits, isolation, data posture, lifecycle, and acceptance. Contabo runner hosting is not architectural authorization. |
+| Live checkpoint | Supply the still-missing non-production database/config, container runtime, origin/edge and receipt authorities before first mutation. |
 | V3 DB maintenance/recovery | Supply current PG18 population/invariant evidence and an executable reviewed backup/restore/PITR procedure. Until then, recovery remains fail-closed. |
 
 No final Search/Grid/Cluster authority document exists yet. Active audits feed

--- a/docs/colonisation-redesign/spatial-platform-architecture-decision.md
+++ b/docs/colonisation-redesign/spatial-platform-architecture-decision.md
@@ -2,9 +2,9 @@
 
 **Decision:** accepted in Stage 27A, 2026-08-31; current V3 architecture
 authority
-**Implementation status:** PR #601 is the active integration lane and contains
-a fresh Babylon Explore/Finder results → Inspect slice at its currently known
-head. This is active-PR state, not a claim that it has merged to `main`.
+**Implementation status:** PR #601's fresh Babylon Explore/Finder results →
+Inspect slice merged to `main` at exact commit
+`6d574a2908ebda146a2c271f8fb46a9e272ad12e`.
 
 ## Context and historically accurate decision
 

--- a/docs/colonisation-redesign/spatial-platform-product-contract.md
+++ b/docs/colonisation-redesign/spatial-platform-product-contract.md
@@ -276,11 +276,10 @@ tests must prove:
 
 ## Current implementation posture
 
-PR #601 is the single active V3 application integration lane. At currently
-known head `190d26446a2487596299cbb6b497ffa5201fee0b`, it contains a real
-Explore/Finder → fresh Babylon results → canonical Inspect slice. This document
-governs that product behaviour, but does not claim the PR is merged into the
-`main` base used by this documentation branch.
+PR #601's real Explore/Finder → fresh Babylon results → canonical Inspect slice
+merged to `main` at exact commit
+`6d574a2908ebda146a2c271f8fb46a9e272ad12e`. This document continues to govern
+that product behaviour.
 
 System Map, Commander History/Journal, Routes, Powerplay, richer Colonisation,
 CPE planned overlays, and CRE Digital Twin contributions remain later product

--- a/docs/development/v3-application-stack-decision.md
+++ b/docs/development/v3-application-stack-decision.md
@@ -20,11 +20,9 @@ behaviour, user journeys, accessibility expectations, screenshots, and parity
 until equivalent coverage exists. It is not the architecture target or current
 production authority. R3F's Stage 26 bakeoff win remains accurate history.
 
-PR #601 is the single active V3 application integration lane. At the selected
-head `12eebac48ca9286e0fd8c180cc5f552dc922d07e`, it contains the real
-Explore/Finder → fresh Babylon results → canonical Inspect slice and the Review
-Lab rebase onto `apps/web` + Babylon. This is active-PR state, not a claim that
-it has merged into `main`.
+PR #601's Explore/Finder → fresh Babylon results → canonical Inspect slice and
+Review Lab rebase onto `apps/web` + Babylon merged to `main` at exact commit
+`6d574a2908ebda146a2c271f8fb46a9e272ad12e`.
 
 ## Historical post-cutover starting evidence
 
@@ -240,7 +238,8 @@ Deck.gl/Luma.gl are not automatically retained. Current use is renderer-bakeoff/
 The reset remains serialized to avoid unrelated simultaneous cutovers. The
 programme order is authoritative in [`../ROADMAP.md`](../ROADMAP.md):
 
-1. Stabilize and accept PR #601's Svelte/Finder/Babylon/Inspect product slice.
+1. Exit the merged Svelte/Finder/Babylon/Inspect slice through the bounded
+   non-production live-checkpoint path.
 2. Complete CPython 3.14/`uv` and immutable release/provenance hardening.
 3. Merge the exact accepted head, then make an explicit checkpoint decision.
 4. Resolve Search requirements, spatial index/grid/cluster design, scoring

--- a/docs/development/v3-coordination-control-plane.md
+++ b/docs/development/v3-coordination-control-plane.md
@@ -18,7 +18,7 @@ Owner / ChatGPT
       v
 V3 Coordination Control Plane
       |
-      +--> GitHub / PR #601 integration state
+      +--> GitHub / merged #601 baseline state
       +--> Codex governed implementation workers
       +--> normal CI / code contracts
       +--> Product E2E / Visual Acceptance
@@ -55,7 +55,7 @@ It does **not** own:
 
 ### Integration state
 
-PR #601 is the single active Svelte V3 integration lane until a coherent checkpoint is accepted and merged. Worker branches may feed #601 but must not create a second integration hierarchy.
+PR #601 is the merged Svelte V3 application baseline at exact `main` commit `6d574a2908ebda146a2c271f8fb46a9e272ad12e`. New worker branches must not create a second integration hierarchy.
 
 After a checkpoint merges, `main` is the only source from which a live checkpoint release may be built. Contabo must never deploy an unmerged worker branch or an arbitrary source checkout.
 
@@ -144,7 +144,7 @@ Do not make one lane compensate for another. A green Review Lab does not replace
 
 For each meaningful live checkpoint:
 
-1. consolidate the intended implementation into #601;
+1. select the intended implementation from the merged #601 baseline;
 2. run normal source/contract CI on the exact candidate head;
 3. run normal Product E2E / Visual Acceptance on the exact candidate head;
 4. run the relevant Review Lab synthetic scenarios on the exact candidate head;
@@ -160,14 +160,16 @@ No worker branch deploy, no production-host build, no `git pull`, and no unrecei
 
 ## Current implementation state
 
-As of PR #601:
+After PR #601 merged:
 
 - the Codex request/dispatch/worker/trusted-push bridge exists;
 - the narrow `ChatGPT ed-new Ops` workflow exists for a small allowlisted set of operator actions;
 - Product E2E and Review Lab are explicitly separate browser authorities: Product E2E covers the first normal Explore -> Babylon -> Inspect checkpoint in Chrome and Firefox, while Review Lab now drives that same `apps/web` + Babylon frontend against its isolated synthetic runtime;
 - `apps/web` is the V3 application destination and the fresh map will use Babylon;
 - the first bounded V3 Explore/Inspect/Babylon checkpoint now exists with renderer-neutral lifecycle contracts, normal Product E2E authority, and separate synthetic Review Lab coverage; later product expansion remains separately governed;
-- the immutable `main -> images -> Contabo -> smoke -> receipt` live-checkpoint path still needs to be completed;
+- the immutable `main -> images -> Contabo -> smoke -> receipt` boundary is
+  bootstrap-capable but deliberately stops before mutation until the recorded
+  container-runtime, database/config, origin/edge and receipt authorities exist;
 - the older `chatgpt-ops-control-plane.md` contains useful design history but is not the current authority for what operations are implemented or authorised.
 
 ## Safety rules

--- a/docs/operations/infrastructure-status.md
+++ b/docs/operations/infrastructure-status.md
@@ -16,13 +16,25 @@ describe this V3 environment.
 ## Contabo runner and checkpoint boundary
 
 Contabo hosts exactly three self-hosted Codex runners. It is not ED-Finder
-production and it is not automatically the destination for a live checkpoint.
+production. It is now the selected first V3 live-checkpoint target only through
+the separate environment-gated application checkpoint boundary; this does not
+make it a production target or authorize production credentials/data/routing.
 
-A separate read-only capacity audit found only that a small checkpoint could be
-feasible with explicit resource limits and isolation. Checkpoint destination,
-topology, data posture, lifecycle, capacity limits, and acceptance remain a
-deployment decision. Current authority must not couple that destination to the
-runner host.
+Read-only inspection on 2026-09-06 proved host identity
+`vmi3542235` / `vmi3542235.contaboserver.net`, `x86_64`, 8 logical CPUs,
+24,608,576 KiB RAM (23,340,792 KiB then available), and 268,809,076,736 bytes
+free on the root filesystem. Exactly three runner services were active. Only
+SSH on TCP 22 and loopback DNS on TCP 53 were listening. No container runtime,
+Compose installation, containers, container networks or volumes were present.
+
+The reviewed checkpoint namespace is `edfinder-v3-checkpoint`, limited to the
+`api` and `web` application services and 2 CPUs/2 GiB combined. Its lifecycle
+is persistent: application upgrades never rebuild or tear down infrastructure.
+The exact stopped facts and external-authority blockers live in
+`deploy/v3-live-checkpoint/target-authority.json`. In particular, there is no
+authorized checkpoint database/data source, origin/edge wiring, secret mount,
+GHCR pull authority or durable receipt store yet, so first-deployment mutation
+remains stopped. Production PostgreSQL/data must not fill that gap.
 
 Ollama was experimental residue used to test local inference for Octopus. It
 has been removed from production and is not part of the V3 architecture.

--- a/docs/operations/operator-command-contexts.md
+++ b/docs/operations/operator-command-contexts.md
@@ -73,10 +73,14 @@ The only current replacement-host helpers presently identified by the V3 control
 - `scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh`;
 - `scripts/operator/recover_v3_runtime_contract.py`.
 
-The deliberately stopped
 `scripts/operator/actions/v3-app-live-checkpoint-preflight.sh` is separate from
 that production surface. It targets the non-production Contabo live-checkpoint
-boundary and authorizes no deployment mutation.
+boundary and launches the reviewed bootstrap/upgrade validator. The committed
+target authority currently stops before pulls or service mutation because the
+container runtime, database/config, origin/edge and receipt authorities are
+absent. When those facts are separately reviewed, the same boundary may mutate
+only its fixed `api` and `web` application allowlist; it never manages
+PostgreSQL, Redis/Valkey, NATS, edge, runners or volumes.
 
 Other scripts in that directory, including surviving Stage 19 staging/research tools, are **not** current V3 production authority merely because they are checked in. Read `scripts/operator/README.md` and require an explicitly current V3 workflow/runbook before executing any operator script against production.
 

--- a/docs/operations/v3-application-checkpoint-release.md
+++ b/docs/operations/v3-application-checkpoint-release.md
@@ -125,8 +125,16 @@ For an owner checkpoint:
    authorized external API env file without logging or persisting the URL, then
    uses a read-only database session to verify that identity and the complete
    applied `schema_migrations` set against the authoritative schema receipt.
-   Repointed env files, stale receipts, migration drift and unverifiable
-   database identity stop before service mutation.
+   Under the deployment lock it freezes the securely opened env-file bytes into
+   a private read-only snapshot, verifies the database through that snapshot,
+   and revalidates the retained source identity before mutation. Candidate and
+   rollback Compose operations use only that same snapshot; they never reread
+   the external env file after schema verification. Repointed or edited env
+   files, stale receipts, migration drift and unverifiable database identity
+   stop before service mutation. Preflight also parses the Docker network
+   topology and rejects a non-local bridge, unexpected attachments or aliases,
+   and malformed or drifting network evidence before pulls and again before an
+   application recreate.
 5. It pulls and verifies the exact digest images and OCI build-SHA labels, then
    recreates only `api web` with `--no-deps`.
 6. After each candidate or upgrade-rollback Compose apply, it polls bounded

--- a/docs/operations/v3-application-checkpoint-release.md
+++ b/docs/operations/v3-application-checkpoint-release.md
@@ -1,143 +1,127 @@
 # V3 Application Live-Checkpoint Release
 
-## Scope and present state
+## Boundary and current state
 
-This is the owner-facing release foundation for the Svelte V3 application and
-the Contabo live-checkpoint environment. **Contabo is not production.** This
-foundation does not authorize or perform a Contabo deployment, service restart,
-migration, database read/write, DNS change, or secret inspection.
+This is the owner-facing release and deployment boundary for the Svelte V3
+application. **Contabo is not production.** Evidence from Contabo must not be presented as production
+deployment or health evidence, and nothing here grants
+production promotion, routing, credential, database-mutation or migration
+authority.
 
-The executable part today is the manual **V3 application immutable release**
-workflow. It builds the current FastAPI application and static SvelteKit shell
-off-host from the exact `main` SHA, publishes digest-addressed OCI images, and
-seals a machine-readable manifest. The separate **V3 application
-live-checkpoint deploy preflight** verifies a candidate and prior rollback
-manifest through the distinct `v3-live-checkpoint` environment and
-`V3_LIVE_CHECKPOINT_*` pinned SSH trust boundary. It does not reuse production
-credentials or grant deployment authority. The workflow then stops deliberately
-without pulling an image or changing a service.
-
-Before any SSH connection, the preflight authenticates both artifact run IDs
-against GitHub: each must be a successful manual run of the canonical release
-workflow in this repository on `main`, and its head SHA must equal the SHA in
-the downloaded manifest.
-
-That stopped state is required. Current repository/runtime evidence does not
-establish a reviewed Contabo live-checkpoint Compose/topology authority,
-application-service allowlist, network/edge wiring, mounted secret/config
-authority, current PostgreSQL migration identity receipt, receipt store, or an
-accepted immutable rollback release. The stale `edfinder-v3-api:phase4c-r5`
-runtime has a mutable tag and reports `build_sha=unknown`; it is not eligible
-rollback evidence.
-
-## Checkpoint cadence
-
-Use this sequence for every owner-test checkpoint:
-
-1. Make the intended PR head exact and green under the full acceptance policy,
-   including required review disposition.
-2. Merge that exact reviewed head to `main`.
-3. Manually dispatch **V3 application immutable release** with the full
-   40-character SHA now at the head of `main`.
-4. Review the uploaded manifest and its checksum. The workflow builds both
-   images from that one SHA and records only `repository@sha256:...` references.
-5. Select the candidate release run and a distinct, previously accepted,
-   receipt-backed rollback release. Explicitly dispatch the environment-gated
-   live-checkpoint preflight path.
-6. After a future reviewed topology slice makes deployment executable, require
-   successful Contabo origin and externally reachable live-checkpoint edge
-   smoke for the Svelte root/application route,
-   `/api/health` (including the exact `build_sha`), exact `/openapi.json`, and
-   anonymous `/api/auth/session`. Confirm the Frontier route surface before
-   attempting login.
-7. Retain the deployment receipt, candidate and rollback manifests, route
-   results, image digests, migration-set identity and compatibility decision.
-8. Only then hand the checkpoint to the owner for live testing.
-
-Normal PR, merge and `main` push events do not invoke either release or preflight.
-Both workflows accept only an explicit manual dispatch. Building a release is
-not permission to deploy it, and a successful preflight manifest check is not a
-successful deployment.
-
-## Release manifest contract
-
-`scripts/release/v3_release_manifest.py` computes the schema identity from the
-ordered `sql/migration-manifest.txt` entries and the SHA-256 of every referenced
-SQL file. A manifest records:
-
-- the exact Git SHA and derived release ID;
-- allowlisted backend and web image repositories with immutable SHA-256
-  digests;
-- the migration manifest checksum, per-file checksums and aggregate migration
-  identity;
-- an explicit compatibility status, compatible migration identities and a
-  non-secret reviewed evidence identifier;
-- explicit application-only rollback eligibility and rationale.
-
-Unknown or incompatible schema status cannot be rollback eligible. Actual
-application rollback additionally requires an authoritative receipt for the
-current database migration identity and an exact match in the old release's
-compatibility set. A manifest never carries DSNs, passwords, tokens, private
-keys, secret values or credential-bearing URLs.
-
-The release workflow uses Node 24/pnpm 11 with the committed frozen web lock and
-CPython 3.14/uv 0.11.33 with the committed API lock. Normal V3 backend unit,
-integration, coverage, OpenAPI, Product E2E API, Review Lab backend, and release
-image validation all assert CPython 3.14 and sync
-`apps/api/pyproject.toml` + `apps/api/uv.lock` with frozen resolution. The
-every-PR container parity lane builds that exact release Dockerfile and proves
-the running server interpreter plus a loopback-only `/api/health` response
-after the real FastAPI lifespan connects to a disposable PostgreSQL 18 service.
-Repository orchestration/static contracts, importer/canonical tooling,
+The immutable release workflow builds the FastAPI and static SvelteKit images
+off-host from one exact `main` SHA. Normal V3 backend unit, integration,
+coverage, OpenAPI, Product E2E API, Review Lab backend, release image and the
+every-PR container parity lane validate on exact CPython 3.14. The real FastAPI lifespan
+is exercised against disposable PostgreSQL 18. Repository tooling,
 retained frontend tooling, and the Codex worker bootstrap also validate on
-exact CPython 3.14. The API continues to own asyncpg while synchronous tooling
-uses pinned Psycopg 3.
-Static SvelteKit output is copied
-into nginx; no source checkout, build tool or dependency resolution is needed
-on the target host. nginx delegates only `/api` and `/api/*`, exact
-`/openapi.json`, and exact numeric `/s/{id64}` to the API. All other routes stay
-with the Svelte static application fallback.
+exact CPython 3.14. The API continues to own asyncpg; synchronous tooling uses pinned Psycopg 3.
 
-## Why live-checkpoint deployment still fails closed
+The environment-gated deployment workflow authenticates release artifacts
+against a successful manual run of the canonical release workflow on `main`,
+checks the adjacent manifest checksum, and accepts only the allowlisted GHCR
+repositories at `repository@sha256:...`. It never runs `git pull`, a build,
+package installation, migrations or dependency resolution on the target.
 
-The host preflight emits a machine-readable stopped receipt listing the facts
-still required. Review and land all of these as a separate topology authority
-before adding any mutation command:
+The repository now defines the deployment boundary, but the recorded Contabo
+authority remains deliberately stopped. Read-only inspection on 2026-09-06
+proved no container runtime/Compose installation and no authorized checkpoint
+database, HTTP origin, network/edge route, secret mount or receipt store. See
+`deploy/v3-live-checkpoint/target-authority.json` for the exact sanitized facts
+and blockers. Dispatching the workflow while that authority is stopped cannot
+pull an image or change a service.
 
-- Contabo live-checkpoint Compose project/config path and how the deployment
-  bundle is installed without a target-host source checkout;
-- exact app-owned service keys/container names and recreate allowlist;
-- explicit preservation targets for PostgreSQL 18, Redis, NATS and retained
-  edge services;
-- host CPU platform, Docker networks/aliases, API upstream, loopback port and
-  retained TLS-edge wiring;
-- approved GHCR pull/authentication authority;
-- non-secret configuration plus external secret-file/mount authority per
-  service, including ownership/mode and required data/log/receipt mounts;
-- approved read-only source for a current `schema_migrations` identity receipt;
-- durable manifest/deploy-receipt/rollback-history storage and update rules;
-- accepted prior digest release plus deploy receipt proved compatible with the
-  current database;
-- exact Contabo origin/live-checkpoint edge smoke authority and ordering.
+## Persistent topology contract
 
-Do not fill these gaps from the root legacy/local Compose file, old host source,
-historical workflows, or observed container names. The current status helper
-also expects a frontend inside the stale API image, so it remains diagnosis
-evidence rather than the final smoke authority for the separate nginx web image.
+The checkpoint is persistent infrastructure, not a rebuild-every-run stack.
+The fixed Compose project is `edfinder-v3-checkpoint`; its mutation allowlist is
+exactly the `api` and `web` services/containers plus their already-provisioned
+application network. The Compose bundle contains no PostgreSQL, Redis/Valkey,
+NATS, edge/proxy, runner service or named volume.
 
-## Rollback boundary
+Deployment and rollback may use only explicit `api web` service arguments with
+`--no-deps`. They must never use Compose `down`, `--remove-orphans`, volume
+removal, project-wide recreation, or start/stop/recreate PostgreSQL,
+Redis/Valkey, NATS, edge/proxy, runner or unrelated resources. The edge route,
+database, secret/config paths, application network and receipt directory must
+already exist under separate reviewed authority.
 
-Rollback is always explicit and receipt-backed. It may recreate only the
-eventually reviewed V3 application services and must preserve PostgreSQL 18.
-If the prior manifest is missing, tag-only, reports unknown compatibility, or
-does not list the current database migration identity as compatible,
-application-only rollback stops.
+The two app services are capped at 2.00 CPUs and 2 GiB combined: API at 1.50
+CPU/1536 MiB and web at 0.50 CPU/512 MiB. That ceiling is derived from the
+observed 8 logical CPUs and 23 GiB RAM, leaving 75% of CPU and more than 90% of
+nominal RAM outside the checkpoint for the OS and exactly three Codex runners.
+It is a conservative isolation ceiling, not workload sizing proof. The deploy
+preflight stops if the host falls below the audited total baseline or cannot
+currently satisfy the two app services' combined 2 GiB memory ceiling.
 
-This foundation does not implement database rollback/recovery or run
-migrations. A schema-incompatible release requires a separately reviewed and
-rehearsed database procedure; no one-click application rollback may imply that
-such a procedure exists.
+Redis/cache is optional for core Finder and Inspect correctness. The API
+already degrades to no cache when Redis is unavailable and uses in-memory rate
+limits, so the checkpoint baseline intentionally has no cache service. NATS is not a V3 checkpoint baseline dependency.
+Checkpoint configuration also disables
+the live EDDN simulation ingest so a first UI/API checkpoint cannot begin an
+unreviewed background database-writing workload.
 
-The production environment, any future production promotion, and production
-credentials are outside this runbook. Evidence from Contabo must not be presented as production
-deployment or production health evidence.
+## Bootstrap and upgrade modes
+
+Bootstrap checkpoint #1 intentionally has no prior V3 release or deployment
+receipt. It requires the candidate release plus authoritative current database
+migration identity and proves both allowlisted app containers are absent before
+the first pull. A failed bootstrap restores that absence by stopping/removing
+only `api` and `web`; persistent network, edge, database, cache, runners and
+volumes are untouched. Its rollback identity is `predeploy_absence`.
+
+Every subsequent upgrade requires all of the following before mutation:
+
+- a distinct prior digest-only release manifest;
+- its checksum and successful canonical release-run provenance;
+- a durable accepted deployment receipt matching its source SHA, both image
+  digests and manifest checksum;
+- an authoritative current database migration identity listed as compatible by
+  both the candidate and rollback manifests.
+
+If an upgrade smoke fails, only `api` and `web` may be recreated at the accepted
+prior digests. Database rollback/recovery and migrations are outside this path.
+
+## Deployment sequence and receipt
+
+For an owner checkpoint:
+
+1. Merge the exact accepted head to `main` and manually dispatch **V3
+   application immutable release** with that 40-character SHA.
+2. Review the sealed manifest, compatibility evidence, application-only
+   rollback eligibility and basename-only SHA-256 checksum. Both image
+   references must be digest pinned.
+3. Dispatch **V3 application live-checkpoint deploy** in `bootstrap` mode for
+   checkpoint #1, or `upgrade` with the accepted rollback run ID afterward.
+4. The target boundary validates all target/external facts, schema identity,
+   Compose checksum, allowlisted project resources and app absence/prior receipt
+   before an image pull or service change.
+5. It pulls and verifies the exact digest images and OCI build-SHA labels, then
+   recreates only `api web` with `--no-deps`.
+6. It makes bounded, no-redirect origin requests to `/`, `/api/health`,
+   `/openapi.json` and `/api/auth/session`. Health must report
+   `database=connected` and the candidate `build_sha`; OpenAPI must expose the
+   health and session paths; the session must be anonymous.
+7. Only after all smokes pass does it persist an immutable sanitized receipt
+   and checksum, then atomically advance the checksum-bound `current.json`
+   pointer. The workflow uploads the same output even for a stopped preflight.
+
+An accepted receipt contains the authenticated release run ID, source SHA,
+exact image digests, candidate manifest checksum, non-production target identity, current migration identity,
+exact changed app resources, smoke outcomes and rollback identity. It never
+contains DSNs, environment-file contents, passwords, tokens, private keys or
+credential-bearing URLs.
+
+## Exact blockers before checkpoint #1
+
+No authorized checkpoint `DATABASE_URL` or data source exists in current
+repository/host evidence. Production must not be used and production data must
+not be copied. An operator must provide a separately approved persistent
+non-production data source, external API secret/config file, and current schema
+identity receipt.
+
+The other current blockers are container-runtime/Compose installation
+authority, the origin loopback port/listener, persistent app network and edge
+route, target GHCR pull authentication, and a durable deployment receipt
+directory. These are explicit external authority requirements; no port, path,
+network, data source or edge wiring may be inferred from legacy Compose files,
+production, or observed runner names.

--- a/docs/operations/v3-application-checkpoint-release.md
+++ b/docs/operations/v3-application-checkpoint-release.md
@@ -91,15 +91,23 @@ is missing, unsafe, corrupt or inconsistent. GitHub Actions authenticates only
 the new candidate artifact; successful acceptance makes that exact candidate
 the next durable rollback source.
 
-If an upgrade smoke fails, only `api` and `web` may be recreated at the accepted
-prior digests. Database rollback/recovery and migrations are outside this path.
+Before candidate mutation, an upgrade pulls and verifies the accepted prior
+digest images as well as the candidate images. If candidate readiness or smoke
+then fails, only `api` and `web` may be recreated at those already-verified
+prior digests. The rollback Compose operation uses `--pull never` and performs
+no registry pull, so recovery does not depend on registry availability.
+Database rollback/recovery and migrations are outside this path.
 
 ## Deployment sequence and receipt
 
 For an owner checkpoint:
 
 1. Merge the exact accepted head to `main` and manually dispatch **V3
-   application immutable release** with that 40-character SHA.
+   application immutable release** with that 40-character SHA. For a reviewed
+   `backward-compatible` release, supply any additional compatible migration-set
+   identities as lowercase `sha256:` identities, one per line; other modes
+   reject that input, and `exact` always records only the source migration
+   identity.
 2. Review the sealed manifest, compatibility evidence, application-only
    rollback eligibility and basename-only SHA-256 checksum. Both image
    references must be digest pinned.
@@ -109,12 +117,16 @@ For an owner checkpoint:
    is no operator-supplied rollback artifact or rollback run ID.
 4. The target boundary validates all target/external facts, Compose checksum,
    allowlisted project resources and app absence/prior receipt before an image
-   pull or service change. It obtains the non-secret database identity from the
-   `DATABASE_URL` in the authorized external API env file without logging or
-   persisting the URL, then uses a read-only database session to verify that
-   identity and the complete applied `schema_migrations` set against the
-   authoritative schema receipt. Repointed env files, stale receipts, migration
-   drift and unverifiable database identity stop before service mutation.
+   pull or service change. The selected Docker context must be inspectable and
+   resolve exactly to the authorized local rootful daemon at
+   `unix:///var/run/docker.sock`; SSH, TCP, alternate Unix sockets and malformed
+   or unverifiable context results stop before any pull or Compose mutation. It
+   obtains the non-secret database identity from the `DATABASE_URL` in the
+   authorized external API env file without logging or persisting the URL, then
+   uses a read-only database session to verify that identity and the complete
+   applied `schema_migrations` set against the authoritative schema receipt.
+   Repointed env files, stale receipts, migration drift and unverifiable
+   database identity stop before service mutation.
 5. It pulls and verifies the exact digest images and OCI build-SHA labels, then
    recreates only `api web` with `--no-deps`.
 6. After each candidate or upgrade-rollback Compose apply, it polls bounded

--- a/docs/operations/v3-application-checkpoint-release.md
+++ b/docs/operations/v3-application-checkpoint-release.md
@@ -58,7 +58,11 @@ already degrades to no cache when Redis is unavailable and uses in-memory rate
 limits, so the checkpoint baseline intentionally has no cache service. NATS is not a V3 checkpoint baseline dependency.
 Checkpoint configuration also disables
 the live EDDN simulation ingest so a first UI/API checkpoint cannot begin an
-unreviewed background database-writing workload.
+unreviewed background database-writing workload. It also explicitly sets
+`ADMIN_OPERATION_STARTUP_REAP_ENABLED=false`. That checkpoint-only opt-out
+suppresses the FastAPI lifespan's stale `admin_job_runs` housekeeping update;
+it does not make the API generally read-only. Ordinary deployments retain the
+default enabled startup reap and all normal runtime semantics.
 
 ## Bootstrap and upgrade modes
 
@@ -71,12 +75,21 @@ volumes are untouched. Its rollback identity is `predeploy_absence`.
 
 Every subsequent upgrade requires all of the following before mutation:
 
-- a distinct prior digest-only release manifest;
-- its checksum and successful canonical release-run provenance;
-- a durable accepted deployment receipt matching its source SHA, both image
-  digests and manifest checksum;
+- a distinct prior digest-only release manifest and adjacent checksum durably
+  stored in the host receipt directory when that release was accepted;
+- a durable accepted deployment receipt matching the prior manifest's source
+  SHA, release run ID, both image digests and manifest checksum;
 - an authoritative current database migration identity listed as compatible by
   both the candidate and rollback manifests.
+
+Upgrade never reconstructs or re-downloads the rollback manifest from a source
+checkout, a different SHA, or an expiring GitHub Actions artifact. It loads the
+checksum-bound accepted manifest through the durable `current.json` receipt
+chain, re-verifies its release-manifest schema, digest provenance and rollback
+eligibility, and fails closed if any durable file, checksum or receipt binding
+is missing, unsafe, corrupt or inconsistent. GitHub Actions authenticates only
+the new candidate artifact; successful acceptance makes that exact candidate
+the next durable rollback source.
 
 If an upgrade smoke fails, only `api` and `web` may be recreated at the accepted
 prior digests. Database rollback/recovery and migrations are outside this path.
@@ -91,25 +104,63 @@ For an owner checkpoint:
    rollback eligibility and basename-only SHA-256 checksum. Both image
    references must be digest pinned.
 3. Dispatch **V3 application live-checkpoint deploy** in `bootstrap` mode for
-   checkpoint #1, or `upgrade` with the accepted rollback run ID afterward.
-4. The target boundary validates all target/external facts, schema identity,
-   Compose checksum, allowlisted project resources and app absence/prior receipt
-   before an image pull or service change.
+   checkpoint #1, or `upgrade` afterward. Upgrade selects only the release
+   authenticated by the host's durable accepted-receipt/manifest chain; there
+   is no operator-supplied rollback artifact or rollback run ID.
+4. The target boundary validates all target/external facts, Compose checksum,
+   allowlisted project resources and app absence/prior receipt before an image
+   pull or service change. It obtains the non-secret database identity from the
+   `DATABASE_URL` in the authorized external API env file without logging or
+   persisting the URL, then uses a read-only database session to verify that
+   identity and the complete applied `schema_migrations` set against the
+   authoritative schema receipt. Repointed env files, stale receipts, migration
+   drift and unverifiable database identity stop before service mutation.
 5. It pulls and verifies the exact digest images and OCI build-SHA labels, then
    recreates only `api web` with `--no-deps`.
-6. It makes bounded, no-redirect origin requests to `/`, `/api/health`,
-   `/openapi.json` and `/api/auth/session`. Health must report
-   `database=connected` and the candidate `build_sha`; OpenAPI must expose the
-   health and session paths; the session must be anonymous.
+6. After each candidate or upgrade-rollback Compose apply, it polls bounded
+   `/api/health` readiness for at most 120 seconds with a two-second interval.
+   Only after readiness succeeds does it run the authoritative bounded,
+   no-redirect smoke suite against `/`, `/api/health`, `/openapi.json` and
+   `/api/auth/session`. Health must report `database=connected` and the expected
+   `build_sha`; OpenAPI must expose the health and session paths; the session
+   must be anonymous. A transient startup delay therefore cannot trigger an
+   immediate false rollback, while readiness failure remains bounded.
 7. Only after all smokes pass does it persist an immutable sanitized receipt
-   and checksum, then atomically advance the checksum-bound `current.json`
-   pointer. The workflow uploads the same output even for a stopped preflight.
+   and checksum together with the byte-exact accepted release manifest and its
+   checksum, then atomically advance the `current.json` pointer that binds both
+   durable files. The workflow uploads the same receipt output even for a
+   stopped preflight.
 
 An accepted receipt contains the authenticated release run ID, source SHA,
 exact image digests, candidate manifest checksum, non-production target identity, current migration identity,
 exact changed app resources, smoke outcomes and rollback identity. It never
 contains DSNs, environment-file contents, passwords, tokens, private keys or
 credential-bearing URLs.
+
+Database access and service mutation are accounted independently. The
+pre-mutation live schema verification and an upgrade's prior-release health
+smoke are database reads even when a later pull, image verification or apply
+fails; failure receipts record that access without claiming a database
+mutation. The checkpoint path performs no migrations, and the startup reap
+opt-out keeps candidate and rollback startup from updating `admin_job_runs`.
+
+The external schema authority is the
+`ed-finder/v3-live-checkpoint-schema-identity/v2` receipt named by target
+authority. It contains the approved `database_source_authority`, a non-secret
+`database_identity` (`database_name`, literal `server_address`, and
+`server_port`), the canonical `migration_set_identity`, the complete
+release-format `migration_set_entries`, and `captured_at`. The receipt must be
+no more than 24 hours old (with at most five minutes of clock skew), and its
+checksum remains pinned in target authority. The host must provide `psql` on
+the fixed operator `PATH`; preflight verifies the client before any pull and
+then uses it only for the bounded read-only identity/ledger query.
+
+The workflow job ceiling is 75 minutes. Individual operator commands retain
+their 120-second limit, and candidate/rollback readiness windows retain their
+120-second limit; the larger job ceiling covers the full valid worst-case host
+validation, candidate and prior-image pull/inspection, apply, readiness, smoke,
+rollback and receipt/SSH overhead rather than pre-empting the deployer's own
+bounded recovery path.
 
 ## Exact blockers before checkpoint #1
 

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -14,10 +14,14 @@ Do not promote a repository helper into a production command merely because it e
   fail-closed `v3_checkpoint_deploy.py` bootstrap/upgrade boundary. Contabo is
   explicitly non-production and uses separate environment credentials. The
   helper verifies digest manifests, target authority, the fixed `api`/`web`
-  allowlist, app absence or prior receipt, and current schema compatibility
-  before any pull or service change. The committed authority currently stops
-  because the runtime, database/config, origin/edge and receipt facts are
-  absent. It never reads the API env-file contents or manages database, cache,
+  allowlist, app absence or the checksum-bound durable prior receipt/manifest,
+  and the live database identity plus current applied migration set before any
+  pull or service change. Database verification is read-only and never reports
+  or persists the credential-bearing `DATABASE_URL`. Candidate and rollback
+  starts receive bounded readiness polling before authoritative smoke checks;
+  receipts account for database reads independently from service mutation. The
+  committed authority currently stops because the runtime, database/config,
+  origin/edge and receipt facts are absent. It does not manage database, cache,
   NATS, edge, runner or volume resources.
 
 ## Current replacement-host helpers

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -15,11 +15,14 @@ Do not promote a repository helper into a production command merely because it e
   explicitly non-production and uses separate environment credentials. The
   helper verifies digest manifests, target authority, the fixed `api`/`web`
   allowlist, the selected context's exact `unix:///var/run/docker.sock` endpoint,
-  app absence or the checksum-bound durable prior receipt/manifest, and the live
-  database identity plus current applied migration set before any pull or
-  service change. Database verification is read-only and never reports or
-  persists the credential-bearing `DATABASE_URL`. Candidate and rollback starts
-  receive bounded readiness polling before authoritative smoke checks. Upgrade
+  the local bridge network's exact app-only attachments and aliases, app absence
+  or the checksum-bound durable prior receipt/manifest, and the live database
+  identity plus current applied migration set before any pull or service change.
+  Database verification is read-only and never reports or persists the
+  credential-bearing `DATABASE_URL`; Compose receives only a private verified
+  snapshot that is retained through rollback and then removed. Candidate and
+  rollback starts receive bounded readiness polling before authoritative smoke
+  checks. Upgrade
   rollback recreates from the already-verified prior digest images with
   `--pull never` and no registry request; receipts account for database reads
   independently from service mutation. The committed authority currently stops

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -14,15 +14,17 @@ Do not promote a repository helper into a production command merely because it e
   fail-closed `v3_checkpoint_deploy.py` bootstrap/upgrade boundary. Contabo is
   explicitly non-production and uses separate environment credentials. The
   helper verifies digest manifests, target authority, the fixed `api`/`web`
-  allowlist, app absence or the checksum-bound durable prior receipt/manifest,
-  and the live database identity plus current applied migration set before any
-  pull or service change. Database verification is read-only and never reports
-  or persists the credential-bearing `DATABASE_URL`. Candidate and rollback
-  starts receive bounded readiness polling before authoritative smoke checks;
-  receipts account for database reads independently from service mutation. The
-  committed authority currently stops because the runtime, database/config,
-  origin/edge and receipt facts are absent. It does not manage database, cache,
-  NATS, edge, runner or volume resources.
+  allowlist, the selected context's exact `unix:///var/run/docker.sock` endpoint,
+  app absence or the checksum-bound durable prior receipt/manifest, and the live
+  database identity plus current applied migration set before any pull or
+  service change. Database verification is read-only and never reports or
+  persists the credential-bearing `DATABASE_URL`. Candidate and rollback starts
+  receive bounded readiness polling before authoritative smoke checks. Upgrade
+  rollback recreates from the already-verified prior digest images with
+  `--pull never` and no registry request; receipts account for database reads
+  independently from service mutation. The committed authority currently stops
+  because the runtime, database/config, origin/edge and receipt facts are absent.
+  It does not manage database, cache, NATS, edge, runner or volume resources.
 
 ## Current replacement-host helpers
 - `actions/v3-app-status.sh`: fail-closed, read-only application status receipt

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -10,15 +10,15 @@ Do not promote a repository helper into a production command merely because it e
 
 ## Contabo live-checkpoint helper
 
-- `actions/v3-app-live-checkpoint-preflight.sh`: fail-closed, read-only checkpoint
-  deployment preflight for the Contabo live-checkpoint environment, which is
-  explicitly not production and is separate from the production operator
-  environment and credentials. The environment-gated workflow invokes it only after
-  verifying digest release and rollback manifests. It reports the observed host
-  identity while explicitly keeping authoritative Contabo identity unresolved,
-  emits every unresolved topology/secret/schema/rollback fact, and always stops
-  without reading target-host secret files, accessing the database, pulling
-  images, writing files, or changing services.
+- `actions/v3-app-live-checkpoint-preflight.sh`: CPython 3.14 launcher for the
+  fail-closed `v3_checkpoint_deploy.py` bootstrap/upgrade boundary. Contabo is
+  explicitly non-production and uses separate environment credentials. The
+  helper verifies digest manifests, target authority, the fixed `api`/`web`
+  allowlist, app absence or prior receipt, and current schema compatibility
+  before any pull or service change. The committed authority currently stops
+  because the runtime, database/config, origin/edge and receipt facts are
+  absent. It never reads the API env-file contents or manages database, cache,
+  NATS, edge, runner or volume resources.
 
 ## Current replacement-host helpers
 - `actions/v3-app-status.sh`: fail-closed, read-only application status receipt

--- a/scripts/operator/actions/v3-app-live-checkpoint-preflight.sh
+++ b/scripts/operator/actions/v3-app-live-checkpoint-preflight.sh
@@ -1,86 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This is deliberately a read-only, stopped preflight. It must not grow a
-# live-checkpoint deployment command until every item below has reviewed V3
-# authority. Contabo is a live-checkpoint environment, not production.
+# Contabo is a live-checkpoint environment, not production. This launcher
+# rejects any non-CPython-3.14 host before the Python safety boundary runs.
 if command -v python3.14 >/dev/null 2>&1; then
     PYTHON_BIN="$(command -v python3.14)"
 elif command -v python3 >/dev/null 2>&1; then
     PYTHON_BIN="$(command -v python3)"
 else
-    printf '%s\n' '{"schema_version":"ed-finder/v3-application-live-checkpoint-preflight/v1","operation":"v3-application-live-checkpoint-deploy-preflight","status":"stopped","target":{"provider":"contabo","classification":"live-checkpoint","production":false},"failures":["python3_unavailable"],"service_changes_performed":false,"filesystem_writes_performed":false,"database_access_performed":false}'
+    printf '%s\n' '{"status":"stopped","failures":["python3_unavailable"],"service_changes_performed":false}'
     exit 78
 fi
 if ! "$PYTHON_BIN" -c 'import platform, sys; raise SystemExit(0 if platform.python_implementation() == "CPython" and sys.version_info[:2] == (3, 14) else 1)'; then
-    printf '%s\n' '{"schema_version":"ed-finder/v3-application-live-checkpoint-preflight/v1","operation":"v3-application-live-checkpoint-deploy-preflight","status":"stopped","target":{"provider":"contabo","classification":"live-checkpoint","production":false},"failures":["python314_required"],"service_changes_performed":false,"filesystem_writes_performed":false,"database_access_performed":false}'
+    printf '%s\n' '{"status":"stopped","failures":["python314_required"],"service_changes_performed":false}'
     exit 78
 fi
 
-exec "$PYTHON_BIN" - <<'PY'
-from __future__ import annotations
-
-import json
-import socket
-import subprocess
-
-
-REQUIRED_FACTS = sorted(
-    {
-        "accepted_prior_digest_release_and_receipt_compatible_with_current_database",
-        "authoritative_contabo_live_checkpoint_host_identity_and_pinned_host_key",
-        "approved_external_secret_and_nonsecret_config_mount_authority_per_service",
-        "approved_ghcr_pull_authentication_authority",
-        "authoritative_current_schema_migrations_identity_receipt_source",
-        "durable_live_checkpoint_manifest_deploy_receipt_and_rollback_history_storage",
-        "exact_application_service_keys_container_names_and_recreate_allowlist",
-        "explicit_postgresql18_redis_nats_and_edge_preservation_targets",
-        "host_cpu_platform_for_release_images",
-        "required_application_data_log_and_receipt_mounts",
-        "reviewed_live_checkpoint_compose_project_config_path_and_bundle_installation_method",
-        "reviewed_contabo_web_api_network_alias_upstream_loopback_port_and_tls_edge_wiring",
-        "reviewed_live_checkpoint_origin_edge_health_openapi_session_and_svelte_smoke_authority",
-    }
-)
-
-
-def run(argv: list[str]) -> subprocess.CompletedProcess[str]:
-    try:
-        return subprocess.run(argv, capture_output=True, text=True, timeout=5, check=False)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
-
-
-short_host = socket.gethostname().split(".")[0]
-fqdn_result = run(["hostname", "-f"])
-fqdn = fqdn_result.stdout.strip()
-failures = [
-    "authoritative_contabo_live_checkpoint_host_identity_unproven",
-    "live_checkpoint_topology_authority_incomplete",
-]
-if fqdn_result.returncode != 0 or not short_host or not fqdn:
-    failures.append("host_identity_inspection_failed")
-
-receipt = {
-    "schema_version": "ed-finder/v3-application-live-checkpoint-preflight/v1",
-    "operation": "v3-application-live-checkpoint-deploy-preflight",
-    "status": "stopped",
-    "target": {
-        "provider": "contabo",
-        "classification": "live-checkpoint",
-        "production": False,
-    },
-    "host": {"short": short_host, "fqdn": fqdn},
-    "required_facts": REQUIRED_FACTS,
-    "failures": sorted(failures),
-    "authorized_recreate_targets": [],
-    "database_access_performed": False,
-    "migrations_performed": False,
-    "service_changes_performed": False,
-    "filesystem_writes_performed": False,
-    "env_files_read": False,
-    "private_keys_read": False,
-}
-print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
-raise SystemExit(78)
-PY
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$PYTHON_BIN" "$SCRIPT_DIR/../v3_checkpoint_deploy.py" "$@"

--- a/scripts/operator/v3_checkpoint_deploy.py
+++ b/scripts/operator/v3_checkpoint_deploy.py
@@ -7,6 +7,7 @@ import argparse
 import fcntl
 import hashlib
 import importlib.util
+import ipaddress
 import json
 import os
 import re
@@ -15,9 +16,11 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -27,8 +30,8 @@ DEFAULT_AUTHORITY = ROOT / "deploy/v3-live-checkpoint/target-authority.json"
 DEFAULT_COMPOSE = ROOT / "deploy/v3-live-checkpoint/compose.yml"
 TARGET_SCHEMA = "ed-finder/v3-live-checkpoint-target-authority/v1"
 RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-deployment-receipt/v1"
-CURRENT_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-current-receipt/v1"
-SCHEMA_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-schema-identity/v1"
+CURRENT_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-current-receipt/v2"
+SCHEMA_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-schema-identity/v2"
 PROJECT = "edfinder-v3-checkpoint"
 TARGET_HOSTNAME = "vmi3542235"
 TARGET_FQDN = "vmi3542235.contaboserver.net"
@@ -52,6 +55,12 @@ RUN_ID = re.compile(r"[1-9][0-9]{0,19}\Z")
 LOOPBACK_ORIGIN = re.compile(r"http://127\.0\.0\.1:([1-9][0-9]{0,4})\Z")
 MAX_JSON_BYTES = 1024 * 1024
 MAX_SMOKE_BYTES = 2 * 1024 * 1024
+SCHEMA_RECEIPT_MAX_AGE = timedelta(hours=24)
+SCHEMA_RECEIPT_FUTURE_TOLERANCE = timedelta(minutes=5)
+READINESS_TIMEOUT_SECONDS = 120.0
+READINESS_INTERVAL_SECONDS = 2.0
+ORIGIN_REQUEST_TIMEOUT_SECONDS = 10.0
+DATABASE_QUERY_TIMEOUT_SECONDS = 10
 
 
 class DeploymentError(ValueError):
@@ -256,6 +265,192 @@ def stopped_receipt(authority: dict[str, Any], failures: list[str]) -> dict[str,
     }
 
 
+def validate_database_identity(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != {
+        "database_name",
+        "server_address",
+        "server_port",
+    }:
+        raise DeploymentError("schema receipt database identity is invalid")
+    database_name = value.get("database_name")
+    server_address = value.get("server_address")
+    server_port = value.get("server_port")
+    if not isinstance(database_name, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]{1,63}", database_name
+    ):
+        raise DeploymentError("schema receipt database name is invalid")
+    try:
+        if not isinstance(server_address, str):
+            raise ValueError
+        ipaddress.ip_address(server_address)
+    except ValueError as exc:
+        raise DeploymentError("schema receipt database address is invalid") from exc
+    if not isinstance(server_port, int) or not 1 <= server_port <= 65535:
+        raise DeploymentError("schema receipt database port is invalid")
+    return value
+
+
+def read_checkpoint_database_url(
+    api_env_path: Path, *, on_read: Callable[[], None] | None = None
+) -> str:
+    """Read only the exact Compose-compatible DATABASE_URL assignment.
+
+    The checkpoint contract deliberately requires a single unquoted literal URL.
+    Rejecting interpolation and shell syntax makes the value used here identical
+    to the value Compose gives the API without evaluating the env file.
+    """
+
+    try:
+        if api_env_path.stat().st_size > MAX_JSON_BYTES:
+            raise DeploymentError("authorized api_env_file exceeds the size limit")
+        lines = api_env_path.read_text(encoding="utf-8").splitlines()
+        if on_read is not None:
+            on_read()
+    except DeploymentError:
+        raise
+    except (OSError, UnicodeDecodeError) as exc:
+        raise DeploymentError("unable to read authorized api_env_file") from exc
+    values: list[str] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        if key.strip() == "DATABASE_URL":
+            values.append(value.strip())
+    if len(values) != 1:
+        raise DeploymentError("api_env_file must contain exactly one DATABASE_URL")
+    database_url = values[0]
+    if (
+        not database_url
+        or any(character.isspace() for character in database_url)
+        or database_url[0] in {'"', "'"}
+        or "$" in database_url
+        or "#" in database_url
+    ):
+        raise DeploymentError("api_env_file DATABASE_URL must be an unquoted literal")
+    try:
+        parsed = urllib.parse.urlsplit(database_url)
+        database_name = urllib.parse.unquote(parsed.path.removeprefix("/"))
+        port = parsed.port or 5432
+        query_keys = {
+            key.lower() for key, _value in urllib.parse.parse_qsl(parsed.query)
+        }
+    except ValueError as exc:
+        raise DeploymentError("api_env_file DATABASE_URL is invalid") from exc
+    if (
+        parsed.scheme not in {"postgres", "postgresql"}
+        or not parsed.hostname
+        or not database_name
+        or "/" in database_name
+        or parsed.fragment
+        or "options" in query_keys
+        or not 1 <= port <= 65535
+    ):
+        raise DeploymentError("api_env_file DATABASE_URL is invalid")
+    return database_url
+
+
+def verify_database_schema(
+    api_env_path: Path,
+    schema_receipt: dict[str, Any],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+    *,
+    on_env_file_read: Callable[[], None] | None = None,
+    on_query_completed: Callable[[], None] | None = None,
+) -> None:
+    """Verify database and ledger identity through a bounded read-only query."""
+
+    database_url = read_checkpoint_database_url(api_env_path, on_read=on_env_file_read)
+    expected_identity = validate_database_identity(
+        schema_receipt.get("database_identity")
+    )
+    expected_entries = schema_receipt["migration_set_entries"]
+    database_env = {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        # libpq accepts a connection URI through PGDATABASE. Keeping it out of
+        # argv and error text prevents credentials from entering receipts/logs.
+        "PGDATABASE": database_url,
+        "PGCONNECT_TIMEOUT": str(DATABASE_QUERY_TIMEOUT_SECONDS),
+        "PGOPTIONS": (
+            "-c default_transaction_read_only=on "
+            f"-c statement_timeout={DATABASE_QUERY_TIMEOUT_SECONDS * 1000}"
+        ),
+    }
+    query = """
+SELECT json_build_object(
+  'database_name', current_database(),
+  'server_address', inet_server_addr()::text,
+  'server_port', inet_server_port(),
+  'transaction_read_only', current_setting('transaction_read_only'),
+  'migrations', COALESCE((
+    SELECT json_agg(
+      json_build_object('filename', filename, 'checksum_sha256', checksum_sha256)
+      ORDER BY filename
+    )
+    FROM public.schema_migrations
+  ), '[]'::json)
+)::text;
+""".strip()
+    result = runner(
+        [
+            "psql",
+            "-X",
+            "--no-password",
+            "--tuples-only",
+            "--no-align",
+            "--quiet",
+            "--command",
+            query,
+        ],
+        env=database_env,
+    )
+    if on_query_completed is not None:
+        on_query_completed()
+    try:
+        observed = json.loads(result.stdout.strip())
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("database identity query returned invalid JSON") from exc
+    if not isinstance(observed, dict) or set(observed) != {
+        "database_name",
+        "server_address",
+        "server_port",
+        "transaction_read_only",
+        "migrations",
+    }:
+        raise DeploymentError("database identity query returned an invalid shape")
+    if observed["transaction_read_only"] != "on":
+        raise DeploymentError("database identity query was not read-only")
+    observed_identity = {
+        key: observed[key] for key in ("database_name", "server_address", "server_port")
+    }
+    if observed_identity != expected_identity:
+        raise DeploymentError("configured database identity does not match receipt")
+    migrations = observed["migrations"]
+    if not isinstance(migrations, list) or any(
+        not isinstance(item, dict)
+        or set(item) != {"filename", "checksum_sha256"}
+        or not isinstance(item["filename"], str)
+        or not isinstance(item["checksum_sha256"], str)
+        for item in migrations
+    ):
+        raise DeploymentError("database migration ledger query returned invalid data")
+    expected_ledger = sorted(
+        (
+            {
+                "filename": entry["path"].removeprefix("sql/"),
+                "checksum_sha256": entry["sha256"],
+            }
+            for entry in expected_entries
+        ),
+        key=lambda item: item["filename"],
+    )
+    if migrations != expected_ledger:
+        raise DeploymentError("configured database migration ledger has drifted")
+
+
 def validate_release_inputs(
     *,
     mode: str,
@@ -266,7 +461,6 @@ def validate_release_inputs(
     rollback_path: Path | None,
     rollback_checksum: Path | None,
     prior_receipt_path: Path | None,
-    rollback_run_id: str | None = None,
 ) -> dict[str, Any]:
     manifest_tool = load_manifest_tool()
     candidate_sum = verify_checksum(candidate_path, candidate_checksum)
@@ -277,7 +471,9 @@ def validate_release_inputs(
         != {
             "schema_version",
             "database_source_authority",
+            "database_identity",
             "migration_set_identity",
+            "migration_set_entries",
             "captured_at",
         }
         or schema_receipt.get("schema_version") != SCHEMA_RECEIPT_SCHEMA
@@ -289,12 +485,54 @@ def validate_release_inputs(
     try:
         if not isinstance(captured_at, str):
             raise ValueError
-        datetime.strptime(captured_at, "%Y-%m-%dT%H:%M:%SZ")
+        captured = datetime.strptime(captured_at, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
     except ValueError:
         raise DeploymentError("schema identity receipt timestamp is invalid")
+    now = datetime.now(timezone.utc)
+    if captured > now + SCHEMA_RECEIPT_FUTURE_TOLERANCE:
+        raise DeploymentError("schema identity receipt timestamp is in the future")
+    if now - captured > SCHEMA_RECEIPT_MAX_AGE:
+        raise DeploymentError("schema identity receipt is stale")
     current_schema = schema_receipt.get("migration_set_identity")
     if not isinstance(current_schema, str) or not SHA256.fullmatch(current_schema):
         raise DeploymentError("schema identity receipt has no valid migration identity")
+    migration_entries = schema_receipt.get("migration_set_entries")
+    if not isinstance(migration_entries, list) or not migration_entries:
+        raise DeploymentError("schema identity receipt has no migration entries")
+    canonical_entries: list[dict[str, str]] = []
+    for index, entry in enumerate(migration_entries):
+        if not isinstance(entry, dict) or set(entry) != {"path", "mode", "sha256"}:
+            raise DeploymentError(
+                f"schema migration entry {index} has an invalid shape"
+            )
+        if not isinstance(entry["path"], str) or not re.fullmatch(
+            r"sql/[0-9]{3}_[a-z0-9_]+\.sql", entry["path"]
+        ):
+            raise DeploymentError(f"schema migration entry {index} has an invalid path")
+        if (
+            entry["mode"] not in {"auto", "manual"}
+            or not isinstance(entry["sha256"], str)
+            or not re.fullmatch(r"[0-9a-f]{64}", entry["sha256"])
+        ):
+            raise DeploymentError(f"schema migration entry {index} is invalid")
+        canonical_entries.append(entry)
+    if len({entry["path"] for entry in canonical_entries}) != len(canonical_entries):
+        raise DeploymentError("schema identity receipt repeats a migration path")
+    calculated_schema = (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps(
+                canonical_entries, sort_keys=True, separators=(",", ":")
+            ).encode()
+        ).hexdigest()
+    )
+    if calculated_schema != current_schema:
+        raise DeploymentError(
+            "schema identity receipt migration identity is inconsistent"
+        )
+    validate_database_identity(schema_receipt.get("database_identity"))
     try:
         manifest_tool.validate_manifest(
             candidate, purpose="deploy", current_migration_set=current_schema
@@ -365,10 +603,10 @@ def validate_release_inputs(
             "images": rollback.get("images"),
             "manifest_sha256": rollback_sum,
         }
-        if rollback_run_id is not None:
-            if not RUN_ID.fullmatch(rollback_run_id):
-                raise DeploymentError("rollback release run ID is invalid")
-            expected_prior["release_run_id"] = rollback_run_id
+        prior_run_id = prior.get("release_run_id")
+        if not isinstance(prior_run_id, str) or not RUN_ID.fullmatch(prior_run_id):
+            raise DeploymentError("prior receipt release run ID is invalid")
+        expected_prior["release_run_id"] = prior_run_id
         if any(prior.get(key) != value for key, value in expected_prior.items()):
             raise DeploymentError(
                 "prior receipt does not authenticate the rollback release"
@@ -379,12 +617,12 @@ def validate_release_inputs(
             "images": rollback["images"],
             "manifest_sha256": rollback_sum,
         }
-        if rollback_run_id is not None:
-            rollback_identity["release_run_id"] = rollback_run_id
+        rollback_identity["release_run_id"] = prior_run_id
     return {
         "candidate": candidate,
         "candidate_sha256": candidate_sum,
         "current_schema": current_schema,
+        "schema_receipt": schema_receipt,
         "rollback": rollback_identity,
     }
 
@@ -559,6 +797,7 @@ def validate_host_runtime(
     env: dict[str, str],
     runner: Callable[..., subprocess.CompletedProcess[str]] = run_command,
 ) -> None:
+    runner(["psql", "--version"], env=env)
     runner(["docker", "compose", "version"], env=env)
     compose_base = [
         "docker",
@@ -748,13 +987,20 @@ class NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def get_origin(origin: str, path: str) -> tuple[int, bytes, str]:
+def get_origin(
+    origin: str,
+    path: str,
+    *,
+    timeout_seconds: float = ORIGIN_REQUEST_TIMEOUT_SECONDS,
+) -> tuple[int, bytes, str]:
+    if timeout_seconds <= 0:
+        raise DeploymentError("origin request timeout must be positive")
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirect)
     request = urllib.request.Request(
         origin + path, headers={"Accept": "application/json,text/html"}
     )
     try:
-        with opener.open(request, timeout=10) as response:
+        with opener.open(request, timeout=timeout_seconds) as response:
             body = response.read(MAX_SMOKE_BYTES + 1)
             status = response.status
             content_type = response.headers.get("Content-Type", "")
@@ -763,6 +1009,54 @@ def get_origin(origin: str, path: str) -> tuple[int, bytes, str]:
     if not 200 <= status < 300 or len(body) > MAX_SMOKE_BYTES:
         raise DeploymentError(f"origin smoke rejected for {path}")
     return status, body, content_type
+
+
+def _validate_health_body(body: bytes, source_sha: str) -> None:
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("origin health JSON is invalid") from exc
+    if not isinstance(payload, dict) or not (
+        payload.get("status") == "ok"
+        and payload.get("database") == "connected"
+        and payload.get("build_sha") == source_sha
+    ):
+        raise DeploymentError("health smoke build/database identity mismatch")
+
+
+def wait_for_origin_ready(
+    origin: str,
+    source_sha: str,
+    *,
+    timeout_seconds: float = READINESS_TIMEOUT_SECONDS,
+    interval_seconds: float = READINESS_INTERVAL_SECONDS,
+    clock: Callable[[], float] = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> int:
+    """Poll the release health endpoint before the authoritative smoke suite."""
+
+    if timeout_seconds <= 0 or interval_seconds <= 0:
+        raise DeploymentError("readiness timeout and interval must be positive")
+    deadline = clock() + timeout_seconds
+    attempts = 0
+    while True:
+        remaining = deadline - clock()
+        if remaining <= 0:
+            raise DeploymentError("origin readiness timed out")
+        attempts += 1
+        try:
+            _status, body, _content_type = get_origin(
+                origin,
+                "/api/health",
+                timeout_seconds=min(ORIGIN_REQUEST_TIMEOUT_SECONDS, remaining),
+            )
+            _validate_health_body(body, source_sha)
+            return attempts
+        except DeploymentError as exc:
+            remaining = deadline - clock()
+            if remaining <= 0:
+                raise DeploymentError("origin readiness timed out") from exc
+            sleeper(min(interval_seconds, remaining))
 
 
 def smoke_origin(origin: str, source_sha: str) -> dict[str, Any]:
@@ -774,18 +1068,15 @@ def smoke_origin(origin: str, source_sha: str) -> dict[str, Any]:
             if "text/html" not in content_type.lower() or b"<html" not in body.lower():
                 raise DeploymentError("root smoke is not the Svelte HTML application")
             continue
+        if path == "/api/health":
+            _validate_health_body(body, source_sha)
+            continue
         try:
             payload = json.loads(body)
         except json.JSONDecodeError as exc:
             raise DeploymentError(f"origin smoke JSON is invalid for {path}") from exc
         if not isinstance(payload, dict):
             raise DeploymentError(f"origin smoke payload is invalid for {path}")
-        if path == "/api/health" and not (
-            payload.get("status") == "ok"
-            and payload.get("database") == "connected"
-            and payload.get("build_sha") == source_sha
-        ):
-            raise DeploymentError("health smoke build/database identity mismatch")
         if path == "/openapi.json" and not (
             isinstance(payload.get("paths"), dict)
             and "/api/health" in payload["paths"]
@@ -797,24 +1088,40 @@ def smoke_origin(origin: str, source_sha: str) -> dict[str, Any]:
     return outcomes
 
 
-def persist_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
+def persist_receipt(
+    directory: Path, receipt: dict[str, Any], accepted_manifest_path: Path
+) -> Path:
     data = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode()
+    try:
+        if accepted_manifest_path.stat().st_size > MAX_JSON_BYTES:
+            raise OSError("accepted manifest exceeds the size limit")
+        manifest_data = accepted_manifest_path.read_bytes()
+    except OSError:
+        raise
+    manifest_digest = hashlib.sha256(manifest_data).hexdigest()
+    if manifest_digest != receipt["manifest_sha256"]:
+        raise OSError("accepted manifest changed before durable persistence")
     identity = (
         f"{receipt['source_sha']}-{receipt['release_run_id']}-"
         f"{receipt['manifest_sha256']}"
     )
     final = directory / f"{identity}.json"
     checksum = directory / f"{identity}.json.sha256"
-    if final.exists() or checksum.exists():
+    manifest = directory / f"{identity}.release.json"
+    manifest_checksum = directory / f"{identity}.release.json.sha256"
+    if any(path.exists() for path in (final, checksum, manifest, manifest_checksum)):
         raise OSError("immutable deployment receipt identity already exists")
     digest = hashlib.sha256(data).hexdigest()
     checksum_data = f"{digest}  {final.name}\n".encode()
+    manifest_checksum_data = f"{manifest_digest}  {manifest.name}\n".encode()
     pointer_data = (
         json.dumps(
             {
                 "schema_version": CURRENT_RECEIPT_SCHEMA,
                 "receipt_file": final.name,
                 "receipt_sha256": digest,
+                "manifest_file": manifest.name,
+                "manifest_sha256": manifest_digest,
             },
             indent=2,
             sort_keys=True,
@@ -829,6 +1136,8 @@ def persist_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
     temporaries: list[Path] = []
     final_created = False
     checksum_created = False
+    manifest_created = False
+    manifest_checksum_created = False
     current_replaced = False
 
     def staged(data_to_write: bytes, prefix: str) -> Path:
@@ -845,6 +1154,10 @@ def persist_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
     try:
         receipt_temporary = staged(data, ".v3-receipt-")
         checksum_temporary = staged(checksum_data, ".v3-checksum-")
+        manifest_temporary = staged(manifest_data, ".v3-manifest-")
+        manifest_checksum_temporary = staged(
+            manifest_checksum_data, ".v3-manifest-checksum-"
+        )
         current_temporary = staged(pointer_data, ".v3-current-")
         os.replace(receipt_temporary, final)
         temporaries.remove(receipt_temporary)
@@ -852,6 +1165,12 @@ def persist_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
         os.replace(checksum_temporary, checksum)
         temporaries.remove(checksum_temporary)
         checksum_created = True
+        os.replace(manifest_temporary, manifest)
+        temporaries.remove(manifest_temporary)
+        manifest_created = True
+        os.replace(manifest_checksum_temporary, manifest_checksum)
+        temporaries.remove(manifest_checksum_temporary)
+        manifest_checksum_created = True
         os.fsync(directory_fd)
         os.replace(current_temporary, current)
         temporaries.remove(current_temporary)
@@ -872,6 +1191,10 @@ def persist_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
             checksum.unlink(missing_ok=True)
         if final_created:
             final.unlink(missing_ok=True)
+        if manifest_checksum_created:
+            manifest_checksum.unlink(missing_ok=True)
+        if manifest_created:
+            manifest.unlink(missing_ok=True)
         os.fsync(directory_fd)
         raise
     finally:
@@ -910,16 +1233,25 @@ def persist_failure_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
         os.close(directory_fd)
 
 
-def load_current_receipt(directory: Path) -> Path:
-    pointer = load_json(
-        directory / "current.json", "current deployment receipt pointer"
-    )
-    if set(pointer) != {"schema_version", "receipt_file", "receipt_sha256"}:
+def load_current_release(directory: Path) -> tuple[Path, Path, Path]:
+    current_path = directory / "current.json"
+    if current_path.is_symlink():
+        raise DeploymentError("current deployment receipt pointer is unsafe")
+    pointer = load_json(current_path, "current deployment receipt pointer")
+    if set(pointer) != {
+        "schema_version",
+        "receipt_file",
+        "receipt_sha256",
+        "manifest_file",
+        "manifest_sha256",
+    }:
         raise DeploymentError("current deployment receipt pointer shape is invalid")
     if pointer.get("schema_version") != CURRENT_RECEIPT_SCHEMA:
         raise DeploymentError("current deployment receipt pointer schema is invalid")
     receipt_file = pointer.get("receipt_file")
     receipt_sha = pointer.get("receipt_sha256")
+    manifest_file = pointer.get("manifest_file")
+    manifest_sha = pointer.get("manifest_sha256")
     if not isinstance(receipt_file, str) or not re.fullmatch(
         r"[0-9a-f]{40}-[1-9][0-9]{0,19}-[0-9a-f]{64}\.json", receipt_file
     ):
@@ -928,13 +1260,43 @@ def load_current_receipt(directory: Path) -> Path:
         r"[0-9a-f]{64}", receipt_sha
     ):
         raise DeploymentError("current deployment receipt checksum is invalid")
+    expected_manifest_file = receipt_file.removesuffix(".json") + ".release.json"
+    if manifest_file != expected_manifest_file:
+        raise DeploymentError("current accepted manifest filename is invalid")
+    if not isinstance(manifest_sha, str) or not re.fullmatch(
+        r"[0-9a-f]{64}", manifest_sha
+    ):
+        raise DeploymentError("current accepted manifest checksum is invalid")
     receipt_path = directory / receipt_file
     if not receipt_path.is_file() or receipt_path.is_symlink():
         raise DeploymentError("current deployment receipt is missing or unsafe")
+    receipt_checksum_path = Path(f"{receipt_path}.sha256")
+    if receipt_checksum_path.is_symlink():
+        raise DeploymentError("current deployment receipt sidecar is unsafe")
     if sha256_file(receipt_path) != receipt_sha:
         raise DeploymentError("current deployment receipt checksum mismatch")
-    if verify_checksum(receipt_path, Path(f"{receipt_path}.sha256")) != receipt_sha:
+    if verify_checksum(receipt_path, receipt_checksum_path) != receipt_sha:
         raise DeploymentError("current deployment receipt sidecar mismatch")
+    manifest_path = directory / manifest_file
+    manifest_checksum_path = Path(f"{manifest_path}.sha256")
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise DeploymentError("current accepted manifest is missing or unsafe")
+    if manifest_checksum_path.is_symlink():
+        raise DeploymentError("current accepted manifest sidecar is unsafe")
+    if sha256_file(manifest_path) != manifest_sha:
+        raise DeploymentError("current accepted manifest checksum mismatch")
+    if verify_checksum(manifest_path, manifest_checksum_path) != manifest_sha:
+        raise DeploymentError("current accepted manifest sidecar mismatch")
+    prior = load_json(receipt_path, "current deployment receipt")
+    if prior.get("manifest_sha256") != manifest_sha:
+        raise DeploymentError("current receipt does not bind accepted manifest")
+    return receipt_path, manifest_path, manifest_checksum_path
+
+
+def load_current_receipt(directory: Path) -> Path:
+    receipt_path, _manifest_path, _manifest_checksum_path = load_current_release(
+        directory
+    )
     return receipt_path
 
 
@@ -991,6 +1353,8 @@ def operation_receipt(
     changed_resources: list[str],
     smokes: dict[str, Any],
     rollback: dict[str, Any],
+    database_access_performed: bool,
+    env_files_read: bool,
 ) -> dict[str, Any]:
     candidate = release_info["candidate"]
     return {
@@ -1013,7 +1377,7 @@ def operation_receipt(
         "changed_resources": changed_resources,
         "smoke": smokes,
         "rollback": rollback,
-        "database_access_performed": status == "accepted",
+        "database_access_performed": database_access_performed,
         "database_mutation_performed": False,
         "migrations_performed": False,
         "infrastructure_changes_performed": False,
@@ -1021,6 +1385,7 @@ def operation_receipt(
         "image_pulls_performed": status == "accepted",
         "filesystem_writes_performed": True,
         "env_file_consumed_by_compose": status == "accepted",
+        "env_files_read": env_files_read,
         "private_keys_read": False,
     }
 
@@ -1036,12 +1401,6 @@ def execute(
     external = authority["external_authority"]
     if args.candidate_run_id is None or not RUN_ID.fullmatch(args.candidate_run_id):
         raise DeploymentError("candidate release run ID is required")
-    if args.mode == "bootstrap" and args.rollback_run_id is not None:
-        raise DeploymentError("bootstrap must not claim a rollback release run")
-    if args.mode == "upgrade" and (
-        args.rollback_run_id is None or not RUN_ID.fullmatch(args.rollback_run_id)
-    ):
-        raise DeploymentError("upgrade requires a rollback release run ID")
     receipt_directory = Path(external["receipt_directory"])
     validate_host_files(authority, args.compose)
     deployment_lock = acquire_deployment_lock(receipt_directory)
@@ -1050,26 +1409,54 @@ def execute(
     pulled_images: list[str] = []
     service_mutation_attempted = False
     runtime_validation_started = False
+    database_access_attempted = False
+    database_access_performed = False
+    env_file_read_attempted = False
+    env_files_read = False
     smokes: dict[str, Any] = {}
     try:
-        prior_receipt_path = (
-            load_current_receipt(receipt_directory) if args.mode == "upgrade" else None
-        )
+        if args.mode == "upgrade":
+            (
+                prior_receipt_path,
+                rollback_path,
+                rollback_checksum,
+            ) = load_current_release(receipt_directory)
+        else:
+            prior_receipt_path = None
+            rollback_path = None
+            rollback_checksum = None
         release_info = validate_release_inputs(
             mode=args.mode,
             candidate_path=args.candidate,
             candidate_checksum=args.candidate_checksum,
             current_schema_path=Path(external["schema_identity_receipt"]),
             database_source_authority=external["database_source_authority"],
-            rollback_path=args.rollback,
-            rollback_checksum=args.rollback_checksum,
+            rollback_path=rollback_path,
+            rollback_checksum=rollback_checksum,
             prior_receipt_path=prior_receipt_path,
-            rollback_run_id=args.rollback_run_id,
         )
         candidate = release_info["candidate"]
         env = compose_environment(authority, candidate)
         runtime_validation_started = True
         validate_host_runtime(args.compose, env, runner)
+
+        def mark_env_file_read() -> None:
+            nonlocal env_files_read
+            env_files_read = True
+
+        def mark_database_query_completed() -> None:
+            nonlocal database_access_performed
+            database_access_performed = True
+
+        env_file_read_attempted = True
+        database_access_attempted = True
+        verify_database_schema(
+            Path(external["api_env_file"]),
+            release_info["schema_receipt"],
+            runner,
+            on_env_file_read=mark_env_file_read,
+            on_query_completed=mark_database_query_completed,
+        )
         if args.mode == "bootstrap":
             if (receipt_directory / "current.json").exists():
                 raise DeploymentError("bootstrap requires proven prior receipt absence")
@@ -1095,6 +1482,7 @@ def execute(
                 pulled_images.append(image)
         service_mutation_attempted = True
         runner(plan[2], env=env)
+        wait_for_origin_ready(external["origin_bind"], candidate["git_sha"])
         verify_app_containers(env, candidate["git_sha"], candidate["images"])
         smokes = smoke_origin(external["origin_bind"], candidate["git_sha"])
         receipt = operation_receipt(
@@ -1105,8 +1493,10 @@ def execute(
             changed_resources=[CONTAINERS[service] for service in SERVICES],
             smokes=smokes,
             rollback=release_info["rollback"],
+            database_access_performed=database_access_performed,
+            env_files_read=env_files_read,
         )
-        persist_receipt(receipt_directory, receipt)
+        persist_receipt(receipt_directory, receipt, args.candidate)
         return receipt
     except Exception as original:
         # A failure before release validation has no authenticated candidate
@@ -1137,6 +1527,9 @@ def execute(
                     )
                 else:
                     rollback = release_info["rollback"]
+                    wait_for_origin_ready(
+                        external["origin_bind"], rollback["source_sha"]
+                    )
                     verify_app_containers(
                         rollback_env, rollback["source_sha"], rollback["images"]
                     )
@@ -1158,6 +1551,8 @@ def execute(
             ),
             smokes=smokes,
             rollback=rollback_outcome,
+            database_access_performed=database_access_performed,
+            env_files_read=env_files_read,
         )
         failure_receipt.update(
             failure=type(original).__name__,
@@ -1169,7 +1564,14 @@ def execute(
             pulled_images_verified=pulled_images,
             service_mutation_attempted=service_mutation_attempted,
             service_changes_performed=service_mutation_attempted,
-            database_access_may_have_been_performed=service_mutation_attempted,
+            database_access_attempted=database_access_attempted,
+            database_access_may_have_been_performed=(
+                database_access_attempted and not database_access_performed
+            ),
+            env_file_read_attempted=env_file_read_attempted,
+            env_files_may_have_been_read=(
+                env_file_read_attempted and not env_files_read
+            ),
             env_file_consumed_by_compose=False,
             env_file_may_have_been_consumed_by_compose=runtime_validation_started,
         )
@@ -1192,9 +1594,6 @@ def parser() -> argparse.ArgumentParser:
     result.add_argument("--candidate", type=Path)
     result.add_argument("--candidate-checksum", type=Path)
     result.add_argument("--candidate-run-id")
-    result.add_argument("--rollback", type=Path)
-    result.add_argument("--rollback-checksum", type=Path)
-    result.add_argument("--rollback-run-id")
     result.add_argument("--authority-gate", action="store_true")
     return result
 

--- a/scripts/operator/v3_checkpoint_deploy.py
+++ b/scripts/operator/v3_checkpoint_deploy.py
@@ -41,6 +41,10 @@ CONTAINERS = {
     "api": "edfinder-v3-checkpoint-api",
     "web": "edfinder-v3-checkpoint-web",
 }
+NETWORK_ALIASES = {
+    service: frozenset((service, container))
+    for service, container in CONTAINERS.items()
+}
 APP_NETWORK = "edfinder-v3-checkpoint-app"
 RESOURCE_LIMITS = {
     "api": {"cpus": "1.50", "memory": "1536m", "pids": 256},
@@ -261,6 +265,7 @@ def stopped_receipt(authority: dict[str, Any], failures: list[str]) -> dict[str,
         "service_changes_performed": False,
         "image_pulls_performed": False,
         "filesystem_writes_performed": False,
+        "env_file_consumed_by_compose": False,
         "env_files_read": False,
         "private_keys_read": False,
     }
@@ -350,6 +355,179 @@ def read_checkpoint_database_url(
     ):
         raise DeploymentError("api_env_file DATABASE_URL is invalid")
     return database_url
+
+
+def freeze_authorized_env_file(
+    source: Path,
+    directory: Path,
+    *,
+    expected_uid: int,
+    expected_mode: str,
+    on_read: Callable[[], None] | None = None,
+) -> tuple[Path, dict[str, Any], int]:
+    """Copy one securely opened authority file into a private read-only snapshot."""
+
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor: int | None = None
+    snapshot: Path | None = None
+    try:
+        if not source.is_absolute():
+            raise DeploymentError("authorized api_env_file path is unsafe")
+        descriptor = os.open(source, flags)
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_uid != expected_uid
+            or stat.S_IMODE(before.st_mode) != int(expected_mode, 8)
+            or before.st_size > MAX_JSON_BYTES
+        ):
+            raise DeploymentError("authorized api_env_file is missing or unsafe")
+        data = bytearray()
+        while len(data) <= MAX_JSON_BYTES:
+            chunk = os.read(
+                descriptor, min(1024 * 1024, MAX_JSON_BYTES + 1 - len(data))
+            )
+            if not chunk:
+                break
+            data.extend(chunk)
+        if len(data) > MAX_JSON_BYTES:
+            raise DeploymentError("authorized api_env_file exceeds the size limit")
+        after = os.fstat(descriptor)
+        try:
+            lexical = os.lstat(source)
+        except OSError as exc:
+            raise DeploymentError("authorized api_env_file changed while read") from exc
+        stable_fields = (
+            "st_dev",
+            "st_ino",
+            "st_uid",
+            "st_mode",
+            "st_size",
+            "st_mtime_ns",
+            "st_ctime_ns",
+        )
+        if any(
+            getattr(before, field) != getattr(after, field) for field in stable_fields
+        ) or (lexical.st_dev != after.st_dev or lexical.st_ino != after.st_ino):
+            raise DeploymentError("authorized api_env_file changed while read")
+        if on_read is not None:
+            on_read()
+        with tempfile.NamedTemporaryFile(
+            dir=directory, prefix=".v3-verified-api-env-", delete=False
+        ) as handle:
+            snapshot = Path(handle.name)
+            handle.write(data)
+            handle.flush()
+            os.fchmod(handle.fileno(), 0o400)
+            os.fsync(handle.fileno())
+        directory_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+        snapshot_stat = snapshot.stat()
+        fingerprint = {
+            "source_dev": after.st_dev,
+            "source_ino": after.st_ino,
+            "source_size": after.st_size,
+            "source_mtime_ns": after.st_mtime_ns,
+            "source_ctime_ns": after.st_ctime_ns,
+            "sha256": hashlib.sha256(data).hexdigest(),
+            "snapshot_dev": snapshot_stat.st_dev,
+            "snapshot_ino": snapshot_stat.st_ino,
+        }
+        retained_descriptor = descriptor
+        descriptor = None
+        return snapshot, fingerprint, retained_descriptor
+    except (OSError, ValueError) as exc:
+        if snapshot is not None:
+            snapshot.unlink(missing_ok=True)
+        if isinstance(exc, DeploymentError):
+            raise
+        raise DeploymentError("unable to freeze authorized api_env_file") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def verify_frozen_env_snapshot(
+    snapshot: Path,
+    fingerprint: dict[str, Any],
+) -> None:
+    try:
+        snapshot_stat = os.lstat(snapshot)
+    except OSError as exc:
+        raise DeploymentError("verified api_env_file snapshot changed") from exc
+    if (
+        not stat.S_ISREG(snapshot_stat.st_mode)
+        or stat.S_IMODE(snapshot_stat.st_mode) != 0o400
+        or snapshot_stat.st_dev != fingerprint["snapshot_dev"]
+        or snapshot_stat.st_ino != fingerprint["snapshot_ino"]
+        or sha256_file(snapshot) != fingerprint["sha256"]
+    ):
+        raise DeploymentError("verified api_env_file snapshot changed")
+
+
+def verify_authorized_env_unchanged(
+    source: Path,
+    snapshot: Path,
+    fingerprint: dict[str, Any],
+    source_descriptor: int,
+) -> None:
+    """Prove the authority path did not drift and the snapshot is still exact."""
+
+    try:
+        source_stat = os.lstat(source)
+        retained_source_stat = os.fstat(source_descriptor)
+    except OSError as exc:
+        raise DeploymentError("authorized api_env_file or snapshot changed") from exc
+    if (
+        stat.S_ISLNK(source_stat.st_mode)
+        or not stat.S_ISREG(source_stat.st_mode)
+        or source_stat.st_dev != fingerprint["source_dev"]
+        or source_stat.st_ino != fingerprint["source_ino"]
+        or source_stat.st_size != fingerprint["source_size"]
+        or source_stat.st_mtime_ns != fingerprint["source_mtime_ns"]
+        or source_stat.st_ctime_ns != fingerprint["source_ctime_ns"]
+        or retained_source_stat.st_dev != fingerprint["source_dev"]
+        or retained_source_stat.st_ino != fingerprint["source_ino"]
+        or retained_source_stat.st_size != fingerprint["source_size"]
+        or retained_source_stat.st_mtime_ns != fingerprint["source_mtime_ns"]
+        or retained_source_stat.st_ctime_ns != fingerprint["source_ctime_ns"]
+    ):
+        raise DeploymentError("authorized api_env_file or snapshot changed")
+    verify_frozen_env_snapshot(snapshot, fingerprint)
+
+
+def remove_env_file_snapshot(
+    snapshot: Path | None,
+    fingerprint: dict[str, Any] | None,
+    source_descriptor: int | None,
+) -> None:
+    try:
+        if source_descriptor is not None:
+            os.close(source_descriptor)
+        if snapshot is not None and fingerprint is not None:
+            snapshot_stat = os.lstat(snapshot)
+            if (
+                stat.S_ISREG(snapshot_stat.st_mode)
+                and snapshot_stat.st_dev == fingerprint["snapshot_dev"]
+                and snapshot_stat.st_ino == fingerprint["snapshot_ino"]
+            ):
+                snapshot.unlink()
+                directory_fd = os.open(snapshot.parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(directory_fd)
+                finally:
+                    os.close(directory_fd)
+    except FileNotFoundError:
+        pass
+    except OSError:
+        # Do not replace the deployment/rollback outcome with a cleanup error.
+        pass
 
 
 def verify_database_schema(
@@ -629,7 +807,10 @@ def validate_release_inputs(
 
 
 def compose_environment(
-    authority: dict[str, Any], release: dict[str, Any]
+    authority: dict[str, Any],
+    release: dict[str, Any],
+    *,
+    verified_api_env_file: Path | None = None,
 ) -> dict[str, str]:
     external = authority["external_authority"]
     match = LOOPBACK_ORIGIN.fullmatch(external["origin_bind"])
@@ -644,7 +825,9 @@ def compose_environment(
         "V3_CHECKPOINT_API_IMAGE": release["images"]["backend"],
         "V3_CHECKPOINT_WEB_IMAGE": release["images"]["web"],
         "V3_CHECKPOINT_SOURCE_SHA": release["git_sha"],
-        "V3_CHECKPOINT_API_ENV_FILE": external["api_env_file"],
+        "V3_CHECKPOINT_API_ENV_FILE": str(
+            verified_api_env_file or external["api_env_file"]
+        ),
         "V3_CHECKPOINT_ORIGIN_BIND": f"127.0.0.1:{match.group(1)}",
     }
 
@@ -804,10 +987,119 @@ def validate_host_files(authority: dict[str, Any], compose_path: Path) -> None:
         raise DeploymentError("reviewed Compose checksum does not match authority")
 
 
+def validate_network_topology(
+    mode: str,
+    inspection_output: str,
+    env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    try:
+        documents = json.loads(inspection_output)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("checkpoint network inspection is invalid") from exc
+    if not isinstance(documents, list) or len(documents) != 1:
+        raise DeploymentError("checkpoint network inspection is invalid")
+    network = documents[0]
+    network_id = network.get("Id") if isinstance(network, dict) else None
+    if (
+        not isinstance(network, dict)
+        or not isinstance(network_id, str)
+        or not re.fullmatch(r"[0-9a-f]{64}", network_id)
+        or network.get("Name") != APP_NETWORK
+        or network.get("Driver") != "bridge"
+        or network.get("Scope") != "local"
+        or network.get("Ingress") is not False
+        or not isinstance(network.get("Containers"), dict)
+    ):
+        raise DeploymentError("checkpoint network topology is unauthorized")
+    endpoints = network["Containers"]
+    attached: dict[str, tuple[str, str]] = {}
+    for container_id, endpoint in endpoints.items():
+        endpoint_id = endpoint.get("EndpointID") if isinstance(endpoint, dict) else None
+        if (
+            not isinstance(container_id, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", container_id)
+            or not isinstance(endpoint, dict)
+            or not isinstance(endpoint.get("Name"), str)
+            or not isinstance(endpoint_id, str)
+            or not re.fullmatch(r"[0-9a-f]{64}", endpoint_id)
+        ):
+            raise DeploymentError("checkpoint network inspection is unverifiable")
+        name = endpoint["Name"]
+        if name not in CONTAINERS.values() or name in attached:
+            raise DeploymentError("checkpoint network has an unexpected peer")
+        attached[name] = (container_id, endpoint_id)
+    if mode == "bootstrap":
+        attachments_valid = not attached
+    elif mode == "bootstrap-rollback":
+        attachments_valid = set(attached).issubset(CONTAINERS.values())
+    elif mode == "upgrade":
+        attachments_valid = set(attached) == set(CONTAINERS.values())
+    else:
+        raise DeploymentError("checkpoint network deploy mode is invalid")
+    if not attachments_valid:
+        raise DeploymentError("checkpoint network attachments do not match deploy mode")
+    for service, container in CONTAINERS.items():
+        if container not in attached:
+            continue
+        attachment = runner(
+            [
+                "docker",
+                "container",
+                "inspect",
+                container,
+            ],
+            env=env,
+        )
+        try:
+            container_documents = json.loads(attachment.stdout)
+        except json.JSONDecodeError as exc:
+            raise DeploymentError("container network attachment is invalid") from exc
+        if not isinstance(container_documents, list) or len(container_documents) != 1:
+            raise DeploymentError("container network attachment is invalid")
+        container_document = container_documents[0]
+        networks = (
+            container_document.get("NetworkSettings", {}).get("Networks")
+            if isinstance(container_document, dict)
+            else None
+        )
+        if not isinstance(networks, dict) or set(networks) != {APP_NETWORK}:
+            raise DeploymentError("container network attachment is unauthorized")
+        network_attachment = networks[APP_NETWORK]
+        aliases = (
+            network_attachment.get("Aliases")
+            if isinstance(network_attachment, dict)
+            else None
+        )
+        expected_container_id, expected_endpoint_id = attached[container]
+        if (
+            container_document.get("Id") != expected_container_id
+            or not isinstance(network_attachment, dict)
+            or network_attachment.get("NetworkID") != network_id
+            or network_attachment.get("EndpointID") != expected_endpoint_id
+            or not isinstance(aliases, list)
+            or any(not isinstance(alias, str) for alias in aliases)
+            or set(aliases) != NETWORK_ALIASES[service]
+            or len(aliases) != len(NETWORK_ALIASES[service])
+        ):
+            raise DeploymentError("checkpoint container network aliases are invalid")
+
+
+def inspect_network_topology(
+    mode: str,
+    env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    inspection = runner(["docker", "network", "inspect", APP_NETWORK], env=env)
+    validate_network_topology(mode, inspection.stdout, env, runner)
+
+
 def validate_host_runtime(
     compose_path: Path,
     env: dict[str, str],
     runner: Callable[..., subprocess.CompletedProcess[str]] = run_command,
+    *,
+    mode: str = "bootstrap",
 ) -> None:
     runner(["psql", "--version"], env=env)
     context_endpoint = runner(
@@ -852,7 +1144,7 @@ def validate_host_runtime(
     }
     if set(rendered_images.stdout.split()) != expected_images:
         raise DeploymentError("rendered Compose images are not exact release digests")
-    runner(["docker", "network", "inspect", APP_NETWORK], env=env)
+    inspect_network_topology(mode, env, runner)
     active_runners = runner(
         [
             "systemctl",
@@ -1324,6 +1616,16 @@ def load_current_release(directory: Path) -> tuple[Path, Path, Path]:
     return receipt_path, manifest_path, manifest_checksum_path
 
 
+def path_exists_lexically(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise DeploymentError("unable to inspect durable prior-state path") from exc
+    return True
+
+
 def load_current_receipt(directory: Path) -> Path:
     receipt_path, _manifest_path, _manifest_checksum_path = load_current_release(
         directory
@@ -1386,6 +1688,7 @@ def operation_receipt(
     rollback: dict[str, Any],
     database_access_performed: bool,
     env_files_read: bool,
+    env_file_consumed_by_compose: bool,
 ) -> dict[str, Any]:
     candidate = release_info["candidate"]
     return {
@@ -1415,7 +1718,7 @@ def operation_receipt(
         "service_changes_performed": status == "accepted",
         "image_pulls_performed": status == "accepted",
         "filesystem_writes_performed": True,
-        "env_file_consumed_by_compose": status == "accepted",
+        "env_file_consumed_by_compose": env_file_consumed_by_compose,
         "env_files_read": env_files_read,
         "private_keys_read": False,
     }
@@ -1439,11 +1742,15 @@ def execute(
     image_pull_attempted = False
     pulled_images: list[str] = []
     service_mutation_attempted = False
-    runtime_validation_started = False
+    compose_recreate_attempted = False
     database_access_attempted = False
     database_access_performed = False
     env_file_read_attempted = False
     env_files_read = False
+    env_file_consumed_by_compose = False
+    verified_env_snapshot: Path | None = None
+    verified_env_fingerprint: dict[str, Any] | None = None
+    verified_env_source_descriptor: int | None = None
     smokes: dict[str, Any] = {}
     try:
         if args.mode == "upgrade":
@@ -1453,6 +1760,8 @@ def execute(
                 rollback_checksum,
             ) = load_current_release(receipt_directory)
         else:
+            if path_exists_lexically(receipt_directory / "current.json"):
+                raise DeploymentError("bootstrap requires proven prior receipt absence")
             prior_receipt_path = None
             rollback_path = None
             rollback_checksum = None
@@ -1467,9 +1776,6 @@ def execute(
             prior_receipt_path=prior_receipt_path,
         )
         candidate = release_info["candidate"]
-        env = compose_environment(authority, candidate)
-        runtime_validation_started = True
-        validate_host_runtime(args.compose, env, runner)
 
         def mark_env_file_read() -> None:
             nonlocal env_files_read
@@ -1480,17 +1786,35 @@ def execute(
             database_access_performed = True
 
         env_file_read_attempted = True
+        (
+            verified_env_snapshot,
+            verified_env_fingerprint,
+            verified_env_source_descriptor,
+        ) = freeze_authorized_env_file(
+            Path(external["api_env_file"]),
+            receipt_directory,
+            expected_uid=external["api_env_owner_uid"],
+            expected_mode=external["api_env_mode"],
+            on_read=mark_env_file_read,
+        )
         database_access_attempted = True
         verify_database_schema(
-            Path(external["api_env_file"]),
+            verified_env_snapshot,
             release_info["schema_receipt"],
             runner,
-            on_env_file_read=mark_env_file_read,
             on_query_completed=mark_database_query_completed,
         )
+        verify_authorized_env_unchanged(
+            Path(external["api_env_file"]),
+            verified_env_snapshot,
+            verified_env_fingerprint,
+            verified_env_source_descriptor,
+        )
+        env = compose_environment(
+            authority, candidate, verified_api_env_file=verified_env_snapshot
+        )
+        validate_host_runtime(args.compose, env, runner, mode=args.mode)
         if args.mode == "bootstrap":
-            if (receipt_directory / "current.json").exists():
-                raise DeploymentError("bootstrap requires proven prior receipt absence")
             verify_bootstrap_absence(env, external["origin_bind"], runner)
         else:
             rollback = release_info["rollback"]
@@ -1498,6 +1822,12 @@ def execute(
             smoke_origin(external["origin_bind"], rollback["source_sha"])
             verify_origin_state(external["origin_bind"], "upgrade")
 
+        verify_authorized_env_unchanged(
+            Path(external["api_env_file"]),
+            verified_env_snapshot,
+            verified_env_fingerprint,
+            verified_env_source_descriptor,
+        )
         plan = command_plan(args.compose, env)
         for command in plan[:2]:
             image_pull_attempted = True
@@ -1511,8 +1841,17 @@ def execute(
                 runner(["docker", "pull", image], env=env)
                 verify_pulled_image(image, rollback["source_sha"], env, runner)
                 pulled_images.append(image)
+        verify_authorized_env_unchanged(
+            Path(external["api_env_file"]),
+            verified_env_snapshot,
+            verified_env_fingerprint,
+            verified_env_source_descriptor,
+        )
+        inspect_network_topology(args.mode, env, runner)
         service_mutation_attempted = True
+        compose_recreate_attempted = True
         runner(plan[2], env=env)
+        env_file_consumed_by_compose = True
         wait_for_origin_ready(external["origin_bind"], candidate["git_sha"])
         verify_app_containers(env, candidate["git_sha"], candidate["images"])
         smokes = smoke_origin(external["origin_bind"], candidate["git_sha"])
@@ -1526,6 +1865,7 @@ def execute(
             rollback=release_info["rollback"],
             database_access_performed=database_access_performed,
             env_files_read=env_files_read,
+            env_file_consumed_by_compose=env_file_consumed_by_compose,
         )
         persist_receipt(receipt_directory, receipt, args.candidate)
         return receipt
@@ -1550,8 +1890,20 @@ def execute(
                 commands, rollback_env = rollback_plan(
                     args.compose, args.mode, env, release_info["rollback"]
                 )
+                inspect_network_topology(
+                    "bootstrap-rollback" if args.mode == "bootstrap" else "upgrade",
+                    rollback_env,
+                    runner,
+                )
                 for command in commands:
+                    verify_frozen_env_snapshot(
+                        verified_env_snapshot, verified_env_fingerprint
+                    )
+                    if "up" in command:
+                        compose_recreate_attempted = True
                     runner(command, env=rollback_env)
+                    if "up" in command:
+                        env_file_consumed_by_compose = True
                 if args.mode == "bootstrap":
                     verify_bootstrap_absence(
                         rollback_env, external["origin_bind"], runner
@@ -1584,6 +1936,7 @@ def execute(
             rollback=rollback_outcome,
             database_access_performed=database_access_performed,
             env_files_read=env_files_read,
+            env_file_consumed_by_compose=env_file_consumed_by_compose,
         )
         failure_receipt.update(
             failure=type(original).__name__,
@@ -1603,8 +1956,10 @@ def execute(
             env_files_may_have_been_read=(
                 env_file_read_attempted and not env_files_read
             ),
-            env_file_consumed_by_compose=False,
-            env_file_may_have_been_consumed_by_compose=runtime_validation_started,
+            env_file_consumed_by_compose=env_file_consumed_by_compose,
+            env_file_may_have_been_consumed_by_compose=(
+                compose_recreate_attempted and not env_file_consumed_by_compose
+            ),
         )
         try:
             failure_path = persist_failure_receipt(receipt_directory, failure_receipt)
@@ -1614,6 +1969,11 @@ def execute(
             failure_receipt["receipt_persistence"] = "failed"
         raise OperationFailed(failure_receipt) from original
     finally:
+        remove_env_file_snapshot(
+            verified_env_snapshot,
+            verified_env_fingerprint,
+            verified_env_source_descriptor,
+        )
         release_deployment_lock(deployment_lock)
 
 

--- a/scripts/operator/v3_checkpoint_deploy.py
+++ b/scripts/operator/v3_checkpoint_deploy.py
@@ -1,0 +1,1251 @@
+#!/usr/bin/env python3
+"""Fail-closed, application-only V3 live-checkpoint deployment boundary."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import socket
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_AUTHORITY = ROOT / "deploy/v3-live-checkpoint/target-authority.json"
+DEFAULT_COMPOSE = ROOT / "deploy/v3-live-checkpoint/compose.yml"
+TARGET_SCHEMA = "ed-finder/v3-live-checkpoint-target-authority/v1"
+RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-deployment-receipt/v1"
+CURRENT_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-current-receipt/v1"
+SCHEMA_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-schema-identity/v1"
+PROJECT = "edfinder-v3-checkpoint"
+TARGET_HOSTNAME = "vmi3542235"
+TARGET_FQDN = "vmi3542235.contaboserver.net"
+SERVICES = ("api", "web")
+CONTAINERS = {
+    "api": "edfinder-v3-checkpoint-api",
+    "web": "edfinder-v3-checkpoint-web",
+}
+APP_NETWORK = "edfinder-v3-checkpoint-app"
+RESOURCE_LIMITS = {
+    "api": {"cpus": "1.50", "memory": "1536m", "pids": 256},
+    "web": {"cpus": "0.50", "memory": "512m", "pids": 128},
+}
+RUNNER_SERVICES = {
+    "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker.service",
+    "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-2.service",
+    "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-3.service",
+}
+SHA256 = re.compile(r"sha256:[0-9a-f]{64}\Z")
+RUN_ID = re.compile(r"[1-9][0-9]{0,19}\Z")
+LOOPBACK_ORIGIN = re.compile(r"http://127\.0\.0\.1:([1-9][0-9]{0,4})\Z")
+MAX_JSON_BYTES = 1024 * 1024
+MAX_SMOKE_BYTES = 2 * 1024 * 1024
+
+
+class DeploymentError(ValueError):
+    pass
+
+
+class OperationFailed(DeploymentError):
+    def __init__(self, receipt: dict[str, Any]):
+        super().__init__("deployment operation failed")
+        self.receipt = receipt
+
+
+def load_json(path: Path, description: str) -> dict[str, Any]:
+    try:
+        if path.stat().st_size > MAX_JSON_BYTES:
+            raise DeploymentError(f"{description} exceeds the size limit")
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except DeploymentError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeploymentError(
+            f"unable to read {description}: {type(exc).__name__}"
+        ) from exc
+    if not isinstance(value, dict):
+        raise DeploymentError(f"{description} must be an object")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as exc:
+        raise DeploymentError(
+            f"unable to checksum artifact: {type(exc).__name__}"
+        ) from exc
+    return digest.hexdigest()
+
+
+def verify_checksum(document: Path, checksum: Path) -> str:
+    try:
+        fields = checksum.read_text(encoding="utf-8").strip().split()
+    except OSError as exc:
+        raise DeploymentError(f"unable to read checksum: {type(exc).__name__}") from exc
+    if len(fields) != 2 or fields[1].lstrip("*") != document.name:
+        raise DeploymentError("checksum must name only the adjacent manifest basename")
+    expected = fields[0]
+    if not re.fullmatch(r"[0-9a-f]{64}", expected):
+        raise DeploymentError("checksum is not 64 lowercase hexadecimal characters")
+    if sha256_file(document) != expected:
+        raise DeploymentError("manifest checksum mismatch")
+    return expected
+
+
+def load_manifest_tool() -> Any:
+    path = ROOT / "scripts/release/v3_release_manifest.py"
+    spec = importlib.util.spec_from_file_location("v3_release_manifest", path)
+    if spec is None or spec.loader is None:
+        raise DeploymentError("release manifest verifier is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def validate_authority(authority: dict[str, Any]) -> list[str]:
+    if authority.get("schema_version") != TARGET_SCHEMA:
+        raise DeploymentError("unsupported target authority schema")
+    target = authority.get("target")
+    contract = authority.get("application_contract")
+    external = authority.get("external_authority")
+    if not isinstance(target, dict) or target.get("production") is not False:
+        raise DeploymentError("target must be explicitly non-production")
+    if (
+        target.get("provider") != "contabo"
+        or target.get("classification") != "live-checkpoint"
+    ):
+        raise DeploymentError("unexpected live-checkpoint target")
+    if target.get("hostname") != TARGET_HOSTNAME or target.get("fqdn") != TARGET_FQDN:
+        raise DeploymentError("unexpected Contabo host identity authority")
+    if not isinstance(contract, dict) or contract.get("compose_project") != PROJECT:
+        raise DeploymentError("unexpected Compose project authority")
+    if contract.get("network") != APP_NETWORK or contract.get("named_volumes") != []:
+        raise DeploymentError("checkpoint network/volume authority is invalid")
+    service_contract = contract.get("services")
+    if not isinstance(service_contract, dict) or set(service_contract) != set(SERVICES):
+        raise DeploymentError(
+            "application service allowlist must be exactly api and web"
+        )
+    for service, container in CONTAINERS.items():
+        item = service_contract.get(service)
+        if not isinstance(item, dict) or item.get("container_name") != container:
+            raise DeploymentError(f"unexpected {service} container authority")
+        if {key: item.get(key) for key in RESOURCE_LIMITS[service]} != RESOURCE_LIMITS[
+            service
+        ]:
+            raise DeploymentError(f"unexpected {service} resource limit authority")
+    runtime = authority.get("observed_runtime")
+    if (
+        not isinstance(runtime, dict)
+        or set(runtime.get("runner_services", [])) != RUNNER_SERVICES
+    ):
+        raise DeploymentError("exact three-runner preservation authority is missing")
+    status = authority.get("status")
+    blockers = authority.get("blockers")
+    if status not in {"authorized", "stopped"} or not isinstance(blockers, list):
+        raise DeploymentError("target authority status/blockers are invalid")
+    if status == "stopped":
+        if not blockers or any(
+            not isinstance(item, str) or not item for item in blockers
+        ):
+            raise DeploymentError("stopped target authority requires exact blockers")
+        return sorted(set(blockers))
+    if blockers:
+        raise DeploymentError("authorized target authority cannot retain blockers")
+    runtime_networks = runtime.get("docker_networks")
+    if (
+        not isinstance(runtime.get("container_runtime"), str)
+        or not runtime["container_runtime"].strip()
+        or not isinstance(runtime.get("compose"), str)
+        or not runtime["compose"].strip()
+        or not isinstance(runtime_networks, list)
+        or APP_NETWORK not in runtime_networks
+    ):
+        raise DeploymentError(
+            "authorized target requires proven Docker, Compose and app network facts"
+        )
+    required_external = {
+        "api_env_file",
+        "api_env_owner_uid",
+        "api_env_mode",
+        "database_source_authority",
+        "schema_identity_receipt",
+        "schema_identity_receipt_sha256",
+        "origin_bind",
+        "edge_route_authority",
+        "receipt_directory",
+        "receipt_owner_uid",
+        "receipt_mode",
+        "ghcr_pull_authority",
+        "docker_config_directory",
+        "docker_config_owner_uid",
+        "docker_config_mode",
+        "docker_context",
+    }
+    if not isinstance(external, dict) or set(external) != required_external:
+        raise DeploymentError("external authority fields are incomplete")
+    integer_authorities = {
+        "api_env_owner_uid",
+        "receipt_owner_uid",
+        "docker_config_owner_uid",
+    }
+    string_authorities = required_external - integer_authorities
+    if any(
+        not isinstance(external[key], str) or not external[key].strip()
+        for key in string_authorities
+    ) or any(
+        not isinstance(external[key], int) or external[key] < 0
+        for key in integer_authorities
+    ):
+        raise DeploymentError("every external deployment authority must be explicit")
+    for key in ("api_env_mode", "receipt_mode", "docker_config_mode"):
+        if not re.fullmatch(r"0[0-7]{3}", external[key]):
+            raise DeploymentError(
+                "external file modes must be four-digit octal strings"
+            )
+    if not re.fullmatch(r"[0-9a-f]{64}", external["schema_identity_receipt_sha256"]):
+        raise DeploymentError("schema identity receipt checksum authority is invalid")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]{1,64}", external["docker_context"]):
+        raise DeploymentError("Docker context authority is invalid")
+    match = LOOPBACK_ORIGIN.fullmatch(external["origin_bind"])
+    if match is None or int(match.group(1)) > 65535:
+        raise DeploymentError("origin authority must be an exact loopback HTTP origin")
+    return []
+
+
+def stopped_receipt(authority: dict[str, Any], failures: list[str]) -> dict[str, Any]:
+    target = (
+        authority.get("target") if isinstance(authority.get("target"), dict) else {}
+    )
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "operation": "v3-application-live-checkpoint-deploy",
+        "status": "stopped",
+        "target": {
+            "provider": target.get("provider", "unknown"),
+            "classification": target.get("classification", "live-checkpoint"),
+            "production": False,
+            "hostname": target.get("hostname", "unknown"),
+        },
+        "failures": sorted(set(failures)),
+        "authorized_recreate_targets": list(SERVICES),
+        "changed_resources": [],
+        "database_access_performed": False,
+        "migrations_performed": False,
+        "service_changes_performed": False,
+        "image_pulls_performed": False,
+        "filesystem_writes_performed": False,
+        "env_files_read": False,
+        "private_keys_read": False,
+    }
+
+
+def validate_release_inputs(
+    *,
+    mode: str,
+    candidate_path: Path,
+    candidate_checksum: Path,
+    current_schema_path: Path,
+    database_source_authority: str,
+    rollback_path: Path | None,
+    rollback_checksum: Path | None,
+    prior_receipt_path: Path | None,
+    rollback_run_id: str | None = None,
+) -> dict[str, Any]:
+    manifest_tool = load_manifest_tool()
+    candidate_sum = verify_checksum(candidate_path, candidate_checksum)
+    candidate = load_json(candidate_path, "candidate manifest")
+    schema_receipt = load_json(current_schema_path, "schema identity receipt")
+    if (
+        set(schema_receipt)
+        != {
+            "schema_version",
+            "database_source_authority",
+            "migration_set_identity",
+            "captured_at",
+        }
+        or schema_receipt.get("schema_version") != SCHEMA_RECEIPT_SCHEMA
+    ):
+        raise DeploymentError("unsupported schema identity receipt")
+    if schema_receipt.get("database_source_authority") != database_source_authority:
+        raise DeploymentError("schema receipt does not match database source authority")
+    captured_at = schema_receipt.get("captured_at")
+    try:
+        if not isinstance(captured_at, str):
+            raise ValueError
+        datetime.strptime(captured_at, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        raise DeploymentError("schema identity receipt timestamp is invalid")
+    current_schema = schema_receipt.get("migration_set_identity")
+    if not isinstance(current_schema, str) or not SHA256.fullmatch(current_schema):
+        raise DeploymentError("schema identity receipt has no valid migration identity")
+    try:
+        manifest_tool.validate_manifest(
+            candidate, purpose="deploy", current_migration_set=current_schema
+        )
+    except manifest_tool.ManifestError as exc:
+        raise DeploymentError(f"candidate manifest rejected: {exc}") from exc
+    if candidate.get("rollback", {}).get("application_only_eligible") is not True:
+        raise DeploymentError(
+            "candidate must be eligible as the receipt-backed next rollback release"
+        )
+
+    if mode == "bootstrap":
+        if any(
+            value is not None
+            for value in (rollback_path, rollback_checksum, prior_receipt_path)
+        ):
+            raise DeploymentError("bootstrap must not claim a prior release or receipt")
+        rollback_identity: dict[str, Any] = {"kind": "predeploy_absence"}
+    else:
+        if (
+            rollback_path is None
+            or rollback_checksum is None
+            or prior_receipt_path is None
+        ):
+            raise DeploymentError(
+                "upgrade requires a prior manifest, checksum and durable receipt"
+            )
+        rollback_sum = verify_checksum(rollback_path, rollback_checksum)
+        rollback = load_json(rollback_path, "rollback manifest")
+        prior = load_json(prior_receipt_path, "prior deployment receipt")
+        prior_target = prior.get("target")
+        prior_smoke = prior.get("smoke")
+        if (
+            prior.get("schema_version") != RECEIPT_SCHEMA
+            or prior.get("mode") not in {"bootstrap", "upgrade"}
+            or not isinstance(prior_target, dict)
+            or prior_target.get("production") is not False
+            or prior_target.get("provider") != "contabo"
+            or prior_target.get("classification") != "live-checkpoint"
+            or prior_target.get("hostname") != TARGET_HOSTNAME
+            or prior.get("compose_project") != PROJECT
+            or prior.get("migration_set_identity") != current_schema
+            or prior.get("changed_resources")
+            != [CONTAINERS[service] for service in SERVICES]
+            or not isinstance(prior_smoke, dict)
+            or set(prior_smoke)
+            != {"/", "/api/health", "/openapi.json", "/api/auth/session"}
+            or any(
+                not isinstance(outcome, dict)
+                or not 200 <= outcome.get("status", 0) < 300
+                for outcome in prior_smoke.values()
+            )
+            or prior.get("database_mutation_performed") is not False
+            or prior.get("infrastructure_changes_performed") is not False
+        ):
+            raise DeploymentError("prior deployment receipt target/schema is invalid")
+        try:
+            manifest_tool.validate_manifest(
+                rollback, purpose="rollback", current_migration_set=current_schema
+            )
+        except manifest_tool.ManifestError as exc:
+            raise DeploymentError(f"rollback manifest rejected: {exc}") from exc
+        if candidate.get("git_sha") == rollback.get("git_sha"):
+            raise DeploymentError("candidate cannot be its own rollback")
+        expected_prior = {
+            "status": "accepted",
+            "source_sha": rollback.get("git_sha"),
+            "images": rollback.get("images"),
+            "manifest_sha256": rollback_sum,
+        }
+        if rollback_run_id is not None:
+            if not RUN_ID.fullmatch(rollback_run_id):
+                raise DeploymentError("rollback release run ID is invalid")
+            expected_prior["release_run_id"] = rollback_run_id
+        if any(prior.get(key) != value for key, value in expected_prior.items()):
+            raise DeploymentError(
+                "prior receipt does not authenticate the rollback release"
+            )
+        rollback_identity = {
+            "kind": "accepted_release",
+            "source_sha": rollback["git_sha"],
+            "images": rollback["images"],
+            "manifest_sha256": rollback_sum,
+        }
+        if rollback_run_id is not None:
+            rollback_identity["release_run_id"] = rollback_run_id
+    return {
+        "candidate": candidate,
+        "candidate_sha256": candidate_sum,
+        "current_schema": current_schema,
+        "rollback": rollback_identity,
+    }
+
+
+def compose_environment(
+    authority: dict[str, Any], release: dict[str, Any]
+) -> dict[str, str]:
+    external = authority["external_authority"]
+    match = LOOPBACK_ORIGIN.fullmatch(external["origin_bind"])
+    assert match is not None
+    return {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "DOCKER_CONFIG": external["docker_config_directory"],
+        "DOCKER_CONTEXT": external["docker_context"],
+        "COMPOSE_PROJECT_NAME": PROJECT,
+        "V3_CHECKPOINT_API_IMAGE": release["images"]["backend"],
+        "V3_CHECKPOINT_WEB_IMAGE": release["images"]["web"],
+        "V3_CHECKPOINT_SOURCE_SHA": release["git_sha"],
+        "V3_CHECKPOINT_API_ENV_FILE": external["api_env_file"],
+        "V3_CHECKPOINT_ORIGIN_BIND": f"127.0.0.1:{match.group(1)}",
+    }
+
+
+def command_plan(compose_path: Path, env: dict[str, str]) -> list[list[str]]:
+    base = ["docker", "compose", "--project-name", PROJECT, "--file", str(compose_path)]
+    return [
+        ["docker", "pull", env["V3_CHECKPOINT_API_IMAGE"]],
+        ["docker", "pull", env["V3_CHECKPOINT_WEB_IMAGE"]],
+        [
+            *base,
+            "up",
+            "--detach",
+            "--no-deps",
+            "--force-recreate",
+            "--pull",
+            "never",
+            *SERVICES,
+        ],
+    ]
+
+
+def rollback_plan(
+    compose_path: Path,
+    mode: str,
+    env: dict[str, str],
+    rollback: dict[str, Any],
+) -> tuple[list[list[str]], dict[str, str]]:
+    base = ["docker", "compose", "--project-name", PROJECT, "--file", str(compose_path)]
+    if mode == "bootstrap":
+        return [
+            [*base, "stop", *SERVICES],
+            [*base, "rm", "--force", "--stop", *SERVICES],
+        ], env
+    prior_env = {
+        **env,
+        "V3_CHECKPOINT_API_IMAGE": rollback["images"]["backend"],
+        "V3_CHECKPOINT_WEB_IMAGE": rollback["images"]["web"],
+        "V3_CHECKPOINT_SOURCE_SHA": rollback["source_sha"],
+    }
+    return command_plan(compose_path, prior_env), prior_env
+
+
+def run_command(
+    argv: list[str], *, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            argv,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DeploymentError(f"command unavailable or timed out: {argv[0]}") from exc
+    if result.returncode != 0:
+        raise DeploymentError(f"bounded command failed: {argv[0]} {argv[1]}")
+    return result
+
+
+def validate_host_files(authority: dict[str, Any], compose_path: Path) -> None:
+    target = authority["target"]
+    if socket.gethostname().split(".")[0] != target["hostname"]:
+        raise DeploymentError("host short identity does not match authority")
+    if socket.getfqdn() != target["fqdn"]:
+        raise DeploymentError("host FQDN does not match authority")
+    if os.uname().machine != target["architecture"]:
+        raise DeploymentError("host architecture does not match release platform")
+    observed_capacity = authority.get("observed_capacity")
+    if not isinstance(observed_capacity, dict):
+        raise DeploymentError("audited host capacity is missing")
+    if (os.cpu_count() or 0) < observed_capacity.get("logical_cpus", 0):
+        raise DeploymentError(
+            "host CPU capacity is below the audited checkpoint baseline"
+        )
+    try:
+        memory_facts = {
+            line.split(":", 1)[0]: int(line.split()[1])
+            for line in Path("/proc/meminfo").read_text(encoding="utf-8").splitlines()
+            if line.startswith(("MemTotal:", "MemAvailable:"))
+        }
+        memory_total = memory_facts["MemTotal"]
+        memory_available = memory_facts["MemAvailable"]
+    except (OSError, KeyError, ValueError) as exc:
+        raise DeploymentError("unable to verify host memory capacity") from exc
+    if memory_total < observed_capacity.get("memory_total_kib", 0):
+        raise DeploymentError("host memory is below the audited checkpoint baseline")
+    app_memory_limit_kib = (1536 + 512) * 1024
+    if memory_available < app_memory_limit_kib:
+        raise DeploymentError("host cannot currently satisfy checkpoint memory limits")
+    external = authority["external_authority"]
+    api_env = Path(external["api_env_file"])
+    if not api_env.is_absolute() or not api_env.is_file() or api_env.is_symlink():
+        raise DeploymentError("authorized api_env_file is missing or unsafe")
+    api_stat = api_env.stat()
+    if (
+        api_stat.st_uid != external["api_env_owner_uid"]
+        or stat.filemode(api_stat.st_mode)[-9:]
+        != stat.filemode(int(external["api_env_mode"], 8))[-9:]
+    ):
+        raise DeploymentError("authorized api_env_file ownership/mode mismatch")
+    schema_path = Path(external["schema_identity_receipt"])
+    if (
+        not schema_path.is_absolute()
+        or not schema_path.is_file()
+        or schema_path.is_symlink()
+    ):
+        raise DeploymentError("authorized schema_identity_receipt is missing or unsafe")
+    if sha256_file(schema_path) != external["schema_identity_receipt_sha256"]:
+        raise DeploymentError("schema identity receipt checksum mismatch")
+    receipt_dir = Path(external["receipt_directory"])
+    if (
+        not receipt_dir.is_absolute()
+        or not receipt_dir.is_dir()
+        or receipt_dir.is_symlink()
+    ):
+        raise DeploymentError("durable receipt directory is missing")
+    receipt_stat = receipt_dir.stat()
+    if (
+        receipt_stat.st_uid != external["receipt_owner_uid"]
+        or stat.filemode(receipt_stat.st_mode)[-9:]
+        != stat.filemode(int(external["receipt_mode"], 8))[-9:]
+    ):
+        raise DeploymentError("durable receipt directory ownership/mode mismatch")
+    docker_config = Path(external["docker_config_directory"])
+    if (
+        not docker_config.is_absolute()
+        or not docker_config.is_dir()
+        or docker_config.is_symlink()
+    ):
+        raise DeploymentError("authorized Docker config directory is missing or unsafe")
+    docker_stat = docker_config.stat()
+    if (
+        docker_stat.st_uid != external["docker_config_owner_uid"]
+        or stat.filemode(docker_stat.st_mode)[-9:]
+        != stat.filemode(int(external["docker_config_mode"], 8))[-9:]
+    ):
+        raise DeploymentError("authorized Docker config ownership/mode mismatch")
+    if not compose_path.is_file():
+        raise DeploymentError("reviewed Compose file is missing")
+    if sha256_file(compose_path) != authority["application_contract"].get(
+        "compose_sha256"
+    ):
+        raise DeploymentError("reviewed Compose checksum does not match authority")
+
+
+def validate_host_runtime(
+    compose_path: Path,
+    env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]] = run_command,
+) -> None:
+    runner(["docker", "compose", "version"], env=env)
+    compose_base = [
+        "docker",
+        "compose",
+        "--project-name",
+        PROJECT,
+        "--file",
+        str(compose_path),
+        "config",
+    ]
+    rendered_services = runner([*compose_base, "--services"], env=env)
+    if set(rendered_services.stdout.split()) != set(SERVICES):
+        raise DeploymentError("rendered Compose service allowlist is invalid")
+    rendered_volumes = runner([*compose_base, "--volumes"], env=env)
+    if rendered_volumes.stdout.strip():
+        raise DeploymentError("rendered Compose unexpectedly manages volumes")
+    rendered_images = runner([*compose_base, "--images"], env=env)
+    expected_images = {
+        env["V3_CHECKPOINT_API_IMAGE"],
+        env["V3_CHECKPOINT_WEB_IMAGE"],
+    }
+    if set(rendered_images.stdout.split()) != expected_images:
+        raise DeploymentError("rendered Compose images are not exact release digests")
+    runner(["docker", "network", "inspect", APP_NETWORK], env=env)
+    active_runners = runner(
+        [
+            "systemctl",
+            "list-units",
+            "--type=service",
+            "--state=active",
+            "--plain",
+            "--no-legend",
+            "actions.runner.*.service",
+        ],
+        env=env,
+    )
+    active_runner_names = {
+        line.split()[0]
+        for line in active_runners.stdout.splitlines()
+        if line.strip().startswith("actions.runner.")
+    }
+    if active_runner_names != RUNNER_SERVICES:
+        raise DeploymentError("active runner topology differs from exact authority")
+    for service in sorted(RUNNER_SERVICES):
+        runner(["systemctl", "is-active", "--quiet", service], env=env)
+    project_containers = runner(
+        [
+            "docker",
+            "ps",
+            "--all",
+            "--filter",
+            f"label=com.docker.compose.project={PROJECT}",
+            "--format",
+            "{{.Names}}",
+        ],
+        env=env,
+    )
+    names = {
+        line.strip() for line in project_containers.stdout.splitlines() if line.strip()
+    }
+    if not names.issubset(set(CONTAINERS.values())):
+        raise DeploymentError("target project contains a non-allowlisted resource")
+    project_volumes = runner(
+        [
+            "docker",
+            "volume",
+            "ls",
+            "--filter",
+            f"label=com.docker.compose.project={PROJECT}",
+            "--format",
+            "{{.Name}}",
+        ],
+        env=env,
+    )
+    if project_volumes.stdout.strip():
+        raise DeploymentError("target project contains a managed volume")
+
+
+def verify_pulled_image(
+    image: str,
+    source_sha: str,
+    env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    result = runner(
+        [
+            "docker",
+            "image",
+            "inspect",
+            image,
+            "--format",
+            '{{json .RepoDigests}}|{{index .Config.Labels "org.opencontainers.image.revision"}}',
+        ],
+        env=env,
+    )
+    repo_digests, separator, revision = result.stdout.strip().partition("|")
+    try:
+        digests = json.loads(repo_digests)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("pulled image digest inspection is invalid") from exc
+    if not separator or image not in digests or revision != source_sha:
+        raise DeploymentError("pulled image digest/build identity mismatch")
+
+
+def inspect_container(container: str, env: dict[str, str]) -> dict[str, Any] | None:
+    try:
+        result = subprocess.run(
+            ["docker", "container", "inspect", container],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DeploymentError("unable to inspect allowlisted app container") from exc
+    if result.returncode != 0:
+        return None
+    try:
+        documents = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("container inspection returned invalid JSON") from exc
+    if not isinstance(documents, list) or len(documents) != 1:
+        raise DeploymentError("container inspection returned an invalid result")
+    return documents[0]
+
+
+def verify_origin_state(origin: str, mode: str) -> None:
+    match = LOOPBACK_ORIGIN.fullmatch(origin)
+    if match is None:
+        raise DeploymentError("origin authority is invalid")
+    port = int(match.group(1))
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.settimeout(1)
+    try:
+        if mode == "bootstrap":
+            try:
+                probe.bind(("127.0.0.1", port))
+            except OSError as exc:
+                raise DeploymentError(
+                    "bootstrap origin listener is already occupied"
+                ) from exc
+        elif probe.connect_ex(("127.0.0.1", port)) != 0:
+            raise DeploymentError("upgrade origin listener is not reachable")
+    finally:
+        probe.close()
+
+
+def verify_app_containers(
+    env: dict[str, str], source_sha: str, expected_images: dict[str, str]
+) -> None:
+    for service, container in CONTAINERS.items():
+        document = inspect_container(container, env)
+        role = "backend" if service == "api" else "web"
+        if (
+            document is None
+            or document.get("Config", {}).get("Image") != expected_images[role]
+        ):
+            raise DeploymentError("running app container image identity mismatch")
+        if (
+            document.get("Config", {})
+            .get("Labels", {})
+            .get("org.opencontainers.image.revision")
+            != source_sha
+        ):
+            raise DeploymentError("running app container build identity mismatch")
+        labels = document.get("Config", {}).get("Labels", {})
+        if (
+            labels.get("com.docker.compose.project") != PROJECT
+            or labels.get("com.docker.compose.service") != service
+        ):
+            raise DeploymentError("running app container Compose identity mismatch")
+        if document.get("State", {}).get("Running") is not True:
+            raise DeploymentError("allowlisted app container is not running")
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self,
+        req: Any,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def get_origin(origin: str, path: str) -> tuple[int, bytes, str]:
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirect)
+    request = urllib.request.Request(
+        origin + path, headers={"Accept": "application/json,text/html"}
+    )
+    try:
+        with opener.open(request, timeout=10) as response:
+            body = response.read(MAX_SMOKE_BYTES + 1)
+            status = response.status
+            content_type = response.headers.get("Content-Type", "")
+    except (OSError, urllib.error.URLError) as exc:
+        raise DeploymentError(f"origin smoke failed for {path}") from exc
+    if not 200 <= status < 300 or len(body) > MAX_SMOKE_BYTES:
+        raise DeploymentError(f"origin smoke rejected for {path}")
+    return status, body, content_type
+
+
+def smoke_origin(origin: str, source_sha: str) -> dict[str, Any]:
+    outcomes: dict[str, Any] = {}
+    for path in ("/", "/api/health", "/openapi.json", "/api/auth/session"):
+        status, body, content_type = get_origin(origin, path)
+        outcomes[path] = {"status": status, "bytes": len(body)}
+        if path == "/":
+            if "text/html" not in content_type.lower() or b"<html" not in body.lower():
+                raise DeploymentError("root smoke is not the Svelte HTML application")
+            continue
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise DeploymentError(f"origin smoke JSON is invalid for {path}") from exc
+        if not isinstance(payload, dict):
+            raise DeploymentError(f"origin smoke payload is invalid for {path}")
+        if path == "/api/health" and not (
+            payload.get("status") == "ok"
+            and payload.get("database") == "connected"
+            and payload.get("build_sha") == source_sha
+        ):
+            raise DeploymentError("health smoke build/database identity mismatch")
+        if path == "/openapi.json" and not (
+            isinstance(payload.get("paths"), dict)
+            and "/api/health" in payload["paths"]
+            and "/api/auth/session" in payload["paths"]
+        ):
+            raise DeploymentError("OpenAPI smoke lacks required route identity")
+        if path == "/api/auth/session" and payload.get("authenticated") is not False:
+            raise DeploymentError("anonymous session smoke is not anonymous")
+    return outcomes
+
+
+def persist_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
+    data = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode()
+    identity = (
+        f"{receipt['source_sha']}-{receipt['release_run_id']}-"
+        f"{receipt['manifest_sha256']}"
+    )
+    final = directory / f"{identity}.json"
+    checksum = directory / f"{identity}.json.sha256"
+    if final.exists() or checksum.exists():
+        raise OSError("immutable deployment receipt identity already exists")
+    digest = hashlib.sha256(data).hexdigest()
+    checksum_data = f"{digest}  {final.name}\n".encode()
+    pointer_data = (
+        json.dumps(
+            {
+                "schema_version": CURRENT_RECEIPT_SCHEMA,
+                "receipt_file": final.name,
+                "receipt_sha256": digest,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+    current = directory / "current.json"
+    if current.is_symlink():
+        raise OSError("current deployment receipt pointer is unsafe")
+    previous_current = current.read_bytes() if current.exists() else None
+    directory_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    temporaries: list[Path] = []
+    final_created = False
+    checksum_created = False
+    current_replaced = False
+
+    def staged(data_to_write: bytes, prefix: str) -> Path:
+        with tempfile.NamedTemporaryFile(
+            dir=directory, prefix=prefix, delete=False
+        ) as handle:
+            path = Path(handle.name)
+            temporaries.append(path)
+            handle.write(data_to_write)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return path
+
+    try:
+        receipt_temporary = staged(data, ".v3-receipt-")
+        checksum_temporary = staged(checksum_data, ".v3-checksum-")
+        current_temporary = staged(pointer_data, ".v3-current-")
+        os.replace(receipt_temporary, final)
+        temporaries.remove(receipt_temporary)
+        final_created = True
+        os.replace(checksum_temporary, checksum)
+        temporaries.remove(checksum_temporary)
+        checksum_created = True
+        os.fsync(directory_fd)
+        os.replace(current_temporary, current)
+        temporaries.remove(current_temporary)
+        current_replaced = True
+        os.fsync(directory_fd)
+        return final
+    except OSError:
+        # current.json is the acceptance commit point. Restore its previous
+        # state and remove incomplete immutable artifacts before app rollback.
+        if current_replaced:
+            if previous_current is None:
+                current.unlink(missing_ok=True)
+            else:
+                restore_temporary = staged(previous_current, ".v3-current-restore-")
+                os.replace(restore_temporary, current)
+                temporaries.remove(restore_temporary)
+        if checksum_created:
+            checksum.unlink(missing_ok=True)
+        if final_created:
+            final.unlink(missing_ok=True)
+        os.fsync(directory_fd)
+        raise
+    finally:
+        for temporary in temporaries:
+            temporary.unlink(missing_ok=True)
+        os.close(directory_fd)
+
+
+def persist_failure_receipt(directory: Path, receipt: dict[str, Any]) -> Path:
+    data = (json.dumps(receipt, indent=2, sort_keys=True) + "\n").encode()
+    attempt = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    identity = (
+        f"failed-{receipt['source_sha']}-{receipt['release_run_id']}-"
+        f"{receipt['manifest_sha256']}-{attempt}"
+    )
+    final = directory / f"{identity}.json"
+    if final.exists():
+        raise OSError("immutable failure receipt identity already exists")
+    directory_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=directory, prefix=".v3-failure-", delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, final)
+        temporary = None
+        os.fsync(directory_fd)
+        return final
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        os.close(directory_fd)
+
+
+def load_current_receipt(directory: Path) -> Path:
+    pointer = load_json(
+        directory / "current.json", "current deployment receipt pointer"
+    )
+    if set(pointer) != {"schema_version", "receipt_file", "receipt_sha256"}:
+        raise DeploymentError("current deployment receipt pointer shape is invalid")
+    if pointer.get("schema_version") != CURRENT_RECEIPT_SCHEMA:
+        raise DeploymentError("current deployment receipt pointer schema is invalid")
+    receipt_file = pointer.get("receipt_file")
+    receipt_sha = pointer.get("receipt_sha256")
+    if not isinstance(receipt_file, str) or not re.fullmatch(
+        r"[0-9a-f]{40}-[1-9][0-9]{0,19}-[0-9a-f]{64}\.json", receipt_file
+    ):
+        raise DeploymentError("current deployment receipt filename is invalid")
+    if not isinstance(receipt_sha, str) or not re.fullmatch(
+        r"[0-9a-f]{64}", receipt_sha
+    ):
+        raise DeploymentError("current deployment receipt checksum is invalid")
+    receipt_path = directory / receipt_file
+    if not receipt_path.is_file() or receipt_path.is_symlink():
+        raise DeploymentError("current deployment receipt is missing or unsafe")
+    if sha256_file(receipt_path) != receipt_sha:
+        raise DeploymentError("current deployment receipt checksum mismatch")
+    if verify_checksum(receipt_path, Path(f"{receipt_path}.sha256")) != receipt_sha:
+        raise DeploymentError("current deployment receipt sidecar mismatch")
+    return receipt_path
+
+
+def acquire_deployment_lock(directory: Path) -> Any:
+    try:
+        handle = (directory / "deploy.lock").open("a+", encoding="utf-8")
+        os.fchmod(handle.fileno(), 0o600)
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (OSError, BlockingIOError) as exc:
+        try:
+            handle.close()
+        except UnboundLocalError:
+            pass
+        raise DeploymentError("live-checkpoint deployment lock is unavailable") from exc
+    return handle
+
+
+def release_deployment_lock(handle: Any) -> None:
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
+
+
+def verify_bootstrap_absence(
+    env: dict[str, str],
+    origin: str,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    for container in CONTAINERS.values():
+        listed = runner(
+            [
+                "docker",
+                "ps",
+                "--all",
+                "--filter",
+                f"name=^/{container}$",
+                "--format",
+                "{{.Names}}",
+            ],
+            env=env,
+        )
+        if listed.stdout.strip():
+            raise DeploymentError("bootstrap requires proven predeploy app absence")
+    verify_origin_state(origin, "bootstrap")
+
+
+def operation_receipt(
+    *,
+    authority: dict[str, Any],
+    args: argparse.Namespace,
+    release_info: dict[str, Any],
+    status: str,
+    changed_resources: list[str],
+    smokes: dict[str, Any],
+    rollback: dict[str, Any],
+) -> dict[str, Any]:
+    candidate = release_info["candidate"]
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "status": status,
+        "mode": args.mode,
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_sha": candidate["git_sha"],
+        "release_run_id": args.candidate_run_id,
+        "images": candidate["images"],
+        "manifest_sha256": release_info["candidate_sha256"],
+        "migration_set_identity": release_info["current_schema"],
+        "target": {
+            "provider": "contabo",
+            "classification": "live-checkpoint",
+            "production": False,
+            "hostname": authority["target"]["hostname"],
+        },
+        "compose_project": PROJECT,
+        "changed_resources": changed_resources,
+        "smoke": smokes,
+        "rollback": rollback,
+        "database_access_performed": status == "accepted",
+        "database_mutation_performed": False,
+        "migrations_performed": False,
+        "infrastructure_changes_performed": False,
+        "service_changes_performed": status == "accepted",
+        "image_pulls_performed": status == "accepted",
+        "filesystem_writes_performed": True,
+        "env_file_consumed_by_compose": status == "accepted",
+        "private_keys_read": False,
+    }
+
+
+def execute(
+    args: argparse.Namespace,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = run_command,
+) -> dict[str, Any]:
+    authority = load_json(args.authority, "target authority")
+    blockers = validate_authority(authority)
+    if blockers:
+        raise DeploymentError("target authority stopped: " + ",".join(blockers))
+    external = authority["external_authority"]
+    if args.candidate_run_id is None or not RUN_ID.fullmatch(args.candidate_run_id):
+        raise DeploymentError("candidate release run ID is required")
+    if args.mode == "bootstrap" and args.rollback_run_id is not None:
+        raise DeploymentError("bootstrap must not claim a rollback release run")
+    if args.mode == "upgrade" and (
+        args.rollback_run_id is None or not RUN_ID.fullmatch(args.rollback_run_id)
+    ):
+        raise DeploymentError("upgrade requires a rollback release run ID")
+    receipt_directory = Path(external["receipt_directory"])
+    validate_host_files(authority, args.compose)
+    deployment_lock = acquire_deployment_lock(receipt_directory)
+    release_info: dict[str, Any] | None = None
+    image_pull_attempted = False
+    pulled_images: list[str] = []
+    service_mutation_attempted = False
+    runtime_validation_started = False
+    smokes: dict[str, Any] = {}
+    try:
+        prior_receipt_path = (
+            load_current_receipt(receipt_directory) if args.mode == "upgrade" else None
+        )
+        release_info = validate_release_inputs(
+            mode=args.mode,
+            candidate_path=args.candidate,
+            candidate_checksum=args.candidate_checksum,
+            current_schema_path=Path(external["schema_identity_receipt"]),
+            database_source_authority=external["database_source_authority"],
+            rollback_path=args.rollback,
+            rollback_checksum=args.rollback_checksum,
+            prior_receipt_path=prior_receipt_path,
+            rollback_run_id=args.rollback_run_id,
+        )
+        candidate = release_info["candidate"]
+        env = compose_environment(authority, candidate)
+        runtime_validation_started = True
+        validate_host_runtime(args.compose, env, runner)
+        if args.mode == "bootstrap":
+            if (receipt_directory / "current.json").exists():
+                raise DeploymentError("bootstrap requires proven prior receipt absence")
+            verify_bootstrap_absence(env, external["origin_bind"], runner)
+        else:
+            rollback = release_info["rollback"]
+            verify_app_containers(env, rollback["source_sha"], rollback["images"])
+            smoke_origin(external["origin_bind"], rollback["source_sha"])
+            verify_origin_state(external["origin_bind"], "upgrade")
+
+        plan = command_plan(args.compose, env)
+        for command in plan[:2]:
+            image_pull_attempted = True
+            runner(command, env=env)
+            verify_pulled_image(command[-1], candidate["git_sha"], env, runner)
+            pulled_images.append(command[-1])
+        if args.mode == "upgrade":
+            rollback = release_info["rollback"]
+            for image in rollback["images"].values():
+                image_pull_attempted = True
+                runner(["docker", "pull", image], env=env)
+                verify_pulled_image(image, rollback["source_sha"], env, runner)
+                pulled_images.append(image)
+        service_mutation_attempted = True
+        runner(plan[2], env=env)
+        verify_app_containers(env, candidate["git_sha"], candidate["images"])
+        smokes = smoke_origin(external["origin_bind"], candidate["git_sha"])
+        receipt = operation_receipt(
+            authority=authority,
+            args=args,
+            release_info=release_info,
+            status="accepted",
+            changed_resources=[CONTAINERS[service] for service in SERVICES],
+            smokes=smokes,
+            rollback=release_info["rollback"],
+        )
+        persist_receipt(receipt_directory, receipt)
+        return receipt
+    except Exception as original:
+        # A failure before release validation has no authenticated candidate
+        # identity, but the lock file write still has to be reported truthfully.
+        if release_info is None:
+            failure_receipt = stopped_receipt(authority, [type(original).__name__])
+            failure_receipt.update(
+                filesystem_writes_performed=True,
+                deployment_lock_acquired=True,
+            )
+            raise OperationFailed(failure_receipt) from original
+        rollback_outcome: dict[str, Any] = {
+            "identity": release_info["rollback"],
+            "attempted": False,
+            "status": "not-required",
+        }
+        if service_mutation_attempted:
+            rollback_outcome.update(attempted=True, status="started")
+            try:
+                commands, rollback_env = rollback_plan(
+                    args.compose, args.mode, env, release_info["rollback"]
+                )
+                for command in commands:
+                    runner(command, env=rollback_env)
+                if args.mode == "bootstrap":
+                    verify_bootstrap_absence(
+                        rollback_env, external["origin_bind"], runner
+                    )
+                else:
+                    rollback = release_info["rollback"]
+                    verify_app_containers(
+                        rollback_env, rollback["source_sha"], rollback["images"]
+                    )
+                    smoke_origin(external["origin_bind"], rollback["source_sha"])
+                rollback_outcome["status"] = "verified"
+            except Exception as rollback_error:
+                rollback_outcome.update(
+                    status="failed", failure=type(rollback_error).__name__
+                )
+        failure_receipt = operation_receipt(
+            authority=authority,
+            args=args,
+            release_info=release_info,
+            status="failed",
+            changed_resources=(
+                [CONTAINERS[service] for service in SERVICES]
+                if service_mutation_attempted
+                else []
+            ),
+            smokes=smokes,
+            rollback=rollback_outcome,
+        )
+        failure_receipt.update(
+            failure=type(original).__name__,
+            image_pull_attempted=image_pull_attempted,
+            image_pulls_performed=(
+                True if pulled_images else None if image_pull_attempted else False
+            ),
+            image_pulls_may_have_been_performed=image_pull_attempted,
+            pulled_images_verified=pulled_images,
+            service_mutation_attempted=service_mutation_attempted,
+            service_changes_performed=service_mutation_attempted,
+            database_access_may_have_been_performed=service_mutation_attempted,
+            env_file_consumed_by_compose=False,
+            env_file_may_have_been_consumed_by_compose=runtime_validation_started,
+        )
+        try:
+            failure_path = persist_failure_receipt(receipt_directory, failure_receipt)
+            failure_receipt["durable_failure_receipt"] = failure_path.name
+        except OSError:
+            failure_receipt["durable_failure_receipt"] = None
+            failure_receipt["receipt_persistence"] = "failed"
+        raise OperationFailed(failure_receipt) from original
+    finally:
+        release_deployment_lock(deployment_lock)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    result.add_argument("--authority", type=Path, default=DEFAULT_AUTHORITY)
+    result.add_argument("--compose", type=Path, default=DEFAULT_COMPOSE)
+    result.add_argument("--mode", choices=("bootstrap", "upgrade"), default="bootstrap")
+    result.add_argument("--candidate", type=Path)
+    result.add_argument("--candidate-checksum", type=Path)
+    result.add_argument("--candidate-run-id")
+    result.add_argument("--rollback", type=Path)
+    result.add_argument("--rollback-checksum", type=Path)
+    result.add_argument("--rollback-run-id")
+    result.add_argument("--authority-gate", action="store_true")
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    authority: dict[str, Any] = {}
+    try:
+        authority = load_json(args.authority, "target authority")
+        blockers = validate_authority(authority)
+        if blockers:
+            print(json.dumps(stopped_receipt(authority, blockers), sort_keys=True))
+            return 78
+        if args.authority_gate:
+            print(
+                json.dumps(
+                    {
+                        "schema_version": RECEIPT_SCHEMA,
+                        "status": "authority-verified",
+                        "target": authority["target"],
+                        "service_changes_performed": False,
+                        "filesystem_writes_performed": False,
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.candidate is None or args.candidate_checksum is None:
+            raise DeploymentError("candidate manifest and checksum are required")
+        receipt = execute(args)
+    except OperationFailed as exc:
+        print(json.dumps(exc.receipt, sort_keys=True), file=sys.stdout)
+        return 78
+    except DeploymentError as exc:
+        print(
+            json.dumps(stopped_receipt(authority, [str(exc)]), sort_keys=True),
+            file=sys.stdout,
+        )
+        return 78
+    except Exception as exc:
+        print(
+            json.dumps(
+                stopped_receipt(authority, [f"internal_failure:{type(exc).__name__}"]),
+                sort_keys=True,
+            ),
+            file=sys.stdout,
+        )
+        return 78
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operator/v3_checkpoint_deploy.py
+++ b/scripts/operator/v3_checkpoint_deploy.py
@@ -33,6 +33,7 @@ RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-deployment-receipt/v1"
 CURRENT_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-current-receipt/v2"
 SCHEMA_RECEIPT_SCHEMA = "ed-finder/v3-live-checkpoint-schema-identity/v2"
 PROJECT = "edfinder-v3-checkpoint"
+LOCAL_DOCKER_ENDPOINT = "unix:///var/run/docker.sock"
 TARGET_HOSTNAME = "vmi3542235"
 TARGET_FQDN = "vmi3542235.contaboserver.net"
 SERVICES = ("api", "web")
@@ -684,7 +685,18 @@ def rollback_plan(
         "V3_CHECKPOINT_WEB_IMAGE": rollback["images"]["web"],
         "V3_CHECKPOINT_SOURCE_SHA": rollback["source_sha"],
     }
-    return command_plan(compose_path, prior_env), prior_env
+    return [
+        [
+            *base,
+            "up",
+            "--detach",
+            "--no-deps",
+            "--force-recreate",
+            "--pull",
+            "never",
+            *SERVICES,
+        ]
+    ], prior_env
 
 
 def run_command(
@@ -798,6 +810,25 @@ def validate_host_runtime(
     runner: Callable[..., subprocess.CompletedProcess[str]] = run_command,
 ) -> None:
     runner(["psql", "--version"], env=env)
+    context_endpoint = runner(
+        [
+            "docker",
+            "context",
+            "inspect",
+            env["DOCKER_CONTEXT"],
+            "--format",
+            "{{json .Endpoints.docker.Host}}",
+        ],
+        env=env,
+    )
+    try:
+        endpoint = json.loads(context_endpoint.stdout)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("Docker context endpoint inspection is invalid") from exc
+    if endpoint != LOCAL_DOCKER_ENDPOINT:
+        raise DeploymentError(
+            "Docker context is not bound to the authorized local daemon"
+        )
     runner(["docker", "compose", "version"], env=env)
     compose_base = [
         "docker",

--- a/scripts/release/v3_release_run.py
+++ b/scripts/release/v3_release_run.py
@@ -56,10 +56,7 @@ def fetch_run(repository: str, run_id: str, token: str) -> dict[str, Any]:
 
     # Keep the network authority literal and immutable. Only the already
     # validated decimal run id is interpolated into the origin-form resource.
-    url = (
-        "https://api.github.com/repos/"
-        f"{CANONICAL_REPOSITORY}/actions/runs/{run_id}"
-    )
+    url = f"https://api.github.com/repos/{CANONICAL_REPOSITORY}/actions/runs/{run_id}"
     headers = (
         "Accept: application/vnd.github+json\n"
         f"Authorization: Bearer {token}\n"
@@ -144,8 +141,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--repository", required=True)
     parser.add_argument("--candidate-run-id", required=True)
     parser.add_argument("--candidate-manifest", type=Path, required=True)
-    parser.add_argument("--rollback-run-id", required=True)
-    parser.add_argument("--rollback-manifest", type=Path, required=True)
+    parser.add_argument("--rollback-run-id")
+    parser.add_argument("--rollback-manifest", type=Path)
     return parser
 
 
@@ -153,17 +150,24 @@ def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
         token = os.environ.get("GITHUB_TOKEN", "")
-        for role, run_id, manifest_path in (
-            ("candidate", args.candidate_run_id, args.candidate_manifest),
-            ("rollback", args.rollback_run_id, args.rollback_manifest),
-        ):
+        if (args.rollback_run_id is None) != (args.rollback_manifest is None):
+            raise ReleaseRunError(
+                "rollback run ID and manifest must be supplied together"
+            )
+        releases = [("candidate", args.candidate_run_id, args.candidate_manifest)]
+        if args.rollback_run_id is not None:
+            releases.append(("rollback", args.rollback_run_id, args.rollback_manifest))
+        verified_roles = []
+        for role, run_id, manifest_path in releases:
+            assert run_id is not None and manifest_path is not None
             manifest = _load_json(manifest_path)
             run = fetch_run(args.repository, run_id, token)
             validate_run_metadata(run, manifest, args.repository, role)
+            verified_roles.append(role)
     except ReleaseRunError as exc:
         print(json.dumps({"status": "stopped", "error": str(exc)}), file=sys.stderr)
         return 64
-    print(json.dumps({"status": "verified", "runs": ["candidate", "rollback"]}))
+    print(json.dumps({"status": "verified", "runs": verified_roles}))
     return 0
 
 

--- a/tests/test_api_startup_housekeeping.py
+++ b/tests/test_api_startup_housekeeping.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+API_SRC = ROOT / 'apps' / 'api' / 'src'
+
+
+@pytest.fixture
+def api_main(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.syspath_prepend(str(API_SRC))
+    monkeypatch.setenv('CORS_ORIGINS', 'http://test')
+    sys.modules.pop('main', None)
+    module = __import__('main')
+    yield module
+    sys.modules.pop('main', None)
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_startup_skips_admin_operation_reap(api_main, monkeypatch):
+    """The checkpoint's real lifespan must not call the UPDATE-capable reaper."""
+    class FakeConnection:
+        async def fetch(self, _query):
+            return []
+
+    class AcquireContext:
+        async def __aenter__(self):
+            return FakeConnection()
+
+        async def __aexit__(self, _exc_type, _exc, _traceback):
+            return False
+
+    class FakePool:
+        def acquire(self):
+            return AcquireContext()
+
+        async def close(self):
+            pass
+
+    pool = FakePool()
+
+    async def create_pool(**_kwargs):
+        return pool
+
+    def unavailable_redis(*_args, **_kwargs):
+        raise ConnectionError('cache unavailable in focused startup test')
+
+    reap = AsyncMock()
+    monkeypatch.setattr(api_main.asyncpg, 'create_pool', create_pool)
+    monkeypatch.setattr(api_main.aioredis, 'from_url', unavailable_redis)
+    monkeypatch.setattr(api_main, 'reap_stale_admin_operation_runs', reap)
+    monkeypatch.setattr(
+        api_main.settings,
+        'admin_operation_startup_reap_enabled',
+        False,
+    )
+    monkeypatch.setattr(api_main.settings, 'database_readonly_url', None)
+    monkeypatch.setattr(api_main.settings, 'eddn_simulation_ingest_enabled', False)
+
+    async with api_main.app.router.lifespan_context(api_main.app):
+        assert api_main.app.state.pool is pool
+
+    reap.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ordinary_startup_still_reaps_stale_admin_operations(api_main, monkeypatch):
+    """Default runtime semantics retain interrupted-operation recovery."""
+    pool = object()
+    reap = AsyncMock(return_value=2)
+    monkeypatch.setattr(api_main, 'reap_stale_admin_operation_runs', reap)
+    monkeypatch.setattr(
+        api_main.settings,
+        'admin_operation_startup_reap_enabled',
+        True,
+    )
+
+    await api_main._reap_stale_admin_runs_on_startup(pool)
+
+    reap.assert_awaited_once_with(pool)
+
+
+def test_admin_operation_startup_reap_defaults_enabled(monkeypatch):
+    monkeypatch.syspath_prepend(str(API_SRC))
+    monkeypatch.delenv('ADMIN_OPERATION_STARTUP_REAP_ENABLED', raising=False)
+    from edfinder_api.config import Settings
+
+    assert (
+        Settings(cors_origins='http://test', _env_file=None)
+        .admin_operation_startup_reap_enabled
+        is True
+    )

--- a/tests/test_v3_application_checkpoint_release.py
+++ b/tests/test_v3_application_checkpoint_release.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import importlib.util
 import json
+import os
 import re
 import subprocess
 import tomllib
@@ -69,11 +70,16 @@ def _load_checkpoint_module():
     return module
 
 
-def _manifest(*, compatibility: str = "exact", rollback_eligible: bool = True):
+def _manifest(
+    *,
+    compatibility: str = "exact",
+    rollback_eligible: bool = True,
+    compatible_migration_sets: list[str] | None = None,
+):
     module = _load_module()
     evidence = (
         "reviewed-ci-contract:checkpoint-release-v1"
-        if compatibility == "exact"
+        if compatibility in {"exact", "backward-compatible"}
         else None
     )
     args = Namespace(
@@ -84,11 +90,38 @@ def _manifest(*, compatibility: str = "exact", rollback_eligible: bool = True):
         web_image="ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "c" * 64,
         compatibility=compatibility,
         compatibility_evidence=evidence,
-        compatible_migration_set=None,
+        compatible_migration_set=compatible_migration_sets,
         rollback_eligible=rollback_eligible,
         rollback_reason="Eligible only for the explicitly listed migration identity.",
     )
     return module, module.create_manifest(args)
+
+
+def _run_release_compatibility_normalizer(
+    tmp_path: Path, *, compatibility: str, reviewed_sets: str
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    workflow = yaml.load(RELEASE_WORKFLOW.read_text(), Loader=_NoBoolCoercionLoader)
+    step = next(
+        step
+        for step in workflow["jobs"]["validate-source"]["steps"]
+        if step.get("id") == "compatibility"
+    )
+    output = tmp_path / "github-output"
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "COMPATIBILITY": compatibility,
+            "REVIEWED_COMPATIBLE_MIGRATION_SETS": reviewed_sets,
+            "GITHUB_OUTPUT": str(output),
+            "RUNNER_TEMP": str(tmp_path),
+        },
+    )
+    return result, output.read_text() if output.exists() else ""
 
 
 def test_manifest_records_exact_source_images_and_migration_checksums():
@@ -102,6 +135,25 @@ def test_manifest_records_exact_source_images_and_migration_checksums():
     assert len(manifest["migration_set"]["entries"]) > 40
     assert all(entry["sha256"] for entry in manifest["migration_set"]["entries"])
     assert module.validate_manifest(manifest) == manifest
+
+
+def test_manifest_exact_mode_uses_only_source_identity_and_backward_mode_adds_reviewed_sets():
+    reviewed_identity = "sha256:" + "0" * 64
+    module, exact = _manifest(
+        compatibility="exact", compatible_migration_sets=[reviewed_identity]
+    )
+    source_identity = module.migration_set()["identity"]
+    assert exact["schema_compatibility"]["compatible_migration_sets"] == [
+        source_identity
+    ]
+
+    _, backward = _manifest(
+        compatibility="backward-compatible",
+        compatible_migration_sets=[reviewed_identity],
+    )
+    assert backward["schema_compatibility"]["compatible_migration_sets"] == sorted(
+        [reviewed_identity, source_identity]
+    )
 
 
 @pytest.mark.parametrize(
@@ -339,6 +391,74 @@ def test_release_workflow_builds_both_images_from_one_exact_main_sha_and_digests
     assert "--verify-source-migrations" in workflow
     assert "(cd release && sha256sum v3-application-release.json" in workflow
     assert "git pull" not in workflow
+
+
+def test_release_workflow_normalizes_and_passes_reviewed_backward_compatibility_sets(
+    tmp_path,
+):
+    first = "sha256:" + "1" * 64
+    second = "sha256:" + "2" * 64
+    result, output = _run_release_compatibility_normalizer(
+        tmp_path,
+        compatibility="backward-compatible",
+        reviewed_sets=f"  {second}\r\n\n{first}  ",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output == f"compatible_migration_sets={first} {second}\n"
+
+    empty_result, empty_output = _run_release_compatibility_normalizer(
+        tmp_path / "empty",
+        compatibility="backward-compatible",
+        reviewed_sets=" \n\t",
+    )
+    assert empty_result.returncode == 0, empty_result.stderr
+    assert empty_output == "compatible_migration_sets=\n"
+
+    workflow = yaml.load(RELEASE_WORKFLOW.read_text(), Loader=_NoBoolCoercionLoader)
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    assert inputs["reviewed_compatible_migration_sets"]["required"] == "false"
+    assert "one per line" in inputs["reviewed_compatible_migration_sets"]["description"]
+    workflow_text = RELEASE_WORKFLOW.read_text()
+    assert workflow_text.count('args+=(--compatible-migration-set "$identity")') == 2
+    assert (
+        workflow_text.count('if [ "$COMPATIBILITY" = "backward-compatible" ]; then')
+        == 2
+    )
+
+
+@pytest.mark.parametrize(
+    ("compatibility", "reviewed_sets", "error"),
+    [
+        (
+            "exact",
+            "sha256:" + "1" * 64,
+            "accepted only for backward-compatible releases",
+        ),
+        ("backward-compatible", "sha256:ABC", "64 lowercase hex"),
+        (
+            "backward-compatible",
+            "password=not-an-identity",
+            "secret-like material",
+        ),
+        (
+            "backward-compatible",
+            "sha256:" + "1" * 64 + "\nsha256:" + "1" * 64,
+            "must not contain duplicates",
+        ),
+    ],
+)
+def test_release_workflow_rejects_unreviewed_malformed_or_secret_like_sets(
+    tmp_path, compatibility, reviewed_sets, error
+):
+    result, _ = _run_release_compatibility_normalizer(
+        tmp_path,
+        compatibility=compatibility,
+        reviewed_sets=reviewed_sets,
+    )
+
+    assert result.returncode == 64
+    assert error in result.stderr
 
 
 def test_deploy_workflow_supports_bootstrap_and_receipt_backed_upgrade():
@@ -621,7 +741,30 @@ def test_bootstrap_and_upgrade_mutation_plans_are_literal_app_only_allowlists():
         CHECKPOINT_COMPOSE, "bootstrap", env, {"kind": "predeploy_absence"}
     )
     assert all(command[-2:] == ["api", "web"] for command in bootstrap_rollback)
-    flattened = " ".join(" ".join(command) for command in plan + bootstrap_rollback)
+    rollback = {
+        "kind": "accepted_release",
+        "source_sha": "d" * 40,
+        "images": {
+            "backend": "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:"
+            + "e" * 64,
+            "web": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "f" * 64,
+        },
+    }
+    upgrade_rollback, rollback_env = module.rollback_plan(
+        CHECKPOINT_COMPOSE, "upgrade", env, rollback
+    )
+    assert len(upgrade_rollback) == 1
+    assert upgrade_rollback[0][-2:] == ["api", "web"]
+    assert "--no-deps" in upgrade_rollback[0]
+    assert "--force-recreate" in upgrade_rollback[0]
+    assert upgrade_rollback[0][upgrade_rollback[0].index("--pull") + 1] == "never"
+    assert not any(command[:2] == ["docker", "pull"] for command in upgrade_rollback)
+    assert rollback_env["V3_CHECKPOINT_API_IMAGE"] == rollback["images"]["backend"]
+    assert rollback_env["V3_CHECKPOINT_WEB_IMAGE"] == rollback["images"]["web"]
+    assert rollback_env["V3_CHECKPOINT_SOURCE_SHA"] == rollback["source_sha"]
+    flattened = " ".join(
+        " ".join(command) for command in plan + bootstrap_rollback + upgrade_rollback
+    )
     for forbidden in (
         " down ",
         "--remove-orphans",
@@ -637,6 +780,7 @@ def test_bootstrap_and_upgrade_mutation_plans_are_literal_app_only_allowlists():
 def test_rendered_compose_allowlist_is_checked_before_any_pull():
     module = _load_checkpoint_module()
     env = {
+        "DOCKER_CONTEXT": "checkpoint-test",
         "V3_CHECKPOINT_API_IMAGE": "ghcr.io/example/api@sha256:" + "b" * 64,
         "V3_CHECKPOINT_WEB_IMAGE": "ghcr.io/example/web@sha256:" + "c" * 64,
     }
@@ -644,12 +788,92 @@ def test_rendered_compose_allowlist_is_checked_before_any_pull():
 
     def runner(command, **_kwargs):
         commands.append(command)
-        stdout = "api web unexpected\n" if command[-1] == "--services" else ""
+        if command[1:3] == ["context", "inspect"]:
+            stdout = json.dumps(module.LOCAL_DOCKER_ENDPOINT)
+        else:
+            stdout = "api web unexpected\n" if command[-1] == "--services" else ""
         return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
 
     with pytest.raises(module.DeploymentError, match="service allowlist"):
         module.validate_host_runtime(CHECKPOINT_COMPOSE, env, runner)
 
+    assert not any(command[:2] == ["docker", "pull"] for command in commands)
+
+
+def test_checkpoint_runtime_accepts_only_authorized_local_docker_context():
+    module = _load_checkpoint_module()
+    env = {
+        "DOCKER_CONTEXT": "checkpoint-test",
+        "V3_CHECKPOINT_API_IMAGE": "ghcr.io/example/api@sha256:" + "b" * 64,
+        "V3_CHECKPOINT_WEB_IMAGE": "ghcr.io/example/web@sha256:" + "c" * 64,
+    }
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        if command[1:3] == ["context", "inspect"]:
+            stdout = json.dumps(module.LOCAL_DOCKER_ENDPOINT)
+        elif command[-1] == "--services":
+            stdout = "api web\n"
+        elif command[-1] == "--images":
+            stdout = (
+                f"{env['V3_CHECKPOINT_API_IMAGE']}\n{env['V3_CHECKPOINT_WEB_IMAGE']}\n"
+            )
+        elif command[:3] == ["systemctl", "list-units", "--type=service"]:
+            stdout = "".join(
+                f"{service} loaded active running\n"
+                for service in module.RUNNER_SERVICES
+            )
+        else:
+            stdout = ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    module.validate_host_runtime(CHECKPOINT_COMPOSE, env, runner)
+
+    docker_commands = [command for command in commands if command[0] == "docker"]
+    assert docker_commands[0] == [
+        "docker",
+        "context",
+        "inspect",
+        "checkpoint-test",
+        "--format",
+        "{{json .Endpoints.docker.Host}}",
+    ]
+
+
+@pytest.mark.parametrize(
+    "inspection_output",
+    [
+        '"ssh://checkpoint.example"',
+        '"tcp://127.0.0.1:2375"',
+        '"unix:///run/user/1000/docker.sock"',
+        '"unix:///var/run/docker.sock" trailing-output',
+        "null",
+        "",
+    ],
+)
+def test_checkpoint_runtime_rejects_untrusted_or_unverifiable_docker_context(
+    inspection_output,
+):
+    module = _load_checkpoint_module()
+    env = {
+        "DOCKER_CONTEXT": "checkpoint-test",
+        "V3_CHECKPOINT_API_IMAGE": "ghcr.io/example/api@sha256:" + "b" * 64,
+        "V3_CHECKPOINT_WEB_IMAGE": "ghcr.io/example/web@sha256:" + "c" * 64,
+    }
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        stdout = inspection_output if command[1:3] == ["context", "inspect"] else ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    with pytest.raises(module.DeploymentError, match="Docker context"):
+        module.validate_host_runtime(CHECKPOINT_COMPOSE, env, runner)
+
+    assert not any(
+        command[:3] == ["docker", "compose", "version"] for command in commands
+    )
     assert not any(command[:2] == ["docker", "pull"] for command in commands)
 
 
@@ -1312,6 +1536,7 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
     authority_path = tmp_path / "authority.json"
     authority_path.write_text(json.dumps(authority), encoding="utf-8")
     readiness_shas = []
+    commands = []
 
     monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
     monkeypatch.setattr(module, "validate_host_runtime", lambda *_args: None)
@@ -1349,6 +1574,7 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
     monkeypatch.setattr(module, "verify_app_containers", verify_containers)
 
     def runner(command, **_kwargs):
+        commands.append((command, _kwargs["env"]))
         if (
             failure_stage == "candidate-pull"
             and command[:2] == ["docker", "pull"]
@@ -1372,6 +1598,19 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
     if failure_stage == "candidate-container":
         assert readiness_shas == [candidate["git_sha"], rollback["git_sha"]]
         assert receipt["rollback"]["status"] == "verified"
+        compose_up_calls = [call for call in commands if "up" in call[0]]
+        assert len(compose_up_calls) == 2
+        rollback_command, rollback_env = compose_up_calls[1]
+        assert rollback_command[rollback_command.index("--pull") + 1] == "never"
+        assert rollback_command[-2:] == ["api", "web"]
+        assert rollback_env["V3_CHECKPOINT_API_IMAGE"] == rollback["images"]["backend"]
+        assert rollback_env["V3_CHECKPOINT_WEB_IMAGE"] == rollback["images"]["web"]
+        assert rollback_env["V3_CHECKPOINT_SOURCE_SHA"] == rollback["git_sha"]
+        rollback_index = commands.index(compose_up_calls[1])
+        assert not any(
+            command[:2] == ["docker", "pull"]
+            for command, _command_env in commands[rollback_index:]
+        )
     else:
         assert readiness_shas == []
         assert receipt["rollback"]["status"] == "not-required"

--- a/tests/test_v3_application_checkpoint_release.py
+++ b/tests/test_v3_application_checkpoint_release.py
@@ -70,6 +70,42 @@ def _load_checkpoint_module():
     return module
 
 
+def _network_inspection(module, services=()):
+    network_id = "1" * 64
+    containers = {}
+    attachments = {}
+    for index, service in enumerate(services, start=2):
+        container_id = str(index) * 64
+        endpoint_id = str(index + 2) * 64
+        container = module.CONTAINERS[service]
+        containers[container_id] = {
+            "Name": container,
+            "EndpointID": endpoint_id,
+        }
+        attachments[container] = [
+            {
+                "Id": container_id,
+                "NetworkSettings": {
+                    "Networks": {
+                        module.APP_NETWORK: {
+                            "Aliases": [container, service],
+                            "NetworkID": network_id,
+                            "EndpointID": endpoint_id,
+                        }
+                    }
+                },
+            }
+        ]
+    return {
+        "Id": network_id,
+        "Name": module.APP_NETWORK,
+        "Driver": "bridge",
+        "Scope": "local",
+        "Ingress": False,
+        "Containers": containers,
+    }, attachments
+
+
 def _manifest(
     *,
     compatibility: str = "exact",
@@ -808,6 +844,7 @@ def test_checkpoint_runtime_accepts_only_authorized_local_docker_context():
         "V3_CHECKPOINT_WEB_IMAGE": "ghcr.io/example/web@sha256:" + "c" * 64,
     }
     commands = []
+    network, _attachments = _network_inspection(module)
 
     def runner(command, **_kwargs):
         commands.append(command)
@@ -819,6 +856,8 @@ def test_checkpoint_runtime_accepts_only_authorized_local_docker_context():
             stdout = (
                 f"{env['V3_CHECKPOINT_API_IMAGE']}\n{env['V3_CHECKPOINT_WEB_IMAGE']}\n"
             )
+        elif command[:3] == ["docker", "network", "inspect"]:
+            stdout = json.dumps([network])
         elif command[:3] == ["systemctl", "list-units", "--type=service"]:
             stdout = "".join(
                 f"{service} loaded active running\n"
@@ -839,6 +878,103 @@ def test_checkpoint_runtime_accepts_only_authorized_local_docker_context():
         "--format",
         "{{json .Endpoints.docker.Host}}",
     ]
+
+
+def test_checkpoint_network_accepts_empty_bootstrap_and_exact_upgrade_topology():
+    module = _load_checkpoint_module()
+    bootstrap_network, _ = _network_inspection(module)
+    module.validate_network_topology(
+        "bootstrap", json.dumps([bootstrap_network]), {}, lambda *_args, **_kwargs: None
+    )
+
+    upgrade_network, attachments = _network_inspection(module, ("api", "web"))
+
+    def runner(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps(attachments[command[-1]]), stderr=""
+        )
+
+    module.validate_network_topology(
+        "upgrade", json.dumps([upgrade_network]), {}, runner
+    )
+
+    partial_network, partial_attachments = _network_inspection(module, ("api",))
+
+    def partial_runner(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(partial_attachments[command[-1]]),
+            stderr="",
+        )
+
+    module.validate_network_topology(
+        "bootstrap-rollback", json.dumps([partial_network]), {}, partial_runner
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("Driver", "overlay"), ("Scope", "swarm"), ("Ingress", True)],
+)
+def test_checkpoint_network_rejects_wrong_local_bridge_topology(field, value):
+    module = _load_checkpoint_module()
+    network, _ = _network_inspection(module)
+    network[field] = value
+
+    with pytest.raises(module.DeploymentError, match="topology is unauthorized"):
+        module.validate_network_topology(
+            "bootstrap", json.dumps([network]), {}, lambda *_args, **_kwargs: None
+        )
+
+
+@pytest.mark.parametrize("inspection_output", ["", "{}", "[]", "[{}, {}]"])
+def test_checkpoint_network_rejects_malformed_or_unverifiable_output(
+    inspection_output,
+):
+    module = _load_checkpoint_module()
+
+    with pytest.raises(module.DeploymentError, match="network inspection|topology"):
+        module.validate_network_topology(
+            "bootstrap", inspection_output, {}, lambda *_args, **_kwargs: None
+        )
+
+
+def test_upgrade_network_rejects_unexpected_peer_before_any_pull():
+    module = _load_checkpoint_module()
+    network, attachments = _network_inspection(module, ("api", "web"))
+    network["Containers"]["6" * 64] = {
+        "Name": "untrusted-api-peer",
+        "EndpointID": "7" * 64,
+    }
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps(attachments.get(command[-1], [])), stderr=""
+        )
+
+    with pytest.raises(module.DeploymentError, match="unexpected peer"):
+        module.validate_network_topology("upgrade", json.dumps([network]), {}, runner)
+    assert not any(command[:2] == ["docker", "pull"] for command in commands)
+
+
+def test_upgrade_network_rejects_unexpected_api_alias_on_web_peer():
+    module = _load_checkpoint_module()
+    network, attachments = _network_inspection(module, ("api", "web"))
+    web = module.CONTAINERS["web"]
+    attachments[web][0]["NetworkSettings"]["Networks"][module.APP_NETWORK][
+        "Aliases"
+    ].append("api")
+
+    def runner(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps(attachments[command[-1]]), stderr=""
+        )
+
+    with pytest.raises(module.DeploymentError, match="network aliases"):
+        module.validate_network_topology("upgrade", json.dumps([network]), {}, runner)
 
 
 @pytest.mark.parametrize(
@@ -910,6 +1046,12 @@ def _schema_receipt(module, manifest, **overrides):
 
 
 def _authorized_checkpoint_authority(tmp_path: Path, schema_path: Path) -> dict:
+    api_env = tmp_path / "api.env"
+    api_env.write_text(
+        "DATABASE_URL=postgresql://checkpoint:test@192.0.2.10/checkpoint\n",
+        encoding="utf-8",
+    )
+    api_env.chmod(0o600)
     authority = json.loads(CHECKPOINT_AUTHORITY.read_text())
     authority["status"] = "authorized"
     authority["blockers"] = []
@@ -917,8 +1059,8 @@ def _authorized_checkpoint_authority(tmp_path: Path, schema_path: Path) -> dict:
     authority["observed_runtime"]["compose"] = "Docker Compose test authority"
     authority["observed_runtime"]["docker_networks"] = ["edfinder-v3-checkpoint-app"]
     authority["external_authority"] = {
-        "api_env_file": str(tmp_path / "api.env"),
-        "api_env_owner_uid": 0,
+        "api_env_file": str(api_env),
+        "api_env_owner_uid": os.getuid(),
         "api_env_mode": "0600",
         "database_source_authority": "approved-test-db",
         "schema_identity_receipt": str(schema_path),
@@ -928,11 +1070,11 @@ def _authorized_checkpoint_authority(tmp_path: Path, schema_path: Path) -> dict:
         "origin_bind": "http://127.0.0.1:12345",
         "edge_route_authority": "approved-test-edge-route",
         "receipt_directory": str(tmp_path),
-        "receipt_owner_uid": 0,
+        "receipt_owner_uid": os.getuid(),
         "receipt_mode": "0700",
         "ghcr_pull_authority": "approved-test-ghcr-principal",
         "docker_config_directory": str(tmp_path / "docker-config"),
-        "docker_config_owner_uid": 0,
+        "docker_config_owner_uid": os.getuid(),
         "docker_config_mode": "0700",
         "docker_context": "checkpoint-test",
     }
@@ -1416,6 +1558,108 @@ def test_unsafe_host_identity_stops_before_any_runtime_or_mutation_command(
     assert not (tmp_path / "deploy.lock").exists()
 
 
+def test_bootstrap_rejects_dangling_current_pointer_before_any_command(
+    tmp_path, monkeypatch
+):
+    module = _load_checkpoint_module()
+    schema = tmp_path / "schema.json"
+    schema.write_text("{}", encoding="utf-8")
+    authority = _authorized_checkpoint_authority(tmp_path, schema)
+    authority_path = tmp_path / "authority.json"
+    authority_path.write_text(json.dumps(authority), encoding="utf-8")
+    current = tmp_path / "current.json"
+    current.symlink_to(tmp_path / "missing-prior-receipt.json")
+    commands = []
+
+    monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
+    monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
+    monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
+
+    args = Namespace(
+        authority=authority_path,
+        compose=CHECKPOINT_COMPOSE,
+        mode="bootstrap",
+        candidate=tmp_path / "candidate.json",
+        candidate_checksum=tmp_path / "candidate.json.sha256",
+        candidate_run_id="12345",
+    )
+    with pytest.raises(module.OperationFailed) as failure:
+        module.execute(
+            args,
+            runner=lambda command, **_kwargs: commands.append(command),
+        )
+
+    assert current.is_symlink()
+    assert commands == []
+    assert failure.value.receipt["service_changes_performed"] is False
+    assert failure.value.receipt["image_pulls_performed"] is False
+
+
+@pytest.mark.parametrize("drift", ["edit", "replacement", "symlink"])
+def test_verified_env_source_drift_stops_before_pull_and_cleans_snapshot(
+    tmp_path, monkeypatch, drift
+):
+    module = _load_checkpoint_module()
+    _, candidate = _manifest()
+    candidate_path, candidate_checksum = _write_json_with_checksum(
+        tmp_path, "candidate.json", candidate
+    )
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps(_schema_receipt(module, candidate)), encoding="utf-8")
+    authority = _authorized_checkpoint_authority(tmp_path, schema)
+    authority_path = tmp_path / "authority.json"
+    authority_path.write_text(json.dumps(authority), encoding="utf-8")
+    source = Path(authority["external_authority"]["api_env_file"])
+    commands = []
+    schema_probe_paths = []
+
+    monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
+    monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
+    monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
+
+    def verified_database(path, _receipt, _runner, **callbacks):
+        schema_probe_paths.append(path)
+        assert path != source
+        assert path.read_bytes() == source.read_bytes()
+        callbacks["on_query_completed"]()
+        if drift == "edit":
+            source.write_text(
+                "DATABASE_URL=postgresql://changed:test@192.0.2.11/other\n",
+                encoding="utf-8",
+            )
+        else:
+            source.unlink()
+            if drift == "replacement":
+                source.write_text(
+                    "DATABASE_URL=postgresql://changed:test@192.0.2.11/other\n",
+                    encoding="utf-8",
+                )
+                source.chmod(0o600)
+            else:
+                source.symlink_to(tmp_path / "missing-api.env")
+
+    monkeypatch.setattr(module, "verify_database_schema", verified_database)
+    args = Namespace(
+        authority=authority_path,
+        compose=CHECKPOINT_COMPOSE,
+        mode="bootstrap",
+        candidate=candidate_path,
+        candidate_checksum=candidate_checksum,
+        candidate_run_id="12345",
+    )
+    with pytest.raises(module.OperationFailed) as failure:
+        module.execute(
+            args,
+            runner=lambda command, **_kwargs: commands.append(command),
+        )
+
+    assert schema_probe_paths
+    assert commands == []
+    assert failure.value.receipt["service_mutation_attempted"] is False
+    assert failure.value.receipt["image_pulls_performed"] is False
+    assert not list(tmp_path.glob(".v3-verified-api-env-*"))
+
+
 def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     tmp_path, monkeypatch
 ):
@@ -1432,14 +1676,14 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     commands = []
 
     monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
-    monkeypatch.setattr(module, "validate_host_runtime", lambda *_args: None)
+    monkeypatch.setattr(module, "validate_host_runtime", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "verify_bootstrap_absence", lambda *_args: None)
     monkeypatch.setattr(module, "verify_pulled_image", lambda *_args: None)
+    monkeypatch.setattr(module, "inspect_network_topology", lambda *_args: None)
     monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
     monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
 
     def verified_database(_path, _receipt, _runner, **callbacks):
-        callbacks["on_env_file_read"]()
         callbacks["on_query_completed"]()
 
     monkeypatch.setattr(module, "verify_database_schema", verified_database)
@@ -1468,6 +1712,8 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     assert receipt["status"] == "failed"
     assert receipt["pulled_images_verified"] == list(candidate["images"].values())
     assert receipt["service_mutation_attempted"] is True
+    assert receipt["env_file_consumed_by_compose"] is False
+    assert receipt["env_file_may_have_been_consumed_by_compose"] is True
     assert receipt["database_access_performed"] is True
     assert receipt["env_files_read"] is True
     assert receipt["changed_resources"] == list(module.CONTAINERS.values())
@@ -1483,9 +1729,19 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     ]
     assert mutation_commands[0][-2:] == ["api", "web"]
     assert all(command[-2:] == ["api", "web"] for command in rollback_commands)
+    assert not list(tmp_path.glob(".v3-verified-api-env-*"))
 
 
-@pytest.mark.parametrize("failure_stage", ["candidate-container", "candidate-pull"])
+@pytest.mark.parametrize(
+    "failure_stage",
+    [
+        "candidate-container",
+        "candidate-readiness",
+        "candidate-smoke",
+        "candidate-receipt",
+        "candidate-pull",
+    ],
+)
 def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
     tmp_path, monkeypatch, failure_stage
 ):
@@ -1539,27 +1795,42 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
     commands = []
 
     monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
-    monkeypatch.setattr(module, "validate_host_runtime", lambda *_args: None)
+    monkeypatch.setattr(module, "validate_host_runtime", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(module, "verify_origin_state", lambda *_args: None)
     monkeypatch.setattr(module, "verify_pulled_image", lambda *_args: None)
+    monkeypatch.setattr(module, "inspect_network_topology", lambda *_args: None)
     monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
     monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
-    monkeypatch.setattr(
-        module,
-        "wait_for_origin_ready",
-        lambda _origin, source_sha: readiness_shas.append(source_sha),
-    )
-    monkeypatch.setattr(
-        module,
-        "smoke_origin",
-        lambda *_args: {
+
+    def wait_for_origin_ready(_origin, source_sha):
+        readiness_shas.append(source_sha)
+        if (
+            failure_stage == "candidate-readiness"
+            and source_sha == candidate["git_sha"]
+        ):
+            raise module.DeploymentError("candidate readiness failed")
+
+    monkeypatch.setattr(module, "wait_for_origin_ready", wait_for_origin_ready)
+
+    def smoke_origin(_origin, source_sha):
+        if failure_stage == "candidate-smoke" and source_sha == candidate["git_sha"]:
+            raise module.DeploymentError("candidate smoke failed")
+        return {
             path: {"status": 200}
             for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
-        },
-    )
+        }
+
+    monkeypatch.setattr(module, "smoke_origin", smoke_origin)
+    real_persist_receipt = module.persist_receipt
+
+    def persist_receipt(directory, receipt, manifest):
+        if failure_stage == "candidate-receipt":
+            raise OSError("candidate receipt persistence failed")
+        return real_persist_receipt(directory, receipt, manifest)
+
+    monkeypatch.setattr(module, "persist_receipt", persist_receipt)
 
     def verified_database(_path, _receipt, _runner, **callbacks):
-        callbacks["on_env_file_read"]()
         callbacks["on_query_completed"]()
 
     monkeypatch.setattr(module, "verify_database_schema", verified_database)
@@ -1581,6 +1852,15 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
             and command[-1] == candidate["images"]["backend"]
         ):
             raise module.DeploymentError("candidate pull failed")
+        if (
+            failure_stage != "candidate-pull"
+            and "up" in command
+            and len([item for item, _env in commands if "up" in item]) == 1
+        ):
+            Path(authority["external_authority"]["api_env_file"]).write_text(
+                "DATABASE_URL=postgresql://changed:test@192.0.2.11/other\n",
+                encoding="utf-8",
+            )
         return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
 
     args = Namespace(
@@ -1595,7 +1875,7 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
         module.execute(args, runner=runner)
 
     receipt = failure.value.receipt
-    if failure_stage == "candidate-container":
+    if failure_stage != "candidate-pull":
         assert readiness_shas == [candidate["git_sha"], rollback["git_sha"]]
         assert receipt["rollback"]["status"] == "verified"
         compose_up_calls = [call for call in commands if "up" in call[0]]
@@ -1606,6 +1886,17 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
         assert rollback_env["V3_CHECKPOINT_API_IMAGE"] == rollback["images"]["backend"]
         assert rollback_env["V3_CHECKPOINT_WEB_IMAGE"] == rollback["images"]["web"]
         assert rollback_env["V3_CHECKPOINT_SOURCE_SHA"] == rollback["git_sha"]
+        candidate_env = compose_up_calls[0][1]
+        assert (
+            candidate_env["V3_CHECKPOINT_API_ENV_FILE"]
+            == rollback_env["V3_CHECKPOINT_API_ENV_FILE"]
+        )
+        assert (
+            candidate_env["V3_CHECKPOINT_API_ENV_FILE"]
+            != authority["external_authority"]["api_env_file"]
+        )
+        assert receipt["env_file_consumed_by_compose"] is True
+        assert receipt["env_file_may_have_been_consumed_by_compose"] is False
         rollback_index = commands.index(compose_up_calls[1])
         assert not any(
             command[:2] == ["docker", "pull"]
@@ -1615,7 +1906,10 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
         assert readiness_shas == []
         assert receipt["rollback"]["status"] == "not-required"
         assert receipt["service_mutation_attempted"] is False
+        assert receipt["env_file_consumed_by_compose"] is False
+        assert receipt["env_file_may_have_been_consumed_by_compose"] is False
     assert receipt["database_access_performed"] is True
+    assert not list(tmp_path.glob(".v3-verified-api-env-*"))
 
 
 def test_current_target_authority_records_proven_facts_and_exact_blockers():

--- a/tests/test_v3_application_checkpoint_release.py
+++ b/tests/test_v3_application_checkpoint_release.py
@@ -345,11 +345,6 @@ def test_deploy_workflow_supports_bootstrap_and_receipt_backed_upgrade():
     workflow = DEPLOY_WORKFLOW.read_text()
 
     assert "--purpose deploy-candidate" in workflow
-    assert "--purpose rollback-candidate" in workflow
-    assert "inputs.deployment_mode == 'upgrade'" in workflow
-    assert "Bootstrap must not claim a prior release" in workflow
-    assert "Upgrade requires a valid rollback run ID" in workflow
-    assert "Candidate cannot be its own rollback" in workflow
     assert "Authenticate release workflow run provenance" in workflow
     assert "scripts/release/v3_release_run.py" in workflow
     assert "StrictHostKeyChecking=yes" in workflow
@@ -374,6 +369,8 @@ def test_deploy_workflow_supports_bootstrap_and_receipt_backed_upgrade():
     assert workflow.index("--authority-gate") < workflow.index("ssh -i")
     assert 'remote_receipt="$RECEIPT.remote"' in workflow
     assert "remote_transport_or_bundle_failed" in workflow
+    assert "rollback_run_id" not in workflow
+    assert "artifacts/rollback" not in workflow
     for forbidden in ("ssh-keyscan", "git pull", "pnpm install", "uv sync", "psql"):
         assert forbidden not in workflow.lower()
 
@@ -587,6 +584,12 @@ def test_checkpoint_compose_owns_only_bounded_application_resources():
         compose["services"]["api"]["environment"]["EDDN_SIMULATION_INGEST_ENABLED"]
         == "false"
     )
+    assert (
+        compose["services"]["api"]["environment"][
+            "ADMIN_OPERATION_STARTUP_REAP_ENABLED"
+        ]
+        == "false"
+    )
     for service in compose["services"].values():
         assert "build" not in service
         assert "depends_on" not in service
@@ -663,6 +666,25 @@ def _write_json_with_checksum(
     return document, checksum
 
 
+def _schema_receipt(module, manifest, **overrides):
+    value = {
+        "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
+        "database_source_authority": "approved-test-db",
+        "database_identity": {
+            "database_name": "checkpoint",
+            "server_address": "192.0.2.10",
+            "server_port": 5432,
+        },
+        "migration_set_identity": manifest["migration_set"]["identity"],
+        "migration_set_entries": manifest["migration_set"]["entries"],
+        "captured_at": module.datetime.now(module.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        ),
+    }
+    value.update(overrides)
+    return value
+
+
 def _authorized_checkpoint_authority(tmp_path: Path, schema_path: Path) -> dict:
     authority = json.loads(CHECKPOINT_AUTHORITY.read_text())
     authority["status"] = "authorized"
@@ -700,17 +722,7 @@ def test_bootstrap_needs_no_prior_release_but_upgrade_requires_receipt(tmp_path)
         tmp_path, "candidate.json", candidate
     )
     schema = tmp_path / "schema.json"
-    schema.write_text(
-        json.dumps(
-            {
-                "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
-                "database_source_authority": "approved-test-db",
-                "migration_set_identity": candidate["migration_set"]["identity"],
-                "captured_at": "2026-09-06T12:00:00Z",
-            }
-        ),
-        encoding="utf-8",
-    )
+    schema.write_text(json.dumps(_schema_receipt(module, candidate)), encoding="utf-8")
 
     validated = module.validate_release_inputs(
         mode="bootstrap",
@@ -756,17 +768,7 @@ def test_upgrade_requires_receipt_matching_prior_digest_release(tmp_path):
         tmp_path, "rollback.json", rollback
     )
     schema = tmp_path / "schema.json"
-    schema.write_text(
-        json.dumps(
-            {
-                "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
-                "database_source_authority": "approved-test-db",
-                "migration_set_identity": candidate["migration_set"]["identity"],
-                "captured_at": "2026-09-06T12:00:00Z",
-            }
-        ),
-        encoding="utf-8",
-    )
+    schema.write_text(json.dumps(_schema_receipt(module, candidate)), encoding="utf-8")
     rollback_sum = hashlib.sha256(rollback_path.read_bytes()).hexdigest()
     prior_receipt = tmp_path / "prior.json"
     prior_receipt.write_text(
@@ -776,6 +778,7 @@ def test_upgrade_requires_receipt_matching_prior_digest_release(tmp_path):
                 "status": "accepted",
                 "mode": "bootstrap",
                 "source_sha": rollback["git_sha"],
+                "release_run_id": "122",
                 "images": rollback["images"],
                 "manifest_sha256": rollback_sum,
                 "target": {
@@ -814,6 +817,24 @@ def test_upgrade_requires_receipt_matching_prior_digest_release(tmp_path):
         prior_receipt_path=prior_receipt,
     )
     assert validated["rollback"]["source_sha"] == rollback["git_sha"]
+    assert validated["rollback"]["release_run_id"] == "122"
+
+    prior_document = json.loads(prior_receipt.read_text())
+    module.persist_receipt(tmp_path, prior_document, rollback_path)
+    durable_receipt, durable_manifest, durable_checksum = module.load_current_release(
+        tmp_path
+    )
+    durable_validated = module.validate_release_inputs(
+        mode="upgrade",
+        candidate_path=candidate_path,
+        candidate_checksum=candidate_checksum,
+        current_schema_path=schema,
+        database_source_authority="approved-test-db",
+        rollback_path=durable_manifest,
+        rollback_checksum=durable_checksum,
+        prior_receipt_path=durable_receipt,
+    )
+    assert durable_validated["rollback"] == validated["rollback"]
 
     bad_receipt = json.loads(prior_receipt.read_text())
     bad_receipt["images"]["web"] = candidate["images"]["web"]
@@ -898,8 +919,156 @@ def test_origin_smoke_checks_exact_required_routes_and_build_identity(monkeypatc
         module.smoke_origin("http://127.0.0.1:12345", GIT_SHA)
 
 
+def test_readiness_poll_tolerates_startup_latency_and_has_bounded_timeout(monkeypatch):
+    module = _load_checkpoint_module()
+    elapsed = [0.0]
+    attempts = [0]
+
+    def clock():
+        return elapsed[0]
+
+    def sleeper(seconds):
+        elapsed[0] += seconds
+
+    def eventually_ready(_origin, _path, **_kwargs):
+        attempts[0] += 1
+        if attempts[0] < 3:
+            raise module.DeploymentError("still starting")
+        return (
+            200,
+            json.dumps(
+                {"status": "ok", "database": "connected", "build_sha": GIT_SHA}
+            ).encode(),
+            "application/json",
+        )
+
+    monkeypatch.setattr(module, "get_origin", eventually_ready)
+    assert (
+        module.wait_for_origin_ready(
+            "http://127.0.0.1:12345",
+            GIT_SHA,
+            timeout_seconds=10,
+            interval_seconds=2,
+            clock=clock,
+            sleeper=sleeper,
+        )
+        == 3
+    )
+    assert elapsed[0] == 4
+
+    monkeypatch.setattr(
+        module,
+        "get_origin",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            module.DeploymentError("not ready")
+        ),
+    )
+    elapsed[0] = 0
+    with pytest.raises(module.DeploymentError, match="readiness timed out"):
+        module.wait_for_origin_ready(
+            "http://127.0.0.1:12345",
+            GIT_SHA,
+            timeout_seconds=4,
+            interval_seconds=2,
+            clock=clock,
+            sleeper=sleeper,
+        )
+    assert elapsed[0] == 4
+
+
+def test_database_schema_probe_binds_env_target_and_ledger_without_leaking_url(
+    tmp_path,
+):
+    module = _load_checkpoint_module()
+    _, manifest = _manifest()
+    schema_receipt = _schema_receipt(module, manifest)
+    secret_url = "postgresql://checkpoint:do-not-log@db.example:5432/checkpoint"
+    api_env = tmp_path / "api.env"
+    api_env.write_text(f"DATABASE_URL={secret_url}\n", encoding="utf-8")
+    expected_migrations = [
+        {
+            "filename": entry["path"].removeprefix("sql/"),
+            "checksum_sha256": entry["sha256"],
+        }
+        for entry in manifest["migration_set"]["entries"]
+    ]
+    observed = {
+        **schema_receipt["database_identity"],
+        "transaction_read_only": "on",
+        "migrations": sorted(expected_migrations, key=lambda item: item["filename"]),
+    }
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append((command, kwargs["env"]))
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps(observed), stderr=""
+        )
+
+    module.verify_database_schema(api_env, schema_receipt, runner)
+    command, env = calls[0]
+    assert command[0] == "psql"
+    assert secret_url not in " ".join(command)
+    assert env["PGDATABASE"] == secret_url
+    assert "default_transaction_read_only=on" in env["PGOPTIONS"]
+
+    mismatched = copy.deepcopy(observed)
+    mismatched["server_address"] = "192.0.2.11"
+    completed = []
+    with pytest.raises(module.DeploymentError, match="identity does not match"):
+        module.verify_database_schema(
+            api_env,
+            schema_receipt,
+            lambda command, **_kwargs: subprocess.CompletedProcess(
+                command, 0, stdout=json.dumps(mismatched), stderr=""
+            ),
+            on_query_completed=lambda: completed.append(True),
+        )
+    assert completed == [True]
+
+    drifted = copy.deepcopy(observed)
+    drifted["migrations"][0]["checksum_sha256"] = "0" * 64
+    with pytest.raises(module.DeploymentError, match="ledger has drifted"):
+        module.verify_database_schema(
+            api_env,
+            schema_receipt,
+            lambda command, **_kwargs: subprocess.CompletedProcess(
+                command, 0, stdout=json.dumps(drifted), stderr=""
+            ),
+        )
+
+
+def test_schema_receipt_fails_closed_when_stale(tmp_path):
+    module = _load_checkpoint_module()
+    _, candidate = _manifest()
+    candidate_path, candidate_checksum = _write_json_with_checksum(
+        tmp_path, "candidate.json", candidate
+    )
+    schema = tmp_path / "schema.json"
+    schema.write_text(
+        json.dumps(
+            _schema_receipt(module, candidate, captured_at="2020-01-01T00:00:00Z")
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(module.DeploymentError, match="receipt is stale"):
+        module.validate_release_inputs(
+            mode="bootstrap",
+            candidate_path=candidate_path,
+            candidate_checksum=candidate_checksum,
+            current_schema_path=schema,
+            database_source_authority="approved-test-db",
+            rollback_path=None,
+            rollback_checksum=None,
+            prior_receipt_path=None,
+        )
+
+
 def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
     module = _load_checkpoint_module()
+    accepted_manifest = tmp_path / "accepted-input.json"
+    accepted_manifest.write_text("{}", encoding="utf-8")
+    accepted_manifest_sha = hashlib.sha256(accepted_manifest.read_bytes()).hexdigest()
     receipt = {
         "schema_version": module.RECEIPT_SCHEMA,
         "status": "accepted",
@@ -910,7 +1079,7 @@ def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
             + "b" * 64,
             "web": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "c" * 64,
         },
-        "manifest_sha256": "d" * 64,
+        "manifest_sha256": accepted_manifest_sha,
         "target": {"provider": "contabo", "production": False},
         "changed_resources": list(module.CONTAINERS.values()),
         "smoke": {
@@ -919,7 +1088,7 @@ def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
         },
         "rollback": {"kind": "predeploy_absence"},
     }
-    path = module.persist_receipt(tmp_path, receipt)
+    path = module.persist_receipt(tmp_path, receipt, accepted_manifest)
 
     assert json.loads(path.read_text()) == receipt
     pointer = json.loads((tmp_path / "current.json").read_text())
@@ -927,8 +1096,13 @@ def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
         "schema_version": module.CURRENT_RECEIPT_SCHEMA,
         "receipt_file": path.name,
         "receipt_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "manifest_file": path.name.removesuffix(".json") + ".release.json",
+        "manifest_sha256": accepted_manifest_sha,
     }
     assert module.load_current_receipt(tmp_path) == path
+    _, durable_manifest, durable_checksum = module.load_current_release(tmp_path)
+    assert durable_manifest.read_bytes() == accepted_manifest.read_bytes()
+    assert durable_checksum.is_file()
     checksum = (tmp_path / f"{path.name}.sha256").read_text().split()
     assert checksum == [hashlib.sha256(path.read_bytes()).hexdigest(), path.name]
     serialized = path.read_text().lower()
@@ -936,7 +1110,17 @@ def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
         assert forbidden not in serialized
 
     with pytest.raises(OSError, match="immutable deployment receipt"):
-        module.persist_receipt(tmp_path, receipt)
+        module.persist_receipt(tmp_path, receipt, accepted_manifest)
+
+    original_manifest = durable_manifest.read_bytes()
+    durable_manifest.write_text("{}\n", encoding="utf-8")
+    with pytest.raises(module.DeploymentError, match="manifest checksum mismatch"):
+        module.load_current_release(tmp_path)
+    durable_manifest.write_bytes(original_manifest)
+    durable_manifest.unlink()
+    with pytest.raises(module.DeploymentError, match="manifest is missing"):
+        module.load_current_release(tmp_path)
+    durable_manifest.write_bytes(original_manifest)
 
     path.write_text("{}", encoding="utf-8")
     with pytest.raises(module.DeploymentError, match="checksum mismatch"):
@@ -953,6 +1137,11 @@ def test_receipt_pointer_failure_removes_uncommitted_accepted_artifacts(
         "manifest_sha256": "d" * 64,
         "status": "accepted",
     }
+    accepted_manifest = tmp_path / "accepted-input.json"
+    accepted_manifest.write_text("{}", encoding="utf-8")
+    receipt["manifest_sha256"] = hashlib.sha256(
+        accepted_manifest.read_bytes()
+    ).hexdigest()
     real_replace = module.os.replace
 
     def fail_current_pointer(source, destination):
@@ -962,7 +1151,7 @@ def test_receipt_pointer_failure_removes_uncommitted_accepted_artifacts(
 
     monkeypatch.setattr(module.os, "replace", fail_current_pointer)
     with pytest.raises(OSError, match="current pointer"):
-        module.persist_receipt(tmp_path, receipt)
+        module.persist_receipt(tmp_path, receipt, accepted_manifest)
 
     assert not (tmp_path / "current.json").exists()
     assert not list(tmp_path.glob(f"{GIT_SHA}-*.json"))
@@ -1012,17 +1201,7 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
         tmp_path, "candidate.json", candidate
     )
     schema = tmp_path / "schema.json"
-    schema.write_text(
-        json.dumps(
-            {
-                "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
-                "database_source_authority": "approved-test-db",
-                "migration_set_identity": candidate["migration_set"]["identity"],
-                "captured_at": "2026-09-06T12:00:00Z",
-            }
-        ),
-        encoding="utf-8",
-    )
+    schema.write_text(json.dumps(_schema_receipt(module, candidate)), encoding="utf-8")
     authority = _authorized_checkpoint_authority(tmp_path, schema)
     authority_path = tmp_path / "authority.json"
     authority_path.write_text(json.dumps(authority), encoding="utf-8")
@@ -1034,6 +1213,12 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     monkeypatch.setattr(module, "verify_pulled_image", lambda *_args: None)
     monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
     monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
+
+    def verified_database(_path, _receipt, _runner, **callbacks):
+        callbacks["on_env_file_read"]()
+        callbacks["on_query_completed"]()
+
+    monkeypatch.setattr(module, "verify_database_schema", verified_database)
 
     def runner(command, **_kwargs):
         commands.append(command)
@@ -1059,6 +1244,8 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     assert receipt["status"] == "failed"
     assert receipt["pulled_images_verified"] == list(candidate["images"].values())
     assert receipt["service_mutation_attempted"] is True
+    assert receipt["database_access_performed"] is True
+    assert receipt["env_files_read"] is True
     assert receipt["changed_resources"] == list(module.CONTAINERS.values())
     assert receipt["rollback"] == {
         "identity": {"kind": "predeploy_absence"},
@@ -1072,6 +1259,124 @@ def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
     ]
     assert mutation_commands[0][-2:] == ["api", "web"]
     assert all(command[-2:] == ["api", "web"] for command in rollback_commands)
+
+
+@pytest.mark.parametrize("failure_stage", ["candidate-container", "candidate-pull"])
+def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
+    tmp_path, monkeypatch, failure_stage
+):
+    module = _load_checkpoint_module()
+    _, candidate = _manifest()
+    rollback = copy.deepcopy(candidate)
+    rollback["git_sha"] = "d" * 40
+    rollback["release_id"] = "git-" + "d" * 40
+    rollback["images"] = {
+        "backend": "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:"
+        + "e" * 64,
+        "web": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "f" * 64,
+    }
+    candidate_path, candidate_checksum = _write_json_with_checksum(
+        tmp_path, "candidate.json", candidate
+    )
+    rollback_path, _rollback_checksum = _write_json_with_checksum(
+        tmp_path, "prior-input.json", rollback
+    )
+    schema = tmp_path / "schema.json"
+    schema.write_text(json.dumps(_schema_receipt(module, candidate)), encoding="utf-8")
+    prior_receipt = {
+        "schema_version": module.RECEIPT_SCHEMA,
+        "status": "accepted",
+        "mode": "bootstrap",
+        "source_sha": rollback["git_sha"],
+        "release_run_id": "122",
+        "images": rollback["images"],
+        "manifest_sha256": hashlib.sha256(rollback_path.read_bytes()).hexdigest(),
+        "target": {
+            "provider": "contabo",
+            "classification": "live-checkpoint",
+            "production": False,
+            "hostname": module.TARGET_HOSTNAME,
+        },
+        "compose_project": module.PROJECT,
+        "migration_set_identity": candidate["migration_set"]["identity"],
+        "changed_resources": list(module.CONTAINERS.values()),
+        "smoke": {
+            path: {"status": 200}
+            for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
+        },
+        "database_mutation_performed": False,
+        "infrastructure_changes_performed": False,
+    }
+    module.persist_receipt(tmp_path, prior_receipt, rollback_path)
+    authority = _authorized_checkpoint_authority(tmp_path, schema)
+    authority_path = tmp_path / "authority.json"
+    authority_path.write_text(json.dumps(authority), encoding="utf-8")
+    readiness_shas = []
+
+    monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
+    monkeypatch.setattr(module, "validate_host_runtime", lambda *_args: None)
+    monkeypatch.setattr(module, "verify_origin_state", lambda *_args: None)
+    monkeypatch.setattr(module, "verify_pulled_image", lambda *_args: None)
+    monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
+    monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
+    monkeypatch.setattr(
+        module,
+        "wait_for_origin_ready",
+        lambda _origin, source_sha: readiness_shas.append(source_sha),
+    )
+    monkeypatch.setattr(
+        module,
+        "smoke_origin",
+        lambda *_args: {
+            path: {"status": 200}
+            for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
+        },
+    )
+
+    def verified_database(_path, _receipt, _runner, **callbacks):
+        callbacks["on_env_file_read"]()
+        callbacks["on_query_completed"]()
+
+    monkeypatch.setattr(module, "verify_database_schema", verified_database)
+
+    def verify_containers(_env, source_sha, _images):
+        if (
+            failure_stage == "candidate-container"
+            and source_sha == candidate["git_sha"]
+        ):
+            raise module.DeploymentError("candidate container verification failed")
+
+    monkeypatch.setattr(module, "verify_app_containers", verify_containers)
+
+    def runner(command, **_kwargs):
+        if (
+            failure_stage == "candidate-pull"
+            and command[:2] == ["docker", "pull"]
+            and command[-1] == candidate["images"]["backend"]
+        ):
+            raise module.DeploymentError("candidate pull failed")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    args = Namespace(
+        authority=authority_path,
+        compose=CHECKPOINT_COMPOSE,
+        mode="upgrade",
+        candidate=candidate_path,
+        candidate_checksum=candidate_checksum,
+        candidate_run_id="123",
+    )
+    with pytest.raises(module.OperationFailed) as failure:
+        module.execute(args, runner=runner)
+
+    receipt = failure.value.receipt
+    if failure_stage == "candidate-container":
+        assert readiness_shas == [candidate["git_sha"], rollback["git_sha"]]
+        assert receipt["rollback"]["status"] == "verified"
+    else:
+        assert readiness_shas == []
+        assert receipt["rollback"]["status"] == "not-required"
+        assert receipt["service_mutation_attempted"] is False
+    assert receipt["database_access_performed"] is True
 
 
 def test_current_target_authority_records_proven_facts_and_exact_blockers():

--- a/tests/test_v3_application_checkpoint_release.py
+++ b/tests/test_v3_application_checkpoint_release.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import importlib.util
 import json
 import re
@@ -19,6 +20,9 @@ RELEASE_RUN_TOOL = ROOT / "scripts" / "release" / "v3_release_run.py"
 HOST_PREFLIGHT = (
     ROOT / "scripts" / "operator" / "actions" / "v3-app-live-checkpoint-preflight.sh"
 )
+CHECKPOINT_TOOL = ROOT / "scripts" / "operator" / "v3_checkpoint_deploy.py"
+CHECKPOINT_COMPOSE = ROOT / "deploy" / "v3-live-checkpoint" / "compose.yml"
+CHECKPOINT_AUTHORITY = ROOT / "deploy" / "v3-live-checkpoint" / "target-authority.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "v3-application-release.yml"
 DEPLOY_WORKFLOW = (
     ROOT / ".github" / "workflows" / "v3-application-live-checkpoint-preflight.yml"
@@ -49,6 +53,16 @@ def _load_module():
 
 def _load_release_run_module():
     spec = importlib.util.spec_from_file_location("v3_release_run", RELEASE_RUN_TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_checkpoint_module():
+    spec = importlib.util.spec_from_file_location(
+        "v3_checkpoint_deploy", CHECKPOINT_TOOL
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -304,7 +318,7 @@ def test_release_and_deploy_workflows_are_manual_only_and_separate():
     assert set(release["on"]) == {"workflow_dispatch"}
     assert set(deploy["on"]) == {"workflow_dispatch"}
     assert "environment" not in release["jobs"]["manifest"]
-    assert deploy["jobs"]["preflight"]["environment"] == "v3-live-checkpoint"
+    assert deploy["jobs"]["deploy"]["environment"] == "v3-live-checkpoint"
     for document in (release, deploy):
         assert "pull_request" not in document["on"]
         assert "push" not in document["on"]
@@ -323,21 +337,25 @@ def test_release_workflow_builds_both_images_from_one_exact_main_sha_and_digests
     assert "needs.build-web.outputs.digest" in workflow
     assert "v3_release_manifest.py verify" in workflow
     assert "--verify-source-migrations" in workflow
+    assert "(cd release && sha256sum v3-application-release.json" in workflow
     assert "git pull" not in workflow
 
 
-def test_deploy_preflight_consumes_manifests_reuses_only_existing_ssh_boundary():
+def test_deploy_workflow_supports_bootstrap_and_receipt_backed_upgrade():
     workflow = DEPLOY_WORKFLOW.read_text()
 
     assert "--purpose deploy-candidate" in workflow
     assert "--purpose rollback-candidate" in workflow
+    assert "inputs.deployment_mode == 'upgrade'" in workflow
+    assert "Bootstrap must not claim a prior release" in workflow
+    assert "Upgrade requires a valid rollback run ID" in workflow
     assert "Candidate cannot be its own rollback" in workflow
     assert "Authenticate release workflow run provenance" in workflow
     assert "scripts/release/v3_release_run.py" in workflow
     assert "StrictHostKeyChecking=yes" in workflow
     assert "UserKnownHostsFile=~/.ssh/known_hosts" in workflow
     assert "Contabo live-checkpoint" in workflow
-    assert "distinct from the production operator" in workflow
+    assert "distinct from production credentials" in workflow
     secret_names = set(re.findall(r"secrets\.([A-Z0-9_]+)", workflow))
     assert secret_names == {
         "V3_LIVE_CHECKPOINT_SSH_KEY",
@@ -347,14 +365,16 @@ def test_deploy_preflight_consumes_manifests_reuses_only_existing_ssh_boundary()
         "V3_LIVE_CHECKPOINT_SSH_KNOWN_HOSTS",
     }
     assert "ED_NEW_OPERATOR_" not in workflow
-    for forbidden in (
-        "ssh-keyscan",
-        "docker compose",
-        "docker pull",
-        "git pull",
-        "psql",
-        "migrate",
-    ):
+    assert "v3_checkpoint_deploy.py" in workflow
+    assert "Upload sanitized deployment receipt" in workflow
+    assert "if: always()" in workflow
+    assert workflow.index(
+        "Stop locally when target authority is incomplete"
+    ) < workflow.index("Download candidate release manifest")
+    assert workflow.index("--authority-gate") < workflow.index("ssh -i")
+    assert 'remote_receipt="$RECEIPT.remote"' in workflow
+    assert "remote_transport_or_bundle_failed" in workflow
+    for forbidden in ("ssh-keyscan", "git pull", "pnpm install", "uv sync", "psql"):
         assert forbidden not in workflow.lower()
 
 
@@ -390,6 +410,39 @@ def test_release_run_provenance_requires_canonical_successful_main_workflow():
             )
 
 
+def test_release_run_cli_allows_candidate_only_bootstrap_and_pairs_upgrade_args():
+    module = _load_release_run_module()
+    bootstrap = module._parser().parse_args(
+        [
+            "--repository",
+            "brianstewart377-rgb/ed-finder",
+            "--candidate-run-id",
+            "123",
+            "--candidate-manifest",
+            "candidate.json",
+        ]
+    )
+    assert bootstrap.rollback_run_id is None
+    assert bootstrap.rollback_manifest is None
+
+    upgrade = module._parser().parse_args(
+        [
+            "--repository",
+            "brianstewart377-rgb/ed-finder",
+            "--candidate-run-id",
+            "123",
+            "--candidate-manifest",
+            "candidate.json",
+            "--rollback-run-id",
+            "122",
+            "--rollback-manifest",
+            "rollback.json",
+        ]
+    )
+    assert upgrade.rollback_run_id == "122"
+    assert upgrade.rollback_manifest == Path("rollback.json")
+
+
 def test_release_run_fetch_uses_one_fixed_https_authority_and_keeps_token_off_argv(
     monkeypatch,
 ):
@@ -403,9 +456,7 @@ def test_release_run_fetch_uses_one_fixed_https_authority_and_keeps_token_off_ar
         return subprocess.CompletedProcess(command, 0, stdout=payload, stderr=b"")
 
     monkeypatch.setattr(module.subprocess, "run", fake_run)
-    result = module.fetch_run(
-        "brianstewart377-rgb/ed-finder", "123456789", token
-    )
+    result = module.fetch_run("brianstewart377-rgb/ed-finder", "123456789", token)
 
     assert result == {"id": 42}
     command = observed["command"]
@@ -474,9 +525,7 @@ def test_release_run_fetch_rejects_header_injection_before_network(monkeypatch):
     )
 
     with pytest.raises(module.ReleaseRunError, match="header characters"):
-        module.fetch_run(
-            "brianstewart377-rgb/ed-finder", "123", "token\r\nX-Evil: yes"
-        )
+        module.fetch_run("brianstewart377-rgb/ed-finder", "123", "token\r\nX-Evil: yes")
 
 
 @pytest.mark.parametrize(
@@ -519,7 +568,539 @@ def test_release_run_fetch_enforces_a_post_transport_response_bound(monkeypatch)
         module.fetch_run("brianstewart377-rgb/ed-finder", "123", "token")
 
 
-def test_host_preflight_is_machine_readable_and_always_stops_before_mutation():
+def test_checkpoint_compose_owns_only_bounded_application_resources():
+    compose = yaml.safe_load(CHECKPOINT_COMPOSE.read_text())
+
+    assert compose["name"] == "edfinder-v3-checkpoint"
+    assert set(compose["services"]) == {"api", "web"}
+    assert compose.get("volumes") is None
+    assert compose["networks"] == {
+        "app": {"name": "edfinder-v3-checkpoint-app", "external": True}
+    }
+    assert compose["services"]["api"]["container_name"] == "edfinder-v3-checkpoint-api"
+    assert compose["services"]["web"]["container_name"] == "edfinder-v3-checkpoint-web"
+    assert compose["services"]["api"]["cpus"] == "1.50"
+    assert compose["services"]["api"]["mem_limit"] == "1536m"
+    assert compose["services"]["web"]["cpus"] == "0.50"
+    assert compose["services"]["web"]["mem_limit"] == "512m"
+    assert (
+        compose["services"]["api"]["environment"]["EDDN_SIMULATION_INGEST_ENABLED"]
+        == "false"
+    )
+    for service in compose["services"].values():
+        assert "build" not in service
+        assert "depends_on" not in service
+    assert all(
+        name not in compose["services"]
+        for name in ("postgres", "redis", "valkey", "nats", "edge", "runner")
+    )
+
+
+def test_bootstrap_and_upgrade_mutation_plans_are_literal_app_only_allowlists():
+    module = _load_checkpoint_module()
+    env = {
+        "V3_CHECKPOINT_API_IMAGE": "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:"
+        + "b" * 64,
+        "V3_CHECKPOINT_WEB_IMAGE": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:"
+        + "c" * 64,
+        "V3_CHECKPOINT_SOURCE_SHA": GIT_SHA,
+    }
+    plan = module.command_plan(CHECKPOINT_COMPOSE, env)
+
+    assert plan[0] == ["docker", "pull", env["V3_CHECKPOINT_API_IMAGE"]]
+    assert plan[1] == ["docker", "pull", env["V3_CHECKPOINT_WEB_IMAGE"]]
+    assert plan[2][-2:] == ["api", "web"]
+    assert "--no-deps" in plan[2]
+    assert "--force-recreate" in plan[2]
+    assert plan[2][plan[2].index("--pull") + 1] == "never"
+
+    bootstrap_rollback, _ = module.rollback_plan(
+        CHECKPOINT_COMPOSE, "bootstrap", env, {"kind": "predeploy_absence"}
+    )
+    assert all(command[-2:] == ["api", "web"] for command in bootstrap_rollback)
+    flattened = " ".join(" ".join(command) for command in plan + bootstrap_rollback)
+    for forbidden in (
+        " down ",
+        "--remove-orphans",
+        "--volumes",
+        "postgres",
+        "redis",
+        "valkey",
+        "nats",
+    ):
+        assert forbidden not in f" {flattened.lower()} "
+
+
+def test_rendered_compose_allowlist_is_checked_before_any_pull():
+    module = _load_checkpoint_module()
+    env = {
+        "V3_CHECKPOINT_API_IMAGE": "ghcr.io/example/api@sha256:" + "b" * 64,
+        "V3_CHECKPOINT_WEB_IMAGE": "ghcr.io/example/web@sha256:" + "c" * 64,
+    }
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        stdout = "api web unexpected\n" if command[-1] == "--services" else ""
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+    with pytest.raises(module.DeploymentError, match="service allowlist"):
+        module.validate_host_runtime(CHECKPOINT_COMPOSE, env, runner)
+
+    assert not any(command[:2] == ["docker", "pull"] for command in commands)
+
+
+def _write_json_with_checksum(
+    directory: Path, name: str, value: dict
+) -> tuple[Path, Path]:
+    document = directory / name
+    document.write_text(json.dumps(value, sort_keys=True), encoding="utf-8")
+    checksum = directory / f"{name}.sha256"
+    checksum.write_text(
+        f"{hashlib.sha256(document.read_bytes()).hexdigest()}  {name}\n",
+        encoding="utf-8",
+    )
+    return document, checksum
+
+
+def _authorized_checkpoint_authority(tmp_path: Path, schema_path: Path) -> dict:
+    authority = json.loads(CHECKPOINT_AUTHORITY.read_text())
+    authority["status"] = "authorized"
+    authority["blockers"] = []
+    authority["observed_runtime"]["container_runtime"] = "Docker test authority"
+    authority["observed_runtime"]["compose"] = "Docker Compose test authority"
+    authority["observed_runtime"]["docker_networks"] = ["edfinder-v3-checkpoint-app"]
+    authority["external_authority"] = {
+        "api_env_file": str(tmp_path / "api.env"),
+        "api_env_owner_uid": 0,
+        "api_env_mode": "0600",
+        "database_source_authority": "approved-test-db",
+        "schema_identity_receipt": str(schema_path),
+        "schema_identity_receipt_sha256": hashlib.sha256(
+            schema_path.read_bytes()
+        ).hexdigest(),
+        "origin_bind": "http://127.0.0.1:12345",
+        "edge_route_authority": "approved-test-edge-route",
+        "receipt_directory": str(tmp_path),
+        "receipt_owner_uid": 0,
+        "receipt_mode": "0700",
+        "ghcr_pull_authority": "approved-test-ghcr-principal",
+        "docker_config_directory": str(tmp_path / "docker-config"),
+        "docker_config_owner_uid": 0,
+        "docker_config_mode": "0700",
+        "docker_context": "checkpoint-test",
+    }
+    return authority
+
+
+def test_bootstrap_needs_no_prior_release_but_upgrade_requires_receipt(tmp_path):
+    module = _load_checkpoint_module()
+    _, candidate = _manifest()
+    candidate_path, candidate_checksum = _write_json_with_checksum(
+        tmp_path, "candidate.json", candidate
+    )
+    schema = tmp_path / "schema.json"
+    schema.write_text(
+        json.dumps(
+            {
+                "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
+                "database_source_authority": "approved-test-db",
+                "migration_set_identity": candidate["migration_set"]["identity"],
+                "captured_at": "2026-09-06T12:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    validated = module.validate_release_inputs(
+        mode="bootstrap",
+        candidate_path=candidate_path,
+        candidate_checksum=candidate_checksum,
+        current_schema_path=schema,
+        database_source_authority="approved-test-db",
+        rollback_path=None,
+        rollback_checksum=None,
+        prior_receipt_path=None,
+    )
+    assert validated["rollback"] == {"kind": "predeploy_absence"}
+
+    with pytest.raises(module.DeploymentError, match="upgrade requires"):
+        module.validate_release_inputs(
+            mode="upgrade",
+            candidate_path=candidate_path,
+            candidate_checksum=candidate_checksum,
+            current_schema_path=schema,
+            database_source_authority="approved-test-db",
+            rollback_path=None,
+            rollback_checksum=None,
+            prior_receipt_path=None,
+        )
+
+
+def test_upgrade_requires_receipt_matching_prior_digest_release(tmp_path):
+    module = _load_checkpoint_module()
+    _, candidate = _manifest()
+    rollback = copy.deepcopy(candidate)
+    rollback["git_sha"] = "d" * 40
+    rollback["release_id"] = "git-" + "d" * 40
+    rollback["images"]["backend"] = (
+        "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:" + "e" * 64
+    )
+    rollback["images"]["web"] = (
+        "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "f" * 64
+    )
+    candidate_path, candidate_checksum = _write_json_with_checksum(
+        tmp_path, "candidate.json", candidate
+    )
+    rollback_path, rollback_checksum = _write_json_with_checksum(
+        tmp_path, "rollback.json", rollback
+    )
+    schema = tmp_path / "schema.json"
+    schema.write_text(
+        json.dumps(
+            {
+                "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
+                "database_source_authority": "approved-test-db",
+                "migration_set_identity": candidate["migration_set"]["identity"],
+                "captured_at": "2026-09-06T12:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    rollback_sum = hashlib.sha256(rollback_path.read_bytes()).hexdigest()
+    prior_receipt = tmp_path / "prior.json"
+    prior_receipt.write_text(
+        json.dumps(
+            {
+                "schema_version": module.RECEIPT_SCHEMA,
+                "status": "accepted",
+                "mode": "bootstrap",
+                "source_sha": rollback["git_sha"],
+                "images": rollback["images"],
+                "manifest_sha256": rollback_sum,
+                "target": {
+                    "provider": "contabo",
+                    "classification": "live-checkpoint",
+                    "production": False,
+                    "hostname": "vmi3542235",
+                },
+                "compose_project": module.PROJECT,
+                "migration_set_identity": candidate["migration_set"]["identity"],
+                "changed_resources": list(module.CONTAINERS.values()),
+                "smoke": {
+                    path: {"status": 200}
+                    for path in (
+                        "/",
+                        "/api/health",
+                        "/openapi.json",
+                        "/api/auth/session",
+                    )
+                },
+                "database_mutation_performed": False,
+                "infrastructure_changes_performed": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    validated = module.validate_release_inputs(
+        mode="upgrade",
+        candidate_path=candidate_path,
+        candidate_checksum=candidate_checksum,
+        current_schema_path=schema,
+        database_source_authority="approved-test-db",
+        rollback_path=rollback_path,
+        rollback_checksum=rollback_checksum,
+        prior_receipt_path=prior_receipt,
+    )
+    assert validated["rollback"]["source_sha"] == rollback["git_sha"]
+
+    bad_receipt = json.loads(prior_receipt.read_text())
+    bad_receipt["images"]["web"] = candidate["images"]["web"]
+    prior_receipt.write_text(json.dumps(bad_receipt), encoding="utf-8")
+    with pytest.raises(module.DeploymentError, match="does not authenticate"):
+        module.validate_release_inputs(
+            mode="upgrade",
+            candidate_path=candidate_path,
+            candidate_checksum=candidate_checksum,
+            current_schema_path=schema,
+            database_source_authority="approved-test-db",
+            rollback_path=rollback_path,
+            rollback_checksum=rollback_checksum,
+            prior_receipt_path=prior_receipt,
+        )
+
+
+def test_manifest_checksum_rejects_path_bearing_or_tampered_artifacts(tmp_path):
+    module = _load_checkpoint_module()
+    document = tmp_path / "manifest.json"
+    document.write_text("{}", encoding="utf-8")
+    digest = hashlib.sha256(document.read_bytes()).hexdigest()
+    checksum = tmp_path / "manifest.json.sha256"
+
+    checksum.write_text(f"{digest}  release/manifest.json\n", encoding="utf-8")
+    with pytest.raises(module.DeploymentError, match="adjacent manifest basename"):
+        module.verify_checksum(document, checksum)
+    checksum.write_text(f"{'0' * 64}  manifest.json\n", encoding="utf-8")
+    with pytest.raises(module.DeploymentError, match="mismatch"):
+        module.verify_checksum(document, checksum)
+
+
+def test_origin_smoke_checks_exact_required_routes_and_build_identity(monkeypatch):
+    module = _load_checkpoint_module()
+    responses = {
+        "/": (200, b"<!doctype html><html><body>ED-Finder</body></html>", "text/html"),
+        "/api/health": (
+            200,
+            json.dumps(
+                {"status": "ok", "database": "connected", "build_sha": GIT_SHA}
+            ).encode(),
+            "application/json",
+        ),
+        "/openapi.json": (
+            200,
+            json.dumps(
+                {"paths": {"/api/health": {}, "/api/auth/session": {}}}
+            ).encode(),
+            "application/json",
+        ),
+        "/api/auth/session": (
+            200,
+            json.dumps({"authenticated": False}).encode(),
+            "application/json",
+        ),
+    }
+    observed = []
+
+    def fake_get(origin, path):
+        observed.append((origin, path))
+        return responses[path]
+
+    monkeypatch.setattr(module, "get_origin", fake_get)
+    outcomes = module.smoke_origin("http://127.0.0.1:12345", GIT_SHA)
+
+    assert [path for _, path in observed] == [
+        "/",
+        "/api/health",
+        "/openapi.json",
+        "/api/auth/session",
+    ]
+    assert all(value["status"] == 200 for value in outcomes.values())
+
+    responses["/api/health"] = (
+        200,
+        json.dumps(
+            {"status": "ok", "database": "connected", "build_sha": "d" * 40}
+        ).encode(),
+        "application/json",
+    )
+    with pytest.raises(module.DeploymentError, match="build/database identity"):
+        module.smoke_origin("http://127.0.0.1:12345", GIT_SHA)
+
+
+def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
+    module = _load_checkpoint_module()
+    receipt = {
+        "schema_version": module.RECEIPT_SCHEMA,
+        "status": "accepted",
+        "source_sha": GIT_SHA,
+        "release_run_id": "12345",
+        "images": {
+            "backend": "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:"
+            + "b" * 64,
+            "web": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "c" * 64,
+        },
+        "manifest_sha256": "d" * 64,
+        "target": {"provider": "contabo", "production": False},
+        "changed_resources": list(module.CONTAINERS.values()),
+        "smoke": {
+            path: {"status": 200}
+            for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
+        },
+        "rollback": {"kind": "predeploy_absence"},
+    }
+    path = module.persist_receipt(tmp_path, receipt)
+
+    assert json.loads(path.read_text()) == receipt
+    pointer = json.loads((tmp_path / "current.json").read_text())
+    assert pointer == {
+        "schema_version": module.CURRENT_RECEIPT_SCHEMA,
+        "receipt_file": path.name,
+        "receipt_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+    assert module.load_current_receipt(tmp_path) == path
+    checksum = (tmp_path / f"{path.name}.sha256").read_text().split()
+    assert checksum == [hashlib.sha256(path.read_bytes()).hexdigest(), path.name]
+    serialized = path.read_text().lower()
+    for forbidden in ("database_url", "password", "private_key", "access_token"):
+        assert forbidden not in serialized
+
+    with pytest.raises(OSError, match="immutable deployment receipt"):
+        module.persist_receipt(tmp_path, receipt)
+
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(module.DeploymentError, match="checksum mismatch"):
+        module.load_current_receipt(tmp_path)
+
+
+def test_receipt_pointer_failure_removes_uncommitted_accepted_artifacts(
+    tmp_path, monkeypatch
+):
+    module = _load_checkpoint_module()
+    receipt = {
+        "source_sha": GIT_SHA,
+        "release_run_id": "12345",
+        "manifest_sha256": "d" * 64,
+        "status": "accepted",
+    }
+    real_replace = module.os.replace
+
+    def fail_current_pointer(source, destination):
+        if Path(destination).name == "current.json":
+            raise OSError("simulated current pointer failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(module.os, "replace", fail_current_pointer)
+    with pytest.raises(OSError, match="current pointer"):
+        module.persist_receipt(tmp_path, receipt)
+
+    assert not (tmp_path / "current.json").exists()
+    assert not list(tmp_path.glob(f"{GIT_SHA}-*.json"))
+    assert not list(tmp_path.glob(f"{GIT_SHA}-*.json.sha256"))
+
+
+def test_unsafe_host_identity_stops_before_any_runtime_or_mutation_command(
+    tmp_path, monkeypatch
+):
+    module = _load_checkpoint_module()
+    schema = tmp_path / "schema.json"
+    schema.write_text("{}", encoding="utf-8")
+    authority = _authorized_checkpoint_authority(tmp_path, schema)
+    authority_path = tmp_path / "authority.json"
+    authority_path.write_text(json.dumps(authority), encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(module.socket, "gethostname", lambda: "wrong-host")
+
+    def forbidden_runner(command, **_kwargs):
+        calls.append(command)
+        raise AssertionError("unsafe target facts reached the command boundary")
+
+    args = Namespace(
+        authority=authority_path,
+        compose=CHECKPOINT_COMPOSE,
+        mode="bootstrap",
+        candidate=tmp_path / "candidate.json",
+        candidate_checksum=tmp_path / "candidate.json.sha256",
+        candidate_run_id="12345",
+        rollback=None,
+        rollback_checksum=None,
+        rollback_run_id=None,
+    )
+    with pytest.raises(module.DeploymentError, match="host short identity"):
+        module.execute(args, runner=forbidden_runner)
+    assert calls == []
+    assert not (tmp_path / "deploy.lock").exists()
+
+
+def test_failed_bootstrap_reports_pulls_mutation_and_verified_absence_rollback(
+    tmp_path, monkeypatch
+):
+    module = _load_checkpoint_module()
+    _, candidate = _manifest()
+    candidate_path, candidate_checksum = _write_json_with_checksum(
+        tmp_path, "candidate.json", candidate
+    )
+    schema = tmp_path / "schema.json"
+    schema.write_text(
+        json.dumps(
+            {
+                "schema_version": module.SCHEMA_RECEIPT_SCHEMA,
+                "database_source_authority": "approved-test-db",
+                "migration_set_identity": candidate["migration_set"]["identity"],
+                "captured_at": "2026-09-06T12:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+    authority = _authorized_checkpoint_authority(tmp_path, schema)
+    authority_path = tmp_path / "authority.json"
+    authority_path.write_text(json.dumps(authority), encoding="utf-8")
+    commands = []
+
+    monkeypatch.setattr(module, "validate_host_files", lambda *_args: None)
+    monkeypatch.setattr(module, "validate_host_runtime", lambda *_args: None)
+    monkeypatch.setattr(module, "verify_bootstrap_absence", lambda *_args: None)
+    monkeypatch.setattr(module, "verify_pulled_image", lambda *_args: None)
+    monkeypatch.setattr(module, "acquire_deployment_lock", lambda *_args: object())
+    monkeypatch.setattr(module, "release_deployment_lock", lambda *_args: None)
+
+    def runner(command, **_kwargs):
+        commands.append(command)
+        if "up" in command:
+            raise module.DeploymentError("simulated app recreation failure")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    args = Namespace(
+        authority=authority_path,
+        compose=CHECKPOINT_COMPOSE,
+        mode="bootstrap",
+        candidate=candidate_path,
+        candidate_checksum=candidate_checksum,
+        candidate_run_id="12345",
+        rollback=None,
+        rollback_checksum=None,
+        rollback_run_id=None,
+    )
+    with pytest.raises(module.OperationFailed) as failure:
+        module.execute(args, runner=runner)
+
+    receipt = failure.value.receipt
+    assert receipt["status"] == "failed"
+    assert receipt["pulled_images_verified"] == list(candidate["images"].values())
+    assert receipt["service_mutation_attempted"] is True
+    assert receipt["changed_resources"] == list(module.CONTAINERS.values())
+    assert receipt["rollback"] == {
+        "identity": {"kind": "predeploy_absence"},
+        "attempted": True,
+        "status": "verified",
+    }
+    assert (tmp_path / receipt["durable_failure_receipt"]).is_file()
+    mutation_commands = [command for command in commands if "up" in command]
+    rollback_commands = [
+        command for command in commands if "stop" in command or "rm" in command
+    ]
+    assert mutation_commands[0][-2:] == ["api", "web"]
+    assert all(command[-2:] == ["api", "web"] for command in rollback_commands)
+
+
+def test_current_target_authority_records_proven_facts_and_exact_blockers():
+    authority = json.loads(CHECKPOINT_AUTHORITY.read_text())
+    module = _load_checkpoint_module()
+
+    assert module.validate_authority(authority) == sorted(authority["blockers"])
+    assert authority["status"] == "stopped"
+    assert authority["target"] == {
+        "provider": "contabo",
+        "classification": "live-checkpoint",
+        "production": False,
+        "hostname": "vmi3542235",
+        "fqdn": "vmi3542235.contaboserver.net",
+        "architecture": "x86_64",
+    }
+    assert authority["observed_capacity"]["logical_cpus"] == 8
+    assert len(authority["observed_runtime"]["runner_services"]) == 3
+    assert authority["observed_runtime"]["container_runtime"] is None
+    assert authority["external_authority"]["database_source_authority"] is None
+    assert "authorized_checkpoint_database_source_missing" in authority["blockers"]
+    assert "container_runtime_and_compose_unavailable" in authority["blockers"]
+    assert (
+        hashlib.sha256(CHECKPOINT_COMPOSE.read_bytes()).hexdigest()
+        == authority["application_contract"]["compose_sha256"]
+    )
+
+
+def test_host_preflight_is_machine_readable_and_stops_before_mutation():
     result = subprocess.run(
         ["bash", str(HOST_PREFLIGHT)], capture_output=True, text=True
     )
@@ -527,45 +1108,22 @@ def test_host_preflight_is_machine_readable_and_always_stops_before_mutation():
     assert result.returncode == 78
     receipt = json.loads(result.stdout)
     assert receipt["status"] == "stopped"
-    assert receipt["target"] == {
-        "provider": "contabo",
-        "classification": "live-checkpoint",
-        "production": False,
-    }
-    assert receipt["authorized_recreate_targets"] == []
+    assert receipt["target"]["provider"] == "contabo"
+    assert receipt["target"]["classification"] == "live-checkpoint"
+    assert receipt["target"]["production"] is False
+    assert receipt["authorized_recreate_targets"] == ["api", "web"]
+    assert receipt["changed_resources"] == []
     assert receipt["service_changes_performed"] is False
     assert receipt["database_access_performed"] is False
     assert receipt["migrations_performed"] is False
-    assert receipt["filesystem_writes_performed"] is False
-    assert receipt["required_facts"] == sorted(receipt["required_facts"])
-    assert (
-        "accepted_prior_digest_release_and_receipt_compatible_with_current_database"
-        in receipt["required_facts"]
-    )
-    assert (
-        "explicit_postgresql18_redis_nats_and_edge_preservation_targets"
-        in receipt["required_facts"]
-    )
-    assert "live_checkpoint_topology_authority_incomplete" in receipt["failures"]
-    assert (
-        "authoritative_contabo_live_checkpoint_host_identity_unproven"
-        in receipt["failures"]
-    )
+    assert "authorized_checkpoint_database_source_missing" in receipt["failures"]
+    assert "container_runtime_and_compose_unavailable" in receipt["failures"]
 
     source = HOST_PREFLIGHT.read_text()
     assert "Contabo is a live-checkpoint environment, not production" in source
     assert "ed-finder-prod" not in source
     assert "nb79a3d.mevnode.com" not in source
-    for forbidden in (
-        "docker compose up",
-        "docker restart",
-        "docker rm",
-        "docker pull",
-        "git pull",
-        "psql",
-        "pg_restore",
-        'subprocess.run(["docker"',
-    ):
+    for forbidden in ("git pull", "psql", "pg_restore"):
         assert forbidden not in source
 
 
@@ -576,6 +1134,8 @@ def test_operator_runbook_keeps_contabo_outside_the_production_boundary():
 
     assert "**Contabo is not production.**" in runbook
     assert "exact `main` SHA" in runbook
-    assert "without a target-host source checkout" in runbook
+    assert "never runs `git pull`" in runbook
     assert "Evidence from Contabo must not be presented as production" in runbook
-    assert "V3 production Compose authority" not in runbook
+    assert "Bootstrap checkpoint #1 intentionally has no prior V3 release" in runbook
+    assert "persistent infrastructure" in runbook
+    assert "NATS is not a V3 checkpoint baseline dependency" in runbook

--- a/tests/test_v3_application_stack_decision.py
+++ b/tests/test_v3_application_stack_decision.py
@@ -187,10 +187,11 @@ def test_browser_product_acceptance_and_review_lab_are_separate_babylon_lanes():
     assert browser_lanes.count("babylon") >= 2
 
 
-def test_pr_601_is_described_as_an_active_product_integration_lane():
+def test_pr_601_is_described_as_the_merged_product_baseline():
     roadmap = _contract(ROADMAP).lower()
 
-    assert "#601" in roadmap and "active" in roadmap
+    assert "#601" in roadmap and "merged" in roadmap
+    assert "6d574a2908ebda146a2c271f8fb46a9e272ad12e" in roadmap
     for product_slice in ("finder", "inspect", "babylon"):
         assert product_slice in roadmap
     assert not re.search(r"#601.{0,160}foundation[- ]only", roadmap)
@@ -203,10 +204,6 @@ def test_primary_authorities_do_not_restore_superseded_stage_or_checkpoint_claim
     forbidden_claims = (
         r"(?:archived?|historical) (?:documents?|docs).{0,80}(?:are|as) "
         r"(?:the )?(?:current|primary) authority",
-        r"contabo live[- ]checkpoint",
-        r"contabo.{0,80}live[- ]checkpoint environment",
-        r"contabo is (?:the |a )?(?:live[- ]?)?checkpoint",
-        r"checkpoint (?:target|destination|environment) is contabo",
         r"27a.{0,80}only authori[sz]es 27b",
         r"babylon runtime is not authori[sz]ed in this stage",
         r"(?:#601|apps/web).{0,120}foundation[- ]only",

--- a/tests/test_v3_checkpoint_workflow_contract.py
+++ b/tests/test_v3_checkpoint_workflow_contract.py
@@ -1,0 +1,44 @@
+"""Workflow-only contracts for the bounded V3 live-checkpoint deploy."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = (
+    ROOT / ".github" / "workflows" / "v3-application-live-checkpoint-preflight.yml"
+)
+
+
+def test_checkpoint_workflow_ceiling_covers_bounded_deploy_and_rollback_budget():
+    workflow = yaml.load(WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+    deploy = workflow["jobs"]["deploy"]
+
+    assert int(deploy["timeout-minutes"]) == 75
+
+    source = WORKFLOW.read_text()
+    assert "each command at 120 seconds" in source
+    assert "readiness window at 120 seconds" in source
+    assert "candidate apply/smoke, rollback" in source
+
+
+def test_upgrade_uses_durable_host_rollback_state_not_expiring_artifact():
+    workflow = yaml.load(WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+    inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    step_names = [step.get("name") for step in workflow["jobs"]["deploy"]["steps"]]
+
+    assert set(inputs) == {"deployment_mode", "release_run_id"}
+    assert "Download candidate release manifest" in step_names
+    assert "Download accepted rollback manifest" not in step_names
+
+    source = WORKFLOW.read_text()
+    for stale_artifact_path in (
+        "rollback_run_id",
+        "artifacts/rollback",
+        "--rollback-run-id",
+        "--rollback-manifest",
+        "--rollback-checksum",
+        "--purpose rollback-candidate",
+    ):
+        assert stale_artifact_path not in source

--- a/tests/test_v3_checkpoint_workflow_contract.py
+++ b/tests/test_v3_checkpoint_workflow_contract.py
@@ -1,7 +1,11 @@
 """Workflow-only contracts for the bounded V3 live-checkpoint deploy."""
 
+import hashlib
+import os
 from pathlib import Path
+import subprocess
 
+import pytest
 import yaml
 
 
@@ -9,6 +13,25 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = (
     ROOT / ".github" / "workflows" / "v3-application-live-checkpoint-preflight.yml"
 )
+
+
+def _workflow_step(name: str) -> dict[str, str]:
+    workflow = yaml.load(WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+    return next(
+        step for step in workflow["jobs"]["deploy"]["steps"] if step.get("name") == name
+    )
+
+
+def _run_checksum_step(candidate_dir: Path) -> subprocess.CompletedProcess[str]:
+    step = _workflow_step("Verify downloaded artifact checksum")
+    return subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=ROOT,
+        env={**os.environ, "CANDIDATE_DIR": str(candidate_dir)},
+        check=False,
+        text=True,
+        capture_output=True,
+    )
 
 
 def test_checkpoint_workflow_ceiling_covers_bounded_deploy_and_rollback_budget():
@@ -42,3 +65,58 @@ def test_upgrade_uses_durable_host_rollback_state_not_expiring_artifact():
         "--purpose rollback-candidate",
     ):
         assert stale_artifact_path not in source
+
+
+def test_untrusted_release_run_stops_before_artifact_checksum_processing():
+    workflow = yaml.load(WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["deploy"]["steps"]
+    step_names = [step.get("name") for step in steps]
+    provenance_index = step_names.index("Authenticate release workflow run provenance")
+    checksum_index = step_names.index("Verify downloaded artifact checksum")
+
+    assert provenance_index < checksum_index
+    provenance = steps[provenance_index]
+    assert provenance.get("continue-on-error") is None
+    assert provenance.get("if") is None
+    assert "scripts/release/v3_release_run.py" in provenance["run"]
+
+
+def test_candidate_checksum_verifier_accepts_only_the_expected_basename(tmp_path):
+    manifest = tmp_path / "v3-application-release.json"
+    manifest.write_bytes(b'{"trusted": true}\n')
+    digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    (tmp_path / "v3-application-release.json.sha256").write_text(
+        f"{digest}  v3-application-release.json\n"
+    )
+
+    result = _run_checksum_step(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("path_kind", ["absolute", "parent"])
+def test_candidate_checksum_verifier_rejects_absolute_and_parent_paths(
+    tmp_path, path_kind
+):
+    manifest = tmp_path / "v3-application-release.json"
+    manifest.write_bytes(b'{"trusted": true}\n')
+    outside = tmp_path.parent / f"{tmp_path.name}-attacker-controlled"
+    outside.write_bytes(manifest.read_bytes())
+    hostile_path = str(outside) if path_kind == "absolute" else f"../{outside.name}"
+    digest = hashlib.sha256(outside.read_bytes()).hexdigest()
+    (tmp_path / "v3-application-release.json.sha256").write_text(
+        f"{digest}  {hostile_path}\n"
+    )
+
+    result = _run_checksum_step(tmp_path)
+
+    assert result.returncode == 64
+    assert "must name only v3-application-release.json" in result.stderr
+
+
+def test_candidate_checksum_step_never_executes_gnu_checksum_lists():
+    source = _workflow_step("Verify downloaded artifact checksum")["run"]
+
+    assert "sha256sum" not in source
+    assert "--check" not in source
+    assert 'manifest_basename = "v3-application-release.json"' in source

--- a/tests/test_v3_coordination_control_plane.py
+++ b/tests/test_v3_coordination_control_plane.py
@@ -4,70 +4,85 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CONTROL_PLANE = ROOT / 'docs' / 'development' / 'v3-coordination-control-plane.md'
-BROWSER_LANES = ROOT / 'docs' / 'development' / 'v3-browser-validation-lanes.md'
-HISTORICAL_OPS_DESIGN = ROOT / 'docs' / 'development' / 'chatgpt-ops-control-plane.md'
-CODEX_DISPATCH = ROOT / '.github' / 'workflows' / 'codex-dispatch.yml'
-CODEX_WORKER = ROOT / '.github' / 'workflows' / 'codex-laptop.yml'
-OPS_WORKFLOW = ROOT / '.github' / 'workflows' / 'chatgpt-ed-new-ops.yml'
+CONTROL_PLANE = ROOT / "docs" / "development" / "v3-coordination-control-plane.md"
+BROWSER_LANES = ROOT / "docs" / "development" / "v3-browser-validation-lanes.md"
+HISTORICAL_OPS_DESIGN = ROOT / "docs" / "development" / "chatgpt-ops-control-plane.md"
+CODEX_DISPATCH = ROOT / ".github" / "workflows" / "codex-dispatch.yml"
+CODEX_WORKER = ROOT / ".github" / "workflows" / "codex-laptop.yml"
+OPS_WORKFLOW = ROOT / ".github" / "workflows" / "chatgpt-ed-new-ops.yml"
 
 
 @pytest.mark.unit
 def test_v3_coordination_control_plane_is_not_an_application_runtime_bus():
-    text = CONTROL_PLANE.read_text(encoding='utf-8')
+    text = CONTROL_PLANE.read_text(encoding="utf-8")
 
-    assert 'coordination and evidence' in text
-    assert 'not a new application runtime service' in text
-    assert 'PR #601 is the single active Svelte V3 integration lane' in text
-    assert 'Svelte / SvelteKit' in text
-    assert 'renderer-neutral spatial contracts' in text
-    assert 'Babylon runtime adapter' in text
-    assert 'Domain/feature code must not import Babylon types.' in text
-    assert 'Typed API contracts are the liaison between browser application and backend' in text
+    assert "coordination and evidence" in text
+    assert "not a new application runtime service" in text
+    assert "PR #601 is the merged Svelte V3 application baseline" in text
+    assert "Svelte / SvelteKit" in text
+    assert "renderer-neutral spatial contracts" in text
+    assert "Babylon runtime adapter" in text
+    assert "Domain/feature code must not import Babylon types." in text
+    assert (
+        "Typed API contracts are the liaison between browser application and backend"
+        in text
+    )
 
 
 @pytest.mark.unit
 def test_control_plane_preserves_separate_validation_authorities():
-    control = CONTROL_PLANE.read_text(encoding='utf-8')
-    browser = BROWSER_LANES.read_text(encoding='utf-8')
+    control = CONTROL_PLANE.read_text(encoding="utf-8")
+    browser = BROWSER_LANES.read_text(encoding="utf-8")
 
-    assert 'Product E2E / Visual Acceptance' in control
-    assert 'Review Lab' in control
-    assert 'A green Review Lab does not replace Product E2E.' in control
-    assert 'same `apps/web` + Babylon frontend/renderer' in control
-    assert 'Review Lab screenshots are diagnostic evidence, not approved product visual baselines.' in browser
+    assert "Product E2E / Visual Acceptance" in control
+    assert "Review Lab" in control
+    assert "A green Review Lab does not replace Product E2E." in control
+    assert "same `apps/web` + Babylon frontend/renderer" in control
+    assert (
+        "Review Lab screenshots are diagnostic evidence, not approved product visual baselines."
+        in browser
+    )
 
 
 @pytest.mark.unit
 def test_live_checkpoint_path_is_main_immutable_and_receipted():
-    text = CONTROL_PLANE.read_text(encoding='utf-8')
+    text = CONTROL_PLANE.read_text(encoding="utf-8")
 
-    assert 'After a checkpoint merges, `main` is the only source from which a live checkpoint release may be built.' in text
-    assert 'main exact SHA' in text
-    assert 'digest-pinned release manifest' in text
-    assert 'Contabo live-checkpoint environment' in text
-    assert 'deployment receipt' in text
-    assert 'No worker branch deploy' in text
-    assert 'no `git pull`' in text
+    assert (
+        "After a checkpoint merges, `main` is the only source from which a live checkpoint release may be built."
+        in text
+    )
+    assert "main exact SHA" in text
+    assert "digest-pinned release manifest" in text
+    assert "Contabo live-checkpoint environment" in text
+    assert "deployment receipt" in text
+    assert "No worker branch deploy" in text
+    assert "no `git pull`" in text
 
 
 @pytest.mark.unit
 def test_historical_ops_design_cannot_be_mistaken_for_current_authority():
-    historical = HISTORICAL_OPS_DESIGN.read_text(encoding='utf-8')
-    current = CONTROL_PLANE.read_text(encoding='utf-8')
+    historical = HISTORICAL_OPS_DESIGN.read_text(encoding="utf-8")
+    current = CONTROL_PLANE.read_text(encoding="utf-8")
 
-    assert 'DESIGN/HISTORICAL DOCUMENT — NOT AN OPERATOR RUNBOOK' in historical
-    assert 'older `chatgpt-ops-control-plane.md` contains useful design history but is not the current authority' in current
+    assert "DESIGN/HISTORICAL DOCUMENT — NOT AN OPERATOR RUNBOOK" in historical
+    assert (
+        "older `chatgpt-ops-control-plane.md` contains useful design history but is not the current authority"
+        in current
+    )
 
 
 @pytest.mark.unit
 def test_codex_and_operator_control_surfaces_remain_narrow():
-    dispatch = CODEX_DISPATCH.read_text(encoding='utf-8')
-    worker = CODEX_WORKER.read_text(encoding='utf-8')
-    ops = OPS_WORKFLOW.read_text(encoding='utf-8')
+    dispatch = CODEX_DISPATCH.read_text(encoding="utf-8")
+    worker = CODEX_WORKER.read_text(encoding="utf-8")
+    ops = OPS_WORKFLOW.read_text(encoding="utf-8")
 
-    assert 'codex-task-requests' in dispatch
-    assert 'target_branch is protected/control-plane state and cannot be updated by Codex' in worker
-    assert 'contents: read' in worker
-    assert 'Allowlisted ed-new operation' in ops
-    assert 'Unsupported operation' in ops
+    assert "codex-task-requests" in dispatch
+    assert (
+        "target_branch is protected/control-plane state and cannot be updated by Codex"
+        in worker
+    )
+    assert "contents: read" in worker
+    assert "Allowlisted ed-new operation" in ops
+    assert "Unsupported operation" in ops

--- a/tests/test_v3_decommission_contract.py
+++ b/tests/test_v3_decommission_contract.py
@@ -5,165 +5,191 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def _read(*parts: str) -> str:
-    return ROOT.joinpath(*parts).read_text(encoding='utf-8')
+    return ROOT.joinpath(*parts).read_text(encoding="utf-8")
 
 
 def test_roadmap_has_explicit_v3_cutover_boundary_and_keeps_v2_historical():
-    roadmap = _read('docs', 'ROADMAP.md')
+    roadmap = _read("docs", "ROADMAP.md")
 
-    assert 'ed-finder-prod' in roadmap
-    assert 'nb79a3d.mevnode.com' in roadmap
-    assert 'Hetzner/V2 is gone.' in roadmap
-    assert 'Old host, runtime, cron, database, backup, and rollback receipts are history.' in roadmap
-    assert 'PostgreSQL 18' in roadmap
+    assert "ed-finder-prod" in roadmap
+    assert "nb79a3d.mevnode.com" in roadmap
+    assert "Hetzner/V2 is gone." in roadmap
+    assert (
+        "Old host, runtime, cron, database, backup, and rollback receipts are history."
+        in roadmap
+    )
+    assert "PostgreSQL 18" in roadmap
 
 
 def test_current_infrastructure_fails_closed_without_pg18_recovery_runbook():
-    status = _read('docs', 'operations', 'infrastructure-status.md')
+    status = _read("docs", "operations", "infrastructure-status.md")
 
-    assert 'V3 database recovery boundary' in status
-    assert 'does not currently contain an executable PostgreSQL 18 backup/restore/PITR recovery runbook' in status
-    assert 'repository-driven production database backup restoration, PITR execution, or disaster-recovery commands are **not authorized**' in status
+    assert "V3 database recovery boundary" in status
+    assert (
+        "does not currently contain an executable PostgreSQL 18 backup/restore/PITR recovery runbook"
+        in status
+    )
+    assert (
+        "repository-driven production database backup restoration, PITR execution, or disaster-recovery commands are **not authorized**"
+        in status
+    )
 
 
 def test_destructive_v2_storage_recovery_runbook_is_tombstoned():
-    runbook = _read('docs', 'operations', 'storage-recovery-runbook-2026-07-12.md')
-    normalized = ' '.join(runbook.replace('**', '').split())
+    runbook = _read("docs", "operations", "storage-recovery-runbook-2026-07-12.md")
+    normalized = " ".join(runbook.replace("**", "").split())
 
-    assert 'RETIRED — V1/V2 production storage recovery runbook' in runbook
-    assert '**Do not execute this file.**' in runbook
-    assert 'It is not a PostgreSQL 18/V3 production runbook' in normalized
-    assert 'Issue #573' in runbook
-    assert 'DROP INDEX CONCURRENTLY' not in runbook
-    assert 'pg_repack ratings' not in runbook
+    assert "RETIRED — V1/V2 production storage recovery runbook" in runbook
+    assert "**Do not execute this file.**" in runbook
+    assert "It is not a PostgreSQL 18/V3 production runbook" in normalized
+    assert "Issue #573" in runbook
+    assert "DROP INDEX CONCURRENTLY" not in runbook
+    assert "pg_repack ratings" not in runbook
 
 
 def test_frontier_oauth_doc_fails_closed_away_from_v2_provisioning():
-    oauth = _read('docs', 'operations', 'frontier-oauth.md')
+    oauth = _read("docs", "operations", "frontier-oauth.md")
 
-    assert 'V3 production configuration boundary' in oauth
-    assert 'does **not** authorize placing production secrets' in oauth
-    assert 'does not currently contain a reviewed V3 production' in oauth
-    assert 'https://ed-finder.app/api/auth/frontier/callback' in oauth
-    assert 'v3-app-status' in oauth
-    assert 'normal deployment wrapper applies' not in oauth
-    assert 'Set these values in the production `.env`' not in oauth
+    assert "V3 production configuration boundary" in oauth
+    assert "does **not** authorize placing production secrets" in oauth
+    assert "does not currently contain a reviewed V3 production" in oauth
+    assert "https://ed-finder.app/api/auth/frontier/callback" in oauth
+    assert "v3-app-status" in oauth
+    assert "normal deployment wrapper applies" not in oauth
+    assert "Set these values in the production `.env`" not in oauth
 
 
 def test_v2_deploy_and_setup_entrypoints_cannot_return():
-    deploy = _read('scripts', 'deploy_main.sh')
+    deploy = _read("scripts", "deploy_main.sh")
 
-    assert not (ROOT / 'setup.sh').exists()
-    assert not (ROOT / 'scripts' / 'release-main-to-prod.ps1').exists()
-    assert not (ROOT / 'scripts' / 'deploy-hetzner-over-ssh.ps1').exists()
-    assert 'RETIRED — V2 single-host deployment entrypoint' in deploy
-    assert 'exit 64' in deploy
-    for action in ('git pull --ff-only', 'docker compose up', 'bash scripts/apply_migrations.sh'):
+    assert not (ROOT / "setup.sh").exists()
+    assert not (ROOT / "scripts" / "release-main-to-prod.ps1").exists()
+    assert not (ROOT / "scripts" / "deploy-hetzner-over-ssh.ps1").exists()
+    assert "RETIRED — V2 single-host deployment entrypoint" in deploy
+    assert "exit 64" in deploy
+    for action in (
+        "git pull --ff-only",
+        "docker compose up",
+        "bash scripts/apply_migrations.sh",
+    ):
         assert action not in deploy
 
 
 def test_hosted_review_is_absent_from_active_runtime_configs():
-    active = '\n'.join(
+    active = "\n".join(
         (
-            _read('docker-compose.yml'),
-            _read('config', 'nginx.conf'),
-            _read('config', 'nginx-ci.conf'),
+            _read("docker-compose.yml"),
+            _read("config", "nginx.conf"),
+            _read("config", "nginx-ci.conf"),
         )
     )
 
     for retired in (
-        'review.ed-finder.app',
-        '/opt/ed-finder-review',
-        'edfinder-review-edge',
-        'review-api:8000',
+        "review.ed-finder.app",
+        "/opt/ed-finder-review",
+        "edfinder-review-edge",
+        "review-api:8000",
     ):
         assert retired not in active
 
 
 def test_legacy_compose_and_maintenance_are_not_v3_pg18_authority():
-    compose = _read('docker-compose.yml')
-    maintenance = _read('apps', 'maintenance', 'Dockerfile')
+    compose = _read("docker-compose.yml")
+    maintenance = _read("apps", "maintenance", "Dockerfile")
 
-    assert 'LEGACY SELF-HOST / LOCAL-CI COMPOSE — NEVER V3 PRODUCTION OR BACKUP AUTHORITY' in compose
-    assert 'PostgreSQL 16 — legacy/local Compose compatibility' in compose
-    assert 'PostgreSQL 18' in compose
-    assert 'LEGACY SELF-HOST / LOCAL-CI IMAGE — NEVER V3 PRODUCTION OR BACKUP AUTHORITY' in maintenance
-    assert 'retained root Compose environment still uses PostgreSQL 16' in maintenance
-    assert 'Current V3' in maintenance and 'PostgreSQL 18' in maintenance
+    assert (
+        "LEGACY SELF-HOST / LOCAL-CI COMPOSE — NEVER V3 PRODUCTION OR BACKUP AUTHORITY"
+        in compose
+    )
+    assert "PostgreSQL 16 — legacy/local Compose compatibility" in compose
+    assert "PostgreSQL 18" in compose
+    assert (
+        "LEGACY SELF-HOST / LOCAL-CI IMAGE — NEVER V3 PRODUCTION OR BACKUP AUTHORITY"
+        in maintenance
+    )
+    assert "retained root Compose environment still uses PostgreSQL 16" in maintenance
+    assert "Current V3" in maintenance and "PostgreSQL 18" in maintenance
 
 
 def test_stale_operational_design_docs_fail_closed():
-    ledger = _read('docs', 'operations', 'migration-ledger-implementation-plan.md')
-    control_plane = _read('docs', 'development', 'chatgpt-ops-control-plane.md')
+    ledger = _read("docs", "operations", "migration-ledger-implementation-plan.md")
+    control_plane = _read("docs", "development", "chatgpt-ops-control-plane.md")
 
-    assert 'SUPERSEDED DESIGN-ONLY PLAN. DO NOT EXECUTE.' in ledger
-    assert 'neither a current V3 migration procedure nor authority' in ledger
-    assert 'DESIGN/HISTORICAL DOCUMENT — NOT AN OPERATOR RUNBOOK.' in control_plane
-    assert 'operations proposed below were never implemented' in control_plane
-    assert 'chatgpt-ed-new-ops.yml' in control_plane
+    assert "SUPERSEDED DESIGN-ONLY PLAN. DO NOT EXECUTE." in ledger
+    assert "neither a current V3 migration procedure nor authority" in ledger
+    assert "DESIGN/HISTORICAL DOCUMENT — NOT AN OPERATOR RUNBOOK." in control_plane
+    assert "operations proposed below were never implemented" in control_plane
+    assert "chatgpt-ed-new-ops.yml" in control_plane
 
 
 def test_application_hard_cut_is_current_authority():
-    roadmap = _read('docs', 'ROADMAP.md')
-    stack = _read('docs', 'development', 'v3-application-stack-decision.md')
-    browser = _read('docs', 'development', 'v3-browser-validation-lanes.md')
-    agent_contract = _read('CLAUDE.md')
-    readme = _read('README.md')
+    roadmap = _read("docs", "ROADMAP.md")
+    stack = _read("docs", "development", "v3-application-stack-decision.md")
+    browser = _read("docs", "development", "v3-browser-validation-lanes.md")
+    agent_contract = _read("CLAUDE.md")
+    readme = _read("README.md")
 
     for authority in (roadmap, stack, agent_contract):
-        assert 'apps/web/' in authority
-        assert 'sole' in authority
-    assert 'apps/web/' in readme
-    assert 'PR #601 is the single active V3 application' in roadmap
-    assert 'not the architecture target' in stack
-    assert 'sole target for new browser application work' in agent_contract
-    assert 'not the V3 target' in readme
-    assert 'Cypress' in browser
-    assert 'apps/web' in browser
+        assert "apps/web/" in authority
+        assert "sole" in authority
+    assert "apps/web/" in readme
+    assert "Merged application baseline" in roadmap
+    assert "6d574a2908ebda146a2c271f8fb46a9e272ad12e" in roadmap
+    assert "not the architecture target" in stack
+    assert "sole target for new browser application work" in agent_contract
+    assert "not the V3 target" in readme
+    assert "Cypress" in browser
+    assert "apps/web" in browser
 
 
 def test_live_api_and_layout_importer_copy_is_provider_neutral():
-    layout_provider = _read('apps', 'api', 'src', 'colony_planner', 'layout_import_provider.py')
-    admin_router = _read('apps', 'api', 'src', 'routers', 'admin.py')
-    simulation_router = _read('apps', 'api', 'src', 'routers', 'simulation.py')
-    main = _read('apps', 'api', 'src', 'main.py')
-    config = _read('apps', 'api', 'src', 'config.py')
+    layout_provider = _read(
+        "apps", "api", "src", "colony_planner", "layout_import_provider.py"
+    )
+    admin_router = _read("apps", "api", "src", "routers", "admin.py")
+    simulation_router = _read("apps", "api", "src", "routers", "simulation.py")
+    main = _read("apps", "api", "src", "main.py")
+    config = _read("apps", "api", "src", "config.py")
 
-    assert 'Live layout-source import is not wired yet' in layout_provider
-    assert 'Live Spansh layout import is not wired yet' not in layout_provider
-    assert 'external data providers' in admin_router
-    assert 'external-source imported' in simulation_router
-    assert 'Spansh-imported' not in simulation_router
-    assert 'Hetzner' not in main
-    assert 'hetzner' not in config.lower()
+    assert "Live layout-source import is not wired yet" in layout_provider
+    assert "Live Spansh layout import is not wired yet" not in layout_provider
+    assert "external data providers" in admin_router
+    assert "external-source imported" in simulation_router
+    assert "Spansh-imported" not in simulation_router
+    assert "Hetzner" not in main
+    assert "hetzner" not in config.lower()
 
 
 def test_active_env_example_does_not_publish_v2_storagebox_credentials():
-    env_example = _read('env.example')
+    env_example = _read("env.example")
 
-    assert 'NOT the V3 production secret/configuration authority' in env_example
-    assert 'sudo bash setup.sh' not in env_example
-    assert 'storagebox:ed-finder/backups/postgres' not in env_example
-    assert 'RCLONE_CONFIG_STORAGEBOX_' not in env_example
+    assert "NOT the V3 production secret/configuration authority" in env_example
+    assert "sudo bash setup.sh" not in env_example
+    assert "storagebox:ed-finder/backups/postgres" not in env_example
+    assert "RCLONE_CONFIG_STORAGEBOX_" not in env_example
 
 
 def test_protected_integration_lane_exercises_postgresql_18():
-    workflow = _read('.github', 'workflows', 'ci.yml')
-    integration = workflow[workflow.index('  integration:'):workflow.index('  canonical-safety:')]
+    workflow = _read(".github", "workflows", "ci.yml")
+    integration = workflow[
+        workflow.index("  integration:") : workflow.index("  canonical-safety:")
+    ]
 
-    assert 'image: postgres:18-alpine' in integration
-    assert 'image: postgres:16-alpine' not in integration
-    assert 'bash scripts/seed_check.sh' in integration
-    assert 'Run data invariants against seeded integration DB' in integration
-    assert 'Run integration test suite' in integration
+    assert "image: postgres:18-alpine" in integration
+    assert "image: postgres:16-alpine" not in integration
+    assert "bash scripts/seed_check.sh" in integration
+    assert "Run data invariants against seeded integration DB" in integration
+    assert "Run integration test suite" in integration
 
 
 def test_backend_coverage_lane_exercises_postgresql_18():
-    workflow = _read('.github', 'workflows', 'coverage.yml')
-    backend = workflow[workflow.index('  backend-coverage:'):workflow.index('  frontend-coverage:')]
+    workflow = _read(".github", "workflows", "coverage.yml")
+    backend = workflow[
+        workflow.index("  backend-coverage:") : workflow.index("  frontend-coverage:")
+    ]
 
-    assert 'image: postgres:18-alpine' in backend
-    assert 'image: postgres:16-alpine' not in backend
-    assert 'bash scripts/seed_check.sh' in backend
-    assert 'Validate seeded coverage database' in backend
-    assert 'Append integration coverage' in backend
+    assert "image: postgres:18-alpine" in backend
+    assert "image: postgres:16-alpine" not in backend
+    assert "bash scripts/seed_check.sh" in backend
+    assert "Validate seeded coverage database" in backend
+    assert "Append integration coverage" in backend


### PR DESCRIPTION
## Purpose

Turn the merged V3 application baseline into a bounded, immutable, non-production live-checkpoint deployment path for owner testing.

## What this adds

- a governed V3 live-checkpoint deployment workflow with explicit bootstrap vs upgrade modes;
- release provenance and manifest verification before any host mutation;
- an isolated `edfinder-v3-checkpoint` Compose project containing only web/API application containers;
- resource limits sized against the observed Contabo runner host capacity;
- deployment receipt generation and rollback-aware upgrade handling;
- fail-closed target authority that records exactly which Contabo prerequisites are still missing;
- documentation updates reflecting that PR #601 is merged and the programme is now exiting through the checkpoint path.

## Current target posture

The first read-only host inspection established that the selected Contabo host has ample spare CPU/RAM/disk but currently has no container runtime/Compose and no authorised checkpoint DB/config/origin/edge/receipt/GHCR authorities. Accordingly, `deploy/v3-live-checkpoint/target-authority.json` remains `status: stopped` and the workflow refuses mutation until those authorities are supplied.

This PR therefore implements the safe deployment mechanism; it does **not** deploy V3, alter production, create database/schema changes, touch DNS, or authorize a production cutover.

## Provenance

- base: merged V3 `main` at `6d574a2908ebda146a2c271f8fb46a9e272ad12e`
- governed Codex worker run: `34038747485`
- sealed implementation head: `7c38338a5dba3016156dd2ed92fc95fcfea11272`
- prepare / implementation / seal / artifact / trusted-push stages all completed successfully

## Acceptance

- protected CI and browser/review gates must pass on this exact head;
- review any deployment/rollback/security findings before merge;
- after merge, provision the explicitly missing non-production checkpoint authorities in a separate bounded task;
- only then build an immutable release from `main` and perform the first checkpoint deployment.