### PR TITLE
Provision persistent V3 live-checkpoint infrastructure on Contabo

### DIFF
--- a/.github/v3-live-checkpoint-provision-requests/README.md
+++ b/.github/v3-live-checkpoint-provision-requests/README.md
@@ -1,0 +1,21 @@
+# V3 live-checkpoint provisioning requests
+
+This directory is the allowlisted request surface for the separate
+non-production Contabo provisioning workflow. Request commits belong only on
+the dedicated `v3-live-checkpoint-provision-requests` branch and contain
+exactly one changed JSON file.
+
+The document has exactly three string fields:
+
+```json
+{
+  "operation": "provision-infrastructure",
+  "backend_image": "",
+  "web_image": ""
+}
+```
+
+Leave both image fields empty to emit the explicit secret-backed GHCR blocker.
+To prove anonymous public pulls, provide both canonical digest-pinned V3 image
+references. Requests cannot supply credentials, hosts, paths, commands, or a
+deployment/release operation.

--- a/.github/workflows/v3-live-checkpoint-provision.yml
+++ b/.github/workflows/v3-live-checkpoint-provision.yml
@@ -1,0 +1,288 @@
+name: V3 live-checkpoint infrastructure provisioning
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Allowlisted non-production provisioning operation
+        required: true
+        default: provision-infrastructure
+        type: choice
+        options:
+          - provision-infrastructure
+      backend_image:
+        description: Optional digest-pinned V3 backend image for an anonymous GHCR pull proof
+        required: false
+        type: string
+      web_image:
+        description: Optional digest-pinned V3 web image for an anonymous GHCR pull proof
+        required: false
+        type: string
+  push:
+    branches:
+      - v3-live-checkpoint-provision-requests
+    paths:
+      - '.github/v3-live-checkpoint-provision-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v3-live-checkpoint-infrastructure-provisioning
+  cancel-in-progress: false
+
+jobs:
+  provision:
+    name: Provision the bounded non-production Contabo checkpoint
+    runs-on: ubuntu-latest
+    environment: v3-live-checkpoint
+    # Includes bounded package operations plus the canonical fresh-schema and
+    # preview-seed window without pre-empting sanitized failure receipt output.
+    timeout-minutes: 150
+    steps:
+      - name: Checkout provisioning request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Set up CPython 3.14 for request and bundle validation
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Resolve allowlisted provisioning request
+        id: request
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_OPERATION: ${{ inputs.operation }}
+          INPUT_BACKEND_IMAGE: ${{ inputs.backend_image }}
+          INPUT_WEB_IMAGE: ${{ inputs.web_image }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          operation=""
+          backend_image=""
+          web_image=""
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            operation="$INPUT_OPERATION"
+            backend_image="$INPUT_BACKEND_IMAGE"
+            web_image="$INPUT_WEB_IMAGE"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            [[ "$BEFORE_SHA" =~ ^[0-9a-f]{40}$ && "$CURRENT_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "Request push SHAs are invalid" >&2
+              exit 64
+            }
+            mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+            [ "${#changed_files[@]}" -eq 1 ] || {
+              echo "Expected exactly one changed checkpoint provisioning request" >&2
+              exit 64
+            }
+            case "${changed_files[0]}" in
+              .github/v3-live-checkpoint-provision-requests/*.json) ;;
+              *) echo "Push changed a path outside the provisioning request allowlist" >&2; exit 64 ;;
+            esac
+            request_values="$RUNNER_TEMP/provision-request-values"
+            python - "${changed_files[0]}" > "$request_values" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          try:
+              value = json.loads(path.read_text(encoding="utf-8"))
+          except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+              raise SystemExit(f"Invalid provisioning request: {type(exc).__name__}") from exc
+          expected = {"operation", "backend_image", "web_image"}
+          if not isinstance(value, dict) or set(value) != expected:
+              raise SystemExit("Provisioning request keys must be exactly operation, backend_image, web_image")
+          if any(not isinstance(value[key], str) for key in expected):
+              raise SystemExit("Every provisioning request value must be a string")
+          if any("\n" in value[key] or "\r" in value[key] for key in expected):
+              raise SystemExit("Provisioning request values must be single-line")
+          print(value["operation"])
+          print(value["backend_image"])
+          print(value["web_image"])
+          PY
+            mapfile -t values < "$request_values"
+            [ "${#values[@]}" -eq 3 ] || { echo "Provisioning request shape is invalid" >&2; exit 64; }
+            operation="${values[0]}"
+            backend_image="${values[1]}"
+            web_image="${values[2]}"
+          else
+            echo "Unsupported event: $EVENT_NAME" >&2
+            exit 64
+          fi
+
+          [ "$operation" = "provision-infrastructure" ] || {
+            echo "Unsupported provisioning operation" >&2
+            exit 64
+          }
+          backend_prefix='ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:'
+          web_prefix='ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:'
+          if [ -n "$backend_image" ] || [ -n "$web_image" ]; then
+            [[ "$backend_image" =~ ^${backend_prefix}[0-9a-f]{64}$ ]] || { echo "Backend GHCR probe image is invalid" >&2; exit 64; }
+            [[ "$web_image" =~ ^${web_prefix}[0-9a-f]{64}$ ]] || { echo "Web GHCR probe image is invalid" >&2; exit 64; }
+          fi
+          {
+            echo "operation=$operation"
+            echo "backend_image=$backend_image"
+            echo "web_image=$web_image"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout trusted provisioning implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare pinned Contabo SSH trust boundary
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.V3_LIVE_CHECKPOINT_SSH_KEY }}
+          SSH_HOST: ${{ secrets.V3_LIVE_CHECKPOINT_HOST }}
+          SSH_PORT: ${{ secrets.V3_LIVE_CHECKPOINT_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.V3_LIVE_CHECKPOINT_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" || { echo "Missing V3_LIVE_CHECKPOINT_SSH_KEY" >&2; exit 1; }
+          test -n "$SSH_HOST" || { echo "Missing V3_LIVE_CHECKPOINT_HOST" >&2; exit 1; }
+          [[ "$SSH_PORT" =~ ^[1-9][0-9]{0,4}$ ]] && [ "$SSH_PORT" -le 65535 ] || { echo "Invalid V3_LIVE_CHECKPOINT_PORT" >&2; exit 1; }
+          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing pinned live-checkpoint known-hosts secret" >&2; exit 1; }
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/v3_live_checkpoint_key
+          chmod 600 ~/.ssh/v3_live_checkpoint_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          if [ "$SSH_PORT" = "22" ]; then known_host_lookup="$SSH_HOST"; else known_host_lookup="[$SSH_HOST]:$SSH_PORT"; fi
+          ssh-keygen -F "$known_host_lookup" -f ~/.ssh/known_hosts >/dev/null || {
+            echo "Pinned known-host trust does not cover the configured host and port" >&2
+            exit 1
+          }
+
+      - name: Assemble source-free provisioning bundle
+        shell: bash
+        env:
+          BUNDLE: ${{ runner.temp }}/v3-live-checkpoint-provisioning-bundle
+        run: |
+          set -euo pipefail
+          install -d -m 700 "$BUNDLE/scripts/operator/actions" "$BUNDLE/scripts/release" "$BUNDLE/scripts" "$BUNDLE/sql" "$BUNDLE/deploy/v3-live-checkpoint" "$BUNDLE/artifacts"
+          install -m 700 trusted-main/scripts/operator/actions/v3-live-checkpoint-provision.sh "$BUNDLE/scripts/operator/actions/"
+          install -m 700 trusted-main/scripts/apply_migrations.sh trusted-main/scripts/seed_check.sh "$BUNDLE/scripts/"
+          install -m 600 trusted-main/scripts/release/v3_release_manifest.py "$BUNDLE/scripts/release/"
+          install -m 600 trusted-main/sql/*.sql trusted-main/sql/migration-manifest.txt "$BUNDLE/sql/"
+          install -m 600 trusted-main/deploy/v3-live-checkpoint/compose.yml "$BUNDLE/deploy/v3-live-checkpoint/"
+          (
+            cd trusted-main
+            python - <<'PY' > "$BUNDLE/artifacts/migration-set.json"
+          import json
+          from scripts.release.v3_release_manifest import migration_set
+          print(json.dumps(migration_set(), indent=2, sort_keys=True))
+          PY
+          )
+          python -m json.tool "$BUNDLE/artifacts/migration-set.json" >/dev/null
+
+      - name: Run bounded source-free provisioning
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.V3_LIVE_CHECKPOINT_HOST }}
+          SSH_PORT: ${{ secrets.V3_LIVE_CHECKPOINT_PORT }}
+          SSH_USER: ${{ secrets.V3_LIVE_CHECKPOINT_USER }}
+          BUNDLE: ${{ runner.temp }}/v3-live-checkpoint-provisioning-bundle
+          OUTPUT: ${{ runner.temp }}/v3-live-checkpoint-provisioning-output
+          BACKEND_IMAGE: ${{ steps.request.outputs.backend_image }}
+          WEB_IMAGE: ${{ steps.request.outputs.web_image }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing V3_LIVE_CHECKPOINT_USER" >&2; exit 1; }
+          printf '%s\0' --backend-image "$BACKEND_IMAGE" --web-image "$WEB_IMAGE" > "$BUNDLE/arguments"
+          remote_archive="$RUNNER_TEMP/v3-live-checkpoint-provisioning-output.tar"
+          set +e
+          tar -C "$BUNDLE" -cf - . | ssh -i ~/.ssh/v3_live_checkpoint_key \
+            -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'set -eu; umask 077; work="$(mktemp -d)"; trap '\''rm -rf -- "$work"'\'' EXIT HUP INT TERM; tar -xf - -C "$work"; output="$work/output"; install -d -m 700 "$output"; operator_user="$(id -un)"; set +e; xargs -0 sudo -n bash "$work/scripts/operator/actions/v3-live-checkpoint-provision.sh" --operator-user "$operator_user" --output-dir "$output" < "$work/arguments"; rc="$?"; set -e; tar -C "$output" -cf - provisioning-receipt.json target-authority-candidate.json; exit "$rc"' \
+            > "$remote_archive"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+          install -d -m 700 "$OUTPUT"
+          if [ "${pipeline_status[0]}" -eq 0 ] && [ -s "$remote_archive" ] && tar -tf "$remote_archive" | diff -u <(printf '%s\n' provisioning-receipt.json target-authority-candidate.json) - >/dev/null; then
+            tar -xf "$remote_archive" -C "$OUTPUT"
+          else
+            python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          output = Path(os.environ["OUTPUT"])
+          target = {"provider":"contabo","classification":"live-checkpoint","production":False,"hostname":"vmi3542235","fqdn":"vmi3542235.contaboserver.net","architecture":"x86_64"}
+          receipt = {"schema_version":"ed-finder/v3-live-checkpoint-provisioning-receipt/v1","operation":"provision-infrastructure","status":"stopped","target":target,"failures":["remote_transport_or_bundle_failed"],"mutation_started":None,"runner_services_verified_before":None,"runner_services_verified_after":None,"runner_service_continuity_preserved":None,"credentials_emitted":False,"production_access_performed":False,"production_data_copied":False,"dns_changes_performed":False,"application_deploy_performed":False}
+          authority_path = Path("trusted-main/deploy/v3-live-checkpoint/target-authority.json")
+          candidate = json.loads(authority_path.read_text(encoding="utf-8"))
+          candidate["status"] = "stopped"
+          candidate["blockers"] = sorted(set(candidate["blockers"] + ["remote_transport_or_bundle_failed"]))
+          (output / "provisioning-receipt.json").write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+          (output / "target-authority-candidate.json").write_text(json.dumps(candidate, indent=2, sort_keys=True) + "\n")
+          PY
+          fi
+          python -m json.tool "$OUTPUT/provisioning-receipt.json" >/dev/null
+          python -m json.tool "$OUTPUT/target-authority-candidate.json" >/dev/null
+          python - "$OUTPUT/provisioning-receipt.json" "$OUTPUT/target-authority-candidate.json" <<'PY'
+          import importlib.util
+          import json
+          import re
+          import sys
+          from pathlib import Path
+
+          receipt = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          candidate = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+          if receipt.get("schema_version") != "ed-finder/v3-live-checkpoint-provisioning-receipt/v1":
+              raise SystemExit("Unexpected provisioning receipt schema")
+          if receipt.get("status") not in {"provisioned", "provisioned_with_blocker", "stopped"}:
+              raise SystemExit("Unexpected provisioning receipt status")
+          target = receipt.get("target", {})
+          if target.get("production") is not False or target.get("hostname") != "vmi3542235":
+              raise SystemExit("Provisioning receipt target is invalid")
+
+          forbidden_keys = {"password", "token", "dsn", "database_url", "secret"}
+          credential_url = re.compile(r"[a-z][a-z0-9+.-]*://[^/@\s:]+:[^/@\s]+@", re.I)
+          def check_sanitized(value):
+              if isinstance(value, dict):
+                  for key, item in value.items():
+                      if str(key).lower() in forbidden_keys:
+                          raise SystemExit("Provisioning evidence contains a forbidden secret field")
+                      check_sanitized(item)
+              elif isinstance(value, list):
+                  for item in value:
+                      check_sanitized(item)
+              elif isinstance(value, str) and credential_url.search(value):
+                  raise SystemExit("Provisioning evidence contains credential-bearing URL material")
+          check_sanitized(receipt)
+          check_sanitized(candidate)
+
+          deploy_path = Path("trusted-main/scripts/operator/v3_checkpoint_deploy.py")
+          spec = importlib.util.spec_from_file_location("trusted_v3_checkpoint_deploy", deploy_path)
+          if spec is None or spec.loader is None:
+              raise SystemExit("Unable to load trusted target-authority validator")
+          deploy = importlib.util.module_from_spec(spec)
+          spec.loader.exec_module(deploy)
+          blockers = deploy.validate_authority(candidate)
+          if candidate.get("status") == "authorized" and blockers:
+              raise SystemExit("Authorized candidate unexpectedly retains blockers")
+          if candidate.get("status") == "stopped" and not blockers:
+              raise SystemExit("Stopped candidate must retain a blocker")
+          PY
+          [ "${pipeline_status[0]}" -eq 0 ] && [ "${pipeline_status[1]}" -eq 0 ] || exit 78
+
+      - name: Upload sanitized provisioning evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-live-checkpoint-provisioning-evidence
+          path: |
+            ${{ runner.temp }}/v3-live-checkpoint-provisioning-output/provisioning-receipt.json
+            ${{ runner.temp }}/v3-live-checkpoint-provisioning-output/target-authority-candidate.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/operations/infrastructure-status.md
+++ b/docs/operations/infrastructure-status.md
@@ -36,6 +36,12 @@ authorized checkpoint database/data source, origin/edge wiring, secret mount,
 GHCR pull authority or durable receipt store yet, so first-deployment mutation
 remains stopped. Production PostgreSQL/data must not fill that gap.
 
+The repository now includes a separately environment-gated, source-free
+[checkpoint infrastructure provisioner](./v3-live-checkpoint-provisioning.md)
+that can resolve those facts on the exact Contabo target. Its presence is not
+evidence that it ran: the committed target authority stays stopped until a
+sanitized real receipt and candidate are reviewed in a separate follow-up.
+
 Ollama was experimental residue used to test local inference for Octopus. It
 has been removed from production and is not part of the V3 architecture.
 

--- a/docs/operations/operator-command-contexts.md
+++ b/docs/operations/operator-command-contexts.md
@@ -82,6 +82,13 @@ absent. When those facts are separately reviewed, the same boundary may mutate
 only its fixed `api` and `web` application allowlist; it never manages
 PostgreSQL, Redis/Valkey, NATS, edge, runners or volumes.
 
+`scripts/operator/actions/v3-live-checkpoint-provision.sh` is the still
+separate, request-triggered infrastructure operator for that non-production
+checkpoint. It may run only through the dedicated environment-gated workflow
+and exact host/runner guard documented in
+[`v3-live-checkpoint-provisioning.md`](./v3-live-checkpoint-provisioning.md).
+Its sanitized target-authority candidate is evidence for review, not authority.
+
 Other scripts in that directory, including surviving Stage 19 staging/research tools, are **not** current V3 production authority merely because they are checked in. Read `scripts/operator/README.md` and require an explicitly current V3 workflow/runbook before executing any operator script against production.
 
 ## Final recommendation

--- a/docs/operations/v3-application-checkpoint-release.md
+++ b/docs/operations/v3-application-checkpoint-release.md
@@ -196,3 +196,10 @@ route, target GHCR pull authentication, and a durable deployment receipt
 directory. These are explicit external authority requirements; no port, path,
 network, data source or edge wiring may be inferred from legacy Compose files,
 production, or observed runner names.
+
+The bounded procedure that may create these non-production resources is
+documented in
+[`v3-live-checkpoint-provisioning.md`](./v3-live-checkpoint-provisioning.md).
+It is deliberately separate from this release/deploy dispatcher and emits a
+candidate only; committed target authority remains stopped until a real run is
+reviewed and accepted by a follow-up change.

--- a/docs/operations/v3-live-checkpoint-provisioning.md
+++ b/docs/operations/v3-live-checkpoint-provisioning.md
@@ -1,0 +1,140 @@
+# V3 Live-Checkpoint Infrastructure Provisioning
+
+## Boundary
+
+This runbook describes the reviewed operator for provisioning the first V3
+live-checkpoint host. The target is exactly Contabo
+`vmi3542235` / `vmi3542235.contaboserver.net` on `x86_64`. It is
+**NON-PRODUCTION**. Running this operator is not a release, application deploy,
+production promotion, or grant of deployment target authority.
+
+The committed [`target-authority.json`](../../deploy/v3-live-checkpoint/target-authority.json)
+remains unchanged and stopped. A successful run emits a sanitized candidate
+for a separate reviewed follow-up commit; that review is the only place target
+authority may change.
+
+## Control plane and request
+
+Use **V3 live-checkpoint infrastructure provisioning**. It is a manual and
+allowlisted request-file workflow with the dedicated `v3-live-checkpoint`
+GitHub environment and only `V3_LIVE_CHECKPOINT_*` SSH secrets. Pinned
+known-host verification is mandatory. It does not use the production
+`ED_NEW_OPERATOR_*` boundary.
+
+The only operation is `provision-infrastructure`. A request commit may change
+exactly one JSON file below
+`.github/v3-live-checkpoint-provision-requests/` on the dedicated request
+branch. The request cannot select a host, remote path, command, release, or
+credential. Optional backend and web values are accepted only as the two exact
+canonical GHCR repositories at digest-pinned references and are used solely
+for an anonymous pull proof.
+
+The workflow checks out the implementation independently from trusted `main`,
+builds a temporary allowlisted bundle, and streams it over SSH. The bundle
+contains only the provisioner, canonical migration/seed helpers, SQL,
+migration identity, and checkpoint Compose contract. It is removed after the
+run. There is no persistent source checkout, `git pull`, application build, or
+dependency resolution/build from repository source on the target.
+
+## Fail-closed target gate
+
+Before the first target mutation, the provisioner requires all of:
+
+- short hostname `vmi3542235`;
+- FQDN `vmi3542235.contaboserver.net`;
+- machine architecture `x86_64` and package architecture `amd64`;
+- an allowlisted supported Ubuntu release; and
+- exactly these three active runner units, with no additional active
+  `actions.runner.*` service:
+  - `actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker.service`
+  - `actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-2.service`
+  - `actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-3.service`
+
+The three services are never started, stopped, restarted, enabled, disabled,
+or reconfigured. Package handling runs `needrestart` in list-only mode, and
+their exact active set plus stable main PIDs/activation timestamps are checked
+again after provisioning.
+First-run foreign checkpoint paths, a container runtime/state, PostgreSQL
+listener, or HTTP listener stop ownership instead of being adopted. A
+root-owned marker permits a partial run to resume and makes repeat runs
+idempotent.
+
+## Owned persistent resources
+
+The operator installs Docker Engine and Compose from Docker's signed Ubuntu
+repository, plus `psql` and PostgreSQL 18 from the PostgreSQL Apt repository.
+It then owns only:
+
+- local rootful Docker context `edfinder-v3-checkpoint` at
+  `unix:///var/run/docker.sock`, with operator-owned mode-`0700` config;
+- empty/preserved external local bridge `edfinder-v3-checkpoint-app` at
+  `172.30.54.0/24`, accepting attachments only from the fixed checkpoint
+  `api` and `web` container names;
+- native persistent database `edfinder_v3_checkpoint`, owned by the dedicated
+  local/DB role `edfinder_checkpoint_db`;
+- a generated read-only application DB role, password, and generated API
+  admin token in `/etc/ed-finder/v3-checkpoint/api.env`, owner-only mode
+  `0600`;
+- `/var/lib/edfinder-v3-checkpoint/receipts` and the local Docker config,
+  owner-only mode `0700`;
+- loopback application origin `http://127.0.0.1:18080`; and
+- an nginx HTTP-only route for exact Host
+  `vmi3542235.contaboserver.net`, rejecting other hostnames and proxying only
+  to that loopback origin.
+
+The route does not configure DNS or TLS and never mentions or changes the
+production hostname. Docker's external-network creation is infrastructure
+only: the provisioner does not run Compose or create/start an application
+container.
+
+Provisioning and application deployment share the receipt-directory operation
+lock, so a later idempotent provisioning refresh cannot overlap a deployment.
+
+No Redis, Valkey, NATS, EDDN worker, OAuth activation, production database,
+backup, restore, derived-data bootstrap, or V2 data source is part of this
+operator.
+
+## Fresh preview database and identity proof
+
+The database is created only inside the provisioner's independently owned
+namespace. It never copies production data. On first bootstrap the dedicated
+owner runs canonical `scripts/seed_check.sh`, which invokes
+`scripts/apply_migrations.sh --include-manual`, applies
+`sql/seed_preview.sql`, checks the preview counts and rating coverage, and
+refreshes the map/archetype materialized views. This is the repository's
+existing Finder/search/detail/map preview dataset.
+
+After grants are reduced to the application read role, the provisioner repeats
+the seed acceptance checks in a transaction-read-only session. It also compares
+the complete live `schema_migrations` ledger with the migration entries
+generated by canonical `v3_release_manifest.migration_set()` from the trusted
+bundle. Only that bounded read-only proof can produce the fresh sanitized
+`ed-finder/v3-live-checkpoint-schema-identity/v2` receipt. The receipt contains
+no DSN, username, or password and its SHA-256 is recorded in the authority
+candidate.
+
+Credentials are generated once on target, retained on an idempotent rerun,
+never printed, and never uploaded. Command output is redirected to a private
+temporary log that is deleted before return.
+
+## GHCR authority and artifacts
+
+No registry credential is accepted by this workflow. If both optional
+digest-pinned image references are supplied, Docker uses a temporary empty
+configuration to attempt actual anonymous pulls. The candidate records
+anonymous/public pull authority only when both succeed. Missing or failed
+proof emits the sanitized blocker
+`explicit_secret_backed_ghcr_pull_authority_required`; a later design must
+name an explicit secret-backed authority rather than inventing credentials.
+
+The only uploaded files are:
+
+- `provisioning-receipt.json`; and
+- `target-authority-candidate.json`.
+
+Review the receipt, schema identity, exact runner preservation, package/runtime
+facts, path owners/modes, route, and GHCR result. Do not treat the candidate as
+active authority and do not copy it mechanically over the committed authority.
+If a run stops after mutation begins, inspect the sanitized failure receipt and
+rerun the same operator; do not delete persistent database, network, receipts,
+or Docker state to simulate a clean run.

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -10,6 +10,15 @@ Do not promote a repository helper into a production command merely because it e
 
 ## Contabo live-checkpoint helper
 
+- `actions/v3-live-checkpoint-provision.sh`: privileged, source-free and
+  idempotent infrastructure provisioner for exactly the non-production Contabo
+  checkpoint host and exact three-runner set. It provisions the separate
+  PostgreSQL 18 preview database, Docker/Compose and local context, persistent
+  external app network, private config/receipt paths, loopback origin and
+  provider-FQDN-only HTTP edge. It emits only sanitized provisioning evidence
+  and an authority candidate; it does not edit target authority or deploy the
+  application. See
+  [`docs/operations/v3-live-checkpoint-provisioning.md`](../../docs/operations/v3-live-checkpoint-provisioning.md).
 - `actions/v3-app-live-checkpoint-preflight.sh`: CPython 3.14 launcher for the
   fail-closed `v3_checkpoint_deploy.py` bootstrap/upgrade boundary. Contabo is
   explicitly non-production and uses separate environment credentials. The

--- a/scripts/operator/actions/v3-live-checkpoint-provision.sh
+++ b/scripts/operator/actions/v3-live-checkpoint-provision.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+#
+# Idempotent, source-free provisioning for the NON-PRODUCTION Contabo V3
+# live-checkpoint. This script owns infrastructure only; it never deploys the
+# api/web application and never changes deployment target authority.
+set -Eeuo pipefail
+umask 077
+
+TARGET_HOSTNAME="vmi3542235"
+TARGET_FQDN="vmi3542235.contaboserver.net"
+TARGET_ARCH="x86_64"
+PROJECT="edfinder-v3-checkpoint"
+APP_NETWORK="edfinder-v3-checkpoint-app"
+APP_SUBNET="172.30.54.0/24"
+APP_GATEWAY="172.30.54.1"
+ORIGIN_PORT="18080"
+DB_NAME="edfinder_v3_checkpoint"
+DB_OWNER="edfinder_checkpoint_db"
+DB_APP_ROLE="edfinder_checkpoint_app"
+DB_AUTHORITY="contabo-vmi3542235-native-postgresql18-preview-v1"
+DOCKER_CONTEXT="edfinder-v3-checkpoint"
+STATE_DIR="/var/lib/edfinder-v3-checkpoint-provisioner"
+OWNERSHIP_FILE="$STATE_DIR/ownership-v1"
+CONFIG_DIR="/etc/ed-finder/v3-checkpoint"
+API_ENV_FILE="$CONFIG_DIR/api.env"
+RUNTIME_DIR="/var/lib/edfinder-v3-checkpoint"
+RECEIPT_DIR="$RUNTIME_DIR/receipts"
+DOCKER_CONFIG_DIR="$RUNTIME_DIR/docker-config"
+SCHEMA_RECEIPT="$RUNTIME_DIR/schema-identity.json"
+NGINX_SITE="/etc/nginx/sites-available/edfinder-v3-checkpoint"
+NGINX_ENABLED="/etc/nginx/sites-enabled/edfinder-v3-checkpoint"
+RUNNER_SERVICES=(
+  "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker.service"
+  "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-2.service"
+  "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-3.service"
+)
+
+OPERATOR_USER=""
+OUTPUT_DIR=""
+BACKEND_IMAGE=""
+WEB_IMAGE=""
+BUNDLE_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../../.." && pwd)"
+RECEIPT_WRITTEN=0
+RUNNERS_BEFORE=false
+RUNNERS_AFTER=false
+RUNNER_STATE_BEFORE=""
+RUNNER_CONTINUITY=false
+MUTATION_STARTED=false
+GHCR_STATUS="explicit_secret_backed_authority_required"
+GHCR_AUTHORITY=""
+DB_BUNDLE_DIR=""
+
+usage() {
+  printf '%s\n' "usage: $0 --operator-user USER --output-dir DIR [--backend-image GHCR_DIGEST --web-image GHCR_DIGEST]" >&2
+  exit 64
+}
+
+while (($#)); do
+  case "$1" in
+    --operator-user) OPERATOR_USER="${2:-}"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="${2:-}"; shift 2 ;;
+    --backend-image) BACKEND_IMAGE="${2:-}"; shift 2 ;;
+    --web-image) WEB_IMAGE="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ $EUID -eq 0 ]] || { printf '%s\n' "provisioner requires non-interactive root authority" >&2; exit 77; }
+[[ "$OPERATOR_USER" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]] || usage
+[[ -n "$OUTPUT_DIR" && "$OUTPUT_DIR" == /tmp/* ]] || usage
+[[ -d "$OUTPUT_DIR" && ! -L "$OUTPUT_DIR" ]] || usage
+operator_uid="$(id -u "$OPERATOR_USER" 2>/dev/null)" || usage
+[[ "$(stat -c %u "$OUTPUT_DIR")" == "$operator_uid" ]] || usage
+[[ "$(stat -c %a "$OUTPUT_DIR")" == "700" ]] || usage
+
+expected_backend_prefix="ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:"
+expected_web_prefix="ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:"
+if [[ -n "$BACKEND_IMAGE" || -n "$WEB_IMAGE" ]]; then
+  [[ "$BACKEND_IMAGE" =~ ^${expected_backend_prefix}[0-9a-f]{64}$ ]] || usage
+  [[ "$WEB_IMAGE" =~ ^${expected_web_prefix}[0-9a-f]{64}$ ]] || usage
+fi
+
+receipt_path="$OUTPUT_DIR/provisioning-receipt.json"
+candidate_path="$OUTPUT_DIR/target-authority-candidate.json"
+private_log="$OUTPUT_DIR/.provisioning.log"
+install -m 600 /dev/null "$private_log"
+
+json_array_lines() {
+  local first=1 value
+  printf '['
+  for value in "$@"; do
+    ((first)) || printf ','
+    printf '"%s"' "$value"
+    first=0
+  done
+  printf ']'
+}
+
+write_stopped_artifacts() {
+  local failure="${1:-unexpected_provisioning_failure}"
+  [[ "$failure" =~ ^[a-z0-9_]+$ ]] || failure="unexpected_provisioning_failure"
+  local changed=false
+  $MUTATION_STARTED && changed=true
+  cat >"$receipt_path.tmp" <<JSON
+{"schema_version":"ed-finder/v3-live-checkpoint-provisioning-receipt/v1","operation":"provision-infrastructure","status":"stopped","target":{"provider":"contabo","classification":"live-checkpoint","production":false,"hostname":"$TARGET_HOSTNAME","fqdn":"$TARGET_FQDN","architecture":"$TARGET_ARCH"},"failures":["$failure"],"mutation_started":$changed,"runner_services_verified_before":$RUNNERS_BEFORE,"runner_services_verified_after":$RUNNERS_AFTER,"runner_service_continuity_preserved":$RUNNER_CONTINUITY,"credentials_emitted":false,"production_access_performed":false,"production_data_copied":false,"dns_changes_performed":false,"application_deploy_performed":false}
+JSON
+  local compose_sha=""
+  if [[ -f "$BUNDLE_ROOT/deploy/v3-live-checkpoint/compose.yml" ]]; then
+    compose_sha="$(sha256sum "$BUNDLE_ROOT/deploy/v3-live-checkpoint/compose.yml" 2>/dev/null | awk '{print $1}')"
+  fi
+  cat >"$candidate_path.tmp" <<JSON
+{"schema_version":"ed-finder/v3-live-checkpoint-target-authority/v1","status":"stopped","target":{"provider":"contabo","classification":"live-checkpoint","production":false,"hostname":"$TARGET_HOSTNAME","fqdn":"$TARGET_FQDN","architecture":"$TARGET_ARCH"},"observed_at":"$(date -u +%Y-%m-%d)","observed_capacity":{},"observed_runtime":{"container_runtime":null,"compose":null,"alternative_container_clis_present":[],"container_names":[],"docker_networks":[],"docker_volumes":[],"tcp_listeners":[],"runner_services":$(json_array_lines "${RUNNER_SERVICES[@]}"),"checkpoint_directories_found_under_opt_srv_var_lib":[]},"application_contract":{"compose_project":"$PROJECT","compose_sha256":"$compose_sha","services":{"api":{"container_name":"edfinder-v3-checkpoint-api","cpus":"1.50","memory":"1536m","pids":256},"web":{"container_name":"edfinder-v3-checkpoint-web","cpus":"0.50","memory":"512m","pids":128}},"network":"$APP_NETWORK","network_lifecycle":"externally-provisioned-persistent","named_volumes":[]},"external_authority":{"api_env_file":null,"api_env_owner_uid":null,"api_env_mode":null,"database_source_authority":null,"schema_identity_receipt":null,"schema_identity_receipt_sha256":null,"origin_bind":null,"edge_route_authority":null,"receipt_directory":null,"receipt_owner_uid":null,"receipt_mode":null,"ghcr_pull_authority":null,"docker_config_directory":null,"docker_config_owner_uid":null,"docker_config_mode":null,"docker_context":null},"blockers":["$failure"]}
+JSON
+  install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$receipt_path.tmp" "$receipt_path"
+  install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$candidate_path.tmp" "$candidate_path"
+  rm -f -- "$receipt_path.tmp" "$candidate_path.tmp"
+  RECEIPT_WRITTEN=1
+}
+
+stop() {
+  local code="$1"
+  printf 'Provisioning stopped: %s\n' "$code" >&2
+  write_stopped_artifacts "$code"
+  exit 78
+}
+
+on_exit() {
+  local rc=$?
+  rm -f -- "$private_log"
+  if [[ "$DB_BUNDLE_DIR" == /tmp/edfinder-v3-db-bundle.* ]]; then
+    rm -rf -- "$DB_BUNDLE_DIR"
+  fi
+  if ((rc != 0)) && ((RECEIPT_WRITTEN == 0)); then
+    set +e
+    if exact_runners_active; then
+      RUNNERS_AFTER=true
+      [[ -n "$RUNNER_STATE_BEFORE" && "$(runner_state_snapshot)" == "$RUNNER_STATE_BEFORE" ]] && RUNNER_CONTINUITY=true
+    fi
+    write_stopped_artifacts unexpected_provisioning_failure
+  fi
+}
+trap on_exit EXIT
+
+exact_runners_active() {
+  local expected observed
+  expected="$(printf '%s\n' "${RUNNER_SERVICES[@]}" | LC_ALL=C sort)"
+  observed="$(systemctl list-units --type=service --state=active --plain --no-legend --no-pager 'actions.runner.*.service' 2>/dev/null | awk '{print $1}' | LC_ALL=C sort)"
+  [[ "$observed" == "$expected" ]] || return 1
+  local service
+  for service in "${RUNNER_SERVICES[@]}"; do
+    systemctl is-active --quiet "$service" || return 1
+  done
+}
+
+runner_state_snapshot() {
+  local service
+  for service in "${RUNNER_SERVICES[@]}"; do
+    printf '%s:' "$service"
+    systemctl show "$service" --property=MainPID --property=ActiveEnterTimestampMonotonic --value 2>/dev/null | paste -sd: -
+  done
+}
+
+run_logged() {
+  timeout --signal=TERM --kill-after=30s "$1" "${@:2}" >>"$private_log" 2>&1
+}
+
+# Nothing above this line mutates the target except the private output log in
+# the caller-owned temporary directory.
+[[ "$(hostname -s 2>/dev/null)" == "$TARGET_HOSTNAME" ]] || stop hostname_mismatch
+[[ "$(hostname -f 2>/dev/null)" == "$TARGET_FQDN" ]] || stop fqdn_mismatch
+[[ "$(uname -m)" == "$TARGET_ARCH" ]] || stop architecture_mismatch
+[[ "$(dpkg --print-architecture 2>/dev/null)" == "amd64" ]] || stop package_architecture_mismatch
+[[ -r /etc/os-release ]] || stop unsupported_operating_system
+# shellcheck source=/dev/null
+. /etc/os-release
+[[ "${ID:-}" == "ubuntu" ]] || stop unsupported_operating_system
+[[ "${VERSION_CODENAME:-}" =~ ^(jammy|noble|resolute)$ ]] || stop unsupported_operating_system
+command -v systemctl >/dev/null 2>&1 || stop systemd_unavailable
+command -v timeout >/dev/null 2>&1 || stop timeout_unavailable
+command -v flock >/dev/null 2>&1 || stop flock_unavailable
+exact_runners_active || stop runner_service_set_mismatch
+RUNNERS_BEFORE=true
+RUNNER_STATE_BEFORE="$(runner_state_snapshot)" || stop runner_service_state_unavailable
+[[ "$(nproc)" -ge 8 ]] || stop host_capacity_below_recorded_target
+[[ "$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)" -ge 24608576 ]] || stop host_capacity_below_recorded_target
+
+if [[ -e "$OWNERSHIP_FILE" ]]; then
+  [[ -f "$OWNERSHIP_FILE" && ! -L "$OWNERSHIP_FILE" ]] || stop unsafe_ownership_marker
+  [[ "$(stat -c '%U:%G:%a' "$OWNERSHIP_FILE")" == "root:root:600" ]] || stop unsafe_ownership_marker
+  [[ "$(<"$OWNERSHIP_FILE")" == "ed-finder-v3-checkpoint-provisioner-v1" ]] || stop foreign_ownership_marker
+else
+  [[ ! -e "$STATE_DIR" && ! -e "$CONFIG_DIR" && ! -e "$RUNTIME_DIR" ]] || stop unowned_checkpoint_paths_present
+  [[ ! -d /etc/nginx || -z "$(find /etc/nginx -mindepth 1 -print -quit 2>/dev/null)" ]] || stop unowned_checkpoint_edge_present
+  dpkg-query -W -f='${db:Status-Status}' nginx 2>/dev/null | grep -qx installed && stop unowned_http_edge_package_present
+  [[ ! -d /etc/postgresql || -z "$(find /etc/postgresql -mindepth 1 -print -quit 2>/dev/null)" ]] || stop unowned_postgresql_cluster_present
+  [[ ! -d /var/lib/postgresql || -z "$(find /var/lib/postgresql -mindepth 1 -print -quit 2>/dev/null)" ]] || stop unowned_postgresql_data_present
+  id "$DB_OWNER" >/dev/null 2>&1 && stop unowned_checkpoint_database_owner_present
+  command -v docker >/dev/null 2>&1 && stop unowned_container_runtime_present
+  for conflicting_package in docker.io docker-compose docker-compose-v2 docker-doc docker-buildx podman-docker containerd runc; do
+    dpkg-query -W -f='${db:Status-Status}' "$conflicting_package" 2>/dev/null | grep -qx installed && stop unowned_docker_conflicting_package_present
+  done
+  [[ ! -d /var/lib/docker || -z "$(find /var/lib/docker -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]] || stop unowned_container_state_present
+  ss -H -ltn 2>/dev/null | awk '{print $4}' | grep -Eq '(^|:)5432$' && stop unowned_postgresql_listener_present
+  ss -H -ltn 2>/dev/null | awk '{print $4}' | grep -Eq '(^|:)80$' && stop unowned_http_listener_present
+  command -v podman >/dev/null 2>&1 && stop unowned_alternative_container_cli_present
+  command -v nerdctl >/dev/null 2>&1 && stop unowned_alternative_container_cli_present
+fi
+
+MUTATION_STARTED=true
+install -d -o root -g root -m 700 "$STATE_DIR"
+if [[ ! -e "$OWNERSHIP_FILE" ]]; then
+  printf '%s\n' 'ed-finder-v3-checkpoint-provisioner-v1' >"$OWNERSHIP_FILE.tmp"
+  install -o root -g root -m 600 "$OWNERSHIP_FILE.tmp" "$OWNERSHIP_FILE"
+  rm -f -- "$OWNERSHIP_FILE.tmp"
+fi
+install -d -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 700 "$CONFIG_DIR" "$RUNTIME_DIR" "$RECEIPT_DIR" "$DOCKER_CONFIG_DIR"
+deployment_lock="$RECEIPT_DIR/deploy.lock"
+if [[ -e "$deployment_lock" ]]; then
+  [[ -f "$deployment_lock" && ! -L "$deployment_lock" ]] || stop unsafe_deployment_lock
+  [[ "$(stat -c '%u:%a' "$deployment_lock")" == "$operator_uid:600" ]] || stop unsafe_deployment_lock
+else
+  install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 /dev/null "$deployment_lock"
+fi
+exec 9<>"$deployment_lock"
+flock -n 9 || stop checkpoint_operation_already_running
+
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=l
+run_logged 900 apt-get update
+run_logged 900 apt-get install -y --no-install-recommends ca-certificates curl gnupg jq openssl
+
+install -d -m 755 /etc/apt/keyrings /usr/share/postgresql-common/pgdg
+run_logged 120 curl --fail --silent --show-error --location https://download.docker.com/linux/ubuntu/gpg --output /etc/apt/keyrings/docker.asc
+run_logged 120 curl --fail --silent --show-error --location https://www.postgresql.org/media/keys/ACCC4CF8.asc --output /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+docker_fingerprint="$(gpg --show-keys --with-colons /etc/apt/keyrings/docker.asc 2>/dev/null | awk -F: '$1=="fpr" {print $10; exit}')"
+pgdg_fingerprint="$(gpg --show-keys --with-colons /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc 2>/dev/null | awk -F: '$1=="fpr" {print $10; exit}')"
+[[ "$docker_fingerprint" == "9DC858229FC7DD38854AE2D88D81803C0EBFCD88" ]] || stop docker_repository_key_mismatch
+[[ "$pgdg_fingerprint" == "B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8" ]] || stop postgresql_repository_key_mismatch
+chmod 644 /etc/apt/keyrings/docker.asc /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+
+cat >/etc/apt/sources.list.d/docker.sources <<SOURCES
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $VERSION_CODENAME
+Components: stable
+Architectures: amd64
+Signed-By: /etc/apt/keyrings/docker.asc
+SOURCES
+cat >/etc/apt/sources.list.d/pgdg.sources <<SOURCES
+Types: deb
+URIs: https://apt.postgresql.org/pub/repos/apt
+Suites: ${VERSION_CODENAME}-pgdg
+Components: main
+Architectures: amd64
+Signed-By: /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc
+SOURCES
+chmod 644 /etc/apt/sources.list.d/docker.sources /etc/apt/sources.list.d/pgdg.sources
+
+# Prevent the package's default nginx site from becoming briefly reachable.
+systemctl mask nginx.service >>"$private_log" 2>&1 || true
+run_logged 900 apt-get update
+run_logged 1200 apt-get install -y --no-install-recommends docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin postgresql-18 postgresql-client-18 postgresql-contrib-18 nginx
+systemctl unmask nginx.service >>"$private_log" 2>&1 || stop nginx_unmask_failed
+
+command -v docker >/dev/null 2>&1 || stop docker_engine_unavailable
+command -v psql >/dev/null 2>&1 || stop psql_unavailable
+[[ "$(psql --version | awk '{print $3}' | cut -d. -f1)" == "18" ]] || stop postgresql_client_not_18
+systemctl enable --now docker.service >>"$private_log" 2>&1 || stop docker_service_unavailable
+systemctl enable --now postgresql.service >>"$private_log" 2>&1 || stop postgresql_service_unavailable
+docker compose version >>"$private_log" 2>&1 || stop docker_compose_unavailable
+
+[[ -f "$BUNDLE_ROOT/artifacts/migration-set.json" && ! -L "$BUNDLE_ROOT/artifacts/migration-set.json" ]] || stop migration_identity_missing
+migration_identity="$(jq -er '.identity | select(test("^sha256:[0-9a-f]{64}$"))' "$BUNDLE_ROOT/artifacts/migration-set.json")" || stop migration_identity_invalid
+migration_entries="$(jq -ce '.entries' "$BUNDLE_ROOT/artifacts/migration-set.json")" || stop migration_entries_invalid
+manifest_hash="$(jq -er '.manifest_sha256 | select(test("^[0-9a-f]{64}$"))' "$BUNDLE_ROOT/artifacts/migration-set.json")" || stop migration_manifest_identity_invalid
+[[ "$(sha256sum "$BUNDLE_ROOT/sql/migration-manifest.txt" | awk '{print $1}')" == "$manifest_hash" ]] || stop migration_manifest_checksum_mismatch
+while IFS=$'\t' read -r relative expected_hash; do
+  [[ "$relative" =~ ^sql/[0-9]{3}_[a-z0-9_]+\.sql$ && "$expected_hash" =~ ^[0-9a-f]{64}$ ]] || stop migration_entry_invalid
+  [[ -f "$BUNDLE_ROOT/$relative" && ! -L "$BUNDLE_ROOT/$relative" ]] || stop migration_file_missing
+  [[ "$(sha256sum "$BUNDLE_ROOT/$relative" | awk '{print $1}')" == "$expected_hash" ]] || stop migration_file_checksum_mismatch
+done < <(jq -r '.entries[] | [.path,.sha256] | @tsv' "$BUNDLE_ROOT/artifacts/migration-set.json")
+
+# The database owner cannot traverse the SSH user's mode-0700 extraction
+# directory. Give it a distinct secret-free temporary bundle containing only
+# the canonical database bootstrap inputs, and always remove that bundle.
+DB_BUNDLE_DIR="$(mktemp -d /tmp/edfinder-v3-db-bundle.XXXXXX)"
+chmod 755 "$DB_BUNDLE_DIR"
+install -d -o root -g root -m 755 "$DB_BUNDLE_DIR/scripts" "$DB_BUNDLE_DIR/sql"
+install -o root -g root -m 755 "$BUNDLE_ROOT/scripts/apply_migrations.sh" "$BUNDLE_ROOT/scripts/seed_check.sh" "$DB_BUNDLE_DIR/scripts/"
+install -o root -g root -m 644 "$BUNDLE_ROOT/sql/"*.sql "$BUNDLE_ROOT/sql/migration-manifest.txt" "$DB_BUNDLE_DIR/sql/"
+
+getent group docker >/dev/null || stop docker_group_unavailable
+usermod -aG docker "$OPERATOR_USER"
+
+network_json="$(docker network inspect "$APP_NETWORK" 2>/dev/null || true)"
+if [[ -z "$network_json" ]]; then
+  run_logged 120 docker network create --driver bridge --subnet "$APP_SUBNET" --gateway "$APP_GATEWAY" "$APP_NETWORK"
+  network_json="$(docker network inspect "$APP_NETWORK" 2>/dev/null)" || stop app_network_unavailable
+fi
+jq -e --arg name "$APP_NETWORK" --arg subnet "$APP_SUBNET" --arg gateway "$APP_GATEWAY" '
+  length == 1 and .[0].Name == $name and .[0].Driver == "bridge" and
+  .[0].Scope == "local" and .[0].Ingress == false and
+  .[0].IPAM.Config == [{"Subnet":$subnet,"Gateway":$gateway}] and
+  ((.[0].Containers // {}) | to_entries | all(.value.Name == "edfinder-v3-checkpoint-api" or .value.Name == "edfinder-v3-checkpoint-web"))
+' <<<"$network_json" >/dev/null || stop app_network_topology_mismatch
+mapfile -t docker_networks < <(docker network ls --format '{{.Name}}' | LC_ALL=C sort)
+[[ "$(printf '%s\n' "${docker_networks[@]}")" == $'bridge\nedfinder-v3-checkpoint-app\nhost\nnone' ]] || stop unexpected_docker_network_present
+mapfile -t container_names < <(docker ps --all --format '{{.Names}}' | LC_ALL=C sort)
+for container_name in "${container_names[@]}"; do
+  [[ "$container_name" == "edfinder-v3-checkpoint-api" || "$container_name" == "edfinder-v3-checkpoint-web" ]] || stop unexpected_container_present
+done
+[[ -z "$(docker volume ls --quiet)" ]] || stop unexpected_docker_volume_present
+command -v podman >/dev/null 2>&1 && stop unexpected_alternative_container_cli_present
+command -v nerdctl >/dev/null 2>&1 && stop unexpected_alternative_container_cli_present
+
+if [[ ! -s "$DOCKER_CONFIG_DIR/config.json" ]]; then
+  printf '%s\n' '{}' >"$DOCKER_CONFIG_DIR/config.json.tmp"
+  install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$DOCKER_CONFIG_DIR/config.json.tmp" "$DOCKER_CONFIG_DIR/config.json"
+  rm -f -- "$DOCKER_CONFIG_DIR/config.json.tmp"
+fi
+
+run_as_operator() {
+  runuser -u "$OPERATOR_USER" -- env HOME="$(getent passwd "$OPERATOR_USER" | cut -d: -f6)" DOCKER_CONFIG="$DOCKER_CONFIG_DIR" "$@"
+}
+if ! run_as_operator docker context inspect "$DOCKER_CONTEXT" >>"$private_log" 2>&1; then
+  run_as_operator docker context create "$DOCKER_CONTEXT" --docker "host=unix:///var/run/docker.sock" >>"$private_log" 2>&1 || stop docker_context_create_failed
+fi
+context_endpoint="$(run_as_operator docker context inspect "$DOCKER_CONTEXT" --format '{{.Endpoints.docker.Host}}' 2>/dev/null)" || stop docker_context_unavailable
+[[ "$context_endpoint" == "unix:///var/run/docker.sock" ]] || stop docker_context_not_local_rootful
+chown -R "$operator_uid:$(id -g "$OPERATOR_USER")" "$DOCKER_CONFIG_DIR"
+find "$DOCKER_CONFIG_DIR" -type d -exec chmod 700 {} +
+find "$DOCKER_CONFIG_DIR" -type f -exec chmod 600 {} +
+
+if ! id "$DB_OWNER" >/dev/null 2>&1; then
+  useradd --system --home-dir "$STATE_DIR/db-owner" --create-home --shell /usr/sbin/nologin "$DB_OWNER"
+fi
+runuser -u postgres -- psql -X --no-password --quiet --set=ON_ERROR_STOP=1 postgres >>"$private_log" 2>&1 <<SQL
+SELECT format('CREATE ROLE %I LOGIN', '$DB_OWNER') WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$DB_OWNER') \gexec
+ALTER ROLE "$DB_OWNER" LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION PASSWORD NULL;
+SELECT format('CREATE ROLE %I LOGIN', '$DB_APP_ROLE') WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$DB_APP_ROLE') \gexec
+ALTER ROLE "$DB_APP_ROLE" LOGIN NOINHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION;
+SQL
+role_memberships="$(runuser -u postgres -- psql -X --no-password --tuples-only --no-align postgres --command "SELECT count(*) FROM pg_auth_members WHERE roleid IN ((SELECT oid FROM pg_roles WHERE rolname='$DB_OWNER'),(SELECT oid FROM pg_roles WHERE rolname='$DB_APP_ROLE')) OR member IN ((SELECT oid FROM pg_roles WHERE rolname='$DB_OWNER'),(SELECT oid FROM pg_roles WHERE rolname='$DB_APP_ROLE'))")"
+[[ "$role_memberships" == "0" ]] || stop checkpoint_database_role_membership_present
+if ! runuser -u postgres -- psql -X --no-password --tuples-only --no-align postgres --command "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" | grep -qx 1; then
+  run_logged 120 runuser -u postgres -- createdb --owner "$DB_OWNER" "$DB_NAME"
+fi
+db_owner_observed="$(runuser -u postgres -- psql -X --no-password --tuples-only --no-align postgres --command "SELECT pg_catalog.pg_get_userbyid(datdba) FROM pg_database WHERE datname='$DB_NAME'")"
+[[ "$db_owner_observed" == "$DB_OWNER" ]] || stop database_owner_mismatch
+
+if [[ ! -s "$API_ENV_FILE" ]]; then
+  db_password="$(openssl rand -hex 32)"
+  admin_token="$(openssl rand -hex 32)"
+  umask 077
+  cat >"$API_ENV_FILE.tmp" <<ENV
+DATABASE_URL=postgresql://$DB_APP_ROLE:$db_password@$APP_GATEWAY:5432/$DB_NAME
+DATABASE_READONLY_URL=postgresql://$DB_APP_ROLE:$db_password@$APP_GATEWAY:5432/$DB_NAME
+ADMIN_TOKEN=$admin_token
+CORS_ORIGINS=http://$TARGET_FQDN
+FRONTIER_REDIRECT_URI=http://$TARGET_FQDN/api/auth/frontier/callback
+AUTH_COOKIE_SECURE=false
+ENV
+  install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$API_ENV_FILE.tmp" "$API_ENV_FILE"
+  rm -f -- "$API_ENV_FILE.tmp"
+else
+  [[ -f "$API_ENV_FILE" && ! -L "$API_ENV_FILE" ]] || stop unsafe_api_env_file
+  [[ "$(stat -c '%u:%a' "$API_ENV_FILE")" == "$operator_uid:600" ]] || stop unsafe_api_env_file
+fi
+[[ "$(wc -l <"$API_ENV_FILE")" -eq 6 ]] || stop invalid_api_env_file_shape
+grep -Eq "^DATABASE_READONLY_URL=postgresql://$DB_APP_ROLE:[0-9a-f]{64}@$APP_GATEWAY:5432/$DB_NAME$" "$API_ENV_FILE" || stop invalid_api_env_file_shape
+grep -Eq '^ADMIN_TOKEN=[0-9a-f]{64}$' "$API_ENV_FILE" || stop invalid_api_env_file_shape
+grep -Fqx "CORS_ORIGINS=http://$TARGET_FQDN" "$API_ENV_FILE" || stop invalid_api_env_file_shape
+grep -Fqx "FRONTIER_REDIRECT_URI=http://$TARGET_FQDN/api/auth/frontier/callback" "$API_ENV_FILE" || stop invalid_api_env_file_shape
+grep -Fqx 'AUTH_COOKIE_SECURE=false' "$API_ENV_FILE" || stop invalid_api_env_file_shape
+db_password="$(sed -n "s#^DATABASE_URL=postgresql://$DB_APP_ROLE:\([^@]*\)@$APP_GATEWAY:5432/$DB_NAME\$#\1#p" "$API_ENV_FILE")"
+[[ "$db_password" =~ ^[0-9a-f]{64}$ ]] || stop invalid_api_database_credential
+grep -Fqx "DATABASE_READONLY_URL=postgresql://$DB_APP_ROLE:$db_password@$APP_GATEWAY:5432/$DB_NAME" "$API_ENV_FILE" || stop api_database_credentials_disagree
+runuser -u postgres -- psql -X --no-password --quiet --set=ON_ERROR_STOP=1 postgres >>"$private_log" 2>&1 <<SQL
+SET password_encryption = 'scram-sha-256';
+ALTER ROLE "$DB_APP_ROLE" PASSWORD '$db_password';
+ALTER ROLE "$DB_APP_ROLE" IN DATABASE "$DB_NAME" SET default_transaction_read_only = on;
+SQL
+unset admin_token
+
+postgres_conf="/etc/postgresql/18/main/conf.d/edfinder-v3-checkpoint.conf"
+install -d -o postgres -g postgres -m 750 "$(dirname "$postgres_conf")"
+cat >"$postgres_conf.tmp" <<CONF
+# Managed by the bounded ED-Finder non-production checkpoint provisioner.
+listen_addresses = '127.0.0.1,$APP_GATEWAY'
+password_encryption = 'scram-sha-256'
+CONF
+install -o postgres -g postgres -m 640 "$postgres_conf.tmp" "$postgres_conf"
+rm -f -- "$postgres_conf.tmp"
+hba_file="/etc/postgresql/18/main/pg_hba.conf"
+if ! grep -Fqx "host $DB_NAME $DB_APP_ROLE $APP_SUBNET scram-sha-256" "$hba_file"; then
+  printf '\n# ED-Finder V3 checkpoint app network only\nhost %s %s %s scram-sha-256\n' "$DB_NAME" "$DB_APP_ROLE" "$APP_SUBNET" >>"$hba_file"
+fi
+systemctl restart postgresql.service >>"$private_log" 2>&1 || stop postgresql_restart_failed
+runuser -u postgres -- psql -X --no-password --tuples-only --no-align --command 'SHOW server_version_num' "$DB_NAME" | grep -Eq '^18[0-9]{4}$' || stop postgresql_server_not_18
+
+seed_marker="$STATE_DIR/seed-complete-v1"
+if [[ ! -e "$seed_marker" ]]; then
+  # Canonical seed_check invokes apply_migrations.sh --include-manual, applies
+  # sql/seed_preview.sql, and runs its established preview invariants.
+  run_logged 3600 runuser -u "$DB_OWNER" -- env DATABASE_URL="postgresql:///$DB_NAME?host=/var/run/postgresql" ENV_FILE="$STATE_DIR/no-env-file" SQL_DIR="$DB_BUNDLE_DIR/sql" bash "$DB_BUNDLE_DIR/scripts/seed_check.sh"
+  install -o root -g root -m 600 /dev/null "$seed_marker"
+fi
+
+runuser -u postgres -- psql -X --no-password --quiet --set=ON_ERROR_STOP=1 "$DB_NAME" >>"$private_log" 2>&1 <<SQL
+REVOKE ALL ON DATABASE "$DB_NAME" FROM PUBLIC;
+GRANT CONNECT ON DATABASE "$DB_NAME" TO "$DB_APP_ROLE";
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+GRANT USAGE ON SCHEMA public TO "$DB_APP_ROLE";
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO "$DB_APP_ROLE";
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO "$DB_APP_ROLE";
+ALTER DEFAULT PRIVILEGES FOR ROLE "$DB_OWNER" IN SCHEMA public GRANT SELECT ON TABLES TO "$DB_APP_ROLE";
+ALTER DEFAULT PRIVILEGES FOR ROLE "$DB_OWNER" IN SCHEMA public GRANT SELECT ON SEQUENCES TO "$DB_APP_ROLE";
+SQL
+
+seed_counts="$(PGPASSWORD="$db_password" PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=10000' psql -X --no-password --tuples-only --no-align --quiet -h "$APP_GATEWAY" -U "$DB_APP_ROLE" -d "$DB_NAME" --command "SELECT json_build_object('systems',(SELECT count(*) FROM systems),'ratings',(SELECT count(*) FROM ratings),'bodies',(SELECT count(*) FROM bodies),'stations',(SELECT count(*) FROM stations),'galaxy_regions',(SELECT count(*) FROM galaxy_regions),'unrated_systems',(SELECT count(*) FROM systems s LEFT JOIN ratings r ON r.system_id64=s.id64 WHERE r.system_id64 IS NULL),'transaction_read_only',current_setting('transaction_read_only'))")" || stop seed_acceptance_read_failed
+jq -e '.systems >= 40 and .ratings >= 40 and .bodies >= 10 and .stations >= 5 and .galaxy_regions >= 42 and .unrated_systems == 0 and .transaction_read_only == "on"' <<<"$seed_counts" >/dev/null || stop seed_acceptance_failed
+
+observed_db="$(PGPASSWORD="$db_password" PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=10000' psql -X --no-password --tuples-only --no-align --quiet -h "$APP_GATEWAY" -U "$DB_APP_ROLE" -d "$DB_NAME" --command "SELECT json_build_object('database_name',current_database(),'server_address',inet_server_addr()::text,'server_port',inet_server_port(),'transaction_read_only',current_setting('transaction_read_only'),'migrations',COALESCE((SELECT json_agg(json_build_object('filename',filename,'checksum_sha256',checksum_sha256) ORDER BY filename) FROM schema_migrations),'[]'::json))")" || stop schema_readonly_proof_failed
+expected_ledger="$(jq -cS '[.entries[] | {filename:(.path | sub("^sql/";"")),checksum_sha256:.sha256}] | sort_by(.filename)' "$BUNDLE_ROOT/artifacts/migration-set.json")"
+observed_ledger="$(jq -cS '.migrations | sort_by(.filename)' <<<"$observed_db")" || stop schema_readonly_proof_invalid
+jq -e --arg db "$DB_NAME" --arg address "$APP_GATEWAY" '.database_name == $db and .server_address == $address and .server_port == 5432 and .transaction_read_only == "on"' <<<"$observed_db" >/dev/null || stop schema_database_identity_mismatch
+[[ "$observed_ledger" == "$expected_ledger" ]] || stop schema_migration_ledger_mismatch
+
+captured_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+jq -n --arg authority "$DB_AUTHORITY" --arg database "$DB_NAME" --arg address "$APP_GATEWAY" --arg identity "$migration_identity" --arg captured "$captured_at" --argjson entries "$migration_entries" '{schema_version:"ed-finder/v3-live-checkpoint-schema-identity/v2",database_source_authority:$authority,database_identity:{database_name:$database,server_address:$address,server_port:5432},migration_set_identity:$identity,migration_set_entries:$entries,captured_at:$captured}' >"$SCHEMA_RECEIPT.tmp"
+[[ ! -e "$SCHEMA_RECEIPT" || ( -f "$SCHEMA_RECEIPT" && ! -L "$SCHEMA_RECEIPT" ) ]] || stop unsafe_schema_receipt
+chown "$operator_uid:$(id -g "$OPERATOR_USER")" "$SCHEMA_RECEIPT.tmp"
+chmod 600 "$SCHEMA_RECEIPT.tmp"
+mv -fT "$SCHEMA_RECEIPT.tmp" "$SCHEMA_RECEIPT"
+schema_receipt_sha="$(sha256sum "$SCHEMA_RECEIPT" | awk '{print $1}')"
+
+cat >"$NGINX_SITE.tmp" <<NGINX
+# HTTP-only, provider-FQDN-only NON-PRODUCTION checkpoint edge. No DNS or TLS.
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name _;
+    return 404;
+}
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $TARGET_FQDN;
+    add_header X-EDFinder-Checkpoint-Edge v1 always;
+    location / {
+        proxy_pass http://127.0.0.1:$ORIGIN_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Forwarded-Proto http;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 30s;
+        proxy_send_timeout 30s;
+    }
+}
+NGINX
+install -o root -g root -m 644 "$NGINX_SITE.tmp" "$NGINX_SITE"
+rm -f -- "$NGINX_SITE.tmp" /etc/nginx/sites-enabled/default
+ln -sfn "$NGINX_SITE" "$NGINX_ENABLED"
+find /etc/nginx/sites-enabled -mindepth 1 -maxdepth 1 ! -name 'edfinder-v3-checkpoint' -print -quit | grep -q . && stop unexpected_nginx_site_enabled
+find /etc/nginx/conf.d -type f -print -quit 2>/dev/null | grep -q . && stop unexpected_nginx_conf_enabled
+run_logged 120 nginx -t
+systemctl enable --now nginx.service >>"$private_log" 2>&1 || stop nginx_service_unavailable
+systemctl reload nginx.service >>"$private_log" 2>&1 || stop nginx_reload_failed
+curl --silent --output /dev/null --max-time 5 --header 'Host: rejected.invalid' --write-out '%{http_code}' http://127.0.0.1/ | grep -qx 404 || stop edge_default_route_not_rejected
+edge_headers="$(curl --silent --show-error --dump-header - --output /dev/null --max-time 5 --header "Host: $TARGET_FQDN" http://127.0.0.1/ 2>/dev/null)" || stop checkpoint_edge_route_unavailable
+grep -Eiq '^X-EDFinder-Checkpoint-Edge: v1\r?$' <<<"$edge_headers" || stop checkpoint_edge_route_not_selected
+
+if [[ -n "$BACKEND_IMAGE" ]]; then
+  probe_config="$(mktemp -d "$OUTPUT_DIR/.anonymous-docker.XXXXXX")"
+  chmod 700 "$probe_config"
+  printf '%s\n' '{}' >"$probe_config/config.json"
+  chmod 600 "$probe_config/config.json"
+  if runuser -u "$OPERATOR_USER" -- env -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/nonexistent DOCKER_CONFIG="$probe_config" docker --host unix:///var/run/docker.sock pull "$BACKEND_IMAGE" >>"$private_log" 2>&1 &&
+     runuser -u "$OPERATOR_USER" -- env -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/nonexistent DOCKER_CONFIG="$probe_config" docker --host unix:///var/run/docker.sock pull "$WEB_IMAGE" >>"$private_log" 2>&1; then
+    GHCR_STATUS="anonymous_public_digest_pull_proven"
+    GHCR_AUTHORITY="anonymous-public-digest-pull:${BACKEND_IMAGE},${WEB_IMAGE}"
+  fi
+  rm -rf -- "$probe_config"
+fi
+
+exact_runners_active || stop runner_service_set_changed
+[[ "$(runner_state_snapshot)" == "$RUNNER_STATE_BEFORE" ]] || stop runner_service_continuity_changed
+RUNNERS_AFTER=true
+RUNNER_CONTINUITY=true
+docker_version="$(docker version --format '{{.Server.Version}}' 2>/dev/null)" || stop docker_version_unavailable
+compose_version="$(docker compose version --short 2>/dev/null)" || stop compose_version_unavailable
+postgres_version="$(runuser -u postgres -- psql -X --no-password --tuples-only --no-align --command 'SHOW server_version' "$DB_NAME")" || stop postgresql_version_unavailable
+compose_sha="$(sha256sum "$BUNDLE_ROOT/deploy/v3-live-checkpoint/compose.yml" | awk '{print $1}')"
+cpu_count="$(nproc)"
+memory_total="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+memory_available="$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)"
+read -r root_bytes root_available < <(df -B1 --output=size,avail / | awk 'NR==2 {print $1,$2}')
+cpu_model="$(awk -F: '/model name/ {sub(/^[[:space:]]+/,"",$2); print $2; exit}' /proc/cpuinfo | tr -cd '[:alnum:] ._()+/-' | cut -c1-120)"
+swap_total="$(awk '/^SwapTotal:/ {print $2}' /proc/meminfo)"
+root_filesystem="$(findmnt --noheadings --output FSTYPE / | tr -cd '[:alnum:]_.-')"
+mapfile -t tcp_listeners < <(ss -H -ltn | awk '{print $4}' | LC_ALL=C sort -u)
+
+blockers='[]'
+candidate_status="authorized"
+if [[ "$GHCR_STATUS" != "anonymous_public_digest_pull_proven" ]]; then
+  blockers='["explicit_secret_backed_ghcr_pull_authority_required"]'
+  candidate_status="stopped"
+fi
+
+jq -n \
+  --arg status "$candidate_status" --arg observed "$(date -u +%Y-%m-%d)" --arg docker "$docker_version" --arg compose "$compose_version" \
+  --arg compose_sha "$compose_sha" --arg cpu_model "$cpu_model" --arg root_filesystem "$root_filesystem" --argjson cpus "$cpu_count" --argjson mem_total "$memory_total" --argjson mem_available "$memory_available" \
+  --argjson swap_total "$swap_total" --argjson root_bytes "$root_bytes" --argjson root_available "$root_available" --argjson owner_uid "$operator_uid" --arg schema_sha "$schema_receipt_sha" \
+  --arg ghcr "$GHCR_AUTHORITY" --argjson blockers "$blockers" --argjson docker_networks "$(json_array_lines "${docker_networks[@]}")" --argjson container_names "$(json_array_lines "${container_names[@]}")" --argjson tcp_listeners "$(json_array_lines "${tcp_listeners[@]}")" '
+  {schema_version:"ed-finder/v3-live-checkpoint-target-authority/v1",status:$status,
+   target:{provider:"contabo",classification:"live-checkpoint",production:false,hostname:"vmi3542235",fqdn:"vmi3542235.contaboserver.net",architecture:"x86_64"},observed_at:$observed,
+   observed_capacity:{logical_cpus:$cpus,cpu_model:$cpu_model,memory_total_kib:$mem_total,memory_available_kib:$mem_available,swap_total_kib:$swap_total,root_bytes:$root_bytes,root_available_bytes:$root_available,root_filesystem:$root_filesystem},
+   observed_runtime:{container_runtime:$docker,compose:$compose,alternative_container_clis_present:[],container_names:$container_names,docker_networks:$docker_networks,docker_volumes:[],tcp_listeners:$tcp_listeners,runner_services:["actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker.service","actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-2.service","actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-3.service"],checkpoint_directories_found_under_opt_srv_var_lib:["/var/lib/edfinder-v3-checkpoint"]},
+   application_contract:{compose_project:"edfinder-v3-checkpoint",compose_sha256:$compose_sha,services:{api:{container_name:"edfinder-v3-checkpoint-api",cpus:"1.50",memory:"1536m",pids:256},web:{container_name:"edfinder-v3-checkpoint-web",cpus:"0.50",memory:"512m",pids:128}},network:"edfinder-v3-checkpoint-app",network_lifecycle:"externally-provisioned-persistent",named_volumes:[],resource_derivation:"The fixed app limits remain 2 CPUs and 2 GiB combined, preserving the recorded runner capacity boundary."},
+   external_authority:{api_env_file:"/etc/ed-finder/v3-checkpoint/api.env",api_env_owner_uid:$owner_uid,api_env_mode:"0600",database_source_authority:"contabo-vmi3542235-native-postgresql18-preview-v1",schema_identity_receipt:"/var/lib/edfinder-v3-checkpoint/schema-identity.json",schema_identity_receipt_sha256:$schema_sha,origin_bind:"http://127.0.0.1:18080",edge_route_authority:"http-only-provider-fqdn-vmi3542235.contaboserver.net-to-loopback-18080-no-dns",receipt_directory:"/var/lib/edfinder-v3-checkpoint/receipts",receipt_owner_uid:$owner_uid,receipt_mode:"0700",ghcr_pull_authority:(if $ghcr == "" then null else $ghcr end),docker_config_directory:"/var/lib/edfinder-v3-checkpoint/docker-config",docker_config_owner_uid:$owner_uid,docker_config_mode:"0700",docker_context:"edfinder-v3-checkpoint"},blockers:$blockers}' >"$candidate_path.tmp"
+
+jq -n --arg status "$( [[ "$candidate_status" == authorized ]] && printf provisioned || printf provisioned_with_blocker )" --arg created "$captured_at" --arg docker "$docker_version" --arg compose "$compose_version" --arg postgres "$postgres_version" --arg migration "$migration_identity" --arg schema_sha "$schema_receipt_sha" --arg ghcr "$GHCR_STATUS" --argjson owner_uid "$operator_uid" --argjson runners "$(json_array_lines "${RUNNER_SERVICES[@]}")" --argjson probe_images "$(if [[ -n "$BACKEND_IMAGE" ]]; then json_array_lines "$BACKEND_IMAGE" "$WEB_IMAGE"; else printf '[]'; fi)" '
+  {schema_version:"ed-finder/v3-live-checkpoint-provisioning-receipt/v1",operation:"provision-infrastructure",status:$status,created_at:$created,
+   target:{provider:"contabo",classification:"live-checkpoint",production:false,hostname:"vmi3542235",fqdn:"vmi3542235.contaboserver.net",architecture:"x86_64"},runner_services:{expected:$runners,verified_before:true,verified_after:true,continuity_preserved:true,managed:false},
+   runtime:{docker_engine:$docker,docker_compose:$compose,context:"edfinder-v3-checkpoint",endpoint:"unix:///var/run/docker.sock",external_network:"edfinder-v3-checkpoint-app"},
+   database:{major:18,server_version:$postgres,source_authority:"contabo-vmi3542235-native-postgresql18-preview-v1",database_name:"edfinder_v3_checkpoint",owner_role:"edfinder_checkpoint_db",application_role:"edfinder_checkpoint_app",persistent:true,non_production:true,production_data_copied:false,canonical_apply_migrations_include_manual:true,preview_seed_applied:true,seed_acceptance_passed:true,read_only_schema_proof_passed:true,migration_set_identity:$migration,schema_receipt_sha256:$schema_sha},
+   files:{api_env:{path:"/etc/ed-finder/v3-checkpoint/api.env",owner_uid:$owner_uid,mode:"0600",credentials_emitted:false},schema_receipt:{path:"/var/lib/edfinder-v3-checkpoint/schema-identity.json",owner_uid:$owner_uid,mode:"0600"},receipt_directory:{path:"/var/lib/edfinder-v3-checkpoint/receipts",owner_uid:$owner_uid,mode:"0700"},docker_config_directory:{path:"/var/lib/edfinder-v3-checkpoint/docker-config",owner_uid:$owner_uid,mode:"0700"}},
+   routing:{origin:"http://127.0.0.1:18080",edge:"http://vmi3542235.contaboserver.net",http_only:true,dns_changes_performed:false,production_route_touched:false},
+   ghcr:{status:$ghcr,probe_images:$probe_images,credentials_used:false},application_deploy_performed:false,production_access_performed:false,redis_provisioned:false,valkey_provisioned:false,nats_provisioned:false}' >"$receipt_path.tmp"
+
+install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$candidate_path.tmp" "$candidate_path"
+install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$receipt_path.tmp" "$receipt_path"
+rm -f -- "$candidate_path.tmp" "$receipt_path.tmp"
+durable_copy="$RECEIPT_DIR/provisioning-${captured_at//[:\-]/}.json"
+if [[ ! -e "$durable_copy" ]]; then
+  install -o "$operator_uid" -g "$(id -g "$OPERATOR_USER")" -m 600 "$receipt_path" "$durable_copy"
+fi
+RECEIPT_WRITTEN=1

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -52,6 +52,7 @@ CHECKED_WORKFLOWS = (
     'v3-application-live-checkpoint-preflight.yml',
     'v3-application-release.yml',
     'v3-derived-data-status.yml',
+    'v3-live-checkpoint-provision.yml',
 )
 
 

--- a/tests/test_v3_checkpoint_provisioning.py
+++ b/tests/test_v3_checkpoint_provisioning.py
@@ -1,0 +1,340 @@
+"""Contracts for bounded Contabo V3 live-checkpoint infrastructure provisioning."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import importlib.util
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/v3-live-checkpoint-provision.yml"
+PROVISIONER = ROOT / "scripts/operator/actions/v3-live-checkpoint-provision.sh"
+AUTHORITY = ROOT / "deploy/v3-live-checkpoint/target-authority.json"
+
+
+def _workflow() -> dict:
+    return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _step(name: str) -> dict:
+    return next(
+        item
+        for item in _workflow()["jobs"]["provision"]["steps"]
+        if item.get("name") == name
+    )
+
+
+def _run_dispatch_request(
+    tmp_path: Path, **overrides: str
+) -> subprocess.CompletedProcess[str]:
+    output = tmp_path / "github-output"
+    env = {
+        **os.environ,
+        "EVENT_NAME": "workflow_dispatch",
+        "INPUT_OPERATION": "provision-infrastructure",
+        "INPUT_BACKEND_IMAGE": "",
+        "INPUT_WEB_IMAGE": "",
+        "BEFORE_SHA": "",
+        "CURRENT_SHA": "",
+        "RUNNER_TEMP": str(tmp_path),
+        "GITHUB_OUTPUT": str(output),
+        **overrides,
+    }
+    return subprocess.run(
+        ["bash", "-c", _step("Resolve allowlisted provisioning request")["run"]],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_workflow_is_separate_request_triggered_and_environment_gated():
+    workflow = _workflow()
+    triggers = workflow["on"]
+    job = workflow["jobs"]["provision"]
+
+    assert set(triggers) == {"workflow_dispatch", "push"}
+    assert triggers["push"]["branches"] == ["v3-live-checkpoint-provision-requests"]
+    assert triggers["push"]["paths"] == [
+        ".github/v3-live-checkpoint-provision-requests/*.json"
+    ]
+    assert set(triggers["workflow_dispatch"]["inputs"]) == {
+        "operation",
+        "backend_image",
+        "web_image",
+    }
+    assert triggers["workflow_dispatch"]["inputs"]["operation"]["options"] == [
+        "provision-infrastructure"
+    ]
+    assert workflow["permissions"] == {"contents": "read"}
+    assert job["environment"] == "v3-live-checkpoint"
+    assert workflow["concurrency"]["cancel-in-progress"] == "false"
+
+
+def test_request_allowlist_rejects_partial_wrong_or_unpinned_ghcr_inputs(tmp_path):
+    backend = "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:" + "a" * 64
+    web = "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "b" * 64
+    accepted = _run_dispatch_request(
+        tmp_path, INPUT_BACKEND_IMAGE=backend, INPUT_WEB_IMAGE=web
+    )
+    assert accepted.returncode == 0, accepted.stderr
+
+    cases = (
+        {"INPUT_OPERATION": "deploy"},
+        {"INPUT_BACKEND_IMAGE": backend},
+        {
+            "INPUT_BACKEND_IMAGE": "ghcr.io/attacker/image@sha256:" + "a" * 64,
+            "INPUT_WEB_IMAGE": web,
+        },
+        {
+            "INPUT_BACKEND_IMAGE": backend.replace("@sha256:", ":latest"),
+            "INPUT_WEB_IMAGE": web,
+        },
+    )
+    for index, values in enumerate(cases):
+        result = _run_dispatch_request(tmp_path / str(index), **values)
+        assert result.returncode == 64
+
+
+def test_workflow_uses_trusted_main_source_free_bundle_and_sanitized_outputs_only():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    steps = _workflow()["jobs"]["provision"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert names.index("Resolve allowlisted provisioning request") < names.index(
+        "Checkout trusted provisioning implementation"
+    )
+    trusted = _step("Checkout trusted provisioning implementation")
+    assert trusted["with"] == {
+        "ref": "main",
+        "path": "trusted-main",
+        "persist-credentials": "false",
+    }
+    bundle = _step("Assemble source-free provisioning bundle")["run"]
+    assert "scripts/apply_migrations.sh" in bundle
+    assert "scripts/seed_check.sh" in bundle
+    assert "sql/*.sql" in bundle
+    assert "v3_release_manifest import migration_set" in bundle
+    assert "apps/api" not in bundle
+    assert "apps/web" not in bundle
+
+    upload = _step("Upload sanitized provisioning evidence")["with"]
+    assert upload["path"].splitlines() == [
+        "${{ runner.temp }}/v3-live-checkpoint-provisioning-output/provisioning-receipt.json",
+        "${{ runner.temp }}/v3-live-checkpoint-provisioning-output/target-authority-candidate.json",
+    ]
+    assert "deploy/v3-live-checkpoint/target-authority.json" not in bundle
+    assert (
+        'Path("trusted-main/deploy/v3-live-checkpoint/target-authority.json")' in source
+    )
+    for forbidden in (
+        "ssh-keyscan",
+        "ED_NEW_OPERATOR_",
+        "git pull",
+        "docker compose up",
+    ):
+        assert forbidden not in source
+
+
+def test_workflow_uses_only_dedicated_pinned_ssh_secret_boundary():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    secrets = set(re.findall(r"secrets\.([A-Z0-9_]+)", source))
+    assert secrets == {
+        "V3_LIVE_CHECKPOINT_SSH_KEY",
+        "V3_LIVE_CHECKPOINT_HOST",
+        "V3_LIVE_CHECKPOINT_PORT",
+        "V3_LIVE_CHECKPOINT_USER",
+        "V3_LIVE_CHECKPOINT_SSH_KNOWN_HOSTS",
+    }
+    assert "StrictHostKeyChecking=yes" in source
+    assert "UserKnownHostsFile=~/.ssh/known_hosts" in source
+    assert "ssh-keygen -F" in source
+
+
+def test_provisioner_guards_exact_target_and_runner_set_before_mutation():
+    source = PROVISIONER.read_text(encoding="utf-8")
+    mutation = source.index("MUTATION_STARTED=true")
+
+    for guard in (
+        '[[ "$(hostname -s 2>/dev/null)" == "$TARGET_HOSTNAME" ]]',
+        '[[ "$(hostname -f 2>/dev/null)" == "$TARGET_FQDN" ]]',
+        '[[ "$(uname -m)" == "$TARGET_ARCH" ]]',
+        "exact_runners_active || stop runner_service_set_mismatch",
+    ):
+        assert source.index(guard) < mutation
+    assert (
+        source.count(
+            "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker.service"
+        )
+        >= 2
+    )
+    assert (
+        source.count(
+            "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-2.service"
+        )
+        >= 2
+    )
+    assert (
+        source.count(
+            "actions.runner.brianstewart377-rgb-ed-finder.contabo-codex-worker-3.service"
+        )
+        >= 2
+    )
+    assert (
+        source.index("exact_runners_active || stop runner_service_set_changed")
+        > mutation
+    )
+    for forbidden in (
+        "systemctl restart actions.runner",
+        "systemctl stop actions.runner",
+        "systemctl start actions.runner",
+    ):
+        assert forbidden not in source
+
+
+def test_provisioner_owns_only_checkpoint_infrastructure_and_never_deploys_app():
+    source = PROVISIONER.read_text(encoding="utf-8")
+
+    assert 'APP_NETWORK="edfinder-v3-checkpoint-app"' in source
+    assert 'ORIGIN_PORT="18080"' in source
+    assert "postgresql-18 postgresql-client-18" in source
+    assert "scripts/seed_check.sh" in source
+    assert "apply_migrations.sh --include-manual" in source
+    assert "sql/seed_preview.sql" in source
+    assert "default_transaction_read_only=on" in source
+    assert "server_name $TARGET_FQDN;" in source
+    assert "return 404" in source
+    assert "production_data_copied:false" in source
+    assert "application_deploy_performed:false" in source
+    assert "redis_provisioned:false" in source
+    assert "valkey_provisioned:false" in source
+    assert "nats_provisioned:false" in source
+    for forbidden in (
+        "docker compose up",
+        "docker compose down",
+        "git pull",
+        "git clone",
+        "target-authority.json",
+        "nb79a3d.mevnode.com",
+    ):
+        assert forbidden not in source
+
+
+def test_ghcr_authority_requires_real_anonymous_digest_pulls_or_blocker():
+    source = PROVISIONER.read_text(encoding="utf-8")
+    assert "printf '%s\\n' '{}' >\"$probe_config/config.json\"" in source
+    assert 'docker --host unix:///var/run/docker.sock pull "$BACKEND_IMAGE"' in source
+    assert 'docker --host unix:///var/run/docker.sock pull "$WEB_IMAGE"' in source
+    assert 'GHCR_STATUS="anonymous_public_digest_pull_proven"' in source
+    assert "explicit_secret_backed_ghcr_pull_authority_required" in source
+    assert "docker login" not in source
+    assert "GITHUB_TOKEN" not in source
+
+
+def test_committed_target_authority_remains_the_original_stopped_document():
+    import json
+
+    authority = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+    assert authority["status"] == "stopped"
+    assert authority["external_authority"]["api_env_file"] is None
+    assert authority["external_authority"]["database_source_authority"] is None
+    assert authority["external_authority"]["ghcr_pull_authority"] is None
+
+
+def test_success_and_transport_blocker_candidate_shapes_pass_deploy_validator():
+    import copy
+    import json
+
+    spec = importlib.util.spec_from_file_location(
+        "v3_checkpoint_deploy",
+        ROOT / "scripts/operator/v3_checkpoint_deploy.py",
+    )
+    assert spec is not None and spec.loader is not None
+    deploy = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(deploy)
+
+    recorded = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+    transport = copy.deepcopy(recorded)
+    transport["blockers"] = sorted(
+        set(transport["blockers"] + ["remote_transport_or_bundle_failed"])
+    )
+    assert "remote_transport_or_bundle_failed" in deploy.validate_authority(transport)
+
+    candidate = copy.deepcopy(recorded)
+    candidate["status"] = "authorized"
+    candidate["blockers"] = []
+    candidate["observed_runtime"]["container_runtime"] = "29.1.0"
+    candidate["observed_runtime"]["compose"] = "5.0.0"
+    candidate["observed_runtime"]["docker_networks"] = [
+        "bridge",
+        "edfinder-v3-checkpoint-app",
+        "host",
+        "none",
+    ]
+    candidate["external_authority"] = {
+        "api_env_file": "/etc/ed-finder/v3-checkpoint/api.env",
+        "api_env_owner_uid": 1000,
+        "api_env_mode": "0600",
+        "database_source_authority": (
+            "contabo-vmi3542235-native-postgresql18-preview-v1"
+        ),
+        "schema_identity_receipt": (
+            "/var/lib/edfinder-v3-checkpoint/schema-identity.json"
+        ),
+        "schema_identity_receipt_sha256": "a" * 64,
+        "origin_bind": "http://127.0.0.1:18080",
+        "edge_route_authority": (
+            "http-only-provider-fqdn-vmi3542235.contaboserver.net-"
+            "to-loopback-18080-no-dns"
+        ),
+        "receipt_directory": "/var/lib/edfinder-v3-checkpoint/receipts",
+        "receipt_owner_uid": 1000,
+        "receipt_mode": "0700",
+        "ghcr_pull_authority": "anonymous-public-digest-pull:proved",
+        "docker_config_directory": ("/var/lib/edfinder-v3-checkpoint/docker-config"),
+        "docker_config_owner_uid": 1000,
+        "docker_config_mode": "0700",
+        "docker_context": "edfinder-v3-checkpoint",
+    }
+    assert deploy.validate_authority(candidate) == []
+
+    source = PROVISIONER.read_text(encoding="utf-8")
+    for key in candidate["external_authority"]:
+        assert f"{key}:" in source
+
+
+def test_provisioner_rejects_non_root_before_target_mutation(tmp_path):
+    if os.geteuid() == 0:
+        pytest.skip("non-root boundary test requires a non-root test runner")
+    result = subprocess.run(
+        [
+            str(PROVISIONER),
+            "--operator-user",
+            subprocess.check_output(["id", "-un"], text=True).strip(),
+            "--output-dir",
+            str(tmp_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 77
+    assert result.stdout == ""
+    assert "requires non-interactive root authority" in result.stderr
+
+
+@pytest.mark.parametrize("shell", ["bash"])
+def test_provisioner_has_valid_shell_syntax(shell):
+    result = subprocess.run(
+        [shell, "-n", str(PROVISIONER)], text=True, capture_output=True, check=False
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Build the real persistent non-production V3 checkpoint infrastructure on Contabo without touching production.

This adds the bounded provisioning operator and request-triggered workflow for `vmi3542235`, preserving all three Codex runners. It provisions Docker/Compose, native PostgreSQL 18, a fresh current-schema preview database using the canonical migration + `seed_preview.sql` path, a separate read-only application role, the persistent app network, secure target-local config, schema identity receipt, durable receipt store, Docker context, and an HTTP-only provider-FQDN edge route. Redis/Valkey and NATS remain absent.

GHCR authority stays fail-closed: provisioning without release digests may finish with the single explicit GHCR blocker; rerunning with exact backend/web digests proves anonymous public pull or keeps the blocker for a separately authorized credential path.

No application deploy, production access/data copy, production DNS change, or build/git-pull on the target is authorized by this PR.