### PR TITLE
Add V3 production-in-place application promotion authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
           bash -n scripts/checks/local-ci-parity.sh
           bash -n scripts/run_canonical_safety_tests.sh
           bash -n scripts/deploy_main.sh
+          bash -n scripts/operator/actions/v3-production-inventory.sh
+          bash -n scripts/operator/actions/v3-production-promote.sh
       - name: Reject inline shell password SQL
         run: |
           password_sql_hits="$(
@@ -145,6 +147,7 @@ jobs:
             tests/test_repo_hygiene_contract.py \
             tests/test_backup_restore_ops.py \
             tests/test_windows_local_db_reset_contract.py \
+            tests/test_v3_production_application_deployment.py \
             -q
 
   synchronous-tooling:

--- a/.github/workflows/v3-production-application-deploy.yml
+++ b/.github/workflows/v3-production-application-deploy.yml
@@ -321,18 +321,29 @@ jobs:
           else
             RECEIPT_OPERATION="$receipt_operation" python - <<'PY' > "$RECEIPT"
           import json, os
-          print(json.dumps({
+          operation = os.environ["RECEIPT_OPERATION"]
+          preflight = operation == "production-preflight"
+          receipt = {
               "schema_version": "ed-finder/v3-production-deployment-receipt/v1",
-              "operation": os.environ["RECEIPT_OPERATION"], "status": "stopped",
+              "operation": operation, "status": "stopped",
               "target": {"production": True, "hostname": "ed-finder-prod", "fqdn": "nb79a3d.mevnode.com"},
               "failures": ["remote_transport_or_receipt_failed"],
               "database_access_performed": None, "database_access_may_have_been_performed": True,
-              "database_writes_performed": None, "migrations_performed": None,
-              "application_data_writes_performed": None, "image_pulls_performed": None,
-              "service_changes_performed": None, "service_changes_may_have_been_performed": True,
-              "edge_recreated": None, "protected_resources_changed": None,
-              "filesystem_writes_performed": None, "rollback_status": "inspect_durable_host_receipts",
-          }, sort_keys=True))
+              "database_writes_performed": False if preflight else None,
+              "migrations_performed": False if preflight else None,
+              "application_data_writes_performed": False if preflight else None,
+              "image_pulls_performed": False if preflight else None,
+              "service_changes_performed": False if preflight else None,
+              "service_changes_may_have_been_performed": not preflight,
+              "edge_recreated": False if preflight else None,
+              "protected_resources_changed": False if preflight else None,
+              "filesystem_writes_performed": None,
+              "filesystem_writes_may_have_been_performed": True,
+              "env_files_read": None, "env_files_may_have_been_read": True,
+              "env_contents_recorded": False, "private_keys_read": False,
+              "rollback_status": "inspect_durable_host_receipts",
+          }
+          print(json.dumps(receipt, sort_keys=True))
           PY
             cat "$RECEIPT"
           fi

--- a/.github/workflows/v3-production-application-deploy.yml
+++ b/.github/workflows/v3-production-application-deploy.yml
@@ -1,0 +1,369 @@
+name: V3 production application promotion
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Read-only inventory/preflight or protected application promotion
+        required: true
+        default: inventory
+        type: choice
+        options:
+          - inventory
+          - preflight
+          - promote
+      deployment_mode:
+        description: First accepted V3 release or receipt-backed blue/green upgrade
+        required: true
+        default: bootstrap
+        type: choice
+        options:
+          - bootstrap
+          - upgrade
+      release_run_id:
+        description: Successful canonical immutable release run (not used by inventory)
+        required: false
+        type: string
+      target_confirmation:
+        description: Type ed-finder-prod/nb79a3d.mevnode.com
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  packages: read
+
+concurrency:
+  group: v3-production-application-authority
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    name: Resolve exact trusted production request
+    if: github.repository == 'brianstewart377-rgb/ed-finder' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      source_sha: ${{ steps.guard.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Require literal target and exact current main
+        id: guard
+        env:
+          TARGET_CONFIRMATION: ${{ inputs.target_confirmation }}
+        run: |
+          set -euo pipefail
+          [ "$TARGET_CONFIRMATION" = "ed-finder-prod/nb79a3d.mevnode.com" ] || {
+            echo "Exact production target confirmation is required" >&2
+            exit 64
+          }
+          [ "$(git rev-parse HEAD)" = "$GITHUB_SHA" ] || exit 64
+          git fetch --no-tags origin refs/heads/main
+          [ "$(git rev-parse FETCH_HEAD)" = "$GITHUB_SHA" ] || {
+            echo "Dispatched SHA is no longer the exact current main head" >&2
+            exit 64
+          }
+          echo "source_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+  inventory:
+    name: Read-only production inventory
+    needs: guard
+    if: inputs.operation == 'inventory'
+    runs-on: ubuntu-24.04
+    environment: v3-production-readonly
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: Prepare pinned production SSH trust
+        env:
+          SSH_KEY: ${{ secrets.V3_PRODUCTION_SSH_KEY }}
+          SSH_HOST: ${{ secrets.V3_PRODUCTION_HOST }}
+          SSH_PORT: ${{ secrets.V3_PRODUCTION_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.V3_PRODUCTION_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          [ "$SSH_HOST" = "nb79a3d.mevnode.com" ] || { echo "Unexpected production SSH host" >&2; exit 64; }
+          [[ "$SSH_PORT" =~ ^[0-9]{1,5}$ ]] || exit 64
+          test -n "$SSH_KEY" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          install -m 600 /dev/null ~/.ssh/v3_production_key
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/v3_production_key
+          install -m 600 /dev/null ~/.ssh/known_hosts
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+      - name: Collect bounded read-only production receipt
+        env:
+          SSH_HOST: ${{ secrets.V3_PRODUCTION_HOST }}
+          SSH_PORT: ${{ secrets.V3_PRODUCTION_PORT }}
+          SSH_USER: ${{ secrets.V3_PRODUCTION_USER }}
+          RECEIPT: ${{ runner.temp }}/v3-production-inventory.json
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          set +e
+          ssh -i ~/.ssh/v3_production_key -p "$SSH_PORT" -o BatchMode=yes \
+              -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+              'if command -v python3 >/dev/null 2>&1; then exec python3 -I -S -; else printf "%s\n" "{\"schema_version\":\"ed-finder/v3-production-inventory/v1\",\"operation\":\"v3-production-inventory\",\"status\":\"stopped\",\"read_only\":true,\"filesystem_writes_performed\":false,\"failures\":[\"python3_unavailable\"]}"; exit 78; fi' \
+              < scripts/operator/v3_production_inventory.py > "$RECEIPT"
+          remote_status=$?
+          set -e
+          python -m json.tool "$RECEIPT" >/dev/null
+          cat "$RECEIPT"
+          [ "$remote_status" -eq 0 ] || exit "$remote_status"
+      - name: Upload sanitized production inventory
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-production-inventory
+          path: ${{ runner.temp }}/v3-production-inventory.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  prepare:
+    name: Authenticate and seal production operation
+    needs: guard
+    if: inputs.operation != 'inventory'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      source_sha: ${{ steps.manifest.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: Stop before credentials or SSH while production authority is blocked
+        run: python scripts/operator/v3_production_deploy.py --operation authority-gate
+      - name: Require a bounded release run ID
+        env:
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || { echo "release_run_id is required" >&2; exit 64; }
+      - name: Authenticate canonical immutable release run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID" > "$RUNNER_TEMP/release-run.json"
+          python - "$RUNNER_TEMP/release-run.json" <<'PY'
+          import json, os, pathlib, sys
+          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          checks = {
+              "workflow": run.get("path") == ".github/workflows/v3-application-release.yml",
+              "event": run.get("event") == "workflow_dispatch",
+              "result": run.get("status") == "completed" and run.get("conclusion") == "success",
+              "branch": run.get("head_branch") == "main",
+              "repository": (run.get("head_repository") or {}).get("full_name", "").lower() == os.environ["GITHUB_REPOSITORY"].lower(),
+          }
+          failed = sorted(key for key, passed in checks.items() if not passed)
+          if failed:
+              raise SystemExit("Release provenance failed: " + ",".join(failed))
+          PY
+      - name: Download candidate release manifest
+        uses: actions/download-artifact@37930b1c80d454462c3107e7378932bdb48a5e8e # v8.0.1
+        with:
+          name: v3-application-release-manifest
+          path: ${{ runner.temp }}/candidate
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.release_run_id }}
+      - name: Verify candidate checksum, manifest, and run SHA
+        id: manifest
+        env:
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          GITHUB_TOKEN: ${{ github.token }}
+          CURRENT_MAIN_SHA: ${{ needs.guard.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/candidate"
+          python "$GITHUB_WORKSPACE/scripts/release/v3_release_manifest.py" verify \
+            v3-application-release.json --purpose deploy-candidate
+          python "$GITHUB_WORKSPACE/scripts/release/v3_release_run.py" \
+            --repository "$GITHUB_REPOSITORY" \
+            --candidate-run-id "$RELEASE_RUN_ID" \
+            --candidate-manifest v3-application-release.json
+          python - "$RUNNER_TEMP/release-run.json" <<'PY'
+          import hashlib, json, os, pathlib, re, sys
+          directory = pathlib.Path(os.environ["RUNNER_TEMP"]) / "candidate"
+          manifest_path = directory / "v3-application-release.json"
+          sidecar = (directory / "v3-application-release.json.sha256").read_text().strip().split()
+          if len(sidecar) != 2 or sidecar[1].lstrip("*") != manifest_path.name or not re.fullmatch(r"[0-9a-f]{64}", sidecar[0]):
+              raise SystemExit("Checksum must name only the adjacent manifest basename")
+          if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != sidecar[0]:
+              raise SystemExit("Candidate checksum mismatch")
+          manifest = json.loads(manifest_path.read_text())
+          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if manifest.get("git_sha") != run.get("head_sha"):
+              raise SystemExit("Candidate manifest does not match release run SHA")
+          if manifest.get("git_sha") != os.environ["CURRENT_MAIN_SHA"]:
+              raise SystemExit("Candidate is not the exact current main release")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              print("source_sha=" + manifest["git_sha"], file=output)
+          PY
+
+  production-operation:
+    name: Run protected production preflight or promotion
+    needs: [guard, prepare]
+    if: inputs.operation != 'inventory'
+    runs-on: ubuntu-24.04
+    environment: v3-production
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard.outputs.source_sha }}
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+      - name: Download candidate release manifest in this isolated job
+        uses: actions/download-artifact@37930b1c80d454462c3107e7378932bdb48a5e8e # v8.0.1
+        with:
+          name: v3-application-release-manifest
+          path: ${{ runner.temp }}/candidate
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.release_run_id }}
+      - name: Reauthenticate candidate in the protected production job
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          EXPECTED_SOURCE_SHA: ${{ needs.guard.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/candidate"
+          python "$GITHUB_WORKSPACE/scripts/release/v3_release_run.py" \
+            --repository "$GITHUB_REPOSITORY" \
+            --candidate-run-id "$RELEASE_RUN_ID" \
+            --candidate-manifest v3-application-release.json
+          python "$GITHUB_WORKSPACE/scripts/release/v3_release_manifest.py" verify \
+            v3-application-release.json --purpose deploy-candidate \
+            --expected-git-sha "$EXPECTED_SOURCE_SHA"
+          python - <<'PY'
+          import hashlib, pathlib, re
+          manifest = pathlib.Path("v3-application-release.json")
+          fields = pathlib.Path("v3-application-release.json.sha256").read_text().strip().split()
+          if len(fields) != 2 or fields[1].lstrip("*") != manifest.name or not re.fullmatch(r"[0-9a-f]{64}", fields[0]):
+              raise SystemExit("Checksum must name only the adjacent manifest basename")
+          if hashlib.sha256(manifest.read_bytes()).hexdigest() != fields[0]:
+              raise SystemExit("Candidate checksum mismatch")
+          PY
+      - name: Prepare sealed source-free operation bundle and pinned SSH trust
+        env:
+          SSH_KEY: ${{ secrets.V3_PRODUCTION_SSH_KEY }}
+          SSH_HOST: ${{ secrets.V3_PRODUCTION_HOST }}
+          SSH_PORT: ${{ secrets.V3_PRODUCTION_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.V3_PRODUCTION_SSH_KNOWN_HOSTS }}
+          REGISTRY_TOKEN: ${{ github.token }}
+          BUNDLE: ${{ runner.temp }}/v3-production-bundle
+          REQUESTED_OPERATION: ${{ inputs.operation }}
+        run: |
+          set -euo pipefail
+          [ "$SSH_HOST" = "nb79a3d.mevnode.com" ] || { echo "Unexpected production SSH host" >&2; exit 64; }
+          [[ "$SSH_PORT" =~ ^[0-9]{1,5}$ ]] || exit 64
+          test -n "$SSH_KEY" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh "$BUNDLE/scripts/operator/actions" "$BUNDLE/scripts/release" "$BUNDLE/deploy/v3-production" "$BUNDLE/artifacts/candidate"
+          install -m 600 /dev/null ~/.ssh/v3_production_key
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/v3_production_key
+          install -m 600 /dev/null ~/.ssh/known_hosts
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+          install -m 700 scripts/operator/v3_production_deploy.py "$BUNDLE/scripts/operator/"
+          install -m 700 scripts/operator/actions/v3-production-promote.sh "$BUNDLE/scripts/operator/actions/"
+          install -m 600 scripts/release/v3_release_manifest.py "$BUNDLE/scripts/release/"
+          install -m 600 deploy/v3-production/compose.yml deploy/v3-production/target-authority.json "$BUNDLE/deploy/v3-production/"
+          install -m 600 "$RUNNER_TEMP/candidate/v3-application-release.json" "$RUNNER_TEMP/candidate/v3-application-release.json.sha256" "$BUNDLE/artifacts/candidate/"
+          if [ "$REQUESTED_OPERATION" = promote ]; then
+            install -m 600 /dev/null "$BUNDLE/registry-token"
+            printf '%s' "$REGISTRY_TOKEN" > "$BUNDLE/registry-token"
+          fi
+      - name: Execute exact production authority
+        env:
+          SSH_HOST: ${{ secrets.V3_PRODUCTION_HOST }}
+          SSH_PORT: ${{ secrets.V3_PRODUCTION_PORT }}
+          SSH_USER: ${{ secrets.V3_PRODUCTION_USER }}
+          BUNDLE: ${{ runner.temp }}/v3-production-bundle
+          RECEIPT: ${{ runner.temp }}/v3-production-operation.json
+          OPERATION: ${{ inputs.operation }}
+          DEPLOYMENT_MODE: ${{ inputs.deployment_mode }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          remote_receipt="$RECEIPT.remote"
+          set +e
+          tar -C "$BUNDLE" -cf - . | ssh -i ~/.ssh/v3_production_key -p "$SSH_PORT" \
+            -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            "set -eu; umask 077; work=\"\$(mktemp -d)\"; child=''; cleanup() { rm -rf -- \"\$work\"; }; terminate() { trap - HUP INT TERM; if [ -n \"\$child\" ]; then kill -TERM \"\$child\" 2>/dev/null || true; wait \"\$child\" 2>/dev/null || true; fi; exit 143; }; trap cleanup EXIT; trap terminate HUP INT TERM; tar -xf - -C \"\$work\"; cd \"\$work\"; bash scripts/operator/actions/v3-production-promote.sh --operation '$OPERATION' --mode '$DEPLOYMENT_MODE' --candidate artifacts/candidate/v3-application-release.json --candidate-checksum artifacts/candidate/v3-application-release.json.sha256 --candidate-run-id '$RELEASE_RUN_ID' --registry-token-file registry-token --registry-username '$REGISTRY_USERNAME' --runtime-directory \"\$work\" & child=\$!; wait \"\$child\"" \
+            > "$remote_receipt"
+          pipeline_status=("${PIPESTATUS[@]}")
+          set -e
+          if [ -s "$remote_receipt" ] && python -m json.tool "$remote_receipt" >/dev/null 2>&1; then
+            mv "$remote_receipt" "$RECEIPT"
+            cat "$RECEIPT"
+          else
+            python - <<'PY' > "$RECEIPT"
+          import json
+          print(json.dumps({
+              "schema_version": "ed-finder/v3-production-deployment-receipt/v1",
+              "operation": "production-promotion", "status": "stopped",
+              "target": {"production": True, "hostname": "ed-finder-prod", "fqdn": "nb79a3d.mevnode.com"},
+              "failures": ["remote_transport_or_receipt_failed"],
+              "database_access_performed": None, "database_access_may_have_been_performed": True,
+              "database_writes_performed": None, "migrations_performed": None,
+              "application_data_writes_performed": None, "image_pulls_performed": None,
+              "service_changes_performed": None, "service_changes_may_have_been_performed": True,
+              "edge_recreated": None, "protected_resources_changed": None,
+              "filesystem_writes_performed": None, "rollback_status": "inspect_durable_host_receipts",
+          }, sort_keys=True))
+          PY
+            cat "$RECEIPT"
+          fi
+          [ "${pipeline_status[0]}" -eq 0 ] && [ "${pipeline_status[1]}" -eq 0 ] || exit 78
+      - name: Remove local ephemeral registry credential
+        if: always()
+        env:
+          BUNDLE: ${{ runner.temp }}/v3-production-bundle
+        run: |
+          if [ -f "$BUNDLE/registry-token" ]; then
+            chmod 600 "$BUNDLE/registry-token"
+            python - "$BUNDLE/registry-token" <<'PY'
+          import os, pathlib, sys
+          path = pathlib.Path(sys.argv[1])
+          try:
+              size = path.stat().st_size
+              with path.open("r+b", buffering=0) as handle:
+                  handle.write(b"\0" * size)
+                  handle.flush()
+                  os.fsync(handle.fileno())
+          finally:
+              path.unlink(missing_ok=True)
+          PY
+          fi
+      - name: Upload sanitized production operation receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-production-application-operation
+          path: ${{ runner.temp }}/v3-production-operation.json
+          if-no-files-found: warn
+          retention-days: 180

--- a/.github/workflows/v3-production-application-deploy.yml
+++ b/.github/workflows/v3-production-application-deploy.yml
@@ -206,6 +206,17 @@ jobs:
         with:
           ref: ${{ needs.guard.outputs.source_sha }}
           persist-credentials: false
+      - name: Revalidate exact current main after production approval
+        env:
+          EXPECTED_SOURCE_SHA: ${{ needs.guard.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          [ "$(git rev-parse HEAD)" = "$EXPECTED_SOURCE_SHA" ] || exit 64
+          git fetch --no-tags origin refs/heads/main
+          [ "$(git rev-parse FETCH_HEAD)" = "$EXPECTED_SOURCE_SHA" ] || {
+            echo "Canonical main moved while production approval was pending" >&2
+            exit 64
+          }
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.14"
@@ -251,10 +262,16 @@ jobs:
           REQUESTED_OPERATION: ${{ inputs.operation }}
         run: |
           set -euo pipefail
+          case "$REQUESTED_OPERATION" in
+            preflight|promote) ;;
+            *) echo "Unexpected production operation" >&2; exit 64 ;;
+          esac
           [ "$SSH_HOST" = "nb79a3d.mevnode.com" ] || { echo "Unexpected production SSH host" >&2; exit 64; }
           [[ "$SSH_PORT" =~ ^[0-9]{1,5}$ ]] || exit 64
           test -n "$SSH_KEY" && test -n "$SSH_KNOWN_HOSTS"
-          install -d -m 700 ~/.ssh "$BUNDLE/scripts/operator/actions" "$BUNDLE/scripts/release" "$BUNDLE/deploy/v3-production" "$BUNDLE/artifacts/candidate"
+          install -d -m 700 ~/.ssh
+          install -d -m 700 "$BUNDLE"
+          install -d -m 700 "$BUNDLE/scripts/operator/actions" "$BUNDLE/scripts/release" "$BUNDLE/deploy/v3-production" "$BUNDLE/artifacts/candidate"
           install -m 600 /dev/null ~/.ssh/v3_production_key
           printf '%s\n' "$SSH_KEY" > ~/.ssh/v3_production_key
           install -m 600 /dev/null ~/.ssh/known_hosts
@@ -284,12 +301,17 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_USER"
+          case "$OPERATION" in
+            preflight) receipt_operation=production-preflight ;;
+            promote) receipt_operation=production-promotion ;;
+            *) echo "Unexpected production operation" >&2; exit 64 ;;
+          esac
           remote_receipt="$RECEIPT.remote"
           set +e
           tar -C "$BUNDLE" -cf - . | ssh -i ~/.ssh/v3_production_key -p "$SSH_PORT" \
             -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes \
             -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
-            "set -eu; umask 077; work=\"\$(mktemp -d)\"; child=''; cleanup() { rm -rf -- \"\$work\"; }; terminate() { trap - HUP INT TERM; if [ -n \"\$child\" ]; then kill -TERM \"\$child\" 2>/dev/null || true; wait \"\$child\" 2>/dev/null || true; fi; exit 143; }; trap cleanup EXIT; trap terminate HUP INT TERM; tar -xf - -C \"\$work\"; cd \"\$work\"; bash scripts/operator/actions/v3-production-promote.sh --operation '$OPERATION' --mode '$DEPLOYMENT_MODE' --candidate artifacts/candidate/v3-application-release.json --candidate-checksum artifacts/candidate/v3-application-release.json.sha256 --candidate-run-id '$RELEASE_RUN_ID' --registry-token-file registry-token --registry-username '$REGISTRY_USERNAME' --runtime-directory \"\$work\" & child=\$!; wait \"\$child\"" \
+            "set -eu; umask 077; work=\"\$(mktemp -d)\"; child=''; cleanup() { rm -rf -- \"\$work\"; }; cancel() { trap '' HUP INT TERM; if [ -n \"\$child\" ]; then kill -TERM \"\$child\" 2>/dev/null || true; set +e; wait \"\$child\"; child_status=\$?; set -e; exit \"\$child_status\"; fi; exit 143; }; trap cleanup EXIT; trap cancel HUP INT TERM; chmod 700 \"\$work\"; tar --no-same-permissions --no-overwrite-dir -xf - -C \"\$work\"; chmod 700 \"\$work\"; cd \"\$work\"; bash scripts/operator/actions/v3-production-promote.sh --operation '$OPERATION' --mode '$DEPLOYMENT_MODE' --candidate artifacts/candidate/v3-application-release.json --candidate-checksum artifacts/candidate/v3-application-release.json.sha256 --candidate-run-id '$RELEASE_RUN_ID' --registry-token-file registry-token --registry-username '$REGISTRY_USERNAME' --runtime-directory \"\$work\" & child=\$!; wait \"\$child\"" \
             > "$remote_receipt"
           pipeline_status=("${PIPESTATUS[@]}")
           set -e
@@ -297,11 +319,11 @@ jobs:
             mv "$remote_receipt" "$RECEIPT"
             cat "$RECEIPT"
           else
-            python - <<'PY' > "$RECEIPT"
-          import json
+            RECEIPT_OPERATION="$receipt_operation" python - <<'PY' > "$RECEIPT"
+          import json, os
           print(json.dumps({
               "schema_version": "ed-finder/v3-production-deployment-receipt/v1",
-              "operation": "production-promotion", "status": "stopped",
+              "operation": os.environ["RECEIPT_OPERATION"], "status": "stopped",
               "target": {"production": True, "hostname": "ed-finder-prod", "fqdn": "nb79a3d.mevnode.com"},
               "failures": ["remote_transport_or_receipt_failed"],
               "database_access_performed": None, "database_access_may_have_been_performed": True,

--- a/.github/workflows/v3-production-application-deploy.yml
+++ b/.github/workflows/v3-production-application-deploy.yml
@@ -156,27 +156,6 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$RELEASE_RUN_ID" =~ ^[1-9][0-9]{0,19}$ ]] || { echo "release_run_id is required" >&2; exit 64; }
-      - name: Authenticate canonical immutable release run
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
-        run: |
-          set -euo pipefail
-          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID" > "$RUNNER_TEMP/release-run.json"
-          python - "$RUNNER_TEMP/release-run.json" <<'PY'
-          import json, os, pathlib, sys
-          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          checks = {
-              "workflow": run.get("path") == ".github/workflows/v3-application-release.yml",
-              "event": run.get("event") == "workflow_dispatch",
-              "result": run.get("status") == "completed" and run.get("conclusion") == "success",
-              "branch": run.get("head_branch") == "main",
-              "repository": (run.get("head_repository") or {}).get("full_name", "").lower() == os.environ["GITHUB_REPOSITORY"].lower(),
-          }
-          failed = sorted(key for key, passed in checks.items() if not passed)
-          if failed:
-              raise SystemExit("Release provenance failed: " + ",".join(failed))
-          PY
       - name: Download candidate release manifest
         uses: actions/download-artifact@37930b1c80d454462c3107e7378932bdb48a5e8e # v8.0.1
         with:
@@ -184,7 +163,7 @@ jobs:
           path: ${{ runner.temp }}/candidate
           github-token: ${{ github.token }}
           run-id: ${{ inputs.release_run_id }}
-      - name: Verify candidate checksum, manifest, and run SHA
+      - name: Authenticate canonical release and verify candidate
         id: manifest
         env:
           RELEASE_RUN_ID: ${{ inputs.release_run_id }}
@@ -199,8 +178,8 @@ jobs:
             --repository "$GITHUB_REPOSITORY" \
             --candidate-run-id "$RELEASE_RUN_ID" \
             --candidate-manifest v3-application-release.json
-          python - "$RUNNER_TEMP/release-run.json" <<'PY'
-          import hashlib, json, os, pathlib, re, sys
+          python - <<'PY'
+          import hashlib, json, os, pathlib, re
           directory = pathlib.Path(os.environ["RUNNER_TEMP"]) / "candidate"
           manifest_path = directory / "v3-application-release.json"
           sidecar = (directory / "v3-application-release.json.sha256").read_text().strip().split()
@@ -209,9 +188,6 @@ jobs:
           if hashlib.sha256(manifest_path.read_bytes()).hexdigest() != sidecar[0]:
               raise SystemExit("Candidate checksum mismatch")
           manifest = json.loads(manifest_path.read_text())
-          run = json.loads(pathlib.Path(sys.argv[1]).read_text())
-          if manifest.get("git_sha") != run.get("head_sha"):
-              raise SystemExit("Candidate manifest does not match release run SHA")
           if manifest.get("git_sha") != os.environ["CURRENT_MAIN_SHA"]:
               raise SystemExit("Candidate is not the exact current main release")
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,11 @@ Git history, removed workflows, old artifacts, and superseded design documents a
 
 The V3 application and One Spatial Platform programme is current. PR #601's
 Explore/Finder → fresh Babylon results → canonical Inspect slice merged to
-`main` at `6d574a2908ebda146a2c271f8fb46a9e272ad12e`. The first non-production
-live-checkpoint exit path is now the bounded application release task.
+`main` at `6d574a2908ebda146a2c271f8fb46a9e272ad12e`. The non-production live
+checkpoint remains a separate rehearsal boundary. The explicitly V3 production
+application authority is app-only and currently stopped pending reviewed live
+inventory/schema and external network, secret-file, receipt-store, Docker-context
+and unchanged-edge cutover facts; its presence is not permission to deploy.
 
 `apps/web/` is the sole target for new browser application work. Svelte/SvelteKit
 owns the application, domain orchestration, routes, panels, and accessible DOM;
@@ -83,6 +86,10 @@ Current operator helpers include:
 - `scripts/operator/actions/octopus-edge-status.sh`
 - `scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh`
 - `scripts/operator/recover_v3_runtime_contract.py`
+- `scripts/operator/v3_production_inventory.py` (read-only, already-present host
+  Python runtime allowed; no host Python installation authority)
+- `scripts/operator/v3_production_deploy.py` (only through the protected,
+  manual production workflow and its fail-closed target authority)
 
 Other scripts under `scripts/operator/` are repository tooling unless a current V3 runbook explicitly promotes them to production authority.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ PR #601's Explore/Finder → fresh Babylon results → canonical Inspect product
 slice and Review Lab rebase onto `apps/web` + Babylon merged to `main` at exact
 merge commit `6d574a2908ebda146a2c271f8fb46a9e272ad12e`.
 
-The non-production V3 live checkpoint remains a separate rehearsal boundary.
+The separate Contabo/live checkpoint remains a rehearsal boundary outside
+production.
 The V3 production application promotion authority is now defined independently
 and remains fail-closed until its fresh inventory, schema, network, secret-file,
 receipt-store, Docker-context, and unchanged-edge cutover facts are reviewed.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ PR #601's Explore/Finder → fresh Babylon results → canonical Inspect product
 slice and Review Lab rebase onto `apps/web` + Babylon merged to `main` at exact
 merge commit `6d574a2908ebda146a2c271f8fb46a9e272ad12e`.
 
-The current bounded exit task is the first non-production V3 live checkpoint;
-it is not a production promotion.
+The non-production V3 live checkpoint remains a separate rehearsal boundary.
+The V3 production application promotion authority is now defined independently
+and remains fail-closed until its fresh inventory, schema, network, secret-file,
+receipt-store, Docker-context, and unchanged-edge cutover facts are reviewed.
 
 ## Current authority
 
@@ -123,3 +125,9 @@ fail-closed on the recorded missing runtime, data and route authorities.
 The repository currently has no executable PostgreSQL 18 recovery runbook.
 Stop rather than adapting V2 instructions or inventing host paths, credentials,
 backup targets, or restore commands.
+
+The separate V3 production application promotion authority is documented in
+[`docs/operations/v3-production-application-release.md`](docs/operations/v3-production-application-release.md).
+Its committed target is fail-closed pending reviewed inventory and schema/edge
+facts; the root Compose and Contabo checkpoint do not become production
+authority.

--- a/deploy/v3-production/compose.yml
+++ b/deploy/v3-production/compose.yml
@@ -1,0 +1,82 @@
+name: edfinder-v3-production
+
+# This is the only V3 production application Compose authority. It deliberately
+# owns two blue/green application slots and nothing else. PostgreSQL, Redis,
+# NATS, the TLS/public-auth edge, the legacy proxy, Octopus, and unrelated
+# containers remain externally managed and must never become dependencies.
+x-api: &api
+  image: ${V3_PRODUCTION_API_IMAGE:?digest-pinned API image is required}
+  restart: unless-stopped
+  env_file:
+    - ${V3_PRODUCTION_API_ENV_FILE:?verified production API env snapshot is required}
+  environment:
+    BUILD_SHA: ${V3_PRODUCTION_SOURCE_SHA:?exact source SHA is required}
+    # Candidate verification must not perform startup/background writes. These
+    # remain disabled after cutover until a separate reviewed worker authority
+    # explicitly owns them.
+    ADMIN_OPERATION_STARTUP_REAP_ENABLED: "false"
+    EDDN_SIMULATION_INGEST_ENABLED: "false"
+  expose:
+    - "8000"
+  networks:
+    - app
+  pids_limit: 512
+  cpus: "2.00"
+  mem_limit: 4096m
+  logging:
+    driver: json-file
+    options:
+      max-size: "20m"
+      max-file: "3"
+  security_opt:
+    - no-new-privileges:true
+
+x-web: &web
+  image: ${V3_PRODUCTION_WEB_IMAGE:?digest-pinned web image is required}
+  restart: unless-stopped
+  environment:
+    BUILD_SHA: ${V3_PRODUCTION_SOURCE_SHA:?exact source SHA is required}
+  networks:
+    - app
+  pids_limit: 256
+  cpus: "1.00"
+  mem_limit: 1024m
+  logging:
+    driver: json-file
+    options:
+      max-size: "20m"
+      max-file: "3"
+  security_opt:
+    - no-new-privileges:true
+
+services:
+  api-blue:
+    <<: *api
+    container_name: edfinder-v3-production-api-blue
+
+  web-blue:
+    <<: *web
+    container_name: edfinder-v3-production-web-blue
+    environment:
+      BUILD_SHA: ${V3_PRODUCTION_SOURCE_SHA:?exact source SHA is required}
+      EDFINDER_API_UPSTREAM: edfinder-v3-production-api-blue:8000
+    ports:
+      - ${V3_PRODUCTION_ORIGIN_BIND:?reviewed loopback origin bind is required}:8080
+
+  api-green:
+    <<: *api
+    container_name: edfinder-v3-production-api-green
+
+  web-green:
+    <<: *web
+    container_name: edfinder-v3-production-web-green
+    environment:
+      BUILD_SHA: ${V3_PRODUCTION_SOURCE_SHA:?exact source SHA is required}
+      EDFINDER_API_UPSTREAM: edfinder-v3-production-api-green:8000
+    ports:
+      - ${V3_PRODUCTION_ORIGIN_BIND:?reviewed loopback origin bind is required}:8080
+
+networks:
+  app:
+    name: ${V3_PRODUCTION_APP_NETWORK:?reviewed external application network is required}
+    external: true

--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "ed-finder/v3-production-target-authority/v1",
+  "status": "stopped",
+  "target": {
+    "provider": "mevspace",
+    "classification": "production",
+    "production": true,
+    "hostname": "ed-finder-prod",
+    "fqdn": "nb79a3d.mevnode.com",
+    "architecture": "x86_64"
+  },
+  "evidence": {
+    "source": "read-only host-status workflow run 34202433965",
+    "fresh_for_implementation": true,
+    "deployment_evidence": false
+  },
+  "reviewed_capacity": null,
+  "observed_runtime": {
+    "api_container": "edfinder-v3-api",
+    "api_image": "edfinder-v3-api:phase4c-r5",
+    "legacy_origin_container": "edfinder-v3-proxy",
+    "public_edge_container": "edfinder-v3-public-auth-edge",
+    "postgres_container": "edfinder-v3-phase4c-full-20260827_r5-postgres",
+    "redis_container": "edfinder-v3-support-redis",
+    "nats_container": "edfinder-v3-support-nats",
+    "octopus_and_unrelated_containers": "preserve-all",
+    "public_ui": "temporary-replacement-shell"
+  },
+  "application_contract": {
+    "compose_project": "edfinder-v3-production",
+    "compose_sha256": "a06a5f0c237b0433457b5f15632fa28cf922768df4cbc4b5936c9f1759a288f4",
+    "slots": ["blue", "green"],
+    "services": ["api-blue", "web-blue", "api-green", "web-green"],
+    "containers": [
+      "edfinder-v3-production-api-blue",
+      "edfinder-v3-production-web-blue",
+      "edfinder-v3-production-api-green",
+      "edfinder-v3-production-web-green"
+    ],
+    "per_active_slot_limits": {
+      "api": {"cpus": "2.00", "memory": "4096m", "pids": 512},
+      "web": {"cpus": "1.00", "memory": "1024m", "pids": 256},
+      "logs": {"driver": "json-file", "max_size": "20m", "max_files": 3}
+    },
+    "named_volumes": [],
+    "database_lifecycle": "external-retained-never-managed",
+    "edge_lifecycle": "external-retained-never-recreated",
+    "cutover_strategy": "verified-loopback-blue-green-port-swap"
+  },
+  "preservation_contract": {
+    "exact_containers": [
+      "edfinder-v3-public-auth-edge",
+      "edfinder-v3-phase4c-full-20260827_r5-postgres",
+      "edfinder-v3-support-redis",
+      "edfinder-v3-support-nats"
+    ],
+    "container_name_patterns": ["^octopus(?:-|$)", "(?:^|-)pg(?:-|$)", "bench", "lab"],
+    "never_compose_services": ["postgres", "redis", "valkey", "nats", "edge", "proxy", "octopus"],
+    "never_recreate_or_remove": true
+  },
+  "external_authority": {
+    "application_network": null,
+    "application_network_allowed_containers": null,
+    "api_env_file": null,
+    "api_env_owner_uid": null,
+    "api_env_mode": null,
+    "schema_identity_file": null,
+    "schema_identity_sha256": null,
+    "schema_identity_owner_uid": null,
+    "schema_identity_mode": null,
+    "active_origin_bind": "127.0.0.1:58080",
+    "staging_origin_bind": "127.0.0.1:58081",
+    "public_origin": "https://ed-finder.app",
+    "edge_route_authority": null,
+    "receipt_directory": null,
+    "receipt_owner_uid": null,
+    "receipt_mode": null,
+    "docker_context": null
+  },
+  "blockers": [
+    "fresh_production_inventory_receipt_not_reviewed",
+    "production_application_network_authority_missing",
+    "production_api_secret_file_authority_missing",
+    "production_schema_identity_and_live_ledger_compatibility_unproved",
+    "production_edge_loopback_cutover_topology_authority_missing",
+    "production_receipt_store_authority_missing",
+    "production_local_docker_context_authority_missing",
+    "production_promotion_cpython314_runtime_unproved",
+    "production_application_resource_capacity_unproved"
+  ]
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,6 +41,11 @@ or override this set.
   route authority keeps mutation stopped.
 - **Inference:** Ollama was an Octopus experiment and has been removed from
   production. It is not part of the architecture.
+- **Production application authority:** the separate app-only V3 production
+  promotion path is defined, but its committed target is stopped pending a
+  reviewed fresh inventory, live schema compatibility and exact external
+  network/secret/receipt/Docker/unchanged-edge cutover facts. The root Compose
+  and Contabo checkpoint remain non-authoritative for production.
 
 ## Product journey and spatial north star
 
@@ -60,21 +65,27 @@ evidence-interpretation, and Digital Twin owner.
 
 ## Execution order
 
-1. **Exit the merged browser slice through a checkpoint.** Exercise the
-   accepted Explore/Finder → Babylon results → Inspect journey through the
-   bounded live-checkpoint path. That environment remains non-production.
+1. **Keep checkpoint and production authorities separate.** The Contabo
+   checkpoint remains non-production. Use only the production authority's
+   read-only inventory to resolve its explicit blockers; do not deploy while
+   its target is stopped.
 2. **Harden the V3 release.** Continue CPython 3.14/`uv`, immutable release
    provenance, same-origin route, health, migration compatibility, and rollback
    work without treating an application release as database recovery.
-3. **Preserve the checkpoint boundary.** Keep Contabo non-production and its
+3. **Promote only after reviewed production preflight.** A candidate must be an
+   authenticated immutable release compatible with the freshly verified live
+   ledger. Preserve PostgreSQL 18, Redis, NATS, the public-auth/TLS edge,
+   Octopus and unrelated containers; schema deltas stop for a separate
+   production migration authority.
+4. **Preserve the checkpoint boundary.** Keep Contabo non-production and its
    persistent app-only namespace isolated from the three runner services.
-4. **Resolve search and data architecture in order.** Establish Search product
+5. **Resolve search and data architecture in order.** Establish Search product
    and performance requirements, then choose the spatial index/grid/cluster
    design, then define the PostgreSQL 18 derived-data bootstrap.
-5. **Resolve judgement dependencies.** Reconcile current Ratings v3.4 uses with
+6. **Resolve judgement dependencies.** Reconcile current Ratings v3.4 uses with
    the roadmap's intended archetype judgement layer before a full ratings,
    grid, cluster, or derived-data build is prescribed.
-6. **Establish V3 database evidence.** Add reviewed PostgreSQL 18 maintenance,
+7. **Establish V3 database evidence.** Add reviewed PostgreSQL 18 maintenance,
    backup, restore, and PITR evidence/procedures before claiming operational
    readiness. Historical V2 receipts cannot fill this gap.
 

--- a/docs/operations/infrastructure-status.md
+++ b/docs/operations/infrastructure-status.md
@@ -7,6 +7,14 @@ replacement infrastructure.
 
 The current environment uses PostgreSQL 18, the current backup/PITR design, the Frontier identity service, and the replacement-host operator boundary. Production actions must use only current V3 runbooks and workflows that explicitly target this environment.
 
+The reviewed V3 application promotion boundary is
+[`v3-production-application-release.md`](v3-production-application-release.md).
+It has its own app-only blue/green Compose authority and is deliberately
+separate from the root/legacy Compose and the Contabo checkpoint. Its committed
+target remains stopped pending a reviewed read-only production inventory,
+schema identity, network/secret/receipt facts, and exact unchanged-edge cutover
+topology. That stopped authority is not permission to deploy.
+
 Do not infer production authority from old Git history, archived artifacts, removed workflows, or obsolete server-side paths.
 
 Hetzner/V2 is decommissioned. Its host, container, cron, database, backup,

--- a/docs/operations/operator-command-contexts.md
+++ b/docs/operations/operator-command-contexts.md
@@ -73,6 +73,15 @@ The only current replacement-host helpers presently identified by the V3 control
 - `scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh`;
 - `scripts/operator/recover_v3_runtime_contract.py`.
 
+The production application promotion surface is separately and exclusively
+identified by `docs/operations/v3-production-application-release.md` and
+`.github/workflows/v3-production-application-deploy.yml`. Its
+`v3-production-inventory` operation is read-only and may use an already-present
+host Python 3 standard-library runtime. Its preflight/promotion helper is not a
+general operator command: the committed target authority is stopped and it may
+run only from the exact protected workflow after all external facts are
+reviewed. It never selects the root Compose or the Contabo authority.
+
 `scripts/operator/actions/v3-app-live-checkpoint-preflight.sh` is separate from
 that production surface. It targets the non-production Contabo live-checkpoint
 boundary and launches the reviewed bootstrap/upgrade validator. The committed

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -42,7 +42,10 @@ provision a runtime.
 
 The same receipt must inspect Docker context `default` and expose only its
 context name and Docker endpoint/host. It must not emit Docker configuration or
-credentials. Review that fact as evidence for
+credentials. The context must resolve exactly to the local rootful
+`unix:///var/run/docker.sock` endpoint, and every Docker inventory command is
+explicitly pinned to it. An unexpected endpoint stops before any container,
+network, port, or ledger evidence is queried. Review that fact as evidence for
 `production_local_docker_context_authority_missing`. Where the already-bounded
 Docker port inventory makes it possible, the receipt must also identify the
 container owners of loopback ports `58080` and `58081`, including an explicit
@@ -65,6 +68,16 @@ repository's exact CPython 3.14 execution contract and stops with
 `python314_required_for_production_mutation` if that runtime is absent. This
 runbook does not authorize installing it; runtime provisioning, if genuinely
 needed for promotion, requires separate review and is not a status-tool repair.
+
+Workflow-driven preflight remains application- and data-read-only, but it is
+not host-filesystem-write-free: the workflow creates a private temporary
+operation directory, extracts the sealed bundle into it, and removes it on
+exit. Preflight receipts therefore report `filesystem_writes_performed=true`
+with scope `ephemeral-operation-bundle-only`, while database writes,
+application-data writes, migrations, image pulls, service changes, edge
+recreation, and protected-resource changes remain `false`. A transport failure
+that cannot prove whether remote extraction began reports that filesystem fact
+as unknown/may-have-occurred rather than falsely reporting `false`.
 
 No current production migration authority exists in this repository. If the
 fresh complete `public.schema_migrations` filename/checksum ledger cannot be
@@ -111,8 +124,10 @@ Promotion uses these gates in order:
    stop the stale legacy API on bootstrap or retire the prior managed slot on
    an upgrade.
 7. Persist a sanitized immutable receipt, byte-exact manifest and checksums, then
-   atomically advance `current.json`. Remove the secret snapshot and registry
-   credentials on every exit.
+   atomically advance `current.json`. If any later persistence step fails,
+   atomically restore the prior pointer (or its prior absence) before candidate
+   artifacts are removed. Remove the secret snapshot and registry credentials
+   on every exit.
 
 Cancellation is a controlled deployment failure. The remote transport forwards
 one termination signal and waits while the deployer terminates and reaps its

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -30,17 +30,35 @@ local Docker context, receipt store, live migration ledger identity, or the
 exact edge-to-loopback cutover topology.
 
 Run only the workflow's default `inventory` operation first. It uses the
-already-present host `python3` standard library—there is no reason or authority
-to install host Python 3.14 for status tooling—and performs only bounded Docker,
-listener, HTTP, and `BEGIN READ ONLY` ledger inspection. Its machine-readable
-receipt excludes container environments, env-file contents, DSNs, passwords,
-tokens, and private keys. Review that sanitized receipt in a separate PR and
-replace every `null` authority plus every blocker with exact reviewed facts.
-Changing the target to `authorized` without those facts is invalid.
+already-present host `python3` standard library and performs only bounded
+runtime, Docker, listener, HTTP, and `BEGIN READ ONLY` ledger inspection. The
+machine-readable receipt must identify the bounded executable path,
+implementation, and version of the default `python3` used to run inventory,
+and separately state whether `python3.14` exists, its bounded executable path
+and version when present, and whether it is exactly CPython 3.14. This
+inspection is evidence for
+`production_promotion_cpython314_runtime_unproved`; it does not install or
+provision a runtime.
 
-Read-only inventory and preflight may use the already-present host Python 3
-standard library. Actual production mutation retains the repository's exact
-CPython 3.14 execution contract and stops with
+The same receipt must inspect Docker context `default` and expose only its
+context name and Docker endpoint/host. It must not emit Docker configuration or
+credentials. Review that fact as evidence for
+`production_local_docker_context_authority_missing`. Where the already-bounded
+Docker port inventory makes it possible, the receipt must also identify the
+container owners of loopback ports `58080` and `58081`, including an explicit
+unowned result, as evidence for the unchanged-edge/cutover topology review.
+
+The receipt excludes container environments, env-file contents, DSNs,
+passwords, tokens, private keys, and Docker credential/configuration content.
+Review the sanitized receipt in a separate PR and replace every `null`
+authority plus every blocker only with exact reviewed facts. Inventory never
+edits `target-authority.json`, fills a blocker, or changes its committed
+`stopped` status automatically. Changing the target to `authorized` without
+those facts is invalid.
+
+Read-only inventory and preflight may use the reported already-present default
+host `python3` standard-library runtime. Actual production mutation retains the
+repository's exact CPython 3.14 execution contract and stops with
 `python314_required_for_production_mutation` if that runtime is absent. This
 runbook does not authorize installing it; runtime provisioning, if genuinely
 needed for promotion, requires separate review and is not a status-tool repair.
@@ -103,7 +121,11 @@ with `--pull never`. There is no database rollback in this path.
 ## Owner sequence after blockers are reviewed away
 
 1. Dispatch `inventory` and review the sanitized receipt without changing the
-   host.
+   host. Require the default inventory Python executable,
+   implementation/version, the separate exact-CPython-3.14 executable and
+   availability result, Docker `default` context name and endpoint/host, and
+   bounded ownership of loopback ports `58080` and `58081`; missing or
+   malformed facts keep the corresponding blockers in place.
 2. Land a separate reviewed PR that supplies exact non-secret target and schema
    authority. Required secrets live only in the protected
    `v3-production-readonly` / `v3-production` environments as

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -56,8 +56,11 @@ edits `target-authority.json`, fills a blocker, or changes its committed
 `stopped` status automatically. Changing the target to `authorized` without
 those facts is invalid.
 
-Read-only inventory and preflight may use the reported already-present default
-host `python3` standard-library runtime. Actual production mutation retains the
+Read-only inventory may use the reported already-present default host `python3`
+standard-library runtime. Authority and preflight prefer a bounded, validated
+exact CPython 3.14 and may fall back only to a bounded, validated CPython 3.9 or
+newer host `python3`. An unsupported runtime emits an operation-accurate stopped
+receipt and performs no installation. Actual production mutation retains the
 repository's exact CPython 3.14 execution contract and stops with
 `python314_required_for_production_mutation` if that runtime is absent. This
 runbook does not authorize installing it; runtime provisioning, if genuinely
@@ -95,9 +98,11 @@ Promotion uses these gates in order:
    running container identities.
 3. Under the production deployment lock, query the complete ledger in a bounded
    read-only transaction and require exact compatibility before any pull.
-4. Freeze the authorized secret file to a private mode-0600 snapshot, use
-   ephemeral GHCR credentials, pull only the two digest images, and start the
-   inactive app slot on `127.0.0.1:58081`.
+4. Require exactly one `127.0.0.1` Docker binding for the active origin and no
+   staging binding; wildcard, IPv6, alternate-address, duplicate, and extra
+   mappings stop the operation. Freeze the authorized secret file to a private
+   mode-0600 snapshot, use ephemeral GHCR credentials, pull only the two digest
+   images, and start the inactive app slot on `127.0.0.1:58081`.
 5. Require bounded Svelte, health/build/database, OpenAPI, and anonymous-session
    smoke success. Recheck every protected container before cutover.
 6. Stop only the prior app origin, bind the verified candidate web slot to
@@ -108,6 +113,11 @@ Promotion uses these gates in order:
 7. Persist a sanitized immutable receipt, byte-exact manifest and checksums, then
    atomically advance `current.json`. Remove the secret snapshot and registry
    credentials on every exit.
+
+Cancellation is a controlled deployment failure. The remote transport forwards
+one termination signal and waits while the deployer terminates and reaps its
+active bounded subprocess, performs any required application rollback, writes a
+durable failure receipt, and removes ephemeral credentials.
 
 The first promotion cannot describe stale `edfinder-v3-api:phase4c-r5` as an
 accepted immutable rollback. Before cutover it can remove only its inactive

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -1,0 +1,120 @@
+# V3 production application release
+
+## Authority and execution boundary
+
+This is the production-in-place application promotion authority for the exact
+target `ed-finder-prod` / `nb79a3d.mevnode.com`. The only executable workflow is
+`.github/workflows/v3-production-application-deploy.yml`; it is manual-only,
+must run from the exact current `main`, and uses protected production
+environments plus pinned SSH host trust.
+
+Creating or reviewing this authority does **not** authorize executing it during
+a pull request or implementation task. No command in this runbook was executed
+against production while it was implemented. Do not use the Contabo checkpoint,
+the root `docker-compose.yml`, a host checkout, or a legacy deployment script as
+production authority.
+
+The generic `.github/workflows/v3-application-release.yml` remains the immutable
+off-host build authority. It produces digest-only backend and Svelte web images,
+an exact `build_sha`, a checksummed migration set, explicit schema compatibility,
+and application-only rollback eligibility. Production consumes that artifact;
+it never builds, resolves dependencies, installs packages, or runs `git pull`.
+
+## Current fail-closed state
+
+The committed `deploy/v3-production/target-authority.json` is intentionally
+`stopped`. Read-only host-status run `34202433965` proves the named production
+containers, retained PostgreSQL 18 container, Redis, NATS, edge, and temporary
+UI shell. It does not prove the application network, secret-file path and mode,
+local Docker context, receipt store, live migration ledger identity, or the
+exact edge-to-loopback cutover topology.
+
+Run only the workflow's default `inventory` operation first. It uses the
+already-present host `python3` standard library—there is no reason or authority
+to install host Python 3.14 for status tooling—and performs only bounded Docker,
+listener, HTTP, and `BEGIN READ ONLY` ledger inspection. Its machine-readable
+receipt excludes container environments, env-file contents, DSNs, passwords,
+tokens, and private keys. Review that sanitized receipt in a separate PR and
+replace every `null` authority plus every blocker with exact reviewed facts.
+Changing the target to `authorized` without those facts is invalid.
+
+Read-only inventory and preflight may use the already-present host Python 3
+standard library. Actual production mutation retains the repository's exact
+CPython 3.14 execution contract and stops with
+`python314_required_for_production_mutation` if that runtime is absent. This
+runbook does not authorize installing it; runtime provisioning, if genuinely
+needed for promotion, requires separate review and is not a status-tool repair.
+
+No current production migration authority exists in this repository. If the
+fresh complete `public.schema_migrations` filename/checksum ledger cannot be
+mapped to a reviewed `ed-finder/v3-production-schema-identity/v1` file, or the
+candidate release does not explicitly list that identity as compatible,
+preflight emits `production_migration_authority_absent_or_schema_incompatible`.
+It must not invoke `apply_migrations.sh`, baseline a ledger, run SQL migrations,
+or perform application-data writes. A schema delta requires a separate reviewed
+production migration authority; this release path never creates one.
+
+## Persistent application topology
+
+`deploy/v3-production/compose.yml` is a separate project named
+`edfinder-v3-production`. It owns only blue/green API and web application slots.
+It contains no database, volume, Redis/Valkey, NATS, edge, proxy, Octopus, lab,
+bench, or unrelated service. The external application network and API secret
+file must be exact reviewed authorities.
+
+Candidate startup explicitly disables EDDN simulation ingest and startup
+`admin_job_runs` reaping so staging cannot initiate background or housekeeping
+writes. Redis and NATS are not removed or replaced. The current public-auth/TLS
+edge is never recreated.
+
+Promotion uses these gates in order:
+
+1. Authenticate a successful manual canonical release run from exact `main`;
+   verify its adjacent basename-only checksum, digest images, and OCI revision.
+2. Recheck exact host/FQDN/architecture, the local rootful Docker context,
+   Compose checksum/service/volume allowlist, secret-file metadata, receipt
+   store, live CPU/memory/disk headroom, external network, and protected
+   running container identities.
+3. Under the production deployment lock, query the complete ledger in a bounded
+   read-only transaction and require exact compatibility before any pull.
+4. Freeze the authorized secret file to a private mode-0600 snapshot, use
+   ephemeral GHCR credentials, pull only the two digest images, and start the
+   inactive app slot on `127.0.0.1:58081`.
+5. Require bounded Svelte, health/build/database, OpenAPI, and anonymous-session
+   smoke success. Recheck every protected container before cutover.
+6. Stop only the prior app origin, bind the verified candidate web slot to
+   `127.0.0.1:58080`, leave `edfinder-v3-public-auth-edge` untouched, and require
+   both loopback and public HTTPS smoke success. Only after that verification,
+   stop the stale legacy API on bootstrap or retire the prior managed slot on
+   an upgrade.
+7. Persist a sanitized immutable receipt, byte-exact manifest and checksums, then
+   atomically advance `current.json`. Remove the secret snapshot and registry
+   credentials on every exit.
+
+The first promotion cannot describe stale `edfinder-v3-api:phase4c-r5` as an
+accepted immutable rollback. Before cutover it can remove only its inactive
+candidate. If the first verified port swap fails, it may abort the cutover by
+restarting both stale legacy application services; the receipt labels this as
+a cutover abort, not an accepted-release rollback. Every later upgrade may roll
+back only to the checksum-bound prior accepted production manifest/receipt,
+only when the fresh live schema identity is still explicitly compatible, and
+with `--pull never`. There is no database rollback in this path.
+
+## Owner sequence after blockers are reviewed away
+
+1. Dispatch `inventory` and review the sanitized receipt without changing the
+   host.
+2. Land a separate reviewed PR that supplies exact non-secret target and schema
+   authority. Required secrets live only in the protected
+   `v3-production-readonly` / `v3-production` environments as
+   `V3_PRODUCTION_HOST`, `V3_PRODUCTION_PORT`, `V3_PRODUCTION_USER`,
+   `V3_PRODUCTION_SSH_KEY`, and `V3_PRODUCTION_SSH_KNOWN_HOSTS`.
+3. Build a candidate through `V3 application immutable release`, with the
+   observed production migration identity explicitly reviewed as compatible.
+4. Dispatch `preflight` with the exact release run ID and literal confirmation
+   `ed-finder-prod/nb79a3d.mevnode.com`. Review the stopped/passed receipt.
+5. Only after owner approval, dispatch `promote` with the same inputs and the
+   correct `bootstrap` or `upgrade` mode.
+
+If any fact differs, stop. Do not repair infrastructure, alter the database,
+recreate the edge, or adapt a legacy/root Compose command from this runbook.

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -58,6 +58,22 @@ Do not promote a repository helper into a production command merely because it e
   It does not manage database, cache, NATS, edge, runner or volume resources.
 
 ## Current replacement-host helpers
+- `actions/v3-production-inventory.sh` and `v3_production_inventory.py`: the
+  exact-host, read-only production inventory authority. It reports bounded
+  container/listener/network/HTTP facts and the complete migration ledger from
+  a `BEGIN READ ONLY` transaction without reading container environments or
+  secret files. It intentionally uses already-present host Python 3 and does
+  not authorize installing host Python 3.14.
+- `actions/v3-production-promote.sh` and `v3_production_deploy.py`: the separate
+  fail-closed production-in-place application authority selected only by the
+  protected manual workflow and current production runbook. It consumes the
+  generic immutable release artifact but never the Contabo or root Compose
+  authority. The committed target is stopped until exact inventory/schema,
+  network, env-file, receipt-store, Docker-context, and edge cutover facts are
+  reviewed. When authorized, it owns only blue/green API/web slots, preserves
+  PostgreSQL 18, Redis, NATS, public-auth/TLS edge, Octopus and unrelated
+  containers, and allows rollback only to a schema-compatible prior accepted
+  immutable production release.
 - `actions/v3-app-status.sh`: fail-closed, read-only application status receipt
   for the current ED-Finder V3 origin and public edge. It checks the fixed V3
   container set, the loopback origin listener, the frontend index classification,

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -61,9 +61,16 @@ Do not promote a repository helper into a production command merely because it e
 - `actions/v3-production-inventory.sh` and `v3_production_inventory.py`: the
   exact-host, read-only production inventory authority. It reports bounded
   container/listener/network/HTTP facts and the complete migration ledger from
-  a `BEGIN READ ONLY` transaction without reading container environments or
-  secret files. It intentionally uses already-present host Python 3 and does
-  not authorize installing host Python 3.14.
+  a `BEGIN READ ONLY` transaction. Its sanitized receipt also reports the
+  bounded executable path, implementation, and version of the default host
+  `python3` used for inventory, whether `python3.14` exists and is exactly
+  CPython 3.14 plus its bounded executable path/version when present, the
+  `default` Docker context name and endpoint/host only, and bounded container
+  ownership of loopback ports `58080`/`58081` when the existing Docker port
+  data supports it. It never reads container environments, secret files,
+  Docker credentials/configuration content, or private keys. It installs
+  nothing and never edits the stopped target authority or fills a blocker
+  automatically.
 - `actions/v3-production-promote.sh` and `v3_production_deploy.py`: the separate
   fail-closed production-in-place application authority selected only by the
   protected manual workflow and current production runbook. It consumes the

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -65,8 +65,11 @@ Do not promote a repository helper into a production command merely because it e
   bounded executable path, implementation, and version of the default host
   `python3` used for inventory, whether `python3.14` exists and is exactly
   CPython 3.14 plus its bounded executable path/version when present, the
-  `default` Docker context name and endpoint/host only, and bounded container
-  ownership of loopback ports `58080`/`58081` when the existing Docker port
+  `default` Docker context name and endpoint/host only, requiring exactly the
+  local rootful `unix:///var/run/docker.sock` endpoint and explicitly pinning
+  every Docker evidence command to that context. Context drift stops before
+  daemon inventory. The receipt also includes bounded container ownership of
+  loopback ports `58080`/`58081` when the existing Docker port
   data supports it. It never reads container environments, secret files,
   Docker credentials/configuration content, or private keys. It installs
   nothing and never edits the stopped target authority or fills a blocker

--- a/scripts/operator/actions/v3-production-inventory.sh
+++ b/scripts/operator/actions/v3-production-inventory.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only production inventory is deliberately allowed to use the host's
+# already-present Python 3 standard library. Do not install CPython 3.14 merely
+# to run this status/preflight path.
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' '{"schema_version":"ed-finder/v3-production-inventory/v1","operation":"v3-production-inventory","status":"stopped","read_only":true,"direct_db_access_performed":false,"db_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"env_files_read":false,"container_environment_read":false,"private_keys_read":false,"service_changes_performed":false,"filesystem_writes_performed":false,"failures":["python3_unavailable"]}'
+    exit 78
+fi
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$(command -v python3)" -I -S "$SCRIPT_DIR/../v3_production_inventory.py"

--- a/scripts/operator/actions/v3-production-promote.sh
+++ b/scripts/operator/actions/v3-production-promote.sh
@@ -26,7 +26,13 @@ esac
 
 stopped_runtime_receipt() {
     failure="$1"
-    printf '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"%s","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["%s"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}\n' "$receipt_operation" "$failure"
+    filesystem_writes=false
+    filesystem_scope=""
+    if [ "$operation" = preflight ] || [ "$operation" = promote ]; then
+        filesystem_writes=true
+        filesystem_scope=',"filesystem_write_scope":"ephemeral-operation-bundle-only"'
+    fi
+    printf '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"%s","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["%s"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"protected_resources_changed":false,"filesystem_writes_performed":%s,"env_files_read":false,"env_contents_recorded":false,"private_keys_read":false%s}\n' "$receipt_operation" "$failure" "$filesystem_writes" "$filesystem_scope"
 }
 
 exact_cpython314() {

--- a/scripts/operator/actions/v3-production-promote.sh
+++ b/scripts/operator/actions/v3-production-promote.sh
@@ -1,30 +1,78 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Read-only authority/preflight may use the already-present Python 3 standard
-# library. Actual mutation retains exact CPython 3.14 and never installs it.
+# Read-only authority/preflight may use a compatible already-present CPython
+# standard library. Actual mutation retains exact CPython 3.14 and never
+# installs it. Every runtime probe is bounded before any Python code is trusted.
 operation="authority-gate"
 previous=""
 for argument in "$@"; do
     if [ "$previous" = "--operation" ]; then operation="$argument"; fi
+    case "$argument" in
+        --operation=*) operation="${argument#--operation=}" ;;
+    esac
     previous="$argument"
 done
 
+case "$operation" in
+    authority-gate) receipt_operation="production-authority-gate" ;;
+    preflight) receipt_operation="production-preflight" ;;
+    promote) receipt_operation="production-promotion" ;;
+    *)
+        printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-authority-gate","status":"stopped","failures":["invalid_requested_operation"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
+        exit 78
+        ;;
+esac
+
+stopped_runtime_receipt() {
+    failure="$1"
+    printf '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"%s","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["%s"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}\n' "$receipt_operation" "$failure"
+}
+
+exact_cpython314() {
+    timeout --signal=KILL 10 "$1" -I -S -c 'import platform, sys; raise SystemExit(0 if platform.python_implementation() == "CPython" and sys.version_info[:2] == (3, 14) else 1)' </dev/null >/dev/null 2>&1
+}
+
+compatible_readonly_python() {
+    timeout --signal=KILL 10 "$1" -I -S -c 'import platform, sys; raise SystemExit(0 if platform.python_implementation() == "CPython" and sys.version_info.major == 3 and sys.version_info.minor >= 9 else 1)' </dev/null >/dev/null 2>&1
+}
+
 if [ "$operation" = "promote" ]; then
     if ! command -v python3.14 >/dev/null 2>&1; then
-        printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-promotion","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["python314_required_for_production_mutation"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
+        stopped_runtime_receipt "python314_required_for_production_mutation"
         exit 78
     fi
     PYTHON_BIN="$(command -v python3.14)"
-    if ! "$PYTHON_BIN" -I -S -c 'import platform, sys; raise SystemExit(0 if platform.python_implementation() == "CPython" and sys.version_info[:2] == (3, 14) else 1)'; then
-        printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-promotion","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["python314_required_for_production_mutation"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
+    if ! exact_cpython314 "$PYTHON_BIN"; then
+        stopped_runtime_receipt "python314_required_for_production_mutation"
         exit 78
     fi
-elif ! command -v python3 >/dev/null 2>&1; then
-    printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-promotion","status":"stopped","failures":["python3_unavailable"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
-    exit 78
 else
-    PYTHON_BIN="$(command -v python3)"
+    PYTHON_BIN=""
+    runtime_candidate_seen=false
+    if command -v python3.14 >/dev/null 2>&1; then
+        runtime_candidate_seen=true
+        candidate="$(command -v python3.14)"
+        if exact_cpython314 "$candidate"; then
+            PYTHON_BIN="$candidate"
+        fi
+    fi
+    if [ -z "$PYTHON_BIN" ]; then
+        if ! command -v python3 >/dev/null 2>&1; then
+            if [ "$runtime_candidate_seen" = true ]; then
+                stopped_runtime_receipt "python3_unsupported_for_production_readonly"
+            else
+                stopped_runtime_receipt "python3_unavailable"
+            fi
+            exit 78
+        fi
+        candidate="$(command -v python3)"
+        if ! compatible_readonly_python "$candidate"; then
+            stopped_runtime_receipt "python3_unsupported_for_production_readonly"
+            exit 78
+        fi
+        PYTHON_BIN="$candidate"
+    fi
 fi
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"

--- a/scripts/operator/actions/v3-production-promote.sh
+++ b/scripts/operator/actions/v3-production-promote.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only authority/preflight may use the already-present Python 3 standard
+# library. Actual mutation retains exact CPython 3.14 and never installs it.
+operation="authority-gate"
+previous=""
+for argument in "$@"; do
+    if [ "$previous" = "--operation" ]; then operation="$argument"; fi
+    previous="$argument"
+done
+
+if [ "$operation" = "promote" ]; then
+    if ! command -v python3.14 >/dev/null 2>&1; then
+        printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-promotion","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["python314_required_for_production_mutation"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
+        exit 78
+    fi
+    PYTHON_BIN="$(command -v python3.14)"
+    if ! "$PYTHON_BIN" -I -S -c 'import platform, sys; raise SystemExit(0 if platform.python_implementation() == "CPython" and sys.version_info[:2] == (3, 14) else 1)'; then
+        printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-promotion","status":"stopped","target":{"production":true,"hostname":"ed-finder-prod","fqdn":"nb79a3d.mevnode.com"},"failures":["python314_required_for_production_mutation"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
+        exit 78
+    fi
+elif ! command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' '{"schema_version":"ed-finder/v3-production-deployment-receipt/v1","operation":"production-promotion","status":"stopped","failures":["python3_unavailable"],"database_access_performed":false,"database_writes_performed":false,"migrations_performed":false,"application_data_writes_performed":false,"image_pulls_performed":false,"service_changes_performed":false,"edge_recreated":false,"filesystem_writes_performed":false}'
+    exit 78
+else
+    PYTHON_BIN="$(command -v python3)"
+fi
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+exec "$PYTHON_BIN" -I -S "$SCRIPT_DIR/../v3_production_deploy.py" "$@"

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -1,0 +1,1481 @@
+#!/usr/bin/env python3
+"""Fail-closed, production-in-place V3 application promotion.
+
+This production authority is intentionally separate from the Contabo checkpoint.
+It never builds, resolves dependencies, pulls source, runs migrations, or owns
+PostgreSQL, Redis, NATS, the public-auth edge, Octopus, or unrelated containers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import shutil
+import socket
+import stat
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_AUTHORITY = ROOT / "deploy/v3-production/target-authority.json"
+DEFAULT_COMPOSE = ROOT / "deploy/v3-production/compose.yml"
+TARGET_SCHEMA = "ed-finder/v3-production-target-authority/v1"
+SCHEMA_IDENTITY_SCHEMA = "ed-finder/v3-production-schema-identity/v1"
+RECEIPT_SCHEMA = "ed-finder/v3-production-deployment-receipt/v1"
+CURRENT_SCHEMA = "ed-finder/v3-production-current-release/v1"
+PROJECT = "edfinder-v3-production"
+EXPECTED_HOST = "ed-finder-prod"
+EXPECTED_FQDN = "nb79a3d.mevnode.com"
+EXPECTED_ARCH = "x86_64"
+POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+LEGACY_API = "edfinder-v3-api"
+LEGACY_ORIGIN = "edfinder-v3-proxy"
+PUBLIC_EDGE = "edfinder-v3-public-auth-edge"
+LOCAL_DOCKER_ENDPOINT = "unix:///var/run/docker.sock"
+SLOTS = ("blue", "green")
+SERVICES = tuple(f"{kind}-{slot}" for slot in SLOTS for kind in ("api", "web"))
+CONTAINERS = {
+    f"{kind}-{slot}": f"edfinder-v3-production-{kind}-{slot}"
+    for slot in SLOTS for kind in ("api", "web")
+}
+SHA256 = re.compile(r"sha256:[0-9a-f]{64}\Z")
+RUN_ID = re.compile(r"[1-9][0-9]{0,19}\Z")
+MODE = re.compile(r"0[0-7]{3}\Z")
+MAX_JSON = 2 * 1024 * 1024
+MAX_SMOKE = 4 * 1024 * 1024
+MAX_ENV_FILE = 256 * 1024
+MAX_REGISTRY_TOKEN = 64 * 1024
+COMMAND_TIMEOUT = 120
+READINESS_TIMEOUT = 120.0
+LEDGER_SQL = r"""
+BEGIN READ ONLY;
+SET LOCAL statement_timeout = '10000ms';
+SELECT json_build_object(
+  'database_name', current_database(),
+  'server_address', COALESCE(inet_server_addr()::text, 'local'),
+  'server_port', COALESCE(inet_server_port(), current_setting('port')::int),
+  'transaction_read_only', current_setting('transaction_read_only'),
+  'migrations', COALESCE((
+    SELECT json_agg(
+      json_build_object('filename', filename, 'checksum_sha256', checksum_sha256)
+      ORDER BY filename
+    ) FROM public.schema_migrations
+  ), '[]'::json)
+)::text;
+COMMIT;
+""".strip()
+
+
+class DeploymentError(ValueError):
+    pass
+
+
+class OperationFailed(DeploymentError):
+    def __init__(self, receipt: dict[str, Any]):
+        super().__init__("production promotion failed")
+        self.receipt = receipt
+
+
+def run_command(
+    argv: list[str], *, env: dict[str, str] | None = None, input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            argv, input=input_text, text=True, capture_output=True, check=False,
+            timeout=COMMAND_TIMEOUT, env=env,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DeploymentError(f"bounded command failed: {type(exc).__name__}") from exc
+    if result.returncode != 0:
+        raise DeploymentError(f"bounded command failed: {Path(argv[0]).name}")
+    return result
+
+
+def load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        if path.stat().st_size > MAX_JSON or path.is_symlink():
+            raise DeploymentError(f"{label} is oversized or unsafe")
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except DeploymentError:
+        raise
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeploymentError(f"unable to read {label}") from exc
+    if not isinstance(value, dict):
+        raise DeploymentError(f"{label} must be an object")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while True:
+                chunk = handle.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except OSError as exc:
+        raise DeploymentError("unable to checksum file") from exc
+    return digest.hexdigest()
+
+
+def verify_checksum(document: Path, sidecar: Path) -> str:
+    try:
+        fields = sidecar.read_text(encoding="utf-8").strip().split()
+    except OSError as exc:
+        raise DeploymentError("unable to read checksum") from exc
+    if len(fields) != 2 or fields[1].lstrip("*") != document.name:
+        raise DeploymentError("checksum must name only the adjacent manifest basename")
+    if not re.fullmatch(r"[0-9a-f]{64}", fields[0]):
+        raise DeploymentError("checksum must be 64 lowercase hexadecimal characters")
+    if sha256_file(document) != fields[0]:
+        raise DeploymentError("manifest checksum mismatch")
+    return fields[0]
+
+
+def manifest_tool() -> Any:
+    path = ROOT / "scripts/release/v3_release_manifest.py"
+    spec = importlib.util.spec_from_file_location("v3_release_manifest", path)
+    if spec is None or spec.loader is None:
+        raise DeploymentError("release manifest verifier unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def stopped_receipt(
+    authority: dict[str, Any], failures: list[str], *, operation: str = "production-promotion",
+) -> dict[str, Any]:
+    target = authority.get("target") if isinstance(authority.get("target"), dict) else {}
+    return {
+        "schema_version": RECEIPT_SCHEMA,
+        "operation": operation,
+        "status": "stopped",
+        "target": {
+            "production": True,
+            "hostname": target.get("hostname", EXPECTED_HOST),
+            "fqdn": target.get("fqdn", EXPECTED_FQDN),
+        },
+        "failures": failures,
+        "database_access_performed": False,
+        "database_writes_performed": False,
+        "migrations_performed": False,
+        "application_data_writes_performed": False,
+        "image_pulls_performed": False,
+        "service_changes_performed": False,
+        "edge_recreated": False,
+        "protected_resources_changed": False,
+        "filesystem_writes_performed": False,
+        "env_files_read": False,
+        "env_contents_recorded": False,
+        "private_keys_read": False,
+    }
+
+
+def validate_authority(value: dict[str, Any]) -> list[str]:
+    if value.get("schema_version") != TARGET_SCHEMA:
+        raise DeploymentError("unsupported production target authority")
+    target = value.get("target")
+    if not isinstance(target, dict) or target != {
+        "provider": "mevspace", "classification": "production", "production": True,
+        "hostname": EXPECTED_HOST, "fqdn": EXPECTED_FQDN, "architecture": EXPECTED_ARCH,
+    }:
+        raise DeploymentError("exact production target identity authority is invalid")
+    contract = value.get("application_contract")
+    if not isinstance(contract, dict):
+        raise DeploymentError("production application contract is missing")
+    if contract.get("compose_project") != PROJECT or contract.get("slots") != list(SLOTS):
+        raise DeploymentError("production Compose project/slot authority is invalid")
+    if contract.get("services") != list(SERVICES):
+        raise DeploymentError("production service allowlist is invalid")
+    if contract.get("containers") != [CONTAINERS[item] for item in SERVICES]:
+        raise DeploymentError("production container allowlist is invalid")
+    if contract.get("named_volumes") != []:
+        raise DeploymentError("production application Compose must not own volumes")
+    preservation = value.get("preservation_contract")
+    if not isinstance(preservation, dict) or preservation.get("never_recreate_or_remove") is not True:
+        raise DeploymentError("production preservation contract is invalid")
+    required = {PUBLIC_EDGE, POSTGRES_CONTAINER, "edfinder-v3-support-redis", "edfinder-v3-support-nats"}
+    if set(preservation.get("exact_containers", [])) != required:
+        raise DeploymentError("production exact preservation allowlist is invalid")
+    status = value.get("status")
+    blockers = value.get("blockers")
+    if status not in {"stopped", "authorized"} or not isinstance(blockers, list):
+        raise DeploymentError("production authority status is invalid")
+    if status == "stopped":
+        if not blockers or any(not isinstance(item, str) or not item for item in blockers):
+            raise DeploymentError("stopped production authority requires concrete blockers")
+        return sorted(set(blockers))
+    if blockers:
+        raise DeploymentError("authorized production authority cannot retain blockers")
+    external = value.get("external_authority")
+    if not isinstance(external, dict) or any(item is None for item in external.values()):
+        raise DeploymentError("authorized production external authority is incomplete")
+    capacity = value.get("reviewed_capacity")
+    if (
+        not isinstance(capacity, dict)
+        or not isinstance(capacity.get("logical_cpus"), int)
+        or capacity["logical_cpus"] < 12
+        or not isinstance(capacity.get("memory_available_kib"), int)
+        or capacity["memory_available_kib"] < 15 * 1024 * 1024
+        or capacity.get("blue_green_peak")
+        != {"cpus": "6.00", "memory": "10240m"}
+    ):
+        raise DeploymentError("reviewed production blue/green capacity is insufficient")
+    if external.get("active_origin_bind") != "127.0.0.1:58080" or external.get("staging_origin_bind") != "127.0.0.1:58081":
+        raise DeploymentError("production origin authority is invalid")
+    if external.get("public_origin") != "https://ed-finder.app":
+        raise DeploymentError("production public origin authority is invalid")
+    if external.get("edge_route_authority") != {
+        "strategy": "verified-loopback-blue-green-port-swap",
+        "edge_container": PUBLIC_EDGE,
+        "active_origin_bind": "127.0.0.1:58080",
+        "evidence": "reviewed-production-inventory-receipt",
+    }:
+        raise DeploymentError("production unchanged-edge cutover authority is invalid")
+    network_allowlist = external.get("application_network_allowed_containers")
+    if (
+        not isinstance(network_allowlist, list)
+        or not network_allowlist
+        or any(
+            not isinstance(item, str)
+            or not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", item)
+            for item in network_allowlist
+        )
+        or len(network_allowlist) != len(set(network_allowlist))
+    ):
+        raise DeploymentError("production application network allowlist is invalid")
+    if external.get("docker_context") != "default":
+        raise DeploymentError("production Docker context authority must be default")
+    for key in ("api_env_owner_uid", "receipt_owner_uid", "schema_identity_owner_uid"):
+        if not isinstance(external.get(key), int) or external[key] < 0:
+            raise DeploymentError(f"{key} is invalid")
+    for key in ("api_env_mode", "receipt_mode", "schema_identity_mode"):
+        if not isinstance(external.get(key), str) or not MODE.fullmatch(external[key]):
+            raise DeploymentError(f"{key} is invalid")
+    if (
+        external["api_env_mode"] != "0600"
+        or external["schema_identity_mode"] != "0600"
+        or external["receipt_mode"] != "0700"
+    ):
+        raise DeploymentError("production secret/schema/receipt modes are not restrictive")
+    if not re.fullmatch(r"[0-9a-f]{64}", str(external.get("schema_identity_sha256", ""))):
+        raise DeploymentError("production schema identity checksum authority is invalid")
+    return []
+
+
+def exact_host_guard(runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    if socket.gethostname().split(".")[0] != EXPECTED_HOST:
+        raise DeploymentError("unexpected production hostname")
+    fqdn = runner(["hostname", "-f"]).stdout.strip()
+    if fqdn != EXPECTED_FQDN or runner(["uname", "-m"]).stdout.strip() != EXPECTED_ARCH:
+        raise DeploymentError("unexpected production FQDN or architecture")
+
+
+def secure_path(path: Path, uid: int, mode: str, *, directory: bool) -> None:
+    if not path.is_absolute() or path.is_symlink() or (not path.is_dir() if directory else not path.is_file()):
+        raise DeploymentError("authorized production path is missing or unsafe")
+    details = path.stat()
+    if details.st_uid != uid or stat.S_IMODE(details.st_mode) != int(mode, 8):
+        raise DeploymentError("authorized production path ownership/mode mismatch")
+
+
+def live_capacity_guard() -> dict[str, int]:
+    memory_available_kib: int | None = None
+    try:
+        with Path("/proc/meminfo").open(encoding="utf-8") as memory_file:
+            for line in memory_file:
+                key, separator, value = line.partition(":")
+                fields = value.split()
+                if separator and key == "MemAvailable" and fields and fields[0].isdigit():
+                    memory_available_kib = int(fields[0])
+                    break
+        filesystem = os.statvfs("/")
+    except OSError as exc:
+        raise DeploymentError("live production capacity inspection failed") from exc
+    logical_cpus = os.cpu_count()
+    root_available_bytes = filesystem.f_bavail * filesystem.f_frsize
+    if (
+        logical_cpus is None
+        or logical_cpus < 12
+        or memory_available_kib is None
+        or memory_available_kib < 15 * 1024 * 1024
+        or root_available_bytes < 10 * 1024 * 1024 * 1024
+    ):
+        raise DeploymentError("live production blue/green capacity is insufficient")
+    return {
+        "logical_cpus": logical_cpus,
+        "memory_available_kib": memory_available_kib,
+        "root_available_bytes": root_available_bytes,
+    }
+
+
+def base_env(external: dict[str, Any]) -> dict[str, str]:
+    return {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "LANG": "C", "LC_ALL": "C", "DOCKER_CONTEXT": external["docker_context"],
+    }
+
+
+def docker_context_guard(env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    context = json.loads(runner(["docker", "context", "inspect", env["DOCKER_CONTEXT"]], env=env).stdout)
+    if not isinstance(context, list) or len(context) != 1:
+        raise DeploymentError("Docker context inspection is ambiguous")
+    endpoint = ((context[0].get("Endpoints") or {}).get("docker") or {}).get("Host")
+    if endpoint != LOCAL_DOCKER_ENDPOINT:
+        raise DeploymentError("Docker context is not the local rootful daemon")
+
+
+def container_snapshot(names: set[str], env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name in sorted(names):
+        raw = runner(["docker", "inspect", "--format", "{{.Id}}\t{{.State.Running}}", name], env=env).stdout.strip().split("\t")
+        if len(raw) != 2 or not re.fullmatch(r"[0-9a-f]{64}", raw[0]) or raw[1] != "true":
+            raise DeploymentError(f"protected container unavailable: {name}")
+        result[name] = raw[0]
+    return result
+
+
+def all_container_snapshot(
+    env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]
+) -> dict[str, str]:
+    output = runner(
+        [
+            "docker", "ps", "--all", "--no-trunc", "--format",
+            "{{.Names}}\t{{.ID}}\t{{.State}}",
+        ],
+        env=env,
+    ).stdout
+    result: dict[str, str] = {}
+    for line in output.splitlines():
+        fields = line.split("\t")
+        if len(fields) != 3 or not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", fields[0]):
+            raise DeploymentError("complete container inventory is malformed")
+        if not re.fullmatch(r"[0-9a-f]{64}", fields[1]):
+            raise DeploymentError("complete container identity is malformed")
+        result[fields[0]] = fields[1] + ":" + fields[2]
+    if not result:
+        raise DeploymentError("complete container inventory is empty")
+    return result
+
+
+def verify_unrelated_snapshot(
+    before: dict[str, str], controlled: set[str], env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    after = all_container_snapshot(env, runner)
+    expected = {key: value for key, value in before.items() if key not in controlled}
+    observed = {key: after.get(key) for key in expected}
+    if observed != expected:
+        raise DeploymentError("unrelated production container identity/state changed")
+
+
+def verify_snapshot(before: dict[str, str], env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    if container_snapshot(set(before), env, runner) != before:
+        raise DeploymentError("protected production container identity changed")
+
+
+def validate_network(
+    external: dict[str, Any], schema: dict[str, Any], managed_slots: set[str],
+    env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    raw = runner(
+        ["docker", "network", "inspect", external["application_network"]], env=env
+    ).stdout
+    try:
+        values = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("production application network inspection invalid") from exc
+    if not isinstance(values, list) or len(values) != 1:
+        raise DeploymentError("production application network inspection ambiguous")
+    value = values[0]
+    if (
+        value.get("Name") != external["application_network"]
+        or value.get("Driver") != "bridge"
+        or value.get("Scope") != "local"
+        or value.get("Internal") is not False
+        or value.get("Ingress") is not False
+    ):
+        raise DeploymentError("production application network is not an external local bridge")
+    attachments = value.get("Containers")
+    if not isinstance(attachments, dict):
+        raise DeploymentError("production application network attachments invalid")
+    names = sorted(
+        item.get("Name") for item in attachments.values()
+        if isinstance(item, dict) and isinstance(item.get("Name"), str)
+    )
+    allowed = external.get("application_network_allowed_containers")
+    expected_names = list(allowed) if isinstance(allowed, list) else []
+    if not managed_slots <= set(SLOTS):
+        raise DeploymentError("production application network slot authority is invalid")
+    for slot in sorted(managed_slots):
+        expected_names.extend([CONTAINERS[f"api-{slot}"], CONTAINERS[f"web-{slot}"]])
+    if not isinstance(allowed, list) or names != sorted(expected_names):
+        raise DeploymentError("production application network attachment authority drifted")
+    database_container = schema["database_identity"]["container"]
+    if database_container not in names:
+        raise DeploymentError("production database is not attached to the authorized app network")
+
+
+def published_port_owners(
+    port: int, env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]
+) -> set[str]:
+    output = runner(
+        ["docker", "ps", "--format", "{{.Names}}\t{{.Ports}}"], env=env
+    ).stdout
+    owners: set[str] = set()
+    marker = re.compile(rf"(?:127\.0\.0\.1|0\.0\.0\.0|\[::\]):{port}->")
+    for line in output.splitlines():
+        name, separator, ports = line.partition("\t")
+        if separator and marker.search(ports):
+            owners.add(name)
+    return owners
+
+
+def listening_ports(
+    env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]
+) -> set[int]:
+    output = runner(["ss", "-H", "-lnt"], env=env).stdout
+    ports: set[int] = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) < 4:
+            raise DeploymentError("production listener inventory is malformed")
+        match = re.search(r":([0-9]{1,5})\Z", fields[3])
+        if match:
+            ports.add(int(match.group(1)))
+    return ports
+
+
+def verify_origin_ownership(
+    mode: str, prior_slot: str | None, env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    ports = listening_ports(env, runner)
+    if 58081 in ports or published_port_owners(58081, env, runner):
+        raise DeploymentError("production staging origin port is already owned")
+    expected = {LEGACY_ORIGIN} if mode == "bootstrap" else {
+        CONTAINERS[f"web-{prior_slot}"] if prior_slot in SLOTS else "invalid"
+    }
+    if published_port_owners(58080, env, runner) != expected:
+        raise DeploymentError("production active origin ownership drifted")
+    if 58080 not in ports:
+        raise DeploymentError("production active origin listener is missing")
+
+
+def verify_edge_routes_to_active_origin() -> None:
+    origin_status, origin_body, _ = get("http://127.0.0.1:58080", "/api/health")
+    public_status, public_body, _ = get("https://ed-finder.app", "/api/health")
+    if (
+        origin_status != 200
+        or public_status != 200
+        or origin_body != public_body
+        or len(origin_body) > MAX_SMOKE
+    ):
+        raise DeploymentError("production edge-to-loopback route authority is unproved")
+
+
+def wait_for_preserved_edge_route() -> None:
+    deadline = time.monotonic() + READINESS_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            verify_edge_routes_to_active_origin()
+            status, _body, _content_type = get(
+                "http://127.0.0.1:58080", "/api/auth/session"
+            )
+            if status == 200:
+                return
+        except DeploymentError:
+            pass
+        time.sleep(2)
+    raise DeploymentError("preserved production origin readiness timed out")
+
+
+def validate_compose(compose: Path, authority: dict[str, Any], env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    if sha256_file(compose) != authority["application_contract"]["compose_sha256"]:
+        raise DeploymentError("production Compose checksum mismatch")
+    compose_env = {
+        **env,
+        "V3_PRODUCTION_API_IMAGE": "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:" + "0" * 64,
+        "V3_PRODUCTION_WEB_IMAGE": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:" + "1" * 64,
+        "V3_PRODUCTION_SOURCE_SHA": "0" * 40,
+        "V3_PRODUCTION_API_ENV_FILE": authority["external_authority"]["api_env_file"],
+        "V3_PRODUCTION_ORIGIN_BIND": authority["external_authority"]["staging_origin_bind"],
+        "V3_PRODUCTION_APP_NETWORK": authority["external_authority"]["application_network"],
+    }
+    base = ["docker", "compose", "--project-name", PROJECT, "--file", str(compose)]
+    services = runner([*base, "config", "--services"], env=compose_env).stdout.split()
+    volumes = runner([*base, "config", "--volumes"], env=compose_env).stdout.split()
+    if services != list(SERVICES) or volumes:
+        raise DeploymentError("rendered production Compose escapes app-only authority")
+
+
+def validate_schema_file(path: Path, expected_sha: str) -> dict[str, Any]:
+    if sha256_file(path) != expected_sha:
+        raise DeploymentError("production schema identity checksum mismatch")
+    value = load_json(path, "production schema identity")
+    expected_keys = {"schema_version", "database_identity", "migration_set_identity", "migration_set_entries", "evidence"}
+    if set(value) != expected_keys or value.get("schema_version") != SCHEMA_IDENTITY_SCHEMA:
+        raise DeploymentError("production schema identity shape is invalid")
+    identity = value.get("database_identity")
+    if identity != {
+        "container": POSTGRES_CONTAINER,
+        "database_name": "edfinder",
+        "database_user": "edfinder",
+        "application_host": POSTGRES_CONTAINER,
+        "server_address": "local",
+        "server_port": 5432,
+    }:
+        raise DeploymentError("production database identity is invalid")
+    entries = value.get("migration_set_entries")
+    if not isinstance(entries, list) or not entries:
+        raise DeploymentError("production schema identity has no entries")
+    for item in entries:
+        if not isinstance(item, dict) or set(item) != {"path", "mode", "sha256"}:
+            raise DeploymentError("production schema entry shape is invalid")
+        if not re.fullmatch(r"sql/[0-9]{3}_[a-z0-9_]+\.sql", str(item["path"])) or item["mode"] not in {"auto", "manual"} or not re.fullmatch(r"[0-9a-f]{64}", str(item["sha256"])):
+            raise DeploymentError("production schema entry is invalid")
+    if len({item["path"] for item in entries}) != len(entries):
+        raise DeploymentError("production schema entries are duplicated")
+    evidence = value.get("evidence")
+    if not isinstance(evidence, str) or not evidence.strip():
+        raise DeploymentError("production schema identity lacks reviewed evidence")
+    if re.search(
+        r"(?i)(password|passwd|secret|private[-_ ]?key|access[-_ ]?token|dsn|credential)",
+        evidence,
+    ) or re.search(r"(?i)[a-z][a-z0-9+.-]*://[^\s/@:]+:[^\s/@]+@", evidence):
+        raise DeploymentError("production schema evidence contains secret-like text")
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    calculated = "sha256:" + hashlib.sha256(canonical).hexdigest()
+    if value.get("migration_set_identity") != calculated:
+        raise DeploymentError("production schema identity is inconsistent")
+    return value
+
+
+def database_identity_from_env(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise DeploymentError("unable to read verified production API env snapshot") from exc
+    assignments: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, raw_value = line.partition("=")
+        if separator and key.strip() == "DATABASE_URL":
+            assignments.append(raw_value.strip())
+    if len(assignments) != 1:
+        raise DeploymentError("production API env must contain exactly one DATABASE_URL")
+    value = assignments[0]
+    if (
+        not value
+        or value[0] in {"'", '"'}
+        or "$" in value
+        or "`" in value
+        or any(character.isspace() for character in value)
+    ):
+        raise DeploymentError("production DATABASE_URL must be one unquoted literal")
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        database_name = urllib.parse.unquote(parsed.path.removeprefix("/"))
+        username = urllib.parse.unquote(parsed.username or "")
+        password = parsed.password
+        port = parsed.port
+    except (ValueError, UnicodeError) as exc:
+        raise DeploymentError("production DATABASE_URL identity is invalid") from exc
+    if (
+        parsed.scheme not in {"postgresql", "postgres"}
+        or username != "edfinder"
+        or not password
+        or parsed.hostname != POSTGRES_CONTAINER
+        or port not in {None, 5432}
+        or database_name != "edfinder"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise DeploymentError("production DATABASE_URL does not target retained PostgreSQL")
+    return {
+        "container": POSTGRES_CONTAINER,
+        "database_name": database_name,
+        "database_user": username,
+        "application_host": parsed.hostname,
+        "server_address": "local",
+        "server_port": port or 5432,
+    }
+
+
+def verify_live_schema(schema: dict[str, Any], env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    result = runner(
+        ["docker", "exec", POSTGRES_CONTAINER, "psql", "-X", "--no-password", "--tuples-only", "--no-align", "--quiet", "--field-separator", "\t", "--set", "ON_ERROR_STOP=1", "--username", "edfinder", "--dbname", "edfinder", "--command", LEDGER_SQL],
+        env=env,
+    )
+    if len(result.stdout.encode("utf-8")) > MAX_JSON:
+        raise DeploymentError("production migration ledger output exceeds size limit")
+    try:
+        observed = json.loads(result.stdout.strip())
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("production migration ledger returned invalid JSON") from exc
+    if not isinstance(observed, dict) or set(observed) != {
+        "database_name", "server_address", "server_port",
+        "transaction_read_only", "migrations",
+    }:
+        raise DeploymentError("production migration ledger returned invalid shape")
+    ledger = observed["migrations"]
+    if (
+        not isinstance(ledger, list)
+        or any(
+            not isinstance(item, dict)
+            or set(item) != {"filename", "checksum_sha256"}
+            or not re.fullmatch(r"[0-9]{3}_[a-z0-9_]+\.sql", str(item["filename"]))
+            or not re.fullmatch(r"[0-9a-f]{64}", str(item["checksum_sha256"]))
+            for item in ledger
+        )
+        or len({item["filename"] for item in ledger}) != len(ledger)
+    ):
+        raise DeploymentError("production migration ledger entries are invalid")
+    expected = sorted(
+        (
+            {
+                "filename": item["path"].removeprefix("sql/"),
+                "checksum_sha256": item["sha256"],
+            }
+            for item in schema["migration_set_entries"]
+        ),
+        key=lambda item: item["filename"],
+    )
+    if (
+        observed["database_name"] != "edfinder"
+        or observed["server_address"] != "local"
+        or observed["server_port"] != 5432
+        or observed["transaction_read_only"] != "on"
+        or ledger != expected
+    ):
+        raise DeploymentError("production_migration_authority_absent_or_schema_incompatible")
+
+
+def validate_candidate(
+    candidate_path: Path, checksum_path: Path, schema: dict[str, Any]
+) -> tuple[dict[str, Any], str, bytes]:
+    checksum = verify_checksum(candidate_path, checksum_path)
+    try:
+        candidate_bytes = candidate_path.read_bytes()
+        candidate = json.loads(candidate_bytes)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeploymentError("unable to freeze candidate manifest") from exc
+    if (
+        not isinstance(candidate, dict)
+        or hashlib.sha256(candidate_bytes).hexdigest() != checksum
+    ):
+        raise DeploymentError("candidate manifest changed during validation")
+    tool = manifest_tool()
+    try:
+        tool.validate_manifest(candidate, purpose="deploy", current_migration_set=schema["migration_set_identity"])
+    except tool.ManifestError as exc:
+        raise DeploymentError(f"candidate manifest is not production-schema compatible: {exc}") from exc
+    if candidate.get("rollback", {}).get("application_only_eligible") is not True:
+        raise DeploymentError("candidate is not eligible as an application-only rollback release")
+    return candidate, checksum, candidate_bytes
+
+
+def compose_env(external: dict[str, Any], release: dict[str, Any], env_file: Path, origin: str, docker_env: dict[str, str]) -> dict[str, str]:
+    return {
+        **docker_env,
+        "V3_PRODUCTION_API_IMAGE": release["images"]["backend"],
+        "V3_PRODUCTION_WEB_IMAGE": release["images"]["web"],
+        "V3_PRODUCTION_SOURCE_SHA": release["git_sha"],
+        "V3_PRODUCTION_API_ENV_FILE": str(env_file),
+        "V3_PRODUCTION_ORIGIN_BIND": origin,
+        "V3_PRODUCTION_APP_NETWORK": external["application_network"],
+    }
+
+
+def compose_base(compose: Path) -> list[str]:
+    return ["docker", "compose", "--project-name", PROJECT, "--file", str(compose)]
+
+
+def verify_image(image: str, sha: str, env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
+    raw = runner(["docker", "image", "inspect", "--format", "{{json .}}", image], env=env).stdout
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("pulled image inspection is invalid") from exc
+    labels = (value.get("Config") or {}).get("Labels") or {}
+    digests = value.get("RepoDigests") or []
+    if labels.get("org.opencontainers.image.revision") != sha or image not in digests:
+        raise DeploymentError("pulled image digest/build SHA verification failed")
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> None:
+        return None
+
+
+def get(origin: str, path: str) -> tuple[int, bytes, str]:
+    request = urllib.request.Request(origin + path, headers={"User-Agent": "edfinder-v3-production-promote/1"})
+    try:
+        with urllib.request.build_opener(
+            urllib.request.ProxyHandler({}), NoRedirect
+        ).open(request, timeout=10) as response:
+            body = response.read(MAX_SMOKE + 1)
+            return response.status, body, response.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(MAX_SMOKE + 1), exc.headers.get("Content-Type", "")
+    except (OSError, urllib.error.URLError, TimeoutError) as exc:
+        raise DeploymentError("origin request failed") from exc
+
+
+def smoke(origin: str, sha: str) -> dict[str, Any]:
+    outcomes: dict[str, Any] = {}
+    bodies: dict[str, bytes] = {}
+    for path in ("/", "/api/health", "/openapi.json", "/api/auth/session"):
+        status, body, content_type = get(origin, path)
+        if not 200 <= status < 300 or len(body) > MAX_SMOKE:
+            raise DeploymentError(f"smoke failed: {path}")
+        outcomes[path] = {"status": status, "bytes": len(body), "content_type": content_type[:128]}
+        bodies[path] = body
+    try:
+        health = json.loads(bodies["/api/health"])
+        session = json.loads(bodies["/api/auth/session"])
+        openapi = json.loads(bodies["/openapi.json"])
+    except json.JSONDecodeError as exc:
+        raise DeploymentError("smoke JSON response invalid") from exc
+    if health.get("status") != "ok" or health.get("database") != "connected" or health.get("build_sha") != sha:
+        raise DeploymentError("health release identity mismatch")
+    if session.get("authenticated") is not False or session.get("user") is not None:
+        raise DeploymentError("anonymous session smoke failed")
+    paths = openapi.get("paths") if isinstance(openapi, dict) else None
+    if not isinstance(paths, dict) or not {"/api/health", "/api/auth/session"}.issubset(paths):
+        raise DeploymentError("OpenAPI smoke routes missing")
+    marker = f'name="edfinder-build-sha" content="{sha}"'.encode()
+    if bodies["/"].count(marker) != 1:
+        raise DeploymentError("Svelte HTML release identity mismatch")
+    return outcomes
+
+
+def wait_ready(origin: str, sha: str) -> None:
+    deadline = time.monotonic() + READINESS_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            status, body, _ = get(origin, "/api/health")
+            value = json.loads(body)
+            if status == 200 and value.get("status") == "ok" and value.get("database") == "connected" and value.get("build_sha") == sha:
+                return
+        except (DeploymentError, json.JSONDecodeError):
+            pass
+        time.sleep(2)
+    raise DeploymentError("candidate readiness timed out")
+
+
+def load_current(directory: Path) -> tuple[dict[str, Any], dict[str, Any], Path]:
+    pointer = load_json(directory / "current.json", "current production release pointer")
+    if set(pointer) != {"schema_version", "receipt_file", "receipt_sha256", "manifest_file", "manifest_sha256"} or pointer.get("schema_version") != CURRENT_SCHEMA:
+        raise DeploymentError("current production release pointer is invalid")
+    for key in ("receipt_file", "manifest_file"):
+        if not isinstance(pointer[key], str) or Path(pointer[key]).name != pointer[key]:
+            raise DeploymentError("current production release filename is unsafe")
+    if not re.fullmatch(
+        r"[0-9a-f]{40}-[1-9][0-9]{0,19}-[0-9a-f]{64}\.json",
+        pointer["receipt_file"],
+    ) or pointer["manifest_file"] != pointer["receipt_file"].removesuffix(
+        ".json"
+    ) + ".release.json":
+        raise DeploymentError("current production release filename is invalid")
+    receipt_path = directory / pointer["receipt_file"]
+    manifest_path = directory / pointer["manifest_file"]
+    receipt_sidecar = Path(str(receipt_path) + ".sha256")
+    manifest_sidecar = Path(str(manifest_path) + ".sha256")
+    if any(
+        path.is_symlink()
+        for path in (receipt_path, manifest_path, receipt_sidecar, manifest_sidecar)
+    ):
+        raise DeploymentError("current production release path is unsafe")
+    if (
+        sha256_file(receipt_path) != pointer["receipt_sha256"]
+        or sha256_file(manifest_path) != pointer["manifest_sha256"]
+        or verify_checksum(receipt_path, receipt_sidecar) != pointer["receipt_sha256"]
+        or verify_checksum(manifest_path, manifest_sidecar) != pointer["manifest_sha256"]
+    ):
+        raise DeploymentError("current production release checksum mismatch")
+    receipt = load_json(receipt_path, "accepted production receipt")
+    manifest = load_json(manifest_path, "accepted production manifest")
+    if (
+        receipt.get("schema_version") != RECEIPT_SCHEMA
+        or receipt.get("status") != "accepted"
+        or receipt.get("target", {}).get("hostname") != EXPECTED_HOST
+        or receipt.get("target", {}).get("fqdn") != EXPECTED_FQDN
+        or receipt.get("target", {}).get("production") is not True
+        or receipt.get("compose_project") != PROJECT
+        or receipt.get("source_sha") != manifest.get("git_sha")
+        or receipt.get("images") != manifest.get("images")
+        or receipt.get("manifest_sha256") != pointer["manifest_sha256"]
+        or not RUN_ID.fullmatch(str(receipt.get("release_run_id", "")))
+    ):
+        raise DeploymentError("accepted production receipt does not bind its release")
+    return receipt, manifest, manifest_path
+
+
+def validate_prior_runtime(
+    receipt: dict[str, Any], manifest: dict[str, Any], schema: dict[str, Any],
+    env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> str:
+    slot = receipt.get("active_slot")
+    if slot not in SLOTS or receipt.get("migration_set_identity") != schema["migration_set_identity"]:
+        raise DeploymentError("prior accepted production receipt is schema-incompatible")
+    tool = manifest_tool()
+    try:
+        tool.validate_manifest(
+            manifest,
+            purpose="rollback",
+            current_migration_set=schema["migration_set_identity"],
+        )
+    except tool.ManifestError as exc:
+        raise DeploymentError("prior accepted release is not rollback-compatible") from exc
+    for image in manifest["images"].values():
+        verify_image(image, manifest["git_sha"], env, runner)
+    for service in (f"api-{slot}", f"web-{slot}"):
+        raw = runner(
+            [
+                "docker", "inspect", "--format",
+                "{{.State.Running}}\t{{.Config.Image}}\t"
+                "{{index .Config.Labels \"org.opencontainers.image.revision\"}}",
+                CONTAINERS[service],
+            ],
+            env=env,
+        ).stdout.strip().split("\t")
+        expected_image = manifest["images"][
+            "backend" if service.startswith("api-") else "web"
+        ]
+        if raw != ["true", expected_image, manifest["git_sha"]]:
+            raise DeploymentError("prior accepted application container drifted")
+    smoke("http://127.0.0.1:58080", manifest["git_sha"])
+    return slot
+
+
+def persist_accepted(
+    directory: Path, receipt: dict[str, Any], manifest_bytes: bytes
+) -> None:
+    receipt_bytes = (json.dumps(receipt, sort_keys=True, indent=2) + "\n").encode()
+    stem = f"{receipt['source_sha']}-{receipt['release_run_id']}-{receipt['manifest_sha256']}"
+    receipt_name = stem + ".json"
+    manifest_name = stem + ".release.json"
+    receipt_sidecar = receipt_name + ".sha256"
+    manifest_sidecar = manifest_name + ".sha256"
+    for name in (
+        receipt_name, manifest_name, receipt_sidecar, manifest_sidecar,
+        "current.json",
+    ):
+        if Path(name).name != name:
+            raise DeploymentError("unsafe receipt identity")
+    def atomic(name: str, data: bytes) -> None:
+        handle, temp_name = tempfile.mkstemp(prefix=".v3-production-", dir=directory)
+        try:
+            os.fchmod(handle, 0o600)
+            with os.fdopen(handle, "wb") as output:
+                output.write(data); output.flush(); os.fsync(output.fileno())
+            os.replace(temp_name, directory / name)
+        finally:
+            try: os.unlink(temp_name)
+            except FileNotFoundError: pass
+    if any(
+        (directory / name).exists()
+        for name in (receipt_name, manifest_name, receipt_sidecar, manifest_sidecar)
+    ):
+        raise DeploymentError("immutable production receipt identity already exists")
+    created: list[str] = []
+    try:
+        atomic(receipt_name, receipt_bytes)
+        created.append(receipt_name)
+        atomic(manifest_name, manifest_bytes)
+        created.append(manifest_name)
+        atomic(
+            receipt_sidecar,
+            f"{hashlib.sha256(receipt_bytes).hexdigest()}  {receipt_name}\n".encode(),
+        )
+        created.append(receipt_sidecar)
+        atomic(
+            manifest_sidecar,
+            f"{hashlib.sha256(manifest_bytes).hexdigest()}  {manifest_name}\n".encode(),
+        )
+        created.append(manifest_sidecar)
+        pointer = {
+            "schema_version": CURRENT_SCHEMA,
+            "receipt_file": receipt_name,
+            "receipt_sha256": hashlib.sha256(receipt_bytes).hexdigest(),
+            "manifest_file": manifest_name,
+            "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
+        }
+        directory_handle = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_handle)
+        finally:
+            os.close(directory_handle)
+        atomic(
+            "current.json",
+            (json.dumps(pointer, sort_keys=True, indent=2) + "\n").encode(),
+        )
+        directory_handle = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_handle)
+        except OSError:
+            # The pointer and every target are already complete and consistent;
+            # never delete its targets after advancing it.
+            pass
+        finally:
+            os.close(directory_handle)
+    except Exception:
+        for name in reversed(created):
+            try:
+                (directory / name).unlink()
+            except OSError:
+                pass
+        raise
+
+
+def persist_failure(directory: Path, receipt: dict[str, Any]) -> str:
+    data = (json.dumps(receipt, sort_keys=True, indent=2) + "\n").encode()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    basename = (
+        f"failed-{receipt.get('source_sha', 'unknown')}-"
+        f"{receipt.get('release_run_id', 'unknown')}-{stamp}-{os.getpid()}.json"
+    )
+    if Path(basename).name != basename:
+        raise DeploymentError("unsafe failure receipt identity")
+    path = directory / basename
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as output:
+        output.write(data)
+        output.flush()
+        os.fsync(output.fileno())
+    sidecar = Path(str(path) + ".sha256")
+    checksum = hashlib.sha256(data).hexdigest()
+    sidecar.write_text(f"{checksum}  {basename}\n", encoding="utf-8")
+    os.chmod(sidecar, 0o600)
+    return basename
+
+
+def freeze_env(
+    source: Path, directory: Path, expected_uid: int, expected_mode: str,
+) -> tuple[Path, tuple[int, int, int, int, int, str]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(source, flags)
+    try:
+        before = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or before.st_nlink != 1
+            or before.st_uid != expected_uid
+            or stat.S_IMODE(before.st_mode) != int(expected_mode, 8)
+        ):
+            raise DeploymentError("authorized production API env file is unsafe")
+        if before.st_size > MAX_ENV_FILE:
+            raise DeploymentError("authorized production API env file exceeds size limit")
+        chunks = []
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        after = os.fstat(descriptor)
+        current = source.lstat()
+        if (
+            (before.st_dev, before.st_ino, before.st_size, before.st_mode, before.st_uid)
+            != (after.st_dev, after.st_ino, after.st_size, after.st_mode, after.st_uid)
+            or (before.st_dev, before.st_ino) != (current.st_dev, current.st_ino)
+        ):
+            raise DeploymentError("authorized production API env file changed while opening")
+    finally:
+        os.close(descriptor)
+    fingerprint = (
+        before.st_dev, before.st_ino, before.st_size, before.st_mode,
+        before.st_uid, hashlib.sha256(data).hexdigest(),
+    )
+    handle, name = tempfile.mkstemp(prefix=".v3-production-env-", dir=directory)
+    os.fchmod(handle, 0o600)
+    with os.fdopen(handle, "wb") as output:
+        output.write(data); output.flush(); os.fsync(output.fileno())
+    return Path(name), fingerprint
+
+
+def verify_env_unchanged(
+    source: Path, fingerprint: tuple[int, int, int, int, int, str],
+) -> None:
+    descriptor = os.open(source, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1 or before.st_size > MAX_ENV_FILE:
+            raise DeploymentError("authorized production API env file is unsafe")
+        digest = hashlib.sha256()
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+        after = os.fstat(descriptor)
+        current = source.lstat()
+    finally:
+        os.close(descriptor)
+    observed = (
+        before.st_dev, before.st_ino, before.st_size, before.st_mode,
+        before.st_uid, digest.hexdigest(),
+    )
+    stable = (
+        before.st_dev, before.st_ino, before.st_size, before.st_mode, before.st_uid
+    ) == (
+        after.st_dev, after.st_ino, after.st_size, after.st_mode, after.st_uid
+    )
+    if (
+        observed != fingerprint
+        or not stable
+        or (before.st_dev, before.st_ino) != (current.st_dev, current.st_ino)
+    ):
+        raise DeploymentError("authorized production API env file changed during promotion")
+
+
+def acquire_lock(directory: Path) -> Any:
+    handle = (directory / "deploy.lock").open("a+", encoding="utf-8")
+    os.fchmod(handle.fileno(), 0o600)
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        handle.close()
+        raise DeploymentError("production deployment lock unavailable") from exc
+    return handle
+
+
+def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callable[..., subprocess.CompletedProcess[str]] = run_command) -> dict[str, Any]:
+    external = authority["external_authority"]
+    receipt_operation = (
+        "production-preflight" if args.operation == "preflight" else "production-promotion"
+    )
+    env = base_env(external)
+    exact_host_guard(runner)
+    secure_path(Path(external["api_env_file"]), external["api_env_owner_uid"], external["api_env_mode"], directory=False)
+    receipt_dir = Path(external["receipt_directory"])
+    secure_path(receipt_dir, external["receipt_owner_uid"], external["receipt_mode"], directory=True)
+    schema_path = Path(external["schema_identity_file"])
+    secure_path(
+        schema_path, external["schema_identity_owner_uid"],
+        external["schema_identity_mode"], directory=False,
+    )
+    docker_context_guard(env, runner)
+    validate_compose(args.compose, authority, env, runner)
+    schema = validate_schema_file(schema_path, external["schema_identity_sha256"])
+    network_slots: set[str] = set()
+    if args.mode == "upgrade":
+        network_receipt, _network_manifest, _network_path = load_current(receipt_dir)
+        network_active_slot = network_receipt.get("active_slot")
+        if network_active_slot not in SLOTS:
+            raise DeploymentError("accepted production network slot is invalid")
+        network_slots.add(network_active_slot)
+    validate_network(external, schema, network_slots, env, runner)
+    live_capacity = live_capacity_guard()
+    try:
+        api_database_identity = database_identity_from_env(
+            Path(external["api_env_file"])
+        )
+    except DeploymentError as exc:
+        receipt = stopped_receipt(
+            authority, [str(exc)], operation=receipt_operation
+        )
+        receipt["env_files_read"] = True
+        raise OperationFailed(receipt) from exc
+    if api_database_identity != schema["database_identity"]:
+        receipt = stopped_receipt(
+            authority,
+            ["production API database target does not match schema authority"],
+            operation=receipt_operation,
+        )
+        receipt["env_files_read"] = True
+        raise OperationFailed(receipt)
+    candidate, candidate_sum, candidate_bytes = validate_candidate(
+        args.candidate, args.candidate_checksum, schema
+    )
+    if not RUN_ID.fullmatch(args.candidate_run_id or ""):
+        raise DeploymentError("authenticated candidate release run ID required")
+    protected = set(authority["preservation_contract"]["exact_containers"])
+    protected_before = container_snapshot(protected, env, runner)
+    all_before = all_container_snapshot(env, runner)
+
+    if args.mode == "bootstrap":
+        prior_slot_for_preflight = None
+        if set(CONTAINERS.values()) & set(all_before):
+            raise DeploymentError("bootstrap requires production slot absence")
+        for legacy_name in (LEGACY_API, LEGACY_ORIGIN):
+            if not all_before.get(legacy_name, "").endswith(":running"):
+                raise DeploymentError("bootstrap requires running legacy application services")
+    else:
+        prior_for_preflight, prior_manifest_for_preflight, _ = load_current(
+            receipt_dir
+        )
+        prior_slot_for_preflight = validate_prior_runtime(
+            prior_for_preflight, prior_manifest_for_preflight, schema, env, runner
+        )
+    verify_origin_ownership(args.mode, prior_slot_for_preflight, env, runner)
+    verify_edge_routes_to_active_origin()
+
+    if args.operation == "preflight":
+        try:
+            verify_live_schema(schema, env, runner)
+            verify_snapshot(protected_before, env, runner)
+            verify_unrelated_snapshot(all_before, set(), env, runner)
+            live_capacity = live_capacity_guard()
+        except DeploymentError as exc:
+            receipt = stopped_receipt(
+                authority, [str(exc)], operation="production-preflight"
+            )
+            receipt.update(
+                database_access_performed=None,
+                database_access_may_have_been_performed=True,
+                env_files_read=True,
+            )
+            raise OperationFailed(receipt) from exc
+        return {
+            **stopped_receipt(authority, [], operation="production-preflight"),
+            "status": "preflight-passed", "mode": args.mode,
+            "source_sha": candidate["git_sha"], "release_run_id": args.candidate_run_id,
+            "manifest_sha256": candidate_sum, "migration_set_identity": schema["migration_set_identity"],
+            "images": candidate["images"],
+            "rollback_compatible": args.mode == "upgrade",
+            "live_capacity": live_capacity,
+            "database_access_performed": True,
+            "env_files_read": True,
+        }
+
+    if args.runtime_directory is None:
+        raise DeploymentError("private production operation runtime directory required")
+    supplied_runtime_directory = args.runtime_directory
+    runtime_directory = supplied_runtime_directory.resolve()
+    if (
+        not supplied_runtime_directory.is_absolute()
+        or supplied_runtime_directory != runtime_directory
+        or supplied_runtime_directory.is_symlink()
+        or not runtime_directory.is_dir()
+        or runtime_directory.stat().st_uid != os.geteuid()
+        or stat.S_IMODE(runtime_directory.stat().st_mode) != 0o700
+    ):
+        raise DeploymentError("private production operation runtime directory is unsafe")
+    lock = acquire_lock(receipt_dir)
+    snapshot: Path | None = None
+    docker_config: str | None = None
+    mutation_started = False
+    cutover_started = False
+    image_pull_attempted = False
+    pulled_images: list[str] = []
+    database_verified = False
+    prior_receipt: dict[str, Any] | None = None
+    prior_manifest: dict[str, Any] | None = None
+    target_slot = "blue"
+    try:
+        live_capacity = live_capacity_guard()
+        verify_live_schema(schema, env, runner)
+        database_verified = True
+        current_path = receipt_dir / "current.json"
+        if args.mode == "bootstrap":
+            if current_path.exists():
+                raise DeploymentError("bootstrap requires no accepted production release")
+            prior_slot = None
+        else:
+            prior_receipt, prior_manifest, _ = load_current(receipt_dir)
+            prior_slot = validate_prior_runtime(
+                prior_receipt, prior_manifest, schema, env, runner
+            )
+            if prior_manifest.get("git_sha") == candidate.get("git_sha"):
+                raise DeploymentError("candidate cannot be its own prior release")
+            target_slot = "green" if prior_slot == "blue" else "blue"
+        validate_network(
+            external, schema, {prior_slot} if prior_slot is not None else set(),
+            env, runner,
+        )
+        verify_origin_ownership(args.mode, prior_slot, env, runner)
+        verify_edge_routes_to_active_origin()
+        snapshot, fingerprint = freeze_env(
+            Path(external["api_env_file"]), runtime_directory,
+            external["api_env_owner_uid"], external["api_env_mode"],
+        )
+        if database_identity_from_env(snapshot) != schema["database_identity"]:
+            raise DeploymentError("frozen production API database target does not match schema authority")
+        verify_env_unchanged(Path(external["api_env_file"]), fingerprint)
+        if (
+            args.registry_token_file is None
+            or not args.registry_token_file.is_file()
+            or args.registry_token_file.is_symlink()
+            or not isinstance(args.registry_username, str)
+            or not re.fullmatch(r"[A-Za-z0-9-]{1,39}", args.registry_username)
+        ):
+            raise DeploymentError("ephemeral production registry authority is missing")
+        token_details = args.registry_token_file.stat(follow_symlinks=False)
+        if (
+            token_details.st_uid != os.geteuid()
+            or stat.S_IMODE(token_details.st_mode) != 0o600
+            or token_details.st_nlink != 1
+        ):
+            raise DeploymentError("ephemeral registry token path is unsafe")
+        if args.registry_token_file.stat().st_size > MAX_REGISTRY_TOKEN:
+            raise DeploymentError("ephemeral registry token exceeds size limit")
+        token = args.registry_token_file.read_text(encoding="utf-8").strip()
+        if not token or "\n" in token or "\r" in token:
+            raise DeploymentError("ephemeral registry token is invalid")
+        docker_config = tempfile.mkdtemp(
+            prefix=".v3-production-docker-", dir=runtime_directory
+        )
+        os.chmod(docker_config, 0o700)
+        env["DOCKER_CONFIG"] = docker_config
+        runner(
+            [
+                "docker", "login", "ghcr.io", "--username",
+                args.registry_username, "--password-stdin",
+            ],
+            env=env,
+            input_text=token + "\n",
+        )
+        token = ""
+        for image in candidate["images"].values():
+            image_pull_attempted = True
+            runner(["docker", "pull", image], env=env)
+            verify_image(image, candidate["git_sha"], env, runner)
+            pulled_images.append(image)
+        release_env = compose_env(external, candidate, snapshot, external["staging_origin_bind"], env)
+        base = compose_base(args.compose)
+        selected = [f"api-{target_slot}", f"web-{target_slot}"]
+        mutation_started = True
+        runner([*base, "up", "--detach", "--no-deps", "--force-recreate", "--pull", "never", *selected], env=release_env)
+        wait_ready("http://" + external["staging_origin_bind"], candidate["git_sha"])
+        staging_smoke = smoke("http://" + external["staging_origin_bind"], candidate["git_sha"])
+        verify_snapshot(protected_before, env, runner)
+        controlled = {CONTAINERS[item] for item in selected}
+        verify_unrelated_snapshot(all_before, controlled, env, runner)
+        verify_env_unchanged(Path(external["api_env_file"]), fingerprint)
+        verify_live_schema(schema, env, runner)
+        staged_slots = {target_slot}
+        if prior_slot is not None:
+            staged_slots.add(prior_slot)
+        validate_network(external, schema, staged_slots, env, runner)
+
+        cutover_started = True
+        if args.mode == "bootstrap":
+            runner(["docker", "stop", LEGACY_ORIGIN], env=env)
+        else:
+            assert prior_slot is not None
+            runner([*base, "stop", f"web-{prior_slot}"], env=release_env)
+        active_env = compose_env(external, candidate, snapshot, external["active_origin_bind"], env)
+        runner([*base, "up", "--detach", "--no-deps", "--force-recreate", "--pull", "never", f"web-{target_slot}"], env=active_env)
+        wait_ready("http://" + external["active_origin_bind"], candidate["git_sha"])
+        active_smoke = smoke("http://" + external["active_origin_bind"], candidate["git_sha"])
+        public_smoke = smoke(external["public_origin"], candidate["git_sha"])
+        verify_live_schema(schema, env, runner)
+        verify_env_unchanged(Path(external["api_env_file"]), fingerprint)
+        verify_snapshot(protected_before, env, runner)
+        controlled.add(LEGACY_ORIGIN if args.mode == "bootstrap" else CONTAINERS[f"web-{prior_slot}"])
+        if args.mode == "upgrade":
+            assert prior_slot is not None
+            runner([*base, "stop", f"api-{prior_slot}"], env=active_env)
+            controlled.add(CONTAINERS[f"api-{prior_slot}"])
+            runner(
+                [*base, "rm", "--force", f"api-{prior_slot}", f"web-{prior_slot}"],
+                env=active_env,
+            )
+        else:
+            runner(["docker", "stop", LEGACY_API], env=env)
+            controlled.add(LEGACY_API)
+        validate_network(external, schema, {target_slot}, env, runner)
+        verify_unrelated_snapshot(all_before, controlled, env, runner)
+        changed_resources = [CONTAINERS[item] for item in selected]
+        if args.mode == "bootstrap":
+            changed_resources.extend([LEGACY_API, LEGACY_ORIGIN])
+        else:
+            assert prior_slot is not None
+            changed_resources.extend(
+                [CONTAINERS[f"api-{prior_slot}"], CONTAINERS[f"web-{prior_slot}"]]
+            )
+        receipt = {
+            "schema_version": RECEIPT_SCHEMA, "operation": "production-promotion", "status": "accepted",
+            "mode": args.mode, "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "target": authority["target"], "compose_project": PROJECT, "active_slot": target_slot,
+            "source_sha": candidate["git_sha"], "release_run_id": args.candidate_run_id,
+            "images": candidate["images"], "manifest_sha256": candidate_sum,
+            "migration_set_identity": schema["migration_set_identity"],
+            "changed_resources": changed_resources,
+            "preserved_resources": protected_before, "staging_smoke": staging_smoke,
+            "live_capacity": live_capacity,
+            "active_smoke": active_smoke, "public_smoke": public_smoke,
+            "rollback": {"kind": "none-first-promotion"} if prior_receipt is None else {
+                "kind": "prior-accepted-immutable-release", "source_sha": prior_receipt["source_sha"],
+                "release_run_id": prior_receipt["release_run_id"], "schema_compatible": True,
+            },
+            "database_access_performed": True, "database_writes_performed": False,
+            "migrations_performed": False, "application_data_writes_performed": False,
+            "image_pulls_performed": True, "service_changes_performed": True,
+            "edge_recreated": False, "protected_resources_changed": False,
+            "filesystem_writes_performed": True, "env_contents_recorded": False,
+            "env_files_read": True,
+            "private_keys_read": False,
+        }
+        persist_accepted(receipt_dir, receipt, candidate_bytes)
+        return receipt
+    except Exception as original:
+        rollback = {"attempted": False, "status": "not-required"}
+        if mutation_started:
+            rollback = {"attempted": True, "status": "started"}
+            try:
+                base = compose_base(args.compose)
+                candidate_env = compose_env(external, candidate, snapshot or Path(external["api_env_file"]), external["staging_origin_bind"], env)
+                runner([*base, "stop", f"web-{target_slot}", f"api-{target_slot}"], env=candidate_env)
+                runner([*base, "rm", "--force", f"web-{target_slot}", f"api-{target_slot}"], env=candidate_env)
+                if cutover_started and args.mode == "bootstrap":
+                    runner(["docker", "start", LEGACY_API], env=env)
+                    runner(["docker", "start", LEGACY_ORIGIN], env=env)
+                    wait_for_preserved_edge_route()
+                    rollback = {"attempted": True, "status": "verified", "kind": "first-cutover-abort-to-preserved-origin", "accepted_release_rollback": False}
+                elif cutover_started and prior_receipt is not None and prior_manifest is not None:
+                    verify_live_schema(schema, env, runner)
+                    rollback_tool = manifest_tool()
+                    rollback_tool.validate_manifest(
+                        prior_manifest,
+                        purpose="rollback",
+                        current_migration_set=schema["migration_set_identity"],
+                    )
+                    prior_slot = prior_receipt["active_slot"]
+                    prior_env = compose_env(external, prior_manifest, snapshot or Path(external["api_env_file"]), external["active_origin_bind"], env)
+                    runner([*base, "up", "--detach", "--no-deps", "--force-recreate", "--pull", "never", f"api-{prior_slot}", f"web-{prior_slot}"], env=prior_env)
+                    wait_ready("http://" + external["active_origin_bind"], prior_manifest["git_sha"])
+                    smoke("http://" + external["active_origin_bind"], prior_manifest["git_sha"])
+                    smoke(external["public_origin"], prior_manifest["git_sha"])
+                    verify_snapshot(protected_before, env, runner)
+                    rollback = {"attempted": True, "status": "verified", "kind": "prior-accepted-immutable-release", "source_sha": prior_manifest["git_sha"], "schema_compatible": True}
+                else:
+                    rollback = {"attempted": True, "status": "verified", "kind": "candidate-stage-removed"}
+            except Exception as rollback_error:
+                rollback = {"attempted": True, "status": "failed", "failure": type(rollback_error).__name__}
+        failure = str(original) if isinstance(original, DeploymentError) else type(original).__name__
+        resource_drift = failure in {
+            "protected production container identity changed",
+            "unrelated production container identity/state changed",
+        }
+        receipt = stopped_receipt(authority, [failure])
+        receipt.update(
+            status="failed", source_sha=candidate["git_sha"], release_run_id=args.candidate_run_id,
+            manifest_sha256=candidate_sum, migration_set_identity=schema["migration_set_identity"],
+            database_access_performed=True if database_verified else None,
+            database_access_may_have_been_performed=not database_verified,
+            image_pull_attempted=image_pull_attempted,
+            image_pulls_performed=(
+                True if pulled_images else None if image_pull_attempted else False
+            ),
+            pulled_images_verified=pulled_images,
+            service_changes_performed=None if mutation_started else False,
+            service_changes_may_have_been_performed=mutation_started,
+            protected_resources_changed=True if resource_drift else None if mutation_started else False,
+            protected_resources_may_have_changed=mutation_started and not resource_drift,
+            filesystem_writes_performed=True,
+            env_files_read=True,
+            rollback=rollback,
+        )
+        try:
+            receipt["durable_failure_receipt"] = persist_failure(
+                receipt_dir, receipt
+            )
+        except (OSError, DeploymentError):
+            receipt["durable_failure_receipt"] = None
+            receipt["failure_receipt_persistence"] = "failed"
+        raise OperationFailed(receipt) from original
+    finally:
+        if docker_config:
+            try: runner(["docker", "logout", "ghcr.io"], env=env)
+            except DeploymentError: pass
+            shutil.rmtree(docker_config, ignore_errors=True)
+        if snapshot is not None:
+            try:
+                size = snapshot.stat().st_size
+                with snapshot.open("r+b", buffering=0) as handle:
+                    handle.write(b"\0" * size)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                snapshot.unlink()
+            except OSError:
+                pass
+        fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+        lock.close()
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser()
+    result.add_argument("--authority", type=Path, default=DEFAULT_AUTHORITY)
+    result.add_argument("--compose", type=Path, default=DEFAULT_COMPOSE)
+    result.add_argument("--operation", choices=("authority-gate", "preflight", "promote"), default="authority-gate")
+    result.add_argument("--mode", choices=("bootstrap", "upgrade"), default="bootstrap")
+    result.add_argument("--candidate", type=Path)
+    result.add_argument("--candidate-checksum", type=Path)
+    result.add_argument("--candidate-run-id")
+    result.add_argument("--registry-token-file", type=Path)
+    result.add_argument("--registry-username")
+    result.add_argument("--runtime-directory", type=Path)
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    authority: dict[str, Any] = {}
+    try:
+        authority = load_json(args.authority, "production target authority")
+        blockers = validate_authority(authority)
+        if blockers:
+            operation = {
+                "preflight": "production-preflight",
+                "promote": "production-promotion",
+                "authority-gate": "production-authority-gate",
+            }[args.operation]
+            print(json.dumps(stopped_receipt(authority, blockers, operation=operation), sort_keys=True))
+            return 78
+        if args.operation == "authority-gate":
+            receipt = stopped_receipt(
+                authority, [], operation="production-authority-gate"
+            )
+            receipt["status"] = "authority-verified"
+            print(json.dumps(receipt, sort_keys=True))
+            return 0
+        if args.candidate is None or args.candidate_checksum is None:
+            raise DeploymentError("candidate manifest and checksum are required")
+        receipt = promote(args, authority)
+    except OperationFailed as exc:
+        print(json.dumps(exc.receipt, sort_keys=True))
+        return 78
+    except DeploymentError as exc:
+        operation = {
+            "preflight": "production-preflight",
+            "promote": "production-promotion",
+            "authority-gate": "production-authority-gate",
+        }[args.operation]
+        print(json.dumps(stopped_receipt(authority, [str(exc)], operation=operation), sort_keys=True))
+        return 78
+    except Exception as exc:
+        operation = {
+            "preflight": "production-preflight",
+            "promote": "production-promotion",
+            "authority-gate": "production-authority-gate",
+        }[args.operation]
+        print(json.dumps(stopped_receipt(
+            authority, [f"internal_failure:{type(exc).__name__}"], operation=operation,
+        ), sort_keys=True))
+        return 78
+    print(json.dumps(receipt, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -280,7 +280,7 @@ def stopped_receipt(
     authority: dict[str, Any], failures: list[str], *, operation: str = "production-promotion",
 ) -> dict[str, Any]:
     target = authority.get("target") if isinstance(authority.get("target"), dict) else {}
-    return {
+    receipt = {
         "schema_version": RECEIPT_SCHEMA,
         "operation": operation,
         "status": "stopped",
@@ -298,11 +298,15 @@ def stopped_receipt(
         "service_changes_performed": False,
         "edge_recreated": False,
         "protected_resources_changed": False,
-        "filesystem_writes_performed": False,
+        "filesystem_writes_performed": operation
+        in {"production-preflight", "production-promotion"},
         "env_files_read": False,
         "env_contents_recorded": False,
         "private_keys_read": False,
     }
+    if operation == "production-preflight":
+        receipt["filesystem_write_scope"] = "ephemeral-operation-bundle-only"
+    return receipt
 
 
 def validate_authority(value: dict[str, Any]) -> list[str]:
@@ -777,11 +781,15 @@ def validate_schema_file(path: Path, expected_sha: str) -> dict[str, Any]:
     return value
 
 
-def database_identity_from_env(path: Path) -> dict[str, Any]:
+def database_identity_from_env(
+    path: Path, *, on_read: Callable[[], None] | None = None,
+) -> dict[str, Any]:
     try:
         text = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         raise DeploymentError("unable to read verified production API env snapshot") from exc
+    if on_read is not None:
+        on_read()
     assignments: list[str] = []
     for raw_line in text.splitlines():
         line = raw_line.strip()
@@ -1092,6 +1100,16 @@ def persist_accepted(
     ):
         if Path(name).name != name:
             raise DeploymentError("unsafe receipt identity")
+    current_path = directory / "current.json"
+    if current_path.is_symlink():
+        raise DeploymentError("current production release pointer is unsafe")
+    try:
+        prior_pointer = current_path.read_bytes() if current_path.exists() else None
+    except OSError as exc:
+        raise DeploymentError("unable to preserve current production release pointer") from exc
+    if prior_pointer is not None and len(prior_pointer) > MAX_JSON:
+        raise DeploymentError("current production release pointer is oversized")
+
     def atomic(name: str, data: bytes) -> None:
         handle, temp_name = tempfile.mkstemp(prefix=".v3-production-", dir=directory)
         try:
@@ -1102,12 +1120,21 @@ def persist_accepted(
         finally:
             try: os.unlink(temp_name)
             except FileNotFoundError: pass
+
+    def fsync_directory() -> None:
+        directory_handle = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_handle)
+        finally:
+            os.close(directory_handle)
+
     if any(
         (directory / name).exists()
         for name in (receipt_name, manifest_name, receipt_sidecar, manifest_sidecar)
     ):
         raise DeploymentError("immutable production receipt identity already exists")
     created: list[str] = []
+    pointer_replaced = False
     try:
         atomic(receipt_name, receipt_bytes)
         created.append(receipt_name)
@@ -1130,30 +1157,37 @@ def persist_accepted(
             "manifest_file": manifest_name,
             "manifest_sha256": hashlib.sha256(manifest_bytes).hexdigest(),
         }
-        directory_handle = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory_handle)
-        finally:
-            os.close(directory_handle)
+        fsync_directory()
         atomic(
             "current.json",
             (json.dumps(pointer, sort_keys=True, indent=2) + "\n").encode(),
         )
-        directory_handle = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory_handle)
-        except OSError:
-            # The pointer and every target are already complete and consistent;
-            # never delete its targets after advancing it.
-            pass
-        finally:
-            os.close(directory_handle)
+        pointer_replaced = True
+        fsync_directory()
     except Exception:
-        for name in reversed(created):
+        pointer_restored = not pointer_replaced
+        if pointer_replaced:
             try:
-                (directory / name).unlink()
-            except OSError:
-                pass
+                if prior_pointer is None:
+                    current_path.unlink()
+                else:
+                    atomic("current.json", prior_pointer)
+                fsync_directory()
+                pointer_restored = True
+            except Exception as restore_error:
+                raise DeploymentError(
+                    "accepted production pointer restoration failed; candidate artifacts retained"
+                ) from restore_error
+        if pointer_restored:
+            for name in reversed(created):
+                try:
+                    (directory / name).unlink()
+                except OSError:
+                    pass
+        try:
+            fsync_directory()
+        except OSError:
+            pass
         raise
 
 
@@ -1315,82 +1349,93 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
         network_slots.add(network_active_slot)
     validate_network(external, schema, network_slots, env, runner)
     live_capacity = live_capacity_guard()
+    env_files_read = False
+    preflight_database_access_attempted = False
+    preflight_database_access_performed = False
+
+    def mark_env_file_read() -> None:
+        nonlocal env_files_read
+        env_files_read = True
+
     try:
         api_database_identity = database_identity_from_env(
-            Path(external["api_env_file"])
+            Path(external["api_env_file"]), on_read=mark_env_file_read
         )
-    except DeploymentError as exc:
-        receipt = stopped_receipt(
-            authority, [str(exc)], operation=receipt_operation
+        if api_database_identity != schema["database_identity"]:
+            raise DeploymentError(
+                "production API database target does not match schema authority"
+            )
+        candidate, candidate_sum, candidate_bytes = validate_candidate(
+            args.candidate, args.candidate_checksum, schema
         )
-        receipt["env_files_read"] = True
-        raise OperationFailed(receipt) from exc
-    if api_database_identity != schema["database_identity"]:
-        receipt = stopped_receipt(
-            authority,
-            ["production API database target does not match schema authority"],
-            operation=receipt_operation,
-        )
-        receipt["env_files_read"] = True
-        raise OperationFailed(receipt)
-    candidate, candidate_sum, candidate_bytes = validate_candidate(
-        args.candidate, args.candidate_checksum, schema
-    )
-    if not RUN_ID.fullmatch(args.candidate_run_id or ""):
-        raise DeploymentError("authenticated candidate release run ID required")
-    protected = set(authority["preservation_contract"]["exact_containers"])
-    protected_before = container_snapshot(protected, env, runner)
-    all_before = all_container_snapshot(env, runner)
+        if not RUN_ID.fullmatch(args.candidate_run_id or ""):
+            raise DeploymentError("authenticated candidate release run ID required")
+        protected = set(authority["preservation_contract"]["exact_containers"])
+        protected_before = container_snapshot(protected, env, runner)
+        all_before = all_container_snapshot(env, runner)
 
-    if args.mode == "bootstrap":
-        prior_slot_for_preflight = None
-        if set(CONTAINERS.values()) & set(all_before):
-            raise DeploymentError("bootstrap requires production slot absence")
-        for legacy_name in (LEGACY_API, LEGACY_ORIGIN):
-            if not all_before.get(legacy_name, "").endswith(":running"):
-                raise DeploymentError("bootstrap requires running legacy application services")
-    else:
-        prior_for_preflight, prior_manifest_for_preflight, _ = load_current(
-            receipt_dir
-        )
-        prior_slot_for_preflight = validate_prior_runtime(
-            prior_for_preflight, prior_manifest_for_preflight, schema, env, runner
-        )
-    verify_origin_ownership(args.mode, prior_slot_for_preflight, env, runner)
-    verify_edge_routes_to_active_origin()
+        if args.mode == "bootstrap":
+            prior_slot_for_preflight = None
+            if set(CONTAINERS.values()) & set(all_before):
+                raise DeploymentError("bootstrap requires production slot absence")
+            for legacy_name in (LEGACY_API, LEGACY_ORIGIN):
+                if not all_before.get(legacy_name, "").endswith(":running"):
+                    raise DeploymentError(
+                        "bootstrap requires running legacy application services"
+                    )
+        else:
+            prior_for_preflight, prior_manifest_for_preflight, _ = load_current(
+                receipt_dir
+            )
+            prior_slot_for_preflight = validate_prior_runtime(
+                prior_for_preflight, prior_manifest_for_preflight, schema, env, runner
+            )
+        verify_origin_ownership(args.mode, prior_slot_for_preflight, env, runner)
+        verify_edge_routes_to_active_origin()
 
-    if args.operation == "preflight":
-        try:
+        if args.operation == "preflight":
+            preflight_database_access_attempted = True
             verify_live_schema(schema, env, runner)
+            preflight_database_access_performed = True
             verify_snapshot(protected_before, env, runner)
             verify_unrelated_snapshot(all_before, set(), env, runner)
             live_capacity = live_capacity_guard()
-        except DeploymentError as exc:
-            receipt = stopped_receipt(
-                authority, [str(exc)], operation="production-preflight"
-            )
+            return {
+                **stopped_receipt(authority, [], operation="production-preflight"),
+                "status": "preflight-passed", "mode": args.mode,
+                "source_sha": candidate["git_sha"], "release_run_id": args.candidate_run_id,
+                "manifest_sha256": candidate_sum, "migration_set_identity": schema["migration_set_identity"],
+                "images": candidate["images"],
+                "rollback_compatible": args.mode == "upgrade",
+                "live_capacity": live_capacity,
+                "database_access_performed": True,
+                "env_files_read": True,
+            }
+        if args.runtime_directory is None:
+            raise DeploymentError("private production operation runtime directory required")
+        runtime_directory = validate_runtime_directory(args.runtime_directory)
+        lock = acquire_lock(receipt_dir)
+    except OperationFailed:
+        raise
+    except Exception as exc:
+        failure = (
+            str(exc)
+            if isinstance(exc, DeploymentError)
+            else f"internal_failure:{type(exc).__name__}"
+        )
+        receipt = stopped_receipt(authority, [failure], operation=receipt_operation)
+        receipt["env_files_read"] = env_files_read
+        if preflight_database_access_attempted:
             receipt.update(
-                database_access_performed=None,
-                database_access_may_have_been_performed=True,
-                env_files_read=True,
+                database_access_performed=(
+                    True if preflight_database_access_performed else None
+                ),
+                database_access_may_have_been_performed=(
+                    not preflight_database_access_performed
+                ),
             )
-            raise OperationFailed(receipt) from exc
-        return {
-            **stopped_receipt(authority, [], operation="production-preflight"),
-            "status": "preflight-passed", "mode": args.mode,
-            "source_sha": candidate["git_sha"], "release_run_id": args.candidate_run_id,
-            "manifest_sha256": candidate_sum, "migration_set_identity": schema["migration_set_identity"],
-            "images": candidate["images"],
-            "rollback_compatible": args.mode == "upgrade",
-            "live_capacity": live_capacity,
-            "database_access_performed": True,
-            "env_files_read": True,
-        }
+        raise OperationFailed(receipt) from exc
 
-    if args.runtime_directory is None:
-        raise DeploymentError("private production operation runtime directory required")
-    runtime_directory = validate_runtime_directory(args.runtime_directory)
-    lock = acquire_lock(receipt_dir)
     snapshot: Path | None = None
     docker_config: str | None = None
     mutation_started = False

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -9,6 +9,7 @@ PostgreSQL, Redis, NATS, the public-auth edge, Octopus, or unrelated containers.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import fcntl
 import hashlib
 import importlib.util
@@ -16,6 +17,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import socket
 import stat
 import subprocess
@@ -58,8 +60,11 @@ MAX_JSON = 2 * 1024 * 1024
 MAX_SMOKE = 4 * 1024 * 1024
 MAX_ENV_FILE = 256 * 1024
 MAX_REGISTRY_TOKEN = 64 * 1024
+MAX_CONTAINERS = 256
 COMMAND_TIMEOUT = 120
+PROCESS_TERMINATION_GRACE = 5
 READINESS_TIMEOUT = 120.0
+CANCELLATION_SIGNALS = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
 LEDGER_SQL = r"""
 BEGIN READ ONLY;
 SET LOCAL statement_timeout = '10000ms';
@@ -89,16 +94,131 @@ class OperationFailed(DeploymentError):
         self.receipt = receipt
 
 
+class OperationCancelled(DeploymentError):
+    def __init__(self, signum: int):
+        self.signum = signum
+        super().__init__(f"operation_cancelled:{signal.Signals(signum).name}")
+
+
+class CancellationController:
+    """Turn the first termination signal into one catchable deployment failure."""
+
+    def __init__(self) -> None:
+        self.received: int | None = None
+        self.commit_started = False
+        self.previous: dict[int, Any] = {}
+
+    def handler(self, signum: int, _frame: Any) -> None:
+        if self.commit_started or self.received is not None:
+            return
+        self.received = signum
+        # Rollback, failure-receipt persistence, and cleanup must not be
+        # interrupted by repeated cancellation signals.
+        for handled in CANCELLATION_SIGNALS:
+            signal.signal(handled, signal.SIG_IGN)
+        raise OperationCancelled(signum)
+
+    def mark_commit_started(self) -> None:
+        # Cutover has already passed every verification gate. From this point
+        # the small atomic receipt transaction must finish without interruption.
+        self.commit_started = True
+        for handled in CANCELLATION_SIGNALS:
+            signal.signal(handled, signal.SIG_IGN)
+
+
+_CANCELLATION_CONTROLLER: CancellationController | None = None
+_PREMUTATION_FAILURE_RECEIPT_DIR: Path | None = None
+
+
+@contextlib.contextmanager
+def controlled_cancellation() -> Any:
+    global _CANCELLATION_CONTROLLER
+    controller = CancellationController()
+    prior_controller = _CANCELLATION_CONTROLLER
+    _CANCELLATION_CONTROLLER = controller
+    try:
+        for handled in CANCELLATION_SIGNALS:
+            controller.previous[handled] = signal.getsignal(handled)
+            signal.signal(handled, controller.handler)
+        yield controller
+    finally:
+        for handled, previous in controller.previous.items():
+            signal.signal(handled, previous)
+        _CANCELLATION_CONTROLLER = prior_controller
+
+
+@contextlib.contextmanager
+def cancellation_blocked() -> Any:
+    if _CANCELLATION_CONTROLLER is None or not hasattr(signal, "pthread_sigmask"):
+        yield
+        return
+    previous = signal.pthread_sigmask(signal.SIG_BLOCK, CANCELLATION_SIGNALS)
+    try:
+        yield
+    finally:
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous)
+
+
+def terminate_and_reap(process: subprocess.Popen[str]) -> None:
+    if _CANCELLATION_CONTROLLER is not None:
+        # Once child cleanup starts, no later signal may interrupt the bounded
+        # TERM/KILL/reap sequence and leak a Docker/Compose subprocess.
+        for handled in CANCELLATION_SIGNALS:
+            signal.signal(handled, signal.SIG_IGN)
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.communicate(timeout=PROCESS_TERMINATION_GRACE)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.communicate()
+
+
 def run_command(
     argv: list[str], *, env: dict[str, str] | None = None, input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    process: subprocess.Popen[str] | None = None
     try:
-        result = subprocess.run(
-            argv, input=input_text, text=True, capture_output=True, check=False,
-            timeout=COMMAND_TIMEOUT, env=env,
+        # A pending cancellation is delivered only after Popen returns and the
+        # new process-group leader is assigned to ``process``.
+        with cancellation_blocked():
+            process = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE if input_text is not None else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+                start_new_session=True,
+            )
+        stdout, stderr = process.communicate(
+            input=input_text, timeout=COMMAND_TIMEOUT
         )
-    except (OSError, subprocess.TimeoutExpired) as exc:
+    except OperationCancelled:
+        if process is not None:
+            terminate_and_reap(process)
+        raise
+    except subprocess.TimeoutExpired as exc:
+        if process is not None:
+            terminate_and_reap(process)
+        raise DeploymentError("bounded command failed: TimeoutExpired") from exc
+    except OSError as exc:
+        if process is not None:
+            terminate_and_reap(process)
         raise DeploymentError(f"bounded command failed: {type(exc).__name__}") from exc
+    except BaseException:
+        if process is not None:
+            terminate_and_reap(process)
+        raise
+    assert process is not None
+    result = subprocess.CompletedProcess(argv, process.returncode, stdout, stderr)
     if result.returncode != 0:
         raise DeploymentError(f"bounded command failed: {Path(argv[0]).name}")
     return result
@@ -431,50 +551,141 @@ def validate_network(
         raise DeploymentError("production database is not attached to the authorized app network")
 
 
-def published_port_owners(
-    port: int, env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]
-) -> set[str]:
-    output = runner(
-        ["docker", "ps", "--format", "{{.Names}}\t{{.Ports}}"], env=env
-    ).stdout
-    owners: set[str] = set()
-    marker = re.compile(rf"(?:127\.0\.0\.1|0\.0\.0\.0|\[::\]):{port}->")
-    for line in output.splitlines():
-        name, separator, ports = line.partition("\t")
-        if separator and marker.search(ports):
-            owners.add(name)
-    return owners
+def published_port_bindings(
+    protected_ports: set[int], env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> dict[int, list[dict[str, Any]]]:
+    """Return every Docker binding for a protected host port without deduping."""
+    if not protected_ports or any(not 1 <= port <= 65535 for port in protected_ports):
+        raise DeploymentError("protected port inventory request is invalid")
+    names = runner(
+        ["docker", "ps", "--no-trunc", "--format", "{{.Names}}"], env=env
+    ).stdout.splitlines()
+    if (
+        len(names) > MAX_CONTAINERS
+        or len(names) != len(set(names))
+        or any(not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", name) for name in names)
+    ):
+        raise DeploymentError("running container inventory is malformed")
+    bindings: dict[int, list[dict[str, Any]]] = {
+        port: [] for port in protected_ports
+    }
+    for name in names:
+        raw = runner(
+            [
+                "docker", "inspect", "--format",
+                "{{json .NetworkSettings.Ports}}", name,
+            ],
+            env=env,
+        ).stdout
+        try:
+            mappings = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise DeploymentError("published port inventory is malformed") from exc
+        if not isinstance(mappings, dict):
+            raise DeploymentError("published port inventory is malformed")
+        for target, host_bindings in mappings.items():
+            match = re.fullmatch(r"([0-9]{1,5})/(tcp|udp)", str(target))
+            if match is None or not 1 <= int(match.group(1)) <= 65535:
+                raise DeploymentError("published port inventory is malformed")
+            if host_bindings is None:
+                continue
+            if not isinstance(host_bindings, list):
+                raise DeploymentError("published port inventory is malformed")
+            for host_binding in host_bindings:
+                if not isinstance(host_binding, dict) or set(host_binding) != {
+                    "HostIp", "HostPort"
+                }:
+                    raise DeploymentError("published port inventory is malformed")
+                host_ip = host_binding["HostIp"]
+                host_port = host_binding["HostPort"]
+                if (
+                    not isinstance(host_ip, str)
+                    or not 0 < len(host_ip) <= 64
+                    or not isinstance(host_port, str)
+                    or not host_port.isdigit()
+                    or not 1 <= int(host_port) <= 65535
+                ):
+                    raise DeploymentError("published port inventory is malformed")
+                observed_host_port = int(host_port)
+                if observed_host_port in protected_ports:
+                    bindings[observed_host_port].append(
+                        {
+                            "container": name,
+                            "bind_address": host_ip,
+                            "host_port": observed_host_port,
+                            "container_port": int(match.group(1)),
+                            "protocol": match.group(2),
+                        }
+                    )
+    return bindings
 
 
-def listening_ports(
+def listening_addresses(
     env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]
-) -> set[int]:
+) -> dict[int, list[str]]:
     output = runner(["ss", "-H", "-lnt"], env=env).stdout
-    ports: set[int] = set()
+    listeners: dict[int, list[str]] = {}
     for line in output.splitlines():
         fields = line.split()
         if len(fields) < 4:
             raise DeploymentError("production listener inventory is malformed")
-        match = re.search(r":([0-9]{1,5})\Z", fields[3])
-        if match:
-            ports.add(int(match.group(1)))
-    return ports
+        address, separator, raw_port = fields[3].rpartition(":")
+        if (
+            not separator
+            or not raw_port.isdigit()
+            or not 1 <= int(raw_port) <= 65535
+            or not address
+        ):
+            raise DeploymentError("production listener inventory is malformed")
+        normalized = address.removeprefix("[").removesuffix("]")
+        listeners.setdefault(int(raw_port), []).append(normalized)
+    return listeners
+
+
+def verify_exact_origin_bindings(
+    active_owner: str, staging_owner: str | None, env: dict[str, str],
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> None:
+    listeners = listening_addresses(env, runner)
+    bindings = published_port_bindings({58080, 58081}, env, runner)
+    active_bindings = bindings[58080]
+    staging_bindings = bindings[58081]
+    if (
+        len(active_bindings) != 1
+        or active_bindings[0]["container"] != active_owner
+        or active_bindings[0]["bind_address"] != "127.0.0.1"
+        or active_bindings[0]["protocol"] != "tcp"
+    ):
+        raise DeploymentError("production active origin ownership drifted")
+    active_listeners = listeners.get(58080, [])
+    if not active_listeners:
+        raise DeploymentError("production active origin listener is missing")
+    if any(address != "127.0.0.1" for address in active_listeners):
+        raise DeploymentError("production active origin listener is not exact loopback")
+    staging_listeners = listeners.get(58081, [])
+    if staging_owner is None:
+        if staging_bindings or staging_listeners:
+            raise DeploymentError("production staging origin port is already owned")
+    elif (
+        len(staging_bindings) != 1
+        or staging_bindings[0]["container"] != staging_owner
+        or staging_bindings[0]["bind_address"] != "127.0.0.1"
+        or staging_bindings[0]["protocol"] != "tcp"
+        or not staging_listeners
+        or any(address != "127.0.0.1" for address in staging_listeners)
+    ):
+        raise DeploymentError("production staging origin ownership drifted")
 
 
 def verify_origin_ownership(
     mode: str, prior_slot: str | None, env: dict[str, str],
     runner: Callable[..., subprocess.CompletedProcess[str]],
 ) -> None:
-    ports = listening_ports(env, runner)
-    if 58081 in ports or published_port_owners(58081, env, runner):
-        raise DeploymentError("production staging origin port is already owned")
-    expected = {LEGACY_ORIGIN} if mode == "bootstrap" else {
+    active_owner = LEGACY_ORIGIN if mode == "bootstrap" else (
         CONTAINERS[f"web-{prior_slot}"] if prior_slot in SLOTS else "invalid"
-    }
-    if published_port_owners(58080, env, runner) != expected:
-        raise DeploymentError("production active origin ownership drifted")
-    if 58080 not in ports:
-        raise DeploymentError("production active origin listener is missing")
+    )
+    verify_exact_origin_bindings(active_owner, None, env, runner)
 
 
 def verify_edge_routes_to_active_origin() -> None:
@@ -1058,7 +1269,23 @@ def acquire_lock(directory: Path) -> Any:
     return handle
 
 
+def validate_runtime_directory(supplied: Path) -> Path:
+    runtime_directory = supplied.resolve()
+    if (
+        not supplied.is_absolute()
+        or supplied != runtime_directory
+        or supplied.is_symlink()
+        or not runtime_directory.is_dir()
+        or runtime_directory.stat().st_uid != os.geteuid()
+        or stat.S_IMODE(runtime_directory.stat().st_mode) != 0o700
+    ):
+        raise DeploymentError("private production operation runtime directory is unsafe")
+    return runtime_directory
+
+
 def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callable[..., subprocess.CompletedProcess[str]] = run_command) -> dict[str, Any]:
+    global _PREMUTATION_FAILURE_RECEIPT_DIR
+    _PREMUTATION_FAILURE_RECEIPT_DIR = None
     external = authority["external_authority"]
     receipt_operation = (
         "production-preflight" if args.operation == "preflight" else "production-promotion"
@@ -1068,6 +1295,9 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
     secure_path(Path(external["api_env_file"]), external["api_env_owner_uid"], external["api_env_mode"], directory=False)
     receipt_dir = Path(external["receipt_directory"])
     secure_path(receipt_dir, external["receipt_owner_uid"], external["receipt_mode"], directory=True)
+    # Only an exact verified host and receipt store may receive a durable
+    # pre-mutation cancellation receipt.
+    _PREMUTATION_FAILURE_RECEIPT_DIR = receipt_dir
     schema_path = Path(external["schema_identity_file"])
     secure_path(
         schema_path, external["schema_identity_owner_uid"],
@@ -1159,17 +1389,7 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
 
     if args.runtime_directory is None:
         raise DeploymentError("private production operation runtime directory required")
-    supplied_runtime_directory = args.runtime_directory
-    runtime_directory = supplied_runtime_directory.resolve()
-    if (
-        not supplied_runtime_directory.is_absolute()
-        or supplied_runtime_directory != runtime_directory
-        or supplied_runtime_directory.is_symlink()
-        or not runtime_directory.is_dir()
-        or runtime_directory.stat().st_uid != os.geteuid()
-        or stat.S_IMODE(runtime_directory.stat().st_mode) != 0o700
-    ):
-        raise DeploymentError("private production operation runtime directory is unsafe")
+    runtime_directory = validate_runtime_directory(args.runtime_directory)
     lock = acquire_lock(receipt_dir)
     snapshot: Path | None = None
     docker_config: str | None = None
@@ -1257,6 +1477,12 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
         runner([*base, "up", "--detach", "--no-deps", "--force-recreate", "--pull", "never", *selected], env=release_env)
         wait_ready("http://" + external["staging_origin_bind"], candidate["git_sha"])
         staging_smoke = smoke("http://" + external["staging_origin_bind"], candidate["git_sha"])
+        active_owner = LEGACY_ORIGIN if args.mode == "bootstrap" else CONTAINERS[
+            f"web-{prior_slot}"
+        ]
+        verify_exact_origin_bindings(
+            active_owner, CONTAINERS[f"web-{target_slot}"], env, runner
+        )
         verify_snapshot(protected_before, env, runner)
         controlled = {CONTAINERS[item] for item in selected}
         verify_unrelated_snapshot(all_before, controlled, env, runner)
@@ -1276,6 +1502,9 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
         active_env = compose_env(external, candidate, snapshot, external["active_origin_bind"], env)
         runner([*base, "up", "--detach", "--no-deps", "--force-recreate", "--pull", "never", f"web-{target_slot}"], env=active_env)
         wait_ready("http://" + external["active_origin_bind"], candidate["git_sha"])
+        verify_exact_origin_bindings(
+            CONTAINERS[f"web-{target_slot}"], None, env, runner
+        )
         active_smoke = smoke("http://" + external["active_origin_bind"], candidate["git_sha"])
         public_smoke = smoke(external["public_origin"], candidate["git_sha"])
         verify_live_schema(schema, env, runner)
@@ -1326,6 +1555,8 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
             "env_files_read": True,
             "private_keys_read": False,
         }
+        if _CANCELLATION_CONTROLLER is not None:
+            _CANCELLATION_CONTROLLER.mark_commit_started()
         persist_accepted(receipt_dir, receipt, candidate_bytes)
         return receipt
     except Exception as original:
@@ -1428,7 +1659,7 @@ def parser() -> argparse.ArgumentParser:
     return result
 
 
-def main(argv: list[str] | None = None) -> int:
+def _main(argv: list[str] | None = None) -> int:
     args = parser().parse_args(argv)
     authority: dict[str, Any] = {}
     try:
@@ -1461,7 +1692,34 @@ def main(argv: list[str] | None = None) -> int:
             "promote": "production-promotion",
             "authority-gate": "production-authority-gate",
         }[args.operation]
-        print(json.dumps(stopped_receipt(authority, [str(exc)], operation=operation), sort_keys=True))
+        receipt = stopped_receipt(authority, [str(exc)], operation=operation)
+        if (
+            isinstance(exc, OperationCancelled)
+            and args.operation == "promote"
+            and _PREMUTATION_FAILURE_RECEIPT_DIR is not None
+        ):
+            # A cancellation during the read-only pre-mutation gates occurs
+            # before promote() creates any ephemeral credentials or services,
+            # but it still needs durable host evidence.
+            receipt.update(
+                status="failed",
+                source_sha="unknown",
+                release_run_id=args.candidate_run_id or "unknown",
+                database_access_performed=None,
+                database_access_may_have_been_performed=True,
+                service_changes_performed=False,
+                service_changes_may_have_been_performed=False,
+                filesystem_writes_performed=True,
+                rollback={"attempted": False, "status": "not-required"},
+            )
+            try:
+                receipt["durable_failure_receipt"] = persist_failure(
+                    _PREMUTATION_FAILURE_RECEIPT_DIR, receipt
+                )
+            except (OSError, DeploymentError):
+                receipt["durable_failure_receipt"] = None
+                receipt["failure_receipt_persistence"] = "failed"
+        print(json.dumps(receipt, sort_keys=True))
         return 78
     except Exception as exc:
         operation = {
@@ -1475,6 +1733,11 @@ def main(argv: list[str] | None = None) -> int:
         return 78
     print(json.dumps(receipt, sort_keys=True))
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    with controlled_cancellation():
+        return _main(argv)
 
 
 if __name__ == "__main__":

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Read-only, secret-safe inventory for the exact V3 production host.
+
+The helper accepts no target or command input. It intentionally runs on the
+already-present host Python because installing a new host runtime is outside a
+read-only inventory. Application and release runtimes remain CPython 3.14.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import socket
+import subprocess
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+EXPECTED_HOST = "ed-finder-prod"
+EXPECTED_FQDN = "nb79a3d.mevnode.com"
+POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+DB_USER = "edfinder"
+DB_NAME = "edfinder"
+ORIGIN = "http://127.0.0.1:58080"
+PUBLIC = "https://ed-finder.app"
+MAX_CONTAINERS = 256
+MAX_LISTENERS = 128
+MAX_BODY = 65536
+TIMEOUT_SECONDS = 15
+LEDGER_SQL = r"""
+BEGIN READ ONLY;
+SET LOCAL statement_timeout = '10000ms';
+SELECT json_build_object(
+  'database_name', current_database(),
+  'server_address', COALESCE(inet_server_addr()::text, 'local'),
+  'server_port', COALESCE(inet_server_port(), current_setting('port')::int),
+  'transaction_read_only', current_setting('transaction_read_only'),
+  'migrations', COALESCE((
+    SELECT json_agg(
+      json_build_object('filename', filename, 'checksum_sha256', checksum_sha256)
+      ORDER BY filename
+    ) FROM public.schema_migrations
+  ), '[]'::json)
+)::text;
+COMMIT;
+""".strip()
+
+
+def run(argv: list[str], *, timeout: int = TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            argv, text=True, capture_output=True, timeout=timeout, check=False,
+            env={"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG": "C", "LC_ALL": "C"},
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
+
+
+def docker_json_lines(argv: list[str]) -> tuple[bool, list[dict[str, Any]]]:
+    result = run(argv)
+    items: list[dict[str, Any]] = []
+    if result.returncode == 0:
+        try:
+            for line in result.stdout.splitlines():
+                value = json.loads(line)
+                if not isinstance(value, dict):
+                    raise ValueError
+                items.append(value)
+        except (json.JSONDecodeError, ValueError):
+            return False, []
+    return result.returncode == 0, items
+
+
+def sanitize_container(item: dict[str, Any]) -> dict[str, Any]:
+    allowed = ("Names", "Image", "ID", "State", "Status", "Ports", "Networks")
+    return {key: item.get(key) for key in allowed}
+
+
+def sanitize_network(item: dict[str, Any]) -> dict[str, Any]:
+    allowed = ("Name", "ID", "Driver", "Scope", "Internal", "IPv6")
+    return {key: item.get(key) for key in allowed}
+
+
+def host_capacity() -> dict[str, Any]:
+    memory: dict[str, int] = {}
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as memory_file:
+            for line in memory_file:
+                key, separator, value = line.partition(":")
+                if separator and key in {"MemTotal", "MemAvailable", "SwapTotal"}:
+                    fields = value.split()
+                    if fields and fields[0].isdigit():
+                        memory[key] = int(fields[0])
+    except OSError:
+        pass
+    try:
+        filesystem = os.statvfs("/")
+        root_available = filesystem.f_bavail * filesystem.f_frsize
+    except OSError:
+        root_available = None
+    return {
+        "logical_cpus": os.cpu_count(),
+        "memory_total_kib": memory.get("MemTotal"),
+        "memory_available_kib": memory.get("MemAvailable"),
+        "swap_total_kib": memory.get("SwapTotal"),
+        "root_available_bytes": root_available,
+    }
+
+
+def inspect_container_networks(name: str) -> dict[str, Any] | None:
+    if not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", name):
+        return None
+    result = run(
+        [
+            "docker", "inspect", "--format",
+            "{{json .NetworkSettings.Networks}}", name,
+        ]
+    )
+    try:
+        value = json.loads(result.stdout) if result.returncode == 0 else None
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, dict):
+        return None
+    # Docker's network attachment object contains no container environment.
+    return {
+        network: {
+            "aliases": sorted(
+                alias for alias in (detail.get("Aliases") or [])
+                if isinstance(alias, str) and len(alias) <= 128
+            ),
+            "ip_address": detail.get("IPAddress") if isinstance(detail.get("IPAddress"), str) else None,
+        }
+        for network, detail in sorted(value.items())
+        if isinstance(network, str) and isinstance(detail, dict)
+    }
+
+
+def parse_ledger(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "inspection_succeeded": False,
+        "query_read_only": False,
+        "database_identity": None,
+        "entries": [],
+        "ledger_rows_sha256": None,
+    }
+    if result.returncode != 0:
+        return value
+    try:
+        observed = json.loads(result.stdout.strip())
+    except json.JSONDecodeError:
+        return value
+    if not isinstance(observed, dict) or set(observed) != {
+        "database_name", "server_address", "server_port",
+        "transaction_read_only", "migrations",
+    }:
+        return value
+    entries = observed["migrations"]
+    if (
+        not isinstance(entries, list)
+        or not entries
+        or any(
+            not isinstance(item, dict)
+            or set(item) != {"filename", "checksum_sha256"}
+            or not re.fullmatch(r"[0-9]{3}_[a-z0-9_]+\.sql", str(item["filename"]))
+            or not re.fullmatch(r"[0-9a-f]{64}", str(item["checksum_sha256"]))
+            for item in entries
+        )
+    ):
+        return value
+    identity = {
+        "database_name": observed["database_name"],
+        "server_address": observed["server_address"],
+        "server_port": observed["server_port"],
+    }
+    value["query_read_only"] = observed["transaction_read_only"] == "on"
+    if not value["query_read_only"]:
+        return value
+    if entries != sorted(entries, key=lambda item: item["filename"]):
+        return value
+    if len({item["filename"] for item in entries}) != len(entries):
+        return value
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    value.update(
+        inspection_succeeded=True,
+        database_identity=identity,
+        entries=entries,
+        ledger_rows_sha256="sha256:" + hashlib.sha256(canonical).hexdigest(),
+    )
+    return value
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> None:
+        return None
+
+
+def get(url: str) -> tuple[dict[str, Any], bytes]:
+    request = urllib.request.Request(url, headers={"User-Agent": "edfinder-v3-production-inventory/1"})
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}), NoRedirect)
+    try:
+        with opener.open(request, timeout=10) as response:
+            body = response.read(MAX_BODY + 1)
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read(MAX_BODY + 1)
+        status = exc.code
+    except (OSError, urllib.error.URLError, TimeoutError):
+        return {
+            "inspection_succeeded": False,
+            "status_code": None,
+            "body_bytes": 0,
+            "body_sha256": None,
+        }, b""
+    bounded = len(body) <= MAX_BODY
+    return {
+        "inspection_succeeded": bounded,
+        "status_code": status,
+        "body_bytes": len(body[:MAX_BODY]),
+        "body_sha256": hashlib.sha256(body[:MAX_BODY]).hexdigest(),
+        "redirects_followed": False,
+    }, body[:MAX_BODY]
+
+
+def health_shape(body: bytes) -> dict[str, Any] | None:
+    try:
+        value = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(value, dict):
+        return None
+    allowed: dict[str, Any] = {}
+    for key in ("status", "database", "version", "build_sha"):
+        item = value.get(key)
+        if isinstance(item, str) and len(item) <= 128:
+            allowed[key] = item
+    return allowed if set(allowed) == {"status", "database", "version", "build_sha"} else None
+
+
+def main() -> int:
+    receipt: dict[str, Any] = {
+        "schema_version": "ed-finder/v3-production-inventory/v1",
+        "operation": "v3-production-inventory",
+        "status": "stopped",
+        "target": {"production": True, "hostname": EXPECTED_HOST, "fqdn": EXPECTED_FQDN},
+        "read_only": True,
+        "direct_db_access_performed": False,
+        "db_writes_performed": False,
+        "migrations_performed": False,
+        "application_data_writes_performed": False,
+        "env_files_read": False,
+        "container_environment_read": False,
+        "private_keys_read": False,
+        "service_changes_performed": False,
+        "filesystem_writes_performed": False,
+    }
+    failures: list[str] = []
+    host = socket.gethostname().split(".")[0]
+    fqdn_result = run(["hostname", "-f"])
+    fqdn = fqdn_result.stdout.strip()
+    receipt["observed_host"] = {"hostname": host, "fqdn": fqdn}
+    if host != EXPECTED_HOST or fqdn_result.returncode != 0 or fqdn != EXPECTED_FQDN:
+        receipt["failures"] = ["unexpected_production_host_identity"]
+        print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+        return 78
+    receipt["capacity"] = host_capacity()
+
+    docker_ok, containers = docker_json_lines(
+        ["docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"]
+    )
+    if len(containers) > MAX_CONTAINERS:
+        containers = containers[:MAX_CONTAINERS]
+        failures.append("container_inventory_truncated")
+    if not docker_ok:
+        failures.append("container_inventory_failed")
+    containers = [sanitize_container(item) for item in containers]
+    for item in containers:
+        name = item.get("Names")
+        item["NetworksDetail"] = inspect_container_networks(name) if isinstance(name, str) else None
+    receipt["containers"] = {"inspection_succeeded": docker_ok, "items": containers, "limit": MAX_CONTAINERS}
+    required_containers = {
+        "edfinder-v3-api", "edfinder-v3-proxy", "edfinder-v3-public-auth-edge",
+        POSTGRES_CONTAINER, "edfinder-v3-support-redis", "edfinder-v3-support-nats",
+    }
+    present_names = {str(item.get("Names")) for item in containers}
+    missing_required = sorted(required_containers - present_names)
+    receipt["containers"]["missing_required"] = missing_required
+    if missing_required:
+        failures.append("required_production_container_missing")
+    if not any(name.startswith("octopus-") for name in present_names):
+        failures.append("octopus_container_inventory_missing")
+
+    network_ok, networks = docker_json_lines(
+        ["docker", "network", "ls", "--no-trunc", "--format", "{{json .}}"]
+    )
+    if len(networks) > MAX_CONTAINERS:
+        failures.append("network_inventory_truncated")
+    receipt["networks"] = {
+        "inspection_succeeded": network_ok,
+        "items": [sanitize_network(item) for item in networks[:MAX_CONTAINERS]],
+        "limit": MAX_CONTAINERS,
+    }
+    if not network_ok:
+        failures.append("network_inventory_failed")
+
+    listeners_result = run(["ss", "-H", "-lnt"])
+    listeners = []
+    if listeners_result.returncode == 0:
+        for line in listeners_result.stdout.splitlines():
+            fields = line.split()
+            if len(fields) >= 4:
+                listeners.append(fields[3][:256])
+    if len(listeners) > MAX_LISTENERS:
+        listeners = listeners[:MAX_LISTENERS]
+        failures.append("listener_inventory_truncated")
+    receipt["listeners"] = {"inspection_succeeded": listeners_result.returncode == 0, "items": listeners}
+    if listeners_result.returncode != 0:
+        failures.append("listener_inventory_failed")
+
+    postgres = next((item for item in containers if item.get("Names") == POSTGRES_CONTAINER), None)
+    if postgres is None or not str(postgres.get("State", "")).lower().startswith("running"):
+        failures.append("retained_postgres_container_unavailable")
+        receipt["database"] = {"inspection_succeeded": False, "entries": []}
+    else:
+        receipt["direct_db_access_performed"] = True
+        ledger_result = run(
+            [
+                "docker", "exec", POSTGRES_CONTAINER,
+                "psql", "-X", "--no-password", "--tuples-only", "--no-align", "--quiet",
+                "--field-separator", "\t", "--set", "ON_ERROR_STOP=1",
+                "--username", DB_USER, "--dbname", DB_NAME, "--command", LEDGER_SQL,
+            ],
+            timeout=20,
+        )
+        receipt["database"] = parse_ledger(ledger_result)
+        if not receipt["database"]["inspection_succeeded"]:
+            failures.append("production_migration_ledger_unavailable_or_invalid")
+
+    origin_root, origin_root_body = get(ORIGIN + "/")
+    origin_health, origin_health_body = get(ORIGIN + "/api/health")
+    public_root, public_root_body = get(PUBLIC + "/")
+    public_health, public_health_body = get(PUBLIC + "/api/health")
+    receipt["http"] = {
+        "origin_root": origin_root,
+        "origin_health": origin_health,
+        "public_root": public_root,
+        "public_health": public_health,
+    }
+    api_container = next(
+        (item for item in containers if item.get("Names") == "edfinder-v3-api"),
+        None,
+    )
+    receipt["current_release"] = {
+        "api_container": api_container,
+        "origin_health": health_shape(origin_health_body),
+        "public_health": health_shape(public_health_body),
+        "origin_temporary_shell": b"replacement ED-Finder backend is online" in origin_root_body,
+        "public_temporary_shell": b"replacement ED-Finder backend is online" in public_root_body,
+    }
+    for label, item, shape in (
+        ("origin_root", origin_root, True),
+        ("origin_health", origin_health, health_shape(origin_health_body) is not None),
+        ("public_root", public_root, True),
+        ("public_health", public_health, health_shape(public_health_body) is not None),
+    ):
+        status_code = item.get("status_code")
+        if (
+            not item.get("inspection_succeeded")
+            or not isinstance(status_code, int)
+            or not 200 <= status_code < 300
+            or not shape
+        ):
+            failures.append(f"{label}_inventory_failed")
+    receipt["failures"] = sorted(set(failures))
+    receipt["status"] = "success" if not failures else "stopped"
+    print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+    return 0 if not failures else 78
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -278,21 +278,76 @@ def inspect_default_docker_context() -> dict[str, Any]:
     }
 
 
+def inspect_container_port_bindings(name: str) -> list[dict[str, Any]] | None:
+    """Read bounded structured Docker port bindings without container config."""
+    if not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", name):
+        return None
+    result = run(
+        [
+            "docker", "inspect", "--format",
+            "{{json .NetworkSettings.Ports}}", name,
+        ]
+    )
+    if result.returncode != 0 or len(result.stdout) > 65536:
+        return None
+    try:
+        mappings = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(mappings, dict):
+        return None
+    result_bindings: list[dict[str, Any]] = []
+    for target, host_bindings in mappings.items():
+        match = re.fullmatch(r"([0-9]{1,5})/(tcp|udp)", str(target))
+        if match is None or not 1 <= int(match.group(1)) <= 65535:
+            return None
+        if host_bindings is None:
+            continue
+        if not isinstance(host_bindings, list) or len(host_bindings) > 128:
+            return None
+        for host_binding in host_bindings:
+            if not isinstance(host_binding, dict) or set(host_binding) != {
+                "HostIp", "HostPort"
+            }:
+                return None
+            host_ip = host_binding["HostIp"]
+            host_port = host_binding["HostPort"]
+            if (
+                not isinstance(host_ip, str)
+                or not 0 < len(host_ip) <= 64
+                or not isinstance(host_port, str)
+                or not host_port.isdigit()
+                or not 1 <= int(host_port) <= 65535
+            ):
+                return None
+            result_bindings.append(
+                {
+                    "bind_address": host_ip,
+                    "host_port": int(host_port),
+                    "container_port": int(match.group(1)),
+                    "protocol": match.group(2),
+                }
+            )
+    return result_bindings
+
+
 def loopback_origin_ownership(
     containers: list[dict[str, Any]], *, inspection_succeeded: bool,
 ) -> dict[str, Any]:
-    """Derive bounded exact-loopback bindings from sanitized Docker port data."""
+    """Report every protected binding and whether it is exact-loopback-only."""
     ports = {
-        "58080": {"bind_address": "127.0.0.1", "owners": [], "bindings": []},
-        "58081": {"bind_address": "127.0.0.1", "owners": [], "bindings": []},
+        "58080": {
+            "expected_bind_address": "127.0.0.1", "owners": [],
+            "bindings": [], "exact_loopback_only": True,
+        },
+        "58081": {
+            "expected_bind_address": "127.0.0.1", "owners": [],
+            "bindings": [], "exact_loopback_only": True,
+        },
     }
     complete = inspection_succeeded
-    pattern = re.compile(
-        r"(?:^|,\s*)127\.0\.0\.1:(58080|58081)->([0-9]{1,5})/(tcp|udp)(?=,|$)"
-    )
     for item in containers:
         name = item.get("Names")
-        published = item.get("Ports")
         state = item.get("State")
         if (
             not isinstance(name, str)
@@ -303,36 +358,62 @@ def loopback_origin_ownership(
             continue
         if state.lower() != "running":
             continue
-        if published is None:
-            published = ""
-        if not isinstance(published, str) or len(published) > 4096:
+        published = item.get("PortsDetail")
+        if not isinstance(published, list):
             complete = False
             continue
-        for match in pattern.finditer(published):
-            host_port, container_port, protocol = match.groups()
-            target_port = int(container_port)
-            if not 1 <= target_port <= 65535:
+        for observed in published:
+            if (
+                not isinstance(observed, dict)
+                or set(observed) != {
+                    "bind_address", "host_port", "container_port", "protocol"
+                }
+                or not isinstance(observed["bind_address"], str)
+                or not 0 < len(observed["bind_address"]) <= 64
+                or not isinstance(observed["host_port"], int)
+                or isinstance(observed["host_port"], bool)
+                or not 1 <= observed["host_port"] <= 65535
+                or not isinstance(observed["container_port"], int)
+                or isinstance(observed["container_port"], bool)
+                or not 1 <= observed["container_port"] <= 65535
+                or observed["protocol"] not in {"tcp", "udp"}
+            ):
                 complete = False
+                continue
+            host_port = observed["host_port"]
+            if str(host_port) not in ports:
                 continue
             binding = {
                 "container": name,
-                "container_port": target_port,
-                "protocol": protocol,
+                "bind_address": observed.get("bind_address"),
+                "container_port": observed.get("container_port"),
+                "protocol": observed.get("protocol"),
             }
-            if binding not in ports[host_port]["bindings"]:
-                ports[host_port]["bindings"].append(binding)
+            ports[str(host_port)]["bindings"].append(binding)
     for value in ports.values():
         value["bindings"].sort(
             key=lambda item: (
-                item["container"], item["container_port"], item["protocol"]
+                str(item["container"]), str(item["bind_address"]),
+                str(item["container_port"]), str(item["protocol"]),
             )
         )
         value["owners"] = sorted(
             {item["container"] for item in value["bindings"]}
         )
+        value["exact_loopback_only"] = (
+            len(value["bindings"]) <= 1
+            and all(
+                item["bind_address"] == "127.0.0.1"
+                and item["protocol"] == "tcp"
+                for item in value["bindings"]
+            )
+        )
     return {
         "inspection_succeeded": complete,
-        "source": "docker_ps_ports",
+        "source": "docker_network_settings_ports",
+        "exact_loopback_only": all(
+            value["exact_loopback_only"] for value in ports.values()
+        ),
         "ports": ports,
     }
 
@@ -546,12 +627,19 @@ def main() -> int:
     for item in containers:
         name = item.get("Names")
         item["NetworksDetail"] = inspect_container_networks(name) if isinstance(name, str) else None
+        item["PortsDetail"] = (
+            inspect_container_port_bindings(name)
+            if isinstance(name, str) and str(item.get("State", "")).lower() == "running"
+            else []
+        )
     receipt["containers"] = {"inspection_succeeded": docker_ok, "items": containers, "limit": MAX_CONTAINERS}
     receipt["loopback_origin_port_ownership"] = loopback_origin_ownership(
         containers, inspection_succeeded=containers_complete
     )
     if not receipt["loopback_origin_port_ownership"]["inspection_succeeded"]:
         failures.append("loopback_origin_ownership_derivation_failed")
+    elif not receipt["loopback_origin_port_ownership"]["exact_loopback_only"]:
+        failures.append("protected_origin_binding_not_exact_loopback")
     required_containers = {
         "edfinder-v3-api", "edfinder-v3-proxy", "edfinder-v3-public-auth-edge",
         POSTGRES_CONTAINER, "edfinder-v3-support-redis", "edfinder-v3-support-nats",

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -37,6 +37,8 @@ TIMEOUT_SECONDS = 15
 SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 MAX_RUNTIME_VERSION = 64
 MAX_DOCKER_ENDPOINT = 256
+DOCKER_CONTEXT = "default"
+LOCAL_DOCKER_ENDPOINT = "unix:///var/run/docker.sock"
 LEDGER_SQL = r"""
 BEGIN READ ONLY;
 SET LOCAL statement_timeout = '10000ms';
@@ -114,8 +116,13 @@ def run(argv: list[str], *, timeout: int = TIMEOUT_SECONDS) -> subprocess.Comple
         return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
 
 
-def docker_json_lines(argv: list[str]) -> tuple[bool, list[dict[str, Any]]]:
-    result = run(argv)
+def docker_argv(*arguments: str) -> list[str]:
+    """Pin every daemon evidence command to the reviewed local context."""
+    return ["docker", "--context", DOCKER_CONTEXT, *arguments]
+
+
+def docker_json_lines(arguments: list[str]) -> tuple[bool, list[dict[str, Any]]]:
+    result = run(docker_argv(*arguments))
     items: list[dict[str, Any]] = []
     if result.returncode == 0:
         try:
@@ -248,7 +255,7 @@ def inspect_default_docker_context() -> dict[str, Any]:
     """Return only the bounded name and endpoint, never context config data."""
     result = run(
         [
-            "docker", "context", "inspect", "default", "--format",
+            *docker_argv("context", "inspect", DOCKER_CONTEXT, "--format"),
             "{{json .Name}}\t{{json .Endpoints.docker.Host}}",
         ]
     )
@@ -269,7 +276,7 @@ def inspect_default_docker_context() -> dict[str, Any]:
     except json.JSONDecodeError:
         return failed
     endpoint = bounded_docker_endpoint(endpoint)
-    if name != "default" or endpoint is None:
+    if name != DOCKER_CONTEXT or endpoint != LOCAL_DOCKER_ENDPOINT:
         return failed
     return {
         "inspection_succeeded": True,
@@ -284,7 +291,7 @@ def inspect_container_port_bindings(name: str) -> list[dict[str, Any]] | None:
         return None
     result = run(
         [
-            "docker", "inspect", "--format",
+            *docker_argv("inspect", "--format"),
             "{{json .NetworkSettings.Ports}}", name,
         ]
     )
@@ -449,7 +456,7 @@ def inspect_container_networks(name: str) -> dict[str, Any] | None:
         return None
     result = run(
         [
-            "docker", "inspect", "--format",
+            *docker_argv("inspect", "--format"),
             "{{json .NetworkSettings.Networks}}", name,
         ]
     )
@@ -612,9 +619,12 @@ def main() -> int:
     receipt["docker_context"] = inspect_default_docker_context()
     if not receipt["docker_context"]["inspection_succeeded"]:
         failures.append("default_docker_context_inventory_failed")
+        receipt["failures"] = failures
+        print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
+        return 78
 
     docker_ok, containers = docker_json_lines(
-        ["docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"]
+        ["ps", "--all", "--no-trunc", "--format", "{{json .}}"]
     )
     containers_complete = docker_ok
     if len(containers) > MAX_CONTAINERS:
@@ -653,7 +663,7 @@ def main() -> int:
         failures.append("octopus_container_inventory_missing")
 
     network_ok, networks = docker_json_lines(
-        ["docker", "network", "ls", "--no-trunc", "--format", "{{json .}}"]
+        ["network", "ls", "--no-trunc", "--format", "{{json .}}"]
     )
     if len(networks) > MAX_CONTAINERS:
         failures.append("network_inventory_truncated")
@@ -687,7 +697,7 @@ def main() -> int:
         receipt["direct_db_access_performed"] = True
         ledger_result = run(
             [
-                "docker", "exec", POSTGRES_CONTAINER,
+                *docker_argv("exec", POSTGRES_CONTAINER),
                 "psql", "-X", "--no-password", "--tuples-only", "--no-align", "--quiet",
                 "--field-separator", "\t", "--set", "ON_ERROR_STOP=1",
                 "--username", DB_USER, "--dbname", DB_NAME, "--command", LEDGER_SQL,

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import platform
 import re
+import shutil
 import socket
 import subprocess
+import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -30,6 +34,9 @@ MAX_CONTAINERS = 256
 MAX_LISTENERS = 128
 MAX_BODY = 65536
 TIMEOUT_SECONDS = 15
+SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+MAX_RUNTIME_VERSION = 64
+MAX_DOCKER_ENDPOINT = 256
 LEDGER_SQL = r"""
 BEGIN READ ONLY;
 SET LOCAL statement_timeout = '10000ms';
@@ -49,11 +56,59 @@ COMMIT;
 """.strip()
 
 
+def bounded_executable(value: str | None) -> str | None:
+    if (
+        isinstance(value, str)
+        and len(value) <= 256
+        and re.fullmatch(r"/[A-Za-z0-9_./+-]+", value)
+        and ".." not in value.split("/")
+    ):
+        return value
+    return None
+
+
+def bounded_docker_endpoint(value: Any) -> str | None:
+    if (
+        not isinstance(value, str)
+        or not 0 < len(value) <= MAX_DOCKER_ENDPOINT
+        or not value.isprintable()
+        or any(character.isspace() for character in value)
+    ):
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(value)
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.username is not None or parsed.password is not None:
+        return None
+    if parsed.query or parsed.fragment:
+        return None
+    if parsed.scheme == "unix":
+        if (
+            parsed.netloc
+            or not re.fullmatch(r"/[A-Za-z0-9_./-]+", parsed.path)
+            or ".." in parsed.path.split("/")
+        ):
+            return None
+        return value
+    if parsed.scheme == "tcp":
+        if (
+            parsed.hostname is None
+            or port is None
+            or parsed.path not in {"", "/"}
+            or not re.fullmatch(r"[A-Za-z0-9_.:-]+", parsed.hostname)
+        ):
+            return None
+        return value
+    return None
+
+
 def run(argv: list[str], *, timeout: int = TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
             argv, text=True, capture_output=True, timeout=timeout, check=False,
-            env={"PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "LANG": "C", "LC_ALL": "C"},
+            env={"PATH": SAFE_PATH, "LANG": "C", "LC_ALL": "C"},
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return subprocess.CompletedProcess(argv, 125, "", type(exc).__name__)
@@ -82,6 +137,204 @@ def sanitize_container(item: dict[str, Any]) -> dict[str, Any]:
 def sanitize_network(item: dict[str, Any]) -> dict[str, Any]:
     allowed = ("Name", "ID", "Driver", "Scope", "Internal", "IPv6")
     return {key: item.get(key) for key in allowed}
+
+
+def inventory_runtime() -> dict[str, Any]:
+    """Describe the interpreter already selected by the read-only launcher."""
+    implementation = platform.python_implementation()
+    version = platform.python_version()
+    executable = bounded_executable(sys.executable)
+    return {
+        "inspection_succeeded": (
+            0 < len(implementation) <= MAX_RUNTIME_VERSION
+            and 0 < len(version) <= MAX_RUNTIME_VERSION
+            and executable is not None
+        ),
+        "command": "python3",
+        "used_for_inventory": True,
+        "executable": executable,
+        "implementation": implementation[:MAX_RUNTIME_VERSION],
+        "version": version[:MAX_RUNTIME_VERSION],
+        "version_info": [
+            sys.version_info.major,
+            sys.version_info.minor,
+            sys.version_info.micro,
+        ],
+        "is_exact_cpython_3_14": (
+            implementation == "CPython"
+            and sys.version_info[:2] == (3, 14)
+        ),
+    }
+
+
+def inspect_python314_runtime() -> dict[str, Any]:
+    """Inspect, but never install, the mutation runtime required by authority."""
+    executable = shutil.which("python3.14", path=SAFE_PATH)
+    unavailable: dict[str, Any] = {
+        "inspection_succeeded": True,
+        "command": "python3.14",
+        "exists": False,
+        "executable": None,
+        "implementation": None,
+        "version": None,
+        "version_info": None,
+        "is_exact_cpython_3_14": False,
+    }
+    if executable is None:
+        return unavailable
+    bounded_path = bounded_executable(executable)
+    if bounded_path is None:
+        return {**unavailable, "inspection_succeeded": False, "exists": True}
+    probe = run(
+        [
+            bounded_path,
+            "-I",
+            "-S",
+            "-c",
+            (
+                "import json,platform,sys;"
+                "print(json.dumps({'implementation':platform.python_implementation(),"
+                "'version':platform.python_version(),"
+                "'version_info':list(sys.version_info[:3])},separators=(',',':')))"
+            ),
+        ]
+    )
+    failed = {
+        **unavailable,
+        "inspection_succeeded": False,
+        "exists": True,
+        "executable": bounded_path,
+    }
+    if probe.returncode != 0 or len(probe.stdout) > 512:
+        return failed
+    try:
+        observed = json.loads(probe.stdout.strip())
+    except json.JSONDecodeError:
+        return failed
+    if not isinstance(observed, dict) or set(observed) != {
+        "implementation", "version", "version_info",
+    }:
+        return failed
+    implementation = observed["implementation"]
+    version = observed["version"]
+    version_info = observed["version_info"]
+    if (
+        not isinstance(implementation, str)
+        or not 0 < len(implementation) <= MAX_RUNTIME_VERSION
+        or not isinstance(version, str)
+        or not re.fullmatch(r"[0-9A-Za-z.+-]{1,64}", version)
+        or not isinstance(version_info, list)
+        or len(version_info) != 3
+        or any(
+            not isinstance(item, int) or isinstance(item, bool)
+            for item in version_info
+        )
+    ):
+        return failed
+    return {
+        "inspection_succeeded": True,
+        "exists": True,
+        "executable": bounded_path,
+        "implementation": implementation,
+        "version": version,
+        "version_info": version_info,
+        "is_exact_cpython_3_14": (
+            implementation == "CPython" and version_info[:2] == [3, 14]
+        ),
+    }
+
+
+def inspect_default_docker_context() -> dict[str, Any]:
+    """Return only the bounded name and endpoint, never context config data."""
+    result = run(
+        [
+            "docker", "context", "inspect", "default", "--format",
+            "{{json .Name}}\t{{json .Endpoints.docker.Host}}",
+        ]
+    )
+    failed = {
+        "inspection_succeeded": False,
+        "name": None,
+        "docker_endpoint": None,
+    }
+    lines = result.stdout.splitlines()
+    if result.returncode != 0 or len(lines) != 1:
+        return failed
+    raw_name, separator, raw_endpoint = lines[0].partition("\t")
+    if not separator:
+        return failed
+    try:
+        name = json.loads(raw_name)
+        endpoint = json.loads(raw_endpoint)
+    except json.JSONDecodeError:
+        return failed
+    endpoint = bounded_docker_endpoint(endpoint)
+    if name != "default" or endpoint is None:
+        return failed
+    return {
+        "inspection_succeeded": True,
+        "name": name,
+        "docker_endpoint": endpoint,
+    }
+
+
+def loopback_origin_ownership(
+    containers: list[dict[str, Any]], *, inspection_succeeded: bool,
+) -> dict[str, Any]:
+    """Derive bounded exact-loopback bindings from sanitized Docker port data."""
+    ports = {
+        "58080": {"bind_address": "127.0.0.1", "owners": [], "bindings": []},
+        "58081": {"bind_address": "127.0.0.1", "owners": [], "bindings": []},
+    }
+    complete = inspection_succeeded
+    pattern = re.compile(
+        r"(?:^|,\s*)127\.0\.0\.1:(58080|58081)->([0-9]{1,5})/(tcp|udp)(?=,|$)"
+    )
+    for item in containers:
+        name = item.get("Names")
+        published = item.get("Ports")
+        state = item.get("State")
+        if (
+            not isinstance(name, str)
+            or not re.fullmatch(r"[A-Za-z0-9_.-]{1,128}", name)
+            or not isinstance(state, str)
+        ):
+            complete = False
+            continue
+        if state.lower() != "running":
+            continue
+        if published is None:
+            published = ""
+        if not isinstance(published, str) or len(published) > 4096:
+            complete = False
+            continue
+        for match in pattern.finditer(published):
+            host_port, container_port, protocol = match.groups()
+            target_port = int(container_port)
+            if not 1 <= target_port <= 65535:
+                complete = False
+                continue
+            binding = {
+                "container": name,
+                "container_port": target_port,
+                "protocol": protocol,
+            }
+            if binding not in ports[host_port]["bindings"]:
+                ports[host_port]["bindings"].append(binding)
+    for value in ports.values():
+        value["bindings"].sort(
+            key=lambda item: (
+                item["container"], item["container_port"], item["protocol"]
+            )
+        )
+        value["owners"] = sorted(
+            {item["container"] for item in value["bindings"]}
+        )
+    return {
+        "inspection_succeeded": complete,
+        "source": "docker_ps_ports",
+        "ports": ports,
+    }
 
 
 def host_capacity() -> dict[str, Any]:
@@ -266,13 +519,26 @@ def main() -> int:
         receipt["failures"] = ["unexpected_production_host_identity"]
         print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
         return 78
+    receipt["host_runtime"] = {
+        "inventory_python": inventory_runtime(),
+        "python3_14": inspect_python314_runtime(),
+    }
+    if not receipt["host_runtime"]["inventory_python"]["inspection_succeeded"]:
+        failures.append("inventory_python_runtime_inspection_failed")
+    if not receipt["host_runtime"]["python3_14"]["inspection_succeeded"]:
+        failures.append("python314_runtime_inspection_failed")
     receipt["capacity"] = host_capacity()
+    receipt["docker_context"] = inspect_default_docker_context()
+    if not receipt["docker_context"]["inspection_succeeded"]:
+        failures.append("default_docker_context_inventory_failed")
 
     docker_ok, containers = docker_json_lines(
         ["docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"]
     )
+    containers_complete = docker_ok
     if len(containers) > MAX_CONTAINERS:
         containers = containers[:MAX_CONTAINERS]
+        containers_complete = False
         failures.append("container_inventory_truncated")
     if not docker_ok:
         failures.append("container_inventory_failed")
@@ -281,6 +547,11 @@ def main() -> int:
         name = item.get("Names")
         item["NetworksDetail"] = inspect_container_networks(name) if isinstance(name, str) else None
     receipt["containers"] = {"inspection_succeeded": docker_ok, "items": containers, "limit": MAX_CONTAINERS}
+    receipt["loopback_origin_port_ownership"] = loopback_origin_ownership(
+        containers, inspection_succeeded=containers_complete
+    )
+    if not receipt["loopback_origin_port_ownership"]["inspection_succeeded"]:
+        failures.append("loopback_origin_ownership_derivation_failed")
     required_containers = {
         "edfinder-v3-api", "edfinder-v3-proxy", "edfinder-v3-public-auth-edge",
         POSTGRES_CONTAINER, "edfinder-v3-support-redis", "edfinder-v3-support-nats",

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -54,6 +54,7 @@ CHECKED_WORKFLOWS = (
     'v3-application-release.yml',
     'v3-derived-data-status.yml',
     'v3-live-checkpoint-control.yml',
+    'v3-production-application-deploy.yml',
 )
 
 

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE = ROOT / "deploy/v3-production/compose.yml"
+AUTHORITY = ROOT / "deploy/v3-production/target-authority.json"
+DEPLOYER = ROOT / "scripts/operator/v3_production_deploy.py"
+INVENTORY = ROOT / "scripts/operator/v3_production_inventory.py"
+INVENTORY_ACTION = ROOT / "scripts/operator/actions/v3-production-inventory.sh"
+PROMOTE_ACTION = ROOT / "scripts/operator/actions/v3-production-promote.sh"
+WORKFLOW = ROOT / ".github/workflows/v3-production-application-deploy.yml"
+RUNBOOK = ROOT / "docs/operations/v3-production-application-release.md"
+
+
+def _load_deployer():
+    spec = importlib.util.spec_from_file_location("v3_production_deploy", DEPLOYER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _workflow() -> dict:
+    return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def test_production_authority_is_separate_exact_and_currently_fail_closed():
+    value = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+    module = _load_deployer()
+
+    assert value["target"] == {
+        "provider": "mevspace",
+        "classification": "production",
+        "production": True,
+        "hostname": "ed-finder-prod",
+        "fqdn": "nb79a3d.mevnode.com",
+        "architecture": "x86_64",
+    }
+    assert value["status"] == "stopped"
+    assert set(module.validate_authority(value)) == set(value["blockers"])
+    assert value["application_contract"]["compose_project"] == "edfinder-v3-production"
+    assert "checkpoint" not in value["application_contract"]["compose_project"]
+    assert value["application_contract"]["compose_sha256"] == hashlib.sha256(COMPOSE.read_bytes()).hexdigest()
+    assert all(value["external_authority"][key] is None for key in (
+        "application_network", "api_env_file", "schema_identity_file",
+        "edge_route_authority", "receipt_directory", "docker_context",
+    ))
+
+
+def test_production_compose_owns_only_blue_green_application_slots():
+    value = yaml.safe_load(COMPOSE.read_text(encoding="utf-8"))
+    services = value["services"]
+
+    assert value["name"] == "edfinder-v3-production"
+    assert set(services) == {"api-blue", "web-blue", "api-green", "web-green"}
+    assert set(value["networks"]) == {"app"}
+    assert value["networks"]["app"]["external"] is True
+    assert "volumes" not in value
+    assert all("depends_on" not in service for service in services.values())
+    assert services["api-blue"]["environment"]["EDDN_SIMULATION_INGEST_ENABLED"] == "false"
+    assert services["api-blue"]["environment"]["ADMIN_OPERATION_STARTUP_REAP_ENABLED"] == "false"
+    for service_name in services:
+        assert not any(
+            token in service_name for token in ("postgres", "redis", "valkey", "nats", "octopus", "edge", "proxy")
+        )
+
+
+def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_reads():
+    source = INVENTORY.read_text(encoding="utf-8")
+    action = INVENTORY_ACTION.read_text(encoding="utf-8")
+
+    assert 'EXPECTED_HOST = "ed-finder-prod"' in source
+    assert 'EXPECTED_FQDN = "nb79a3d.mevnode.com"' in source
+    assert 'POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"' in source
+    assert "BEGIN READ ONLY;" in source
+    assert "statement_timeout" in source
+    assert "FROM public.schema_migrations" in source
+    assert "ORDER BY filename" in source
+    assert '"container_environment_read": False' in source
+    assert '"filesystem_writes_performed": False' in source
+    assert "command -v python3.14" not in action
+    assert "command -v python3" in action
+    for forbidden in (".Config.Env", "docker restart", "docker stop", "docker start", "compose up", "INSERT INTO", "UPDATE ", "DELETE FROM", "TRUNCATE", "ALTER TABLE", "DROP TABLE"):
+        assert forbidden not in source
+
+
+def test_production_deployer_uses_release_manifest_and_fresh_schema_compatibility():
+    source = DEPLOYER.read_text(encoding="utf-8")
+
+    assert 'ROOT / "scripts/release/v3_release_manifest.py"' in source
+    assert 'purpose="deploy"' in source
+    assert 'purpose="rollback"' in source
+    assert "current_migration_set=schema[\"migration_set_identity\"]" in source
+    assert "BEGIN READ ONLY;" in source
+    assert "production_migration_authority_absent_or_schema_incompatible" in source
+    assert "candidate.get(\"rollback\", {}).get(\"application_only_eligible\")" in source
+    for forbidden in ("apply_migrations.sh", "baseline_migration_ledger.sh", "git pull", "docker compose down", "--remove-orphans", "docker volume rm"):
+        assert forbidden not in source
+
+
+def test_production_schema_identity_preserves_release_manifest_order(tmp_path):
+    deployer = _load_deployer()
+    release_spec = importlib.util.spec_from_file_location(
+        "v3_release_manifest_for_production_test",
+        ROOT / "scripts/release/v3_release_manifest.py",
+    )
+    assert release_spec and release_spec.loader
+    release = importlib.util.module_from_spec(release_spec)
+    release_spec.loader.exec_module(release)
+    migration_set = release.migration_set(ROOT)
+    assert migration_set["entries"] != sorted(
+        migration_set["entries"], key=lambda item: item["path"]
+    )
+    schema = {
+        "schema_version": deployer.SCHEMA_IDENTITY_SCHEMA,
+        "database_identity": {
+            "container": deployer.POSTGRES_CONTAINER,
+            "database_name": "edfinder",
+            "database_user": "edfinder",
+            "application_host": deployer.POSTGRES_CONTAINER,
+            "server_address": "local",
+            "server_port": 5432,
+        },
+        "migration_set_identity": migration_set["identity"],
+        "migration_set_entries": migration_set["entries"],
+        "evidence": "reviewed-production-inventory-receipt",
+    }
+    path = tmp_path / "schema.json"
+    path.write_text(json.dumps(schema), encoding="utf-8")
+
+    assert deployer.validate_schema_file(
+        path, hashlib.sha256(path.read_bytes()).hexdigest()
+    )["migration_set_identity"] == migration_set["identity"]
+
+
+def test_mutation_is_explicit_app_only_and_preserves_edge_database_redis_nats():
+    source = DEPLOYER.read_text(encoding="utf-8")
+
+    assert 'runner([*base, "up", "--detach", "--no-deps", "--force-recreate", "--pull", "never", *selected]' in source
+    assert 'runner(["docker", "stop", LEGACY_ORIGIN]' in source
+    assert 'runner(["docker", "stop", LEGACY_API]' in source
+    assert 'runner(["docker", "start", LEGACY_API]' in source
+    assert 'runner(["docker", "start", LEGACY_ORIGIN]' in source
+    assert "verify_snapshot(protected_before" in source
+    assert source.count("live_capacity_guard()") >= 3
+    assert source.count("validate_network(") >= 4
+    assert 'PUBLIC_EDGE = "edfinder-v3-public-auth-edge"' in source
+    assert 'POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"' in source
+    assert '"edfinder-v3-support-redis"' in AUTHORITY.read_text()
+    assert '"edfinder-v3-support-nats"' in AUTHORITY.read_text()
+    assert '"edge_recreated": False' in source
+
+
+def test_rollback_comes_only_from_checksum_bound_prior_accepted_release():
+    source = DEPLOYER.read_text(encoding="utf-8")
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'load_current(receipt_dir)' in source
+    assert 'sha256_file(receipt_path) != pointer["receipt_sha256"]' in source
+    assert 'sha256_file(manifest_path) != pointer["manifest_sha256"]' in source
+    assert '"--pull", "never"' in source
+    assert '"kind": "prior-accepted-immutable-release"' in source
+    assert "rollback_run_id" not in workflow
+    assert "rollback-manifest" not in workflow
+
+
+def test_workflow_is_manual_main_only_protected_and_uses_pinned_ssh_trust():
+    workflow = _workflow()
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert set(workflow["on"]) == {"workflow_dispatch"}
+    assert "github.ref == 'refs/heads/main'" in source
+    assert "github.repository == 'brianstewart377-rgb/ed-finder'" in source
+    assert workflow["jobs"]["inventory"]["environment"] == "v3-production-readonly"
+    assert workflow["jobs"]["production-operation"]["environment"] == "v3-production"
+    assert source.count("persist-credentials: false") >= 4
+    assert "StrictHostKeyChecking=yes" in source
+    assert "UserKnownHostsFile=~/.ssh/known_hosts" in source
+    assert "ssh-keyscan" not in source
+    assert "V3_PRODUCTION_SSH_KEY" in source
+    assert "V3_LIVE_CHECKPOINT" not in source
+    assert "ED_NEW_OPERATOR" not in source
+    assert "target_confirmation" in source
+    assert source.count("uses: actions/download-artifact@") == 2
+    assert "Stop before credentials or SSH while production authority is blocked" in source
+    assert "Candidate is not the exact current main release" in source
+    assert "exec bash scripts/operator/actions/v3-production-promote.sh" not in source
+    assert "--runtime-directory" in source
+    assert "kill -TERM" in source
+
+
+def test_receipts_are_machine_readable_and_secret_safe_by_contract():
+    source = DEPLOYER.read_text(encoding="utf-8")
+
+    for field in (
+        "database_access_performed", "database_writes_performed", "migrations_performed",
+        "application_data_writes_performed", "image_pulls_performed",
+        "service_changes_performed", "edge_recreated", "protected_resources_changed",
+        "env_contents_recorded", "private_keys_read",
+    ):
+        assert field in source
+    assert "production DATABASE_URL does not target retained PostgreSQL" in source
+    assert "parsed.password" in source
+    assert ".Config.Env" not in source
+    assert "password=" not in source.lower()
+
+
+def test_runbook_states_no_execution_boundary_and_concrete_first_run_blockers():
+    source = RUNBOOK.read_text(encoding="utf-8")
+
+    assert "does **not** authorize executing it during" in source
+    assert "No command in this runbook was executed\nagainst production" in source
+    assert "root `docker-compose.yml`" in source
+    assert "Contabo checkpoint" in source
+    assert "production_migration_authority_absent_or_schema_incompatible" in source
+    assert "stale `edfinder-v3-api:phase4c-r5`" in source
+    assert "Redis and NATS are not removed or replaced" in source
+
+
+def test_new_shell_launchers_parse():
+    for path in (INVENTORY_ACTION, PROMOTE_ACTION):
+        result = subprocess.run(["bash", "-n", str(path)], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+
+
+def test_inventory_ledger_parser_rejects_extra_or_malformed_output():
+    spec = importlib.util.spec_from_file_location(
+        "v3_production_inventory_for_parser_test", INVENTORY
+    )
+    assert spec and spec.loader
+    inventory = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(inventory)
+    good = json.dumps(
+        {
+            "database_name": "edfinder",
+            "server_address": "local",
+            "server_port": 5432,
+            "transaction_read_only": "on",
+            "migrations": [
+                {"filename": "001_initial.sql", "checksum_sha256": "a" * 64}
+            ],
+        }
+    )
+    completed = subprocess.CompletedProcess(["psql"], 0, good, "")
+    assert inventory.parse_ledger(completed)["inspection_succeeded"] is True
+
+    for hostile in (
+        good + "\nignored-extra-output",
+        json.dumps(
+            {
+                **json.loads(good),
+                "migrations": [
+                    {"filename": "001_initial.sql", "checksum_sha256": "a" * 64},
+                    {"filename": "002_bad\nname.sql", "checksum_sha256": "b" * 64},
+                ],
+            }
+        ),
+    ):
+        result = inventory.parse_ledger(
+            subprocess.CompletedProcess(["psql"], 0, hostile, "")
+        )
+        assert result["inspection_succeeded"] is False

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -229,6 +229,9 @@ def test_workflow_is_manual_main_only_protected_and_uses_pinned_ssh_trust():
     assert "ED_NEW_OPERATOR" not in source
     assert "target_confirmation" in source
     assert source.count("uses: actions/download-artifact@") == 2
+    assert source.count("scripts/release/v3_release_run.py") == 2
+    assert "gh api" not in source
+    assert "release-run.json" not in source
     assert "Stop before credentials or SSH while production authority is blocked" in source
     assert "Candidate is not the exact current main release" in source
     assert "exec bash scripts/operator/actions/v3-production-promote.sh" not in source

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -3,9 +3,18 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 from pathlib import Path
+import signal
+import stat
 import subprocess
+import sys
+import tarfile
+import textwrap
+import time
+from types import SimpleNamespace
 
+import pytest
 import yaml
 
 
@@ -113,7 +122,7 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
         'receipt["docker_context"]',
         '"docker_endpoint"',
         '"loopback_origin_port_ownership"',
-        '"docker_ps_ports"',
+        '"docker_network_settings_ports"',
         '"58080"',
         '"58081"',
         '"bindings"',
@@ -237,6 +246,9 @@ def test_workflow_is_manual_main_only_protected_and_uses_pinned_ssh_trust():
     assert "exec bash scripts/operator/actions/v3-production-promote.sh" not in source
     assert "--runtime-directory" in source
     assert "kill -TERM" in source
+    assert "trap '' HUP INT TERM" in source
+    assert source.index("kill -TERM") < source.index('wait \\"\\$child\\"')
+    assert "kill -KILL" not in source
 
 
 def test_receipts_are_machine_readable_and_secret_safe_by_contract():
@@ -463,17 +475,31 @@ def test_inventory_reports_only_default_docker_endpoint_and_loopback_owners(monk
             {
                 "Names": "edfinder-v3-proxy",
                 "State": "running",
-                "Ports": "127.0.0.1:58080->80/tcp, 0.0.0.0:58081->81/tcp",
+                "PortsDetail": [
+                    {
+                        "bind_address": "127.0.0.1", "host_port": 58080,
+                        "container_port": 80, "protocol": "tcp",
+                    },
+                    {
+                        "bind_address": "0.0.0.0", "host_port": 58081,
+                        "container_port": 81, "protocol": "tcp",
+                    },
+                ],
             },
             {
                 "Names": "candidate-web",
                 "State": "running",
-                "Ports": "127.0.0.1:58081->3000/tcp",
+                "PortsDetail": [
+                    {
+                        "bind_address": "127.0.0.1", "host_port": 58081,
+                        "container_port": 3000, "protocol": "tcp",
+                    }
+                ],
             },
             {
                 "Names": "stopped-web",
                 "State": "exited",
-                "Ports": "127.0.0.1:58081->3000/tcp",
+                "PortsDetail": None,
             },
         ],
         inspection_succeeded=True,
@@ -481,17 +507,653 @@ def test_inventory_reports_only_default_docker_endpoint_and_loopback_owners(monk
     assert ownership["inspection_succeeded"] is True
     assert ownership["ports"]["58080"]["owners"] == ["edfinder-v3-proxy"]
     assert ownership["ports"]["58080"]["bindings"] == [
-        {"container": "edfinder-v3-proxy", "container_port": 80, "protocol": "tcp"}
+        {
+            "container": "edfinder-v3-proxy", "bind_address": "127.0.0.1",
+            "container_port": 80, "protocol": "tcp",
+        }
     ]
-    assert ownership["ports"]["58081"]["owners"] == ["candidate-web"]
+    assert ownership["ports"]["58080"]["exact_loopback_only"] is True
+    assert ownership["ports"]["58081"]["owners"] == [
+        "candidate-web", "edfinder-v3-proxy"
+    ]
     assert ownership["ports"]["58081"]["bindings"] == [
-        {"container": "candidate-web", "container_port": 3000, "protocol": "tcp"}
+        {
+            "container": "candidate-web", "bind_address": "127.0.0.1",
+            "container_port": 3000, "protocol": "tcp",
+        },
+        {
+            "container": "edfinder-v3-proxy", "bind_address": "0.0.0.0",
+            "container_port": 81, "protocol": "tcp",
+        },
     ]
+    assert ownership["ports"]["58081"]["exact_loopback_only"] is False
+    assert ownership["exact_loopback_only"] is False
 
     incomplete = inventory.loopback_origin_ownership(
-        [{"Names": "malformed", "State": "running", "Ports": ["not-a-string"]}],
+        [{"Names": "malformed", "State": "running", "PortsDetail": "bad"}],
         inspection_succeeded=False,
     )
     assert incomplete["inspection_succeeded"] is False
     assert incomplete["ports"]["58080"]["owners"] == []
     assert incomplete["ports"]["58081"]["owners"] == []
+
+
+def test_protected_job_refetches_main_before_credentials_and_maps_fallback_receipts():
+    workflow = _workflow()
+    steps = workflow["jobs"]["production-operation"]["steps"]
+    names = [step.get("name", "") for step in steps]
+    recheck_index = names.index("Revalidate exact current main after production approval")
+    prepare_index = names.index("Prepare sealed source-free operation bundle and pinned SSH trust")
+    execute_index = names.index("Execute exact production authority")
+    recheck = steps[recheck_index]["run"]
+    execute = steps[execute_index]["run"]
+
+    assert recheck_index < prepare_index < execute_index
+    assert "git fetch --no-tags origin refs/heads/main" in recheck
+    assert 'git rev-parse HEAD' in recheck
+    assert 'git rev-parse FETCH_HEAD' in recheck
+    assert steps[recheck_index]["env"]["EXPECTED_SOURCE_SHA"] == "${{ needs.guard.outputs.source_sha }}"
+    assert "preflight) receipt_operation=production-preflight" in execute
+    assert "promote) receipt_operation=production-promotion" in execute
+    assert 'os.environ["RECEIPT_OPERATION"]' in execute
+    assert '"operation": "production-promotion"' not in execute
+
+
+def test_bundle_and_remote_runtime_roots_remain_private_after_archive_extraction(tmp_path):
+    source = WORKFLOW.read_text(encoding="utf-8")
+    assert 'install -d -m 700 "$BUNDLE"' in source
+    assert 'tar --no-same-permissions --no-overwrite-dir -xf - -C' in source
+    extract = source.index("tar --no-same-permissions --no-overwrite-dir -xf - -C")
+    assert source.index('chmod 700 \\"\\$work\\"', extract) > extract
+
+    bundle = tmp_path / "bundle"
+    bundle.mkdir(mode=0o755)
+    (bundle / "payload").write_text("sealed", encoding="utf-8")
+    archive = tmp_path / "bundle.tar"
+    with tarfile.open(archive, "w") as handle:
+        handle.add(bundle, arcname=".")
+    runtime = tmp_path / "runtime"
+    runtime.mkdir(mode=0o700)
+    subprocess.run(
+        [
+            "tar", "--no-same-permissions", "--no-overwrite-dir", "-xf",
+            str(archive), "-C", str(runtime),
+        ],
+        check=True,
+    )
+    runtime.chmod(0o700)
+
+    deployer = _load_deployer()
+    assert deployer.validate_runtime_directory(runtime) == runtime
+    assert stat.S_IMODE(runtime.stat().st_mode) == 0o700
+
+
+def _launcher_environment(fake_bin: Path) -> dict[str, str]:
+    return {
+        **os.environ,
+        "PATH": f"{fake_bin}:/usr/bin:/bin",
+        "LANG": "C",
+        "LC_ALL": "C",
+    }
+
+
+def _write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_preflight_launcher_prefers_exact_cpython314_and_falls_back_compatibly(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    actual_python = Path(sys.executable).resolve()
+    (fake_bin / "python3.14").symlink_to(actual_python)
+    marker = tmp_path / "python3-used"
+    _write_executable(
+        fake_bin / "python3",
+        f"#!/bin/sh\nprintf used > {marker}\nexit 1\n",
+    )
+    preferred = subprocess.run(
+        ["bash", str(PROMOTE_ACTION), "--operation", "preflight"],
+        text=True,
+        capture_output=True,
+        env=_launcher_environment(fake_bin),
+        timeout=10,
+    )
+    assert preferred.returncode == 78
+    assert json.loads(preferred.stdout)["operation"] == "production-preflight"
+    assert not marker.exists()
+
+    (fake_bin / "python3.14").unlink()
+    _write_executable(fake_bin / "python3.14", "#!/bin/sh\nexit 1\n")
+    (fake_bin / "python3").unlink()
+    (fake_bin / "python3").symlink_to("/usr/bin/python3")
+    fallback = subprocess.run(
+        ["bash", str(PROMOTE_ACTION), "--operation", "authority-gate"],
+        text=True,
+        capture_output=True,
+        env=_launcher_environment(fake_bin),
+        timeout=10,
+    )
+    assert fallback.returncode == 78
+    assert json.loads(fallback.stdout)["operation"] == "production-authority-gate"
+
+
+def test_launcher_runtime_failures_use_only_validated_operation_names(tmp_path):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "python3.14", "#!/bin/sh\nexit 1\n")
+    _write_executable(fake_bin / "python3", "#!/bin/sh\nexit 1\n")
+    env = _launcher_environment(fake_bin)
+
+    unsupported = subprocess.run(
+        ["bash", str(PROMOTE_ACTION), "--operation", "preflight"],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    assert unsupported.returncode == 78
+    unsupported_receipt = json.loads(unsupported.stdout)
+    assert unsupported_receipt["operation"] == "production-preflight"
+    assert unsupported_receipt["failures"] == [
+        "python3_unsupported_for_production_readonly"
+    ]
+
+    mutation = subprocess.run(
+        ["bash", str(PROMOTE_ACTION), "--operation", "promote"],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    assert mutation.returncode == 78
+    mutation_receipt = json.loads(mutation.stdout)
+    assert mutation_receipt["operation"] == "production-promotion"
+    assert mutation_receipt["failures"] == [
+        "python314_required_for_production_mutation"
+    ]
+
+    hostile = subprocess.run(
+        ["bash", str(PROMOTE_ACTION), "--operation", 'promote\"bad'],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    assert hostile.returncode == 78
+    hostile_receipt = json.loads(hostile.stdout)
+    assert hostile_receipt["operation"] == "production-authority-gate"
+    assert hostile_receipt["failures"] == ["invalid_requested_operation"]
+    assert "bad" not in hostile.stdout
+
+    equals_form = subprocess.run(
+        ["bash", str(PROMOTE_ACTION), "--operation=preflight"],
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+    assert equals_form.returncode == 78
+    assert json.loads(equals_form.stdout)["operation"] == "production-preflight"
+
+
+def test_launcher_runtime_probe_is_bounded_and_invalid_314_is_unsupported(tmp_path):
+    invalid_only = tmp_path / "invalid-only"
+    invalid_only.mkdir()
+    (invalid_only / "timeout").symlink_to("/usr/bin/timeout")
+    _write_executable(invalid_only / "python3.14", "#!/bin/sh\nexit 1\n")
+    invalid = subprocess.run(
+        ["/bin/bash", str(PROMOTE_ACTION), "--operation", "preflight"],
+        text=True,
+        capture_output=True,
+        env={"PATH": str(invalid_only), "LANG": "C", "LC_ALL": "C"},
+        timeout=5,
+    )
+    assert invalid.returncode == 78
+    assert json.loads(invalid.stdout)["failures"] == [
+        "python3_unsupported_for_production_readonly"
+    ]
+
+    hanging = tmp_path / "hanging"
+    hanging.mkdir()
+    _write_executable(hanging / "python3", "#!/bin/sh\nsleep 30\n")
+    started = time.monotonic()
+    bounded = subprocess.run(
+        ["/bin/bash", str(PROMOTE_ACTION), "--operation", "preflight"],
+        text=True,
+        capture_output=True,
+        env=_launcher_environment(hanging),
+        timeout=15,
+    )
+    elapsed = time.monotonic() - started
+    assert bounded.returncode == 78
+    assert elapsed < 13
+    assert json.loads(bounded.stdout)["failures"] == [
+        "python3_unsupported_for_production_readonly"
+    ]
+
+
+def _origin_runner(bindings, listener="127.0.0.1:58080"):
+    ports = {"8080/tcp": bindings} if bindings else {"8080/tcp": None}
+
+    def runner(argv, **_kwargs):
+        if argv[:3] == ["docker", "ps", "--no-trunc"]:
+            return subprocess.CompletedProcess(argv, 0, "edfinder-v3-proxy\n", "")
+        if argv[:3] == ["docker", "inspect", "--format"]:
+            return subprocess.CompletedProcess(argv, 0, json.dumps(ports), "")
+        if argv[:3] == ["ss", "-H", "-lnt"]:
+            stdout = f"LISTEN 0 4096 {listener} 0.0.0.0:*\n" if listener else ""
+            return subprocess.CompletedProcess(argv, 0, stdout, "")
+        raise AssertionError(argv)
+
+    return runner
+
+
+@pytest.mark.parametrize(
+    "bindings",
+    [
+        [{"HostIp": "0.0.0.0", "HostPort": "58080"}],
+        [{"HostIp": "::", "HostPort": "58080"}],
+        [{"HostIp": "[::]", "HostPort": "58080"}],
+        [{"HostIp": "192.0.2.10", "HostPort": "58080"}],
+        [
+            {"HostIp": "127.0.0.1", "HostPort": "58080"},
+            {"HostIp": "0.0.0.0", "HostPort": "58080"},
+        ],
+        [
+            {"HostIp": "127.0.0.1", "HostPort": "58080"},
+            {"HostIp": "127.0.0.1", "HostPort": "58080"},
+        ],
+    ],
+)
+def test_origin_ownership_rejects_wildcard_alternate_and_duplicate_bindings(bindings):
+    deployer = _load_deployer()
+    with pytest.raises(deployer.DeploymentError, match="ownership drifted"):
+        deployer.verify_origin_ownership(
+            "bootstrap", None, {}, _origin_runner(bindings)
+        )
+
+
+def test_origin_ownership_requires_exact_loopback_listener_and_no_staging_binding():
+    deployer = _load_deployer()
+    exact = [{"HostIp": "127.0.0.1", "HostPort": "58080"}]
+    deployer.verify_origin_ownership("bootstrap", None, {}, _origin_runner(exact))
+
+    with pytest.raises(deployer.DeploymentError, match="not exact loopback"):
+        deployer.verify_origin_ownership(
+            "bootstrap", None, {}, _origin_runner(exact, "0.0.0.0:58080")
+        )
+
+    mixed = [
+        {"HostIp": "127.0.0.1", "HostPort": "58080"},
+        {"HostIp": "127.0.0.1", "HostPort": "58081"},
+    ]
+    with pytest.raises(deployer.DeploymentError, match="staging origin"):
+        deployer.verify_origin_ownership(
+            "bootstrap", None, {}, _origin_runner(mixed)
+        )
+
+
+def test_origin_bindings_are_rechecked_for_staging_and_active_cutover():
+    deployer = _load_deployer()
+    owners = {
+        deployer.LEGACY_ORIGIN: {
+            "8080/tcp": [{"HostIp": "127.0.0.1", "HostPort": "58080"}]
+        },
+        deployer.CONTAINERS["web-blue"]: {
+            "8080/tcp": [{"HostIp": "127.0.0.1", "HostPort": "58081"}]
+        },
+    }
+
+    def runner(argv, **_kwargs):
+        if argv[:3] == ["docker", "ps", "--no-trunc"]:
+            return subprocess.CompletedProcess(
+                argv, 0, "\n".join(owners) + "\n", ""
+            )
+        if argv[:3] == ["docker", "inspect", "--format"]:
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps(owners[argv[-1]]), ""
+            )
+        if argv[:3] == ["ss", "-H", "-lnt"]:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                "LISTEN 0 4096 127.0.0.1:58080 0.0.0.0:*\n"
+                "LISTEN 0 4096 127.0.0.1:58081 0.0.0.0:*\n",
+                "",
+            )
+        raise AssertionError(argv)
+
+    deployer.verify_exact_origin_bindings(
+        deployer.LEGACY_ORIGIN, deployer.CONTAINERS["web-blue"], {}, runner
+    )
+    source = DEPLOYER.read_text(encoding="utf-8")
+    assert source.count("verify_exact_origin_bindings(") >= 4
+
+    owners[deployer.CONTAINERS["web-blue"]]["8080/tcp"].append(
+        {"HostIp": "::", "HostPort": "58081"}
+    )
+    with pytest.raises(deployer.DeploymentError, match="staging origin"):
+        deployer.verify_exact_origin_bindings(
+            deployer.LEGACY_ORIGIN, deployer.CONTAINERS["web-blue"], {}, runner
+        )
+
+
+def test_inventory_preserves_duplicate_and_non_loopback_binding_evidence():
+    inventory = _load_inventory()
+    ownership = inventory.loopback_origin_ownership(
+        [
+            {
+                "Names": "edfinder-v3-proxy",
+                "State": "running",
+                "PortsDetail": [
+                    {
+                        "bind_address": "127.0.0.1", "host_port": 58080,
+                        "container_port": 8080, "protocol": "tcp",
+                    },
+                    {
+                        "bind_address": "127.0.0.1", "host_port": 58080,
+                        "container_port": 8080, "protocol": "tcp",
+                    },
+                    {
+                        "bind_address": "::", "host_port": 58081,
+                        "container_port": 8080, "protocol": "tcp",
+                    },
+                ],
+            }
+        ],
+        inspection_succeeded=True,
+    )
+    assert len(ownership["ports"]["58080"]["bindings"]) == 2
+    assert ownership["ports"]["58080"]["exact_loopback_only"] is False
+    assert ownership["ports"]["58081"]["bindings"][0]["bind_address"] == "::"
+    assert ownership["ports"]["58081"]["exact_loopback_only"] is False
+    assert ownership["exact_loopback_only"] is False
+
+
+def _cancellation_promote_setup(monkeypatch, tmp_path, deployer):
+    runtime = tmp_path / "runtime"
+    runtime.mkdir(mode=0o700)
+    receipt_dir = tmp_path / "receipts"
+    receipt_dir.mkdir(mode=0o700)
+    api_env = tmp_path / "api.env"
+    api_env.write_text("DATABASE_URL=postgresql://edfinder:x@db/edfinder\n", encoding="utf-8")
+    api_env.chmod(0o600)
+    schema_path = tmp_path / "schema.json"
+    schema_path.write_text("{}", encoding="utf-8")
+    schema_path.chmod(0o600)
+    token = tmp_path / "token"
+    token.write_text("ephemeral", encoding="utf-8")
+    token.chmod(0o600)
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    candidate_path = tmp_path / "candidate.json"
+    checksum_path = tmp_path / "candidate.json.sha256"
+    candidate_path.write_text("{}", encoding="utf-8")
+    checksum_path.write_text("unused", encoding="utf-8")
+
+    database_identity = {
+        "container": deployer.POSTGRES_CONTAINER,
+        "database_name": "edfinder",
+        "database_user": "edfinder",
+        "application_host": deployer.POSTGRES_CONTAINER,
+        "server_address": "local",
+        "server_port": 5432,
+    }
+    schema = {
+        "database_identity": database_identity,
+        "migration_set_identity": "sha256:" + "c" * 64,
+    }
+    candidate = {
+        "git_sha": "a" * 40,
+        "images": {
+            "backend": "ghcr.io/example/backend@sha256:" + "b" * 64,
+            "web": "ghcr.io/example/web@sha256:" + "d" * 64,
+        },
+    }
+    authority = {
+        "target": {
+            "production": True,
+            "hostname": deployer.EXPECTED_HOST,
+            "fqdn": deployer.EXPECTED_FQDN,
+        },
+        "external_authority": {
+            "api_env_file": str(api_env),
+            "api_env_owner_uid": os.geteuid(),
+            "api_env_mode": "0600",
+            "receipt_directory": str(receipt_dir),
+            "receipt_owner_uid": os.geteuid(),
+            "receipt_mode": "0700",
+            "schema_identity_file": str(schema_path),
+            "schema_identity_owner_uid": os.geteuid(),
+            "schema_identity_mode": "0600",
+            "schema_identity_sha256": "e" * 64,
+            "docker_context": "default",
+            "application_network": "production-app",
+            "staging_origin_bind": "127.0.0.1:58081",
+            "active_origin_bind": "127.0.0.1:58080",
+            "public_origin": "https://ed-finder.app",
+        },
+        "preservation_contract": {"exact_containers": []},
+    }
+    args = SimpleNamespace(
+        operation="promote",
+        mode="bootstrap",
+        compose=compose,
+        candidate=candidate_path,
+        candidate_checksum=checksum_path,
+        candidate_run_id="12345",
+        registry_token_file=token,
+        registry_username="operator",
+        runtime_directory=runtime,
+    )
+    snapshot = runtime / ".snapshot"
+
+    monkeypatch.setattr(deployer, "exact_host_guard", lambda _runner: None)
+    monkeypatch.setattr(deployer, "secure_path", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(deployer, "docker_context_guard", lambda *_args: None)
+    monkeypatch.setattr(deployer, "validate_compose", lambda *_args: None)
+    monkeypatch.setattr(deployer, "validate_schema_file", lambda *_args: schema)
+    monkeypatch.setattr(deployer, "validate_network", lambda *_args: None)
+    monkeypatch.setattr(deployer, "live_capacity_guard", lambda: {"logical_cpus": 16})
+    monkeypatch.setattr(deployer, "database_identity_from_env", lambda _path: database_identity)
+    monkeypatch.setattr(
+        deployer, "validate_candidate",
+        lambda *_args: (candidate, "f" * 64, b'{}'),
+    )
+    monkeypatch.setattr(deployer, "container_snapshot", lambda *_args: {})
+    monkeypatch.setattr(
+        deployer, "all_container_snapshot",
+        lambda *_args: {
+            deployer.LEGACY_API: "1" * 64 + ":running",
+            deployer.LEGACY_ORIGIN: "2" * 64 + ":running",
+        },
+    )
+    monkeypatch.setattr(deployer, "verify_origin_ownership", lambda *_args: None)
+    monkeypatch.setattr(deployer, "verify_exact_origin_bindings", lambda *_args: None)
+    monkeypatch.setattr(deployer, "verify_edge_routes_to_active_origin", lambda: None)
+    monkeypatch.setattr(deployer, "verify_unrelated_snapshot", lambda *_args: None)
+    monkeypatch.setattr(deployer, "verify_snapshot", lambda *_args: None)
+    monkeypatch.setattr(deployer, "verify_env_unchanged", lambda *_args: None)
+    monkeypatch.setattr(deployer, "verify_image", lambda *_args: None)
+    monkeypatch.setattr(deployer, "wait_ready", lambda *_args: None)
+    monkeypatch.setattr(deployer, "smoke", lambda *_args: {})
+
+    def freeze_env(*_args):
+        snapshot.write_text("frozen", encoding="utf-8")
+        snapshot.chmod(0o600)
+        return snapshot, (0, 0, 0, 0, 0, "digest")
+
+    monkeypatch.setattr(deployer, "freeze_env", freeze_env)
+    return args, authority, receipt_dir, snapshot
+
+
+def _assert_durable_failure_receipt(receipt_dir: Path, receipt: dict) -> None:
+    basename = receipt["durable_failure_receipt"]
+    path = receipt_dir / basename
+    sidecar = Path(str(path) + ".sha256")
+    assert path.is_file()
+    fields = sidecar.read_text(encoding="utf-8").split()
+    assert fields == [hashlib.sha256(path.read_bytes()).hexdigest(), basename]
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["failures"] == receipt["failures"]
+    assert persisted["rollback"] == receipt["rollback"]
+    assert persisted["service_changes_performed"] == receipt[
+        "service_changes_performed"
+    ]
+
+
+def test_cancellation_before_mutation_writes_durable_failure_without_service_change(monkeypatch, tmp_path):
+    deployer = _load_deployer()
+    args, authority, receipt_dir, snapshot = _cancellation_promote_setup(
+        monkeypatch, tmp_path, deployer
+    )
+    commands = []
+
+    def runner(argv, **_kwargs):
+        commands.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    def cancel_before_mutation(*_args):
+        signal.raise_signal(signal.SIGTERM)
+
+    monkeypatch.setattr(deployer, "verify_live_schema", cancel_before_mutation)
+    with deployer.controlled_cancellation():
+        with pytest.raises(deployer.OperationFailed) as failed:
+            deployer.promote(args, authority, runner)
+
+    receipt = failed.value.receipt
+    assert receipt["failures"] == ["operation_cancelled:SIGTERM"]
+    assert receipt["rollback"] == {"attempted": False, "status": "not-required"}
+    assert receipt["service_changes_performed"] is False
+    assert not any("up" in command or "stop" in command for command in commands)
+    assert not snapshot.exists()
+    _assert_durable_failure_receipt(receipt_dir, receipt)
+
+
+def test_pre_mutation_gate_cancellation_is_persisted_by_main(monkeypatch, tmp_path, capsys):
+    deployer = _load_deployer()
+    receipt_dir = tmp_path / "receipts"
+    receipt_dir.mkdir(mode=0o700)
+    authority_path = tmp_path / "authority.json"
+    authority_path.write_text(
+        json.dumps(
+            {
+                "target": {
+                    "production": True,
+                    "hostname": deployer.EXPECTED_HOST,
+                    "fqdn": deployer.EXPECTED_FQDN,
+                },
+                "external_authority": {
+                    "receipt_directory": str(receipt_dir),
+                    "receipt_owner_uid": os.geteuid(),
+                    "receipt_mode": "0700",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(deployer, "validate_authority", lambda _authority: [])
+    def cancel_in_verified_pre_mutation_gate(*_args):
+        deployer._PREMUTATION_FAILURE_RECEIPT_DIR = receipt_dir
+        raise deployer.OperationCancelled(signal.SIGTERM)
+
+    monkeypatch.setattr(deployer, "promote", cancel_in_verified_pre_mutation_gate)
+
+    status = deployer._main(
+        [
+            "--authority", str(authority_path),
+            "--operation", "promote",
+            "--candidate", str(tmp_path / "candidate.json"),
+            "--candidate-checksum", str(tmp_path / "candidate.sha256"),
+            "--candidate-run-id", "12345",
+        ]
+    )
+    assert status == 78
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["failures"] == ["operation_cancelled:SIGTERM"]
+    assert receipt["rollback"] == {"attempted": False, "status": "not-required"}
+    _assert_durable_failure_receipt(receipt_dir, receipt)
+
+
+def test_cancellation_after_cutover_rolls_back_and_writes_durable_failure(monkeypatch, tmp_path):
+    deployer = _load_deployer()
+    args, authority, receipt_dir, snapshot = _cancellation_promote_setup(
+        monkeypatch, tmp_path, deployer
+    )
+    commands = []
+    route_restored = []
+    monkeypatch.setattr(deployer, "verify_live_schema", lambda *_args: None)
+    monkeypatch.setattr(
+        deployer, "wait_for_preserved_edge_route", lambda: route_restored.append(True)
+    )
+
+    def runner(argv, **_kwargs):
+        commands.append(argv)
+        if (
+            "up" in argv
+            and argv[-1] == "web-blue"
+            and argv[-2] == "never"
+        ):
+            signal.raise_signal(signal.SIGTERM)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    with deployer.controlled_cancellation():
+        with pytest.raises(deployer.OperationFailed) as failed:
+            deployer.promote(args, authority, runner)
+
+    receipt = failed.value.receipt
+    assert receipt["failures"] == ["operation_cancelled:SIGTERM"]
+    assert receipt["rollback"] == {
+        "attempted": True,
+        "status": "verified",
+        "kind": "first-cutover-abort-to-preserved-origin",
+        "accepted_release_rollback": False,
+    }
+    assert ["docker", "start", deployer.LEGACY_API] in commands
+    assert ["docker", "start", deployer.LEGACY_ORIGIN] in commands
+    assert any("rm" in command and "web-blue" in command for command in commands)
+    assert route_restored == [True]
+    assert not snapshot.exists()
+    _assert_durable_failure_receipt(receipt_dir, receipt)
+
+
+def test_controlled_cancellation_terminates_and_reaps_active_bounded_child(tmp_path):
+    child_pid_file = tmp_path / "child.pid"
+    helper = textwrap.dedent(
+        """
+        import signal
+        import sys
+        from scripts.operator import v3_production_deploy as deployer
+
+        deployer.PROCESS_TERMINATION_GRACE = 0.1
+        child_code = (
+            "import os,signal,sys,time;"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN);"
+            "open(sys.argv[1], 'w').write(str(os.getpid()));"
+            "time.sleep(60)"
+        )
+        try:
+            with deployer.controlled_cancellation():
+                deployer.run_command([sys.executable, "-c", child_code, sys.argv[1]])
+        except deployer.OperationCancelled:
+            raise SystemExit(78)
+        """
+    )
+    process = subprocess.Popen(
+        [sys.executable, "-c", helper, str(child_pid_file)],
+        cwd=ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5
+    while not child_pid_file.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert child_pid_file.exists()
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    process.send_signal(signal.SIGTERM)
+    stdout, stderr = process.communicate(timeout=5)
+    assert process.returncode == 78, (stdout, stderr)
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -28,6 +28,14 @@ def _load_deployer():
     return module
 
 
+def _load_inventory():
+    spec = importlib.util.spec_from_file_location("v3_production_inventory", INVENTORY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def _workflow() -> dict:
     return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
 
@@ -46,6 +54,11 @@ def test_production_authority_is_separate_exact_and_currently_fail_closed():
     }
     assert value["status"] == "stopped"
     assert set(module.validate_authority(value)) == set(value["blockers"])
+    assert {
+        "production_local_docker_context_authority_missing",
+        "production_promotion_cpython314_runtime_unproved",
+        "production_edge_loopback_cutover_topology_authority_missing",
+    }.issubset(value["blockers"])
     assert value["application_contract"]["compose_project"] == "edfinder-v3-production"
     assert "checkpoint" not in value["application_contract"]["compose_project"]
     assert value["application_contract"]["compose_sha256"] == hashlib.sha256(COMPOSE.read_bytes()).hexdigest()
@@ -86,9 +99,35 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
     assert "ORDER BY filename" in source
     assert '"container_environment_read": False' in source
     assert '"filesystem_writes_performed": False' in source
+    for required_inventory_fact in (
+        'receipt["host_runtime"]',
+        '"inventory_python"',
+        '"python3_14"',
+        '"command": "python3"',
+        '"command": "python3.14"',
+        '"executable"',
+        '"implementation"',
+        '"version"',
+        '"version_info"',
+        '"is_exact_cpython_3_14"',
+        'receipt["docker_context"]',
+        '"docker_endpoint"',
+        '"loopback_origin_port_ownership"',
+        '"docker_ps_ports"',
+        '"58080"',
+        '"58081"',
+        '"bindings"',
+        '"owners"',
+    ):
+        assert required_inventory_fact in source
+    assert '"docker", "context", "inspect", "default"' in source
     assert "command -v python3.14" not in action
     assert "command -v python3" in action
-    for forbidden in (".Config.Env", "docker restart", "docker stop", "docker start", "compose up", "INSERT INTO", "UPDATE ", "DELETE FROM", "TRUNCATE", "ALTER TABLE", "DROP TABLE"):
+    for forbidden in (
+        ".Config.Env", ".docker/config", "docker context export", "docker restart",
+        "docker stop", "docker start", "compose up", "INSERT INTO", "UPDATE ",
+        "DELETE FROM", "TRUNCATE", "ALTER TABLE", "DROP TABLE",
+    ):
         assert forbidden not in source
 
 
@@ -221,6 +260,13 @@ def test_runbook_states_no_execution_boundary_and_concrete_first_run_blockers():
     assert "root `docker-compose.yml`" in source
     assert "Contabo checkpoint" in source
     assert "production_migration_authority_absent_or_schema_incompatible" in source
+    assert "production_promotion_cpython314_runtime_unproved" in source
+    assert "production_local_docker_context_authority_missing" in source
+    assert "default `python3` used to run inventory" in source
+    assert "exactly CPython 3.14" in source
+    assert "Docker context `default`" in source
+    assert "loopback ports `58080` and `58081`" in source
+    assert "fills a blocker" in source
     assert "stale `edfinder-v3-api:phase4c-r5`" in source
     assert "Redis and NATS are not removed or replaced" in source
 
@@ -232,12 +278,7 @@ def test_new_shell_launchers_parse():
 
 
 def test_inventory_ledger_parser_rejects_extra_or_malformed_output():
-    spec = importlib.util.spec_from_file_location(
-        "v3_production_inventory_for_parser_test", INVENTORY
-    )
-    assert spec and spec.loader
-    inventory = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(inventory)
+    inventory = _load_inventory()
     good = json.dumps(
         {
             "database_name": "edfinder",
@@ -268,3 +309,186 @@ def test_inventory_ledger_parser_rejects_extra_or_malformed_output():
             subprocess.CompletedProcess(["psql"], 0, hostile, "")
         )
         assert result["inspection_succeeded"] is False
+
+
+def test_inventory_runtime_facts_are_bounded_and_exact(monkeypatch):
+    inventory = _load_inventory()
+
+    current = inventory.inventory_runtime()
+    assert current["command"] == "python3"
+    assert current["used_for_inventory"] is True
+    assert current["inspection_succeeded"] is True
+    assert current["executable"].startswith("/")
+    assert len(current["executable"]) <= 256
+    assert len(current["implementation"]) <= inventory.MAX_RUNTIME_VERSION
+    assert len(current["version"]) <= inventory.MAX_RUNTIME_VERSION
+    assert len(current["version_info"]) == 3
+    assert isinstance(current["is_exact_cpython_3_14"], bool)
+
+    monkeypatch.setattr(inventory.shutil, "which", lambda *_args, **_kwargs: None)
+    unavailable = inventory.inspect_python314_runtime()
+    assert unavailable["exists"] is False
+    assert unavailable["inspection_succeeded"] is True
+    assert unavailable["command"] == "python3.14"
+    assert unavailable["executable"] is None
+    assert unavailable["is_exact_cpython_3_14"] is False
+    assert unavailable["version"] is None
+
+    monkeypatch.setattr(
+        inventory.shutil,
+        "which",
+        lambda *_args, **_kwargs: "/usr/bin/python3.14",
+    )
+    monkeypatch.setattr(
+        inventory,
+        "run",
+        lambda _argv: subprocess.CompletedProcess(
+            _argv,
+            0,
+            '{"implementation":"CPython","version":"3.14.1",'
+            '"version_info":[3,14,1]}\n',
+            "",
+        ),
+    )
+    exact = inventory.inspect_python314_runtime()
+    assert exact["inspection_succeeded"] is True
+    assert exact["exists"] is True
+    assert exact["executable"] == "/usr/bin/python3.14"
+    assert exact["implementation"] == "CPython"
+    assert exact["version"] == "3.14.1"
+    assert exact["version_info"] == [3, 14, 1]
+    assert exact["is_exact_cpython_3_14"] is True
+
+    monkeypatch.setattr(
+        inventory,
+        "run",
+        lambda _argv: subprocess.CompletedProcess(
+            _argv,
+            0,
+            '{"implementation":"PyPy","version":"3.14.1",'
+            '"version_info":[3,14,1]}\n',
+            "",
+        ),
+    )
+    wrong_implementation = inventory.inspect_python314_runtime()
+    assert wrong_implementation["inspection_succeeded"] is True
+    assert wrong_implementation["exists"] is True
+    assert wrong_implementation["is_exact_cpython_3_14"] is False
+
+    monkeypatch.setattr(
+        inventory,
+        "run",
+        lambda _argv: subprocess.CompletedProcess(
+            _argv,
+            0,
+            '{"implementation":"CPython","version":"3.13.9",'
+            '"version_info":[3,13,9]}\n',
+            "",
+        ),
+    )
+    wrong_version = inventory.inspect_python314_runtime()
+    assert wrong_version["inspection_succeeded"] is True
+    assert wrong_version["exists"] is True
+    assert wrong_version["is_exact_cpython_3_14"] is False
+
+    monkeypatch.setattr(
+        inventory,
+        "run",
+        lambda _argv: subprocess.CompletedProcess(_argv, 0, "not-json\n", ""),
+    )
+    malformed = inventory.inspect_python314_runtime()
+    assert malformed["inspection_succeeded"] is False
+    assert malformed["exists"] is True
+    assert malformed["implementation"] is None
+    assert malformed["version"] is None
+
+
+def test_inventory_reports_only_default_docker_endpoint_and_loopback_owners(monkeypatch):
+    inventory = _load_inventory()
+    observed_argv: list[str] = []
+
+    def context_run(argv):
+        observed_argv.extend(argv)
+        return subprocess.CompletedProcess(
+            argv, 0, '"default"\t"unix:///var/run/docker.sock"\n', ""
+        )
+
+    monkeypatch.setattr(inventory, "run", context_run)
+    assert inventory.inspect_default_docker_context() == {
+        "inspection_succeeded": True,
+        "name": "default",
+        "docker_endpoint": "unix:///var/run/docker.sock",
+    }
+    assert observed_argv == [
+        "docker", "context", "inspect", "default", "--format",
+        "{{json .Name}}\t{{json .Endpoints.docker.Host}}",
+    ]
+
+    monkeypatch.setattr(
+        inventory,
+        "run",
+        lambda argv: subprocess.CompletedProcess(
+            argv, 0, '"default"\t"tcp://127.0.0.1:2375"\n', ""
+        ),
+    )
+    assert inventory.inspect_default_docker_context() == {
+        "inspection_succeeded": True,
+        "name": "default",
+        "docker_endpoint": "tcp://127.0.0.1:2375",
+    }
+
+    for unsafe_endpoint in (
+        "ssh://user:password@example.invalid/run/docker.sock",
+        "tcp://token@example.invalid:2375",
+    ):
+        monkeypatch.setattr(
+            inventory,
+            "run",
+            lambda argv, endpoint=unsafe_endpoint: subprocess.CompletedProcess(
+                argv, 0, json.dumps("default") + "\t" + json.dumps(endpoint) + "\n", ""
+            ),
+        )
+        rejected = inventory.inspect_default_docker_context()
+        assert rejected == {
+            "inspection_succeeded": False,
+            "name": None,
+            "docker_endpoint": None,
+        }
+
+    ownership = inventory.loopback_origin_ownership(
+        [
+            {
+                "Names": "edfinder-v3-proxy",
+                "State": "running",
+                "Ports": "127.0.0.1:58080->80/tcp, 0.0.0.0:58081->81/tcp",
+            },
+            {
+                "Names": "candidate-web",
+                "State": "running",
+                "Ports": "127.0.0.1:58081->3000/tcp",
+            },
+            {
+                "Names": "stopped-web",
+                "State": "exited",
+                "Ports": "127.0.0.1:58081->3000/tcp",
+            },
+        ],
+        inspection_succeeded=True,
+    )
+    assert ownership["inspection_succeeded"] is True
+    assert ownership["ports"]["58080"]["owners"] == ["edfinder-v3-proxy"]
+    assert ownership["ports"]["58080"]["bindings"] == [
+        {"container": "edfinder-v3-proxy", "container_port": 80, "protocol": "tcp"}
+    ]
+    assert ownership["ports"]["58081"]["owners"] == ["candidate-web"]
+    assert ownership["ports"]["58081"]["bindings"] == [
+        {"container": "candidate-web", "container_port": 3000, "protocol": "tcp"}
+    ]
+
+    incomplete = inventory.loopback_origin_ownership(
+        [{"Names": "malformed", "State": "running", "Ports": ["not-a-string"]}],
+        inspection_succeeded=False,
+    )
+    assert incomplete["inspection_succeeded"] is False
+    assert incomplete["ports"]["58080"]["owners"] == []
+    assert incomplete["ports"]["58081"]["owners"] == []

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -129,7 +129,8 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
         '"owners"',
     ):
         assert required_inventory_fact in source
-    assert '"docker", "context", "inspect", "default"' in source
+    assert 'return ["docker", "--context", DOCKER_CONTEXT, *arguments]' in source
+    assert source.count('"docker"') == 1
     assert "command -v python3.14" not in action
     assert "command -v python3" in action
     for forbidden in (
@@ -220,6 +221,110 @@ def test_rollback_comes_only_from_checksum_bound_prior_accepted_release():
     assert "rollback-manifest" not in workflow
 
 
+def _accepted_receipt(deployer, source_sha: str, run_id: str, manifest: bytes) -> dict:
+    return {
+        "schema_version": deployer.RECEIPT_SCHEMA,
+        "operation": "production-promotion",
+        "status": "accepted",
+        "source_sha": source_sha,
+        "release_run_id": run_id,
+        "manifest_sha256": hashlib.sha256(manifest).hexdigest(),
+    }
+
+
+@pytest.mark.parametrize("prior_exists", [True, False])
+def test_post_replace_persistence_failure_restores_prior_pointer_or_absence(
+    monkeypatch, tmp_path, prior_exists
+):
+    deployer = _load_deployer()
+    prior_manifest = b'{"git_sha":"' + b"a" * 40 + b'"}\n'
+    prior_receipt = _accepted_receipt(deployer, "a" * 40, "111", prior_manifest)
+    if prior_exists:
+        deployer.persist_accepted(tmp_path, prior_receipt, prior_manifest)
+        prior_pointer_bytes = (tmp_path / "current.json").read_bytes()
+        prior_pointer = json.loads(prior_pointer_bytes)
+    else:
+        prior_pointer_bytes = None
+        prior_pointer = None
+
+    candidate_manifest = b'{"git_sha":"' + b"b" * 40 + b'"}\n'
+    candidate_receipt = _accepted_receipt(
+        deployer, "b" * 40, "222", candidate_manifest
+    )
+    candidate_stem = f"{'b' * 40}-222-{hashlib.sha256(candidate_manifest).hexdigest()}"
+    original_fsync = deployer.os.fsync
+    directory_fsyncs = 0
+
+    def fail_after_pointer_replace(descriptor):
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs == 2:
+                raise OSError("injected post-replace fsync failure")
+        return original_fsync(descriptor)
+
+    monkeypatch.setattr(deployer.os, "fsync", fail_after_pointer_replace)
+    with pytest.raises(OSError, match="post-replace"):
+        deployer.persist_accepted(tmp_path, candidate_receipt, candidate_manifest)
+
+    if prior_exists:
+        assert (tmp_path / "current.json").read_bytes() == prior_pointer_bytes
+        assert prior_pointer is not None
+        for key in ("receipt_file", "manifest_file"):
+            path = tmp_path / prior_pointer[key]
+            assert path.is_file()
+            assert Path(str(path) + ".sha256").is_file()
+    else:
+        assert not (tmp_path / "current.json").exists()
+    for suffix in (".json", ".release.json", ".json.sha256", ".release.json.sha256"):
+        assert not (tmp_path / f"{candidate_stem}{suffix}").exists()
+
+
+def test_pointer_restore_failure_retains_candidate_targets(monkeypatch, tmp_path):
+    deployer = _load_deployer()
+    prior_manifest = b'{"git_sha":"' + b"a" * 40 + b'"}\n'
+    deployer.persist_accepted(
+        tmp_path,
+        _accepted_receipt(deployer, "a" * 40, "111", prior_manifest),
+        prior_manifest,
+    )
+    candidate_manifest = b'{"git_sha":"' + b"b" * 40 + b'"}\n'
+    candidate_receipt = _accepted_receipt(
+        deployer, "b" * 40, "222", candidate_manifest
+    )
+    original_fsync = deployer.os.fsync
+    original_replace = deployer.os.replace
+    directory_fsyncs = 0
+    current_replacements = 0
+
+    def fail_after_pointer_replace(descriptor):
+        nonlocal directory_fsyncs
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            directory_fsyncs += 1
+            if directory_fsyncs == 2:
+                raise OSError("injected post-replace fsync failure")
+        return original_fsync(descriptor)
+
+    def fail_pointer_restore(source, destination):
+        nonlocal current_replacements
+        if Path(destination) == tmp_path / "current.json":
+            current_replacements += 1
+            if current_replacements == 2:
+                raise OSError("injected pointer restore failure")
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(deployer.os, "fsync", fail_after_pointer_replace)
+    monkeypatch.setattr(deployer.os, "replace", fail_pointer_restore)
+    with pytest.raises(deployer.DeploymentError, match="candidate artifacts retained"):
+        deployer.persist_accepted(tmp_path, candidate_receipt, candidate_manifest)
+
+    current = json.loads((tmp_path / "current.json").read_text(encoding="utf-8"))
+    for key in ("receipt_file", "manifest_file"):
+        path = tmp_path / current[key]
+        assert path.is_file()
+        assert Path(str(path) + ".sha256").is_file()
+
+
 def test_workflow_is_manual_main_only_protected_and_uses_pinned_ssh_trust():
     workflow = _workflow()
     source = WORKFLOW.read_text(encoding="utf-8")
@@ -280,6 +385,10 @@ def test_runbook_states_no_execution_boundary_and_concrete_first_run_blockers():
     assert "default `python3` used to run inventory" in source
     assert "exactly CPython 3.14" in source
     assert "Docker context `default`" in source
+    assert "`unix:///var/run/docker.sock`" in source
+    assert "ephemeral-operation-bundle-only" in source
+    assert "application- and data-read-only" in source
+    assert "atomically restore the prior pointer" in source
     assert "loopback ports `58080` and `58081`" in source
     assert "fills a blocker" in source
     assert "stale `edfinder-v3-api:phase4c-r5`" in source
@@ -435,7 +544,7 @@ def test_inventory_reports_only_default_docker_endpoint_and_loopback_owners(monk
         "docker_endpoint": "unix:///var/run/docker.sock",
     }
     assert observed_argv == [
-        "docker", "context", "inspect", "default", "--format",
+        "docker", "--context", "default", "context", "inspect", "default", "--format",
         "{{json .Name}}\t{{json .Endpoints.docker.Host}}",
     ]
 
@@ -447,14 +556,15 @@ def test_inventory_reports_only_default_docker_endpoint_and_loopback_owners(monk
         ),
     )
     assert inventory.inspect_default_docker_context() == {
-        "inspection_succeeded": True,
-        "name": "default",
-        "docker_endpoint": "tcp://127.0.0.1:2375",
+        "inspection_succeeded": False,
+        "name": None,
+        "docker_endpoint": None,
     }
 
     for unsafe_endpoint in (
         "ssh://user:password@example.invalid/run/docker.sock",
         "tcp://token@example.invalid:2375",
+        "unix:///tmp/docker.sock",
     ):
         monkeypatch.setattr(
             inventory,
@@ -538,6 +648,44 @@ def test_inventory_reports_only_default_docker_endpoint_and_loopback_owners(monk
     assert incomplete["ports"]["58081"]["owners"] == []
 
 
+def test_inventory_stops_before_daemon_evidence_when_default_context_is_not_local(
+    monkeypatch, capsys
+):
+    inventory = _load_inventory()
+    docker_commands = []
+
+    monkeypatch.setattr(inventory.socket, "gethostname", lambda: inventory.EXPECTED_HOST)
+    monkeypatch.setattr(
+        inventory, "inventory_runtime", lambda: {"inspection_succeeded": True}
+    )
+    monkeypatch.setattr(
+        inventory, "inspect_python314_runtime", lambda: {"inspection_succeeded": True}
+    )
+    monkeypatch.setattr(inventory, "host_capacity", lambda: {})
+
+    def context_only(argv, **_kwargs):
+        if argv == ["hostname", "-f"]:
+            return subprocess.CompletedProcess(
+                argv, 0, inventory.EXPECTED_FQDN + "\n", ""
+            )
+        if argv[:3] == ["docker", "--context", "default"]:
+            docker_commands.append(argv)
+            if argv[3:6] != ["context", "inspect", "default"]:
+                raise AssertionError(f"daemon evidence escaped failed context gate: {argv}")
+            return subprocess.CompletedProcess(
+                argv, 0, '"default"\t"tcp://127.0.0.1:2375"\n', ""
+            )
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(inventory, "run", context_only)
+    assert inventory.main() == 78
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["failures"] == ["default_docker_context_inventory_failed"]
+    assert receipt["direct_db_access_performed"] is False
+    assert len(docker_commands) == 1
+    assert docker_commands[0][:3] == ["docker", "--context", "default"]
+
+
 def test_protected_job_refetches_main_before_credentials_and_maps_fallback_receipts():
     workflow = _workflow()
     steps = workflow["jobs"]["production-operation"]["steps"]
@@ -557,6 +705,12 @@ def test_protected_job_refetches_main_before_credentials_and_maps_fallback_recei
     assert "promote) receipt_operation=production-promotion" in execute
     assert 'os.environ["RECEIPT_OPERATION"]' in execute
     assert '"operation": "production-promotion"' not in execute
+    assert 'preflight = operation == "production-preflight"' in execute
+    assert '"database_writes_performed": False if preflight else None' in execute
+    assert '"service_changes_performed": False if preflight else None' in execute
+    assert '"filesystem_writes_performed": None' in execute
+    assert '"filesystem_writes_may_have_been_performed": True' in execute
+    assert '"env_files_read": None, "env_files_may_have_been_read": True' in execute
 
 
 def test_bundle_and_remote_runtime_roots_remain_private_after_archive_extraction(tmp_path):
@@ -658,6 +812,17 @@ def test_launcher_runtime_failures_use_only_validated_operation_names(tmp_path):
     assert unsupported_receipt["failures"] == [
         "python3_unsupported_for_production_readonly"
     ]
+    assert unsupported_receipt["filesystem_writes_performed"] is True
+    assert unsupported_receipt["filesystem_write_scope"] == (
+        "ephemeral-operation-bundle-only"
+    )
+    for field in (
+        "database_writes_performed", "migrations_performed",
+        "application_data_writes_performed", "image_pulls_performed",
+        "service_changes_performed", "edge_recreated",
+        "protected_resources_changed",
+    ):
+        assert unsupported_receipt[field] is False
 
     mutation = subprocess.run(
         ["bash", str(PROMOTE_ACTION), "--operation", "promote"],
@@ -672,6 +837,7 @@ def test_launcher_runtime_failures_use_only_validated_operation_names(tmp_path):
     assert mutation_receipt["failures"] == [
         "python314_required_for_production_mutation"
     ]
+    assert mutation_receipt["filesystem_writes_performed"] is True
 
     hostile = subprocess.run(
         ["bash", str(PROMOTE_ACTION), "--operation", 'promote\"bad'],
@@ -956,7 +1122,14 @@ def _cancellation_promote_setup(monkeypatch, tmp_path, deployer):
     monkeypatch.setattr(deployer, "validate_schema_file", lambda *_args: schema)
     monkeypatch.setattr(deployer, "validate_network", lambda *_args: None)
     monkeypatch.setattr(deployer, "live_capacity_guard", lambda: {"logical_cpus": 16})
-    monkeypatch.setattr(deployer, "database_identity_from_env", lambda _path: database_identity)
+    def database_identity_from_env(_path, *, on_read=None):
+        if on_read is not None:
+            on_read()
+        return database_identity
+
+    monkeypatch.setattr(
+        deployer, "database_identity_from_env", database_identity_from_env
+    )
     monkeypatch.setattr(
         deployer, "validate_candidate",
         lambda *_args: (candidate, "f" * 64, b'{}'),
@@ -1001,6 +1174,91 @@ def _assert_durable_failure_receipt(receipt_dir: Path, receipt: dict) -> None:
     assert persisted["service_changes_performed"] == receipt[
         "service_changes_performed"
     ]
+
+
+def test_preflight_reports_ephemeral_bundle_writes_without_application_mutation(
+    monkeypatch, tmp_path
+):
+    deployer = _load_deployer()
+    args, authority, _receipt_dir, _snapshot = _cancellation_promote_setup(
+        monkeypatch, tmp_path, deployer
+    )
+    args.operation = "preflight"
+    monkeypatch.setattr(deployer, "verify_live_schema", lambda *_args: None)
+
+    receipt = deployer.promote(
+        args,
+        authority,
+        lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0, "", ""),
+    )
+
+    assert receipt["status"] == "preflight-passed"
+    assert receipt["filesystem_writes_performed"] is True
+    assert receipt["filesystem_write_scope"] == "ephemeral-operation-bundle-only"
+    assert receipt["env_files_read"] is True
+    for field in (
+        "database_writes_performed", "migrations_performed",
+        "application_data_writes_performed", "image_pulls_performed",
+        "service_changes_performed", "edge_recreated",
+        "protected_resources_changed",
+    ):
+        assert receipt[field] is False
+
+
+@pytest.mark.parametrize(
+    ("failure_point", "message"),
+    [
+        ("validate_candidate", "candidate validation stopped"),
+        ("all_container_snapshot", "container validation stopped"),
+        ("verify_origin_ownership", "origin validation stopped"),
+    ],
+)
+def test_failures_after_api_env_read_preserve_audit_state(
+    monkeypatch, tmp_path, failure_point, message
+):
+    deployer = _load_deployer()
+    args, authority, _receipt_dir, _snapshot = _cancellation_promote_setup(
+        monkeypatch, tmp_path, deployer
+    )
+    args.operation = "preflight"
+
+    def stop(*_args, **_kwargs):
+        raise deployer.DeploymentError(message)
+
+    monkeypatch.setattr(deployer, failure_point, stop)
+    with pytest.raises(deployer.OperationFailed) as failed:
+        deployer.promote(
+            args,
+            authority,
+            lambda argv, **_kwargs: subprocess.CompletedProcess(argv, 0, "", ""),
+        )
+
+    receipt = failed.value.receipt
+    assert receipt["failures"] == [message]
+    assert receipt["env_files_read"] is True
+    assert receipt["env_contents_recorded"] is False
+    assert receipt["filesystem_writes_performed"] is True
+    assert "postgresql://" not in json.dumps(receipt)
+
+
+def test_env_audit_marker_changes_only_after_file_read_succeeds(tmp_path):
+    deployer = _load_deployer()
+    marker = []
+    env_file = tmp_path / "api.env"
+    env_file.write_text("not-a-database-url\n", encoding="utf-8")
+
+    with pytest.raises(deployer.DeploymentError, match="exactly one DATABASE_URL"):
+        deployer.database_identity_from_env(
+            env_file, on_read=lambda: marker.append("read")
+        )
+    assert marker == ["read"]
+
+    marker.clear()
+    with pytest.raises(deployer.DeploymentError, match="unable to read"):
+        deployer.database_identity_from_env(
+            tmp_path / "missing.env", on_read=lambda: marker.append("read")
+        )
+    assert marker == []
 
 
 def test_cancellation_before_mutation_writes_durable_failure_without_service_change(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Add the missing reviewed V3 production application promotion path for the existing single-host production environment at `ed-finder-prod` / `nb79a3d.mevnode.com`.

This PR deliberately does **not** deploy or mutate production. The committed production target authority remains `stopped`; the only intended first operation after merge is the new read-only inventory.

### What this adds

- explicit `deploy/v3-production/compose.yml` authority owning only blue/green API + web slots;
- exact production target/preservation authority, initially fail-closed with concrete blockers;
- manual-only protected production workflow with exact-current-`main`, literal target confirmation, immutable release provenance, pinned SSH trust, machine-readable receipts and production environment gates;
- read-only production inventory using the host's existing Python 3 rather than requiring Python 3.14 for status;
- fail-closed production preflight/promotion logic with exact host/FQDN/architecture, local Docker context, capacity, network, secret-file metadata, schema identity and live migration-ledger compatibility checks;
- digest/build-SHA verification, inactive-slot staging on loopback, smoke before cutover, preserved public edge, and checksum-bound application-only rollback;
- explicit preservation of PostgreSQL, Redis, NATS, Octopus and unrelated containers;
- tests and operator/runbook updates.

### Current production facts used

Read-only host-status run `34202433965` confirmed the production host and current transitional containers, including stale `edfinder-v3-api:phase4c-r5`, proxy/auth edge, retained PostgreSQL, Redis/NATS, and Octopus. No production writes or service changes were made.

### Important blockers intentionally retained

`deploy/v3-production/target-authority.json` remains `status: stopped` until a fresh sanitized inventory is reviewed and exact non-secret facts are committed for the application network, API env-file metadata, schema identity/live ledger compatibility, edge-to-loopback topology, receipt store, Docker context, production mutation runtime, and capacity.

No migration authority is invented here. If the live ledger is not exactly compatible with a reviewed schema identity, preflight stops with `production_migration_authority_absent_or_schema_incompatible`.

### Implementation provenance

Governed Codex implementation worker: `34202782475`

Initial exact head: `e4c51ce105a5b11e94adf02c95a9b592b44d90f6`

No production operation was triggered during implementation.