### PR TITLE
Add one-shot V3 production ledger diagnostic

### DIFF
--- a/.github/workflows/v3-production-ledger-diagnostic.yml
+++ b/.github/workflows/v3-production-ledger-diagnostic.yml
@@ -1,0 +1,214 @@
+name: V3 production ledger diagnostic
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/v3-production-ledger-diagnostic.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v3-production-ledger-diagnostic
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Inspect production migration ledger read-only
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 5
+    steps:
+      - name: Prepare pinned production SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" || { echo "Missing ED_NEW_OPERATOR_SSH_KEY" >&2; exit 1; }
+          test -n "$SSH_HOST" || { echo "Missing ED_NEW_OPERATOR_HOST" >&2; exit 1; }
+          test -n "$SSH_PORT" || { echo "Missing ED_NEW_OPERATOR_PORT" >&2; exit 1; }
+          test -n "$SSH_KNOWN_HOSTS" || { echo "Missing pinned ed-new known-hosts secret" >&2; exit 1; }
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          if [ "$SSH_PORT" = "22" ]; then
+            lookup="$SSH_HOST"
+          else
+            lookup="[$SSH_HOST]:$SSH_PORT"
+          fi
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null || {
+            echo "Pinned known-host trust does not cover configured production host" >&2
+            exit 1
+          }
+
+      - name: Probe exact production ledger read-only
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          output="$RUNNER_TEMP/v3-production-ledger-diagnostic.json"
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'python3 -' > "$output" <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import re
+          import socket
+          import subprocess
+
+          EXPECTED_HOST = "ed-finder-prod"
+          EXPECTED_FQDN = "nb79a3d.mevnode.com"
+          POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+          SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          LEDGER_SQL = r"""
+          BEGIN READ ONLY;
+          SET LOCAL statement_timeout = '10000ms';
+          SELECT json_build_object(
+            'database_name', current_database(),
+            'server_address', COALESCE(inet_server_addr()::text, 'local'),
+            'server_port', COALESCE(inet_server_port(), current_setting('port')::int),
+            'transaction_read_only', current_setting('transaction_read_only'),
+            'migrations', COALESCE((
+              SELECT json_agg(
+                json_build_object('filename', filename, 'checksum_sha256', checksum_sha256)
+                ORDER BY filename
+              ) FROM public.schema_migrations
+            ), '[]'::json)
+          )::text;
+          COMMIT;
+          """.strip()
+
+          diagnostic = {
+              "schema_version": "ed-finder/v3-production-ledger-diagnostic/v1",
+              "operation": "production-ledger-diagnostic",
+              "read_only": True,
+              "db_writes_performed": False,
+              "migrations_performed": False,
+              "service_changes_performed": False,
+          }
+          host = socket.gethostname().split(".")[0]
+          try:
+              fqdn = subprocess.run(
+                  ["hostname", "-f"], text=True, capture_output=True, timeout=5,
+                  check=False, env={"PATH": SAFE_PATH, "LANG": "C", "LC_ALL": "C"},
+              )
+          except (OSError, subprocess.TimeoutExpired) as exc:
+              diagnostic.update(status="stopped", stage="host_identity", error=type(exc).__name__)
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+          diagnostic["host"] = {"hostname": host, "fqdn": fqdn.stdout.strip()}
+          if host != EXPECTED_HOST or fqdn.returncode != 0 or fqdn.stdout.strip() != EXPECTED_FQDN:
+              diagnostic.update(status="stopped", stage="host_identity", error="unexpected_host_identity")
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+
+          argv = [
+              "docker", "--context", "default", "exec", POSTGRES_CONTAINER,
+              "psql", "-X", "--no-password", "--tuples-only", "--no-align", "--quiet",
+              "--field-separator", "\t", "--set", "ON_ERROR_STOP=1",
+              "--username", "edfinder", "--dbname", "edfinder", "--command", LEDGER_SQL,
+          ]
+          try:
+              result = subprocess.run(
+                  argv, text=True, capture_output=True, timeout=20, check=False,
+                  env={"PATH": SAFE_PATH, "LANG": "C", "LC_ALL": "C"},
+              )
+          except (OSError, subprocess.TimeoutExpired) as exc:
+              diagnostic.update(status="stopped", stage="psql_execution", error=type(exc).__name__)
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+
+          diagnostic["psql"] = {
+              "returncode": result.returncode,
+              "stdout_bytes": len(result.stdout.encode("utf-8")),
+              "stdout_line_count": len(result.stdout.splitlines()),
+              "stderr_bytes": len(result.stderr.encode("utf-8")),
+          }
+          if result.returncode != 0:
+              lines = [line.strip() for line in result.stderr.splitlines() if line.strip()]
+              tail = lines[-1] if lines else ""
+              tail = "".join(character for character in tail if character.isprintable())[:240]
+              diagnostic["psql"]["stderr_tail"] = tail or None
+              diagnostic.update(status="stopped", stage="psql_execution")
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+
+          try:
+              observed = json.loads(result.stdout.strip())
+          except json.JSONDecodeError as exc:
+              preview = result.stdout.strip().replace("\n", "\\n")[:240]
+              diagnostic["psql"].update(json_parse=False, stdout_preview=preview)
+              diagnostic.update(status="stopped", stage="json_parse", error=type(exc).__name__)
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+
+          diagnostic["psql"]["json_parse"] = True
+          diagnostic["observed_type"] = type(observed).__name__
+          if not isinstance(observed, dict):
+              diagnostic.update(status="stopped", stage="shape", error="top_level_not_object")
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+
+          diagnostic["keys"] = sorted(str(key) for key in observed)
+          diagnostic["database_name"] = observed.get("database_name")
+          diagnostic["transaction_read_only"] = observed.get("transaction_read_only")
+          entries = observed.get("migrations")
+          diagnostic["migrations_type"] = type(entries).__name__
+          if not isinstance(entries, list):
+              diagnostic.update(status="stopped", stage="migrations_shape", error="migrations_not_list")
+              print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+              raise SystemExit(0)
+
+          filenames = [item.get("filename") for item in entries if isinstance(item, dict)]
+          checksums = [item.get("checksum_sha256") for item in entries if isinstance(item, dict)]
+          diagnostic.update(
+              migration_count=len(entries),
+              first_filename=filenames[0] if filenames else None,
+              last_filename=filenames[-1] if filenames else None,
+              non_object_entries=sum(not isinstance(item, dict) for item in entries),
+              wrong_key_entries=sum(
+                  isinstance(item, dict) and set(item) != {"filename", "checksum_sha256"}
+                  for item in entries
+              ),
+              invalid_filename_entries=sum(
+                  not isinstance(name, str) or re.fullmatch(r"[0-9]{3}_[a-z0-9_]+\.sql", name) is None
+                  for name in filenames
+              ),
+              invalid_checksum_entries=sum(
+                  not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None
+                  for value in checksums
+              ),
+              duplicate_filename_entries=(len(filenames) - len(set(filenames))) if all(isinstance(name, str) for name in filenames) else None,
+              sorted_by_filename=(filenames == sorted(filenames)) if all(isinstance(name, str) for name in filenames) else None,
+          )
+          diagnostic["status"] = "success"
+          print(json.dumps(diagnostic, sort_keys=True, separators=(",", ":")))
+          PY
+          python3 -m json.tool "$output" >/dev/null
+
+      - name: Upload ledger diagnostic
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        with:
+          name: v3-production-ledger-diagnostic
+          path: ${{ runner.temp }}/v3-production-ledger-diagnostic.json
+          if-no-files-found: error
+          retention-days: 2


### PR DESCRIPTION
Temporary, read-only diagnostic only. Uses the existing ed-new-operator SSH credentials, validates the exact production host, reproduces the current production ledger query, and uploads only bounded structural/error facts. It performs no database writes, migrations, service changes, or application changes. The workflow triggers only when this diagnostic workflow file itself changes on main.