### PR TITLE
Fix ledger diagnostic action pin

### DIFF
--- a/.github/workflows/v3-production-ledger-diagnostic.yml
+++ b/.github/workflows/v3-production-ledger-diagnostic.yml
@@ -206,7 +206,7 @@ jobs:
           python3 -m json.tool "$output" >/dev/null
 
       - name: Upload ledger diagnostic
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0 # v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: v3-production-ledger-diagnostic
           path: ${{ runner.temp }}/v3-production-ledger-diagnostic.json


### PR DESCRIPTION
One-character fix only: use the full pinned SHA for actions/upload-artifact so the read-only ledger diagnostic can start. No production mutation, application change, or deployment authority change.