### PR TITLE
Identify live V3 API database target read-only

### DIFF
--- a/.github/workflows/v3-production-ledger-shape-diagnostic.yml
+++ b/.github/workflows/v3-production-ledger-shape-diagnostic.yml
@@ -29,7 +29,7 @@ jobs:
           lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
           ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
 
-      - name: Probe ledger shape read-only
+      - name: Identify live API DB target and ledger read-only
         shell: bash
         env:
           SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
@@ -39,35 +39,69 @@ jobs:
           set -euo pipefail
           ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
           import json, socket, subprocess
-          C="edfinder-v3-phase4c-full-20260827_r5-postgres"
+          from urllib.parse import urlsplit, unquote
+
+          PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
+          API="edfinder-v3-api"
           E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
+
           fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False).stdout.strip()
           assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
-          env=subprocess.run(["docker","--context","default","inspect",C,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True).stdout.splitlines()
-          vals={}
-          for line in env:
-              if line.startswith("POSTGRES_USER="): vals["user"]=line.split("=",1)[1]
-              if line.startswith("POSTGRES_DB="): vals["database"]=line.split("=",1)[1]
-          base=["docker","--context","default","exec",C,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",vals["user"],"--dbname",vals["database"],"--command"]
-          shape_sql="SELECT json_build_object('table',to_regclass('public.schema_migrations')::text,'columns',COALESCE((SELECT json_agg(column_name ORDER BY ordinal_position) FROM information_schema.columns WHERE table_schema='public' AND table_name='schema_migrations'),'[]'::json))::text;"
-          shape=subprocess.run(base+[shape_sql],text=True,capture_output=True,env=E,check=False)
-          result={"runtime_database_identity":vals,"shape_returncode":shape.returncode}
-          if shape.returncode==0:
-              try: result["shape"]=json.loads(shape.stdout.strip())
-              except Exception: result["shape_stdout_preview"]=shape.stdout.strip()[:300]
-          else:
-              result["shape_error"]=" | ".join(x.strip() for x in shape.stderr.splitlines() if x.strip())[:500]
-          if result.get("shape",{}).get("table"):
-              count=subprocess.run(base+["BEGIN READ ONLY; SELECT count(*) FROM public.schema_migrations; COMMIT;"],text=True,capture_output=True,env=E,check=False)
-              result["count_returncode"]=count.returncode
-              result["count_stdout"]=count.stdout.strip()[:100]
-              if count.returncode:
-                  result["count_error"]=" | ".join(x.strip() for x in count.stderr.splitlines() if x.strip())[:500]
-          exact="""BEGIN READ ONLY; SET LOCAL statement_timeout='10000ms'; SELECT json_build_object('database_name',current_database(),'server_address',COALESCE(inet_server_addr()::text,'local'),'server_port',COALESCE(inet_server_port(),current_setting('port')::int),'transaction_read_only',current_setting('transaction_read_only'),'migrations',COALESCE((SELECT json_agg(json_build_object('filename',filename,'checksum_sha256',checksum_sha256) ORDER BY filename) FROM public.schema_migrations),'[]'::json))::text; COMMIT;"""
-          p=subprocess.run(base+[exact],text=True,capture_output=True,env=E,check=False)
-          result["exact_returncode"]=p.returncode
-          result["exact_stdout_preview"]=p.stdout.strip().replace('\n','\\n')[:300]
-          if p.returncode:
-              result["exact_error"]=" | ".join(x.strip() for x in p.stderr.splitlines() if x.strip())[:700]
+
+          def inspect_env(container):
+              return subprocess.run(["docker","--context","default","inspect",container,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True).stdout.splitlines()
+
+          pg_env=inspect_env(PG)
+          pg={}
+          for line in pg_env:
+              if line.startswith("POSTGRES_USER="): pg["user"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="): pg["database"]=line.split("=",1)[1]
+
+          api_env=inspect_env(API)
+          target={"database_url_present":False}
+          for line in api_env:
+              if line.startswith("DATABASE_URL="):
+                  target["database_url_present"]=True
+                  parsed=urlsplit(line.split("=",1)[1])
+                  target.update({
+                      "scheme":parsed.scheme,
+                      "user":unquote(parsed.username) if parsed.username else None,
+                      "host":parsed.hostname,
+                      "port":parsed.port,
+                      "database":unquote(parsed.path.lstrip('/')) if parsed.path else None,
+                      "password_present":parsed.password is not None,
+                  })
+              elif line.startswith("POSTGRES_USER="):
+                  target["postgres_user_env"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="):
+                  target["postgres_db_env"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_HOST="):
+                  target["postgres_host_env"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_PORT="):
+                  target["postgres_port_env"]=line.split("=",1)[1]
+
+          base=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",pg["user"]]
+          dbs=subprocess.run(base+["--dbname",pg["database"],"--command","SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate ORDER BY datname;"],text=True,capture_output=True,env=E,check=False,timeout=10)
+          database_names=[line.strip() for line in dbs.stdout.splitlines() if line.strip()] if dbs.returncode==0 else []
+          ledger_locations=[]
+          for database in database_names:
+              probe=subprocess.run(base+["--dbname",database,"--command","SELECT COALESCE(to_regclass('public.schema_migrations')::text,'');"],text=True,capture_output=True,env=E,check=False,timeout=10)
+              if probe.returncode==0 and probe.stdout.strip():
+                  count=subprocess.run(base+["--dbname",database,"--command","BEGIN READ ONLY; SELECT count(*) FROM public.schema_migrations; COMMIT;"],text=True,capture_output=True,env=E,check=False,timeout=10)
+                  ledger_locations.append({"database":database,"table":probe.stdout.strip(),"count_returncode":count.returncode,"count_stdout":count.stdout.strip()[:120]})
+
+          result={
+              "postgres_container_identity":pg,
+              "api_database_target":target,
+              "database_list_returncode":dbs.returncode,
+              "database_names":database_names,
+              "ledger_locations":ledger_locations,
+              "read_only":True,
+              "db_writes_performed":False,
+              "migrations_performed":False,
+              "service_changes_performed":False,
+          }
+          if dbs.returncode:
+              result["database_list_error"]=" | ".join(x.strip() for x in dbs.stderr.splitlines() if x.strip())[:500]
           print(json.dumps(result,sort_keys=True,separators=(",",":")))
           PY


### PR DESCRIPTION
One-shot read-only diagnostic. Sanitizes the live API DATABASE_URL to user/host/port/database only and checks which databases in the existing Postgres cluster contain public.schema_migrations. Password content is never emitted. No DB writes, migrations, or service changes.