### PR TITLE
Probe live V3 migration markers read-only

### DIFF
--- a/.github/workflows/v3-production-ledger-shape-diagnostic.yml
+++ b/.github/workflows/v3-production-ledger-shape-diagnostic.yml
@@ -29,7 +29,7 @@ jobs:
           lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
           ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
 
-      - name: Identify live API DB target and ledger read-only
+      - name: Probe live migration markers read-only
         shell: bash
         env:
           SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
@@ -39,69 +39,162 @@ jobs:
           set -euo pipefail
           ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
           import json, socket, subprocess
-          from urllib.parse import urlsplit, unquote
 
           PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
           API="edfinder-v3-api"
           E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
-
-          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False).stdout.strip()
+          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False,timeout=5).stdout.strip()
           assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
 
           def inspect_env(container):
-              return subprocess.run(["docker","--context","default","inspect",container,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True).stdout.splitlines()
+              return subprocess.run(["docker","--context","default","inspect",container,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
 
-          pg_env=inspect_env(PG)
           pg={}
-          for line in pg_env:
+          for line in inspect_env(PG):
               if line.startswith("POSTGRES_USER="): pg["user"]=line.split("=",1)[1]
               elif line.startswith("POSTGRES_DB="): pg["database"]=line.split("=",1)[1]
+          assert pg.get("user") and pg.get("database")
 
-          api_env=inspect_env(API)
-          target={"database_url_present":False}
-          for line in api_env:
+          api={"database_url_present":False}
+          from urllib.parse import urlsplit, unquote
+          for line in inspect_env(API):
               if line.startswith("DATABASE_URL="):
-                  target["database_url_present"]=True
-                  parsed=urlsplit(line.split("=",1)[1])
-                  target.update({
-                      "scheme":parsed.scheme,
-                      "user":unquote(parsed.username) if parsed.username else None,
-                      "host":parsed.hostname,
-                      "port":parsed.port,
-                      "database":unquote(parsed.path.lstrip('/')) if parsed.path else None,
-                      "password_present":parsed.password is not None,
-                  })
-              elif line.startswith("POSTGRES_USER="):
-                  target["postgres_user_env"]=line.split("=",1)[1]
-              elif line.startswith("POSTGRES_DB="):
-                  target["postgres_db_env"]=line.split("=",1)[1]
-              elif line.startswith("POSTGRES_HOST="):
-                  target["postgres_host_env"]=line.split("=",1)[1]
-              elif line.startswith("POSTGRES_PORT="):
-                  target["postgres_port_env"]=line.split("=",1)[1]
+                  p=urlsplit(line.split("=",1)[1])
+                  api={"database_url_present":True,"user":unquote(p.username) if p.username else None,"host":p.hostname,"port":p.port,"database":unquote(p.path.lstrip('/')) if p.path else None,"password_present":p.password is not None}
+          assert api.get("database")==pg["database"] and api.get("user")==pg["user"]
 
-          base=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",pg["user"]]
-          dbs=subprocess.run(base+["--dbname",pg["database"],"--command","SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate ORDER BY datname;"],text=True,capture_output=True,env=E,check=False,timeout=10)
-          database_names=[line.strip() for line in dbs.stdout.splitlines() if line.strip()] if dbs.returncode==0 else []
-          ledger_locations=[]
-          for database in database_names:
-              probe=subprocess.run(base+["--dbname",database,"--command","SELECT COALESCE(to_regclass('public.schema_migrations')::text,'');"],text=True,capture_output=True,env=E,check=False,timeout=10)
-              if probe.returncode==0 and probe.stdout.strip():
-                  count=subprocess.run(base+["--dbname",database,"--command","BEGIN READ ONLY; SELECT count(*) FROM public.schema_migrations; COMMIT;"],text=True,capture_output=True,env=E,check=False,timeout=10)
-                  ledger_locations.append({"database":database,"table":probe.stdout.strip(),"count_returncode":count.returncode,"count_stdout":count.stdout.strip()[:120]})
-
-          result={
-              "postgres_container_identity":pg,
-              "api_database_target":target,
-              "database_list_returncode":dbs.returncode,
-              "database_names":database_names,
-              "ledger_locations":ledger_locations,
-              "read_only":True,
-              "db_writes_performed":False,
-              "migrations_performed":False,
-              "service_changes_performed":False,
-          }
-          if dbs.returncode:
-              result["database_list_error"]=" | ".join(x.strip() for x in dbs.stderr.splitlines() if x.strip())[:500]
+          sql=r"""
+          BEGIN READ ONLY;
+          SET LOCAL statement_timeout = '10000ms';
+          SELECT json_build_object(
+            '019_coords_nullable_and_no_defaults', (
+              SELECT count(*)=3 AND bool_and(is_nullable='YES' AND column_default IS NULL)
+              FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='systems' AND column_name IN ('x','y','z')
+            ),
+            '020_rating_version', EXISTS (
+              SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='ratings' AND column_name='rating_version'
+            ),
+            '021_station_body_links', to_regclass('public.station_body_links') IS NOT NULL,
+            '022_dirty_triggers', (
+              SELECT count(*)=4 FROM pg_trigger
+              WHERE NOT tgisinternal AND tgname IN ('trg_system_dirty','trg_body_dirty_insert','trg_body_dirty_update','trg_body_dirty_delete')
+            ),
+            '023_station_data_provenance', (
+              SELECT count(*)=9 FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='stations' AND column_name IN (
+                'distance_source','distance_confidence','distance_updated_at','station_type_source','station_type_confidence','station_type_updated_at','body_name_source','body_name_confidence','body_name_updated_at'
+              )
+            ),
+            '024_body_rings', to_regclass('public.body_rings') IS NOT NULL,
+            '025_ring_source_body_id', EXISTS (
+              SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='body_rings' AND column_name='source_body_id'
+            ),
+            '031_ring_identity_hardening', (
+              to_regclass('public.body_rings_eddn_identity_report') IS NOT NULL
+              AND EXISTS (SELECT 1 FROM pg_constraint WHERE conname='chk_body_rings_association_status' AND conrelid=to_regclass('public.body_rings'))
+            ),
+            '026_enrichment_staging', (
+              to_regclass('public.enrichment_source_runs') IS NOT NULL
+              AND to_regclass('public.enrichment_raw_records') IS NOT NULL
+              AND to_regclass('public.staging_edsm_stations') IS NOT NULL
+            ),
+            '027_station_external_identity', to_regclass('public.station_external_identity') IS NOT NULL,
+            '028_dodec_enum', EXISTS (
+              SELECT 1 FROM pg_type t JOIN pg_enum e ON e.enumtypid=t.oid WHERE t.typname='station_type' AND e.enumlabel='Dodec'
+            ),
+            '029_source_runs', to_regclass('public.source_runs') IS NOT NULL,
+            '030_evidence_store', (
+              to_regclass('public.evidence_records') IS NOT NULL
+              AND to_regclass('public.derived_features') IS NOT NULL
+              AND to_regclass('public.rule_proposals') IS NOT NULL
+              AND to_regclass('public.rule_decisions') IS NOT NULL
+            ),
+            '032_journal_import_staging', to_regclass('public.journal_import_staging') IS NOT NULL,
+            '033_body_contract_function', to_regprocedure('public.fn_mark_body_system_dirty()') IS NOT NULL,
+            '034_station_contract_triggers', (
+              SELECT count(*)=2 FROM pg_trigger
+              WHERE NOT tgisinternal AND tgname IN ('trg_station_body_link_contract_guard','trg_station_body_link_body_delete_guard')
+            ),
+            '035_population_nullable', EXISTS (
+              SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='systems' AND column_name='population' AND is_nullable='YES' AND column_default IS NULL
+            ),
+            '036_evidence_lifecycle', (
+              EXISTS (
+                SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid
+                WHERE c.relname='uq_evidence_records_active_subject_fact' AND i.indisvalid
+              )
+              AND EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname='chk_evidence_records_record_status' AND pg_get_constraintdef(oid) LIKE '%quarantined%'
+              )
+            ),
+            '037_canonical_app_data', (
+              EXISTS (SELECT 1 FROM pg_constraint WHERE conname='chk_source_runs_source_name' AND pg_get_constraintdef(oid) LIKE '%canonical_app_data%')
+              AND EXISTS (SELECT 1 FROM pg_constraint WHERE conname='chk_evidence_records_source_name' AND pg_get_constraintdef(oid) LIKE '%canonical_app_data%')
+            ),
+            '038_admin_job_runs', to_regclass('public.admin_job_runs') IS NOT NULL,
+            '039_ratings_score_viable_index', EXISTS (
+              SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_rat_score_viable' AND i.indisvalid
+            ),
+            '040_cluster_counts_integer', (
+              SELECT count(*)=13 AND bool_and(data_type='integer')
+              FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='cluster_summary' AND column_name IN (
+                'agriculture_count','agriculture_best','refinery_count','refinery_best','industrial_count','industrial_best','hightech_count','hightech_best','military_count','military_best','tourism_count','tourism_best','total_viable'
+              )
+            ),
+            '041_bodies_composite_index', EXISTS (
+              SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_bodies_system_id64_id' AND i.indisvalid AND i.indisunique
+            ),
+            '042_exploration_facts', to_regclass('public.exploration_facts') IS NOT NULL,
+            '043_score_breakdown_dropped', NOT EXISTS (
+              SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='ratings' AND column_name='score_breakdown'
+            ),
+            '044_exploration_projections', (
+              to_regclass('public.exploration_visits') IS NOT NULL
+              AND to_regclass('public.exploration_expedition_routes') IS NOT NULL
+              AND to_regclass('public.exploration_body_completeness') IS NOT NULL
+              AND to_regclass('public.exobiology_sales') IS NOT NULL
+              AND to_regclass('public.exobiology_organisms') IS NOT NULL
+              AND to_regclass('public.codex_observations') IS NOT NULL
+            ),
+            '045_journal_streaming_provenance', (
+              EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='journal_import_staging' AND column_name='sync_key' AND is_nullable='NO')
+              AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='journal_import_staging' AND column_name='source_offset' AND data_type='bigint')
+              AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='journal_import_staging' AND column_name='system_id64' AND is_nullable='YES')
+            ),
+            '046_powerplay_observations', (
+              to_regclass('public.powerplay_observations') IS NOT NULL
+              AND to_regclass('public.commander_powerplay_events') IS NOT NULL
+              AND to_regclass('public.commander_powerplay_state') IS NOT NULL
+              AND to_regclass('public.powerplay_cycles') IS NOT NULL
+            ),
+            '047_routes', (
+              to_regclass('public.routes') IS NOT NULL AND to_regclass('public.route_events') IS NOT NULL
+            ),
+            '048_frontier_accounts', (
+              to_regclass('public.app_users') IS NOT NULL
+              AND to_regclass('public.web_sessions') IS NOT NULL
+              AND to_regclass('public.oauth_login_states') IS NOT NULL
+            )
+          )::text;
+          COMMIT;
+          """
+          argv=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",pg["user"],"--dbname",pg["database"],"--command",sql]
+          p=subprocess.run(argv,text=True,capture_output=True,env=E,check=False,timeout=20)
+          if p.returncode:
+              print(json.dumps({"status":"stopped","stage":"marker_query","returncode":p.returncode,"stderr_tail":" | ".join(x.strip() for x in p.stderr.splitlines() if x.strip())[-700:]},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          rows=[]
+          for line in p.stdout.splitlines():
+              line=line.strip()
+              if line.startswith('{') and line.endswith('}'):
+                  try: rows.append(json.loads(line))
+                  except json.JSONDecodeError: pass
+          if len(rows)!=1:
+              print(json.dumps({"status":"stopped","stage":"marker_parse","json_rows":len(rows),"stdout_preview":p.stdout.strip().replace('\n','\\n')[:500]},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          markers=rows[0]
+          result={"status":"success","postgres_container_identity":pg,"api_database_target":api,"markers":markers,"all_baseline_019_through_035_markers":all(markers[k] for k in markers if k[:3].isdigit() and int(k[:3])<=35),"read_only":True,"db_writes_performed":False,"migrations_performed":False,"service_changes_performed":False}
           print(json.dumps(result,sort_keys=True,separators=(",",":")))
           PY


### PR DESCRIPTION
One-shot read-only production diagnostic. Verifies exact V3 host/API/database identity and checks schema/index/constraint markers for the current migration manifest through 048. No database writes, migrations, service changes, secret contents, or application changes.