### PR TITLE
Probe V3 baseline markers 001 through 018 read-only

### DIFF
--- a/.github/workflows/v3-production-baseline-marker-diagnostic.yml
+++ b/.github/workflows/v3-production-baseline-marker-diagnostic.yml
@@ -1,0 +1,153 @@
+name: V3 production baseline marker diagnostic
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/v3-production-baseline-marker-diagnostic.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 5
+    steps:
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/key && chmod 600 ~/.ssh/key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Probe baseline markers 001 through 018 read-only
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
+          import json, socket, subprocess
+          from urllib.parse import urlsplit, unquote
+
+          PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
+          API="edfinder-v3-api"
+          E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
+          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False,timeout=5).stdout.strip()
+          assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
+
+          def env_lines(container):
+              return subprocess.run(["docker","--context","default","inspect",container,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
+
+          pg={}
+          for line in env_lines(PG):
+              if line.startswith("POSTGRES_USER="): pg["user"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="): pg["database"]=line.split("=",1)[1]
+          api={"database_url_present":False}
+          for line in env_lines(API):
+              if line.startswith("DATABASE_URL="):
+                  p=urlsplit(line.split("=",1)[1])
+                  api={"database_url_present":True,"user":unquote(p.username) if p.username else None,"host":p.hostname,"port":p.port,"database":unquote(p.path.lstrip('/')) if p.path else None,"password_present":p.password is not None}
+          assert pg.get("user") and pg.get("database") and api.get("user")==pg["user"] and api.get("database")==pg["database"]
+
+          sql=r"""
+          BEGIN READ ONLY;
+          SET LOCAL statement_timeout='10000ms';
+          SELECT json_build_object(
+            '001_base_schema', (
+              to_regclass('public.systems') IS NOT NULL AND
+              to_regclass('public.bodies') IS NOT NULL AND
+              to_regclass('public.stations') IS NOT NULL AND
+              to_regclass('public.ratings') IS NOT NULL AND
+              to_regclass('public.cluster_summary') IS NOT NULL AND
+              to_regclass('public.galaxy_regions') IS NOT NULL
+            ),
+            '002_core_indexes', (
+              EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_sys_coords' AND i.indisvalid) AND
+              EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_body_system' AND i.indisvalid) AND
+              EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_rat_score' AND i.indisvalid)
+            ),
+            '003_core_functions', to_regprocedure('public.distance_ly(real,real,real,real,real,real)') IS NOT NULL,
+            '004_ratings_v31', (
+              SELECT count(*)=5 FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='ratings' AND column_name IN ('score_extraction','terraforming_potential','body_diversity','confidence','rationale')
+            ),
+            '005_map_indexes', (
+              EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_systems_first_discovered_at' AND i.indisvalid) AND
+              EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_systems_galaxy_region_populated' AND i.indisvalid) AND
+              EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_cluster_summary_top_score' AND i.indisvalid)
+            ),
+            '006_score_history', to_regclass('public.score_history') IS NOT NULL AND to_regclass('public.score_trends') IS NOT NULL,
+            '007_profile_sync', to_regclass('public.profile_sync') IS NOT NULL,
+            '008_body_filter_aggregates', (
+              SELECT count(*)=3 FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='ratings' AND column_name IN ('ring_count','walkable_count','other_star_count')
+            ),
+            '009_map_materialised_views', (
+              to_regclass('public.mv_map_regions') IS NOT NULL AND
+              to_regclass('public.mv_map_heatmap_200ly') IS NOT NULL AND
+              to_regclass('public.mv_map_timeline_month') IS NOT NULL
+            ),
+            '010_sync_key_scoping', (
+              EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='watchlist' AND column_name='sync_key') AND
+              EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='system_notes' AND column_name='sync_key')
+            ),
+            '011_autocomplete_index', EXISTS (
+              SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid=c.oid WHERE c.relname='idx_sys_name_lower_pattern' AND i.indisvalid
+            ),
+            '012_topology_tables', (
+              to_regclass('public.system_slot_topology') IS NOT NULL AND
+              to_regclass('public.economy_pair_synergy') IS NOT NULL AND
+              to_regclass('public.pair_synergy_constants') IS NOT NULL
+            ),
+            '013_archetype_scores', to_regclass('public.system_archetype_scores') IS NOT NULL AND to_regclass('public.system_archetype_traits') IS NOT NULL,
+            '014_archetype_mv', to_regclass('public.mv_archetype_rankings') IS NOT NULL,
+            '015_simulation_engine', (
+              to_regclass('public.journal_events') IS NOT NULL AND
+              to_regclass('public.body_scan_facts') IS NOT NULL AND
+              to_regclass('public.body_slot_predictions') IS NOT NULL
+            ),
+            '016_regional_analysis', to_regclass('public.system_regional_analysis') IS NOT NULL,
+            '017_observed_facts', to_regclass('public.observed_facts') IS NOT NULL,
+            '018_observed_facts_stage6a', EXISTS (
+              SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='observed_facts' AND column_name='observation_id' AND is_nullable='NO'
+            )
+          )::text;
+          COMMIT;
+          """
+          argv=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",pg["user"],"--dbname",pg["database"],"--command",sql]
+          p=subprocess.run(argv,text=True,capture_output=True,env=E,check=False,timeout=20)
+          if p.returncode:
+              print(json.dumps({"status":"stopped","returncode":p.returncode,"stderr_tail":" | ".join(x.strip() for x in p.stderr.splitlines() if x.strip())[-700:]},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          rows=[]
+          for line in p.stdout.splitlines():
+              line=line.strip()
+              if line.startswith('{') and line.endswith('}'):
+                  try: rows.append(json.loads(line))
+                  except json.JSONDecodeError: pass
+          if len(rows)!=1:
+              print(json.dumps({"status":"stopped","stage":"parse","json_rows":len(rows),"stdout_preview":p.stdout.strip().replace('\n','\\n')[:500]},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          markers=rows[0]
+          ordered=[f"{i:03d}_" for i in range(1,19)]
+          first_false=None
+          for prefix in ordered:
+              key=next((k for k in markers if k.startswith(prefix)),None)
+              if key is None or not markers[key]:
+                  first_false=prefix[:3]
+                  break
+          result={"status":"success","postgres_container_identity":pg,"api_database_target":api,"markers":markers,"first_unproved_baseline_migration":first_false,"all_001_through_018_markers":all(markers.values()),"read_only":True,"db_writes_performed":False,"migrations_performed":False,"service_changes_performed":False}
+          print(json.dumps(result,sort_keys=True,separators=(",",":")))
+          PY


### PR DESCRIPTION
One-shot read-only production diagnostic. Verifies exact V3 host/API/database identity and checks one bounded physical marker for each manifest migration 001 through 018. No database writes, migrations, service changes, secret contents, or application changes.