### PR TITLE
Inspect live Phase4C schema catalog read-only

### DIFF
--- a/.github/workflows/v3-production-phase4c-catalog-diagnostic.yml
+++ b/.github/workflows/v3-production-phase4c-catalog-diagnostic.yml
@@ -1,0 +1,128 @@
+name: V3 production Phase4C catalog diagnostic
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/v3-production-phase4c-catalog-diagnostic.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 5
+    steps:
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/key && chmod 600 ~/.ssh/key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Inspect Phase4C catalog read-only
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
+          import hashlib, json, socket, subprocess
+          from urllib.parse import urlsplit, unquote
+
+          PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
+          API="edfinder-v3-api"
+          E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
+          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False,timeout=5).stdout.strip()
+          assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
+
+          def env_lines(container):
+              return subprocess.run(["docker","--context","default","inspect",container,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
+
+          pg={}
+          for line in env_lines(PG):
+              if line.startswith("POSTGRES_USER="): pg["user"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="): pg["database"]=line.split("=",1)[1]
+          api={}
+          for line in env_lines(API):
+              if line.startswith("DATABASE_URL="):
+                  p=urlsplit(line.split("=",1)[1])
+                  api={"user":unquote(p.username) if p.username else None,"host":p.hostname,"port":p.port,"database":unquote(p.path.lstrip('/')) if p.path else None}
+          assert api.get("user")==pg.get("user") and api.get("database")==pg.get("database")
+
+          sql=r"""
+          BEGIN READ ONLY;
+          SET LOCAL statement_timeout='10000ms';
+          SELECT json_build_object(
+            'relations', COALESCE((
+              SELECT json_agg(json_build_object('name', c.relname, 'kind', c.relkind) ORDER BY c.relname)
+              FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+              WHERE n.nspname='public' AND c.relkind IN ('r','p','v','m')
+            ), '[]'::json),
+            'columns', COALESCE((
+              SELECT json_agg(json_build_object(
+                'table', table_name,
+                'name', column_name,
+                'type', data_type,
+                'udt', udt_name,
+                'nullable', is_nullable,
+                'default', CASE WHEN column_default IS NULL THEN NULL ELSE regexp_replace(column_default, '\\s+', ' ', 'g') END
+              ) ORDER BY table_name, ordinal_position)
+              FROM information_schema.columns WHERE table_schema='public'
+            ), '[]'::json),
+            'constraints', COALESCE((
+              SELECT json_agg(json_build_object('table', c.conrelid::regclass::text, 'name', c.conname, 'type', c.contype, 'definition', pg_get_constraintdef(c.oid, true)) ORDER BY c.conrelid::regclass::text, c.conname)
+              FROM pg_constraint c JOIN pg_namespace n ON n.oid=c.connamespace WHERE n.nspname='public'
+            ), '[]'::json),
+            'indexes', COALESCE((
+              SELECT json_agg(json_build_object('table', tablename, 'name', indexname, 'definition', indexdef) ORDER BY tablename, indexname)
+              FROM pg_indexes WHERE schemaname='public'
+            ), '[]'::json)
+          )::text;
+          COMMIT;
+          """
+          argv=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",pg["user"],"--dbname",pg["database"],"--command",sql]
+          p=subprocess.run(argv,text=True,capture_output=True,env=E,check=False,timeout=20)
+          if p.returncode:
+              print(json.dumps({"status":"stopped","returncode":p.returncode,"stderr_tail":" | ".join(x.strip() for x in p.stderr.splitlines() if x.strip())[-700:]},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          rows=[]
+          for line in p.stdout.splitlines():
+              line=line.strip()
+              if line.startswith('{') and line.endswith('}'):
+                  try: rows.append(json.loads(line))
+                  except json.JSONDecodeError: pass
+          if len(rows)!=1:
+              print(json.dumps({"status":"stopped","stage":"parse","json_rows":len(rows)},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          catalog=rows[0]
+          canonical=json.dumps(catalog,sort_keys=True,separators=(",",":"))
+          relations=[item["name"] for item in catalog["relations"]]
+          columns={}
+          for item in catalog["columns"]:
+              columns.setdefault(item["table"],[]).append(item["name"])
+          result={
+            "status":"success",
+            "database_identity":{"container":PG,"database":pg["database"],"user":pg["user"],"application_host":api.get("host"),"port":api.get("port")},
+            "catalog_sha256":hashlib.sha256(canonical.encode()).hexdigest(),
+            "relation_count":len(catalog["relations"]),
+            "column_count":len(catalog["columns"]),
+            "constraint_count":len(catalog["constraints"]),
+            "index_count":len(catalog["indexes"]),
+            "relations":relations,
+            "core_columns":{name:columns.get(name,[]) for name in sorted(set(relations)&{"systems","bodies","stations","ratings","users","watchlist","system_notes","cluster_summary","galaxy_regions"})},
+            "read_only":True,"db_writes_performed":False,"migrations_performed":False,"service_changes_performed":False
+          }
+          print(json.dumps(result,sort_keys=True,separators=(",",":")))
+          PY


### PR DESCRIPTION
One-shot read-only production diagnostic. Captures only schema/catalog metadata from the retained Phase4C PostgreSQL database, hashes the canonical catalog, and reports relation/core-column names. No row data, passwords, writes, migrations, or service changes.