### PR TITLE
Inspect retained V3 PostgreSQL cluster catalogs read-only

### DIFF
--- a/.github/workflows/v3-production-cluster-catalog-diagnostic.yml
+++ b/.github/workflows/v3-production-cluster-catalog-diagnostic.yml
@@ -1,0 +1,83 @@
+name: V3 production cluster catalog diagnostic
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/v3-production-cluster-catalog-diagnostic.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 5
+    steps:
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/key && chmod 600 ~/.ssh/key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Inspect all retained database catalogs read-only
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
+          import json, socket, subprocess
+
+          PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
+          E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
+          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False,timeout=5).stdout.strip()
+          assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
+
+          raw=subprocess.run(["docker","--context","default","inspect",PG,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
+          identity={}
+          for line in raw:
+              if line.startswith("POSTGRES_USER="): identity["user"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="): identity["database"]=line.split("=",1)[1]
+          user=identity["user"]
+          base=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",user]
+          dbs=subprocess.run(base+["--dbname",identity["database"],"--command","SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate ORDER BY datname;"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
+          result={"status":"success","container_identity":identity,"databases":{},"read_only":True,"db_writes_performed":False,"migrations_performed":False,"service_changes_performed":False}
+          for database in [x.strip() for x in dbs if x.strip()]:
+              sql="""BEGIN READ ONLY;
+              SELECT json_build_object(
+                'schemas', COALESCE((SELECT json_agg(nspname ORDER BY nspname) FROM pg_namespace WHERE nspname !~ '^pg_' AND nspname <> 'information_schema'),'[]'::json),
+                'relations', COALESCE((SELECT json_agg(json_build_object('schema',n.nspname,'name',c.relname,'kind',c.relkind) ORDER BY n.nspname,c.relname) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname !~ '^pg_' AND n.nspname <> 'information_schema' AND c.relkind IN ('r','p','v','m')),'[]'::json),
+                'column_count', (SELECT count(*) FROM information_schema.columns WHERE table_schema NOT IN ('pg_catalog','information_schema'))
+              )::text;
+              COMMIT;"""
+              p=subprocess.run(base+["--dbname",database,"--command",sql],text=True,capture_output=True,env=E,check=False,timeout=15)
+              entry={"returncode":p.returncode}
+              if p.returncode==0:
+                  rows=[]
+                  for line in p.stdout.splitlines():
+                      line=line.strip()
+                      if line.startswith('{') and line.endswith('}'):
+                          try: rows.append(json.loads(line))
+                          except json.JSONDecodeError: pass
+                  if len(rows)==1:
+                      data=rows[0]
+                      entry.update({"schemas":data.get("schemas"),"relation_count":len(data.get("relations") or []),"relations":data.get("relations"),"column_count":data.get("column_count")})
+                  else:
+                      entry["parse_rows"]=len(rows)
+              else:
+                  entry["stderr_tail"]=" | ".join(x.strip() for x in p.stderr.splitlines() if x.strip())[-500:]
+              result["databases"][database]=entry
+          print(json.dumps(result,sort_keys=True,separators=(",",":")))
+          PY


### PR DESCRIPTION
One-shot read-only production diagnostic. Lists only non-system schemas/relation names and column counts across the retained PostgreSQL cluster to determine whether the application schema exists in another database/schema. No row data, secrets, writes, migrations, or service changes.