### PR TITLE
Inspect V3-native migration ledger read-only

### DIFF
--- a/.github/workflows/v3-production-native-ledger-diagnostic.yml
+++ b/.github/workflows/v3-production-native-ledger-diagnostic.yml
@@ -1,0 +1,74 @@
+name: V3 production native ledger diagnostic
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/v3-production-native-ledger-diagnostic.yml']
+
+permissions:
+  contents: read
+
+jobs:
+  inspect:
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 5
+    steps:
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/key && chmod 600 ~/.ssh/key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Inspect V3-native migration ledger read-only
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
+          import json, socket, subprocess
+          PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
+          E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
+          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False,timeout=5).stdout.strip()
+          assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
+          raw=subprocess.run(["docker","--context","default","inspect",PG,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
+          ident={}
+          for line in raw:
+              if line.startswith("POSTGRES_USER="): ident["user"]=line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="): ident["database"]=line.split("=",1)[1]
+          sql="""BEGIN READ ONLY;
+          SELECT json_build_object(
+            'columns', COALESCE((SELECT json_agg(json_build_object('name',column_name,'type',data_type,'udt',udt_name,'nullable',is_nullable) ORDER BY ordinal_position) FROM information_schema.columns WHERE table_schema='v3_meta' AND table_name='schema_migration'),'[]'::json),
+            'row_count', (SELECT count(*) FROM v3_meta.schema_migration),
+            'constraints', COALESCE((SELECT json_agg(json_build_object('name',c.conname,'type',c.contype,'definition',pg_get_constraintdef(c.oid,true)) ORDER BY c.conname) FROM pg_constraint c WHERE c.conrelid='v3_meta.schema_migration'::regclass),'[]'::json),
+            'indexes', COALESCE((SELECT json_agg(json_build_object('name',indexname,'definition',indexdef) ORDER BY indexname) FROM pg_indexes WHERE schemaname='v3_meta' AND tablename='schema_migration'),'[]'::json)
+          )::text;
+          COMMIT;"""
+          argv=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",ident["user"],"--dbname",ident["database"],"--command",sql]
+          p=subprocess.run(argv,text=True,capture_output=True,env=E,check=False,timeout=15)
+          if p.returncode:
+              print(json.dumps({"status":"stopped","returncode":p.returncode,"stderr_tail":" | ".join(x.strip() for x in p.stderr.splitlines() if x.strip())[-600:]},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          rows=[]
+          for line in p.stdout.splitlines():
+              line=line.strip()
+              if line.startswith('{') and line.endswith('}'):
+                  try: rows.append(json.loads(line))
+                  except json.JSONDecodeError: pass
+          if len(rows)!=1:
+              print(json.dumps({"status":"stopped","stage":"parse","json_rows":len(rows)},sort_keys=True,separators=(",",":")))
+              raise SystemExit(1)
+          print(json.dumps({"status":"success","database_identity":ident,"ledger":rows[0],"read_only":True,"db_writes_performed":False,"migrations_performed":False,"service_changes_performed":False},sort_keys=True,separators=(",",":")))
+          PY


### PR DESCRIPTION
One-shot read-only production diagnostic for v3_meta.schema_migration. Reports only column/constraint/index metadata and row count. No migration row contents, secrets, writes, migrations, or service changes.