### PR TITLE
Compute aggregate V3 native ledger identity

### DIFF
--- a/.github/workflows/v3-production-native-ledger-rows-diagnostic.yml
+++ b/.github/workflows/v3-production-native-ledger-rows-diagnostic.yml
@@ -26,10 +26,10 @@ jobs:
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           printf '%s\n' "$SSH_KEY" > ~/.ssh/key && chmod 600 ~/.ssh/key
           printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
-          lookup="$SSH_HOST"; [ "$SSH_PORT" = 22 ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
           ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
 
-      - name: Read V3-native migration identities
+      - name: Compute V3-native aggregate ledger identity read-only
         shell: bash
         env:
           SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
@@ -38,25 +38,56 @@ jobs:
         run: |
           set -euo pipefail
           ssh -i ~/.ssh/key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" 'python3 -' <<'PY'
-          import json, socket, subprocess
-          PG="edfinder-v3-phase4c-full-20260827_r5-postgres"
-          E={"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
-          fqdn=subprocess.run(["hostname","-f"],text=True,capture_output=True,env=E,check=False,timeout=5).stdout.strip()
-          assert socket.gethostname().split('.')[0]=="ed-finder-prod" and fqdn=="nb79a3d.mevnode.com"
-          raw=subprocess.run(["docker","--context","default","inspect",PG,"--format","{{range .Config.Env}}{{println .}}{{end}}"],text=True,capture_output=True,env=E,check=True,timeout=10).stdout.splitlines()
-          ident={}
+          import hashlib, json, socket, subprocess
+
+          PG = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+          SAFE_ENV = {"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","LANG":"C","LC_ALL":"C"}
+          fqdn = subprocess.run(["hostname","-f"], text=True, capture_output=True, env=SAFE_ENV, check=False, timeout=5).stdout.strip()
+          assert socket.gethostname().split('.')[0] == "ed-finder-prod" and fqdn == "nb79a3d.mevnode.com"
+
+          raw = subprocess.run(["docker","--context","default","inspect",PG,"--format","{{range .Config.Env}}{{println .}}{{end}}"], text=True, capture_output=True, env=SAFE_ENV, check=True, timeout=10).stdout.splitlines()
+          identity = {}
           for line in raw:
-              if line.startswith("POSTGRES_USER="): ident["user"]=line.split("=",1)[1]
-              elif line.startswith("POSTGRES_DB="): ident["database"]=line.split("=",1)[1]
-          sql="""BEGIN READ ONLY;
-          SELECT COALESCE(json_agg(json_build_object('migration_name',migration_name,'migration_sha256',encode(migration_sha256,'hex')) ORDER BY migration_name),'[]'::json)::text FROM v3_meta.schema_migration;
+              if line.startswith("POSTGRES_USER="):
+                  identity["user"] = line.split("=",1)[1]
+              elif line.startswith("POSTGRES_DB="):
+                  identity["database"] = line.split("=",1)[1]
+
+          sql = """BEGIN READ ONLY;
+          SELECT COALESCE(json_agg(json_build_object('migration_name', migration_name, 'migration_sha256', encode(migration_sha256,'hex')) ORDER BY migration_name),'[]'::json)::text FROM v3_meta.schema_migration;
           COMMIT;"""
-          argv=["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",ident["user"],"--dbname",ident["database"],"--command",sql]
-          p=subprocess.run(argv,text=True,capture_output=True,env=E,check=True,timeout=15)
-          rows=[]
-          for line in p.stdout.splitlines():
-              line=line.strip()
+          argv = ["docker","--context","default","exec",PG,"psql","-X","--no-password","--tuples-only","--no-align","--quiet","--set","ON_ERROR_STOP=1","--username",identity["user"],"--dbname",identity["database"],"--command",sql]
+          result = subprocess.run(argv, text=True, capture_output=True, env=SAFE_ENV, check=True, timeout=15)
+          rows = []
+          for line in result.stdout.splitlines():
+              line = line.strip()
               if line.startswith('[') and line.endswith(']'):
-                  rows=json.loads(line)
-          print(json.dumps({"status":"success","database_identity":ident,"migrations":rows,"read_only":True,"db_writes_performed":False,"migrations_performed":False,"service_changes_performed":False},sort_keys=True,separators=(",",":")))
+                  rows = json.loads(line)
+          assert rows
+
+          digest = hashlib.sha256()
+          names = []
+          for row in rows:
+              name = row["migration_name"]
+              checksum = row["migration_sha256"]
+              assert isinstance(name, str) and name and isinstance(checksum, str) and len(checksum) == 64
+              digest.update(name.encode("utf-8"))
+              digest.update(b"\0")
+              digest.update(bytes.fromhex(checksum))
+              digest.update(b"\n")
+              names.append(name)
+
+          print(json.dumps({
+              "status":"success",
+              "database_identity":identity,
+              "ledger_table":"v3_meta.schema_migration",
+              "migration_count":len(rows),
+              "migration_names":names,
+              "native_ledger_identity":"sha256:" + digest.hexdigest(),
+              "identity_algorithm":"sha256(concat(utf8(migration_name),NUL,raw_sha256,LF) ordered by migration_name)",
+              "read_only":True,
+              "db_writes_performed":False,
+              "migrations_performed":False,
+              "service_changes_performed":False
+          }, sort_keys=True, separators=(",",":")))
           PY


### PR DESCRIPTION
One-file read-only diagnostic refinement. It stops printing individual migration hashes and instead emits one deterministic SHA-256 identity over the ordered v3_meta.schema_migration rows, plus names/count/database identity. No production writes, migrations, service changes, or application changes.