### PR TITLE
Define V3 search, spatial, scoring and derived-data architecture

### DIFF
--- a/docs/development/ratings-v4-coefficient-calibration.md
+++ b/docs/development/ratings-v4-coefficient-calibration.md
@@ -1,0 +1,56 @@
+# Ratings V4 Coefficient Calibration
+
+**Status:** calibration note; overrides no scoring authority until fixture validation is complete
+**Depends on:** `ratings-v4-scoring-contract.md`, `ratings-v4-validation-fixtures.md`
+
+## Finding
+
+The initial scoring-contract candidate (`native=60`, `modifier-only=45`, `native+modifier=68` with system roll-up `82/11/5/2`) systematically undershoots the fixture expectations for straightforward strong systems.
+
+Example: a Water World with native Agriculture/Tourism plus one documented positive strong-link condition scores about 70 locally under the initial coefficients. Two such candidates roll up to about 65, which is only `Strong`, while fixture F7 expects multiple Water Worlds to be `Excellent` to `Exceptional`.
+
+The fixture suite therefore correctly rejects the initial coefficient set before implementation.
+
+## Revised calibration candidate
+
+Retain the architecture and depth curve but raise the meaning of mechanics-backed local inheritance:
+
+| Evidence | Initial | Revised candidate |
+|---|---:|---:|
+| Native inheritance | 60 | 75 |
+| Modifier inheritance only | 45 | 55 |
+| Native + modifier inheritance | 68 | 85 |
+| Distinct positive strong-link mechanic | +10 | +10 |
+| Distinct negative strong-link mechanic | -10 | -10 |
+
+Strong-link caps remain provisional at +/-25.
+
+The system roll-up remains provisionally:
+
+```text
+0.82*s1 + 0.11*s2 + 0.05*s3 + 0.02*s4
+```
+
+because the identified failure is primarily local opportunity calibration, not body-depth weighting.
+
+## Sanity outcomes
+
+Approximate examples with complete evidence:
+
+- one native-only candidate at 75 -> system potential ~62 (`Strong`);
+- two native-only candidates -> ~70 (`Excellent` threshold);
+- one native + one positive strong-link condition at 85 -> ~70 (`Excellent`);
+- two such 85 candidates -> ~79 (`Excellent`);
+- four such candidates -> 85 (`Exceptional`);
+- native+modifier at 85 plus one strong-link positive -> 95 local; one site -> ~78 system, two -> ~88 system;
+- a fully supported 100 local candidate -> 82 system, preserving room for demonstrated system depth.
+
+This gives a useful interpretation: a single genuinely good native opportunity makes a system `Strong`; repeated/favourably-modified opportunities make it `Excellent`; exceptional system scores require either very high local support or meaningful depth.
+
+## Military consequence
+
+Military currently has no established environmental strong-link modifiers. Under the revised candidate, one main-sequence/Brown-Dwarf native Military opportunity is about 62 at system level and several independent Military-native opportunities can reach the low/mid 70s. This is intentional pending real-system validation: raw Military potential should remain conservative, while a Military Stronghold archetype may incorporate capacity, Industrial support, geography and other strategic dimensions.
+
+## Freeze rule
+
+Do not freeze these revised coefficients merely because they repair F7. The implementation/fixture harness must evaluate every deterministic fixture and a reviewed real-system sample. Coefficients may move again, but the scoring architecture, evidence classes, specialisation split and derived schema do not need to change.

--- a/docs/development/ratings-v4-data-contract.md
+++ b/docs/development/ratings-v4-data-contract.md
@@ -1,0 +1,241 @@
+# Ratings V4 Data Contract
+
+**Status:** proposed V4 data authority; review before implementation
+**Depends on:** `ratings-v4-mechanics-evidence.md`, `ratings-v4-scoring-contract.md`, `ratings-v4-validation-fixtures.md`
+
+## Purpose
+
+This contract maps Ratings V4 mechanics onto the retained V3 canonical data model and defines the rebuildable derived relations needed by the scorer. It deliberately avoids reshaping canonical generation tables merely to suit Ratings V4.
+
+## 1. Source-data rule
+
+Canonical V3 generation data remains source truth. Ratings V4 consumes explicit canonical facts through an adapter and writes only derived data.
+
+Every mechanics input is classified as:
+
+- **AVAILABLE** — directly present in the current canonical V3 generation or normalized supporting relation;
+- **DERIVABLE** — reproducibly computed from available canonical facts;
+- **MISSING_SOURCE** — required by the accepted mechanics model but not currently retained;
+- **UNKNOWN_CAPABLE** — schema supports the fact, but absence must not be interpreted as observed false without completeness/provenance.
+
+No `MISSING_SOURCE` value may be fabricated by the scorer.
+
+## 2. Current V3 source mapping
+
+The current published canonical generation is resolved through `v3_meta.current_canonical_generation` and `v3_meta.canonical_generation.relation_schema`; application/scorer code must never hard-code a particular `v3_gen_*` schema name.
+
+| V4 input | Current V3 source | Status | V4 treatment |
+|---|---|---|---|
+| system id/name | generation `systems.id64/name` | AVAILABLE | canonical identity |
+| x/y/z | generation `systems.x_ly/y_ly/z_ly` | AVAILABLE | Finder/spatial only; not raw economy scoring |
+| region | `systems.galaxy_region_id` + `v3_vocab.galaxy_region` | AVAILABLE | Finder/map; not raw economy scoring |
+| body identity | generation `bodies.body_pk`, `system_id64`, source/frontier body ids | AVAILABLE | scorer candidate identity; preserve source identity/provenance |
+| body type/classification | `bodies.body_type_id` + V3 vocab | AVAILABLE | native economy inheritance |
+| stellar class | `bodies.spectral_class`, `luminosity_class`, `is_main_star` | AVAILABLE | Military / exotic-star inheritance classification |
+| landable | `bodies.is_landable` | AVAILABLE, UNKNOWN_CAPABLE by source completeness | specialisation/buildability only where mechanics require it |
+| tidal lock | `bodies.is_tidally_locked` | AVAILABLE, UNKNOWN_CAPABLE | Agriculture modifier only under active mechanics rule |
+| terraforming state | `bodies.terraforming_state_id` + vocab | AVAILABLE, UNKNOWN_CAPABLE | Agriculture strong-link amplifier; never standalone inheritance |
+| volcanism | `bodies.volcanism_type_id` + vocab | AVAILABLE, UNKNOWN_CAPABLE | Extraction strong-link amplifier; distinct from geological signals |
+| atmosphere classification | `bodies.atmosphere_classification_id` | AVAILABLE | retained for later archetypes; not current raw seven unless a ruleset explicitly uses it |
+| rings | generation ring relations / trusted ring facts | AVAILABLE, UNKNOWN_CAPABLE | Extraction modifier inheritance; missing evidence is unknown, not no-rings |
+| biological signals | generation body signal/current relations where retained | AVAILABLE/DERIVABLE, UNKNOWN_CAPABLE | Agriculture modifier inheritance; High Tech/Tourism modifiers per ruleset |
+| geological signals | generation body signal/current relations where retained | AVAILABLE/DERIVABLE, UNKNOWN_CAPABLE | Extraction + Industrial modifier inheritance; Tourism/High Tech modifiers per ruleset |
+| system exotic-star presence | stellar bodies in generation | DERIVABLE | Tourism system modifier and High Tech/Tourism inheritance opportunities |
+| main-sequence/Brown-Dwarf presence | stellar bodies in generation | DERIVABLE | Military inheritance opportunities |
+| competing inherited economies at one body | body type + ring/bio/geo mechanics features | DERIVABLE | specialisation quality only |
+| source freshness/provenance | generation source/lifecycle/completeness fields | AVAILABLE | evidence completeness/confidence |
+| reserve level | not retained by current ED-Finder importer/canonical V3 shape | MISSING_SOURCE | must remain unknown until ingestion is added |
+| distance from arrival | body/station orbital-distance facts where present | AVAILABLE | archetype/Finder practicality only, not raw economy scores |
+| generic diversity/compactness | canonical facts | DERIVABLE | archetype/Finder only |
+
+## 3. Reserve-level source decision
+
+Reserve level is a real mechanics input for Extraction, Industrial and Refinery, but current ED-Finder code does not ingest or retain it.
+
+Elite scan/journal data exposes `ReserveLevel` for ring-bearing bodies/ring systems using game values such as `PristineResources`, `MajorResources`, `CommonResources`, `LowResources`, and `DepletedResources`. Spansh is the preferred bulk-ingestion source because ED-Finder already uses whole-galaxy Spansh body data and it preserves scan-derived body/ring facts.
+
+### Important semantic correction
+
+Do **not** add a guessed scalar `systems.reserve_level` merely because old code referred to one.
+
+Reserve evidence belongs to the body/ring fact domain. V4 derives any economy-level/system summary from retained reserve observations with explicit provenance.
+
+Target canonical enrichment should retain, at minimum:
+
+```text
+body/ring reserve fact
+- system_id64
+- body identity / ring identity where available
+- reserve_level enum/code
+- source_id / source_run_id
+- observed/source-updated timestamp
+- coverage/completeness state
+```
+
+If a future authoritative source proves reserve level is genuinely system-wide rather than ring/body scoped for the relevant mechanic, that can be represented as another source fact without changing the V4 derived schema.
+
+Until enrichment is populated, reserve-dependent score families remain partially incomplete rather than assuming `Common`, `None`, or any neutral value.
+
+## 4. Derived mechanics feature relation
+
+V4 should materialize normalized mechanics features so the scorer does not repeatedly reinterpret raw canonical rows.
+
+Conceptually:
+
+```text
+v3_derived.system_mechanics_feature
+- derived_generation_id UUID
+- system_id64 BIGINT
+- subject_kind SYSTEM|BODY|RING
+- body_pk BIGINT NULL
+- subject_key TEXT
+- feature_type TEXT
+- feature_value_text TEXT NULL
+- feature_value_numeric DOUBLE PRECISION NULL
+- known_state KNOWN_PRESENT|KNOWN_ABSENT|UNKNOWN
+- source_confidence DOUBLE PRECISION
+- source_freshness_at TIMESTAMPTZ NULL
+- rule_input_version TEXT
+- provenance JSONB
+PRIMARY KEY (derived_generation_id, system_id64, subject_kind, subject_key, feature_type)
+```
+
+Examples of `feature_type`:
+
+- `BODY_CLASS_ELW`
+- `BODY_CLASS_WATER_WORLD`
+- `BODY_CLASS_AMMONIA`
+- `BODY_CLASS_HMC`
+- `BODY_CLASS_METAL_RICH`
+- `BODY_CLASS_ROCKY`
+- `BODY_CLASS_ROCKY_ICE`
+- `BODY_CLASS_ICY`
+- `BODY_CLASS_GAS_GIANT`
+- `STAR_MAIN_SEQUENCE`
+- `STAR_BROWN_DWARF`
+- `STAR_NEUTRON`
+- `STAR_WHITE_DWARF`
+- `STAR_BLACK_HOLE`
+- `RING_PRESENT`
+- `BIOLOGICAL_PRESENT`
+- `GEOLOGICAL_PRESENT`
+- `VOLCANISM_PRESENT`
+- `TERRAFORMABLE`
+- `TIDALLY_LOCKED`
+- `RESERVE_LEVEL`
+
+This table is derived and rebuildable. It does not replace canonical normalized facts.
+
+## 5. Local economy opportunity relation
+
+The scoring contract evaluates candidate local opportunities before system roll-up.
+
+```text
+v3_derived.economy_opportunity
+- derived_generation_id UUID
+- system_id64 BIGINT
+- economy_id SMALLINT / economy_code TEXT
+- candidate_kind SYSTEM|BODY
+- body_pk BIGINT NULL
+- mechanics_version TEXT
+- scorer_version TEXT
+- eligibility_class NATIVE|MODIFIER|NATIVE_AND_MODIFIER
+- local_opportunity_score SMALLINT
+- local_specialisation_quality SMALLINT
+- evidence_completeness DOUBLE PRECISION
+- confidence DOUBLE PRECISION
+- competing_economies TEXT[] / normalized child relation
+- explanation JSONB
+- computed_at TIMESTAMPTZ
+PRIMARY KEY (derived_generation_id, system_id64, economy, candidate_kind, candidate identity)
+```
+
+This relation is useful for Inspect/explanations and for validating why the system-level score moved after a ruleset change.
+
+## 6. System economy rating relation
+
+Semantic authority is one row per system/economy, not one enormous historical-style ratings row.
+
+```text
+v3_derived.system_economy_rating
+- derived_generation_id UUID
+- system_id64 BIGINT
+- economy_id SMALLINT / economy_code TEXT
+- mechanics_version TEXT
+- scorer_version TEXT
+- potential_score SMALLINT CHECK 0..100
+- specialisation_quality SMALLINT CHECK 0..100
+- evidence_completeness DOUBLE PRECISION CHECK 0..1
+- confidence DOUBLE PRECISION CHECK 0..1
+- best_candidate_kind SYSTEM|BODY
+- best_candidate_body_pk BIGINT NULL
+- contributor_count INTEGER
+- constraint_count INTEGER
+- explanation JSONB
+- computed_at TIMESTAMPTZ
+PRIMARY KEY (derived_generation_id, system_id64, economy)
+```
+
+For hot Finder queries a separate wide projection may expose seven potential/specialisation columns, but it is only a performance projection. The normalized row-per-economy relation remains semantic authority.
+
+## 7. Contributor relation
+
+Explanation details should be queryable and testable without treating prose rationale as data authority.
+
+```text
+v3_derived.economy_rating_contributor
+- derived_generation_id
+- system_id64
+- economy
+- candidate_kind
+- body_pk NULL
+- rule_id
+- mechanic_class NATIVE_INHERITANCE|MODIFIER_INHERITANCE|STRONG_LINK_POSITIVE|STRONG_LINK_NEGATIVE|SPECIALISATION_CONSTRAINT
+- feature_type
+- contribution_numeric
+- evidence_grade
+- provenance JSONB
+PRIMARY KEY (... rule/candidate identity ...)
+```
+
+UI rationale is generated from these records.
+
+## 8. Archetype boundary
+
+Archetypes consume V4 ratings plus non-economy dimensions such as buildability, accessibility, body diversity, compactness, economy synergy and strategic/domain features.
+
+Those dimensions must not be copied back into raw economy potential.
+
+`v3_derived.system_archetype` remains separately versioned as defined by the spatial/derived-data decision.
+
+## 9. Stable application boundary
+
+FastAPI reads stable published-generation relations such as:
+
+```text
+v3_app.system_economy_rating
+v3_app.system_economy_opportunity
+v3_app.system_archetype
+v3_app.system_search
+```
+
+The stable boundary resolves `v3_meta.current_derived_generation` explicitly. No generation schema names or `search_path` assumptions leak into application routes.
+
+## 10. Implementation order
+
+1. Add/verify reserve-level source ingestion with provenance; do not block synthetic V4 fixture development on live population.
+2. Implement canonical-to-mechanics feature adapter against current V3 generation relations.
+3. Implement deterministic V4 scorer against synthetic fixtures.
+4. Persist mechanics features/opportunities/ratings into a disposable test derived generation.
+5. Run coefficient/ordering validation, including V3.4 side-by-side regression evidence.
+6. Freeze V4.0 coefficient/ruleset manifest.
+7. Only then create the reviewed production derived-data bootstrap/migration authority.
+
+## Acceptance rules
+
+- No scorer input is silently defaulted from unknown to false/neutral.
+- Reserve absence before enrichment lowers completeness; it does not fabricate reserve state.
+- Geologicals and volcanism remain separate features.
+- ELW inherited Military remains visible but receives no unsupported raw strategic bonus.
+- Any coefficient-only V4.x change requires derived rebuild, not schema migration.
+- Any mechanics-rule change updates version/provenance and triggers rebuild, not canonical mutation.

--- a/docs/development/ratings-v4-mechanics-evidence.md
+++ b/docs/development/ratings-v4-mechanics-evidence.md
@@ -1,0 +1,410 @@
+# Ratings V4 Mechanics Evidence Audit
+
+**Status:** proposed evidence authority for Ratings V4; review before freezing the V4 scoring contract
+**Scope:** system-colonisation economy inheritance, local-body modifiers, strong/weak links, strong-link modifiers, top-two economy protection, and V4 scoring disposition
+
+## Purpose
+
+Ratings V4 must distinguish documented game mechanics from ED-Finder judgement. This audit records the mechanics evidence used to define the seven raw economy scores and identifies which facts belong instead to specialisation, archetype judgement, or Finder ranking.
+
+The scoring architecture is:
+
+```text
+canonical facts
+  -> mechanics features
+  -> raw economy potential + specialisation quality
+  -> archetype judgement
+  -> Finder ranking
+```
+
+Raw economy scores must not silently absorb convenience heuristics such as distance from arrival, generic body diversity, generic strategic value, or complementary-economy strength.
+
+## Evidence hierarchy
+
+Use the strongest applicable evidence in this order:
+
+1. Frontier first-party update/patch notes and official explanations.
+2. Current Colonization Mega Guide where it consolidates or updates official rules.
+3. Raven Colonial observed/modelled behaviour where first-party documentation is silent or ambiguous.
+4. Current maintained community synthesis (for example HerzbubeWiki and comparable research).
+5. Reproducible community experiments and issue reports.
+6. Historical ED-Finder scorer behaviour only as regression evidence, never as mechanics authority.
+
+Mechanics should carry an evidence/provenance grade so later discoveries can update a rule without redesigning the V4 schema.
+
+## Sources reviewed
+
+- Frontier Trailblazers Update 3, April 2025: https://forums.frontier.co.uk/threads/elite-dangerous-trailblazers-update-3-now-live.636973/post-10617548
+- Elite Dangerous Vanguards Patch 1, 22 August 2025: https://store.steampowered.com/news/posts/?appids=359320 (patch text: top-two-economy protection)
+- Colonization Mega Guide: https://thefloweringash.com/elite/colonisation/
+- Herzbube EDColonisation synthesis: https://wiki.herzbube.ch/wiki/EDColonisation
+- Elite Dangerous Wiki System Colonisation economy summary: https://elite-dangerous.fandom.com/wiki/System_Colonisation
+- Recent community/research cross-checks, including Raven Colonial behaviour and 2026 advanced-guide discussions, used only where stronger sources are silent or known to be outdated.
+
+## 1. Base inheritable economies
+
+Frontier's Update 3 establishes that Colony-type ports inherit economies from their local body and that these body rules may stack with local modifiers.
+
+| Local body | Base inheritable economies | V4 disposition |
+|---|---|---|
+| Black Hole | High Tech, Tourism | Direct raw-potential evidence for both; Tourism also gains a system-level strong-link modifier |
+| Neutron Star | High Tech, Tourism | Direct raw-potential evidence for both; Tourism also gains a system-level strong-link modifier |
+| White Dwarf | High Tech, Tourism | Direct raw-potential evidence for both; Tourism also gains a system-level strong-link modifier |
+| Brown Dwarf | Military | Direct Military raw-potential evidence |
+| Other/main-sequence stars | Military | Direct Military raw-potential evidence |
+| Earth-like World | Agriculture, High Tech, Military, Tourism | Eligibility for all four, but not equal weighting: Agriculture/High Tech/Tourism have additional positive link evidence; Military does not |
+| Water World | Agriculture, Tourism | Direct Agriculture/Tourism raw-potential evidence |
+| Ammonia World | High Tech, Tourism | Direct High Tech/Tourism raw-potential evidence |
+| Gas Giant | High Tech, Industrial | Direct High Tech/Industrial raw-potential evidence |
+| High Metal Content | Extraction | Direct Extraction raw-potential evidence |
+| Metal Rich | Extraction | Direct Extraction raw-potential evidence |
+| Rocky Ice | Industrial, Refinery | Direct Industrial/Refinery raw-potential evidence |
+| Rocky | Refinery | Direct Refinery raw-potential evidence |
+| Icy | Industrial | Direct Industrial raw-potential evidence |
+
+### V4 rule
+
+**Inheritance establishes economic eligibility, not equal suitability.** V4 may weight an inherited economy more strongly when additional evidence shows that the same body/system also strengthens that economy or is a documented preferred location.
+
+This prevents the old flat interpretation of an ELW as equally Agriculture/High Tech/Military/Tourism. ELW remains Military-capable, but its strongest V4 raw-economy evidence is Agriculture/Tourism and then High Tech because those have additional positive mechanics; Military receives inheritance evidence only.
+
+## 2. Local-body inheritable modifiers
+
+Frontier documents local-body attributes that add inheritable economies to Colony-type ports.
+
+| Modifier | Added economy/economies | V4 disposition |
+|---|---|---|
+| Rings, including stellar asteroid belts | Extraction | Direct Extraction raw-potential evidence |
+| Organics/Biologicals | Agriculture, Terraforming | Direct Agriculture raw-potential evidence; Terraforming is a separate mechanics feature, not one of the seven economy scores |
+| Geological signals | Extraction, Industrial | Direct Extraction and Industrial raw-potential evidence |
+
+### Important distinction: geologicals vs volcanism
+
+These are different mechanics.
+
+- **Geological signals** add inheritable Extraction + Industrial economy influence.
+- **Volcanism** is a strong-link modifier for Extraction; it does not create Extraction inheritance by itself.
+
+V4 must store these as separate feature types.
+
+## 3. Strong-link mechanics
+
+Frontier's Update 3 establishes:
+
+- Strong links are local-body links between supporting facilities and ports.
+- Weak links apply across non-local bodies.
+- Weak links are not modified by local-body/system strong-link modifiers.
+- Strong links are increased/decreased by environmental characteristics.
+
+Current maintained references model strong-link base strength approximately by facility tier (commonly 0.4 / 0.8 / 1.2), but precise V4 economy suitability should not depend on hypothetical future facility placement unless computing an archetype/build scenario.
+
+### V4 rule
+
+Raw economy potential may use the **existence of favourable/hostile link conditions** as evidence of natural suitability. It must not pretend a supporting facility has already been built.
+
+## 4. Strong-link modifier matrix
+
+### Agriculture
+
+**Positive:**
+- Earth-like World
+- Water World in current maintained research/reference
+- terraformable body
+- biologicals/organics
+
+**Negative:**
+- Icy body
+- tidal-lock cases documented by Frontier/current research
+
+**Evidence nuance:** Frontier's April 2025 notes explicitly list ELW, terraformable and organics as positive and icy/tidal-lock cases as negative. Current Mega Guide/Herzbube additionally lists Water World as a positive Agriculture modifier. The V4 ruleset should retain provenance/version for that Water World modifier.
+
+**V4 disposition:** Agriculture raw potential is principally inherited Agriculture + Agriculture-specific modifiers. Terraformability amplifies an existing Agriculture opportunity; it does not by itself turn a non-Agriculture body into an Agriculture body.
+
+### Extraction
+
+**Positive:**
+- Major or Pristine system reserves
+- body volcanism
+
+**Negative:**
+- Low or Depleted reserves
+
+**V4 disposition:** direct raw-potential amplifiers/penalties. Reserve level is a first-class V4 feature. Volcanism is an amplifier; geologicals are separate inheritance evidence.
+
+### High Tech
+
+**Positive:**
+- Ammonia World
+- Earth-like World
+- Water World in current maintained references
+- biologicals/organics
+- geologicals
+
+**Negative:** none currently established.
+
+**Evidence nuance:** Frontier's April 2025 notes list Ammonia, ELW, geologicals and organics. Current Mega Guide/Herzbube also includes Water World. Preserve provenance for the added Water World rule.
+
+**V4 disposition:** raw High-Tech potential should be grounded in inherited High Tech plus these mechanics. Generic scientific interest/body diversity belongs to a Research archetype, not raw High Tech.
+
+### Industrial
+
+**Positive:**
+- Major or Pristine reserves
+
+**Negative:**
+- Low or Depleted reserves
+
+**V4 disposition:** reserve level directly modifies raw Industrial potential. Extraction/Refinery strength must not inflate raw Industrial; their combination belongs to an industrial-chain archetype.
+
+### Refinery
+
+**Positive:**
+- Major or Pristine reserves
+
+**Negative:**
+- Low or Depleted reserves
+
+**V4 disposition:** reserve level directly modifies raw Refinery potential. Rocky/Rocky-Ice inheritance remains the principal native Refinery evidence.
+
+### Tourism
+
+**Positive:**
+- Ammonia World
+- Earth-like World
+- Water World
+- biologicals/organics
+- geologicals
+- Black Hole in system
+- Neutron Star in system
+- White Dwarf in system
+
+**Negative:** none currently established.
+
+**V4 disposition:** these are direct raw Tourism-potential evidence. Generic body diversity, rings, or merely having many bodies are not Tourism mechanics and should stay outside the raw score.
+
+### Military
+
+No established strong-link environmental modifiers were found in current authoritative/maintained references.
+
+**V4 disposition:** raw Military potential should therefore be intentionally conservative. Main-sequence/Brown-Dwarf inherited Military is strong direct evidence; ELW Military inheritance is supporting eligibility. Generic strategic position, body count, slots, security potential, or Industrial strength belong to a Military Stronghold archetype/Finder profile, not the raw Military score.
+
+## 5. Preferred local bodies / specialisation
+
+The Mega Guide derives practical 'pure market' choices from inheritance and modifier rules:
+
+| Economy | Preferred specialisation location |
+|---|---|
+| Extraction | HMC/Metal-Rich, preferably ringed, while avoiding modifiers that introduce unwanted competing economies when purity is the goal |
+| Refinery | Rocky body, preferably clean of ring/bio/geo economy modifiers; ground slots matter because Refinery Hub is planetary |
+| Industrial | Icy body, preferably clean of competing local modifiers |
+| Military | Main-sequence/Brown-Dwarf star without asteroid belt when a pure inherited Military market is desired |
+| Agriculture | Water World is a preferred native fit; organics can strengthen Agriculture; avoid negative Agriculture conditions |
+| Tourism | Water/Ammonia or exotic non-main-sequence stellar environment depending build intent |
+| High Tech | Ammonia or exotic non-main-sequence stellar environment depending build intent |
+
+### V4 rule: potential and specialisation are different outputs
+
+Every economy should expose at least:
+
+- **potential 0-100:** how strongly the system can support the economy;
+- **specialisation_quality 0-100:** how cleanly a build can make that economy dominant/top-two without unwanted inherited/modifier pressure.
+
+A geo-rich HMC may have outstanding Extraction potential but lower Extraction purity because geologicals also introduce Industrial. V4 must not hide that distinction inside a mystery penalty.
+
+## 6. Top-two economy protection
+
+Frontier's Vanguards Patch 1 (22 August 2025) changed market behaviour so that goods produced by the **top two economies** are no longer consumed/cannibalised by linked ports or settlements of those economies.
+
+This materially weakens the old assumption that any multi-economy system must be heavily penalised.
+
+### V4 consequences
+
+- Remove v3.4-style global cross-economy attenuation from raw economy scores.
+- Do not lower Agriculture merely because Tourism/High Tech are also strong.
+- Do not lower Extraction merely because Industrial is also present.
+- Use `specialisation_quality` to describe how readily an economy can occupy a protected top-two position.
+- Pair/archetype modelling may reward useful complementary combinations without altering the honest independent raw scores.
+
+## 7. Stacking and modelling cautions
+
+Maintained 2026 references add useful implementation detail that is not always explicit in Frontier's original prose:
+
+- Same-economy local-body modifiers generally do not stack repeatedly with themselves/base economy in the straightforward additive way one might assume.
+- Multiple modifiers that create the same inherited economy are commonly treated as one inherited contribution rather than unlimited stacking.
+- Volcanism is a notable separate strong-link modifier and can stack with Extraction inheritance evidence.
+- Strong-link positive/negative adjustments are commonly modelled as +/-0.4 with a floor, but these numeric values rely on guide/Raven observation where Frontier documentation is not complete.
+
+### V4 disposition
+
+Do not hard-wire speculative exact percentages into the core feature model. Store mechanic type, evidence version and derived contribution independently so coefficients can be recalibrated without schema change.
+
+## 8. Rules from old ratings that are NOT raw economy mechanics
+
+The following may remain useful elsewhere but are not supported as direct raw-economy mechanics:
+
+| Factor | V4 home |
+|---|---|
+| Distance from arrival star | Finder accessibility / archetype practicality |
+| Generic body diversity | Archetype/general system-interest dimension |
+| Generic slot count | Buildability/archetype; only economy-specific where a documented facility requirement makes capacity material (for example Refinery ground hubs) |
+| Generic compactness | Finder/archetype practicality |
+| 'Strategic value' | Archetype/domain judgement |
+| Nearby populated systems | Finder/logistics/colonisation planning |
+| Complementary economy strength | Pair/archetype layer |
+| Generic scientific interest | Research/High-Tech archetype, not raw High Tech |
+| Current population | Existing-colony state/production analysis, not intrinsic pre-build economy potential |
+
+## 9. Absolute scoring, not percentile scoring
+
+V4 economy potential should be an **absolute mechanics-based 0-100 measure**, with the same semantic meaning across imports/generations.
+
+Galaxy percentile/rank belongs to Finder and may be calculated separately.
+
+## 10. Unknown is not zero
+
+Missing evidence must not be scored as known absence.
+
+Each economy result should carry:
+
+- `potential_score`
+- `specialisation_quality`
+- `evidence_completeness`
+- `confidence`
+- contributor/explanation data
+- mechanics/rule version
+
+Examples:
+
+```text
+Tourism potential: 88
+Evidence completeness: 64%
+Confidence: Medium
+```
+
+is materially different from the same score at 99% completeness.
+
+For geologicals, biologicals, rings, reserve level, terraformability and other source-sensitive facts, unknown coverage must remain unknown.
+
+## 11. Seven-economy V4 interpretation
+
+### Agriculture
+
+Question: **How naturally and strongly can the known system support Agriculture through Agriculture-inheriting bodies/modifiers and Agriculture-specific link conditions?**
+
+Core evidence:
+- ELW
+- Water World
+- biologicals/organics
+- positive Agriculture strong-link conditions
+
+Terraformability is an amplifier, not standalone Agriculture inheritance.
+
+### Refinery
+
+Question: **How naturally can the system support Refinery markets and the local planetary infrastructure required to strengthen them?**
+
+Core evidence:
+- Rocky
+- Rocky-Ice
+- reserve level
+- practical local ground capacity as a separate buildability/specialisation feature
+
+### Industrial
+
+Question: **How naturally and strongly can the system support Industrial economy influence?**
+
+Core evidence:
+- Icy
+- Rocky-Ice
+- Gas Giant
+- geological modifier
+- reserve level
+
+### High Tech
+
+Question: **How naturally and strongly can the known system support High-Tech economy influence under the documented inheritance/link mechanics?**
+
+Core evidence:
+- ELW
+- Ammonia
+- Gas Giant
+- exotic stars (BH/Neutron/WD)
+- documented High-Tech strong-link modifiers
+
+Research/scientific-interest judgement is deliberately separate.
+
+### Military
+
+Question: **How naturally does the local-body inheritance model support Military economy influence?**
+
+Core evidence:
+- Main-sequence/Brown-Dwarf star inheritance
+- ELW inheritance as secondary evidence
+
+No generic strategic/archetype factors are included in raw Military potential.
+
+### Tourism
+
+Question: **How naturally and strongly can the system support Tourism through Tourism-inheriting worlds/exotic stellar bodies and Tourism-specific strong-link modifiers?**
+
+Core evidence:
+- ELW
+- Water World
+- Ammonia World
+- BH/Neutron/White Dwarf
+- biological/geological Tourism modifiers
+
+### Extraction
+
+Question: **How naturally and strongly can the system support Extraction through mineral bodies, rings/geological inheritance, reserve level and Extraction-specific link conditions?**
+
+Core evidence:
+- HMC
+- Metal Rich
+- rings/asteroid belts
+- geologicals
+- reserve level
+- volcanism as amplifier
+
+## 12. Evidence discrepancies that V4 must preserve explicitly
+
+Some rules changed or were clarified after Frontier's April 2025 announcement. Do not erase that history.
+
+Examples:
+
+- Water World is listed by current maintained references as a High-Tech strong-link positive, while Frontier's April 2025 list did not include it.
+- Water World Agriculture strong-link boosting is present in current maintained references but was not in the original Frontier April list.
+- Community testing found periods where Frontier-documented terraformable Agriculture behaviour did not match live behaviour; later 2026 community references report changes/fixes. Treat this mechanic as versioned evidence rather than timeless fact.
+- Tidal-lock behaviour has also received community corrections to the simple original wording.
+
+V4 therefore needs a mechanics ruleset version and source provenance. A later game patch changes coefficients/rules and triggers a derived rebuild; it does not require a schema redesign.
+
+## 13. Freeze criteria for the final Ratings V4 contract
+
+Before declaring V4 scoring final:
+
+1. Map every canonical V3 body/system field needed by the mechanics matrix.
+2. Mark each input as authoritative, unknown-capable, or unavailable.
+3. Define the exact normalization curve for each raw economy potential.
+4. Define `specialisation_quality` independently from potential.
+5. Define diminishing returns for multiple contributing bodies as an ED-Finder judgement rule, not a claimed Frontier mechanic.
+6. Validate representative synthetic systems for each economy and mixed-economy edge cases.
+7. Compare V4 against v3.4 only as regression/reference evidence, not as the target outcome.
+8. Version the complete mechanics + coefficients manifest.
+9. Only then freeze archetype inputs and derived database columns.
+
+## Conclusion
+
+The web mechanics review confirms the core V4 direction but rejects carrying the v3.4 formula forward as authority.
+
+The durable V4 model is:
+
+```text
+mechanics-supported economy potential
++ separately stated specialisation quality
++ evidence completeness/confidence
+-> archetype judgement
+-> Finder ranking
+```
+
+This keeps game mechanics, ED-Finder judgement, build practicality and query preference separate enough to evolve independently.

--- a/docs/development/ratings-v4-scoring-contract.md
+++ b/docs/development/ratings-v4-scoring-contract.md
@@ -1,0 +1,420 @@
+# Ratings V4 Scoring Contract
+
+**Status:** proposed V4 scoring authority; review and freeze before implementation
+**Depends on:** `ratings-v4-mechanics-evidence.md`
+**Scope:** seven raw economy-potential scores, specialisation quality, evidence completeness/confidence, explanation output, and system-level roll-up
+
+## 1. Purpose
+
+Ratings V4 separates mechanics evidence from ED-Finder judgement and from Finder ranking.
+
+The scoring pipeline is:
+
+```text
+canonical V3 facts
+  -> versioned mechanics features
+  -> local economy opportunities
+  -> system economy potential + specialisation quality
+  -> archetype judgement
+  -> Finder ranking
+```
+
+Raw V4 economy scores answer only:
+
+> **How naturally and strongly can the known system support this economy under the documented colonisation mechanics?**
+
+They do not answer whether the system is globally excellent, strategically well placed, compact, close to arrival, convenient for a particular commander, or part of a good multi-economy build. Those belong to later layers.
+
+## 2. Absolute score semantics
+
+Scores are absolute mechanics-based values, never percentiles.
+
+| Score | Meaning |
+|---:|---|
+| 0 | No known mechanics-supported opportunity |
+| 1-24 | Weak / marginal opportunity |
+| 25-49 | Viable but limited |
+| 50-69 | Strong |
+| 70-84 | Excellent |
+| 85-94 | Exceptional |
+| 95-100 | Near-ideal mechanics support with depth |
+
+A score has the same meaning after the next canonical data import. Galaxy percentile/rank is a separate Finder concern.
+
+## 3. Unknown is not zero
+
+Every economy result carries three distinct values:
+
+- `potential_score` 0-100
+- `evidence_completeness` 0-1
+- `confidence` 0-1
+
+Missing ring, biological, geological, reserve, terraformability, or other source-sensitive evidence is not converted to absence.
+
+The potential score is computed only from known positive/negative evidence. Completeness says how much of the expected evidence set was actually known. Confidence expresses trust in the available evidence/provenance.
+
+A score of 82 at 0.58 completeness is materially different from 82 at 0.99 completeness.
+
+## 4. Mechanics evidence classes
+
+V4 does not treat all body/economy associations as equal.
+
+For economy `E` and candidate local body/location `B`, evidence is classified as:
+
+1. **Native inheritance** — the body directly inherits economy `E`.
+2. **Modifier inheritance** — a local feature such as rings, organics or geologicals adds economy `E`.
+3. **Strong-link positive** — a documented body/system condition strengthens an existing strong link for `E`.
+4. **Strong-link negative** — a documented condition weakens an existing strong link for `E`.
+5. **Preferred specialisation fit** — guide/research evidence says this is a particularly clean/effective location for specialising `E`; this affects specialisation, not raw eligibility.
+
+The mechanics ruleset records provenance and version for every rule.
+
+## 5. Local opportunity score
+
+Each economy is first evaluated per viable local body/location. This avoids turning one giant body-count formula into the mechanics model.
+
+### 5.1 Native opportunity base
+
+A candidate location starts with a native opportunity base according to the strongest known eligibility evidence:
+
+| Evidence | Base local opportunity |
+|---|---:|
+| Native inheritance | 60 |
+| Modifier inheritance only | 45 |
+| Both native + modifier inheritance | 68 |
+| No inheritance evidence | 0 |
+
+These are ED-Finder V4 judgement coefficients, not claimed Frontier percentages. They are versioned and may be recalibrated without schema change.
+
+### 5.2 Strong-link adjustment
+
+Documented strong-link conditions modify the local opportunity after inheritance is established.
+
+Default V4 rule:
+
+- each distinct supported positive strong-link mechanic: `+10`
+- each distinct supported negative strong-link mechanic: `-10`
+- cap total positive strong-link adjustment at `+25`
+- cap total negative strong-link adjustment at `-25`
+- local opportunity remains within `0..100`
+
+Same-economy duplicate evidence is deduplicated by mechanics rule identity; repeated observations of the same mechanic do not stack without an explicit rule permitting it.
+
+### 5.3 System-level strong-link conditions
+
+Conditions such as system reserve level or presence of exotic stars may apply to every eligible local opportunity for the relevant economy. They are applied once per candidate opportunity through the mechanics feature layer, not repeatedly for every source record.
+
+### 5.4 No unsupported convenience modifiers
+
+Local opportunity does **not** receive raw-economy points for:
+
+- distance from arrival;
+- generic body diversity;
+- generic slot count;
+- compactness;
+- generic strategic value;
+- complementary-economy strength;
+- generic scientific interest;
+- nearby population/geography.
+
+## 6. Economy-specific mechanics inputs
+
+The exact rules and provenance live in `ratings-v4-mechanics-evidence.md`. V4 consumes them as follows.
+
+### Agriculture
+
+Eligibility/evidence:
+- ELW native Agriculture
+- Water World native Agriculture
+- organics/biologicals add Agriculture
+- documented Agriculture strong-link positives/negatives
+- terraformability is an amplifier only, not standalone Agriculture inheritance
+
+### Refinery
+
+Eligibility/evidence:
+- Rocky native Refinery
+- Rocky-Ice native Refinery
+- reserve-level Refinery strong-link modifier
+
+Ground/surface capacity does not inflate raw Refinery potential. It contributes to `specialisation_quality` / buildability because Refinery Hub placement is planetary.
+
+### Industrial
+
+Eligibility/evidence:
+- Icy native Industrial
+- Rocky-Ice native Industrial
+- Gas Giant native Industrial
+- geologicals add Industrial
+- reserve-level Industrial strong-link modifier
+
+Extraction or Refinery strength does not inflate raw Industrial potential.
+
+### High Tech
+
+Eligibility/evidence:
+- ELW native High Tech
+- Ammonia native High Tech
+- Gas Giant native High Tech
+- Black Hole / Neutron / White Dwarf native High Tech
+- documented High-Tech strong-link modifiers
+
+Generic scientific interest is archetype evidence, not raw High-Tech evidence.
+
+### Military
+
+Eligibility/evidence:
+- main-sequence stars / Brown Dwarfs native Military
+- ELW native Military
+
+No generic strategic, Industrial, capacity or geography bonuses are included. With no established environmental strong-link modifiers, Military is intentionally conservative.
+
+### Tourism
+
+Eligibility/evidence:
+- ELW native Tourism
+- Water World native Tourism
+- Ammonia native Tourism
+- Black Hole / Neutron / White Dwarf native Tourism
+- documented Tourism strong-link modifiers
+
+Generic diversity and rings are not raw Tourism mechanics unless a later mechanics rule establishes them.
+
+### Extraction
+
+Eligibility/evidence:
+- HMC native Extraction
+- Metal Rich native Extraction
+- rings / asteroid belts add Extraction
+- geologicals add Extraction
+- reserve-level Extraction strong-link modifier
+- volcanism is a strong-link amplifier, not inheritance
+
+## 7. System potential roll-up: quality first, depth second
+
+For each economy, calculate local opportunity scores for all eligible candidate locations and sort descending:
+
+```text
+s1 >= s2 >= s3 >= s4 ...
+```
+
+The system potential is:
+
+```text
+potential = round(
+    0.82*s1
+  + 0.11*s2
+  + 0.05*s3
+  + 0.02*s4
+)
+```
+
+Only the best four opportunities contribute.
+
+Consequences:
+
+- one perfect site scores 82: already excellent;
+- two perfect sites score 93;
+- three perfect sites score 98;
+- four perfect sites score 100;
+- the twentieth mediocre body cannot swamp one genuinely exceptional site;
+- system depth matters, but quality dominates.
+
+This diminishing-return curve is an ED-Finder judgement rule, not a Frontier mechanic, and is versioned with the scorer.
+
+### 7.1 Why four opportunities
+
+Four is sufficient to distinguish shallow vs deep systems while preventing very large systems from winning by catalogue size alone. It is a scorer coefficient and can be changed in a later V4.x ruleset without schema change if validation demonstrates a better curve.
+
+## 8. Specialisation quality
+
+`specialisation_quality` answers:
+
+> **How cleanly can this system make the target economy one of the protected dominant/top-two economies without unwanted local inherited pressure?**
+
+It is distinct from raw potential.
+
+For each candidate location:
+
+1. Start at `100`.
+2. Count **distinct competing inheritable economies** created by the same local body/modifiers.
+3. Apply a competition penalty:
+   - 0 competitors: `0`
+   - 1 competitor: `-8`
+   - 2 competitors: `-20`
+   - 3+ competitors: `-35`
+4. Apply documented preferred-location evidence: `+5`, capped at 100.
+5. Apply documented buildability constraints relevant specifically to specialising that economy (for example absence/unknown ground opportunity for a Refinery strategy) as a separate `specialisation_constraint` component, never as invented raw mechanics.
+
+System `specialisation_quality` uses the best eligible candidate location, with a small depth bonus:
+
+```text
+specialisation = min(100, best_candidate_quality + min(10, 3 * additional_clean_candidates))
+```
+
+The August 2025 top-two-economy protection is respected: one competing economy is only a modest penalty, not a reason to crush the score.
+
+## 9. Potential and specialisation examples
+
+### Example A: clean Rocky Refinery system
+
+A clean Rocky body with Refinery inheritance and favourable reserves may have:
+
+```text
+local Refinery opportunity = 70-85
+local specialisation = 100
+```
+
+A second good Rocky body increases system potential/depth without materially changing purity.
+
+### Example B: geological HMC Extraction site
+
+An HMC has native Extraction. Geologicals also add Extraction + Industrial; volcanism may further strengthen Extraction.
+
+Result can correctly be:
+
+```text
+Extraction potential: very high
+Extraction specialisation: lower than potential
+```
+
+because Industrial pressure exists without making Extraction itself weaker.
+
+### Example C: ELW
+
+ELW provides inherited Agriculture, High Tech, Military and Tourism. Additional strong-link evidence can raise Agriculture/High Tech/Tourism local opportunity. Military receives inheritance evidence but no invented environmental bonus.
+
+Therefore V4 will not flatten the ELW into four equal economy scores.
+
+## 10. Evidence completeness
+
+Completeness is economy-specific. It measures whether the inputs that could materially change that economy score are known.
+
+Each expected evidence family has a weight. Initial V4 weighting:
+
+| Evidence family | Weight |
+|---|---:|
+| Body identity/type/classification coverage | 0.35 |
+| Relevant local modifier coverage (rings/bio/geo/volcanism) | 0.25 |
+| Relevant system modifier coverage (for example reserves) | 0.20 |
+| Relevant terraformability/tidal-lock or other economy-specific facts | 0.10 |
+| Provenance/freshness needed to interpret those facts | 0.10 |
+
+Only families relevant to the economy are included, and their weights are renormalised to 1.0.
+
+Known absence counts as complete evidence. Unknown does not.
+
+## 11. Confidence
+
+Confidence is not a freshness proxy alone. It is derived from source/provenance quality of the evidence actually used.
+
+Initial V4 rule:
+
+```text
+confidence = weighted_mean(source_confidence_of_used_features)
+```
+
+Then apply a conservative completeness guard:
+
+```text
+reported_confidence = min(confidence, 0.5 + 0.5*evidence_completeness)
+```
+
+This prevents a small amount of high-quality evidence from yielding `0.99` confidence when much of the relevant system evidence is still unknown.
+
+Confidence and completeness remain separate API fields.
+
+## 12. Explanation contract
+
+Every economy rating must be explainable from stored components.
+
+Minimum output:
+
+```text
+economy
+potential_score
+specialisation_quality
+evidence_completeness
+confidence
+best_candidate_location
+contributors[]
+constraints[]
+mechanics_ruleset_version
+scorer_version
+```
+
+Each contributor records at least:
+
+```text
+feature_type
+body/system identity where applicable
+mechanic_class: NATIVE_INHERITANCE | MODIFIER_INHERITANCE | STRONG_LINK_POSITIVE | STRONG_LINK_NEGATIVE
+contribution
+rule_id
+provenance/evidence grade
+```
+
+UI rationale is generated from these components; it is not a separate opaque scoring input.
+
+## 13. No universal headline score in the raw ratings layer
+
+The raw Ratings V4 layer does not manufacture one universal `overall_score` from the seven economies.
+
+Instead it exposes seven independent economy results.
+
+A later archetype layer may produce:
+
+- archetype-specific score(s);
+- best colony potential / best archetype;
+- complementary-economy synergy;
+- buildability and practicality dimensions.
+
+Finder then ranks according to an explicit query/profile.
+
+This prevents an apparent universal score from hiding the question being answered.
+
+## 14. V3.4 relationship
+
+Ratings v3.4 remains historical/regression evidence only.
+
+V4 deliberately rejects or relocates these v3.4 behaviours:
+
+- global cross-economy attenuation -> removed;
+- generic compactness/distance/strategic/safety mixing into economy suitability -> archetype/Finder only;
+- one giant ratings row as the entire judgement model -> split into mechanics features, economy ratings, archetypes and ranking profiles;
+- missing evidence treated optimistically or implicitly -> explicit completeness/confidence.
+
+V3.4 should be run side-by-side during V4 validation to identify unexpected regressions, not to constrain V4 semantics.
+
+## 15. Validation fixtures before freeze
+
+Before implementation authority is granted, validate at least these deterministic systems:
+
+1. pure Rocky Refinery specialist;
+2. Rocky + geo/bio/ring contamination case;
+3. pure Icy Industrial specialist;
+4. HMC/Metal-Rich Extraction specialist with reserve variants;
+5. Water-World Agriculture/Tourism system;
+6. ELW mixed-economy system;
+7. Ammonia High-Tech/Tourism system;
+8. exotic-star High-Tech/Tourism system;
+9. main-sequence/Brown-Dwarf Military system;
+10. deep multi-body system proving diminishing returns;
+11. sparse-data system proving unknown != zero;
+12. same mechanics with high vs low/depleted reserves;
+13. top-two mixed-economy case proving no v3.4-style global attenuation.
+
+For each fixture, record expected ordering and score-band expectations before tuning exact coefficients against real systems.
+
+## 16. Freeze criteria
+
+Ratings V4 is ready to freeze when:
+
+1. mechanics rules and provenance are accepted;
+2. every required canonical V3 source field is mapped or explicitly unavailable;
+3. local-opportunity coefficients and system roll-up curve pass the fixture suite;
+4. specialisation behaviour matches the top-two economy model;
+5. unknown/coverage behaviour is demonstrated;
+6. representative real systems produce believable orderings against expert judgement;
+7. v3.4 regression comparison has no unexplained major reversals;
+8. the resulting database table design can represent all scoring components without schema changes for coefficient-only V4.x updates.

--- a/docs/development/ratings-v4-validation-fixtures.md
+++ b/docs/development/ratings-v4-validation-fixtures.md
@@ -1,0 +1,252 @@
+# Ratings V4 Validation Fixtures
+
+**Status:** proposed acceptance fixtures for Ratings V4 coefficient tuning
+**Depends on:** `ratings-v4-mechanics-evidence.md`, `ratings-v4-scoring-contract.md`
+
+## Purpose
+
+These fixtures define expected **ordering and score bands** before implementation. Exact coefficients may move during tuning, but a candidate scorer that violates these expectations needs an explicit mechanics/product explanation rather than ad-hoc coefficient changes.
+
+All fixtures assume complete/high-confidence evidence unless marked otherwise.
+
+## F1 — Pure Rocky Refinery specialist
+
+System contains multiple clean Rocky bodies, no rings, no biological/geological modifiers, favourable reserve state where relevant, and at least one usable planetary location.
+
+Expected:
+
+- Refinery potential: **excellent to exceptional**
+- Refinery specialisation: **very high**
+- Extraction/Industrial/Agriculture: low unless other facts create them
+- A second/third clean Rocky raises depth but with diminishing returns
+
+Acceptance invariant: clean Refinery purity must not be penalised merely because the system has many ordinary non-contributing bodies.
+
+## F2 — Mixed Rocky Refinery contamination case
+
+Same as F1 except the best Rocky bodies carry combinations of rings, biologicals and geologicals.
+
+Expected:
+
+- Refinery potential remains strong because native Refinery inheritance still exists
+- Refinery specialisation is lower than F1 because competing inherited economies are introduced
+- Extraction/Industrial/Agriculture rise according to the actual modifiers
+
+Acceptance invariant: contamination changes specialisation more than raw Refinery potential.
+
+## F3 — Pure Icy Industrial specialist
+
+Several clean Icy bodies, favourable reserve state, no competing local modifiers.
+
+Expected:
+
+- Industrial potential: excellent/exceptional
+- Industrial specialisation: very high
+- Refinery/Extraction remain low absent supporting inheritance
+
+## F4 — Rocky-Ice dual Industrial/Refinery system
+
+Several Rocky-Ice bodies.
+
+Expected:
+
+- Industrial and Refinery both strong
+- neither raw score is attenuated because the other is also strong
+- specialisation for each is lower than a perfectly pure single-economy equivalent, but top-two protection prevents a severe penalty
+
+## F5 — Extraction reserve ladder
+
+Three otherwise identical HMC/Metal-Rich systems:
+
+- F5a Pristine/Major reserves
+- F5b Average/Common reserves
+- F5c Low/Depleted reserves
+
+Expected ordering:
+
+`F5a Extraction > F5b Extraction > F5c Extraction`
+
+The reserve difference must be visible in explanation components.
+
+## F6 — Geological + volcanic Extraction system
+
+HMC with geologicals and volcanism.
+
+Expected:
+
+- native Extraction from HMC
+- additional Extraction + Industrial inheritance from geologicals
+- volcanism strengthens Extraction but does not create a second inheritance event
+- Extraction potential very high
+- Extraction specialisation below a comparable clean HMC because Industrial pressure exists
+
+## F7 — Water-World Agriculture/Tourism system
+
+Multiple Water Worlds, no contradictory evidence.
+
+Expected:
+
+- Agriculture and Tourism both excellent/exceptional
+- neither is attenuated because both are strong
+- Military remains low
+- High Tech only receives effects supported by the active mechanics ruleset/provenance
+
+## F8 — ELW mixed-economy system
+
+One or more ELWs.
+
+Expected:
+
+- Agriculture, Tourism and High Tech all receive meaningful positive support
+- Military receives inheritance eligibility but no fabricated environmental/strategic bonus
+- Agriculture/Tourism should normally outrank Military for an otherwise uncomplicated ELW fixture
+- no global cross-economy attenuation
+
+## F9 — Ammonia High-Tech/Tourism system
+
+Ammonia World(s), otherwise uncomplicated.
+
+Expected:
+
+- High Tech and Tourism strong
+- Agriculture/Military low absent independent support
+
+## F10 — Exotic-star High-Tech/Tourism system
+
+Black Hole, Neutron Star or White Dwarf with no unrelated strong economy bodies.
+
+Expected:
+
+- High Tech and Tourism are the principal raw economy opportunities
+- Tourism benefits from any documented system-level exotic-star modifier
+- Military does not inherit from the exotic star
+
+## F11 — Main-sequence Military system
+
+Main-sequence/Brown-Dwarf stellar environment with no ELW and no strong competing economy bodies.
+
+Expected:
+
+- Military is the principal raw economy score
+- Military score is driven by inheritance, not invented strategic/slot bonuses
+- specialisation is high where no asteroid-belt/modifier pressure introduces competition
+
+## F12 — Deep-body diminishing returns
+
+Compare:
+
+- F12a: one perfect candidate for economy E
+- F12b: two perfect candidates
+- F12c: four perfect candidates
+- F12d: twenty perfect candidates
+
+Expected approximate bands from the proposed roll-up:
+
+- one perfect: ~82
+- two perfect: ~93
+- three perfect: ~98
+- four perfect: 100
+- twenty perfect: still 100, never >100 and never rewarded beyond the best four
+
+Acceptance invariant: quality dominates sheer catalogue size.
+
+## F13 — One excellent vs many mediocre
+
+Compare:
+
+- one local opportunity score 100
+- ten local opportunities around 45
+
+Expected:
+
+The single excellent-site system should rank at least comparably and normally above the many-mediocre system for raw economy potential.
+
+This guards against body-count inflation.
+
+## F14 — Unknown evidence vs known absence
+
+Two otherwise identical systems:
+
+- F14a rings/bio/geo/reserve facts are explicitly known absent/normal
+- F14b those same evidence families are unknown
+
+Expected:
+
+- potential scores may be similar if no positive evidence is present
+- F14a has materially higher evidence completeness
+- F14b must not receive fake negative contributions for unknown inputs
+- confidence guard must prevent F14b from presenting as near-certain
+
+## F15 — Top-two protection
+
+A system with two naturally strong compatible economies and a weaker third.
+
+Expected:
+
+- both top economies keep their independent raw potential
+- the weaker economy is not artificially attenuated merely because it ranks third
+- specialisation/archetype logic may describe competition, but raw scores remain honest
+
+This explicitly rejects Ratings v3.4 global attenuation.
+
+## F16 — Terraformability amplifier only
+
+Two otherwise identical non-Agriculture-native bodies, one terraformable and one not.
+
+Expected:
+
+- terraformability alone must not manufacture Agriculture eligibility where no Agriculture inheritance exists
+
+Then repeat with an Agriculture-eligible body:
+
+- terraformability may improve Agriculture local opportunity according to the active mechanics ruleset
+
+## F17 — Geologicals vs volcanism distinction
+
+Compare:
+
+- body with geologicals only
+- body with volcanism only
+- body with both
+
+Expected:
+
+- geologicals can add Extraction/Industrial inheritance
+- volcanism only modifies an existing Extraction opportunity
+- the two features must produce different explanation records and cannot be collapsed into one boolean
+
+## F18 — Absolute-score stability
+
+Run the same deterministic fixture against two canonical generations containing identical relevant facts but different unrelated catalogue population.
+
+Expected:
+
+- all V4 raw economy scores identical
+- percentile/rank may differ outside Ratings V4
+
+This proves scores are absolute rather than galaxy-relative.
+
+## Real-system validation lane
+
+After deterministic fixtures pass, select a small reviewed set of real systems representing:
+
+- known Tourism/Agriculture showcase
+- known extraction/refinery specialist
+- strong Industrial chain candidate
+- High-Tech/exotic system
+- Military specialist
+- mixed multi-role system
+- sparse/uncertain system
+
+For each, record expert expected ordering before running V4. Exact system names and expected results belong in the validation receipt, not hard-coded in the scoring algorithm.
+
+## Freeze rule
+
+Do not freeze coefficients solely because all numerical tests pass. The fixture suite must also demonstrate:
+
+- explanations match the mechanics evidence;
+- unknown remains unknown;
+- specialisation and potential are visibly distinct;
+- ELW is not flattened into equal Agriculture/HighTech/Military/Tourism treatment;
+- no old v3.4 global attenuation survives;
+- score changes from coefficient tuning are understandable from stored contributors.

--- a/docs/development/ratings-v4-validation-fixtures.md
+++ b/docs/development/ratings-v4-validation-fixtures.md
@@ -226,27 +226,159 @@ Expected:
 
 This proves scores are absolute rather than galaxy-relative.
 
-## Real-system validation lane
+## Real-system validation cohort
 
-After deterministic fixtures pass, select a small reviewed set of real systems representing:
+The following twelve systems are the fixed initial real-world V4 regression cohort. They were selected before the V4 implementation is run against them. The implementation may not tune coefficients merely to make these systems pass; a violated expectation needs a mechanics/product explanation and explicit review.
 
-- known Tourism/Agriculture showcase
-- known extraction/refinery specialist
-- strong Industrial chain candidate
-- High-Tech/exotic system
-- Military specialist
-- mixed multi-role system
-- sparse/uncertain system
+### R1 — Wregoe ZN-X c28-28
 
-For each, record expert expected ordering before running V4. Exact system names and expected results belong in the validation receipt, not hard-coded in the scoring algorithm.
+Role: user-known mining/refining system.
+
+Expected V4 character:
+
+- Extraction and Refinery should be among the strongest raw economies.
+- Industrial may be strong where the canonical body mix independently supports it.
+- Existing built station economies are comparison evidence only and must not feed the intrinsic rating.
+- Failure caught: a scorer that cannot recognise an obvious mining/refining candidate from physical mechanics.
+
+### R2 — Praea Euq WV-W b2-2
+
+Role: user-known four-Water-World system; the four WWs form two orbital pairs.
+
+Expected V4 character:
+
+- Agriculture and Tourism should dominate the raw economy profile.
+- Agriculture and Tourism should both show strong depth without either being attenuated because the other is strong.
+- Military must not be elevated merely because WW/ELW-style mixed-economy rules exist elsewhere.
+- The two-pair orbital topology belongs to archetype/planning judgement, not raw Agriculture/Tourism mechanics unless a later verified rule says otherwise.
+- Failure caught: body-count inflation, cross-economy attenuation, or leaking topology into raw economy scoring.
+
+### R3 — Sol
+
+Role: broad mixed baseline.
+
+Expected V4 character:
+
+- Multiple credible economy families should appear from the varied stellar/body composition.
+- No blanket "famous/mixed system" bonus is permitted.
+- Common/ordinary reserve evidence should not behave like Pristine/Major.
+- Failure caught: generic diversity or strategic-value heuristics leaking into raw economy scores.
+
+### R4 — Achenar
+
+Role: ELW-heavy mixed-economy stress case.
+
+Expected V4 character:
+
+- Agriculture, Tourism and High Tech should all receive strong ELW-backed support.
+- Military receives legitimate inheritance evidence but should normally trail Agriculture/Tourism in an otherwise uncomplicated ELW-led interpretation because it lacks equivalent strong-link environmental support.
+- Failure caught: flattening ELW into equal Agriculture/High Tech/Military/Tourism values.
+
+### R5 — Alioth
+
+Role: strong habitable-world evidence combined with poor/depleted resource conditions.
+
+Expected V4 character:
+
+- Agriculture/Tourism should remain healthy where the body facts support them.
+- Extraction/Industrial/Refinery should reflect poor reserve evidence rather than dragging unrelated economies down.
+- Failure caught: reserve modifiers being applied globally rather than economy-specifically.
+
+### R6 — Maia
+
+Role: exotic-star / Brown-Dwarf separation case.
+
+Expected V4 character:
+
+- Black-hole/exotic stellar evidence should support High Tech and Tourism.
+- Brown-Dwarf inheritance should independently support Military.
+- The scorer must explain both rather than turning exoticness into a universal bonus.
+- Failure caught: generic "exotic system" scoring and incorrect Military inheritance.
+
+### R7 — Borann
+
+Role: deep icy/gas-giant, high-resource and diminishing-returns stress case.
+
+Expected V4 character:
+
+- Industrial/resource-related potential should be prominent where supported.
+- Many contributing bodies must not create scores above 100 or overwhelm the quality-first roll-up.
+- Failure caught: raw body-count domination.
+
+### R8 — HD 38179
+
+Role: resource-rich Extraction fixture with separate Brown-Dwarf Military evidence.
+
+Expected V4 character:
+
+- Extraction should be strong from the relevant mineral/resource facts.
+- Military may also be credible for a different, explicitly inherited reason.
+- Neither should silently boost the other.
+- Failure caught: unrelated economy coupling.
+
+### R9 — Col 285 Sector BW-U c3-5
+
+Role: Industrial/Refinery dual-economy fixture.
+
+Expected V4 character:
+
+- Industrial and Refinery should both be strong where Icy/Rocky-Ice/gas-giant facts justify them.
+- Neither raw score is reduced simply because the other is strong.
+- Failure caught: survival of v3.4-style cross-economy attenuation.
+
+### R10 — Smojoo ZE-R d4-109 (Musica Universalis)
+
+Role: broad multi-role "kitchen sink" system.
+
+Expected V4 character:
+
+- Agriculture, Tourism, High Tech and resource-oriented economies may all be strong for different explainable reasons.
+- The contributor output must show which bodies/rules caused each economy result.
+- A single opaque universal raw score is not acceptable.
+- Failure caught: explanation collapse and over-compression of genuinely multi-role systems.
+
+### R11 — Thaile HW-V e2-7 (Three Worlds Nebula)
+
+Role: exotic mixed-world fixture with ELW/WW/Ammonia/resource evidence.
+
+Expected V4 character:
+
+- Tourism and High Tech should be especially strong from exotic stellar/world evidence.
+- Agriculture should independently benefit from ELW/WW evidence.
+- Extraction should arise only from its own mineral/ring/geological/reserve evidence.
+- Failure caught: one strong archetype contaminating unrelated raw economy scores.
+
+### R12 — Deriv-Dar
+
+Role: intrinsic-potential versus accessibility separation case.
+
+Expected V4 character:
+
+- Agriculture/Tourism can remain intrinsically strong from ELW/WW/terraformable mechanics even where attractive bodies are very distant from arrival.
+- Raw economy potential must not be reduced merely because travel within the system is inconvenient.
+- Finder/accessibility or archetype practicality may later penalise the system strongly.
+- Failure caught: v3.4-style distance/compactness heuristics leaking back into raw economy suitability.
+
+## Real-system acceptance rules
+
+For the cohort above:
+
+1. Record the exact canonical-generation facts consumed for every system.
+2. Record the active mechanics ruleset and scorer version.
+3. Evaluate expected **ordering and character**, not hand-picked exact scores, until coefficient calibration is frozen.
+4. Existing station economies, popularity, fame and user knowledge are post-hoc comparison evidence only.
+5. A system may expose an unexpected economy if the contributor trace proves real mechanics evidence; that is not automatically a failure.
+6. Any unexplained major reversal versus the expected character must be reviewed before V4.0 is frozen.
+7. The cohort is a regression set, not training data.
 
 ## Freeze rule
 
-Do not freeze coefficients solely because all numerical tests pass. The fixture suite must also demonstrate:
+Do not freeze coefficients solely because all numerical tests pass. The fixture suite and real-system cohort must also demonstrate:
 
 - explanations match the mechanics evidence;
 - unknown remains unknown;
 - specialisation and potential are visibly distinct;
 - ELW is not flattened into equal Agriculture/HighTech/Military/Tourism treatment;
 - no old v3.4 global attenuation survives;
-- score changes from coefficient tuning are understandable from stored contributors.
+- score changes from coefficient tuning are understandable from stored contributors;
+- the twelve real systems retain believable, explainable economy ordering without tuning directly to their observed built economies.

--- a/docs/development/v3-search-spatial-derived-data-decision.md
+++ b/docs/development/v3-search-spatial-derived-data-decision.md
@@ -1,0 +1,366 @@
+# ED-Finder V3 Search, Spatial and Derived-Data Decision
+
+**Status:** proposed V3 authority; becomes authoritative only when reviewed and merged
+**Scope:** PostgreSQL 18 search, spatial indexing, map aggregation, clustering, Ratings v3.4 migration, archetype judgement, derived-data generation and publication
+
+## Why this decision exists
+
+The retained production V3 database is a namespaced canonical-generation model. The current published canonical generation contains `systems`, `bodies` and `stations` under a generation-specific schema and uses `v3_meta.current_canonical_generation` to identify the live canonical generation. The historical application/search implementation instead assumes unqualified `public.systems`, `ratings`, old map materialisations and old coordinate names.
+
+This decision does not recreate the historical `public` schema. It defines a clean V3 derived-data architecture around the retained canonical-generation model.
+
+The design goal is that future changes to search requirements, grid sizes, map LOD, clustering algorithms, scoring algorithms or canonical generations require a **rebuild and publication of derived data**, not another application-wide schema redesign.
+
+## Non-negotiable boundaries
+
+1. **Canonical source data stays canonical.** Generation schemas such as `v3_gen_<generation_key>` remain immutable/source-oriented and are never reshaped merely to suit one UI.
+2. **Derived data is disposable and reproducible.** Ratings, archetypes, search projections, spatial cells and clusters may always be rebuilt from named canonical inputs and named rule versions.
+3. **Exact spatial truth is coordinates, not cells.** Elite `x/y/z` light-year coordinates remain authoritative. Grid/cell identifiers are accelerators or aggregation keys only.
+4. **Finder owns querying and ranking.** The renderer does not calculate ranking, cluster membership or scoring.
+5. **Clusters are outputs, not the search index.** A clustering algorithm may change without changing exact spatial search or canonical identity.
+6. **No hidden `search_path` contract.** Application-facing SQL uses explicit stable V3 application/derived relations.
+7. **Publication is atomic.** A partial rebuild must never become the current derived generation.
+
+## 1. Derived-generation identity
+
+Add an explicit derived-generation identity linked to one canonical generation.
+
+Conceptually:
+
+```text
+v3_meta.derived_generation
+- derived_generation_id UUID PK
+- canonical_generation_id UUID FK
+- generation_key TEXT UNIQUE
+- scorer_version TEXT
+- archetype_version TEXT
+- search_projection_version TEXT
+- spatial_pyramid_version TEXT
+- cluster_algorithm_version TEXT
+- lifecycle_state BUILDING|VALIDATING|READY|PUBLISHED|RETIRED|FAILED
+- manifest_sha256 BYTEA
+- validation_receipt JSONB
+- created_at / validated_at / published_at / retired_at / failed_at
+
+v3_meta.current_derived_generation
+- singleton BOOLEAN PK CHECK(singleton)
+- derived_generation_id UUID UNIQUE FK
+- publication_sequence BIGINT
+- published_at TIMESTAMPTZ
+```
+
+A derived generation is immutable once published. Recalculation produces another generation and publication flips only the current pointer after validation.
+
+## 2. Exact spatial search: PostgreSQL `cube` + GiST
+
+Do not make a coarse grid the primary Finder search primitive.
+
+For the stable application search projection, retain numeric coordinates and also expose a 3-D `cube` point:
+
+```text
+position_ly = cube(ARRAY[x_ly, y_ly, z_ly])
+```
+
+Create a GiST index on `position_ly`.
+
+Use it for:
+
+- nearest-system / k-nearest-neighbour queries;
+- search-around-here;
+- bounded-radius candidate retrieval;
+- route and local-neighbour primitives;
+- map target lookup where exact distance matters.
+
+A radius query first narrows with an index-supported cube/bounds predicate and then applies exact Euclidean distance. KNN uses the cube Euclidean distance ordering operator.
+
+The raw numeric coordinates remain in the projection because they are the public/API truth and are useful for vector calculations and rendering.
+
+### Why not PostGIS as the baseline
+
+ED-Finder needs ordinary 3-D Euclidean galactic coordinates, not Earth geography or GIS topology. PostgreSQL's supplied `cube` type directly supports N-dimensional Euclidean distance and GiST KNN. PostGIS may still be justified later by a separate requirement, but it is not required merely to search the Galaxy.
+
+## 3. Search projection
+
+Create a generation-scoped application search projection containing only facts required for high-frequency Finder/Explore/Inspect discovery.
+
+Conceptually:
+
+```text
+v3_derived.system_search
+- derived_generation_id
+- id64
+- name
+- x_ly / y_ly / z_ly
+- position_ly cube
+- galaxy_region_id
+- main-star summary required by product
+- body-count / factual summary inputs required by Finder
+- current colonisation factual summary when authoritative
+- source/freshness fields needed for confidence
+PRIMARY KEY (derived_generation_id, id64)
+```
+
+Indexes are workload-driven and may include:
+
+- GiST `position_ly`;
+- name prefix/trigram search;
+- `galaxy_region_id`;
+- explicit ranking/filter columns proven by Search requirements.
+
+Do not bake every later feature into this row. Heavy domain outputs live in their own derived relations and are joined only when the query needs them.
+
+## 4. Ratings v3.4 remains a scoring contract, not the whole judgement model
+
+Retain the accepted **Ratings v3.4 Best-Build Potential** semantics:
+
+- overall 0-100 best-build potential;
+- seven economy suitability scores including Extraction;
+- complementary top pair and pair score;
+- confidence;
+- rationale;
+- score dimensions: slots, strategic, safety, terraforming, diversity.
+
+Migrate those semantics to a versioned derived relation rather than recreating the old historical `ratings` table contract verbatim.
+
+Conceptually:
+
+```text
+v3_derived.system_rating
+- derived_generation_id
+- system_id64
+- scorer_version
+- best_build_score
+- score_agriculture
+- score_refinery
+- score_industrial
+- score_hightech
+- score_military
+- score_tourism
+- score_extraction
+- top_pair_a / top_pair_b / pair_score
+- confidence
+- rationale
+- dimensions JSONB (or typed columns when the final scorer implementation proves they are hot query fields)
+- computed_at
+PRIMARY KEY (derived_generation_id, system_id64)
+```
+
+The scorer reads normalized canonical V3 body/vocabulary facts through an explicit adapter. Historical assumptions such as old body flags or enum types are not silently recreated.
+
+## 5. Archetype judgement is a separate derived layer
+
+Do not overload Ratings v3.4 to become every later judgement.
+
+Archetype judgement consumes named rating outputs plus named mechanics/rule inputs and writes a separate versioned result:
+
+```text
+v3_derived.system_archetype
+- derived_generation_id
+- system_id64
+- archetype_version
+- primary_archetype
+- secondary_archetype
+- archetype_confidence
+- overall_development_potential
+- buildability_score
+- build_complexity
+- purity_score
+- contamination_risk
+- estimated_total_slots
+- display_tags
+- computed_at
+PRIMARY KEY (derived_generation_id, system_id64)
+```
+
+This resolves the current roadmap ambiguity cleanly:
+
+- Ratings v3.4 remains the accepted suitability/best-build scorer.
+- Archetype judgement is a separately versioned interpretation layer.
+- Finder may rank using either or both through an explicit ranking profile.
+
+## 6. Finder ranking profiles are versioned
+
+Search ranking must not be hard-coded as an accidental SQL expression spread through routers.
+
+Define a named ranking-profile version in code/manifest. A profile declares which derived fields participate and how they are ordered/weighted.
+
+Examples may include:
+
+- `distance`;
+- `best_build`;
+- `development`;
+- later economy-specific or programme-specific ranking.
+
+The API response states the active ranking/profile version where operationally useful. Changing ranking logic does not require rewriting canonical data.
+
+## 7. Map data: a multi-resolution spatial pyramid
+
+Do not choose one permanent grid cell size.
+
+Build a **multi-resolution 3-D cell pyramid** from exact system coordinates. Cells are an aggregation/LOD mechanism only.
+
+Use power-of-two hierarchical cells (octree-style) with a deterministic integer key, preferably a Morton/Z-order code or equivalent stable hierarchical encoding. Store the level and cell bounds explicitly enough that the encoding can be changed by a later pyramid version without changing public APIs.
+
+Conceptually:
+
+```text
+v3_spatial.cell_level
+- spatial_pyramid_version
+- level
+- cell_size_ly
+- intended_scale / target_budget metadata
+
+v3_spatial.cell_summary
+- derived_generation_id
+- spatial_pyramid_version
+- level
+- cell_key
+- min/max x/y/z or deterministic cell origin
+- system_count
+- centroid_x/y/z
+- factual summary counters required at that LOD
+- optional derived score summaries required by named map layers
+- representative_system_id64 when the selection rule is explicit/versioned
+PRIMARY KEY (derived_generation_id, spatial_pyramid_version, level, cell_key)
+```
+
+The map chooses a level from semantic zoom, viewport volume and target-count budget. It does not assume that one cell size fits Galaxy, regional and local views.
+
+### Relationship to existing `grid_x/grid_y/grid_z/macro_grid_key`
+
+The current canonical generation already contains these values. Preserve them as existing canonical-generation fields and evidence. Do **not** make them the permanent V3 Search/Grid/Cluster API contract unless benchmarks prove that exact encoding is the best pyramid implementation.
+
+The new derived pyramid may reuse their calculation if it matches the chosen version, but the public contract is level + cell identity + bounds/summary, not those historical column names.
+
+## 8. Clusters are independently versioned derived products
+
+Cluster membership is domain analysis, not spatial truth and not a renderer responsibility.
+
+Store cluster output separately from the cell pyramid:
+
+```text
+v3_spatial.cluster_run
+- derived_generation_id
+- cluster_run_id
+- owner/domain
+- algorithm
+- algorithm_version
+- parameters JSONB
+- lifecycle / validation receipt
+
+v3_spatial.cluster
+- cluster_run_id
+- cluster_id
+- centroid / bounds
+- member_count
+- summary / provenance
+
+v3_spatial.cluster_member
+- cluster_run_id
+- cluster_id
+- system_id64
+- membership_score/confidence when meaningful
+PRIMARY KEY (cluster_run_id, cluster_id, system_id64)
+```
+
+Consequences:
+
+- DBSCAN/HDBSCAN/domain-specific or later algorithms can replace one another without changing Finder's exact spatial index.
+- Different domains may publish different cluster sets.
+- A cluster can be rebuilt or retired independently.
+- Map hulls/visualisations are projections of cluster membership, never the source of membership truth.
+
+## 9. Stable application boundary
+
+The application must not reference generation-specific canonical schema names.
+
+Expose a stable `v3_app` boundary through reviewed SQL views/functions or an equally explicit stable query layer. It resolves the current derived generation and presents the API contract needed by FastAPI.
+
+Examples:
+
+```text
+v3_app.system_search
+v3_app.system_rating
+v3_app.system_archetype
+v3_app.system_detail
+v3_app.map_cells(...)
+v3_app.cluster_members(...)
+```
+
+Whether the implementation uses stable views, SQL functions, or queries that bind the current derived-generation ID is an implementation choice, but publication semantics must remain atomic and generation-aware.
+
+No production application query may depend on whichever schema happens to appear first in `search_path`.
+
+## 10. Rebuild and publication pipeline
+
+Order is explicit:
+
+1. Resolve the current canonical generation and record its immutable identity.
+2. Create a BUILDING derived generation.
+3. Build the factual search projection.
+4. Build Ratings v3.4-compatible scoring from normalized V3 inputs.
+5. Build archetype judgement using its own version.
+6. Build all configured spatial-pyramid levels.
+7. Build configured cluster runs.
+8. Validate row counts, referential integrity, coordinate invariants, score ranges, reproducibility samples, query plans and bounded performance.
+9. Produce a manifest/checksum and validation receipt.
+10. Mark READY.
+11. Atomically publish `current_derived_generation`.
+12. Retain at least the previous compatible derived generation until rollback eligibility is known.
+
+Failure before publication leaves the previous generation current.
+
+## 11. Resource and operational rules
+
+A full derived bootstrap over the Galaxy is a bounded operator job, not API startup work.
+
+Require:
+
+- resumable/chunked build stages;
+- bounded concurrency and memory;
+- statement and lock policy appropriate for offline derived builds;
+- progress receipts that use real or explicitly unknown totals;
+- no long blocking DDL on canonical generation tables;
+- index construction staged after bulk load where benchmarks support it;
+- `ANALYZE` before validation benchmarks;
+- explain-plan and latency evidence for representative exact-radius, KNN, autocomplete, galaxy-map, regional-map and local-map queries;
+- deterministic version/manifests sufficient to reproduce a generation.
+
+## 12. What this deliberately avoids
+
+- Recreating V2 `public.*` merely to keep old SQL running.
+- Treating one `grid_cell_id` size as the permanent spatial architecture.
+- Coupling cluster membership to map-cell membership.
+- Running rating logic inline on request paths.
+- Letting the renderer calculate ranking, scores or clusters.
+- Treating a materialized map view as canonical truth.
+- Making a scorer rewrite require a canonical-data rebuild.
+- Making a canonical-generation publication immediately invalidate the previous application release without explicit compatibility evidence.
+
+## 13. Decisions to benchmark, not bikeshed
+
+The architecture above is stable while these implementation values remain benchmark-driven:
+
+- exact spatial-pyramid cell sizes/levels;
+- Morton/Z-order encoding details;
+- whether generated or explicitly stored `cube` position performs best;
+- name-index strategy and thresholds;
+- which rating/archetype fields deserve dedicated columns versus JSON detail;
+- cell summary payloads at each semantic LOD;
+- cluster algorithm and parameters per domain;
+- retained derived-generation count.
+
+These are versioned configuration/algorithm decisions, not reasons to reopen the architecture.
+
+## Acceptance bar
+
+Before this becomes production data authority, prove on production-like scale that:
+
+- exact 3-D distance and KNN queries use an index and meet the Search latency budget;
+- galaxy/regional/local map queries are bounded by a target-count contract rather than raw catalogue size;
+- a pyramid-version change requires only rebuilding derived rows;
+- a cluster-algorithm change requires only rebuilding cluster runs;
+- a scorer/archetype version change does not mutate canonical source facts;
+- publishing a failed/partial build is impossible;
+- API queries resolve an explicit published derived generation;
+- canonical generation, derived generation, scorer, archetype, pyramid and cluster versions are visible in operational receipts.

--- a/docs/development/v3-search-spatial-derived-data-decision.md
+++ b/docs/development/v3-search-spatial-derived-data-decision.md
@@ -1,29 +1,32 @@
 # ED-Finder V3 Search, Spatial and Derived-Data Decision
 
 **Status:** proposed V3 authority; becomes authoritative only when reviewed and merged
-**Scope:** PostgreSQL 18 search, spatial indexing, map aggregation, clustering, Ratings v3.4 migration, archetype judgement, derived-data generation and publication
+**Scope:** PostgreSQL 18 search, spatial indexing, map aggregation, clustering, Ratings V4, archetype judgement, derived-data generation and publication
 
 ## Why this decision exists
 
-The retained production V3 database is a namespaced canonical-generation model. The current published canonical generation contains `systems`, `bodies` and `stations` under a generation-specific schema and uses `v3_meta.current_canonical_generation` to identify the live canonical generation. The historical application/search implementation instead assumes unqualified `public.systems`, `ratings`, old map materialisations and old coordinate names.
+The retained production V3 database is a namespaced canonical-generation model. The current canonical generation supplies system/body/station truth while the historical application assumes an old `public.*` search/ratings/map schema.
 
-This decision does not recreate the historical `public` schema. It defines a clean V3 derived-data architecture around the retained canonical-generation model.
+V3 will not recreate that historical schema. It will build a clean, versioned application/derived layer from the currently published canonical generation.
 
-The design goal is that future changes to search requirements, grid sizes, map LOD, clustering algorithms, scoring algorithms or canonical generations require a **rebuild and publication of derived data**, not another application-wide schema redesign.
+The design goal is simple: future changes to search requirements, map cell sizes, LOD policy, clustering algorithms, scoring rules or canonical generations must normally require a **derived rebuild and atomic publication**, not another application-wide schema redesign.
+
+The detailed mechanics evidence for Ratings V4 is in [`ratings-v4-mechanics-evidence.md`](ratings-v4-mechanics-evidence.md).
 
 ## Non-negotiable boundaries
 
-1. **Canonical source data stays canonical.** Generation schemas such as `v3_gen_<generation_key>` remain immutable/source-oriented and are never reshaped merely to suit one UI.
-2. **Derived data is disposable and reproducible.** Ratings, archetypes, search projections, spatial cells and clusters may always be rebuilt from named canonical inputs and named rule versions.
-3. **Exact spatial truth is coordinates, not cells.** Elite `x/y/z` light-year coordinates remain authoritative. Grid/cell identifiers are accelerators or aggregation keys only.
-4. **Finder owns querying and ranking.** The renderer does not calculate ranking, cluster membership or scoring.
-5. **Clusters are outputs, not the search index.** A clustering algorithm may change without changing exact spatial search or canonical identity.
-6. **No hidden `search_path` contract.** Application-facing SQL uses explicit stable V3 application/derived relations.
-7. **Publication is atomic.** A partial rebuild must never become the current derived generation.
+1. Canonical V3 generation schemas remain source truth and are not reshaped for one UI.
+2. Search projections, ratings, archetypes, map cells and clusters are reproducible derived data.
+3. Exact spatial truth is Elite `x/y/z` light-year coordinates, never a grid cell.
+4. Finder owns querying/ranking. The renderer does not calculate rankings, scores or cluster membership.
+5. Clusters are domain-derived outputs, not the search index.
+6. Application SQL uses explicit V3 relations; no hidden `search_path` contract.
+7. A partial/failed derived build can never become current.
+8. Ratings V3.4 is historical/regression evidence. **Ratings V4 is the target scoring authority.**
 
 ## 1. Derived-generation identity
 
-Add an explicit derived-generation identity linked to one canonical generation.
+A derived generation is linked to one canonical generation and records every rule/model family that can change independently.
 
 Conceptually:
 
@@ -32,8 +35,10 @@ v3_meta.derived_generation
 - derived_generation_id UUID PK
 - canonical_generation_id UUID FK
 - generation_key TEXT UNIQUE
+- mechanics_version TEXT
 - scorer_version TEXT
 - archetype_version TEXT
+- ranking_version TEXT
 - search_projection_version TEXT
 - spatial_pyramid_version TEXT
 - cluster_algorithm_version TEXT
@@ -49,41 +54,35 @@ v3_meta.current_derived_generation
 - published_at TIMESTAMPTZ
 ```
 
-A derived generation is immutable once published. Recalculation produces another generation and publication flips only the current pointer after validation.
+Published derived generations are immutable. Recalculation creates a new generation; publication flips a single current pointer after validation.
 
 ## 2. Exact spatial search: PostgreSQL `cube` + GiST
 
 Do not make a coarse grid the primary Finder search primitive.
 
-For the stable application search projection, retain numeric coordinates and also expose a 3-D `cube` point:
+The stable system-search projection retains numeric coordinates and a 3-D PostgreSQL `cube` point:
 
 ```text
 position_ly = cube(ARRAY[x_ly, y_ly, z_ly])
 ```
 
-Create a GiST index on `position_ly`.
+A GiST index on `position_ly` supports:
 
-Use it for:
-
-- nearest-system / k-nearest-neighbour queries;
-- search-around-here;
+- K-nearest-neighbour queries;
+- search/find around here;
 - bounded-radius candidate retrieval;
-- route and local-neighbour primitives;
-- map target lookup where exact distance matters.
+- route/local-neighbour primitives;
+- exact map target lookup.
 
-A radius query first narrows with an index-supported cube/bounds predicate and then applies exact Euclidean distance. KNN uses the cube Euclidean distance ordering operator.
+Radius queries use an index-supported bounds/cube predicate followed by exact Euclidean distance. Raw numeric LY coordinates remain the API/rendering truth.
 
-The raw numeric coordinates remain in the projection because they are the public/API truth and are useful for vector calculations and rendering.
+### Why not PostGIS by default
 
-### Why not PostGIS as the baseline
+The problem is 3-D Euclidean galactic space, not terrestrial geography/GIS topology. PostgreSQL `cube` directly supports N-dimensional Euclidean distance and GiST KNN. PostGIS remains available if a later requirement independently justifies it.
 
-ED-Finder needs ordinary 3-D Euclidean galactic coordinates, not Earth geography or GIS topology. PostgreSQL's supplied `cube` type directly supports N-dimensional Euclidean distance and GiST KNN. PostGIS may still be justified later by a separate requirement, but it is not required merely to search the Galaxy.
+## 3. Stable search projection
 
-## 3. Search projection
-
-Create a generation-scoped application search projection containing only facts required for high-frequency Finder/Explore/Inspect discovery.
-
-Conceptually:
+Generation-scoped derived search data contains only hot Finder/Explore/Inspect facts.
 
 ```text
 v3_derived.system_search
@@ -93,150 +92,196 @@ v3_derived.system_search
 - x_ly / y_ly / z_ly
 - position_ly cube
 - galaxy_region_id
-- main-star summary required by product
-- body-count / factual summary inputs required by Finder
-- current colonisation factual summary when authoritative
-- source/freshness fields needed for confidence
+- required main-star summary
+- required factual body/system summary
+- source/freshness/completeness fields
 PRIMARY KEY (derived_generation_id, id64)
 ```
 
-Indexes are workload-driven and may include:
+Indexes are driven by measured workloads: spatial GiST, autocomplete/name, region and proven hot filter/ranking fields.
 
-- GiST `position_ly`;
-- name prefix/trigram search;
-- `galaxy_region_id`;
-- explicit ranking/filter columns proven by Search requirements.
+Heavy judgement/domain outputs stay in separate relations.
 
-Do not bake every later feature into this row. Heavy domain outputs live in their own derived relations and are joined only when the query needs them.
+## 4. Ratings V4 scoring model
 
-## 4. Ratings v3.4 remains a scoring contract, not the whole judgement model
+V4 separates mechanics, suitability, specialisation, archetype judgement and Finder preference.
 
-Retain the accepted **Ratings v3.4 Best-Build Potential** semantics:
+The pipeline is:
 
-- overall 0-100 best-build potential;
-- seven economy suitability scores including Extraction;
-- complementary top pair and pair score;
-- confidence;
-- rationale;
-- score dimensions: slots, strategic, safety, terraforming, diversity.
+```text
+canonical facts
+  -> versioned mechanics features
+  -> seven independent economy potentials
+  -> economy specialisation quality
+  -> archetype judgement
+  -> Finder ranking profile
+```
 
-Migrate those semantics to a versioned derived relation rather than recreating the old historical `ratings` table contract verbatim.
+### Seven raw economy scores
+
+V4 retains the seven user-facing economy families:
+
+- Agriculture
+- Refinery
+- Industrial
+- High Tech
+- Military
+- Tourism
+- Extraction
+
+Each raw score answers only:
+
+> How naturally and strongly can the known physical/system mechanics support this economy?
+
+Raw scores are **absolute mechanics-based 0-100 values**, not galaxy percentiles and not query-specific rankings.
+
+### Potential and specialisation are separate
+
+Each economy produces at least:
+
+- `potential_score` — natural/evidenced support for the economy;
+- `specialisation_quality` — how cleanly a build can make the economy dominant/top-two without unwanted competing local influence;
+- `evidence_completeness`;
+- `confidence`;
+- contributor/explanation payload;
+- mechanics/scorer versions.
+
+The August 2025 top-two-economy protection means V4 does **not** attenuate one honest raw economy score merely because other economies are also strong.
+
+### Mechanics evidence
+
+Inheritance, local-body modifiers, strong-link modifiers, reserve level, rings, biologicals, geologicals, volcanism, terraformability, tidal-lock rules and evidence discrepancies are governed by `ratings-v4-mechanics-evidence.md`.
+
+Important consequences include:
+
+- ELW can inherit Agriculture/High Tech/Military/Tourism, but these are not equal suitability evidence; Agriculture/Tourism/High Tech have additional positive mechanics while Military does not.
+- Geologicals and volcanism are different mechanics.
+- reserve level is a first-class Extraction/Industrial/Refinery feature.
+- Military raw potential is conservative and does not absorb generic strategic judgement.
+- generic body diversity, compactness and distance from arrival are not raw economy mechanics.
+- unknown evidence is not scored as known absence.
 
 Conceptually:
 
 ```text
-v3_derived.system_rating
+v3_derived.system_economy_rating
 - derived_generation_id
 - system_id64
+- mechanics_version
 - scorer_version
-- best_build_score
-- score_agriculture
-- score_refinery
-- score_industrial
-- score_hightech
-- score_military
-- score_tourism
-- score_extraction
-- top_pair_a / top_pair_b / pair_score
+- economy
+- potential_score
+- specialisation_quality
+- evidence_completeness
 - confidence
-- rationale
-- dimensions JSONB (or typed columns when the final scorer implementation proves they are hot query fields)
+- explanation JSONB
 - computed_at
-PRIMARY KEY (derived_generation_id, system_id64)
+PRIMARY KEY (derived_generation_id, system_id64, economy)
 ```
 
-The scorer reads normalized canonical V3 body/vocabulary facts through an explicit adapter. Historical assumptions such as old body flags or enum types are not silently recreated.
+A compact one-row-per-system projection may additionally expose the seven scores for hot Finder queries, but the semantic authority remains explicit and versioned.
 
-## 5. Archetype judgement is a separate derived layer
+## 5. Headline judgement and archetypes
 
-Do not overload Ratings v3.4 to become every later judgement.
+V4 does not define a universal raw-system score by simply blending unrelated features.
 
-Archetype judgement consumes named rating outputs plus named mechanics/rule inputs and writes a separate versioned result:
+The headline **Best Colony Potential** is an archetype-level judgement: the highest justified potential across viable versioned colony archetypes, with the winning archetype named.
+
+Examples of archetype families may include:
+
+- Agriculture/Tourism Paradise
+- Extraction/Refinery Mining Hub
+- Refinery/Industrial Megacomplex
+- High-Tech/Research Hub
+- Military/Industrial Stronghold
+- flexible multi-role / expansion-capital patterns
+
+Archetype logic may consume:
+
+- economy potential;
+- specialisation quality;
+- explicit economy synergy/pair rules;
+- buildable capacity/slot evidence;
+- accessibility/compactness where relevant;
+- strategic/domain features;
+- confidence/completeness.
+
+Those factors must not leak backwards and corrupt raw economy semantics.
+
+Conceptually:
 
 ```text
 v3_derived.system_archetype
 - derived_generation_id
 - system_id64
 - archetype_version
-- primary_archetype
-- secondary_archetype
-- archetype_confidence
-- overall_development_potential
-- buildability_score
-- build_complexity
-- purity_score
-- contamination_risk
-- estimated_total_slots
-- display_tags
+- archetype_key
+- archetype_score
+- confidence
+- explanation JSONB
 - computed_at
-PRIMARY KEY (derived_generation_id, system_id64)
+PRIMARY KEY (derived_generation_id, system_id64, archetype_key)
 ```
 
-This resolves the current roadmap ambiguity cleanly:
+A separate summary projection may expose primary/secondary archetype and Best Colony Potential for hot queries.
 
-- Ratings v3.4 remains the accepted suitability/best-build scorer.
-- Archetype judgement is a separately versioned interpretation layer.
-- Finder may rank using either or both through an explicit ranking profile.
+## 6. Finder ranking profiles
 
-## 6. Finder ranking profiles are versioned
+Finder ranking is query-specific and separately versioned.
 
-Search ranking must not be hard-coded as an accidental SQL expression spread through routers.
+A ranking profile may combine, as appropriate:
 
-Define a named ranking-profile version in code/manifest. A profile declares which derived fields participate and how they are ordered/weighted.
+- selected economy potential;
+- selected archetype score;
+- Best Colony Potential;
+- distance;
+- confidence/completeness;
+- accessibility;
+- user/query constraints;
+- later programme-specific factors.
 
-Examples may include:
+Ranking logic is not scattered as accidental router SQL and does not mutate stored mechanics truth.
 
-- `distance`;
-- `best_build`;
-- `development`;
-- later economy-specific or programme-specific ranking.
+## 7. Map data: multi-resolution spatial pyramid
 
-The API response states the active ranking/profile version where operationally useful. Changing ranking logic does not require rewriting canonical data.
+Do not choose one permanent grid-cell size.
 
-## 7. Map data: a multi-resolution spatial pyramid
+Build a **multi-resolution 3-D spatial pyramid** from exact system coordinates. Cells exist only for aggregation/LOD.
 
-Do not choose one permanent grid cell size.
-
-Build a **multi-resolution 3-D cell pyramid** from exact system coordinates. Cells are an aggregation/LOD mechanism only.
-
-Use power-of-two hierarchical cells (octree-style) with a deterministic integer key, preferably a Morton/Z-order code or equivalent stable hierarchical encoding. Store the level and cell bounds explicitly enough that the encoding can be changed by a later pyramid version without changing public APIs.
-
-Conceptually:
+Use hierarchical power-of-two cells (octree-style), with a deterministic key such as Morton/Z-order or an equivalent encoding. Encoding details are themselves versioned.
 
 ```text
 v3_spatial.cell_level
 - spatial_pyramid_version
 - level
 - cell_size_ly
-- intended_scale / target_budget metadata
+- intended_scale / target-budget metadata
 
 v3_spatial.cell_summary
 - derived_generation_id
 - spatial_pyramid_version
 - level
 - cell_key
-- min/max x/y/z or deterministic cell origin
+- deterministic bounds/origin
 - system_count
 - centroid_x/y/z
-- factual summary counters required at that LOD
-- optional derived score summaries required by named map layers
-- representative_system_id64 when the selection rule is explicit/versioned
+- factual summary counters for that LOD
+- explicitly versioned derived score/archetype summaries required by map layers
+- representative_system_id64 where the selection rule is explicit
 PRIMARY KEY (derived_generation_id, spatial_pyramid_version, level, cell_key)
 ```
 
-The map chooses a level from semantic zoom, viewport volume and target-count budget. It does not assume that one cell size fits Galaxy, regional and local views.
+The map chooses level from semantic zoom, viewport volume and target-count budget rather than assuming one grid serves Galaxy, regional and local use.
 
-### Relationship to existing `grid_x/grid_y/grid_z/macro_grid_key`
+### Existing `grid_x/grid_y/grid_z/macro_grid_key`
 
-The current canonical generation already contains these values. Preserve them as existing canonical-generation fields and evidence. Do **not** make them the permanent V3 Search/Grid/Cluster API contract unless benchmarks prove that exact encoding is the best pyramid implementation.
+Preserve these canonical-generation fields as existing evidence. Do not make their exact encoding the permanent V3 Search/Grid/Cluster API contract unless benchmarking proves it is the right pyramid implementation.
 
-The new derived pyramid may reuse their calculation if it matches the chosen version, but the public contract is level + cell identity + bounds/summary, not those historical column names.
+Changing cell sizes/encoding is a derived rebuild, not a schema redesign.
 
-## 8. Clusters are independently versioned derived products
+## 8. Clusters are independent derived products
 
-Cluster membership is domain analysis, not spatial truth and not a renderer responsibility.
-
-Store cluster output separately from the cell pyramid:
+Cluster membership is domain analysis, not spatial truth.
 
 ```text
 v3_spatial.cluster_run
@@ -259,108 +304,101 @@ v3_spatial.cluster_member
 - cluster_run_id
 - cluster_id
 - system_id64
-- membership_score/confidence when meaningful
+- membership_score/confidence where meaningful
 PRIMARY KEY (cluster_run_id, cluster_id, system_id64)
 ```
 
-Consequences:
-
-- DBSCAN/HDBSCAN/domain-specific or later algorithms can replace one another without changing Finder's exact spatial index.
-- Different domains may publish different cluster sets.
-- A cluster can be rebuilt or retired independently.
-- Map hulls/visualisations are projections of cluster membership, never the source of membership truth.
+DBSCAN/HDBSCAN/domain-specific or later approaches can replace one another without changing exact spatial search. Different domains may publish different cluster sets. Map hulls are projections of membership, never membership authority.
 
 ## 9. Stable application boundary
 
-The application must not reference generation-specific canonical schema names.
+FastAPI must not reference generation-specific canonical schema names.
 
-Expose a stable `v3_app` boundary through reviewed SQL views/functions or an equally explicit stable query layer. It resolves the current derived generation and presents the API contract needed by FastAPI.
-
-Examples:
+Expose an explicit stable `v3_app` boundary, for example:
 
 ```text
 v3_app.system_search
-v3_app.system_rating
+v3_app.system_economy_rating
 v3_app.system_archetype
 v3_app.system_detail
 v3_app.map_cells(...)
 v3_app.cluster_members(...)
 ```
 
-Whether the implementation uses stable views, SQL functions, or queries that bind the current derived-generation ID is an implementation choice, but publication semantics must remain atomic and generation-aware.
-
-No production application query may depend on whichever schema happens to appear first in `search_path`.
+Views/functions/query helpers resolve the currently published derived generation explicitly.
 
 ## 10. Rebuild and publication pipeline
 
 Order is explicit:
 
-1. Resolve the current canonical generation and record its immutable identity.
+1. Resolve and record immutable current canonical generation identity.
 2. Create a BUILDING derived generation.
-3. Build the factual search projection.
-4. Build Ratings v3.4-compatible scoring from normalized V3 inputs.
-5. Build archetype judgement using its own version.
-6. Build all configured spatial-pyramid levels.
-7. Build configured cluster runs.
-8. Validate row counts, referential integrity, coordinate invariants, score ranges, reproducibility samples, query plans and bounded performance.
-9. Produce a manifest/checksum and validation receipt.
-10. Mark READY.
-11. Atomically publish `current_derived_generation`.
-12. Retain at least the previous compatible derived generation until rollback eligibility is known.
+3. Build factual system/search features.
+4. Build versioned mechanics features.
+5. Build Ratings V4 economy potential/specialisation.
+6. Build archetype judgement and headline Best Colony Potential.
+7. Build configured spatial-pyramid levels.
+8. Build configured cluster runs.
+9. Validate counts, referential integrity, coordinate invariants, score ranges, evidence completeness, reproducibility samples, query plans and bounded performance.
+10. Produce manifest/checksum + validation receipt.
+11. Mark READY.
+12. Atomically publish `current_derived_generation`.
+13. Retain at least the previous compatible derived generation for rollback.
 
 Failure before publication leaves the previous generation current.
 
 ## 11. Resource and operational rules
 
-A full derived bootstrap over the Galaxy is a bounded operator job, not API startup work.
+A full-Galaxy derived build is a bounded operator job, never API startup work.
 
 Require:
 
-- resumable/chunked build stages;
-- bounded concurrency and memory;
-- statement and lock policy appropriate for offline derived builds;
-- progress receipts that use real or explicitly unknown totals;
-- no long blocking DDL on canonical generation tables;
-- index construction staged after bulk load where benchmarks support it;
+- resumable/chunked stages;
+- bounded concurrency/memory;
+- explicit statement/lock policy;
+- truthful progress totals or `unknown` totals;
+- no long blocking DDL on canonical tables;
+- index construction staged after bulk load where appropriate;
 - `ANALYZE` before validation benchmarks;
-- explain-plan and latency evidence for representative exact-radius, KNN, autocomplete, galaxy-map, regional-map and local-map queries;
-- deterministic version/manifests sufficient to reproduce a generation.
+- explain/latency evidence for radius, KNN, autocomplete and map scales;
+- deterministic version/manifests sufficient to reproduce the generation.
 
-## 12. What this deliberately avoids
+## 12. Deliberately avoided designs
 
-- Recreating V2 `public.*` merely to keep old SQL running.
-- Treating one `grid_cell_id` size as the permanent spatial architecture.
-- Coupling cluster membership to map-cell membership.
-- Running rating logic inline on request paths.
-- Letting the renderer calculate ranking, scores or clusters.
-- Treating a materialized map view as canonical truth.
-- Making a scorer rewrite require a canonical-data rebuild.
-- Making a canonical-generation publication immediately invalidate the previous application release without explicit compatibility evidence.
+- recreating old V2 `public.*` merely to keep old SQL working;
+- carrying Ratings V3.4 forward as final V3 scoring authority;
+- one permanent `grid_cell_id` size;
+- using clusters as the search index;
+- request-time global rating calculation;
+- renderer-owned scoring/ranking/clustering;
+- treating map materialisations as canonical truth;
+- requiring canonical-data mutation for scorer/archetype changes;
+- representing unknown mechanics inputs as zero/false.
 
-## 13. Decisions to benchmark, not bikeshed
+## 13. Benchmark/configuration decisions that do not reopen architecture
 
-The architecture above is stable while these implementation values remain benchmark-driven:
+These remain versioned and benchmark-driven:
 
-- exact spatial-pyramid cell sizes/levels;
+- pyramid cell sizes/levels;
 - Morton/Z-order encoding details;
-- whether generated or explicitly stored `cube` position performs best;
-- name-index strategy and thresholds;
-- which rating/archetype fields deserve dedicated columns versus JSON detail;
-- cell summary payloads at each semantic LOD;
-- cluster algorithm and parameters per domain;
+- generated vs stored `cube` position;
+- name-index strategy;
+- hot typed columns vs explanation JSON;
+- map cell summary payloads;
+- cluster algorithms/parameters;
+- V4 normalization coefficients after mechanics review;
 - retained derived-generation count.
-
-These are versioned configuration/algorithm decisions, not reasons to reopen the architecture.
 
 ## Acceptance bar
 
-Before this becomes production data authority, prove on production-like scale that:
+Before production authority:
 
-- exact 3-D distance and KNN queries use an index and meet the Search latency budget;
-- galaxy/regional/local map queries are bounded by a target-count contract rather than raw catalogue size;
-- a pyramid-version change requires only rebuilding derived rows;
-- a cluster-algorithm change requires only rebuilding cluster runs;
-- a scorer/archetype version change does not mutate canonical source facts;
-- publishing a failed/partial build is impossible;
-- API queries resolve an explicit published derived generation;
-- canonical generation, derived generation, scorer, archetype, pyramid and cluster versions are visible in operational receipts.
+- Ratings V4 contract and coefficient manifest are frozen against the mechanics evidence audit;
+- representative single/mixed-economy systems demonstrate explainable V4 output;
+- V3.4 comparison is used as regression evidence only;
+- exact 3-D radius/KNN queries use indexes and meet Search budgets;
+- Galaxy/regional/local map responses are target-count bounded;
+- changing scorer, pyramid or cluster algorithm requires derived rebuild only;
+- partial builds cannot publish;
+- API reads an explicit published generation;
+- canonical/derived/mechanics/scorer/archetype/ranking/pyramid/cluster versions appear in operational receipts.


### PR DESCRIPTION
Turns the current ROADMAP Search/Grid/Cluster and scoring gates into one proposed long-term PostgreSQL 18 design.

Key decisions:
- retain immutable V3 canonical generations;
- use PostgreSQL `cube` + GiST for exact 3-D Finder/radius/KNN search rather than making a coarse grid the search primitive;
- use a versioned multi-resolution octree/Morton-style spatial pyramid for Galaxy/regional/local map aggregation;
- keep clusters as independently versioned domain-derived outputs, not the spatial index;
- retain Ratings v3.4 semantics in a generation-scoped derived scoring relation;
- separate archetype judgement from Ratings rather than overloading one table/model;
- publish derived generations atomically behind a stable `v3_app` boundary;
- make grid sizes, LOD, cluster algorithms and scorer versions rebuild/configuration decisions rather than future schema redesigns.

This is documentation/decision only. It performs no database or production mutation.