### PR TITLE
Align V3 deploy and status gates with the /api/v1 auth surface

### DIFF
--- a/docs/operations/v3-application-checkpoint-release.md
+++ b/docs/operations/v3-application-checkpoint-release.md
@@ -155,7 +155,7 @@ For an owner checkpoint:
    `/api/health` readiness for at most 120 seconds with a two-second interval.
    Only after readiness succeeds does it run the authoritative bounded,
    no-redirect smoke suite against `/`, `/api/health`, `/openapi.json` and
-   `/api/auth/session`. Health must report `database=connected` and the expected
+   `/api/v1/auth/session`. Health must report `database=connected` and the expected
    `build_sha`; OpenAPI must expose the health and session paths; the session
    must be anonymous. A transient startup delay therefore cannot trigger an
    immediate false rollback, while readiness failure remains bounded.

--- a/scripts/operator/README.md
+++ b/scripts/operator/README.md
@@ -87,7 +87,7 @@ Do not promote a repository helper into a production command merely because it e
 - `actions/v3-app-status.sh`: fail-closed, read-only application status receipt
   for the current ED-Finder V3 origin and public edge. It checks the fixed V3
   container set, the loopback origin listener, the frontend index classification,
-  `/api/health`, anonymous `/api/auth/session`, and the runtime OpenAPI OAuth
+  `/api/health`, anonymous `/api/v1/auth/session`, and the runtime OpenAPI OAuth
   route surface. It does not start an OAuth login, read environment/private-key
   files, access PostgreSQL directly, write files, or restart services. The
   public application health endpoint may itself perform its normal bounded DB

--- a/scripts/operator/actions/v3-app-status.sh
+++ b/scripts/operator/actions/v3-app-status.sh
@@ -271,7 +271,7 @@ receipt["frontend_comparison"] = {
 # edge must not be mistaken for proof that the loopback V3 origin is healthy.
 origin_root, _ = get(ORIGIN + "/", body=False, follow_redirects=False)
 origin_health, health_body = get(ORIGIN + "/api/health", follow_redirects=False)
-origin_session, session_body = get(ORIGIN + "/api/auth/session", follow_redirects=False)
+origin_session, session_body = get(ORIGIN + "/api/v1/auth/session", follow_redirects=False)
 origin_openapi, openapi_body = get(
     ORIGIN + "/openapi.json",
     follow_redirects=False,
@@ -281,11 +281,11 @@ origin_openapi, openapi_body = get(
 health_shape = parse_health_response(health_body)
 session_shape = parse_anonymous_session(session_body)
 required_oauth_paths = {
-    "/api/auth/frontier/login",
-    "/api/auth/frontier/callback",
-    "/api/auth/session",
-    "/api/auth/logout",
-    "/api/auth/owner/claim",
+    "/api/v1/auth/frontier/login",
+    "/api/v1/auth/frontier/callback",
+    "/api/v1/auth/session",
+    "/api/v1/auth/logout",
+    "/api/v1/auth/owner/claim",
 }
 openapi_paths = set()
 try:
@@ -319,7 +319,7 @@ if required_oauth_paths - openapi_paths:
 # an HTML SPA fallback or redirect is not a healthy public API/auth surface.
 public_root, _ = get(PUBLIC + "/", body=False, follow_redirects=True)
 public_health, public_health_body = get(PUBLIC + "/api/health", follow_redirects=False)
-public_session, public_session_body = get(PUBLIC + "/api/auth/session", follow_redirects=False)
+public_session, public_session_body = get(PUBLIC + "/api/v1/auth/session", follow_redirects=False)
 public_health_shape = parse_health_response(public_health_body)
 public_session_shape = parse_anonymous_session(public_session_body)
 receipt["public"] = {

--- a/scripts/operator/v3_checkpoint_deploy.py
+++ b/scripts/operator/v3_checkpoint_deploy.py
@@ -758,7 +758,7 @@ def validate_release_inputs(
             != [CONTAINERS[service] for service in SERVICES]
             or not isinstance(prior_smoke, dict)
             or set(prior_smoke)
-            != {"/", "/api/health", "/openapi.json", "/api/auth/session"}
+            != {"/", "/api/health", "/openapi.json", "/api/v1/auth/session"}
             or any(
                 not isinstance(outcome, dict)
                 or not 200 <= outcome.get("status", 0) < 300
@@ -1384,7 +1384,7 @@ def wait_for_origin_ready(
 
 def smoke_origin(origin: str, source_sha: str) -> dict[str, Any]:
     outcomes: dict[str, Any] = {}
-    for path in ("/", "/api/health", "/openapi.json", "/api/auth/session"):
+    for path in ("/", "/api/health", "/openapi.json", "/api/v1/auth/session"):
         status, body, content_type = get_origin(origin, path)
         outcomes[path] = {"status": status, "bytes": len(body)}
         if path == "/":
@@ -1403,10 +1403,13 @@ def smoke_origin(origin: str, source_sha: str) -> dict[str, Any]:
         if path == "/openapi.json" and not (
             isinstance(payload.get("paths"), dict)
             and "/api/health" in payload["paths"]
-            and "/api/auth/session" in payload["paths"]
+            and "/api/v1/auth/session" in payload["paths"]
         ):
             raise DeploymentError("OpenAPI smoke lacks required route identity")
-        if path == "/api/auth/session" and payload.get("authenticated") is not False:
+        if (
+            path == "/api/v1/auth/session"
+            and payload.get("authenticated") is not False
+        ):
             raise DeploymentError("anonymous session smoke is not anonymous")
     return outcomes
 

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -710,7 +710,7 @@ def wait_for_preserved_edge_route() -> None:
         try:
             verify_edge_routes_to_active_origin()
             status, _body, _content_type = get(
-                "http://127.0.0.1:58080", "/api/auth/session"
+                "http://127.0.0.1:58080", "/api/v1/auth/session"
             )
             if status == 200:
                 return
@@ -961,7 +961,7 @@ def get(origin: str, path: str) -> tuple[int, bytes, str]:
 def smoke(origin: str, sha: str) -> dict[str, Any]:
     outcomes: dict[str, Any] = {}
     bodies: dict[str, bytes] = {}
-    for path in ("/", "/api/health", "/openapi.json", "/api/auth/session"):
+    for path in ("/", "/api/health", "/openapi.json", "/api/v1/auth/session"):
         status, body, content_type = get(origin, path)
         if not 200 <= status < 300 or len(body) > MAX_SMOKE:
             raise DeploymentError(f"smoke failed: {path}")
@@ -969,7 +969,7 @@ def smoke(origin: str, sha: str) -> dict[str, Any]:
         bodies[path] = body
     try:
         health = json.loads(bodies["/api/health"])
-        session = json.loads(bodies["/api/auth/session"])
+        session = json.loads(bodies["/api/v1/auth/session"])
         openapi = json.loads(bodies["/openapi.json"])
     except json.JSONDecodeError as exc:
         raise DeploymentError("smoke JSON response invalid") from exc
@@ -978,7 +978,10 @@ def smoke(origin: str, sha: str) -> dict[str, Any]:
     if session.get("authenticated") is not False or session.get("user") is not None:
         raise DeploymentError("anonymous session smoke failed")
     paths = openapi.get("paths") if isinstance(openapi, dict) else None
-    if not isinstance(paths, dict) or not {"/api/health", "/api/auth/session"}.issubset(paths):
+    if not isinstance(paths, dict) or not {
+        "/api/health",
+        "/api/v1/auth/session",
+    }.issubset(paths):
         raise DeploymentError("OpenAPI smoke routes missing")
     marker = f'name="edfinder-build-sha" content="{sha}"'.encode()
     if bodies["/"].count(marker) != 1:

--- a/tests/test_v3_app_status.py
+++ b/tests/test_v3_app_status.py
@@ -60,11 +60,11 @@ def test_v3_app_status_checks_frontend_health_and_oauth_without_starting_login()
     source = _read(ACTION)
 
     assert 'get(ORIGIN + "/api/health", follow_redirects=False)' in source
-    assert 'get(ORIGIN + "/api/auth/session", follow_redirects=False)' in source
+    assert 'get(ORIGIN + "/api/v1/auth/session", follow_redirects=False)' in source
     assert 'ORIGIN + "/openapi.json"' in source
     assert 'max_body=MAX_OPENAPI_BODY' in source
     assert 'get(PUBLIC + "/api/health", follow_redirects=False)' in source
-    assert 'get(PUBLIC + "/api/auth/session", follow_redirects=False)' in source
+    assert 'get(PUBLIC + "/api/v1/auth/session", follow_redirects=False)' in source
     assert 'parse_health_response(public_health_body)' in source
     assert 'parse_anonymous_session(public_session_body)' in source
     assert 'public_health_shape_invalid' in source
@@ -75,11 +75,11 @@ def test_v3_app_status_checks_frontend_health_and_oauth_without_starting_login()
     assert 'get(PUBLIC + "/api/auth/frontier/login")' not in source
 
     for path in (
-        '/api/auth/frontier/login',
-        '/api/auth/frontier/callback',
-        '/api/auth/session',
-        '/api/auth/logout',
-        '/api/auth/owner/claim',
+        '/api/v1/auth/frontier/login',
+        '/api/v1/auth/frontier/callback',
+        '/api/v1/auth/session',
+        '/api/v1/auth/logout',
+        '/api/v1/auth/owner/claim',
     ):
         assert path in source
 
@@ -91,7 +91,7 @@ def test_v3_app_status_does_not_mask_origin_with_public_redirects():
     assert 'if follow_redirects:\n        argv.append("--location")' in source
     assert 'origin_root, _ = get(ORIGIN + "/", body=False, follow_redirects=False)' in source
     assert 'get(ORIGIN + "/api/health", follow_redirects=False)' in source
-    assert 'get(ORIGIN + "/api/auth/session", follow_redirects=False)' in source
+    assert 'get(ORIGIN + "/api/v1/auth/session", follow_redirects=False)' in source
     assert 'public_root, _ = get(PUBLIC + "/", body=False, follow_redirects=True)' in source
     assert '200 <= code < 300' in source
 

--- a/tests/test_v3_application_checkpoint_release.py
+++ b/tests/test_v3_application_checkpoint_release.py
@@ -1162,7 +1162,7 @@ def test_upgrade_requires_receipt_matching_prior_digest_release(tmp_path):
                         "/",
                         "/api/health",
                         "/openapi.json",
-                        "/api/auth/session",
+                        "/api/v1/auth/session",
                     )
                 },
                 "database_mutation_performed": False,
@@ -1247,11 +1247,11 @@ def test_origin_smoke_checks_exact_required_routes_and_build_identity(monkeypatc
         "/openapi.json": (
             200,
             json.dumps(
-                {"paths": {"/api/health": {}, "/api/auth/session": {}}}
+                {"paths": {"/api/health": {}, "/api/v1/auth/session": {}}}
             ).encode(),
             "application/json",
         ),
-        "/api/auth/session": (
+        "/api/v1/auth/session": (
             200,
             json.dumps({"authenticated": False}).encode(),
             "application/json",
@@ -1270,7 +1270,7 @@ def test_origin_smoke_checks_exact_required_routes_and_build_identity(monkeypatc
         "/",
         "/api/health",
         "/openapi.json",
-        "/api/auth/session",
+        "/api/v1/auth/session",
     ]
     assert all(value["status"] == 200 for value in outcomes.values())
 
@@ -1450,7 +1450,12 @@ def test_sanitized_receipt_is_atomic_current_upgrade_authority(tmp_path):
         "changed_resources": list(module.CONTAINERS.values()),
         "smoke": {
             path: {"status": 200}
-            for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
+            for path in (
+                "/",
+                "/api/health",
+                "/openapi.json",
+                "/api/v1/auth/session",
+            )
         },
         "rollback": {"kind": "predeploy_absence"},
     }
@@ -1782,7 +1787,12 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
         "changed_resources": list(module.CONTAINERS.values()),
         "smoke": {
             path: {"status": 200}
-            for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
+            for path in (
+                "/",
+                "/api/health",
+                "/openapi.json",
+                "/api/v1/auth/session",
+            )
         },
         "database_mutation_performed": False,
         "infrastructure_changes_performed": False,
@@ -1817,7 +1827,12 @@ def test_failed_upgrade_uses_durable_rollback_and_tracks_database_access(
             raise module.DeploymentError("candidate smoke failed")
         return {
             path: {"status": 200}
-            for path in ("/", "/api/health", "/openapi.json", "/api/auth/session")
+            for path in (
+                "/",
+                "/api/health",
+                "/openapi.json",
+                "/api/v1/auth/session",
+            )
         }
 
     monkeypatch.setattr(module, "smoke_origin", smoke_origin)


### PR DESCRIPTION
Follow-up to #649, which moved the V3 auth surface to `/api/v1/auth`.

Three operator surfaces still probed the retired `/api/auth/session` path, so the next production or checkpoint promotion would have failed closed at smoke, and the read-only app-status receipt would have reported a failed origin/public session probe.

Updated to the canonical path:

- `scripts/operator/v3_production_deploy.py` - production promotion smoke path list, response parse, and the OpenAPI route-identity assertion.
- `scripts/operator/v3_checkpoint_deploy.py` - checkpoint smoke path list, prior-receipt smoke key set, OpenAPI identity check, and the anonymous-session check.
- `scripts/operator/actions/v3-app-status.sh` - loopback-origin and public-edge session probes, plus the runtime OpenAPI OAuth route set.
- Tests and docs that pin those paths.

One correctness fix beyond the rename: `/api/auth/frontier/callback` is the registered OAuth callback alias and is deliberately `include_in_schema=False`, so requiring it in the app-status OpenAPI route set could never be satisfied. The required set is now the five canonical `/api/v1/auth/*` schema routes.

Local verification is limited on Windows (`fcntl` is POSIX-only and `bash -n` needs a POSIX shell), so `python -m py_compile` was run over every edited Python file, `bash -n` over the edited shell action, and `ruff check scripts tests` is clean. The pinned expectations were reviewed line by line against the renamed probes. CI is the authority for these lanes.