### PR TITLE
Capture the host deployment root in the read-only production inventory

### DIFF
--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -39,6 +39,15 @@ MAX_RUNTIME_VERSION = 64
 MAX_DOCKER_ENDPOINT = 256
 DOCKER_CONTEXT = "default"
 LOCAL_DOCKER_ENDPOINT = "unix:///var/run/docker.sock"
+# Non-secret Compose identity labels. Deployment paths are required to review
+# the production target authority; every other label is dropped so container
+# labels can never become a credential channel in the receipt.
+COMPOSE_LABEL_KEYS = (
+    "com.docker.compose.project",
+    "com.docker.compose.service",
+    "com.docker.compose.project.working_dir",
+    "com.docker.compose.project.config_files",
+)
 LEDGER_SQL = r"""
 BEGIN READ ONLY;
 SET LOCAL statement_timeout = '10000ms';
@@ -137,9 +146,30 @@ def docker_json_lines(arguments: list[str]) -> tuple[bool, list[dict[str, Any]]]
     return result.returncode == 0, items
 
 
+def sanitize_compose_labels(raw: Any) -> dict[str, str] | None:
+    """Keep only the non-secret Compose identity labels for one container.
+
+    ``docker ps --format '{{json .}}'`` reports labels as a comma-joined
+    string. The reviewed production authority needs the deployment location, so
+    the working directory and config-file path are retained; no other label is
+    ever copied into the receipt.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+    labels: dict[str, str] = {}
+    for chunk in raw.split(","):
+        key, separator, value = chunk.partition("=")
+        key = key.strip()
+        if separator and key in COMPOSE_LABEL_KEYS:
+            labels[key] = value.strip()
+    return labels or None
+
+
 def sanitize_container(item: dict[str, Any]) -> dict[str, Any]:
     allowed = ("Names", "Image", "ID", "State", "Status", "Ports", "Networks")
-    return {key: item.get(key) for key in allowed}
+    sanitized = {key: item.get(key) for key in allowed}
+    sanitized["ComposeLabels"] = sanitize_compose_labels(item.get("Labels"))
+    return sanitized
 
 
 def sanitize_network(item: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -137,6 +137,8 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
         '"58081"',
         '"bindings"',
         '"owners"',
+        '"ComposeLabels"',
+        "COMPOSE_LABEL_KEYS",
     ):
         assert required_inventory_fact in source
     assert 'return ["docker", "--context", DOCKER_CONTEXT, *arguments]' in source
@@ -149,6 +151,49 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
         "DELETE FROM", "TRUNCATE", "ALTER TABLE", "DROP TABLE",
     ):
         assert forbidden not in source
+
+
+def test_inventory_container_labels_are_limited_to_compose_identity():
+    inventory = _load_inventory()
+
+    labels = inventory.sanitize_compose_labels(
+        "com.docker.compose.project=edfinder-v3-production,"
+        "com.docker.compose.service=web-blue,"
+        "com.docker.compose.project.working_dir=/opt/ed-finder,"
+        "com.docker.compose.project.config_files=/opt/ed-finder/compose.yml,"
+        "com.example.token=must-not-appear"
+    )
+
+    assert labels == {
+        "com.docker.compose.project": "edfinder-v3-production",
+        "com.docker.compose.service": "web-blue",
+        "com.docker.compose.project.working_dir": "/opt/ed-finder",
+        "com.docker.compose.project.config_files": "/opt/ed-finder/compose.yml",
+    }
+    assert "must-not-appear" not in json.dumps(labels)
+    assert inventory.sanitize_compose_labels(None) is None
+    assert inventory.sanitize_compose_labels("com.example.token=x") is None
+
+    item = inventory.sanitize_container(
+        {
+            "Names": "edfinder-v3-api",
+            "Image": "edfinder-v3-api:release-6a4fe0ef",
+            "ID": "abc",
+            "State": "running",
+            "Status": "Up 1 day",
+            "Ports": "",
+            "Networks": "edfinder-v3-production",
+            "Labels": "com.docker.compose.project=edfinder-v3-production",
+            "Config": {"Env": ["SECRET=leak"]},
+        }
+    )
+    assert item["ComposeLabels"] == {
+        "com.docker.compose.project": "edfinder-v3-production"
+    }
+    assert set(item) == {
+        "Names", "Image", "ID", "State", "Status", "Ports", "Networks",
+        "ComposeLabels",
+    }
 
 
 def test_production_deployer_uses_release_manifest_and_fresh_schema_compatibility():


### PR DESCRIPTION
Follow-up to #651. That PR cleared the application-network blocker, but two blockers remain that depend on *where* the deployment lives on the host: `production_api_secret_file_authority_missing` and `production_receipt_store_authority_missing`.

Those two are operator-designated rather than discoverable - the api env file is a mode-0600 snapshot the promotion freezes, and the receipt directory is a durable store the promotion writes to. But they cannot be designated sensibly without knowing the host deployment root, and the inventory never captured it: `docker ps` already reports Compose labels, and the receipt's container whitelist dropped them.

**Change:** keep only four non-secret Compose identity labels per container - `com.docker.compose.project`, `com.docker.compose.service`, `com.docker.compose.project.working_dir`, `com.docker.compose.project.config_files`. Every other label is discarded, so container labels can never become a credential channel in the receipt. The existing `container_environment_read: false` guarantee is unchanged, and no new Docker invocation is added.

**Test:** `test_inventory_container_labels_are_limited_to_compose_identity` proves a non-allowlisted label (`com.example.token`) never reaches the receipt, that `Config.Env` is never copied, and that the sanitized container exposes exactly the expected key set.

**Next after this merges:** re-dispatch `inventory` to read the deployment working directory, then designate canonical paths for the api env snapshot and the receipt directory and add stat-only capture (path, owner, mode - never contents) so those two blockers clear with evidence instead of assumption.

Local verification: `ruff check scripts tests` clean; both the inventory guard test and the new label test pass.