### PR TITLE
Note the designated production secret and receipt paths in the roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,10 +44,25 @@ or override this set.
 - **Inference:** Ollama was an Octopus experiment and has been removed from
   production. It is not part of the architecture.
 - **Production application authority:** the separate app-only V3 production
-  promotion path is defined, but its committed target is stopped pending a
-  reviewed fresh inventory, live schema compatibility and exact external
-  network/secret/receipt/Docker/unchanged-edge cutover facts. The root Compose
-  and Contabo checkpoint remain non-authoritative for production.
+  promotion path is defined and its committed target is still stopped, but the
+  reviewed read-only inventory of 2026-09-10 proved the application network,
+  the local Docker context, exact loopback ownership of ports 58080/58081, host
+  capacity and the live schema/ledger identity. Five blockers remain: the api
+  secret file, the receipt store, the reviewed schema identity file, the
+  unchanged-edge cutover topology and an exact CPython 3.14 mutation runtime.
+  Production already serves the 2026-09-09 in-place release; that promotion is
+  recorded as a description of what runs, not as governed acceptance. The root
+  Compose and Contabo checkpoint remain non-authoritative for production.
+- **Designated production secret and receipt paths (not yet provisioned):** the
+  api env snapshot is to live at `/etc/ed-finder/v3-production/api.env` (owner
+  uid `0`, mode `0600`) and the durable promotion receipt store at
+  `/var/lib/ed-finder/v3-production/receipts` (owner uid `0`, mode `0700`).
+  Neither path exists on the host yet, and no deployment root can be derived
+  from the running containers: they carry no Compose project directory, and the
+  only labels present belong to unrelated stacks. Both are free parameters that
+  the target authority must pin, and
+  [`scripts/operator/v3_production_deploy.py`](../scripts/operator/v3_production_deploy.py)
+  verifies them with `secure_path` rather than supplying a default.
 
 ## Product journey and spatial north star
 
@@ -101,6 +116,7 @@ evidence-interpretation, and Digital Twin owner.
 | Scoring and judgement | Ratings V4.0 is frozen by PR #646. Seven independent raw scores; archetype judgement and Finder ranking remain later layers. |
 | Derived-data bootstrap | Implement recovered canonical inputs, bounded generation builds, complete validation and atomic publication/rollback through reviewed production controls. |
 | Live checkpoint | Supply the still-missing non-production database/config, container runtime, origin/edge and receipt authorities before first mutation. |
+| Production app promotion authority | Provision the two designated non-secret paths (`/etc/ed-finder/v3-production/api.env`, `/var/lib/ed-finder/v3-production/receipts`) at the recorded owner uid and mode, author the api env snapshot, and capture stat-only existence/owner/mode evidence before the target can be authorized. An exact CPython 3.14 mutation runtime is still absent from the host, and the live loopback bindings must match the reviewed single-active-origin cutover model. |
 | V3 DB maintenance/recovery | Supply current PG18 population/invariant evidence and an executable reviewed backup/restore/PITR procedure. Until then, recovery remains fail-closed. |
 
 The merged V3 search/spatial decision and Ratings V4.0 freeze are architecture

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -90,6 +90,18 @@ The runtime identity drift is recorded in
 the legacy name `edfinder-v3-api` rather than the Compose slot name
 `edfinder-v3-production-api-blue`.
 
+Two external paths are designated but not yet provisioned. The api env snapshot
+is to live at `/etc/ed-finder/v3-production/api.env` with owner uid `0` and mode
+`0600`, and the durable receipt store at
+`/var/lib/ed-finder/v3-production/receipts` with owner uid `0` and mode `0700`.
+Neither exists on the host, and no deployment root can be derived from the
+running containers because they carry no Compose project directory. Provision
+them at exactly these owner/mode values, capture stat-only evidence (existence,
+owner, mode - never contents), and only then replace `api_env_file` and
+`receipt_directory` with proven facts. Authoring the api env snapshot is a
+secret-handling step: it must supply the real production API configuration, and
+no automation here reads container environments to synthesise it.
+
 Run only the workflow's default `inventory` operation first. It uses the
 already-present host `python3` standard library and performs only bounded
 runtime, Docker, listener, HTTP, and `BEGIN READ ONLY` ledger inspection. The


### PR DESCRIPTION
Records the two designated paths for the production promotion authority, so they stop being an open question.

**Designated, not yet provisioned**

| Purpose | Path | Owner | Mode |
|---|---|---|---|
| api env snapshot | `/etc/ed-finder/v3-production/api.env` | uid `0` | `0600` |
| durable receipt store | `/var/lib/ed-finder/v3-production/receipts` | uid `0` | `0700` |

**Why they are designations rather than discoveries.** The read-only inventory now captures non-secret Compose identity labels (from #652), and the answer is that the running application containers carry **no Compose project directory at all** - `edfinder-v3-production-web-blue`, `edfinder-v3-public-auth-edge` and `edfinder-v3-proxy` have none, and `edfinder-v3-api` carries only the phase4c dataset project's label. The only real deployment roots on the host belong to unrelated stacks (`/opt/octopus`, and the phase4c rehearsal and benchmark under `/root`). The deployer also supplies no defaults: `secure_path` verifies whatever the authority names, while hard-requiring `api_env_mode` of `0600` and an exact receipt-directory owner and mode.

**What this PR changes**

- `docs/ROADMAP.md` - refreshes the production-authority bullet to the reviewed 2026-09-10 inventory and the remaining five blockers, adds the designated-paths bullet, and adds a decision-gate row naming what must happen before the target can be authorized.
- `docs/operations/v3-production-application-release.md` - the same designation in the operator sequence, with the stat-only evidence requirement and the note that authoring the api env snapshot is a deliberate secret-handling step: nothing here reads container environments to synthesise it.

**Next:** provision the receipt directory at the recorded owner/mode, author the env snapshot, then add stat-only capture (existence, owner, mode - never contents) to clear `production_api_secret_file_authority_missing` and `production_receipt_store_authority_missing` with evidence.

Local verification: the roadmap, runbook, version-string and documentation-governance guards all pass (28 + 3 tests).