### PR TITLE
Point the public edge at the single active origin and publish the cutover authority

### DIFF
--- a/deploy/v3-production/public-auth-edge.nginx.conf
+++ b/deploy/v3-production/public-auth-edge.nginx.conf
@@ -88,10 +88,12 @@ http {
     }
 
     # The public TLS terminator remains externally managed.  It forwards the
-    # complete application surface to the verified blue web slot; the web
-    # slot owns static files and proxies /api/* to the V3 API container.
+    # complete application surface to the single active origin on
+    # 127.0.0.1:58080.  Whichever slot is active owns that bind and serves the
+    # SPA plus the /api/* proxy, so the blue/green cutover swaps the owning
+    # slot without this edge being repointed or recreated.
     location / {
-      proxy_pass http://127.0.0.1:58081;
+      proxy_pass http://127.0.0.1:58080;
       proxy_http_version 1.1;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;

--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -90,7 +90,12 @@
     "active_origin_bind": "127.0.0.1:58080",
     "staging_origin_bind": "127.0.0.1:58081",
     "public_origin": "https://ed-finder.app",
-    "edge_route_authority": null,
+    "edge_route_authority": {
+      "strategy": "verified-loopback-blue-green-port-swap",
+      "edge_container": "edfinder-v3-public-auth-edge",
+      "active_origin_bind": "127.0.0.1:58080",
+      "evidence": "reviewed-production-inventory-receipt"
+    },
     "receipt_directory": null,
     "receipt_owner_uid": null,
     "receipt_mode": null,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,12 @@ or override this set.
   capacity and the live schema/ledger identity. Five blockers remain: the api
   secret file, the receipt store, the reviewed schema identity file, the
   unchanged-edge cutover topology and an exact CPython 3.14 mutation runtime.
+  The reviewed unchanged-edge cutover authority is now published as
+  `edge_route_authority`, and the committed edge configuration forwards the
+  public application surface to the single active origin rather than the staging
+  port, so the topology blocker is host state only: the deployed edge still
+  targets `127.0.0.1:58081` and the web slot is still staged there pending the
+  governed bootstrap cutover.
   Production already serves the 2026-09-09 in-place release; that promotion is
   recorded as a description of what runs, not as governed acceptance. The root
   Compose and Contabo checkpoint remain non-authoritative for production.
@@ -116,7 +122,7 @@ evidence-interpretation, and Digital Twin owner.
 | Scoring and judgement | Ratings V4.0 is frozen by PR #646. Seven independent raw scores; archetype judgement and Finder ranking remain later layers. |
 | Derived-data bootstrap | Implement recovered canonical inputs, bounded generation builds, complete validation and atomic publication/rollback through reviewed production controls. |
 | Live checkpoint | Supply the still-missing non-production database/config, container runtime, origin/edge and receipt authorities before first mutation. |
-| Production app promotion authority | Provision the two designated non-secret paths (`/etc/ed-finder/v3-production/api.env`, `/var/lib/ed-finder/v3-production/receipts`) at the recorded owner uid and mode, author the api env snapshot, and capture stat-only existence/owner/mode evidence before the target can be authorized. An exact CPython 3.14 mutation runtime is still absent from the host, and the live loopback bindings must match the reviewed single-active-origin cutover model. |
+| Production app promotion authority | Provision the two designated non-secret paths (`/etc/ed-finder/v3-production/api.env`, `/var/lib/ed-finder/v3-production/receipts`) at the recorded owner uid and mode, author the api env snapshot, and capture stat-only existence/owner/mode evidence before the target can be authorized. An exact CPython 3.14 mutation runtime is still absent from the host, and the live loopback bindings must match the reviewed single-active-origin cutover model, whose authority and edge configuration are now published but not yet applied to the host. |
 | V3 DB maintenance/recovery | Supply current PG18 population/invariant evidence and an executable reviewed backup/restore/PITR procedure. Until then, recovery remains fail-closed. |
 
 The merged V3 search/spatial decision and Ratings V4.0 freeze are architecture

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -72,13 +72,22 @@ executed, so there is still no canonical immutable release, no durable
 promotion receipt, and no checksum-bound rollback target for the running
 release. Two facts must be reconciled before a governed promotion can run:
 
-1. **Topology.** The cutover model below assumes one active origin bind
+1. **Topology.** The cutover model below keeps one active origin bind
    (`127.0.0.1:58080`) with the inactive slot on `127.0.0.1:58081`, and the
    deployer refuses an active bind that also presents a staging binding. The
-   live host presents both, with the web slot on `58081` and the retained
-   `edfinder-v3-proxy` on `58080`. Either the host wiring or the reviewed
-   authority and its deployer checks must be brought into agreement. The
-   authority must not be marked `authorized` while they disagree.
+   reviewed authority and its edge configuration now agree with that model:
+   `edge_route_authority` is published in
+   `deploy/v3-production/target-authority.json`, and
+   `deploy/v3-production/public-auth-edge.nginx.conf` forwards the public
+   application surface to the active origin instead of the staging port.
+   What remains is host state rather than missing authority. The deployed edge
+   still targets `127.0.0.1:58081`, and the web slot is still staged on `58081`
+   while the retained `edfinder-v3-proxy` holds `127.0.0.1:58080`. Bring the
+   host into agreement by applying the reviewed edge configuration and then
+   completing the governed bootstrap cutover in step 6, which binds the
+   verified candidate web slot to `127.0.0.1:58080` and leaves the edge
+   untouched. The authority must not be marked `authorized` while the host
+   disagrees.
 2. **Runtime.** Production mutation requires an exact CPython 3.14 on the host.
    Inventory proves the host's default interpreter reports version 3.13.5 and
    that no `python3.14` exists. The gate is deliberately retained: provisioning

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -25,6 +25,7 @@ DEPLOYER = ROOT / "scripts/operator/v3_production_deploy.py"
 INVENTORY = ROOT / "scripts/operator/v3_production_inventory.py"
 INVENTORY_ACTION = ROOT / "scripts/operator/actions/v3-production-inventory.sh"
 PROMOTE_ACTION = ROOT / "scripts/operator/actions/v3-production-promote.sh"
+PUBLIC_EDGE_CONF = ROOT / "deploy/v3-production/public-auth-edge.nginx.conf"
 WORKFLOW = ROOT / ".github/workflows/v3-production-application-deploy.yml"
 RUNBOOK = ROOT / "docs/operations/v3-production-application-release.md"
 
@@ -77,10 +78,17 @@ def test_production_authority_is_separate_exact_and_currently_fail_closed():
         "edfinder-v3-api",
         "edfinder-v3-production-web-blue",
     ]
-    # Still unproven or unreconciled after that receipt.
+    # The reviewed unchanged-edge cutover authority is published from that
+    # receipt.  The remaining nulls are host facts that are still unprovisioned.
+    assert value["external_authority"]["edge_route_authority"] == {
+        "strategy": "verified-loopback-blue-green-port-swap",
+        "edge_container": "edfinder-v3-public-auth-edge",
+        "active_origin_bind": "127.0.0.1:58080",
+        "evidence": "reviewed-production-inventory-receipt",
+    }
     assert all(value["external_authority"][key] is None for key in (
-        "api_env_file", "schema_identity_file",
-        "edge_route_authority", "receipt_directory",
+        "api_env_file", "api_env_owner_uid", "api_env_mode",
+        "schema_identity_file", "receipt_directory",
     ))
     assert value["external_authority"]["docker_context"] == "default"
 
@@ -448,6 +456,21 @@ def test_runbook_states_no_execution_boundary_and_concrete_first_run_blockers():
     assert "fills a blocker" in source
     assert "stale `edfinder-v3-api:phase4c-r5`" in source
     assert "Redis and NATS are not removed or replaced" in source
+
+
+def test_public_edge_forwards_the_app_surface_to_the_single_active_origin():
+    authority = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+    source = PUBLIC_EDGE_CONF.read_text(encoding="utf-8")
+    external = authority["external_authority"]
+    active = external["active_origin_bind"]
+    staging = external["staging_origin_bind"]
+
+    # The cutover swaps which slot owns the active bind while the edge is never
+    # repointed, so the public application surface must target the active origin
+    # and must never target the staging port.
+    assert f"proxy_pass http://{active};" in source
+    assert f"http://{staging}" not in source
+    assert external["edge_route_authority"]["active_origin_bind"] == active
 
 
 def test_new_shell_launchers_parse():


### PR DESCRIPTION
## What this fixes

The reviewed production cutover model keeps **exactly one** loopback origin bind (`127.0.0.1:58080`) with the inactive slot on `127.0.0.1:58081`, and the deployer re-forms the active bind after each cutover while `edfinder-v3-public-auth-edge` is never recreated or repointed (runbook step 6). Two committed artifacts contradicted that model.

1. `deploy/v3-production/public-auth-edge.nginx.conf` forwarded the entire application surface to `127.0.0.1:58081` — the *staging* port. That pins the edge to whichever slot happens to be staged, which is exactly what the live host exhibits (deployed edge → 58081, retained `edfinder-v3-proxy` on 58080) and what the fail-closed `origin_root` inventory probe keeps flagging.
2. `deploy/v3-production/target-authority.json` left `edge_route_authority` as `null`, although `validate_authority` requires that exact object for the target to ever reach `authorized`.

## Changes

- Edge config now forwards the application surface to the **active origin**; the blue/green cutover swaps the owning slot without touching the edge.
- `edge_route_authority` published from the reviewed 2026-09-10 inventory receipt.
- New test binds the edge file's app-surface upstream to `external_authority.active_origin_bind` (and asserts the staging port is never referenced), so the two cannot drift apart again.
- Runbook and roadmap record the split between **published authority** and **unapplied host state**.

## Deliberately not done

- The topology blocker is **retained**. The live loopback bindings still contradict the reviewed model, so the authority must not be marked `authorized`. The residue is host state: apply the reviewed edge configuration and complete the governed bootstrap cutover.
- No host mutation, no workflow dispatch, no change to the deployer's fail-closed checks.

## Verification

- `validate_authority` shape, JSON validity, and the new edge/authority binding assertion verified directly.
- Existing suites are Linux-only on this host (the deployer imports `fcntl`; `bash`/`tar`/symlink behaviour differ on Windows), so `tests/test_v3_production_application_deployment.py` reports 28 environment failures both before and after this change, with one additional pass — the new test. CI on Linux is the authority for this one.
