### PR TITLE
Capture stat-only evidence for the designated production paths

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,6 +69,9 @@ or override this set.
   the target authority must pin, and
   [`scripts/operator/v3_production_deploy.py`](../scripts/operator/v3_production_deploy.py)
   verifies them with `secure_path` rather than supplying a default.
+  The read-only inventory records stat-only existence/kind/owner-uid/mode
+  evidence for both designated paths without reading their contents, so the next
+  reviewed run supplies the facts those two authority fields need.
 
 ## Product journey and spatial north star
 

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -46,6 +46,15 @@ picture. Without mutation (`db_writes_performed=false`,
   read under `BEGIN READ ONLY`;
 - host capacity still satisfies the reviewed blue/green peak.
 
+The helper also records stat-only evidence for the two designated paths the
+authority still has to pin — existence, kind, owner uid and mode for
+`/etc/ed-finder/v3-production/api.env` and
+`/var/lib/ed-finder/v3-production/receipts`. It never reads their contents, and
+an absent path is recorded as a fact rather than a failure. The 2026-09-10
+receipt predates that addition, so the next reviewed run is the one that
+supplies the owner/mode facts the `api_env_file` and `receipt_directory`
+authority fields need.
+
 The application-network blocker is therefore cleared. These remain, and
 `status` stays `stopped` until each is replaced by exact reviewed facts:
 `production_api_secret_file_authority_missing`,

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -15,6 +15,7 @@ import platform
 import re
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import urllib.error
@@ -48,6 +49,27 @@ COMPOSE_LABEL_KEYS = (
     "com.docker.compose.project.working_dir",
     "com.docker.compose.project.config_files",
 )
+# Designated production paths the promotion authority still has to pin. Reviewing
+# them needs stat-only evidence: existence, kind, owner uid and mode. The helper
+# never reads their contents, and an absent path is a recorded fact rather than a
+# failure, exactly like the absent python3.14 runtime.
+DESIGNATED_PATHS = (
+    {
+        "name": "api_env_file",
+        "path": "/etc/ed-finder/v3-production/api.env",
+        "kind": "file",
+        "owner_uid": 0,
+        "mode": "0600",
+    },
+    {
+        "name": "receipt_directory",
+        "path": "/var/lib/ed-finder/v3-production/receipts",
+        "kind": "directory",
+        "owner_uid": 0,
+        "mode": "0700",
+    },
+)
+MAX_DESIGNATED_PATH = 256
 LEDGER_SQL = r"""
 BEGIN READ ONLY;
 SET LOCAL statement_timeout = '10000ms';
@@ -456,6 +478,64 @@ def loopback_origin_ownership(
     }
 
 
+def inspect_designated_path(spec: dict[str, Any]) -> dict[str, Any]:
+    path = spec["path"]
+    item: dict[str, Any] = {
+        "name": spec["name"],
+        "path": path,
+        "expected_kind": spec["kind"],
+        "expected_owner_uid": spec["owner_uid"],
+        "expected_mode": spec["mode"],
+        "inspection_succeeded": False,
+        "exists": False,
+        "is_symlink": False,
+        "is_file": False,
+        "is_directory": False,
+        "owner_uid": None,
+        "mode": None,
+        "matches_designation": False,
+    }
+    # The live designations are POSIX absolute paths. A relative or oversized
+    # path is a malformed constant rather than a host fact, so it is reported as
+    # a failed inspection instead of being resolved against the working directory.
+    if (
+        not isinstance(path, str)
+        or len(path) > MAX_DESIGNATED_PATH
+        or not (path.startswith("/") or os.path.isabs(path))
+    ):
+        return item
+    try:
+        # lstat never follows a link, so a symlink cannot fake the designation.
+        details = os.lstat(path)
+    except FileNotFoundError:
+        item["inspection_succeeded"] = True
+        return item
+    except OSError:
+        return item
+    is_symlink = stat.S_ISLNK(details.st_mode)
+    is_file = stat.S_ISREG(details.st_mode)
+    is_directory = stat.S_ISDIR(details.st_mode)
+    mode = f"{stat.S_IMODE(details.st_mode):04o}"
+    item.update(
+        {
+            "inspection_succeeded": True,
+            "exists": True,
+            "is_symlink": is_symlink,
+            "is_file": is_file,
+            "is_directory": is_directory,
+            "owner_uid": details.st_uid,
+            "mode": mode,
+        }
+    )
+    item["matches_designation"] = (
+        not is_symlink
+        and (is_file if spec["kind"] == "file" else is_directory)
+        and details.st_uid == spec["owner_uid"]
+        and mode == spec["mode"]
+    )
+    return item
+
+
 def host_capacity() -> dict[str, Any]:
     memory: dict[str, int] = {}
     try:
@@ -650,6 +730,14 @@ def main() -> int:
     if not receipt["host_runtime"]["python3_14"]["inspection_succeeded"]:
         failures.append("python314_runtime_inspection_failed")
     receipt["capacity"] = host_capacity()
+    receipt["designated_paths"] = {
+        "inspection_succeeded": True,
+        "items": [inspect_designated_path(spec) for spec in DESIGNATED_PATHS],
+        "limit": len(DESIGNATED_PATHS),
+    }
+    if not all(item["inspection_succeeded"] for item in receipt["designated_paths"]["items"]):
+        receipt["designated_paths"]["inspection_succeeded"] = False
+        failures.append("designated_path_inspection_failed")
     receipt["docker_context"] = inspect_default_docker_context()
     if not receipt["docker_context"]["inspection_succeeded"]:
         failures.append("default_docker_context_inventory_failed")

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -147,6 +147,12 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
         '"owners"',
         '"ComposeLabels"',
         "COMPOSE_LABEL_KEYS",
+        'receipt["designated_paths"]',
+        "DESIGNATED_PATHS",
+        "os.lstat(",
+        '"matches_designation"',
+        '"expected_owner_uid"',
+        '"expected_mode"',
     ):
         assert required_inventory_fact in source
     assert 'return ["docker", "--context", DOCKER_CONTEXT, *arguments]' in source
@@ -159,6 +165,66 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
         "DELETE FROM", "TRUNCATE", "ALTER TABLE", "DROP TABLE",
     ):
         assert forbidden not in source
+    # The designated production paths are reviewed with stat-only evidence, so
+    # the helper must never read a file, let alone their contents.
+    assert "read_text" not in source
+    assert "read_bytes" not in source
+
+
+def test_inventory_designated_paths_report_stat_only_evidence(tmp_path):
+    inventory = _load_inventory()
+
+    missing = inventory.inspect_designated_path(
+        {
+            "name": "receipt_directory",
+            "path": str(tmp_path / "absent"),
+            "kind": "directory",
+            "owner_uid": 0,
+            "mode": "0700",
+        }
+    )
+    assert missing["inspection_succeeded"] is True
+    assert missing["exists"] is False
+    assert missing["owner_uid"] is None
+    assert missing["mode"] is None
+    assert missing["matches_designation"] is False
+
+    target = tmp_path / "api.env"
+    target.write_text("EDFINDER_SECRET=must-not-be-recorded\n", encoding="utf-8")
+    details = os.lstat(target)
+    spec = {
+        "name": "api_env_file",
+        "path": str(target),
+        "kind": "file",
+        "owner_uid": details.st_uid,
+        "mode": f"{stat.S_IMODE(details.st_mode):04o}",
+    }
+    present = inventory.inspect_designated_path(spec)
+    assert present["inspection_succeeded"] is True
+    assert present["exists"] is True
+    assert present["is_file"] is True
+    assert present["is_symlink"] is False
+    assert present["owner_uid"] == details.st_uid
+    assert present["mode"] == spec["mode"]
+    assert present["matches_designation"] is True
+    assert "must-not-be-recorded" not in json.dumps(present)
+
+    wrong_kind = inventory.inspect_designated_path({**spec, "kind": "directory"})
+    assert wrong_kind["matches_designation"] is False
+    wrong_owner = inventory.inspect_designated_path({**spec, "owner_uid": details.st_uid + 1})
+    assert wrong_owner["matches_designation"] is False
+    wrong_mode = inventory.inspect_designated_path({**spec, "mode": "0644"})
+    if spec["mode"] != "0644":
+        assert wrong_mode["matches_designation"] is False
+
+    link = tmp_path / "api.env.link"
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink creation is unavailable on this platform")
+    linked = inventory.inspect_designated_path({**spec, "path": str(link)})
+    assert linked["is_symlink"] is True
+    assert linked["matches_designation"] is False
 
 
 def test_inventory_container_labels_are_limited_to_compose_identity():


### PR DESCRIPTION
## Why

`api_env_file` and `receipt_directory` are deliberately **free parameters**: `secure_path` verifies them rather than defaulting, so a review needs exact owner uid and mode facts before either field can be pinned. The read-only inventory proved the network, context, ports, ledger and capacity around those paths but said nothing about the paths themselves.

## What

The helper now records, for:
- `/etc/ed-finder/v3-production/api.env` — file, uid `0`, mode `0600`
- `/var/lib/ed-finder/v3-production/receipts` — directory, uid `0`, mode `0700`

existence, kind, symlink status, owner uid and mode, under a new `designated_paths` receipt section.

Two deliberate properties:

- **No contents, ever.** `os.lstat` is used so a symlink cannot masquerade as the designation, and a new guard asserts the helper contains no file-reading call at all.
- **Absent is a fact, not a failure.** A missing path records `exists: false` with `inspection_succeeded: true`, exactly like the already-absent `python3.14`. The failure list keeps meaning "could not inspect" rather than "not provisioned yet" — so the next reviewed run supplies the owner/mode facts without turning the not-yet-provisioned state into a new red gate.

Example (current host state, both paths absent):

```json
{"name": "api_env_file", "path": "/etc/ed-finder/v3-production/api.env",
 "exists": false, "inspection_succeeded": true, "matches_designation": false}
```

## Not done

Evidence gathering only. Provisioning either path, authoring the api env snapshot, and clearing `production_api_secret_file_authority_missing` / `production_receipt_store_authority_missing` remain deliberate separate steps — the runbook does not authorize mutation.

Runbook and roadmap note that the 2026-09-10 receipt predates this addition, so the next reviewed inventory run is the one that carries the facts.

## Verification

- New unit test covers absent, present-and-matching, wrong kind, wrong owner, wrong mode, and symlink-rejected cases, and asserts the secret content is absent from the receipt.
- `tests/test_v3_production_application_deployment.py` reports the same 28 pre-existing environment failures before and after (this suite is Linux-only: `fcntl` import, `bash`/`tar` behaviour), with the new test added; its symlink tail skips on Windows and runs on CI.
- `ruff check` clean on both changed files.
