### PR TITLE
Adopt the retained production database identity

### DIFF
--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -78,7 +78,8 @@
     "application_network": "edfinder-v3-production",
     "application_network_allowed_containers": [
       "edfinder-v3-api",
-      "edfinder-v3-production-web-blue"
+      "edfinder-v3-production-web-blue",
+      "edfinder-v3-phase4c-full-20260827_r5-postgres"
     ],
     "api_env_file": null,
     "api_env_owner_uid": null,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -72,6 +72,13 @@ or override this set.
   The read-only inventory records stat-only existence/kind/owner-uid/mode
   evidence for both designated paths without reading their contents, so the next
   reviewed run supplies the facts those two authority fields need.
+  The retained database identity is adopted from the running release (role
+  `edfinder_v3`, database `edfinder_v3_phase4c_full_20260827_r5`, reached as
+  `edfinder-v3-phase4c-full-20260827_r5-postgres` on the application network),
+  and the retained container now joins that network. The reviewed schema identity
+  file cannot be written until the live `v3_meta.schema_migration` lineage is
+  reconciled: two of its three rows have no tracked source in the repository and
+  one does not match the reviewed `sql/NNN_name.sql` shape.
 
 ## Product journey and spatial north star
 

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -55,6 +55,19 @@ receipt predates that addition, so the next reviewed run is the one that
 supplies the owner/mode facts the `api_env_file` and `receipt_directory`
 authority fields need.
 
+The retained production database identity is adopted from the running release
+rather than from an aspirational name: role `edfinder_v3`, database
+`edfinder_v3_phase4c_full_20260827_r5`, reached as
+`edfinder-v3-phase4c-full-20260827_r5-postgres` on the application network, which
+the retained container now joins. Adopting that identity also exposed a
+remaining incompatibility, because the live `v3_meta.schema_migration` ledger
+cannot be described by the reviewed migration set. Two of its three rows
+(`002_v3_accounts_identity.sql` and `r1_v3/001_structural_shell.sql`) have no
+tracked source in this repository, and the `r1_v3/` row does not match the
+`sql/NNN_name.sql` shape that both the schema-identity contract and the ledger
+compatibility check require. The schema identity file therefore stays unwritten
+until that lineage is reconciled.
+
 The application-network blocker is therefore cleared. These remain, and
 `status` stays `stopped` until each is replaced by exact reviewed facts:
 `production_api_secret_file_authority_missing`,

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -43,6 +43,12 @@ EXPECTED_HOST = "ed-finder-prod"
 EXPECTED_FQDN = "nb79a3d.mevnode.com"
 EXPECTED_ARCH = "x86_64"
 POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+# The retained production database identity, adopted from the reviewed
+# 2026-09-10 inventory of the running release rather than from an aspirational
+# name. That container exposes exactly one application role and one application
+# database, and the reviewed ledger lives in that database.
+DATABASE_NAME = "edfinder_v3_phase4c_full_20260827_r5"
+DATABASE_USER = "edfinder_v3"
 LEGACY_API = "edfinder-v3-api"
 LEGACY_ORIGIN = "edfinder-v3-proxy"
 PUBLIC_EDGE = "edfinder-v3-public-auth-edge"
@@ -749,8 +755,8 @@ def validate_schema_file(path: Path, expected_sha: str) -> dict[str, Any]:
     identity = value.get("database_identity")
     if identity != {
         "container": POSTGRES_CONTAINER,
-        "database_name": "edfinder",
-        "database_user": "edfinder",
+        "database_name": DATABASE_NAME,
+        "database_user": DATABASE_USER,
         "application_host": POSTGRES_CONTAINER,
         "server_address": "local",
         "server_port": 5432,
@@ -819,11 +825,11 @@ def database_identity_from_env(
         raise DeploymentError("production DATABASE_URL identity is invalid") from exc
     if (
         parsed.scheme not in {"postgresql", "postgres"}
-        or username != "edfinder"
+        or username != DATABASE_USER
         or not password
         or parsed.hostname != POSTGRES_CONTAINER
         or port not in {None, 5432}
-        or database_name != "edfinder"
+        or database_name != DATABASE_NAME
         or parsed.query
         or parsed.fragment
     ):
@@ -840,7 +846,7 @@ def database_identity_from_env(
 
 def verify_live_schema(schema: dict[str, Any], env: dict[str, str], runner: Callable[..., subprocess.CompletedProcess[str]]) -> None:
     result = runner(
-        ["docker", "exec", POSTGRES_CONTAINER, "psql", "-X", "--no-password", "--tuples-only", "--no-align", "--quiet", "--field-separator", "\t", "--set", "ON_ERROR_STOP=1", "--username", "edfinder", "--dbname", "edfinder", "--command", LEDGER_SQL],
+        ["docker", "exec", POSTGRES_CONTAINER, "psql", "-X", "--no-password", "--tuples-only", "--no-align", "--quiet", "--field-separator", "\t", "--set", "ON_ERROR_STOP=1", "--username", DATABASE_USER, "--dbname", DATABASE_NAME, "--command", LEDGER_SQL],
         env=env,
     )
     if len(result.stdout.encode("utf-8")) > MAX_JSON:
@@ -878,7 +884,7 @@ def verify_live_schema(schema: dict[str, Any], env: dict[str, str], runner: Call
         key=lambda item: item["filename"],
     )
     if (
-        observed["database_name"] != "edfinder"
+        observed["database_name"] != DATABASE_NAME
         or observed["server_address"] != "local"
         or observed["server_port"] != 5432
         or observed["transaction_read_only"] != "on"

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -77,6 +77,7 @@ def test_production_authority_is_separate_exact_and_currently_fail_closed():
     assert value["external_authority"]["application_network_allowed_containers"] == [
         "edfinder-v3-api",
         "edfinder-v3-production-web-blue",
+        "edfinder-v3-phase4c-full-20260827_r5-postgres",
     ]
     # The reviewed unchanged-edge cutover authority is published from that
     # receipt.  The remaining nulls are host facts that are still unprovisioned.
@@ -301,8 +302,8 @@ def test_production_schema_identity_preserves_release_manifest_order(tmp_path):
         "schema_version": deployer.SCHEMA_IDENTITY_SCHEMA,
         "database_identity": {
             "container": deployer.POSTGRES_CONTAINER,
-            "database_name": "edfinder",
-            "database_user": "edfinder",
+            "database_name": deployer.DATABASE_NAME,
+            "database_user": deployer.DATABASE_USER,
             "application_host": deployer.POSTGRES_CONTAINER,
             "server_address": "local",
             "server_port": 5432,
@@ -1192,7 +1193,16 @@ def _cancellation_promote_setup(monkeypatch, tmp_path, deployer):
     receipt_dir = tmp_path / "receipts"
     receipt_dir.mkdir(mode=0o700)
     api_env = tmp_path / "api.env"
-    api_env.write_text("DATABASE_URL=postgresql://edfinder:x@db/edfinder\n", encoding="utf-8")
+    api_env.write_text(
+        "DATABASE_URL=postgresql://"
+        + deployer.DATABASE_USER
+        + ":x@"
+        + deployer.POSTGRES_CONTAINER
+        + ":5432/"
+        + deployer.DATABASE_NAME
+        + "\n",
+        encoding="utf-8",
+    )
     api_env.chmod(0o600)
     schema_path = tmp_path / "schema.json"
     schema_path.write_text("{}", encoding="utf-8")
@@ -1209,8 +1219,8 @@ def _cancellation_promote_setup(monkeypatch, tmp_path, deployer):
 
     database_identity = {
         "container": deployer.POSTGRES_CONTAINER,
-        "database_name": "edfinder",
-        "database_user": "edfinder",
+        "database_name": deployer.DATABASE_NAME,
+        "database_user": deployer.DATABASE_USER,
         "application_host": deployer.POSTGRES_CONTAINER,
         "server_address": "local",
         "server_port": 5432,


### PR DESCRIPTION
## What changed

The promotion authority hard-coded an aspirational database identity — role `edfinder`, database `edfinder`, reached at the retained container name. **None of it exists on the host.** Meanwhile a truthful API env snapshot could never pass `preflight`, because a file that `preflight` accepts would point at a role and database that aren't there.

Adopting the live identity is the smaller, evidence-backed option: the reviewed inventory, the roadmap, and `docs/development/ratings-v4-production-integration.md` already name this exact database, and nothing has to be created.

- `scripts/operator/v3_production_deploy.py` now names the retained identity explicitly (`DATABASE_NAME`, `DATABASE_USER`) and uses it in all four places that previously assumed `edfinder`: the API env snapshot parse, the schema identity shape, the live-ledger `psql` probe, and the live database-name check.
- The retained PostgreSQL container joins `application_network_allowed_containers`. The deployer requires the database container to be reachable on the application network and resolves it by container name, so this is part of the same identity decision, not a separate one.
- Tests and docs updated.

## What adopting the identity proved

The old `schema identity/live-ledger compatibility unproved` blocker is no longer suspected, it is **proven incompatible**:

| live `v3_meta.schema_migration` row | tracked in repo? |
|---|---|
| `001_v3_baseline.sql` | yes, but at `sql/v3/migrations/`, outside the manifest namespace |
| `002_v3_accounts_identity.sql` | **no** |
| `r1_v3/001_structural_shell.sql` | **no**, and it does not match the required `sql/NNN_name.sql` shape |

So the reviewed schema identity file cannot be written yet: the deployer requires entries matching `sql/[0-9]{3}_[a-z0-9_]+\.sql`, and two live rows have no source in this repository at all. The runbook and roadmap now say so explicitly.

## Host state performed alongside this change

- Retained PostgreSQL attached to `edfinder-v3-production`; network-centric membership is exactly `edfinder-v3-api`, `edfinder-v3-phase4c-full-20260827_r5-postgres`, `edfinder-v3-production-web-blue`; the container name resolves from the web slot; database still `running`, `restarts=0`.
- `/etc/ed-finder/v3-production/api.env` authored (uid 0, mode `0600`) from the running api configuration with the database host re-pointed at the container name. The inventory now reports `matches_designation: true` for it.

Pinning `api_env_file` / `api_env_owner_uid` / `api_env_mode` in the authority and dropping `production_api_secret_file_authority_missing` is the immediate follow-up; it is deliberately not bundled here.

## Verification

`ruff check` clean, both changed files compile, and every pinned runbook/roadmap string that other tests assert still survives. This suite is Linux-only locally (`fcntl`, `bash`/`tar`), so CI is the authority for the test changes.
