### PR TITLE
Commit the V3 production migration lineage the live database runs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@ tests/fixtures/ratings_v4_sources/spansh-system-dumps.zip -text
 # Recovered canonical source is verified against the published run's byte hash.
 apps/importer/src/v3_spansh/*.py -text
 sql/v3/migrations/001_v3_baseline.sql -text
+sql/v3/migrations/002_v3_accounts_identity.sql -text
+sql/r1_v3/001_structural_shell.sql -text
+sql/v3/migration-manifest.txt -text

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,10 +75,13 @@ or override this set.
   The retained database identity is adopted from the running release (role
   `edfinder_v3`, database `edfinder_v3_phase4c_full_20260827_r5`, reached as
   `edfinder-v3-phase4c-full-20260827_r5-postgres` on the application network),
-  and the retained container now joins that network. The reviewed schema identity
-  file cannot be written until the live `v3_meta.schema_migration` lineage is
-  reconciled: two of its three rows have no tracked source in the repository and
-  one does not match the reviewed `sql/NNN_name.sql` shape.
+  and the retained container now joins that network. The live ledger is the
+  independent V3 lineage: all three of its rows are committed under `sql/` with
+  byte hashes re-verified against `v3_meta.schema_migration`, and
+  `sql/v3/migration-manifest.txt` records the lineage as
+  `<sha256> <ledger-name> <path-under-sql>`. Deriving the production schema
+  identity from that manifest, and accepting the `r1_v3/` ledger naming in the
+  schema-identity contract, is the remaining step.
 
 ## Product journey and spatial north star
 

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -59,14 +59,19 @@ The retained production database identity is adopted from the running release
 rather than from an aspirational name: role `edfinder_v3`, database
 `edfinder_v3_phase4c_full_20260827_r5`, reached as
 `edfinder-v3-phase4c-full-20260827_r5-postgres` on the application network, which
-the retained container now joins. Adopting that identity also exposed a
-remaining incompatibility, because the live `v3_meta.schema_migration` ledger
-cannot be described by the reviewed migration set. Two of its three rows
-(`002_v3_accounts_identity.sql` and `r1_v3/001_structural_shell.sql`) have no
-tracked source in this repository, and the `r1_v3/` row does not match the
-`sql/NNN_name.sql` shape that both the schema-identity contract and the ledger
-compatibility check require. The schema identity file therefore stays unwritten
-until that lineage is reconciled.
+the retained container now joins.
+
+The live `v3_meta.schema_migration` ledger is the independent V3 lineage, not the
+V2 `sql/migration-manifest.txt` ordered set, and all three of its rows are now
+committed under `sql/` with byte hashes re-verified against the ledger:
+`001_v3_baseline.sql` and `002_v3_accounts_identity.sql` applied
+2026-08-27T12:05:58Z, and `r1_v3/001_structural_shell.sql` applied
+2026-08-31T16:22:56Z. `sql/v3/migration-manifest.txt` records that lineage as
+`<sha256> <ledger-name> <path-under-sql>` so the reviewed ledger and the manifest
+are compared directly. What remains is to derive the production schema identity
+from that manifest and to accept the `r1_v3/` ledger naming in the schema-identity
+contract and the ledger compatibility check. The migration sources are no longer
+missing, so the schema identity file is now blocked only on that contract change.
 
 The application-network blocker is therefore cleared. These remain, and
 `status` stays `stopped` until each is replaced by exact reviewed facts:

--- a/sql/r1_v3/001_structural_shell.sql
+++ b/sql/r1_v3/001_structural_shell.sql
@@ -1,0 +1,495 @@
+BEGIN;
+
+-- R1 persistence is additive to the normalized V3 warehouse.
+-- This migration intentionally creates no capability data, performs no backfill,
+-- and changes no existing V3 relation.
+
+CREATE SCHEMA r1_meta;
+CREATE SCHEMA r1_cache;
+CREATE SCHEMA r1_plan;
+
+CREATE TABLE r1_meta.mechanics_revision (
+    mechanics_revision_id   TEXT PRIMARY KEY,
+    friendly_version        TEXT NOT NULL,
+    game_patch              TEXT,
+    rules_sha256            CHAR(64) NOT NULL UNIQUE,
+    source_evidence_refs    JSONB NOT NULL DEFAULT '[]'::jsonb,
+    effective_from          TIMESTAMPTZ,
+    effective_to            TIMESTAMPTZ,
+    status                  TEXT NOT NULL,
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+    notes                   TEXT,
+    CONSTRAINT chk_r1_mechanics_rules_sha256
+        CHECK (rules_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_mechanics_source_refs_array
+        CHECK (jsonb_typeof(source_evidence_refs) = 'array'),
+    CONSTRAINT chk_r1_mechanics_status
+        CHECK (status IN ('experimental', 'active', 'retired')),
+    CONSTRAINT chk_r1_mechanics_effective_window
+        CHECK (effective_to IS NULL OR effective_from IS NULL OR effective_to > effective_from)
+);
+
+CREATE UNIQUE INDEX uq_r1_mechanics_single_active
+    ON r1_meta.mechanics_revision (status)
+    WHERE status = 'active';
+
+CREATE TABLE r1_meta.model_revision (
+    model_revision_id             TEXT PRIMARY KEY,
+    friendly_version              TEXT NOT NULL,
+    code_commit_sha               CHAR(40) NOT NULL,
+    model_sha256                  CHAR(64) NOT NULL UNIQUE,
+    canonical_contract_revision   TEXT NOT NULL,
+    capability_revision           TEXT NOT NULL,
+    candidate_generator_revision  TEXT NOT NULL,
+    fit_policy_revision           TEXT,
+    status                        TEXT NOT NULL,
+    created_at                    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    effective_from                TIMESTAMPTZ,
+    effective_to                  TIMESTAMPTZ,
+    notes                         TEXT,
+    CONSTRAINT chk_r1_model_commit_sha
+        CHECK (code_commit_sha ~ '^[0-9a-f]{40}$'),
+    CONSTRAINT chk_r1_model_sha256
+        CHECK (model_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_model_status
+        CHECK (status IN ('experimental', 'shadow', 'active', 'retired')),
+    CONSTRAINT chk_r1_model_effective_window
+        CHECK (effective_to IS NULL OR effective_from IS NULL OR effective_to > effective_from)
+);
+
+CREATE UNIQUE INDEX uq_r1_model_single_active
+    ON r1_meta.model_revision (status)
+    WHERE status = 'active';
+
+CREATE TABLE r1_meta.programme_revision (
+    programme_id         TEXT NOT NULL,
+    programme_revision   TEXT NOT NULL,
+    programme_name       TEXT NOT NULL,
+    definition_sha256    CHAR(64) NOT NULL,
+    definition_json      JSONB NOT NULL,
+    status               TEXT NOT NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    effective_from       TIMESTAMPTZ,
+    effective_to         TIMESTAMPTZ,
+    PRIMARY KEY (programme_id, programme_revision),
+    CONSTRAINT uq_r1_programme_definition UNIQUE (programme_id, definition_sha256),
+    CONSTRAINT chk_r1_programme_definition_sha256
+        CHECK (definition_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_programme_definition_object
+        CHECK (jsonb_typeof(definition_json) = 'object'),
+    CONSTRAINT chk_r1_programme_status
+        CHECK (status IN ('draft', 'shadow', 'active', 'retired')),
+    CONSTRAINT chk_r1_programme_effective_window
+        CHECK (effective_to IS NULL OR effective_from IS NULL OR effective_to > effective_from)
+);
+
+CREATE TABLE r1_meta.capability_generation (
+    capability_generation_id  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    generation_key            TEXT NOT NULL UNIQUE,
+    relation_schema           TEXT NOT NULL UNIQUE,
+    canonical_generation_id   UUID NOT NULL,
+    capability_revision       TEXT NOT NULL,
+    mechanics_revision_id     TEXT NOT NULL,
+    builder_code_sha          CHAR(40) NOT NULL,
+    builder_config_sha256     CHAR(64) NOT NULL,
+    lifecycle_state           TEXT NOT NULL,
+    row_count                 BIGINT,
+    validation_receipt        JSONB,
+    build_started_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    validated_at              TIMESTAMPTZ,
+    published_at              TIMESTAMPTZ,
+    retired_at                TIMESTAMPTZ,
+    failed_at                 TIMESTAMPTZ,
+    failure_reason            TEXT,
+    CONSTRAINT fk_r1_capability_canonical_generation
+        FOREIGN KEY (canonical_generation_id)
+        REFERENCES v3_meta.canonical_generation (generation_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_r1_capability_mechanics_revision
+        FOREIGN KEY (mechanics_revision_id)
+        REFERENCES r1_meta.mechanics_revision (mechanics_revision_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT chk_r1_capability_builder_commit_sha
+        CHECK (builder_code_sha ~ '^[0-9a-f]{40}$'),
+    CONSTRAINT chk_r1_capability_builder_config_sha256
+        CHECK (builder_config_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_capability_lifecycle
+        CHECK (lifecycle_state IN ('building', 'validated', 'published', 'retired', 'failed')),
+    CONSTRAINT chk_r1_capability_row_count
+        CHECK (row_count IS NULL OR row_count >= 0),
+    CONSTRAINT chk_r1_capability_validation_receipt
+        CHECK (validation_receipt IS NULL OR jsonb_typeof(validation_receipt) = 'object')
+);
+
+CREATE INDEX idx_r1_capability_generation_canonical
+    ON r1_meta.capability_generation (
+        canonical_generation_id,
+        capability_revision,
+        mechanics_revision_id
+    );
+
+CREATE INDEX idx_r1_capability_generation_lifecycle
+    ON r1_meta.capability_generation (lifecycle_state, build_started_at DESC);
+
+CREATE TABLE r1_meta.current_capability_generation (
+    singleton                 BOOLEAN PRIMARY KEY DEFAULT TRUE,
+    capability_generation_id  BIGINT NOT NULL,
+    publication_sequence      BIGINT NOT NULL,
+    published_at              TIMESTAMPTZ NOT NULL,
+    CONSTRAINT chk_r1_current_capability_singleton
+        CHECK (singleton),
+    CONSTRAINT chk_r1_current_capability_sequence
+        CHECK (publication_sequence > 0),
+    CONSTRAINT fk_r1_current_capability_generation
+        FOREIGN KEY (capability_generation_id)
+        REFERENCES r1_meta.capability_generation (capability_generation_id)
+        ON DELETE RESTRICT
+);
+
+-- Typed zero-row logical surface. A later separately-authorised capability
+-- publication replaces this view atomically with one pointing at a validated
+-- immutable r1_cap_<generation>.system_capability relation.
+CREATE VIEW r1_cache.system_capability_current AS
+SELECT
+    NULL::BIGINT            AS system_id64,
+    NULL::INTEGER           AS source_body_count,
+    NULL::INTEGER           AS loaded_body_count,
+    NULL::SMALLINT          AS body_inventory_state,
+    NULL::INTEGER           AS star_count,
+    NULL::INTEGER           AS planet_count,
+    NULL::INTEGER           AS hmc_count,
+    NULL::INTEGER           AS metal_rich_body_count,
+    NULL::INTEGER           AS rocky_body_count,
+    NULL::INTEGER           AS rocky_ice_body_count,
+    NULL::INTEGER           AS icy_body_count,
+    NULL::INTEGER           AS water_world_count,
+    NULL::INTEGER           AS earth_like_world_count,
+    NULL::INTEGER           AS ammonia_world_count,
+    NULL::INTEGER           AS gas_giant_count,
+    NULL::INTEGER           AS neutron_star_count,
+    NULL::INTEGER           AS black_hole_count,
+    NULL::INTEGER           AS white_dwarf_count,
+    NULL::INTEGER           AS body_subtype_unknown_count,
+    NULL::INTEGER           AS landable_count,
+    NULL::INTEGER           AS landable_unknown_count,
+    NULL::INTEGER           AS terraformable_count,
+    NULL::INTEGER           AS terraforming_unknown_count,
+    NULL::INTEGER           AS ringed_body_count,
+    NULL::INTEGER           AS geological_body_count,
+    NULL::INTEGER           AS geological_unknown_count,
+    NULL::INTEGER           AS biological_body_count,
+    NULL::INTEGER           AS biological_unknown_count,
+    NULL::INTEGER           AS volcanism_present_count,
+    NULL::INTEGER           AS volcanism_unknown_count,
+    NULL::INTEGER           AS atmosphere_present_count,
+    NULL::INTEGER           AS atmosphere_unknown_count,
+    NULL::INTEGER           AS tidally_locked_count,
+    NULL::INTEGER           AS tidal_lock_unknown_count,
+    NULL::INTEGER           AS signals_incomplete_body_count,
+    NULL::INTEGER           AS genera_incomplete_body_count,
+    NULL::INTEGER           AS distance_unknown_body_count,
+    NULL::INTEGER           AS ring_count,
+    NULL::INTEGER           AS rocky_ring_count,
+    NULL::INTEGER           AS icy_ring_count,
+    NULL::INTEGER           AS metal_rich_ring_count,
+    NULL::INTEGER           AS metallic_ring_count,
+    NULL::INTEGER           AS reserve_depleted_ring_count,
+    NULL::INTEGER           AS reserve_low_ring_count,
+    NULL::INTEGER           AS reserve_common_ring_count,
+    NULL::INTEGER           AS reserve_major_ring_count,
+    NULL::INTEGER           AS reserve_pristine_ring_count,
+    NULL::INTEGER           AS reserve_unknown_ring_count,
+    NULL::INTEGER           AS surface_buildable_body_count,
+    NULL::INTEGER           AS surface_slot_known_body_count,
+    NULL::INTEGER           AS surface_slot_unknown_body_count,
+    NULL::INTEGER           AS surface_slot_total_known,
+    NULL::INTEGER           AS surface_slot_max_known,
+    NULL::INTEGER           AS gas_giant_orbital_slot_total_known,
+    NULL::DOUBLE PRECISION  AS nearest_landable_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_hmc_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_metal_rich_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_ringed_body_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_water_world_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_earth_like_world_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_ammonia_world_distance_ls,
+    NULL::DOUBLE PRECISION  AS nearest_terraformable_distance_ls,
+    NULL::DOUBLE PRECISION  AS furthest_known_body_distance_ls
+WHERE FALSE;
+
+CREATE TABLE r1_plan.saved_plan (
+    plan_id                  UUID PRIMARY KEY,
+    owner_account_id         UUID NOT NULL,
+    system_id64              BIGINT NOT NULL,
+    plan_name                TEXT,
+    plan_state               TEXT NOT NULL,
+    current_revision_number  INTEGER NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    archived_at              TIMESTAMPTZ,
+    CONSTRAINT fk_r1_saved_plan_owner
+        FOREIGN KEY (owner_account_id)
+        REFERENCES v3_identity.account (account_id)
+        ON DELETE CASCADE,
+    CONSTRAINT chk_r1_saved_plan_state
+        CHECK (plan_state IN ('draft', 'selected', 'build_pack', 'archived')),
+    CONSTRAINT chk_r1_saved_plan_current_revision_positive
+        CHECK (current_revision_number > 0)
+);
+
+CREATE INDEX idx_r1_saved_plan_owner_updated
+    ON r1_plan.saved_plan (owner_account_id, updated_at DESC);
+
+CREATE TABLE r1_plan.plan_revision (
+    plan_revision_id                       UUID PRIMARY KEY,
+    plan_id                                UUID NOT NULL,
+    revision_number                        INTEGER NOT NULL,
+    previous_plan_revision_id              UUID,
+    programme_id                           TEXT NOT NULL,
+    programme_revision                     TEXT NOT NULL,
+    carrier_mode                           TEXT NOT NULL,
+    created_from_model_revision_id         TEXT,
+    created_from_mechanics_revision_id     TEXT,
+    created_from_canonical_generation_id   UUID,
+    created_from_evidence_snapshot_sha256  CHAR(64),
+    candidate_plan_sha256                  CHAR(64) NOT NULL,
+    change_kind                            TEXT NOT NULL,
+    created_at                             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT fk_r1_plan_revision_plan
+        FOREIGN KEY (plan_id)
+        REFERENCES r1_plan.saved_plan (plan_id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_r1_plan_revision_programme
+        FOREIGN KEY (programme_id, programme_revision)
+        REFERENCES r1_meta.programme_revision (programme_id, programme_revision)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_r1_plan_revision_model
+        FOREIGN KEY (created_from_model_revision_id)
+        REFERENCES r1_meta.model_revision (model_revision_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_r1_plan_revision_mechanics
+        FOREIGN KEY (created_from_mechanics_revision_id)
+        REFERENCES r1_meta.mechanics_revision (mechanics_revision_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_r1_plan_revision_canonical_generation
+        FOREIGN KEY (created_from_canonical_generation_id)
+        REFERENCES v3_meta.canonical_generation (generation_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT chk_r1_plan_revision_number
+        CHECK (revision_number > 0),
+    CONSTRAINT chk_r1_plan_revision_carrier_mode
+        CHECK (carrier_mode IN ('no_carrier', 'carrier_available')),
+    CONSTRAINT chk_r1_plan_revision_evidence_sha256
+        CHECK (
+            created_from_evidence_snapshot_sha256 IS NULL
+            OR created_from_evidence_snapshot_sha256 ~ '^[0-9a-f]{64}$'
+        ),
+    CONSTRAINT chk_r1_plan_revision_candidate_sha256
+        CHECK (candidate_plan_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_plan_revision_change_kind
+        CHECK (change_kind IN ('finder_generated', 'user_edit', 'programme_change', 'rebase')),
+    CONSTRAINT uq_r1_plan_revision_number UNIQUE (plan_id, revision_number),
+    CONSTRAINT uq_r1_plan_revision_candidate UNIQUE (plan_id, candidate_plan_sha256),
+    CONSTRAINT uq_r1_plan_revision_same_plan_ref UNIQUE (plan_revision_id, plan_id),
+    CONSTRAINT uq_r1_plan_revision_assessment_binding UNIQUE (
+        plan_revision_id,
+        programme_id,
+        programme_revision,
+        carrier_mode,
+        candidate_plan_sha256
+    ),
+    CONSTRAINT fk_r1_plan_revision_previous_same_plan
+        FOREIGN KEY (previous_plan_revision_id, plan_id)
+        REFERENCES r1_plan.plan_revision (plan_revision_id, plan_id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+ALTER TABLE r1_plan.saved_plan
+    ADD CONSTRAINT fk_r1_saved_plan_current_revision
+    FOREIGN KEY (plan_id, current_revision_number)
+    REFERENCES r1_plan.plan_revision (plan_id, revision_number)
+    DEFERRABLE INITIALLY DEFERRED;
+
+CREATE TABLE r1_plan.plan_node (
+    plan_node_id                 UUID PRIMARY KEY,
+    plan_revision_id             UUID NOT NULL,
+    node_key                     TEXT NOT NULL,
+    node_kind                    TEXT NOT NULL,
+    parent_plan_node_id          UUID,
+    facility_type_code           TEXT NOT NULL,
+    intended_role_code           TEXT,
+    locality_key                 TEXT,
+    host_body_pk_snapshot        BIGINT,
+    host_body_source_id64        BIGINT,
+    host_body_frontier_id        INTEGER,
+    host_body_name_snapshot      TEXT,
+    ordinal                      INTEGER NOT NULL,
+    metadata_json                JSONB NOT NULL DEFAULT '{}'::jsonb,
+    CONSTRAINT fk_r1_plan_node_revision
+        FOREIGN KEY (plan_revision_id)
+        REFERENCES r1_plan.plan_revision (plan_revision_id)
+        ON DELETE CASCADE,
+    CONSTRAINT chk_r1_plan_node_ordinal
+        CHECK (ordinal >= 0),
+    CONSTRAINT chk_r1_plan_node_metadata_object
+        CHECK (jsonb_typeof(metadata_json) = 'object'),
+    CONSTRAINT uq_r1_plan_node_key UNIQUE (plan_revision_id, node_key),
+    CONSTRAINT uq_r1_plan_node_ordinal UNIQUE (plan_revision_id, ordinal),
+    CONSTRAINT uq_r1_plan_node_same_revision_ref UNIQUE (plan_node_id, plan_revision_id),
+    CONSTRAINT fk_r1_plan_node_parent_same_revision
+        FOREIGN KEY (parent_plan_node_id, plan_revision_id)
+        REFERENCES r1_plan.plan_node (plan_node_id, plan_revision_id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE TABLE r1_plan.plan_allocation (
+    allocation_id          UUID PRIMARY KEY,
+    plan_revision_id       UUID NOT NULL,
+    requirement_id         TEXT NOT NULL,
+    resource_kind          TEXT NOT NULL,
+    resource_key           TEXT NOT NULL,
+    plan_node_id           UUID,
+    allocation_mode        TEXT NOT NULL,
+    allocation_quantity    NUMERIC,
+    evidence_refs_json     JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ordinal                INTEGER NOT NULL,
+    CONSTRAINT fk_r1_plan_allocation_revision
+        FOREIGN KEY (plan_revision_id)
+        REFERENCES r1_plan.plan_revision (plan_revision_id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_r1_plan_allocation_node_same_revision
+        FOREIGN KEY (plan_node_id, plan_revision_id)
+        REFERENCES r1_plan.plan_node (plan_node_id, plan_revision_id)
+        DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT chk_r1_plan_allocation_mode
+        CHECK (allocation_mode IN ('exclusive', 'shared', 'capacity')),
+    CONSTRAINT chk_r1_plan_allocation_quantity
+        CHECK (allocation_quantity IS NULL OR allocation_quantity >= 0),
+    CONSTRAINT chk_r1_plan_allocation_evidence_array
+        CHECK (jsonb_typeof(evidence_refs_json) = 'array'),
+    CONSTRAINT chk_r1_plan_allocation_ordinal
+        CHECK (ordinal >= 0),
+    CONSTRAINT uq_r1_plan_allocation_requirement_resource
+        UNIQUE NULLS NOT DISTINCT (
+            plan_revision_id,
+            requirement_id,
+            resource_kind,
+            resource_key,
+            plan_node_id
+        ),
+    CONSTRAINT uq_r1_plan_allocation_ordinal UNIQUE (plan_revision_id, ordinal)
+);
+
+CREATE UNIQUE INDEX uq_r1_plan_allocation_exclusive_resource
+    ON r1_plan.plan_allocation (plan_revision_id, resource_kind, resource_key)
+    WHERE allocation_mode = 'exclusive';
+
+CREATE TABLE r1_plan.plan_assessment (
+    assessment_id               UUID PRIMARY KEY,
+    plan_revision_id            UUID NOT NULL,
+    assessment_kind             TEXT NOT NULL,
+    system_id64                 BIGINT NOT NULL,
+    programme_id                TEXT NOT NULL,
+    programme_revision          TEXT NOT NULL,
+    model_revision_id           TEXT NOT NULL,
+    mechanics_revision_id       TEXT NOT NULL,
+    canonical_generation_id     UUID NOT NULL,
+    evidence_snapshot_sha256    CHAR(64) NOT NULL,
+    candidate_plan_sha256       CHAR(64) NOT NULL,
+    carrier_mode                TEXT NOT NULL,
+    assessment_state            TEXT NOT NULL,
+    evidence_disposition        TEXT NOT NULL,
+    reserve_capacity            TEXT,
+    logistics_state             TEXT,
+    plan_pair_resilience        TEXT,
+    plan_fit                    SMALLINT,
+    fit_policy_revision         TEXT,
+    result_sha256               CHAR(64) NOT NULL UNIQUE,
+    trace_json                  JSONB NOT NULL,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT fk_r1_plan_assessment_plan_binding
+        FOREIGN KEY (
+            plan_revision_id,
+            programme_id,
+            programme_revision,
+            carrier_mode,
+            candidate_plan_sha256
+        ) REFERENCES r1_plan.plan_revision (
+            plan_revision_id,
+            programme_id,
+            programme_revision,
+            carrier_mode,
+            candidate_plan_sha256
+        ) ON DELETE CASCADE,
+    CONSTRAINT fk_r1_plan_assessment_model
+        FOREIGN KEY (model_revision_id)
+        REFERENCES r1_meta.model_revision (model_revision_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_r1_plan_assessment_mechanics
+        FOREIGN KEY (mechanics_revision_id)
+        REFERENCES r1_meta.mechanics_revision (mechanics_revision_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT fk_r1_plan_assessment_canonical_generation
+        FOREIGN KEY (canonical_generation_id)
+        REFERENCES v3_meta.canonical_generation (generation_id)
+        ON DELETE RESTRICT,
+    CONSTRAINT chk_r1_plan_assessment_kind
+        CHECK (assessment_kind IN ('saved_plan', 'build_pack', 'plan_audit')),
+    CONSTRAINT chk_r1_plan_assessment_carrier_mode
+        CHECK (carrier_mode IN ('no_carrier', 'carrier_available')),
+    CONSTRAINT chk_r1_plan_assessment_state
+        CHECK (assessment_state IN (
+            'not_assessable',
+            'not_supported',
+            'conditionally_supported',
+            'supported'
+        )),
+    CONSTRAINT chk_r1_plan_assessment_evidence
+        CHECK (evidence_disposition IN ('sufficient', 'partial', 'missing', 'ambiguous', 'conflicting')),
+    CONSTRAINT chk_r1_plan_assessment_reserve
+        CHECK (reserve_capacity IS NULL OR reserve_capacity IN ('tight', 'sufficient', 'resilient', 'expandable', 'unknown')),
+    CONSTRAINT chk_r1_plan_assessment_logistics
+        CHECK (logistics_state IS NULL OR logistics_state IN ('compact', 'moderate', 'spread', 'extreme', 'unknown')),
+    CONSTRAINT chk_r1_plan_assessment_pair_resilience
+        CHECK (plan_pair_resilience IS NULL OR plan_pair_resilience IN ('robust', 'fragile', 'mixed', 'unknown')),
+    CONSTRAINT chk_r1_plan_assessment_plan_fit_range
+        CHECK (plan_fit IS NULL OR plan_fit BETWEEN 0 AND 100),
+    CONSTRAINT chk_r1_plan_assessment_plan_fit_state
+        CHECK (
+            plan_fit IS NULL
+            OR assessment_state IN ('conditionally_supported', 'supported')
+        ),
+    CONSTRAINT chk_r1_plan_assessment_evidence_sha256
+        CHECK (evidence_snapshot_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_plan_assessment_candidate_sha256
+        CHECK (candidate_plan_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_plan_assessment_result_sha256
+        CHECK (result_sha256 ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT chk_r1_plan_assessment_trace_object
+        CHECK (jsonb_typeof(trace_json) = 'object')
+);
+
+CREATE INDEX idx_r1_plan_assessment_revision_created
+    ON r1_plan.plan_assessment (plan_revision_id, created_at DESC);
+
+CREATE INDEX idx_r1_plan_assessment_system_programme_created
+    ON r1_plan.plan_assessment (
+        system_id64,
+        programme_id,
+        programme_revision,
+        created_at DESC
+    );
+
+CREATE INDEX idx_r1_plan_assessment_kind_created
+    ON r1_plan.plan_assessment (assessment_kind, created_at DESC);
+
+COMMENT ON SCHEMA r1_meta IS
+    'R1 immutable revision registries and capability-generation publication metadata.';
+COMMENT ON SCHEMA r1_cache IS
+    'R1 rebuildable, context-independent Finder capability surface; never a universal ratings store.';
+COMMENT ON SCHEMA r1_plan IS
+    'R1 private durable saved-plan revisions, allocations and immutable assessment snapshots.';
+
+COMMENT ON VIEW r1_cache.system_capability_current IS
+    'Typed zero-row shell until a separately authorised validated capability generation is atomically published.';
+
+COMMIT;

--- a/sql/v3/migration-manifest.txt
+++ b/sql/v3/migration-manifest.txt
@@ -1,0 +1,29 @@
+# ED-Finder V3 production migration lineage
+#
+# This is the independent PostgreSQL 18 lineage that the retained production
+# database actually runs. It is deliberately separate from the V2
+# sql/migration-manifest.txt ordered set: never append V2 sql/NNN_*.sql files
+# here.
+#
+# Format: <sha256>  <ledger-name>  <path-under-sql>
+#
+# <ledger-name> is the exact migration_name recorded in v3_meta.schema_migration,
+# so the reviewed live ledger and this manifest are compared directly instead of
+# guessing at a naming convention. <path-under-sql> locates the bytes that hash
+# to <sha256>.
+#
+# Provenance of the reviewed rows, all three re-verified by byte hash against the
+# live ledger read under BEGIN READ ONLY by the 2026-09-10 inventory receipt:
+#
+#   001_v3_baseline.sql           applied 2026-08-27T12:05:58Z by the
+#                                 edfinder-v3-phase4c-full-20260827_r5 rehearsal
+#   002_v3_accounts_identity.sql  applied 2026-08-27T12:05:58Z by the same
+#                                 rehearsal; recovered from the preserved
+#                                 cleanup-snapshot/v3-production-readiness commit
+#   r1_v3/001_structural_shell.sql applied 2026-08-31T16:22:56Z as the additive
+#                                 R1 normalized shell; recovered from the
+#                                 chatgpt-ed-new-ops-requests branch
+
+ee08c17eb3f87f614468db5a038d2f23273ce2b72906226c9aa1f669e724cd2e  001_v3_baseline.sql  v3/migrations/001_v3_baseline.sql
+e7a2f404b7d8194d74ba4e807ae450c7520a1c8a186ca77e41377307e7b12b07  002_v3_accounts_identity.sql  v3/migrations/002_v3_accounts_identity.sql
+1a2d15c2db5cff7714a01a5d0c710a22326ed57d90d9a20e362495714ad97a40  r1_v3/001_structural_shell.sql  r1_v3/001_structural_shell.sql

--- a/sql/v3/migrations/002_v3_accounts_identity.sql
+++ b/sql/v3/migrations/002_v3_accounts_identity.sql
@@ -1,0 +1,113 @@
+-- ED-Finder V3 identity and Frontier OAuth support.
+--
+-- This is the first post-baseline migration in the independent V3 lineage.
+-- It extends the fresh v3_identity schema created by 001_v3_baseline.sql.
+-- It does not inspect, copy, convert, or depend on V2 OAuth tables.
+
+DO $baseline_guard$
+BEGIN
+    IF to_regclass('v3_meta.schema_migration') IS NULL
+       OR to_regclass('v3_identity.account') IS NULL
+       OR to_regclass('v3_identity.external_identity') IS NULL
+       OR to_regclass('v3_identity.commander') IS NULL
+       OR to_regclass('v3_identity.account_commander_access') IS NULL
+       OR to_regclass('v3_identity.session') IS NULL
+       OR to_regclass('v3_identity.security_audit_event') IS NULL THEN
+        RAISE EXCEPTION
+            '002_v3_accounts_identity.sql requires the frozen V3 baseline';
+    END IF;
+END;
+$baseline_guard$;
+
+-- Stable application roles. The numeric identifiers are V3-local and have no
+-- relationship to PostgreSQL roles or the retired V2 OAuth prototype.
+INSERT INTO v3_identity.role(role_id, public_code, description, active)
+VALUES
+    (1, 'OWNER', 'Single bootstrap owner with privileged product access.', true),
+    (2, 'ADMIN', 'Delegated administrative product access.', true),
+    (3, 'MEMBER', 'Authenticated product member.', true),
+    (4, 'SERVICE', 'Application service-principal assignment.', true);
+
+ALTER TABLE v3_identity.account_role
+    ADD COLUMN granted_by_account_id uuid,
+    ADD COLUMN grant_source text NOT NULL DEFAULT 'MIGRATION';
+
+ALTER TABLE v3_identity.account_role
+    ADD CONSTRAINT account_role_granted_by_account_fk
+        FOREIGN KEY (granted_by_account_id)
+        REFERENCES v3_identity.account(account_id),
+    ADD CONSTRAINT account_role_grant_source_not_blank
+        CHECK (btrim(grant_source) <> '');
+
+CREATE UNIQUE INDEX account_role_single_active_owner_uidx
+    ON v3_identity.account_role(role_id)
+    WHERE role_id = 1 AND revoked_at IS NULL;
+
+COMMENT ON INDEX v3_identity.account_role_single_active_owner_uidx IS
+    'V3 owner bootstrap is single-assignment; later role management is separate.';
+
+ALTER TABLE v3_identity.external_identity
+    ADD CONSTRAINT external_identity_provider_normalized
+        CHECK (provider = lower(btrim(provider)) AND btrim(provider) <> ''),
+    ADD CONSTRAINT external_identity_issuer_not_blank
+        CHECK (btrim(issuer) <> ''),
+    ADD CONSTRAINT external_identity_subject_not_blank
+        CHECK (btrim(subject) <> '');
+
+CREATE INDEX external_identity_account_active_idx
+    ON v3_identity.external_identity(account_id, provider)
+    WHERE disabled_at IS NULL;
+
+COMMENT ON INDEX v3_identity.external_identity_account_active_idx IS
+    'List active login identities for one V3 account without name-based inference.';
+
+ALTER TABLE v3_identity.session
+    ADD COLUMN token_issued_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    ADD COLUMN revocation_reason text;
+
+ALTER TABLE v3_identity.session
+    ADD CONSTRAINT session_token_issued_after_creation
+        CHECK (token_issued_at >= created_at),
+    ADD CONSTRAINT session_token_issued_before_absolute_expiry
+        CHECK (token_issued_at < absolute_expires_at),
+    ADD CONSTRAINT session_revocation_reason_state
+        CHECK (
+            revocation_reason IS NULL
+            OR (
+                session_state IN ('ROTATED', 'REVOKED')
+                AND btrim(revocation_reason) <> ''
+            )
+        );
+
+CREATE TABLE v3_identity.oauth_login_state (
+    state_sha256 bytea PRIMARY KEY,
+    code_verifier text NOT NULL,
+    return_to text NOT NULL DEFAULT '/',
+    intent text NOT NULL DEFAULT 'LOGIN' CHECK (intent IN ('LOGIN', 'LINK')),
+    account_id uuid REFERENCES v3_identity.account(account_id),
+    created_at timestamptz NOT NULL DEFAULT transaction_timestamp(),
+    expires_at timestamptz NOT NULL,
+    CHECK (octet_length(state_sha256) = 32),
+    CHECK (btrim(code_verifier) <> ''),
+    CHECK (return_to LIKE '/%' AND return_to NOT LIKE '//%'),
+    CHECK (
+        (intent = 'LOGIN' AND account_id IS NULL)
+        OR (intent = 'LINK' AND account_id IS NOT NULL)
+    ),
+    CHECK (expires_at > created_at)
+);
+
+CREATE INDEX oauth_login_state_expiry_idx
+    ON v3_identity.oauth_login_state(expires_at);
+
+COMMENT ON TABLE v3_identity.oauth_login_state IS
+    'Short-lived PKCE state for V3 login/link; the raw OAuth state and provider tokens are never persisted.';
+
+CREATE INDEX security_audit_event_code_time_idx
+    ON v3_identity.security_audit_event(event_code, occurred_at DESC);
+
+COMMENT ON INDEX v3_identity.security_audit_event_code_time_idx IS
+    'Review security-sensitive V3 events by stable code and time.';
+
+COMMENT ON TABLE v3_identity.account IS
+    'Fresh V3 account authority. No V2 OAuth account or session rows are migrated.';

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -4,6 +4,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 from pathlib import Path
 import signal
 import stat
@@ -28,6 +29,15 @@ PROMOTE_ACTION = ROOT / "scripts/operator/actions/v3-production-promote.sh"
 PUBLIC_EDGE_CONF = ROOT / "deploy/v3-production/public-auth-edge.nginx.conf"
 WORKFLOW = ROOT / ".github/workflows/v3-production-application-deploy.yml"
 RUNBOOK = ROOT / "docs/operations/v3-production-application-release.md"
+V3_MANIFEST = ROOT / "sql/v3/migration-manifest.txt"
+
+# The reviewed live ledger of the retained production database, read under
+# BEGIN READ ONLY by the 2026-09-10 inventory receipt.
+LIVE_V3_LEDGER = (
+    ("001_v3_baseline.sql", "ee08c17eb3f87f614468db5a038d2f23273ce2b72906226c9aa1f669e724cd2e"),
+    ("002_v3_accounts_identity.sql", "e7a2f404b7d8194d74ba4e807ae450c7520a1c8a186ca77e41377307e7b12b07"),
+    ("r1_v3/001_structural_shell.sql", "1a2d15c2db5cff7714a01a5d0c710a22326ed57d90d9a20e362495714ad97a40"),
+)
 
 
 def _load_deployer():
@@ -226,6 +236,32 @@ def test_inventory_designated_paths_report_stat_only_evidence(tmp_path):
     linked = inventory.inspect_designated_path({**spec, "path": str(link)})
     assert linked["is_symlink"] is True
     assert linked["matches_designation"] is False
+
+
+def test_v3_lineage_manifest_reproduces_the_reviewed_live_ledger():
+    entries: dict[str, tuple[str, str]] = {}
+    for raw_line in V3_MANIFEST.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        checksum, first_separator, remainder = line.partition("  ")
+        ledger_name, second_separator, path = remainder.partition("  ")
+        assert first_separator and second_separator, f"unsafe manifest entry: {line!r}"
+        assert re.fullmatch(r"[0-9a-f]{64}", checksum), line
+        assert re.fullmatch(r"(?:[a-z0-9_]+/)?[0-9]{3}_[a-z0-9_]+\.sql", ledger_name), line
+        assert re.fullmatch(r"(?:[a-z0-9_]+/)+[0-9]{3}_[a-z0-9_]+\.sql", path), line
+        assert ledger_name not in entries, line
+        entries[ledger_name] = (path, checksum)
+
+    assert set(entries) == {name for name, _ in LIVE_V3_LEDGER}
+    for ledger_name, reviewed_checksum in LIVE_V3_LEDGER:
+        path, checksum = entries[ledger_name]
+        assert checksum == reviewed_checksum
+        # The committed bytes must be the ones PostgreSQL actually applied, so
+        # they stay LF-terminated and byte-identical on every platform.
+        source = (ROOT / "sql" / path).read_bytes()
+        assert hashlib.sha256(source).hexdigest() == reviewed_checksum
+        assert b"\r\n" not in source
 
 
 def test_inventory_container_labels_are_limited_to_compose_identity():


### PR DESCRIPTION
## Why

The retained production database records three migrations in `v3_meta.schema_migration`, and the repository could describe none of them usefully — one lived outside the reviewed namespace, two had no tracked source at all. That is what actually blocked the reviewed schema identity file, not a missing file.

## What

All three live ledger rows are now committed, each **byte-hash verified** against the ledger as read under `BEGIN READ ONLY` by the 2026-09-10 inventory receipt:

| ledger row | applied (UTC) | origin |
|---|---|---|
| `001_v3_baseline.sql` | 2026-08-27T12:05:58Z | the `…phase4c-full-20260827_r5` rehearsal that built the live DB |
| `002_v3_accounts_identity.sql` | 2026-08-27T12:05:58Z | same rehearsal; recovered from the preserved `cleanup-snapshot/v3-production-readiness` commit |
| `r1_v3/001_structural_shell.sql` | 2026-08-31T16:22:56Z | authored in `34c45eba`, which only ever existed on `chatgpt-ed-new-ops-requests` |

`sql/v3/migration-manifest.txt` records the lineage as `<sha256>  <ledger-name>  <path-under-sql>`. Recording the ledger name explicitly is deliberate — the applier named two rows by basename and one by full path, so any path→name transformation would be guesswork.

The three files join the existing byte-exact artifact rule in `.gitattributes`, so their hashes cannot drift with line-ending conversion. That mattered immediately: with `core.autocrlf=true` a plain checkout inflated `002_v3_accounts_identity.sql` from 4768 to 4881 bytes and broke the hash.

## Test

New `test_v3_lineage_manifest_reproduces_the_reviewed_live_ledger` parses the manifest and asserts every entry resolves to committed, LF-terminated bytes whose sha256 equals the reviewed ledger row.

## Not done

This records the lineage; it does not yet consume it. Deriving the production schema identity from this manifest, and accepting the `r1_v3/` ledger naming in the schema-identity contract (`sql/[0-9]{3}_…`) and in the live-ledger check, is the next change. Runbook and roadmap say so.

## Verification

`ruff check` clean, files compile, and every pinned runbook/roadmap string other tests assert still survives. Locally the suite still reports the same 28 pre-existing environment failures (Linux-only: `fcntl`, `bash`/`tar`) with the new test passing; CI is the authority.
