### PR TITLE
Derive the production schema identity from the V3 lineage

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,9 +79,13 @@ or override this set.
   independent V3 lineage: all three of its rows are committed under `sql/` with
   byte hashes re-verified against `v3_meta.schema_migration`, and
   `sql/v3/migration-manifest.txt` records the lineage as
-  `<sha256> <ledger-name> <path-under-sql>`. Deriving the production schema
-  identity from that manifest, and accepting the `r1_v3/` ledger naming in the
-  schema-identity contract, is the remaining step.
+  `<sha256> <ledger-name> <path-under-sql>`, and
+  `scripts/operator/v3_schema_identity.py` derives the production schema identity
+  from it. Remaining: author that identity file on the host, pin its
+  path/owner/mode/sha256 in the target authority, and have the candidate release
+  declare the resulting V3 identity as an additional compatible migration set,
+  because the canonical release manifest still derives its own set from the V2
+  manifest.
 
 ## Product journey and spatial north star
 

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -68,10 +68,19 @@ committed under `sql/` with byte hashes re-verified against the ledger:
 2026-08-27T12:05:58Z, and `r1_v3/001_structural_shell.sql` applied
 2026-08-31T16:22:56Z. `sql/v3/migration-manifest.txt` records that lineage as
 `<sha256> <ledger-name> <path-under-sql>` so the reviewed ledger and the manifest
-are compared directly. What remains is to derive the production schema identity
-from that manifest and to accept the `r1_v3/` ledger naming in the schema-identity
-contract and the ledger compatibility check. The migration sources are no longer
-missing, so the schema identity file is now blocked only on that contract change.
+are compared directly, and `scripts/operator/v3_schema_identity.py` derives the
+production schema identity document from it. The schema-identity contract and the
+live-ledger check now carry the applied ledger name explicitly and accept the
+`r1_v3/` naming.
+
+Three steps remain before the schema blocker clears. Author the identity file on
+the host from that derivation, pin its path, owner uid, mode and sha256 in the
+target authority, and have the candidate release declare compatibility with the
+resulting V3 identity through the existing `--compatible-migration-set` flag.
+That last point matters: the canonical release manifest still derives its own
+migration set from the V2 `sql/migration-manifest.txt`, so the production
+database's V3 identity has to be declared as an additional compatible set rather
+than inferred.
 
 The application-network blocker is therefore cleared. These remain, and
 `status` stays `stopped` until each is replaced by exact reviewed facts:

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -766,11 +766,21 @@ def validate_schema_file(path: Path, expected_sha: str) -> dict[str, Any]:
     if not isinstance(entries, list) or not entries:
         raise DeploymentError("production schema identity has no entries")
     for item in entries:
-        if not isinstance(item, dict) or set(item) != {"path", "mode", "sha256"}:
+        if not isinstance(item, dict) or set(item) != {"path", "ledger_name", "mode", "sha256"}:
             raise DeploymentError("production schema entry shape is invalid")
-        if not re.fullmatch(r"sql/[0-9]{3}_[a-z0-9_]+\.sql", str(item["path"])) or item["mode"] not in {"auto", "manual"} or not re.fullmatch(r"[0-9a-f]{64}", str(item["sha256"])):
+        # The V3 lineage nests its sources, and the applied ledger name is not
+        # always derivable from the path: the historical applier recorded two
+        # rows by basename and one by path, so both are carried explicitly.
+        if (
+            not re.fullmatch(r"sql/(?:v3/migrations/|r[0-9]+_v3/)[0-9]{3}_[a-z0-9_]+\.sql", str(item["path"]))
+            or not re.fullmatch(r"(?:r[0-9]+_v3/)?[0-9]{3}_[a-z0-9_]+\.sql", str(item["ledger_name"]))
+            or item["mode"] not in {"auto", "manual"}
+            or not re.fullmatch(r"[0-9a-f]{64}", str(item["sha256"]))
+        ):
             raise DeploymentError("production schema entry is invalid")
-    if len({item["path"] for item in entries}) != len(entries):
+    if len({item["path"] for item in entries}) != len(entries) or len(
+        {item["ledger_name"] for item in entries}
+    ) != len(entries):
         raise DeploymentError("production schema entries are duplicated")
     evidence = value.get("evidence")
     if not isinstance(evidence, str) or not evidence.strip():
@@ -866,7 +876,7 @@ def verify_live_schema(schema: dict[str, Any], env: dict[str, str], runner: Call
         or any(
             not isinstance(item, dict)
             or set(item) != {"filename", "checksum_sha256"}
-            or not re.fullmatch(r"[0-9]{3}_[a-z0-9_]+\.sql", str(item["filename"]))
+            or not re.fullmatch(r"(?:r[0-9]+_v3/)?[0-9]{3}_[a-z0-9_]+\.sql", str(item["filename"]))
             or not re.fullmatch(r"[0-9a-f]{64}", str(item["checksum_sha256"]))
             for item in ledger
         )
@@ -876,7 +886,7 @@ def verify_live_schema(schema: dict[str, Any], env: dict[str, str], runner: Call
     expected = sorted(
         (
             {
-                "filename": item["path"].removeprefix("sql/"),
+                "filename": item["ledger_name"],
                 "checksum_sha256": item["sha256"],
             }
             for item in schema["migration_set_entries"]

--- a/scripts/operator/v3_schema_identity.py
+++ b/scripts/operator/v3_schema_identity.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Derive the reviewed V3 production schema identity from the V3 lineage manifest.
+
+The V3 production database runs an independent PostgreSQL 18 lineage that is
+deliberately separate from the canonical V2 ``sql/migration-manifest.txt``
+ordered set. This helper turns that lineage into the exact document the
+production deployer validates, so the identity is derived and reproducible
+instead of hand-written.
+
+Each entry records the migration name exactly as ``v3_meta.schema_migration``
+stores it, alongside the repository path holding the bytes, because the
+historical applier named some rows by basename and one by path.
+
+The output contains no secret material: a database identity, file paths and
+checksums only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_IDENTITY_SCHEMA = "ed-finder/v3-production-schema-identity/v1"
+V3_MANIFEST_PATH = "sql/v3/migration-manifest.txt"
+POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_NAME = "edfinder_v3_phase4c_full_20260827_r5"
+DATABASE_USER = "edfinder_v3"
+DATABASE_IDENTITY = {
+    "container": POSTGRES_CONTAINER,
+    "database_name": DATABASE_NAME,
+    "database_user": DATABASE_USER,
+    "application_host": POSTGRES_CONTAINER,
+    "server_address": "local",
+    "server_port": 5432,
+}
+# The applied ledger naming the codebase already accepts, plus the reviewed
+# repository location of the V3 lineage sources.
+MANIFEST_LEDGER_NAME = re.compile(r"(?:r[0-9]+_v3/)?[0-9]{3}_[a-z0-9_]+\.sql\Z")
+MANIFEST_PATH = re.compile(
+    r"(?:v3/migrations/|r[0-9]+_v3/)[0-9]{3}_[a-z0-9_]+\.sql\Z"
+)
+MAX_ENTRIES = 512
+
+
+class SchemaIdentityError(RuntimeError):
+    pass
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def derive_entries(root: Path = ROOT) -> list[dict[str, str]]:
+    manifest_path = root / V3_MANIFEST_PATH
+    try:
+        manifest_bytes = manifest_path.read_bytes()
+    except OSError as exc:
+        raise SchemaIdentityError("unable to read the V3 migration manifest") from exc
+
+    entries: list[dict[str, str]] = []
+    ledger_names: set[str] = set()
+    for raw_line in manifest_bytes.decode("utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        checksum, first_separator, remainder = line.partition("  ")
+        ledger_name, second_separator, path = remainder.partition("  ")
+        if (
+            not first_separator
+            or not second_separator
+            or not re.fullmatch(r"[0-9a-f]{64}", checksum)
+            or not MANIFEST_LEDGER_NAME.fullmatch(ledger_name)
+            or not MANIFEST_PATH.fullmatch(path)
+            or ledger_name in ledger_names
+        ):
+            raise SchemaIdentityError(f"unsafe V3 migration manifest entry: {line!r}")
+        source = root / "sql" / path
+        if not source.is_file() or source.is_symlink():
+            raise SchemaIdentityError(f"V3 migration source is missing: sql/{path}")
+        digest = _sha256(source.read_bytes())
+        if digest != checksum:
+            raise SchemaIdentityError(f"V3 migration checksum drift: sql/{path}")
+        ledger_names.add(ledger_name)
+        entries.append(
+            {
+                "path": f"sql/{path}",
+                "ledger_name": ledger_name,
+                "mode": "auto",
+                "sha256": digest,
+            }
+        )
+    if not entries or len(entries) > MAX_ENTRIES:
+        raise SchemaIdentityError("V3 migration manifest entry count is invalid")
+    return entries
+
+
+def migration_set_identity(entries: list[dict[str, str]]) -> str:
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + _sha256(canonical)
+
+
+def build(
+    root: Path = ROOT, evidence: str = (
+        "reviewed 2026-09-10 production inventory receipt and the live "
+        "v3_meta.schema_migration ledger read under BEGIN READ ONLY"
+    ),
+) -> dict[str, Any]:
+    entries = derive_entries(root)
+    return {
+        "schema_version": SCHEMA_IDENTITY_SCHEMA,
+        "database_identity": dict(DATABASE_IDENTITY),
+        "migration_set_identity": migration_set_identity(entries),
+        "migration_set_entries": entries,
+        "evidence": evidence,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=None)
+    arguments = parser.parse_args()
+    try:
+        document = build()
+    except SchemaIdentityError as exc:
+        print(f"schema identity derivation failed: {exc}", file=sys.stderr)
+        return 78
+    payload = json.dumps(document, indent=2, sort_keys=True) + "\n"
+    if arguments.output is None:
+        sys.stdout.write(payload)
+    else:
+        arguments.output.write_text(payload, encoding="utf-8")
+        print(f"wrote {arguments.output} sha256={_sha256(payload.encode())}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -24,6 +24,7 @@ COMPOSE = ROOT / "deploy/v3-production/compose.yml"
 AUTHORITY = ROOT / "deploy/v3-production/target-authority.json"
 DEPLOYER = ROOT / "scripts/operator/v3_production_deploy.py"
 INVENTORY = ROOT / "scripts/operator/v3_production_inventory.py"
+SCHEMA_IDENTITY = ROOT / "scripts/operator/v3_schema_identity.py"
 INVENTORY_ACTION = ROOT / "scripts/operator/actions/v3-production-inventory.sh"
 PROMOTE_ACTION = ROOT / "scripts/operator/actions/v3-production-promote.sh"
 PUBLIC_EDGE_CONF = ROOT / "deploy/v3-production/public-auth-edge.nginx.conf"
@@ -42,6 +43,14 @@ LIVE_V3_LEDGER = (
 
 def _load_deployer():
     spec = importlib.util.spec_from_file_location("v3_production_deploy", DEPLOYER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_schema_identity():
+    spec = importlib.util.spec_from_file_location("v3_schema_identity", SCHEMA_IDENTITY)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -321,39 +330,44 @@ def test_production_deployer_uses_release_manifest_and_fresh_schema_compatibilit
         assert forbidden not in source
 
 
-def test_production_schema_identity_preserves_release_manifest_order(tmp_path):
+def test_production_schema_identity_is_derived_from_the_v3_lineage(tmp_path):
     deployer = _load_deployer()
-    release_spec = importlib.util.spec_from_file_location(
-        "v3_release_manifest_for_production_test",
-        ROOT / "scripts/release/v3_release_manifest.py",
-    )
-    assert release_spec and release_spec.loader
-    release = importlib.util.module_from_spec(release_spec)
-    release_spec.loader.exec_module(release)
-    migration_set = release.migration_set(ROOT)
-    assert migration_set["entries"] != sorted(
-        migration_set["entries"], key=lambda item: item["path"]
-    )
-    schema = {
-        "schema_version": deployer.SCHEMA_IDENTITY_SCHEMA,
-        "database_identity": {
-            "container": deployer.POSTGRES_CONTAINER,
-            "database_name": deployer.DATABASE_NAME,
-            "database_user": deployer.DATABASE_USER,
-            "application_host": deployer.POSTGRES_CONTAINER,
-            "server_address": "local",
-            "server_port": 5432,
-        },
-        "migration_set_identity": migration_set["identity"],
-        "migration_set_entries": migration_set["entries"],
-        "evidence": "reviewed-production-inventory-receipt",
-    }
-    path = tmp_path / "schema.json"
-    path.write_text(json.dumps(schema), encoding="utf-8")
+    identity = _load_schema_identity()
 
-    assert deployer.validate_schema_file(
-        path, hashlib.sha256(path.read_bytes()).hexdigest()
-    )["migration_set_identity"] == migration_set["identity"]
+    # The derivation and the deployer must agree on the schema and the database
+    # identity, or the produced document could never be accepted.
+    assert identity.SCHEMA_IDENTITY_SCHEMA == deployer.SCHEMA_IDENTITY_SCHEMA
+    assert identity.DATABASE_IDENTITY == {
+        "container": deployer.POSTGRES_CONTAINER,
+        "database_name": deployer.DATABASE_NAME,
+        "database_user": deployer.DATABASE_USER,
+        "application_host": deployer.POSTGRES_CONTAINER,
+        "server_address": "local",
+        "server_port": 5432,
+    }
+
+    document = identity.build(ROOT)
+    entries = document["migration_set_entries"]
+    assert [(item["ledger_name"], item["sha256"]) for item in entries] == list(
+        LIVE_V3_LEDGER
+    )
+    assert document["migration_set_identity"] == identity.migration_set_identity(entries)
+    # The reviewed lineage order is not directory order, and the identity must
+    # preserve the manifest order rather than re-sorting it.
+    assert entries != sorted(entries, key=lambda item: item["path"])
+
+    path = tmp_path / "schema.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    assert (
+        deployer.validate_schema_file(path, digest)["migration_set_identity"]
+        == document["migration_set_identity"]
+    )
+
+    tampered = {**document, "migration_set_identity": "sha256:" + "a" * 64}
+    path.write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(deployer.DeploymentError, match="checksum mismatch"):
+        deployer.validate_schema_file(path, digest)
 
 
 def test_mutation_is_explicit_app_only_and_preserves_edge_database_redis_nats():


### PR DESCRIPTION
## Why

The schema-identity contract and the live-ledger check were written for the canonical **V2** migration set — flat `sql/NNN_name.sql` paths, and a ledger row whose name could be recovered by stripping the `sql/` prefix. The production database runs the independent **V3** lineage instead, where the applier recorded two rows by basename and one by path, so neither assumption holds and no truthful identity file could be validated.

## What changed

- The applied ledger name is now carried **explicitly per entry** rather than inferred from the path.
- Entry paths and ledger names accept the reviewed V3 locations and the existing `r1_v3/` naming — matching the pattern the read-only inventory already allows.
- Entries are checked for duplicate ledger names as well as duplicate paths.
- New `scripts/operator/v3_schema_identity.py` derives the document from `sql/v3/migration-manifest.txt`, re-hashing every source and refusing drift, so the identity is **reproducible rather than hand-written**.

It deliberately duplicates the database identity instead of importing the deployer: the deployer imports `fcntl`, so it cannot be loaded off Linux, and the derivation needs to be runnable anywhere. A new test asserts the two agree, so the duplication cannot silently drift.

Derived identity: `sha256:3bd851bf6fc93c74195e2eee82212510ef0c1e7766b996f43de5e332ac802afd`

## Blast radius

The canonical release pipeline is untouched — its migration set still comes from the V2 `sql/migration-manifest.txt`. That means a production candidate must declare the V3 identity through the **existing** `--compatible-migration-set` flag rather than restructuring the release manifest. The runbook records that, plus the remaining host steps.

## Not done

Host work: author the identity file, pin its path/owner/mode/sha256 in the target authority, and clear `production_schema_identity_file_missing`.

## Verification

`ruff check` clean, all three files compile, and the derivation was exercised directly (entries, ledger names and checksums all match the reviewed live ledger). Locally the suite still reports the same 28 pre-existing environment failures — the changed test loads the deployer, which needs `fcntl`, so Linux CI is the authority for it.
