### PR TITLE
Pin the provisioned production authorities and clear three blockers

### DIFF
--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -81,13 +81,13 @@
       "edfinder-v3-production-web-blue",
       "edfinder-v3-phase4c-full-20260827_r5-postgres"
     ],
-    "api_env_file": null,
-    "api_env_owner_uid": null,
-    "api_env_mode": null,
-    "schema_identity_file": null,
-    "schema_identity_sha256": null,
-    "schema_identity_owner_uid": null,
-    "schema_identity_mode": null,
+    "api_env_file": "/etc/ed-finder/v3-production/api.env",
+    "api_env_owner_uid": 0,
+    "api_env_mode": "0600",
+    "schema_identity_file": "/etc/ed-finder/v3-production/schema-identity.json",
+    "schema_identity_sha256": "5669ee535a6dc4410ce16001eca15807cad95d5b50930cc44141e0dbdfd7a5c0",
+    "schema_identity_owner_uid": 0,
+    "schema_identity_mode": "0600",
     "active_origin_bind": "127.0.0.1:58080",
     "staging_origin_bind": "127.0.0.1:58081",
     "public_origin": "https://ed-finder.app",
@@ -97,16 +97,13 @@
       "active_origin_bind": "127.0.0.1:58080",
       "evidence": "reviewed-production-inventory-receipt"
     },
-    "receipt_directory": null,
-    "receipt_owner_uid": null,
-    "receipt_mode": null,
+    "receipt_directory": "/var/lib/ed-finder/v3-production/receipts",
+    "receipt_owner_uid": 0,
+    "receipt_mode": "0700",
     "docker_context": "default"
   },
   "blockers": [
-    "production_api_secret_file_authority_missing",
     "production_edge_loopback_cutover_topology_authority_missing",
-    "production_receipt_store_authority_missing",
-    "production_promotion_cpython314_runtime_unproved",
-    "production_schema_identity_file_missing"
+    "production_promotion_cpython314_runtime_unproved"
   ]
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,9 +47,10 @@ or override this set.
   promotion path is defined and its committed target is still stopped, but the
   reviewed read-only inventory of 2026-09-10 proved the application network,
   the local Docker context, exact loopback ownership of ports 58080/58081, host
-  capacity and the live schema/ledger identity. Five blockers remain: the api
-  secret file, the receipt store, the reviewed schema identity file, the
-  unchanged-edge cutover topology and an exact CPython 3.14 mutation runtime.
+  capacity and the live schema/ledger identity. The api secret file, the receipt
+  store and the reviewed schema identity file are now provisioned and pinned in
+  the committed target authority, so two blockers remain: the unchanged-edge
+  cutover topology and an exact CPython 3.14 mutation runtime.
   The reviewed unchanged-edge cutover authority is now published as
   `edge_route_authority`, and the committed edge configuration forwards the
   public application surface to the single active origin rather than the staging
@@ -59,19 +60,18 @@ or override this set.
   Production already serves the 2026-09-09 in-place release; that promotion is
   recorded as a description of what runs, not as governed acceptance. The root
   Compose and Contabo checkpoint remain non-authoritative for production.
-- **Designated production secret and receipt paths (not yet provisioned):** the
-  api env snapshot is to live at `/etc/ed-finder/v3-production/api.env` (owner
-  uid `0`, mode `0600`) and the durable promotion receipt store at
-  `/var/lib/ed-finder/v3-production/receipts` (owner uid `0`, mode `0700`).
-  Neither path exists on the host yet, and no deployment root can be derived
-  from the running containers: they carry no Compose project directory, and the
-  only labels present belong to unrelated stacks. Both are free parameters that
-  the target authority must pin, and
+- **Designated production secret, schema and receipt paths (provisioned):** the
+  api env snapshot lives at `/etc/ed-finder/v3-production/api.env` (owner uid
+  `0`, mode `0600`), the reviewed schema identity at
+  `/etc/ed-finder/v3-production/schema-identity.json` (owner uid `0`, mode
+  `0600`), and the durable promotion receipt store at
+  `/var/lib/ed-finder/v3-production/receipts` (owner uid `0`, mode `0700`). All
+  three are provisioned on the host and pinned by the target authority, and
   [`scripts/operator/v3_production_deploy.py`](../scripts/operator/v3_production_deploy.py)
-  verifies them with `secure_path` rather than supplying a default.
-  The read-only inventory records stat-only existence/kind/owner-uid/mode
-  evidence for both designated paths without reading their contents, so the next
-  reviewed run supplies the facts those two authority fields need.
+  verifies each with `secure_path` rather than supplying a default. The
+  read-only inventory records stat-only existence/kind/owner-uid/mode evidence
+  for all three without reading their contents, so each pinned fact is
+  re-checkable on the next reviewed run.
   The retained database identity is adopted from the running release (role
   `edfinder_v3`, database `edfinder_v3_phase4c_full_20260827_r5`, reached as
   `edfinder-v3-phase4c-full-20260827_r5-postgres` on the application network),

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -73,21 +73,22 @@ production schema identity document from it. The schema-identity contract and th
 live-ledger check now carry the applied ledger name explicitly and accept the
 `r1_v3/` naming.
 
-Three steps remain before the schema blocker clears. Author the identity file on
-the host from that derivation, pin its path, owner uid, mode and sha256 in the
-target authority, and have the candidate release declare compatibility with the
-resulting V3 identity through the existing `--compatible-migration-set` flag.
-That last point matters: the canonical release manifest still derives its own
-migration set from the V2 `sql/migration-manifest.txt`, so the production
-database's V3 identity has to be declared as an additional compatible set rather
-than inferred.
+The identity file is authored on the host from that derivation and pinned in the
+target authority. One release-build step remains: a production candidate has to
+declare compatibility with the resulting V3 identity through the existing
+`--compatible-migration-set` flag. That matters because the canonical release
+manifest still derives its own migration set from the V2
+`sql/migration-manifest.txt`, so the production database's V3 identity has to be
+declared as an additional compatible set rather than inferred.
 
-The application-network blocker is therefore cleared. These remain, and
-`status` stays `stopped` until each is replaced by exact reviewed facts:
-`production_api_secret_file_authority_missing`,
-`production_receipt_store_authority_missing`,
-`production_schema_identity_file_missing`,
-`production_edge_loopback_cutover_topology_authority_missing`, and
+The application-network, api secret file, receipt store and schema identity
+authorities are therefore resolved. `/etc/ed-finder/v3-production/api.env`
+(uid `0`, mode `0600`), `/var/lib/ed-finder/v3-production/receipts`
+(uid `0`, mode `0700`) and
+`/etc/ed-finder/v3-production/schema-identity.json` (uid `0`, mode `0600`) are
+provisioned on the host and pinned with their reviewed evidence. These remain,
+and `status` stays `stopped` until each is replaced by exact reviewed facts:
+`production_edge_loopback_cutover_topology_authority_missing` and
 `production_promotion_cpython314_runtime_unproved`.
 
 ## Live production state and the 2026-09-09 in-place promotion

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -99,17 +99,25 @@ def test_production_authority_is_separate_exact_and_currently_fail_closed():
         "edfinder-v3-phase4c-full-20260827_r5-postgres",
     ]
     # The reviewed unchanged-edge cutover authority is published from that
-    # receipt.  The remaining nulls are host facts that are still unprovisioned.
+    # receipt.
     assert value["external_authority"]["edge_route_authority"] == {
         "strategy": "verified-loopback-blue-green-port-swap",
         "edge_container": "edfinder-v3-public-auth-edge",
         "active_origin_bind": "127.0.0.1:58080",
         "evidence": "reviewed-production-inventory-receipt",
     }
-    assert all(value["external_authority"][key] is None for key in (
-        "api_env_file", "api_env_owner_uid", "api_env_mode",
-        "schema_identity_file", "receipt_directory",
-    ))
+    # The three designated host facts are provisioned and pinned. Their modes are
+    # the restrictive ones the authorized path enforces.
+    assert value["external_authority"]["api_env_file"] == "/etc/ed-finder/v3-production/api.env"
+    assert value["external_authority"]["api_env_owner_uid"] == 0
+    assert value["external_authority"]["api_env_mode"] == "0600"
+    assert value["external_authority"]["receipt_directory"] == "/var/lib/ed-finder/v3-production/receipts"
+    assert value["external_authority"]["receipt_owner_uid"] == 0
+    assert value["external_authority"]["receipt_mode"] == "0700"
+    assert value["external_authority"]["schema_identity_file"] == "/etc/ed-finder/v3-production/schema-identity.json"
+    assert value["external_authority"]["schema_identity_owner_uid"] == 0
+    assert value["external_authority"]["schema_identity_mode"] == "0600"
+    assert re.fullmatch(r"[0-9a-f]{64}", value["external_authority"]["schema_identity_sha256"])
     assert value["external_authority"]["docker_context"] == "default"
 
 


### PR DESCRIPTION
## Why

The api env snapshot, the reviewed schema identity and the durable receipt store now exist on the host with the designated owners and modes, so the target authority should record them rather than leave them null.

## Pinned

| field | value | owner | mode |
|---|---|---|---|
| `api_env_file` | `/etc/ed-finder/v3-production/api.env` | 0 | `0600` |
| `schema_identity_file` | `/etc/ed-finder/v3-production/schema-identity.json` | 0 | `0600` |
| `receipt_directory` | `/var/lib/ed-finder/v3-production/receipts` | 0 | `0700` |

`schema_identity_sha256` is pinned from the authored file (`5669ee53…`), whose content derives reproducibly from the V3 lineage manifest via `scripts/operator/v3_schema_identity.py`.

All three modes are the restrictive ones the authorized path enforces, so the authority is **authorization-ready** rather than merely populated — `validate_authority` would accept these values on the `authorized` path.

## Blockers cleared

`production_api_secret_file_authority_missing`, `production_receipt_store_authority_missing` and `production_schema_identity_file_missing` no longer describe reality. Two remain:

- `production_edge_loopback_cutover_topology_authority_missing` — the authority is published; this is now host execution (apply the reviewed edge config, complete the governed bootstrap cutover).
- `production_promotion_cpython314_runtime_unproved` — no exact CPython 3.14 on the host.

`status` stays `stopped`. Nothing here authorizes a promotion.

## Test change

`test_production_authority_is_separate_exact_and_currently_fail_closed` asserted those three facts were `null`; it now asserts the pinned values, including that the schema identity checksum is a real 64-hex sha256.

## Verification

`ruff check` clean, files compile, runbook/roadmap pinned strings intact, and the authority parses with no remaining nulls in `external_authority`. Locally the suite still reports the same 28 pre-existing environment failures (Linux-only `fcntl`); CI is the authority.
