### PR TITLE
Record the reviewed CPython 3.14 runtime and clear the runtime blocker

### DIFF
--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -10,7 +10,7 @@
     "architecture": "x86_64"
   },
   "evidence": {
-    "source": "reviewed read-only production inventory workflow run 34493285192 (2026-09-10), superseding run 34236384791",
+    "source": "reviewed read-only production inventory workflow run 34517318462 (2026-09-10), superseding runs 34493285192 and 34236384791",
     "fresh_for_implementation": true,
     "deployment_evidence": false
   },
@@ -103,7 +103,6 @@
     "docker_context": "default"
   },
   "blockers": [
-    "production_edge_loopback_cutover_topology_authority_missing",
-    "production_promotion_cpython314_runtime_unproved"
+    "production_edge_loopback_cutover_topology_authority_missing"
   ]
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,8 +49,9 @@ or override this set.
   the local Docker context, exact loopback ownership of ports 58080/58081, host
   capacity and the live schema/ledger identity. The api secret file, the receipt
   store and the reviewed schema identity file are now provisioned and pinned in
-  the committed target authority, so two blockers remain: the unchanged-edge
-  cutover topology and an exact CPython 3.14 mutation runtime.
+  the committed target authority, and exact CPython 3.14.7 is installed on the
+  host from a checksum-verified `uv` release, so one blocker remains: the
+  unchanged-edge cutover topology.
   The reviewed unchanged-edge cutover authority is now published as
   `edge_route_authority`, and the committed edge configuration forwards the
   public application surface to the single active origin rather than the staging

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -86,10 +86,10 @@ authorities are therefore resolved. `/etc/ed-finder/v3-production/api.env`
 (uid `0`, mode `0600`), `/var/lib/ed-finder/v3-production/receipts`
 (uid `0`, mode `0700`) and
 `/etc/ed-finder/v3-production/schema-identity.json` (uid `0`, mode `0600`) are
-provisioned on the host and pinned with their reviewed evidence. These remain,
-and `status` stays `stopped` until each is replaced by exact reviewed facts:
-`production_edge_loopback_cutover_topology_authority_missing` and
-`production_promotion_cpython314_runtime_unproved`.
+provisioned on the host and pinned with their reviewed evidence, and the runtime
+gate is proven (see below). One blocker remains, and `status` stays `stopped`
+until it is replaced by exact reviewed facts:
+`production_edge_loopback_cutover_topology_authority_missing`.
 
 ## Live production state and the 2026-09-09 in-place promotion
 
@@ -125,28 +125,35 @@ release. Two facts must be reconciled before a governed promotion can run:
    verified candidate web slot to `127.0.0.1:58080` and leaves the edge
    untouched. The authority must not be marked `authorized` while the host
    disagrees.
-2. **Runtime.** Production mutation requires an exact CPython 3.14 on the host.
-   Inventory proves the host's default interpreter reports version 3.13.5 and
-   that no `python3.14` exists. The gate is deliberately retained: provisioning
-   a pinned 3.14 is a separate reviewed change, not a status-tool repair, and
-   this runbook does not authorize installing one.
+2. **Runtime.** Production mutation requires an exact CPython 3.14 on the host,
+   and that reviewed provisioning change is now complete. `uv` 0.12.12 is
+   installed at `/usr/local/bin/uv` from the checksum-verified upstream release
+   tarball, and it installed CPython 3.14.7 into
+   `/opt/python/cpython-3.14.7-linux-x86_64-gnu`. `/usr/local/bin/python3.14` is a
+   symlink to that pinned build, so the launcher's `command -v python3.14` lookup
+   resolves on the safe path instead of depending on a user-specific
+   `~/.local/bin`. The launcher's own exactness test passes, and inventory run
+   `34517318462` records `python3_14` as `exists=true`, `version=3.14.7`,
+   `is_exact_cpython_3_14=true`, which is the reviewed evidence that clears
+   `production_promotion_cpython314_runtime_unproved`. The host's default
+   `python3` is still 3.13.5 and still runs the read-only inventory. To reverse
+   the change, remove the symlink, `/opt/python` and `/usr/local/bin/uv`.
 
 The runtime identity drift is recorded in
 `deploy/v3-production/target-authority.json`: the running api container keeps
 the legacy name `edfinder-v3-api` rather than the Compose slot name
 `edfinder-v3-production-api-blue`.
 
-Two external paths are designated but not yet provisioned. The api env snapshot
-is to live at `/etc/ed-finder/v3-production/api.env` with owner uid `0` and mode
-`0600`, and the durable receipt store at
-`/var/lib/ed-finder/v3-production/receipts` with owner uid `0` and mode `0700`.
-Neither exists on the host, and no deployment root can be derived from the
-running containers because they carry no Compose project directory. Provision
-them at exactly these owner/mode values, capture stat-only evidence (existence,
-owner, mode - never contents), and only then replace `api_env_file` and
-`receipt_directory` with proven facts. Authoring the api env snapshot is a
-secret-handling step: it must supply the real production API configuration, and
-no automation here reads container environments to synthesise it.
+All three designated paths now exist at exactly the reviewed owner/mode: the api
+env snapshot at `/etc/ed-finder/v3-production/api.env` (uid `0`, mode `0600`), the
+reviewed schema identity at `/etc/ed-finder/v3-production/schema-identity.json`
+(uid `0`, mode `0600`), and the durable receipt store at
+`/var/lib/ed-finder/v3-production/receipts` (uid `0`, mode `0700`). The target
+authority pins all three, and inventory run `34517318462` records stat-only
+existence/owner/mode evidence for each without reading contents. Authoring the
+api env snapshot was a secret-handling step: it supplies the real production API
+configuration, and no automation here reads container environments to synthesise
+it.
 
 Run only the workflow's default `inventory` operation first. It uses the
 already-present host `python3` standard library and performs only bounded

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -83,10 +83,11 @@ def test_production_authority_is_separate_exact_and_currently_fail_closed():
     }
     assert value["status"] == "stopped"
     assert set(module.validate_authority(value)) == set(value["blockers"])
-    assert {
-        "production_promotion_cpython314_runtime_unproved",
-        "production_edge_loopback_cutover_topology_authority_missing",
-    }.issubset(value["blockers"])
+    # The runtime gate and the three designated host facts are proven; only the
+    # unchanged-edge cutover topology remains, and that is host execution.
+    assert value["blockers"] == [
+        "production_edge_loopback_cutover_topology_authority_missing"
+    ]
     assert value["application_contract"]["compose_project"] == "edfinder-v3-production"
     assert "checkpoint" not in value["application_contract"]["compose_project"]
     assert value["application_contract"]["compose_sha256"] == hashlib.sha256(COMPOSE.read_bytes()).hexdigest()


### PR DESCRIPTION
## What was installed, and how it's proven

Production mutation refuses to run without an exact CPython 3.14 on the host. The host is Debian 13 (trixie) with only the default 3.13.5, and Debian 13 ships no 3.14, so this needed a real change.

| component | location | provenance |
|---|---|---|
| `uv` 0.12.12 | `/usr/local/bin/uv` | upstream release tarball, **sha256 verified** (`ab9b309d…`) |
| CPython 3.14.7 | `/opt/python/cpython-3.14.7-linux-x86_64-gnu` | installed by `uv python install 3.14` |
| `python3.14` | `/usr/local/bin/python3.14` → pinned build | symlink on the deployer's safe path |

The symlink deliberately targets the **version-pinned** directory, not uv's `cpython-3.14-…` minor alias, so a later `uv python install 3.14` cannot silently move the runtime under the deployer's feet.

**Evidence:** the launcher's own `exact_cpython314` test passes, and governed inventory run `34517318462` records:

```json
"python3_14": {"executable": "/usr/local/bin/python3.14", "exists": true,
               "implementation": "CPython", "version": "3.14.7",
               "is_exact_cpython_3_14": true}
```

That run is now cited in the authority's `evidence.source`.

## Blocker cleared

`production_promotion_cpython314_runtime_unproved` is removed. **One blocker remains:** `production_edge_loopback_cutover_topology_authority_missing`, which is host execution rather than missing authority. `status` stays `stopped` — nothing here authorizes a promotion.

## Non-effects, checked

- `python3` still resolves to `/usr/bin/python3` (3.13.5) and still runs the read-only inventory.
- No system packages installed, no `apt` changes, no services restarted, no existing interpreter modified.
- Reversal is removing the symlink, `/opt/python` and `/usr/local/bin/uv`.
- Only root's PATH contains `~/.local/bin`; the `/usr/local/bin` symlink is what makes the runtime usable for any deployer user. Inventory resolved through it, not the user shim.

## Docs

The runbook section that said provisioning 3.14 "is a separate reviewed change" but never described one now records exactly what was done, where, how it's verified and how to reverse it. It also stops describing the three designated paths as unprovisioned, since run `34517318462` shows all three present at the pinned owner and mode.

## Verification

`ruff check` clean, files compile, runbook/roadmap pinned strings intact, authority parses with a single blocker. Locally the suite still reports the same 28 pre-existing environment failures (Linux-only `fcntl`); CI is the authority.
