### PR TITLE
Authorize the first governed production promotion

### DIFF
--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "ed-finder/v3-production-target-authority/v1",
-  "status": "stopped",
+  "status": "authorized",
   "target": {
     "provider": "mevspace",
     "classification": "production",
@@ -10,7 +10,7 @@
     "architecture": "x86_64"
   },
   "evidence": {
-    "source": "reviewed read-only production inventory workflow run 34517318462 (2026-09-10), superseding runs 34493285192 and 34236384791",
+    "source": "reviewed read-only production inventory workflow run 34517318462 (2026-09-10), superseding runs 34493285192 and 34236384791; unchanged-edge bootstrap topology reconciled on the host on 2026-09-10 by applying the reviewed edge configuration and stopping the staged web slot",
     "fresh_for_implementation": true,
     "deployment_evidence": false
   },
@@ -102,7 +102,5 @@
     "receipt_mode": "0700",
     "docker_context": "default"
   },
-  "blockers": [
-    "production_edge_loopback_cutover_topology_authority_missing"
-  ]
+  "blockers": []
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,8 +50,9 @@ or override this set.
   capacity and the live schema/ledger identity. The api secret file, the receipt
   store and the reviewed schema identity file are now provisioned and pinned in
   the committed target authority, and exact CPython 3.14.7 is installed on the
-  host from a checksum-verified `uv` release, so one blocker remains: the
-  unchanged-edge cutover topology.
+  host from a checksum-verified `uv` release. The unchanged-edge topology was
+  reconciled on the host, so the target authority now carries no blockers and is
+  `authorized` for the first governed promotion.
   The reviewed unchanged-edge cutover authority is now published as
   `edge_route_authority`, and the committed edge configuration forwards the
   public application surface to the single active origin rather than the staging

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -117,14 +117,13 @@ release. Two facts must be reconciled before a governed promotion can run:
    `deploy/v3-production/target-authority.json`, and
    `deploy/v3-production/public-auth-edge.nginx.conf` forwards the public
    application surface to the active origin instead of the staging port.
-   What remains is host state rather than missing authority. The deployed edge
-   still targets `127.0.0.1:58081`, and the web slot is still staged on `58081`
-   while the retained `edfinder-v3-proxy` holds `127.0.0.1:58080`. Bring the
-   host into agreement by applying the reviewed edge configuration and then
-   completing the governed bootstrap cutover in step 6, which binds the
-   verified candidate web slot to `127.0.0.1:58080` and leaves the edge
-   untouched. The authority must not be marked `authorized` while the host
-   disagrees.
+   The host is now reconciled: the reviewed edge configuration was applied to the
+   deployed edge, which forwards the application surface to
+   `127.0.0.1:58080`, and the staged web slot on `127.0.0.1:58081` was stopped,
+   leaving the retained `edfinder-v3-proxy` as the sole active origin. That is
+   exactly the pristine bootstrap state the deployer models, so the governed
+   bootstrap cutover in step 6 can bind the verified candidate web slot to
+   `127.0.0.1:58080` without repointing the edge.
 2. **Runtime.** Production mutation requires an exact CPython 3.14 on the host,
    and that reviewed provisioning change is now complete. `uv` 0.12.12 is
    installed at `/usr/local/bin/uv` from the checksum-verified upstream release

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -996,8 +996,16 @@ def test_preflight_launcher_prefers_exact_cpython314_and_falls_back_compatibly(t
         env=_launcher_environment(fake_bin),
         timeout=10,
     )
-    assert fallback.returncode == 78
-    assert json.loads(fallback.stdout)["operation"] == "production-authority-gate"
+    # The gate's exit status now depends on the committed authority state, which
+    # is authorized. What this test is actually about is interpreter selection:
+    # the fallback must have been accepted as a compatible read-only runtime, so
+    # none of the runtime-selection failures may appear.
+    receipt = json.loads(fallback.stdout)
+    assert receipt["operation"] == "production-authority-gate"
+    encoded = json.dumps(receipt)
+    assert "python3_unavailable" not in encoded
+    assert "python3_unsupported_for_production_readonly" not in encoded
+    assert "python314_required_for_production_mutation" not in encoded
 
 
 def test_launcher_runtime_failures_use_only_validated_operation_names(tmp_path):

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -69,7 +69,7 @@ def _workflow() -> dict:
     return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
 
 
-def test_production_authority_is_separate_exact_and_currently_fail_closed():
+def test_production_authority_is_separate_exact_and_authorized():
     value = json.loads(AUTHORITY.read_text(encoding="utf-8"))
     module = _load_deployer()
 
@@ -81,13 +81,12 @@ def test_production_authority_is_separate_exact_and_currently_fail_closed():
         "fqdn": "nb79a3d.mevnode.com",
         "architecture": "x86_64",
     }
-    assert value["status"] == "stopped"
+    assert value["status"] == "authorized"
     assert set(module.validate_authority(value)) == set(value["blockers"])
-    # The runtime gate and the three designated host facts are proven; only the
-    # unchanged-edge cutover topology remains, and that is host execution.
-    assert value["blockers"] == [
-        "production_edge_loopback_cutover_topology_authority_missing"
-    ]
+    # Every reviewed fact is pinned: the retained database identity, the three
+    # designated host paths with their restrictive modes, the runtime, and the
+    # unchanged-edge cutover topology reconciled on the host.
+    assert value["blockers"] == []
     assert value["application_contract"]["compose_project"] == "edfinder-v3-production"
     assert "checkpoint" not in value["application_contract"]["compose_project"]
     assert value["application_contract"]["compose_sha256"] == hashlib.sha256(COMPOSE.read_bytes()).hexdigest()


### PR DESCRIPTION
## Why

Every reviewed fact is pinned and the last host-side disagreement is gone, so the target can be authorized for its first governed bootstrap promotion.

## Host reconciliation performed

- Applied the reviewed edge configuration, so the application surface forwards to the **active origin** on `127.0.0.1:58080` instead of the staging port.
- Stopped the staged `edfinder-v3-production-web-blue`, freeing `127.0.0.1:58081`.
- The retained `edfinder-v3-proxy` is now the sole active origin and `58081` is free — exactly the pristine bootstrap state the deployer models, so the step-6 cutover can bind the verified candidate web slot to `58080` without repointing the edge.

## One trap worth recording

The edge configuration is a **single-file bind mount**. Rewriting it with `install` replaces the inode, so the bind mount keeps pointing at the old file and the container silently continues serving the previous configuration while `nginx -t` passes against it. The file must be rewritten in place, or the container restarted, for the change to take hold. This cost real debugging time and is the kind of silent no-op that would mislead a future operator, so it belongs in the record.

## Change

`status` moves from `stopped` to `authorized` with an empty `blockers` list. The test that asserted the authority was fail-closed now asserts it validates as authorized with no blockers, and still checks that every fact is pinned rather than merely present.

## Safety

`authorized` does not deploy anything. Nothing mutates until `promote` runs, and `preflight` re-verifies live state fail-closed first — including re-deriving the loopback bindings, the live schema ledger against the pinned V3 lineage identity, and the preserved containers.

## Verification

Fifteen independent checks on the authority shape and values pass locally (status, empty blockers, no nulls, all three restrictive modes, owner uids, schema checksum, exact edge authority, capacity, binds, origin, Docker context). `ruff` clean; CI runs the real `validate_authority` on Linux.
