### PR TITLE
Treat Compose service order as outside the app-only authority

### DIFF
--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -741,7 +741,10 @@ def validate_compose(compose: Path, authority: dict[str, Any], env: dict[str, st
     base = ["docker", "compose", "--project-name", PROJECT, "--file", str(compose)]
     services = runner([*base, "config", "--services"], env=compose_env).stdout.split()
     volumes = runner([*base, "config", "--volumes"], env=compose_env).stdout.split()
-    if services != list(SERVICES) or volumes:
+    # Compose reports services in its own order (observed: alphabetical), so this
+    # is a check about the exact set of app-only slots, not their declared order.
+    # The declared order is still enforced against the authority contract.
+    if sorted(services) != sorted(SERVICES) or volumes:
         raise DeploymentError("rendered production Compose escapes app-only authority")
 
 

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -338,6 +338,42 @@ def test_production_deployer_uses_release_manifest_and_fresh_schema_compatibilit
         assert forbidden not in source
 
 
+def test_rendered_compose_order_is_not_part_of_app_only_authority(tmp_path):
+    deployer = _load_deployer()
+    compose = tmp_path / "compose.yml"
+    compose.write_text("services: {}\n", encoding="utf-8")
+    authority = {
+        "application_contract": {
+            "compose_sha256": hashlib.sha256(compose.read_bytes()).hexdigest()
+        },
+        "external_authority": {
+            "api_env_file": "/etc/ed-finder/v3-production/api.env",
+            "staging_origin_bind": "127.0.0.1:58081",
+            "application_network": "edfinder-v3-production",
+        },
+    }
+
+    def runner(argv, **_kwargs):
+        if argv[-1] == "--services":
+            # Docker Compose reports services alphabetically, not in file order.
+            return subprocess.CompletedProcess(
+                argv, 0, "api-blue\napi-green\nweb-blue\nweb-green\n", ""
+            )
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    deployer.validate_compose(compose, authority, {}, runner)
+
+    def escaped(argv, **_kwargs):
+        if argv[-1] == "--services":
+            return subprocess.CompletedProcess(
+                argv, 0, "api-blue\napi-green\nweb-blue\nweb-green\nsurprise\n", ""
+            )
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    with pytest.raises(deployer.DeploymentError, match="escapes app-only authority"):
+        deployer.validate_compose(compose, authority, {}, escaped)
+
+
 def test_production_schema_identity_is_derived_from_the_v3_lineage(tmp_path):
     deployer = _load_deployer()
     identity = _load_schema_identity()


### PR DESCRIPTION
## Why

`validate_compose` required `docker compose config --services` to return the four application slots in the **declared authority order**, then compared that output to the tuple directly:

```
if services != list(SERVICES) or volumes:
    raise DeploymentError("rendered production Compose escapes app-only authority")
```

Docker Compose reports services in its own order — on the production host, alphabetically (`api-blue, api-green, web-blue, web-green`) — so a perfectly correct Compose file was rejected and **no preflight could ever pass**. Observed directly on the host with `Docker Compose version v5.5.0`.

This check had never executed, because no preflight had ever run. That is why the assumption survived: it was written, tested for shape, and never exercised against real Compose output.

## Change

The check now compares the exact **set** of slots, which is what app-only authority means. It still rejects any extra service and any declared volume. The declared order stays enforced where it belongs — against the authority contract, which continues to require `["api-blue", "web-blue", "api-green", "web-green"]`.

## Regression test

New `test_rendered_compose_order_is_not_part_of_app_only_authority` drives both cases through the real validator with a stubbed runner: alphabetical ordering is accepted, and one extra service is still rejected.

## Verification

`ruff` clean, files compile. Locally the suite still reports the same pre-existing environment failures; CI is the authority for the new test.
