### PR TITLE
Permit the legacy API to detach during a bootstrap cutover

### DIFF
--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -549,16 +549,25 @@ def validate_network(
         if isinstance(item, dict) and isinstance(item.get("Name"), str)
     )
     allowed = external.get("application_network_allowed_containers")
-    expected_names = list(allowed) if isinstance(allowed, list) else []
+    if not isinstance(allowed, list) or not allowed:
+        raise DeploymentError("production application network attachment authority is invalid")
     if not managed_slots <= set(SLOTS):
         raise DeploymentError("production application network slot authority is invalid")
-    for slot in sorted(managed_slots):
-        expected_names.extend([CONTAINERS[f"api-{slot}"], CONTAINERS[f"web-{slot}"]])
-    if not isinstance(allowed, list) or names != sorted(expected_names):
-        raise DeploymentError("production application network attachment authority drifted")
+    if len(names) != len(set(names)):
+        raise DeploymentError("production application network attachments are duplicated")
     database_container = schema["database_identity"]["container"]
     if database_container not in names:
         raise DeploymentError("production database is not attached to the authorized app network")
+    # A managed slot must be attached while it is managed. The legacy API is
+    # permitted but not required: stopping a container detaches it from the
+    # network, and a bootstrap cutover stops the legacy API on purpose. Anything
+    # attached beyond the reviewed authority still fails.
+    required = {database_container}
+    for slot in sorted(managed_slots):
+        required.add(CONTAINERS[f"api-{slot}"])
+        required.add(CONTAINERS[f"web-{slot}"])
+    if not required <= set(names) <= (set(allowed) | required | {LEGACY_API}):
+        raise DeploymentError("production application network attachment authority drifted")
 
 
 def published_port_bindings(

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -338,6 +338,74 @@ def test_production_deployer_uses_release_manifest_and_fresh_schema_compatibilit
         assert forbidden not in source
 
 
+def test_network_authority_permits_the_legacy_api_to_detach_on_bootstrap():
+    deployer = _load_deployer()
+    network = "edfinder-v3-production"
+    database = deployer.POSTGRES_CONTAINER
+    authority = {
+        "application_network": network,
+        "application_network_allowed_containers": [
+            deployer.LEGACY_API,
+            deployer.CONTAINERS["web-blue"],
+            database,
+        ],
+    }
+    schema = {"database_identity": {"container": database}}
+
+    def runner_for(attached):
+        def runner(argv, **_kwargs):
+            value = [
+                {
+                    "Name": network,
+                    "Driver": "bridge",
+                    "Scope": "local",
+                    "Internal": False,
+                    "Ingress": False,
+                    "Containers": {
+                        str(index): {"Name": name}
+                        for index, name in enumerate(attached)
+                    },
+                }
+            ]
+            return subprocess.CompletedProcess(argv, 0, json.dumps(value), "")
+
+        return runner
+
+    # Bootstrap: the legacy API is still running, so it is attached.
+    deployer.validate_network(
+        authority, schema, set(), {}, runner_for([database, deployer.LEGACY_API])
+    )
+    # After the cutover the legacy API has been stopped, which detaches it, and
+    # the managed slot is attached in its place.
+    deployer.validate_network(
+        authority,
+        schema,
+        {"blue"},
+        {},
+        runner_for(
+            [
+                database,
+                deployer.CONTAINERS["api-blue"],
+                deployer.CONTAINERS["web-blue"],
+            ]
+        ),
+    )
+    # An unrelated attached container is still rejected.
+    with pytest.raises(deployer.DeploymentError, match="attachment authority drifted"):
+        deployer.validate_network(
+            authority,
+            schema,
+            set(),
+            {},
+            runner_for([database, deployer.LEGACY_API, "unrelated-container"]),
+        )
+    # The retained database must always be attached.
+    with pytest.raises(deployer.DeploymentError, match="not attached"):
+        deployer.validate_network(
+            authority, schema, set(), {}, runner_for([deployer.LEGACY_API])
+        )
+
+
 def test_rendered_compose_order_is_not_part_of_app_only_authority(tmp_path):
     deployer = _load_deployer()
     compose = tmp_path / "compose.yml"


### PR DESCRIPTION
## Why

`validate_network` required the application network's attached containers to **equal** the reviewed allowlist plus any managed slot containers. Stopping a container detaches it from the network — verified on the host — and a bootstrap cutover stops the legacy API *on purpose*.

So the equality could not hold on both sides of the cutover: the pre-cutover check demanded `edfinder-v3-api` be attached, while the post-cutover check demanded it be gone. Like the Compose-order defect, this check had never run, because no preflight had ever passed far enough to reach it.

## Change

The check now:
- requires the retained database to be attached,
- requires every managed slot to be attached while it is managed,
- **permits** the legacy API to be present or absent,
- still rejects any container beyond the reviewed authority, and rejects duplicates explicitly.

The database check keeps its own specific error so a missing database is still unambiguous.

## Regression test

`test_network_authority_permits_the_legacy_api_to_detach_on_bootstrap` drives four cases through the real validator: the bootstrap baseline, the post-cutover state, an unrelated attached container (rejected), and a missing database (rejected).

## Verification

`ruff` clean, files compile. CI is the authority for the new test.
