### PR TITLE
Probe the V3 lineage ledger the production database actually has

### DIFF
--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -81,9 +81,12 @@ SELECT json_build_object(
   'transaction_read_only', current_setting('transaction_read_only'),
   'migrations', COALESCE((
     SELECT json_agg(
-      json_build_object('filename', filename, 'checksum_sha256', checksum_sha256)
-      ORDER BY filename
-    ) FROM public.schema_migrations
+      json_build_object(
+        'filename', migration_name,
+        'checksum_sha256', encode(migration_sha256, 'hex')
+      )
+      ORDER BY migration_name
+    ) FROM v3_meta.schema_migration
   ), '[]'::json)
 )::text;
 COMMIT;

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -338,6 +338,18 @@ def test_production_deployer_uses_release_manifest_and_fresh_schema_compatibilit
         assert forbidden not in source
 
 
+def test_deployer_probe_reads_the_v3_lineage_ledger():
+    source = DEPLOYER.read_text(encoding="utf-8")
+
+    # The retained production database records the independent V3 lineage in
+    # v3_meta.schema_migration. The V2 public.schema_migrations relation does not
+    # exist there, so probing it made every preflight fail at the ledger step.
+    assert "FROM v3_meta.schema_migration" in source
+    assert "public.schema_migrations" not in source
+    assert "'filename', migration_name" in source
+    assert "encode(migration_sha256, 'hex')" in source
+
+
 def test_network_authority_permits_the_legacy_api_to_detach_on_bootstrap():
     deployer = _load_deployer()
     network = "edfinder-v3-production"


### PR DESCRIPTION
## Why

The deployer's live-ledger probe was:

```sql
SELECT json_build_object(..., 'filename', filename, 'checksum_sha256', checksum_sha256)
  ... FROM public.schema_migrations
```

The retained production database records the independent **V3 lineage** in `v3_meta.schema_migration` as `migration_name` / `migration_sha256` — and `public.schema_migrations` **does not exist there at all**. Confirmed on the host:

```
ERROR:  relation "public.schema_migrations" does not exist
```

`psql` therefore exited non-zero and every preflight died with the unhelpful `bounded command failed: docker`. A fourth defect in never-exercised code.

## Change

The probe reads `v3_meta.schema_migration` and maps it to the same `filename` / `checksum_sha256` shape the schema identity carries — the lineage the reviewed identity file already describes.

## Verified against the live database first

Ran the new probe on the host before committing. It returns exactly the three reviewed rows with matching checksums:

| ledger row | checksum |
|---|---|
| `001_v3_baseline.sql` | `ee08c17e…` |
| `002_v3_accounts_identity.sql` | `e7a2f404…` |
| `r1_v3/001_structural_shell.sql` | `1a2d15c2…` |

## Test

`test_deployer_probe_reads_the_v3_lineage_ledger` pins the relation, the column mapping and the hex encoding, and asserts the V2 relation cannot creep back in.
