### PR TITLE
Report the observed metadata when the registry token path is rejected

### DIFF
--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -1524,7 +1524,14 @@ def promote(args: argparse.Namespace, authority: dict[str, Any], runner: Callabl
             or stat.S_IMODE(token_details.st_mode) != 0o600
             or token_details.st_nlink != 1
         ):
-            raise DeploymentError("ephemeral registry token path is unsafe")
+            # Report the observed metadata: these are not secrets, and without
+            # them a rejection here is impossible to diagnose from the receipt.
+            raise DeploymentError(
+                "ephemeral registry token path is unsafe"
+                f" (uid={token_details.st_uid} euid={os.geteuid()}"
+                f" mode={stat.S_IMODE(token_details.st_mode):04o}"
+                f" nlink={token_details.st_nlink})"
+            )
         if args.registry_token_file.stat().st_size > MAX_REGISTRY_TOKEN:
             raise DeploymentError("ephemeral registry token exceeds size limit")
         token = args.registry_token_file.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Why

The first real promotion attempt failed with `ephemeral registry token path is unsafe`, and the durable receipt carried no way to tell **which** of the three conditions failed (`uid == euid`, `mode == 0600`, `nlink == 1`).

A hand reproduction of the workflow's own extraction on the host — `umask 077` plus `tar --no-same-permissions --no-overwrite-dir` — yields `uid=0 mode=0600 nlink=1`, which **passes** the check. So the real file differed, and without the observed values each attempt costs a full CI cycle and a fresh look with no new information.

## Change

The error now reports the observed `uid`, `euid`, `mode` and `nlink`:

```
ephemeral registry token path is unsafe (uid=0 euid=0 mode=0644 nlink=1)
```

None of those are secret, and the message propagates into the durable host receipt, so the next run explains itself.

**The check itself is unchanged and stays fail-closed.** Nothing was relaxed.
