### PR TITLE
Retire the legacy application containers and stop requiring them

### DIFF
--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -24,12 +24,24 @@
     }
   },
   "observed_runtime": {
-    "api_container": "edfinder-v3-api",
-    "api_image": "edfinder-v3-api:release-6a4fe0ef",
-    "api_build_sha": "6a4fe0ef1cb7b8fd03b4151dc8de4802fd3f4c99",
+    "api_container": "edfinder-v3-production-api-blue",
+    "api_image": "ghcr.io/brianstewart377-rgb/ed-finder/v3-backend@sha256:7f9e70eb562e6740b3c4d59fcad91f65e73784a7e24b62ef00963b1c81e7c31a",
+    "api_build_sha": "b1616332c024e262a0aac03018943abbf619c087",
     "web_slot_container": "edfinder-v3-production-web-blue",
-    "web_image": "edfinder-v3-production-web:release-1dc4d099",
-    "legacy_origin_container": "edfinder-v3-proxy",
+    "web_image": "ghcr.io/brianstewart377-rgb/ed-finder/v3-web@sha256:87ee670681e1e5a4792433c7da7fc5fddbb93c7b5286b2d124b69d1f33ac6d6f",
+    "accepted_promotion": {
+      "received_at": "2026-09-10",
+      "release_run_id": "34527597963",
+      "source_sha": "b1616332c024e262a0aac03018943abbf619c087",
+      "mode": "bootstrap",
+      "active_slot": "blue",
+      "rollback_kind": "none-first-promotion"
+    },
+    "retired_legacy_containers": [
+      "edfinder-v3-api",
+      "edfinder-v3-proxy"
+    ],
+    "retired_legacy_forensics": "docker inspect records for the retired legacy application containers are archived under the production receipt store, which is root-owned and mode 0700, because their environments are not reproducible from any committed revision and are not safe to commit.",
     "retained_pre_release_containers": [
       "edfinder-v3-api-pre-release-20260909T200206Z",
       "edfinder-v3-production-web-blue-pre-release-20260909T200231Z"
@@ -39,8 +51,8 @@
     "redis_container": "edfinder-v3-support-redis",
     "nats_container": "edfinder-v3-support-nats",
     "octopus_and_unrelated_containers": "preserve-all",
-    "public_ui": "svelte-release-6a4fe0ef",
-    "live_topology_note": "The running api container and the web slot were promoted in place on 2026-09-09T20:02Z outside this workflow. The api keeps its legacy container name on edfinder-v3-production, the web slot binds 127.0.0.1:58081, and edfinder-v3-proxy still binds 127.0.0.1:58080. This does not match the compose slot naming or the single-active-origin cutover model below, so the topology blocker stands until it is reconciled."
+    "public_ui": "svelte-release-b1616332",
+    "live_topology_note": "The accepted bootstrap promotion of 2026-09-10 (release run 34527597963, source b1616332c024e262a0aac03018943abbf619c087) put the active blue slot on 127.0.0.1:58080 and left 127.0.0.1:58081 free, so the unchanged-edge single-active-origin cutover model now holds and the edge was never repointed or recreated. The legacy api and proxy were stopped by that cutover and then retired on 2026-09-10 once their inspect records were archived, so the application network now carries exactly the retained database and the active slot."
   },
   "application_contract": {
     "compose_project": "edfinder-v3-production",
@@ -77,8 +89,6 @@
   "external_authority": {
     "application_network": "edfinder-v3-production",
     "application_network_allowed_containers": [
-      "edfinder-v3-api",
-      "edfinder-v3-production-web-blue",
       "edfinder-v3-phase4c-full-20260827_r5-postgres"
     ],
     "api_env_file": "/etc/ed-finder/v3-production/api.env",

--- a/docs/operations/v3-production-application-release.md
+++ b/docs/operations/v3-production-application-release.md
@@ -121,10 +121,18 @@ The receipt store holds the durable receipt, the byte-exact release manifest and
 the advanced `current.json` pointer, so there is now a canonical immutable
 release and a checksum-bound rollback target. The rollback kind for the first
 promotion is `none-first-promotion`; every later promotion becomes
-`prior-accepted-immutable-release`. The legacy `edfinder-v3-api` and
-`edfinder-v3-proxy` and the superseded slot containers were stopped and retained
-as rollback evidence, and the read-only inventory now completes with no failures
-at all.
+`prior-accepted-immutable-release`.
+
+The legacy `edfinder-v3-api` and `edfinder-v3-proxy` were stopped by that cutover
+and then retired on 2026-09-10. Their `docker inspect` records were archived into
+the root-owned receipt store first, because their environments are the only
+record of how the ungoverned 2026-09-09 stack ran and are not reproducible from
+any committed revision — and are not safe to commit, since they carry live
+configuration. The superseded 2026-09-09 pre-release containers are still
+retained. The read-only inventory now completes with no failures at all, and its
+required-container set no longer names the legacy pair: it requires the retained
+database, the edge, Redis and NATS, plus a running owner of the active origin, so
+the check survives blue/green rotation instead of pinning two container names.
 
 Two facts had to be reconciled before that promotion could run:
 

--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -561,15 +561,16 @@ def validate_network(
     database_container = schema["database_identity"]["container"]
     if database_container not in names:
         raise DeploymentError("production database is not attached to the authorized app network")
-    # A managed slot must be attached while it is managed. The legacy API is
-    # permitted but not required: stopping a container detaches it from the
-    # network, and a bootstrap cutover stops the legacy API on purpose. Anything
-    # attached beyond the reviewed authority still fails.
+    # The retained database and the reviewed baseline must be attached, and a
+    # managed slot must be attached while it is managed. Anything else attached
+    # fails. The legacy api is deliberately no longer permitted: bootstrap has
+    # been accepted, so it has no role, and leaving its name permitted would keep
+    # a hole in the authority for a container that no longer exists.
     required = {database_container}
     for slot in sorted(managed_slots):
         required.add(CONTAINERS[f"api-{slot}"])
         required.add(CONTAINERS[f"web-{slot}"])
-    if not required <= set(names) <= (set(allowed) | required | {LEGACY_API}):
+    if not required <= set(names) <= (set(allowed) | required):
         raise DeploymentError("production application network attachment authority drifted")
 
 

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -25,6 +25,7 @@ from typing import Any
 
 
 EXPECTED_HOST = "ed-finder-prod"
+COMPOSE_PROJECT = "edfinder-v3-production"
 EXPECTED_FQDN = "nb79a3d.mevnode.com"
 POSTGRES_CONTAINER = "edfinder-v3-phase4c-full-20260827_r5-postgres"
 DB_USER = "edfinder_v3"
@@ -772,9 +773,14 @@ def main() -> int:
         failures.append("loopback_origin_ownership_derivation_failed")
     elif not receipt["loopback_origin_port_ownership"]["exact_loopback_only"]:
         failures.append("protected_origin_binding_not_exact_loopback")
+    elif not receipt["loopback_origin_port_ownership"]["ports"]["58080"]["owners"]:
+        # The active origin must be owned by a running container. This is what
+        # makes the application surface present, and it replaces the retired
+        # legacy api/proxy names with a rule that survives blue/green rotation.
+        failures.append("active_origin_owner_missing")
     required_containers = {
-        "edfinder-v3-api", "edfinder-v3-proxy", "edfinder-v3-public-auth-edge",
-        POSTGRES_CONTAINER, "edfinder-v3-support-redis", "edfinder-v3-support-nats",
+        "edfinder-v3-public-auth-edge", POSTGRES_CONTAINER,
+        "edfinder-v3-support-redis", "edfinder-v3-support-nats",
     }
     present_names = {str(item.get("Names")) for item in containers}
     missing_required = sorted(required_containers - present_names)
@@ -841,7 +847,13 @@ def main() -> int:
         "public_health": public_health,
     }
     api_container = next(
-        (item for item in containers if item.get("Names") == "edfinder-v3-api"),
+        (
+            item for item in containers
+            if str(item.get("State", "")).lower() == "running"
+            and isinstance(item.get("ComposeLabels"), dict)
+            and item["ComposeLabels"].get("com.docker.compose.project") == COMPOSE_PROJECT
+            and str(item["ComposeLabels"].get("com.docker.compose.service", "")).startswith("api-")
+        ),
         None,
     )
     receipt["current_release"] = {

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -90,12 +90,11 @@ def test_production_authority_is_separate_exact_and_authorized():
     assert value["application_contract"]["compose_project"] == "edfinder-v3-production"
     assert "checkpoint" not in value["application_contract"]["compose_project"]
     assert value["application_contract"]["compose_sha256"] == hashlib.sha256(COMPOSE.read_bytes()).hexdigest()
-    # Proven by the reviewed 2026-09-10 inventory receipt: the application
-    # network exists and carries exactly the running api and web-slot members.
+    # The application network carries the retained database plus whichever slot
+    # is managed. The legacy api/proxy were retired after the bootstrap cutover,
+    # so the reviewed baseline is the database alone.
     assert value["external_authority"]["application_network"] == "edfinder-v3-production"
     assert value["external_authority"]["application_network_allowed_containers"] == [
-        "edfinder-v3-api",
-        "edfinder-v3-production-web-blue",
         "edfinder-v3-phase4c-full-20260827_r5-postgres",
     ]
     # The reviewed unchanged-edge cutover authority is published from that
@@ -350,17 +349,13 @@ def test_deployer_probe_reads_the_v3_lineage_ledger():
     assert "encode(migration_sha256, 'hex')" in source
 
 
-def test_network_authority_permits_the_legacy_api_to_detach_on_bootstrap():
+def test_network_authority_allows_a_rotating_slot_and_rejects_the_legacy_api():
     deployer = _load_deployer()
     network = "edfinder-v3-production"
     database = deployer.POSTGRES_CONTAINER
     authority = {
         "application_network": network,
-        "application_network_allowed_containers": [
-            deployer.LEGACY_API,
-            deployer.CONTAINERS["web-blue"],
-            database,
-        ],
+        "application_network_allowed_containers": [database],
     }
     schema = {"database_identity": {"container": database}}
 
@@ -383,12 +378,8 @@ def test_network_authority_permits_the_legacy_api_to_detach_on_bootstrap():
 
         return runner
 
-    # Bootstrap: the legacy API is still running, so it is attached.
-    deployer.validate_network(
-        authority, schema, set(), {}, runner_for([database, deployer.LEGACY_API])
-    )
-    # After the cutover the legacy API has been stopped, which detaches it, and
-    # the managed slot is attached in its place.
+    # Steady state after the accepted bootstrap: the active blue slot is managed
+    # and attached, so the baseline plus its two containers is exactly right.
     deployer.validate_network(
         authority,
         schema,
@@ -402,19 +393,62 @@ def test_network_authority_permits_the_legacy_api_to_detach_on_bootstrap():
             ]
         ),
     )
+    # During an upgrade both the prior and the newly staged slot are managed.
+    deployer.validate_network(
+        authority,
+        schema,
+        {"blue", "green"},
+        {},
+        runner_for(
+            [
+                database,
+                deployer.CONTAINERS["api-blue"],
+                deployer.CONTAINERS["web-blue"],
+                deployer.CONTAINERS["api-green"],
+                deployer.CONTAINERS["web-green"],
+            ]
+        ),
+    )
+    # The retired legacy api is no longer permitted, even though it once was.
+    with pytest.raises(deployer.DeploymentError, match="attachment authority drifted"):
+        deployer.validate_network(
+            authority,
+            schema,
+            {"blue"},
+            {},
+            runner_for(
+                [
+                    database,
+                    deployer.CONTAINERS["api-blue"],
+                    deployer.CONTAINERS["web-blue"],
+                    deployer.LEGACY_API,
+                ]
+            ),
+        )
     # An unrelated attached container is still rejected.
     with pytest.raises(deployer.DeploymentError, match="attachment authority drifted"):
         deployer.validate_network(
             authority,
             schema,
-            set(),
+            {"blue"},
             {},
-            runner_for([database, deployer.LEGACY_API, "unrelated-container"]),
+            runner_for(
+                [
+                    database,
+                    deployer.CONTAINERS["api-blue"],
+                    deployer.CONTAINERS["web-blue"],
+                    "unrelated-container",
+                ]
+            ),
         )
     # The retained database must always be attached.
     with pytest.raises(deployer.DeploymentError, match="not attached"):
         deployer.validate_network(
-            authority, schema, set(), {}, runner_for([deployer.LEGACY_API])
+            authority,
+            schema,
+            {"blue"},
+            {},
+            runner_for([deployer.CONTAINERS["api-blue"]]),
         )
 
 


### PR DESCRIPTION
Retire the legacy application containers and stop requiring them

The inventory required edfinder-v3-api and edfinder-v3-proxy to exist, which was
true only before the bootstrap cutover. That set was stale in the same way as the
defects fixed earlier today: it described the world the inventory was written in.

The bootstrap cutover has been accepted, so the legacy pair has no remaining
role. The authority's preservation contract never covered them, the accepted
receipt records rollback kind none-first-promotion (no rollback target), and the
deployer path that restarts them is bootstrap-only.

The inventory now requires the retained database, the edge, Redis and NATS, plus
a running owner of the active origin, so the check survives blue/green rotation
instead of pinning two container names. The active api container is derived from
the compose project and service labels rather than a hard-coded legacy name, and
a missing active-origin owner is now its own failure.

The authority records the accepted promotion and the post-cutover topology, the
application-network baseline becomes the retained database alone, and the
network check no longer permits the legacy api, so the retired name cannot
become a hole in the authority.

The legacy containers themselves are archived and removed separately: their
docker inspect records carry live configuration and go to the root-owned receipt
store, not to the repository.
