### PR TITLE
Write the derived-data completion plan

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,6 +127,9 @@ evidence-interpretation, and Digital Twin owner.
    derived-generation architecture; PR #646 freezes Ratings V4.0. Recover the
    verified canonical importer, preserve source provenance and unknowns, then
    implement the production derived-generation schema and bounded builder.
+   The table and script inventory for that work, including what is already
+   written but never applied and what is still undesigned, is in
+   [the derived-data completion plan](development/v3-derived-data-completion-plan.md).
 6. **Validate and publish V4.** Prove complete generation coverage, scores,
    explanations, resource use and rollback before exposing a stable API through
    the reviewed production release controls. Archetypes and Finder ranking

--- a/docs/development/v3-derived-data-completion-plan.md
+++ b/docs/development/v3-derived-data-completion-plan.md
@@ -1,0 +1,153 @@
+# V3 derived-data completion plan
+
+**Status:** plan, not authority. The authorities remain
+[the roadmap](../ROADMAP.md),
+[the search/spatial/derived-data decision](v3-search-spatial-derived-data-decision.md)
+and [the Ratings V4 freeze](ratings-v4-freeze/README.md). This document exists to
+make the remaining table and script work reviewable before any SQL is written.
+
+## Purpose
+
+Answer one question precisely: what does the database still need before Finder,
+ratings and exobiology/exploration features can be designed against it, and what
+has to be written and run to get there?
+
+## Measured production scale
+
+Read from the retained production database on 2026-09-10. These numbers constrain
+every design decision below.
+
+| Relation | Rows |
+|---|---|
+| `v3_gen_…r5.systems` | 198,528,286 |
+| `v3_gen_…r5.bodies` | 598,724,752 |
+| `v3_gen_…r5.stations` | 830,740 |
+| `…body_genus_current` | 7,181,400 |
+| `…body_signal_current` | 25,019,890 |
+| `…ring_signal_current` | 3,295,614 |
+| `v3_vocab.genus` / `signal_type` | 21 / 20 |
+| `v3_identity.account` / `commander` | 2 / 0 |
+
+Consequences: a one-row-per-system derived table is a ~200M-row build and must be
+chunked and resumable; a per-body table is ~600M rows and must not duplicate
+system identity per row; and the canonical exobiology facts already exist and are
+populated, so exobiology is a **derived and personal** gap, not a canonical one.
+
+## Inventory
+
+### A. Canonical truth — exists and is populated
+
+`v3_gen_<generation>` (systems, bodies, rings, stations, aliases, compositions,
+current-signal and current-genus relations), `v3_vocab`, `v3_source`,
+`v3_identity`, `v3_private`, `v3_async`, `r1_meta`, `r1_plan`, `r1_cache`. The
+schema is already generation-namespaced: `v3_meta.canonical_generation` and
+`v3_meta.current_canonical_generation` select the live generation.
+
+### B. Designed and written, never applied
+
+`sql/v3/migrations/003_ratings_v4_derived.sql` creates `v3_derived` and `v3_app`:
+
+| Object | Purpose |
+|---|---|
+| `v3_meta.derived_generation` | immutable derived manifest with a lifecycle (`BUILDING → VALIDATING → READY → PUBLISHED → RETIRED/FAILED`) and an immutability trigger |
+| `v3_meta.current_derived_generation` | the published pointer |
+| `v3_meta.derived_publication_audit` | publication sequence, actor, reason |
+| `v3_derived.build_chunk` | per-chunk coverage receipt (systems, canonical/physical bodies, eligible opportunities, content hash) |
+| `v3_derived.system_rating_vector` | the seven frozen economy values per system, exact ten-thousandths |
+| `v3_derived.body_mechanics` | versioned mechanics features per body |
+| `v3_derived.economy_opportunity` | local opportunity per economy |
+| `v3_derived.system_economy_rating`, `v3_app.system_economy_rating` | stable application boundary views |
+
+Not present in production: neither `v3_derived` nor `v3_app` exists there, and the
+migration's own header states that applying it through production "requires the
+separately reviewed V3 migration operation".
+
+### C. Designed in the decision, not yet written
+
+The [search/spatial/derived-data decision](v3-search-spatial-derived-data-decision.md)
+names these shapes explicitly; none exist as SQL today.
+
+| Object | Notes |
+|---|---|
+| `v3_derived.system_search` | `position_ly cube` with a GiST index, numeric LY preserved as truth, region and hot facts; keyed by derived generation and `id64` |
+| `v3_spatial.cell_level` | pyramid level metadata: version, level, cell size, scale/budget metadata |
+| `v3_spatial.cell_summary` | per-level LOD aggregation keyed by `(derived_generation_id, spatial_pyramid_version, level, cell_key)` |
+| `v3_spatial.cluster_run` | versioned cluster run: owner/domain, algorithm, parameters, lifecycle, validation receipt |
+| `v3_spatial.cluster` | cluster centroid/bounds, member count, summary |
+| `v3_spatial.cluster_member` | membership keyed by `(cluster_run_id, cluster_id, system_id64)` |
+| archetype judgement | `system × archetype_key` with score, confidence, explanation JSONB, `computed_at` |
+| summary projections | primary/secondary archetype and Best Colony Potential; optional compact one-row-per-system projection for hot Finder queries |
+
+The existing canonical `grid_x/grid_y/grid_z/macro_grid_key` fields are evidence
+only. Their encoding is explicitly **not** the pyramid contract, so changing cell
+sizes or encoding is a derived rebuild rather than a schema redesign.
+
+### D. Not designed anywhere
+
+| Area | Why it is open |
+|---|---|
+| Finder ranking profiles | The decision describes profile inputs (economy potential, archetype score, Best Colony Potential, distance, confidence, accessibility, constraints) but specifies no relation. Query-time versus materialised is undecided. |
+| Exobiology / organics value | `003` is economy-only. Nothing scores biology, organic value or exploration worth, although the product contract asks the map for biological finds, first-map distinctions and incomplete-scan filters. |
+| Commander exploration records | No relations exist for visits, scans, mapped bodies, first-logged discoveries or Codex entries, and `v3_identity.commander` is empty. The V2 design scoped this personal data by sync key and never promoted it to shared tables; V3 has no equivalent yet. `v3_identity` supplies accounts and `v3_private` supplies a privacy pattern, but nothing connects them to exploration. |
+
+## Scripts
+
+### Exists
+
+`scripts/ratings_v4/`: `canonical_stream.py`, `generation.py`,
+`production_generation.py`, `run_generation.py` (resumable, chunked),
+`verify_freeze.py`, `legacy_v34_reference.py`, `compare_legacy.py`. Ratings
+generation is substantially built and covered by twelve test modules.
+
+### To write
+
+| Script | Purpose |
+|---|---|
+| search-projection builder | populate `v3_derived.system_search` and its GiST index |
+| pyramid builder | build `v3_spatial.cell_level` / `cell_summary` from exact coordinates |
+| cluster builder + publication | build and publish `v3_spatial.cluster*` per domain and algorithm version |
+| archetype builder | judgement and the summary projection |
+| Finder ranking layer | whatever shape the open decision settles on |
+| exobiology / exploration builders | only after the model in section D exists |
+| per-domain validators | coverage and completeness evidence proving every expected system was covered, transitioning the lifecycle and sealing receipts |
+
+## How a migration lands in production
+
+There is no production migration authority today, which is why nothing in
+sections B–D can reach production. Adding one means, for each migration:
+
+1. commit the migration under `sql/v3/migrations/`, and, for the R1 shell style,
+   `sql/r1_v3/`;
+2. add its ledger name, hash and repository path to
+   `sql/v3/migration-manifest.txt`;
+3. regenerate the reviewed schema identity — which changes
+   `schema_identity_sha256` — and re-pin it in
+   `deploy/v3-production/target-authority.json`;
+4. run the reviewed operation, with evidence, against the retained database.
+
+Note the split of authority: DDL belongs to that migration operation, while
+derived **data** (builds, publication, retirement) belongs to the derived
+generation lifecycle already designed in `003`. A derived rebuild must never
+require DDL.
+
+## Sequencing
+
+| Phase | Work | Blocked by |
+|---|---|---|
+| P0 | Reviewed production V3 migration operation | nothing |
+| P1 | Apply `003`; build the first economy generation from the current canonical generation; validate; publish; record evidence | P0 |
+| P2 | `004`: search projection, spatial pyramid, clusters, plus their builders and validators | P1 |
+| P3 | `005`: archetype judgement, summary projections, Finder ranking layer | P2 |
+| P4 | Exobiology/exploration: design, migration, builders | the open decisions in section D |
+
+## Open decisions to settle before SQL
+
+1. Finder ranking: query-time computation, a materialised per-profile relation, or
+   both with a published profile identity?
+2. Exobiology: is exploration value a per-system derived score alongside the
+   economy vector, a per-body value, or a personal/commander-scoped layer?
+3. Commander exploration records: account-scoped tables, the `v3_private` pattern,
+   or a dedicated private schema — and what is ever promoted to shared truth
+   (first-logged discoveries are the obvious candidate)?
+4. Cluster ownership: which domains publish cluster sets, and is that one run per
+   domain or a shared run with domain-specific outputs?


### PR DESCRIPTION
Write the derived-data completion plan

Finder, ratings and exobiology features are meant to be designed against a
finished database, and the repository had no single place stating what is already
built, what is designed but unwritten, and what is not designed at all. This
records that, grounded in the authorities and in measured production data.

Measured on 2026-09-10: 198.5M systems, 598.7M bodies, 830k stations, and
canonical exobiology facts that already exist and are populated (7.2M body genus
rows, 25M body signals, 21 genera). That last point matters: exobiology is a
derived and personal gap, not a canonical one. Commander rows are zero.

The plan separates four states: canonical truth (exists, populated), the Ratings
V4 derived storage written in 003 but never applied (no v3_derived or v3_app
exists in production), the search/pyramid/cluster/archetype relations the
decision names but no SQL implements, and the genuinely undesigned areas - Finder
ranking profiles, exobiology value, and commander exploration records.

It also states how a migration would land, since there is no production migration
authority: migration file, manifest entry, regenerated schema identity and
re-pinned sha256, then the reviewed operation. DDL stays with that operation while
derived data stays with the lifecycle already designed in 003, so a rebuild never
requires DDL.

Phase order is P0 migration operation, P1 apply 003 and publish a first economy
generation, P2 search/pyramid/clusters, P3 archetype and Finder, P4 exobiology
after its open decisions are settled. Four open decisions are listed explicitly
rather than assumed.
