### PR TITLE
Version the production backup schedule and fix the guard that silenced it

### DIFF
--- a/deploy/v3-production/backup/README.md
+++ b/deploy/v3-production/backup/README.md
@@ -1,0 +1,95 @@
+# V3 production backup schedule
+
+Host-level pgBackRest schedule for the retained PostgreSQL 18 container. This
+directory is the versioned source of truth for files that previously existed only
+on the production host, where their bugs were invisible to CI.
+
+For the release-promotion path see
+[the production application release runbook](../../../docs/operations/v3-production-application-release.md).
+This schedule is **not** part of that promotion: it is a separate host operation.
+
+## Layout and install paths
+
+| File here | Installed on the host at |
+|---|---|
+| `pgbackrest-operation.sh` | `/opt/ed-finder-v3-runtime/pgbackrest-operation.sh` |
+| `edfinder-v3-pgbackrest@.service` | `/etc/systemd/system/edfinder-v3-pgbackrest@.service` |
+| `edfinder-v3-backup-full.timer` | `/etc/systemd/system/edfinder-v3-backup-full.timer` |
+| `edfinder-v3-backup-diff.timer` | `/etc/systemd/system/edfinder-v3-backup-diff.timer` |
+| `edfinder-v3-backup-verify.timer` | `/etc/systemd/system/edfinder-v3-backup-verify.timer` |
+
+Install by copying the script to the runtime directory with mode `0700`, the units
+to `/etc/systemd/system/`, then `systemctl daemon-reload` and
+`systemctl enable --now edfinder-v3-backup-{full,diff,verify}.timer`.
+
+## Schedule
+
+| Timer | When (UTC) | Operation |
+|---|---|---|
+| `…-backup-diff.timer` | Mon–Sat 02:30 | `pgbackrest --type=diff backup` |
+| `…-backup-full.timer` | Sun 02:30 | `pgbackrest --type=full backup` |
+| `…-backup-verify.timer` | Sun 12:00 | `pgbackrest verify` |
+
+All three are randomised by 10–15 minutes and use `Persistent=false`, so a run
+missed while the host is down is **not** caught up afterwards.
+
+## Prerequisites the wrapper enforces
+
+The wrapper refuses to run, and exits **0** with a `SKIP:` line, when any of these
+is untrue:
+
+- `/mnt/ed-storagebox` is a mount point — so a failed mount can never silently
+  write backups onto the underlying local disk;
+- its filesystem type is exactly `fuse.rclone`;
+- the retained PostgreSQL container exists;
+- another scheduled operation does not already hold the host lock;
+- no `pgbackrest` backup or verify process is already running in the container.
+
+It then requires pgBackRest itself to report `status: ok` before starting.
+
+## Fixed on 2026-09-10: twelve days of silent failure
+
+The wrapper's "already active" guard ran `docker top <container> -eo args`.
+Docker parses that output and requires a PID column, so it answered
+`Error response from daemon: Couldn't find PID field in ps output`. Because the
+call also redirected stderr to `/dev/null` and the script runs under
+`set -euo pipefail`, the failure aborted the script before any backup and left
+nothing in the journal except systemd's own lines. Every scheduled run since
+installation had failed; the only two backups in the repository were taken
+manually during the 2026-08-29 rehearsal.
+
+The guard now reads `docker top "$c" -eo pid,args` and no longer discards
+stderr. A regression test asserts both properties.
+
+Two related weaknesses remain, deliberately not changed here because each is its
+own decision:
+
+- **No receipt.** The wrapper prints `START`/`PASS` but writes no durable
+  receipt. `/var/lib/pgbackrest/receipts/last-backup.json` exists and is a
+  leftover from the 2026-08-29 rehearsal, so it currently understates the newest
+  backup rather than being maintained.
+- **`Persistent=false`.** A missed run is skipped rather than caught up.
+
+## Running one manually
+
+```bash
+systemctl start --no-block edfinder-v3-pgbackrest@diff.service
+systemctl status edfinder-v3-pgbackrest@diff.service
+journalctl -u edfinder-v3-pgbackrest@diff.service -n 40
+```
+
+Confirm the outcome in the repository rather than trusting the exit status:
+
+```bash
+docker exec -u postgres edfinder-v3-phase4c-full-20260827_r5-postgres \
+  pgbackrest --stanza=edfinder_v3 info
+```
+
+## Still unproven: a restore
+
+The repository holds full and diff backups, encrypted with AES-256-CBC, plus a
+continuous WAL archive. **No restore from this repository has ever been
+rehearsed**, which is the project's own stated bar — a backup that has not been
+test-restored is a hypothesis. The daily diffs are cheap (seconds, single-digit
+megabytes) because the database is read-mostly; the weekly full is the expensive
+one at roughly three hours.

--- a/deploy/v3-production/backup/edfinder-v3-backup-diff.timer
+++ b/deploy/v3-production/backup/edfinder-v3-backup-diff.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=ED-Finder V3 differential backup Monday-Saturday
+
+[Timer]
+OnCalendar=Mon..Sat *-*-* 02:30:00 UTC
+RandomizedDelaySec=10min
+AccuracySec=2min
+Persistent=false
+Unit=edfinder-v3-pgbackrest@diff.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/v3-production/backup/edfinder-v3-backup-full.timer
+++ b/deploy/v3-production/backup/edfinder-v3-backup-full.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=ED-Finder V3 weekly full backup
+
+[Timer]
+OnCalendar=Sun *-*-* 02:30:00 UTC
+RandomizedDelaySec=10min
+AccuracySec=2min
+Persistent=false
+Unit=edfinder-v3-pgbackrest@full.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/v3-production/backup/edfinder-v3-backup-verify.timer
+++ b/deploy/v3-production/backup/edfinder-v3-backup-verify.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=ED-Finder V3 weekly backup repository verification
+
+[Timer]
+OnCalendar=Sun *-*-* 12:00:00 UTC
+RandomizedDelaySec=15min
+AccuracySec=5min
+Persistent=false
+Unit=edfinder-v3-pgbackrest@verify.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/v3-production/backup/edfinder-v3-pgbackrest@.service
+++ b/deploy/v3-production/backup/edfinder-v3-pgbackrest@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ED-Finder V3 pgBackRest %i operation
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+ConditionPathIsMountPoint=/mnt/ed-storagebox
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ed-finder-v3-runtime/pgbackrest-operation.sh %i
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+TimeoutStartSec=infinity

--- a/deploy/v3-production/backup/pgbackrest-operation.sh
+++ b/deploy/v3-production/backup/pgbackrest-operation.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+op="${1:?operation required}"
+c='edfinder-v3-phase4c-full-20260827_r5-postgres'
+mount='/mnt/ed-storagebox'
+lock='/run/lock/edfinder-v3-pgbackrest-schedule.lock'
+
+case "$op" in full|diff|verify) ;; *) echo "unsupported pgBackRest operation: $op" >&2; exit 64 ;; esac
+
+# Never fall back to the underlying local mount directory.
+mountpoint -q "$mount" || { echo 'SKIP: Storage Box is not mounted' >&2; exit 0; }
+fstype="$(findmnt -n -o FSTYPE -T "$mount" || true)"
+[ "$fstype" = 'fuse.rclone' ] || { echo "SKIP: unexpected Storage Box filesystem: $fstype" >&2; exit 0; }
+docker inspect "$c" >/dev/null 2>&1 || { echo 'SKIP: PG18 container missing' >&2; exit 0; }
+
+exec 9>"$lock"
+flock -n 9 || { echo 'SKIP: another scheduled pgBackRest operation owns the host lock'; exit 0; }
+
+# Also respect manually-started or externally-tracked operations.
+active="$(docker top "$c" -eo pid,args | awk 'tolower($0) ~ /pgbackrest/ && tolower($0) ~ /(backup|verify)/ {n++} END {print n+0}')"
+if [ "$active" -gt 0 ]; then
+  echo "SKIP: $active pgBackRest backup/verify process(es) already active"
+  exit 0
+fi
+
+info="$(docker exec -u postgres "$c" pgbackrest --stanza=edfinder_v3 --log-level-console=off --output=json info)"
+python3 -c 'import json,sys; d=json.load(sys.stdin); assert len(d)==1 and d[0].get("status",{}).get("message")=="ok"' <<<"$info"
+
+echo "START: pgBackRest $op"
+if [ "$op" = verify ]; then
+  nice -n 10 ionice -c2 -n7 docker exec -u postgres "$c" \
+    pgbackrest --stanza=edfinder_v3 --log-level-console=info verify
+else
+  nice -n 10 ionice -c2 -n7 docker exec -u postgres "$c" \
+    pgbackrest --stanza=edfinder_v3 --type="$op" --log-level-console=info backup
+fi
+echo "PASS: pgBackRest $op"

--- a/tests/test_v3_production_backup_schedule.py
+++ b/tests/test_v3_production_backup_schedule.py
@@ -1,0 +1,77 @@
+"""Guards for the versioned V3 production backup schedule.
+
+These files previously existed only on the production host, so a broken guard in
+the wrapper failed nightly for twelve days with nothing visible in CI. The
+assertions below pin the properties that failure depended on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKUP = ROOT / "deploy/v3-production/backup"
+WRAPPER = BACKUP / "pgbackrest-operation.sh"
+SERVICE = BACKUP / "edfinder-v3-pgbackrest@.service"
+TIMERS = {
+    "full": BACKUP / "edfinder-v3-backup-full.timer",
+    "diff": BACKUP / "edfinder-v3-backup-diff.timer",
+    "verify": BACKUP / "edfinder-v3-backup-verify.timer",
+}
+
+
+def test_wrapper_reads_the_container_process_table_with_a_pid_column():
+    source = WRAPPER.read_text(encoding="utf-8")
+
+    # Docker rejects ps output without a PID column, and the suppressed stderr
+    # plus `set -euo pipefail` turned that into a silent no-op backup.
+    assert 'docker top "$c" -eo pid,args' in source
+    assert "-eo args 2>/dev/null" not in source
+
+
+def test_wrapper_never_falls_back_to_the_local_mount_directory():
+    source = WRAPPER.read_text(encoding="utf-8")
+
+    assert "mount='/mnt/ed-storagebox'" in source
+    assert 'mountpoint -q "$mount"' in source
+    assert "fuse.rclone" in source
+    # Every refusal is a SKIP with status 0, so a missing mount cannot look like
+    # a successful backup.
+    assert source.count("exit 0") >= 4
+    assert "SKIP:" in source
+
+
+def test_wrapper_supports_exactly_the_scheduled_operations():
+    source = WRAPPER.read_text(encoding="utf-8")
+
+    assert 'case "$op" in full|diff|verify)' in source
+    assert 'pgbackrest --stanza=edfinder_v3 --log-level-console=info verify' in source
+    assert '--type="$op" --log-level-console=info backup' in source
+    # The stanza must be healthy before anything is written.
+    assert '--output=json info' in source
+    assert '=="ok"' in source
+
+
+def test_service_is_oneshot_and_requires_the_storage_box_mount():
+    source = SERVICE.read_text(encoding="utf-8")
+
+    assert "Type=oneshot" in source
+    assert "ConditionPathIsMountPoint=/mnt/ed-storagebox" in source
+    assert "ExecStart=/opt/ed-finder-v3-runtime/pgbackrest-operation.sh %i" in source
+    assert "TimeoutStartSec=infinity" in source
+
+
+def test_each_timer_targets_its_matching_operation():
+    expected = {
+        "full": ("Sun *-*-* 02:30:00 UTC", "edfinder-v3-pgbackrest@full.service"),
+        "diff": ("Mon..Sat *-*-* 02:30:00 UTC", "edfinder-v3-pgbackrest@diff.service"),
+        "verify": ("Sun *-*-* 12:00:00 UTC", "edfinder-v3-pgbackrest@verify.service"),
+    }
+
+    for name, path in TIMERS.items():
+        source = path.read_text(encoding="utf-8")
+        on_calendar, unit = expected[name]
+        assert f"OnCalendar={on_calendar}" in source
+        assert f"Unit={unit}" in source
+        assert "WantedBy=timers.target" in source


### PR DESCRIPTION
Version the production backup schedule and fix the guard that silenced it

The pgBackRest schedule existed only on the production host: the wrapper, the
service and the three timers were unversioned, so a bug in them was invisible to
CI and unrecoverable if the host were rebuilt.

It had been broken from the day it was installed. The wrapper's "already active"
guard ran `docker top <container> -eo args`, and Docker requires a PID column in
that output, so it answered "Couldn't find PID field in ps output". The call also
sent stderr to /dev/null and the script runs under `set -euo pipefail`, so the
failure aborted the script before any backup and left the journal with nothing but
systemd's own lines. Every scheduled run failed; the only two backups in the
repository were manual, from the 2026-08-29 rehearsal.

Fixed on the host, and now committed: the guard reads `-eo pid,args` and no longer
discards stderr. A real diff backup then completed through the systemd path in
about four seconds, landing as 20260829-175457F_20260910-221254D with the WAL
archive advanced to segment ...00000047. The committed wrapper is byte-identical
to the running host file.

The committed copy records the schedule (weekly full, Mon-Sat diff, weekly
verify), the mount and filesystem preconditions, the install paths, the fix
itself, and two weaknesses deliberately left alone: the wrapper writes no durable
receipt, so the existing last-backup.json is stale rehearsal output, and all three
timers use Persistent=false so a run missed during downtime is never caught up.

Five guards pin these properties, including that the ps format keeps its PID
column, that a missing mount can never fall back to local disk, and that each
timer targets its matching operation.
