### PR TITLE
Make the private runtime health check topology-agnostic and version it

### DIFF
--- a/deploy/v3-production/health/README.md
+++ b/deploy/v3-production/health/README.md
@@ -1,0 +1,72 @@
+# V3 production private runtime health check
+
+Host-level systemd health check for the retained PostgreSQL and support services
+plus the active application origin. Versioned here because it previously lived
+only on the production host, where breaking it was invisible.
+
+## Install paths
+
+| File here | Installed on the host at |
+|---|---|
+| `health-check.sh` | `/opt/ed-finder-v3-runtime/health-check.sh` (mode `0700`) |
+| `edfinder-v3-health.service` | `/etc/systemd/system/edfinder-v3-health.service` |
+| `edfinder-v3-health.timer` | `/etc/systemd/system/edfinder-v3-health.timer` |
+
+The timer runs two minutes after boot and every five minutes thereafter, with
+`Persistent=true`, so a run missed during downtime is caught up.
+
+The public surface is deliberately **not** checked here. That belongs to
+`edfinder-v3-public-auth-edge-health`, which already covers the edge. This check
+is the private runtime only, matching its unit description.
+
+## Broken on 2026-09-10 by retiring the legacy containers
+
+The check named the legacy `edfinder-v3-api` and `edfinder-v3-proxy` containers,
+the API's former host port `58095`, and the legacy proxy's `/_proxy-health`
+endpoint. Retiring those containers with the bootstrap cutover turned the check
+red on its next five-minute run:
+
+```
+health-check.sh[45717]: error: no such object: edfinder-v3-api
+```
+
+It failed every five minutes and **nothing alerted**, because this host has no
+external heartbeat. That is the second silent failure in the same week, after
+twelve nights of failed backups, and it is the reason a heartbeat matters more
+than any individual fix here.
+
+The check is now topology-agnostic: it identifies the active origin by requiring
+exactly one container with the `edfinder-v3-production` compose project label to
+publish `127.0.0.1:58080`, and then exercises `/api/health` and
+`/api/v1/auth/session` through that origin. It never names a slot, so a
+blue/green cutover cannot break it, and it never names a legacy container, so
+retiring one cannot either.
+
+## Missing: a heartbeat
+
+The previous production host ran heartbeats against healthchecks.io. This host
+has none, so a failing timer produces only a journal line that nobody reads.
+
+The pattern already exists in this repository: `nightly_update.sh` implements a
+dead-man's switch that pings its heartbeat on success and the `/fail` path when
+the run fails, reading the URL from configuration rather than the repository.
+The same shape should cover, at minimum:
+
+| Check | Period | Notes |
+|---|---|---|
+| private runtime health | 5 min | this unit |
+| public auth edge health | 5 min | `edfinder-v3-public-auth-edge-health` |
+| differential backup | daily | Mon–Sat 02:30 UTC |
+| full backup | weekly | Sun 02:30 UTC |
+| repository verification | weekly | Sun 12:00 UTC |
+
+**One trap to design around.** A heartbeat driven by exit status alone would lie
+for the backups: `pgbackrest-operation.sh` exits **0** on every `SKIP` path,
+including a missing Storage Box mount, so success-ping-by-exit-code would report
+healthy while nothing was backed up — the exact failure that went unnoticed for
+twelve nights. The heartbeat must be driven by evidence that the work actually
+happened, which is also the argument for the wrapper writing a durable receipt
+rather than only printing `PASS`.
+
+Heartbeat URLs are credentials: anyone holding one can fake liveness. They belong
+in a root-owned configuration file on the host, never in this repository.

--- a/deploy/v3-production/health/edfinder-v3-health.service
+++ b/deploy/v3-production/health/edfinder-v3-health.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check ED-Finder V3 private runtime health
+Requires=docker.service
+After=docker.service edfinder-v3-runtime.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/ed-finder-v3-runtime/health-check.sh

--- a/deploy/v3-production/health/edfinder-v3-health.timer
+++ b/deploy/v3-production/health/edfinder-v3-health.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run ED-Finder V3 health check every five minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=edfinder-v3-health.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/v3-production/health/health-check.sh
+++ b/deploy/v3-production/health/health-check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pg='edfinder-v3-phase4c-full-20260827_r5-postgres'
+redis='edfinder-v3-support-redis'
+nats='edfinder-v3-support-nats'
+origin='http://127.0.0.1:58080'
+project='edfinder-v3-production'
+
+# Retained support services. These are preserved across promotions and never
+# managed by the application Compose authority, so their names are stable.
+[ "$(docker inspect -f '{{.State.Health.Status}}' "$pg")" = healthy ]
+docker exec "$redis" redis-cli ping | grep -qx PONG
+[ "$(docker inspect -f '{{.State.Running}}' "$nats")" = true ]
+docker inspect -f '{{json .Config.Cmd}}' "$nats" | grep -q -- '--jetstream'
+
+# Exactly one active origin, and it must be a running member of the promoted
+# compose project. The check must never name a slot: the active slot changes on
+# every blue/green cutover, and naming one is what broke this script when the
+# legacy api and proxy were retired.
+active_owner="$(
+  docker ps --filter "label=com.docker.compose.project=$project" --format '{{.Names}}' \
+    | while read -r name; do
+        if docker port "$name" 2>/dev/null | grep -q '127.0.0.1:58080'; then printf '%s\n' "$name"; fi
+      done
+)"
+[ "$(printf '%s\n' "$active_owner" | grep -c .)" -eq 1 ]
+
+# The active origin serves the SPA and proxies /api/* to whichever api slot is
+# live, so these two checks cover both containers without naming either.
+curl -fsS --max-time 5 "$origin/api/health" \
+  | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get("status")=="ok" and p.get("database")=="connected"'
+curl -fsS --max-time 5 "$origin/api/v1/auth/session" \
+  | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p.get("authenticated") is False'
+
+echo 'V3 runtime health PASS'

--- a/tests/test_v3_production_health_check.py
+++ b/tests/test_v3_production_health_check.py
@@ -1,0 +1,67 @@
+"""Guards for the versioned V3 production private runtime health check.
+
+The check named the legacy api and proxy containers. Retiring them turned it red
+on every five-minute run with nothing alerting, so these assertions pin the
+properties that broke: no legacy names, no fixed slot name, and no assumption
+about which host port the api publishes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HEALTH = ROOT / "deploy/v3-production/health"
+SCRIPT = HEALTH / "health-check.sh"
+SERVICE = HEALTH / "edfinder-v3-health.service"
+TIMER = HEALTH / "edfinder-v3-health.timer"
+
+
+def test_health_check_never_names_a_retired_or_fixed_slot_container():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    # The legacy pair is gone, and any fixed slot name breaks on the next cutover.
+    for forbidden in ("edfinder-v3-api'", "edfinder-v3-proxy'", "api-blue", "web-blue", "api-green", "web-green"):
+        assert forbidden not in source
+
+
+def test_health_check_finds_the_active_origin_by_project_label_and_port():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    # Topology-agnostic: exactly one project container owns the active origin.
+    assert "label=com.docker.compose.project=$project" in source
+    assert "127.0.0.1:58080" in source
+    assert '-eq 1' in source
+    # The former api host port and the legacy proxy endpoint are gone with them.
+    assert "58095" not in source
+    assert "_proxy-health" not in source
+
+
+def test_health_check_still_covers_the_retained_support_services():
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "edfinder-v3-phase4c-full-20260827_r5-postgres" in source
+    assert "State.Health.Status" in source
+    assert "redis-cli ping" in source
+    assert "--jetstream" in source
+    # Both application checks go through the active origin, covering the web slot
+    # and the api slot it proxies to.
+    assert "/api/health" in source
+    assert "/api/v1/auth/session" in source
+
+
+def test_health_timer_runs_every_five_minutes_and_catches_up():
+    source = TIMER.read_text(encoding="utf-8")
+
+    assert "OnUnitActiveSec=5min" in source
+    assert "Persistent=true" in source
+    assert "Unit=edfinder-v3-health.service" in source
+    assert "WantedBy=timers.target" in source
+
+
+def test_health_service_is_oneshot_and_targets_the_versioned_script():
+    source = SERVICE.read_text(encoding="utf-8")
+
+    assert "Type=oneshot" in source
+    assert "ExecStart=/opt/ed-finder-v3-runtime/health-check.sh" in source


### PR DESCRIPTION
Make the private runtime health check topology-agnostic and version it

Retiring the legacy api and proxy containers with the bootstrap cutover turned
the five-minute health check red: it named edfinder-v3-api and edfinder-v3-proxy,
checked the api's former host port 58095, and called the legacy proxy's
/_proxy-health endpoint. It had been failing every five minutes, and nothing
alerted, because this host has no external heartbeat - the second silent failure
this week after twelve nights of failed backups.

The check now identifies the active origin by requiring exactly one container
with the edfinder-v3-production compose project label to publish 127.0.0.1:58080,
then exercises /api/health and /api/v1/auth/session through it. It never names a
slot, so a blue/green cutover cannot break it, and never names a legacy container,
so retiring one cannot either. The retained postgres, redis and nats checks are
unchanged. The public surface stays with the edge health unit rather than being
duplicated here.

The script and both units now live in the repository because this class of script
previously existed only on the host, which is exactly why breaking it was
invisible to CI. The committed script is byte-identical to the running host file,
and the unit run was verified end to end with status=0/SUCCESS.

The README records the missing heartbeat and the trap that must shape it: a
heartbeat driven by exit status alone would lie for the backups, because
pgbackrest-operation.sh exits 0 on every SKIP path, including a missing Storage
Box mount. Heartbeat URLs are credentials and belong in root-owned host
configuration, never in the repository.
