### PR TITLE
Add the reviewed production schema migration operation

### DIFF
--- a/docs/development/v3-derived-data-completion-plan.md
+++ b/docs/development/v3-derived-data-completion-plan.md
@@ -191,8 +191,11 @@ generation is substantially built and covered by twelve test modules.
 
 ## How a migration lands in production
 
-There is no production migration authority today, which is why nothing in
-sections B–D can reach production. Adding one means, for each migration:
+There is no governed delivery for a production migration yet, which is why
+nothing in sections B–D can reach production. The reviewed operation itself now
+exists — see
+[the production schema migration runbook](../operations/v3-production-schema-migration.md)
+for its gates, its operations and its remaining gap. Land a migration by:
 
 1. commit the migration under `sql/v3/migrations/`, and, for the R1 shell style,
    `sql/r1_v3/`;

--- a/docs/operations/v3-production-schema-migration.md
+++ b/docs/operations/v3-production-schema-migration.md
@@ -1,0 +1,77 @@
+# V3 production schema migration
+
+Authority for changing the **schema** of the retained production PostgreSQL 18
+database. The application promotion path is deliberately forbidden from doing
+this, and this operation is deliberately forbidden from changing services.
+
+Executable: [`scripts/operator/v3_production_migrate.py`](../../scripts/operator/v3_production_migrate.py)
+
+## Scope
+
+This operation applies committed V3 lineage migrations and nothing else. It does
+not build derived data — that belongs to the derived-generation lifecycle in
+`003`, which exists so that a derived rebuild never requires DDL.
+
+Creating or reviewing this authority does not authorize running it. No command in
+this runbook has been executed against production.
+
+## What it refuses to do
+
+Every one of these is a stop, not a warning:
+
+- an invalid or unsafe target authority, or a host identity that is not the exact
+  production host, or a Docker context that is not the local rootful socket;
+- a pinned `schema_identity_sha256` that does not match the host schema identity
+  file's owner, mode and checksum;
+- a live ledger that is not an **exact prefix** of the committed lineage — same
+  order, same names, same hashes. A ledger ahead of the lineage, or divergent in
+  any row, stops the operation rather than guessing;
+- a pending migration that does not manage its own transaction. Without
+  `BEGIN; ... COMMIT;` a migration that failed halfway could leave half its
+  statements committed, and the operation would have no honest way to continue;
+- a migration whose bytes changed after the plan was derived;
+- a second operation while the production deployment lock is held, so a schema
+  change can never overlap a promotion.
+
+## Operations
+
+```bash
+python3.14 scripts/operator/v3_production_migrate.py --operation authority-gate
+python3.14 scripts/operator/v3_production_migrate.py --operation plan
+python3.14 scripts/operator/v3_production_migrate.py --operation apply
+```
+
+- **`authority-gate`** validates the authority, host, Docker context and pinned
+  schema identity, then reports how many migrations are pending. No writes.
+- **`plan`** additionally reads the live ledger and prints the receipt it would
+  write, including `applied_before` and `pending`. No writes.
+- **`apply`** takes the production deployment lock and applies each pending
+  migration in committed-lineage order. Each migration runs through `psql` with
+  `ON_ERROR_STOP=1`, and its ledger row is inserted **only after that migration
+  commits**. The live ledger must then equal the committed lineage exactly.
+
+Every run writes a receipt into the authority's `receipt_directory`, with a
+sidecar checksum, recording the desired ledger digest, what was applied before,
+what was pending, what was applied now, the pinned schema identity hash, and
+explicit `database_writes_performed` / `migrations_performed` flags.
+
+## How a migration lands
+
+1. Commit the migration under `sql/v3/migrations/` (or `sql/r1_v3/` for an R1
+   shell) with `BEGIN; ... COMMIT;`.
+2. Add its ledger name, hash and repository path to
+   `sql/v3/migration-manifest.txt`.
+3. Regenerate the reviewed schema identity with
+   `scripts/operator/v3_schema_identity.py` and re-pin
+   `schema_identity_sha256` in `deploy/v3-production/target-authority.json`.
+   The identity describes the state the migration is about to make true.
+4. Install the regenerated identity file on the host at the pinned owner and mode.
+5. Run `plan`, review it, then run `apply`.
+
+## Not yet built: governed delivery
+
+The promotion path reaches the host through a manual-only workflow that ships a
+sealed, source-free bundle over pinned SSH trust. This operation has no equivalent
+yet: it is currently run by invoking the script on the host. Until a governed
+delivery exists, treat this as a reviewed operator action rather than a governed
+one, and say so in the receipt's review note.

--- a/scripts/operator/v3_production_migrate.py
+++ b/scripts/operator/v3_production_migrate.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Reviewed V3 production schema migration operation.
+
+Applies committed V3 lineage migrations to the retained production PostgreSQL
+database through the same fail-closed gates the application promotion path uses,
+and is deliberately separate from it: that deployer is forbidden from changing
+schema, and this operation is forbidden from changing services.
+
+The desired state is the committed V3 lineage manifest. The operation reads what
+the live database actually has, refuses unless the live ledger is an exact prefix
+of the desired set, then applies the remainder in order. Each migration must
+manage its own transaction, and its ledger row is recorded only after that
+migration commits.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_AUTHORITY = ROOT / "deploy/v3-production/target-authority.json"
+MIGRATION_RECEIPT_SCHEMA = "ed-finder/v3-production-migration-receipt/v1"
+LEDGER_NAME = re.compile(r"(?:r[0-9]+_v3/)?[0-9]{3}_[a-z0-9_]+\.sql\Z")
+HEX64 = re.compile(r"[0-9a-f]{64}\Z")
+MAX_MIGRATION_BYTES = 8 * 1024 * 1024
+
+
+class MigrationError(ValueError):
+    """A reviewed migration precondition was not met."""
+
+
+def _load(module_name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise MigrationError(f"{module_name} is unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def deployer_module() -> Any:
+    """Reuse the promotion deployer's guards rather than duplicating them."""
+    return _load("v3_production_deploy", ROOT / "scripts/operator/v3_production_deploy.py")
+
+
+def identity_module() -> Any:
+    return _load("v3_schema_identity", ROOT / "scripts/operator/v3_schema_identity.py")
+
+
+def desired_entries(root: Path = ROOT) -> list[dict[str, str]]:
+    """The committed V3 lineage as an ordered list, with hashes verified on disk."""
+    try:
+        entries = identity_module().derive_entries(root)
+    except Exception as exc:  # the identity helper raises its own error type
+        raise MigrationError(f"unable to derive the desired migration set: {exc}") from exc
+    for entry in entries:
+        if not LEDGER_NAME.fullmatch(str(entry.get("ledger_name", ""))):
+            raise MigrationError("desired migration ledger name is invalid")
+    return entries
+
+
+def desired_digest(entries: list[dict[str, str]]) -> str:
+    canonical = json.dumps(entries, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def live_ledger(
+    deployer: Any, env: dict[str, str], runner: Callable[..., Any]
+) -> list[dict[str, str]]:
+    """Read the applied ledger under BEGIN READ ONLY, exactly as the deployer does."""
+    result = runner(
+        [
+            "docker", "exec", deployer.POSTGRES_CONTAINER, "psql", "-X", "--no-password",
+            "--tuples-only", "--no-align", "--quiet", "--field-separator", "\t",
+            "--set", "ON_ERROR_STOP=1", "--username", deployer.DATABASE_USER,
+            "--dbname", deployer.DATABASE_NAME, "--command", deployer.LEDGER_SQL,
+        ],
+        env=env,
+    )
+    if len(result.stdout.encode("utf-8")) > deployer.MAX_JSON:
+        raise MigrationError("live migration ledger output exceeds size limit")
+    try:
+        observed = json.loads(result.stdout.strip())
+    except json.JSONDecodeError as exc:
+        raise MigrationError("live migration ledger returned invalid JSON") from exc
+    if not isinstance(observed, dict) or set(observed) != {
+        "database_name", "server_address", "server_port",
+        "transaction_read_only", "migrations",
+    }:
+        raise MigrationError("live migration ledger returned invalid shape")
+    if observed["transaction_read_only"] != "on":
+        raise MigrationError("live migration ledger was not read read-only")
+    ledger = observed["migrations"]
+    if not isinstance(ledger, list):
+        raise MigrationError("live migration ledger entries are invalid")
+    for item in ledger:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"filename", "checksum_sha256"}
+            or not LEDGER_NAME.fullmatch(str(item["filename"]))
+            or not HEX64.fullmatch(str(item["checksum_sha256"]))
+        ):
+            raise MigrationError("live migration ledger entries are invalid")
+    if len({item["filename"] for item in ledger}) != len(ledger):
+        raise MigrationError("live migration ledger has duplicate entries")
+    return [
+        {"ledger_name": item["filename"], "sha256": item["checksum_sha256"]}
+        for item in ledger
+    ]
+
+
+def plan_migrations(
+    desired: list[dict[str, str]], live: list[dict[str, str]]
+) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    """Return ``(applied, pending)`` or refuse on any divergence.
+
+    The live ledger must be an exact prefix of the desired set: same order, same
+    names, same hashes. Anything else means the database is not in the state this
+    operation was written to advance, and guessing would be the whole risk.
+    """
+    if len(live) > len(desired):
+        raise MigrationError(
+            "live ledger is ahead of the committed lineage; refusing to guess"
+        )
+    for index, applied in enumerate(live):
+        expected = desired[index]
+        if applied["ledger_name"] != expected["ledger_name"]:
+            raise MigrationError(
+                f"live ledger diverges at position {index + 1}:"
+                f" found {applied['ledger_name']}, expected {expected['ledger_name']}"
+            )
+        if applied["sha256"] != expected["sha256"]:
+            raise MigrationError(
+                f"live ledger hash mismatch for {applied['ledger_name']}"
+            )
+    return live, desired[len(live):]
+
+
+def require_self_transactional(text: str, label: str) -> None:
+    """A migration about to be applied must own its transaction.
+
+    Without this, a migration that fails halfway could leave half its statements
+    committed, and the operation would then have no honest choice but to stop with
+    the database in an unexplained state.
+    """
+    statements = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.strip().startswith("--")
+    ]
+    if not statements or statements[0].upper() != "BEGIN;" or statements[-1].upper() != "COMMIT;":
+        raise MigrationError(
+            f"{label} does not manage its own transaction (needs BEGIN; ... COMMIT;)"
+        )
+
+
+def migration_text(entry: dict[str, str], root: Path = ROOT) -> str:
+    path = root / entry["path"]
+    try:
+        if path.stat().st_size > MAX_MIGRATION_BYTES or path.is_symlink():
+            raise MigrationError(f"{entry['path']} is oversized or unsafe")
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MigrationError(f"unable to read {entry['path']}") from exc
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    if digest != entry["sha256"]:
+        raise MigrationError(f"{entry['path']} changed after the plan was derived")
+    return text
+
+
+def apply_migration(
+    deployer: Any, entry: dict[str, str], env: dict[str, str],
+    runner: Callable[..., Any], root: Path = ROOT,
+) -> None:
+    text = migration_text(entry, root)
+    require_self_transactional(text, entry["path"])
+    psql = [
+        "docker", "exec", "-i", deployer.POSTGRES_CONTAINER, "psql", "-X", "--no-psqlrc",
+        "--set", "ON_ERROR_STOP=1", "--username", deployer.DATABASE_USER,
+        "--dbname", deployer.DATABASE_NAME,
+    ]
+    runner(psql, env=env, input_text=text)
+    # The ledger row is recorded only once the migration has committed. The name
+    # is validated against LEDGER_NAME above, so this interpolation is safe.
+    runner(
+        [*psql, "--command",
+         "BEGIN;\n"
+         f"INSERT INTO v3_meta.schema_migration (migration_name, migration_sha256)\n"
+         f"  VALUES ('{entry['ledger_name']}', decode('{entry['sha256']}', 'hex'));\n"
+         "COMMIT;\n"],
+        env=env,
+    )
+
+
+def verify_schema_identity(deployer: Any, external: dict[str, Any]) -> str:
+    """The pinned reviewed identity must match the host file before any DDL."""
+    path = Path(str(external["schema_identity_file"]))
+    deployer.secure_path(
+        path, external["schema_identity_owner_uid"], external["schema_identity_mode"],
+        directory=False,
+    )
+    digest = deployer.sha256_file(path)
+    if digest != external["schema_identity_sha256"]:
+        raise MigrationError("pinned production schema identity does not match the host file")
+    return digest
+
+
+def write_receipt(directory: Path, name: str, payload: dict[str, Any]) -> Path:
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    body = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    digest = hashlib.sha256(body).hexdigest()
+    handle, temp_name = tempfile.mkstemp(prefix=".v3-production-migration-", dir=directory)
+    try:
+        os.fchmod(handle, 0o600)
+        with os.fdopen(handle, "wb") as output:
+            output.write(body)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temp_name, directory / name)
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+    sidecar = directory / f"{name}.sha256"
+    sidecar.write_text(f"{digest}  {name}\n", encoding="utf-8")
+    os.chmod(sidecar, 0o600)
+    return directory / name
+
+
+def receipt_payload(
+    authority: dict[str, Any], *, status: str, desired: list[dict[str, str]],
+    applied: list[dict[str, str]], pending: list[dict[str, str]],
+    applied_now: list[dict[str, str]], identity_sha256: str | None,
+    failures: list[str], writes: bool,
+) -> dict[str, Any]:
+    target = authority.get("target") if isinstance(authority.get("target"), dict) else {}
+    return {
+        "schema_version": MIGRATION_RECEIPT_SCHEMA,
+        "operation": "production-migration",
+        "status": status,
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "target": {
+            "production": True,
+            "hostname": target.get("hostname"),
+            "fqdn": target.get("fqdn"),
+        },
+        "desired_ledger_sha256": desired_digest(desired),
+        "schema_identity_sha256": identity_sha256,
+        "applied_before": applied,
+        "pending": pending,
+        "applied_now": applied_now,
+        "database_access_performed": True,
+        "database_writes_performed": writes,
+        "migrations_performed": bool(applied_now),
+        "service_changes_performed": False,
+        "edge_recreated": False,
+        "protected_resources_changed": False,
+        "failures": failures,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--operation", choices=("authority-gate", "plan", "apply"), default="authority-gate"
+    )
+    parser.add_argument("--authority", type=Path, default=DEFAULT_AUTHORITY)
+    parser.add_argument("--root", type=Path, default=ROOT)
+    arguments = parser.parse_args()
+
+    deployer = deployer_module()
+    try:
+        authority = deployer.load_json(arguments.authority, "production target authority")
+        deployer.validate_authority(authority)
+        deployer.exact_host_guard(deployer.run_command)
+        external = authority["external_authority"]
+        env = deployer.base_env(external)
+        deployer.docker_context_guard(env, deployer.run_command)
+        identity_sha256 = verify_schema_identity(deployer, external)
+        desired = desired_entries(arguments.root)
+        live = live_ledger(deployer, env, deployer.run_command)
+        applied, pending = plan_migrations(desired, live)
+    except Exception as exc:
+        print(json.dumps({"status": "stopped", "failures": [str(exc)]}, sort_keys=True))
+        return 78
+
+    if arguments.operation == "authority-gate":
+        print(json.dumps(
+            {"status": "migration-authority-verified", "pending": len(pending)},
+            sort_keys=True,
+        ))
+        return 0
+
+    receipt_dir = Path(str(external["receipt_directory"]))
+    if arguments.operation == "plan":
+        payload = receipt_payload(
+            authority, status="planned", desired=desired, applied=applied, pending=pending,
+            applied_now=[], identity_sha256=identity_sha256, failures=[], writes=False,
+        )
+        print(json.dumps(payload, sort_keys=True))
+        return 0
+
+    lock = None
+    applied_now: list[dict[str, str]] = []
+    try:
+        lock = deployer.acquire_lock(receipt_dir)
+        for entry in pending:
+            apply_migration(deployer, entry, env, deployer.run_command, arguments.root)
+            applied_now.append(entry)
+        final_live = live_ledger(deployer, env, deployer.run_command)
+        plan_migrations(desired, final_live)
+        if len(final_live) != len(desired):
+            raise MigrationError("live ledger does not equal the committed lineage after apply")
+        status = "applied"
+        failures: list[str] = []
+    except Exception as exc:
+        status, failures = "stopped", [str(exc)]
+    finally:
+        if lock is not None:
+            lock.close()
+
+    payload = receipt_payload(
+        authority, status=status, desired=desired, applied=applied, pending=pending,
+        applied_now=applied_now, identity_sha256=identity_sha256, failures=failures,
+        writes=bool(applied_now),
+    )
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    name = f"migration-{desired_digest(desired)[7:19]}-{stamp}.json"
+    path = write_receipt(receipt_dir, name, payload)
+    print(json.dumps({**payload, "receipt": str(path)}, sort_keys=True))
+    return 0 if status == "applied" else 78
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_v3_production_migration_operation.py
+++ b/tests/test_v3_production_migration_operation.py
@@ -1,0 +1,211 @@
+"""Guards for the reviewed V3 production schema migration operation.
+
+The operation must never guess: the live ledger has to be an exact prefix of the
+committed lineage, each migration must own its transaction, and the ledger row is
+recorded only after the migration commits. These tests drive that logic with
+fakes so no production host is required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import stat
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MIGRATE = ROOT / "scripts/operator/v3_production_migrate.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("v3_production_migrate", MIGRATE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_deployer(module, *, sha256=None, secure_path=None):
+    return SimpleNamespace(
+        POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres",
+        DATABASE_USER="edfinder_v3",
+        DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5",
+        LEDGER_SQL="SELECT 1",
+        MAX_JSON=2 * 1024 * 1024,
+        secure_path=secure_path or (lambda *_args, **_kwargs: None),
+        sha256_file=sha256
+        or (lambda path: hashlib.sha256(Path(path).read_bytes()).hexdigest()),
+    )
+
+
+def test_desired_entries_are_the_committed_lineage_with_verified_hashes():
+    module = _load()
+
+    entries = module.desired_entries(ROOT)
+
+    assert [entry["ledger_name"] for entry in entries] == [
+        "001_v3_baseline.sql",
+        "002_v3_accounts_identity.sql",
+        "r1_v3/001_structural_shell.sql",
+    ]
+    for entry in entries:
+        source = (ROOT / entry["path"]).read_bytes()
+        assert hashlib.sha256(source).hexdigest() == entry["sha256"]
+
+
+def test_plan_reports_pending_only_when_the_live_ledger_is_an_exact_prefix():
+    module = _load()
+    desired = module.desired_entries(ROOT)
+
+    applied, pending = module.plan_migrations(desired, desired[:2])
+    assert [entry["ledger_name"] for entry in applied] == [
+        "001_v3_baseline.sql",
+        "002_v3_accounts_identity.sql",
+    ]
+    assert [entry["ledger_name"] for entry in pending] == ["r1_v3/001_structural_shell.sql"]
+
+    # Nothing pending is a legitimate state, not an error.
+    applied, pending = module.plan_migrations(desired, desired)
+    assert len(applied) == len(desired) and pending == []
+
+
+def test_plan_refuses_a_live_ledger_that_is_ahead_or_divergent():
+    module = _load()
+    desired = module.desired_entries(ROOT)
+
+    with pytest.raises(module.MigrationError, match="ahead"):
+        module.plan_migrations(desired, [*desired, {"ledger_name": "999_x.sql", "sha256": "a" * 64}])
+
+    divergent_name = [
+        {"ledger_name": "001_something_else.sql", "sha256": desired[0]["sha256"]}
+    ]
+    with pytest.raises(module.MigrationError, match="diverges at position 1"):
+        module.plan_migrations(desired, divergent_name)
+
+    divergent_hash = [{"ledger_name": desired[0]["ledger_name"], "sha256": "b" * 64}]
+    with pytest.raises(module.MigrationError, match="hash mismatch"):
+        module.plan_migrations(desired, divergent_hash)
+
+
+def test_a_migration_about_to_be_applied_must_own_its_transaction():
+    module = _load()
+
+    module.require_self_transactional("BEGIN;\nSELECT 1;\nCOMMIT;\n", "test.sql")
+    module.require_self_transactional("-- lead\nBEGIN;\nSELECT 1;\nCOMMIT;", "test.sql")
+
+    for bad in ("SELECT 1;\n", "BEGIN;\nSELECT 1;\n", "SELECT 1;\nCOMMIT;\n", ""):
+        with pytest.raises(module.MigrationError, match="does not manage its own transaction"):
+            module.require_self_transactional(bad, "test.sql")
+
+    # The next migration in line satisfies the rule; 002 predates it and is
+    # already applied, so it is never re-applied.
+    derived = (ROOT / "sql/v3/migrations/003_ratings_v4_derived.sql").read_text(encoding="utf-8")
+    module.require_self_transactional(derived, "003_ratings_v4_derived.sql")
+
+
+def test_ledger_row_is_recorded_only_after_the_migration_commits():
+    module = _load()
+    entry = module.desired_entries(ROOT)[0]
+    calls: list[dict] = []
+
+    def runner(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return SimpleNamespace(stdout="", returncode=0)
+
+    module.apply_migration(_fake_deployer(module), entry, {}, runner, ROOT)
+
+    assert len(calls) == 2
+    assert calls[0]["input_text"] == (ROOT / entry["path"]).read_text(encoding="utf-8")
+    assert "INSERT INTO v3_meta.schema_migration" in calls[1]["argv"][-1]
+    assert entry["ledger_name"] in calls[1]["argv"][-1]
+    assert entry["sha256"] in calls[1]["argv"][-1]
+
+
+def test_a_failed_migration_never_records_a_ledger_row():
+    module = _load()
+    entry = module.desired_entries(ROOT)[0]
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        raise RuntimeError("psql failed")
+
+    with pytest.raises(RuntimeError):
+        module.apply_migration(_fake_deployer(module), entry, {}, runner, ROOT)
+
+    assert len(calls) == 1
+    assert not any("INSERT INTO" in " ".join(argv) for argv in calls)
+
+
+def test_pinned_schema_identity_must_match_the_host_file(tmp_path):
+    module = _load()
+    identity = tmp_path / "schema-identity.json"
+    identity.write_text("{}\n", encoding="utf-8")
+    digest = hashlib.sha256(identity.read_bytes()).hexdigest()
+    external = {
+        "schema_identity_file": str(identity),
+        "schema_identity_owner_uid": 0,
+        "schema_identity_mode": "0600",
+        "schema_identity_sha256": digest,
+    }
+    seen: list[tuple] = []
+
+    def secure_path(path, uid, mode, *, directory):
+        seen.append((path, uid, mode, directory))
+
+    deployer = _fake_deployer(module, secure_path=secure_path)
+    assert module.verify_schema_identity(deployer, external) == digest
+    assert seen == [(identity, 0, "0600", False)]
+
+    external["schema_identity_sha256"] = "f" * 64
+    with pytest.raises(module.MigrationError, match="does not match the host file"):
+        module.verify_schema_identity(deployer, external)
+
+
+def test_receipt_is_written_root_only_with_a_sidecar(tmp_path):
+    module = _load()
+    authority = {"target": {"hostname": "ed-finder-prod", "fqdn": "nb79a3d.mevnode.com"}}
+    desired = module.desired_entries(ROOT)
+    payload = module.receipt_payload(
+        authority, status="applied", desired=desired, applied=desired[:2],
+        pending=desired[2:], applied_now=desired[2:], identity_sha256="a" * 64,
+        failures=[], writes=True,
+    )
+
+    assert payload["schema_version"] == "ed-finder/v3-production-migration-receipt/v1"
+    assert payload["operation"] == "production-migration"
+    assert payload["migrations_performed"] is True
+    assert payload["service_changes_performed"] is False
+    assert payload["desired_ledger_sha256"].startswith("sha256:")
+
+    path = module.write_receipt(tmp_path, "migration-test.json", payload)
+    body = path.read_bytes()
+    assert json.loads(body)["status"] == "applied"
+    sidecar = tmp_path / "migration-test.json.sha256"
+    assert sidecar.read_text(encoding="utf-8").split()[0] == hashlib.sha256(body).hexdigest()
+    if os.name == "posix":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+
+
+def test_operation_uses_the_v3_ledger_and_never_the_v2_applier():
+    source = MIGRATE.read_text(encoding="utf-8")
+
+    assert "INSERT INTO v3_meta.schema_migration" in source
+    # It borrows the deployer's read-only probe instead of redefining its own.
+    assert "deployer.LEDGER_SQL" in source
+    for forbidden in (
+        "apply_migrations.sh",
+        "sql/migration-manifest.txt",
+        "schema_migrations",
+        "FROM v3_meta.schema_migration",
+    ):
+        assert forbidden not in source
+    # Schema changes must not arrive through the service-changing deployer.
+    assert "'docker', 'stop'" not in source and '"docker", "stop"' not in source


### PR DESCRIPTION
Add the reviewed production schema migration operation

The promotion deployer is forbidden from changing schema, so nothing could reach
production's tables. This is P0 of the derived-data plan: the operation that
applies committed V3 lineage migrations, built on the promotion path's
fail-closed primitives rather than duplicating them.

Everything is fail-closed and testable without a production host. It refuses an
unsafe authority, a host or Docker context that is not the expected one, a pinned
schema identity whose host file does not match owner, mode and checksum, a live
ledger that is not an exact prefix of the committed lineage, a migration that does
not own its transaction, a migration whose bytes changed after the plan, and any
second operation while the production deployment lock is held.

Each migration runs once through psql with ON_ERROR_STOP=1 and its ledger row is
inserted only after that migration commits, so a failure cannot record a
migration that did not happen. The live ledger must then equal the committed
lineage exactly. Every run writes a receipt with a sidecar checksum recording the
desired ledger digest, applied-before, pending, applied-now and the pinned
identity hash.

Three operations: authority-gate and plan are read-only, apply takes the lock.

Deliberately not included: a governed delivery. The promotion path ships a sealed
source-free bundle over pinned SSH trust; this operation currently runs on the
host, and the runbook says so rather than implying a guarantee it does not yet
have. It has never been executed against production.

Nine tests drive the decision logic with fakes: prefix and divergence handling,
the self-transaction rule, ledger-row-after-commit, no-row-on-failure, identity
matching, and receipt shape and permissions.
