### PR TITLE
build(frontend): pin TypeScript to latest 5.x (5.9.3)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -99,7 +99,7 @@
     "postcss": "^8.5.25",
     "storybook": "8.6.14",
     "tailwindcss": "^3.4.18",
-    "typescript": "^5.7.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.65.0",
     "vite": "^8.2.0",
     "vite-plugin-pwa": "^1.3.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7503,7 +7503,7 @@ typescript-eslint@^8.65.0:
     "@typescript-eslint/typescript-estree" "8.67.0"
     "@typescript-eslint/utils" "8.67.0"
 
-typescript@^5.7.2:
+typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## What this does

Pins the frontend TypeScript range to the latest stable 5.x (`^5.9.3`) instead of the stale `^5.7.2` range.

## Why 5.x and not 7.x

TS 6/7 cannot land yet: `openapi-typescript` (used by the required OpenAPI drift check) declares peer `typescript@^5.x`, and `typescript-eslint` caps at `<6.1.0`. 5.9.3 is the newest version both tools support.

## Verified locally

- `yarn typecheck` passes
- `yarn build` passes

Note: the lockfile already resolved `^5.7.2` to 5.9.3, so this is a manifest range pin rather than a behaviour change in the installed compiler.