### PR TITLE
build(frontend): remove unused babylonjs dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,6 @@
     "@sentry/react": "^10.69.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-query-devtools": "^5.101.4",
-    "babylonjs": "^6.39.0",
     "clsx": "^2.1.1",
     "json-with-bigint": "^3.5.10",
     "lucide-react": "^1.28.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3514,11 +3514,6 @@ babel-plugin-polyfill-regenerator@^0.6.6:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.8"
 
-babylonjs@^6.39.0:
-  version "6.49.0"
-  resolved "https://registry.yarnpkg.com/babylonjs/-/babylonjs-6.49.0.tgz#b7e74e687494010964b428ab7101c813fcbb43d4"
-  integrity sha512-KYGpELn2osBvB8UqGuk6gfJBrriojwisw/egXaiBZNQaNuURjjogI1mgwAz4/KJB14JJwELNw3JNB4sp3Rh5Ng==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"


### PR DESCRIPTION
## What this does

Removes the unused `babylonjs@^6.39.0` dependency from the React frontend.

There are no `babylonjs` imports anywhere under `frontend/src`. The Babylon spatial runtime lives in the V3 app (`apps/web`), which already uses `@babylonjs/core@9.23.0` — so this React-frontend dependency is dead weight and is removed rather than migrated.

## Verified locally

- `yarn typecheck` passes
- `yarn build` passes