### PR TITLE
fix(journal): remediate review findings F1-F7

### DIFF
--- a/apps/api/src/edfinder_api/journal/export.py
+++ b/apps/api/src/edfinder_api/journal/export.py
@@ -63,7 +63,7 @@ _SELECT_EVENTS_SQL = """
 SELECT event_type, event_key, event_payload, event_timestamp, source_record_hash
 FROM v3_private.journal_event
 WHERE owner_account_id = $1
-ORDER BY event_type, event_key, event_timestamp
+ORDER BY event_timestamp DESC, event_key, source_record_hash
 LIMIT $2
 """
 
@@ -159,13 +159,18 @@ async def build_export(
 
     ``limit`` applies to RAW ROWS BEFORE sanitization exclusion: an account
     with excluded (travel/identity) events exports FEWER observations than
-    the limit — never more. The applied limit is persisted in the RECEIPT's
-    manifest column (``manifest.limit``, receipt-internal replay metadata —
-    deliberately NOT in the EDRE-visible payload manifest, whose schema
-    forbids extra keys) so a limit-truncated export is replayable: the
-    rebuild reads the limit back from the stored receipt manifest.
+    the limit — never more. Rows are selected newest-first (chronological)
+    so limit truncation keeps the most recent events rather than biasing the
+    surviving set toward alphabetically-earlier event types. The applied
+    limit and a ``truncated`` flag are persisted in the RECEIPT's manifest
+    column (receipt-internal replay metadata — deliberately NOT in the
+    EDRE-visible payload manifest, whose frozen consumer schema forbids
+    extra keys) so a limit-truncated export is replayable: the rebuild reads
+    the limit back from the stored receipt manifest.
     """
-    rows = await pool.fetch(_SELECT_EVENTS_SQL, account_id, limit)
+    rows = await pool.fetch(_SELECT_EVENTS_SQL, account_id, limit + 1)
+    truncated = len(rows) > limit
+    rows = rows[:limit]
     event_rows = [
         {
             'event_type': row['event_type'],
@@ -201,7 +206,7 @@ async def build_export(
     # rebuild to reproduce a limit-truncated export byte-for-byte. It lives
     # in the RECEIPT manifest only — the payload manifest (EDRE-visible) is
     # schema-frozen and must not carry it.
-    receipt_manifest = {**payload['manifest'], 'limit': limit}
+    receipt_manifest = {**payload['manifest'], 'limit': limit, 'truncated': truncated}
     payload_bytes_ = payload_bytes(payload)
     sha_hex = hashlib.sha256(payload_bytes_).hexdigest()
 

--- a/apps/api/src/edfinder_api/journal/store.py
+++ b/apps/api/src/edfinder_api/journal/store.py
@@ -189,6 +189,12 @@ async def import_journal_batch(
 
     async with pool.acquire() as conn:
         async with conn.transaction():
+            # Serialize imports per account so the daily-quota read-then-insert
+            # cannot race two concurrent requests past the cap.
+            await conn.execute(
+                'SELECT pg_advisory_xact_lock(hashtext($1::text)::bigint)',
+                str(account_id),
+            )
             stored_today = int(await conn.fetchval(
                 '''
                 SELECT count(*)
@@ -464,6 +470,12 @@ async def import_journal_batch(
                 event_type = str(event['event_type'])
                 payload = dict(event.get('payload') or {})
                 stripped, n_removed = strip_payload(event_type, payload)
+                # ``source_record_hash`` is the client parser's per-line hash.
+                # For content-addressed event types it is also the dedupe
+                # identity (identity.py). The server cannot recompute the raw
+                # journal line, so the hash is trusted after 32-byte/hex format
+                # validation below. Blast radius is the caller's own
+                # account-scoped data; the raw line is never stored.
                 record_hash = _hash_bytes(
                     event.get('source_record_hash'), field='source_record_hash',
                 )

--- a/apps/api/src/routers/v3.py
+++ b/apps/api/src/routers/v3.py
@@ -242,18 +242,32 @@ async def stations(system_id: SystemId, pool: asyncpg.Pool = Depends(get_readonl
               LEFT JOIN v3_vocab.station_type station_type USING(station_type_id)
               JOIN {schema}.station_placement placement USING(station_pk,system_id64)
              WHERE station.system_id64=$1 ORDER BY station.station_pk""",
-        numeric_id,
+         numeric_id,
     )
-    result: list[StationV1] = []
-    for row in rows:
+    station_pks = [row["station_pk"] for row in rows]
+    economies_by_station: dict = {}
+    if station_pks:
         economy_rows = await pool.fetch(
-            f"""SELECT economy.public_code,economy_current.economy_weight,
-                       economy_current.is_primary,economy_current.is_secondary
+            f"""SELECT economy_current.station_pk, economy.public_code,
+                       economy_current.economy_weight,
+                       economy_current.is_primary, economy_current.is_secondary
                   FROM {schema}.station_economy_current economy_current
                   JOIN v3_vocab.economy economy USING(economy_id)
-                 WHERE economy_current.station_pk=$1 ORDER BY economy.economy_id""",
-            row["station_pk"],
+                 WHERE economy_current.station_pk = ANY($1::bigint[])
+                 ORDER BY economy_current.station_pk, economy.economy_id""",
+            station_pks,
         )
+        for economy in economy_rows:
+            economies_by_station.setdefault(economy["station_pk"], []).append(
+                StationEconomyV1(
+                    economy=economy["public_code"],
+                    economy_weight=economy["economy_weight"],
+                    is_primary=economy["is_primary"],
+                    is_secondary=economy["is_secondary"],
+                )
+            )
+    result: list[StationV1] = []
+    for row in rows:
         result.append(StationV1(
             station_id=str(row["station_pk"]),
             market_id=str(row["market_id"]) if row["market_id"] is not None else None,
@@ -261,9 +275,6 @@ async def stations(system_id: SystemId, pool: asyncpg.Pool = Depends(get_readonl
             distance_from_arrival_ls=row["distance_from_arrival_ls"],
             body_id=str(row["body_pk"]) if row["body_pk"] is not None else None,
             association_state=row["association_state"],
-            economies=[StationEconomyV1(
-                economy=economy["public_code"], economy_weight=economy["economy_weight"],
-                is_primary=economy["is_primary"], is_secondary=economy["is_secondary"],
-            ) for economy in economy_rows],
+            economies=economies_by_station.get(row["station_pk"], []),
         ))
     return result

--- a/apps/api/src/routers/v3_journal_research.py
+++ b/apps/api/src/routers/v3_journal_research.py
@@ -194,7 +194,7 @@ async def _rebuild_observations(
             """SELECT event_type, event_key, event_payload, event_timestamp, source_record_hash
                  FROM v3_private.journal_event
                 WHERE owner_account_id = $1
-                ORDER BY event_type, event_key, event_timestamp""",
+                ORDER BY event_timestamp DESC, event_key, source_record_hash""",
             account_id,
         )
     else:
@@ -202,7 +202,7 @@ async def _rebuild_observations(
             """SELECT event_type, event_key, event_payload, event_timestamp, source_record_hash
                  FROM v3_private.journal_event
                 WHERE owner_account_id = $1
-                ORDER BY event_type, event_key, event_timestamp
+                ORDER BY event_timestamp DESC, event_key, source_record_hash
                 LIMIT $2""",
             account_id,
             limit,

--- a/docs/development/cre-export-schema.md
+++ b/docs/development/cre-export-schema.md
@@ -1,0 +1,75 @@
+# CRE / EDRE Journal Observation Export — sanitization authority
+
+This document is the committed arbitration source for the sanitized journal
+observation export (`ed-finder-cre-journal-observation-export` v1.0.0). It is
+the authority referenced by
+`apps/api/src/edfinder_api/journal/sanitize.py`. If the sanitizer and this
+document disagree, this document wins and the sanitizer must be corrected.
+
+## A1-A14 allowlist mapping
+
+`sanitize_observation` emits only the fields below. Any field not listed is
+never copied into the output (fail-closed).
+
+| ID | Output field | Source / rule |
+|----|--------------|---------------|
+| A1 | `observation_id` | `uuid5` of `event_type:canonical_key_json` |
+| A2 | `observation_type` | journal `event_type` |
+| A3 | `observed_week` | ISO-8601 week bucket of `event_timestamp` (never exact timestamp) |
+| A4 | `source_event_sha256` | `source_record_hash` as lowercase hex |
+| A5 | `evidence_quality` | always `OBSERVED_PERSONAL` |
+| A6 | `system_id64` | decimal string from event key `SystemAddress` (omitted for `SellOrganicData`) |
+| A7 | `system_name` | payload `SystemName` -> `StarSystem` -> `System` (omitted for `SellOrganicData`) |
+| A8 | `body_id` | decimal string from event key `BodyID` (when present) |
+| A9 | `body_name` | payload `BodyName`, else string form of payload `Body` (when present) |
+| A10 | `body_environment` | normalized `Scan`/`FSSBodySignals`/`SAASignalsFound` facts (see unit conversions) |
+| A11 | `signals` / `genuses` | projected signal/genus blocks (see below) |
+| A12 | `codex_region` / `codex_entry_id` | `CodexEntry` only |
+| A13 | `genus` / `species` / `variant` | `ScanOrganic` only |
+| A14 | `sale` | `SellOrganicData` only (see below) |
+
+Optional trailing fields: `game_version`, `game_build` when present in the
+payload.
+
+## Exported and excluded event types
+
+Exported set:
+
+```text
+Scan, FSSBodySignals, SAASignalsFound, SAAScanComplete, CodexEntry,
+ScanOrganic, SellOrganicData, FSSDiscoveryScan, FSSAllBodiesFound
+```
+
+Every other allowlisted journal event type is excluded (travel/identity/credit
+events return `None`), including: `FSDJump`, `CarrierJump`, `Location`,
+`Touchdown`, `Liftoff`, `ApproachBody`, `LeaveBody`, `Disembark`, `Embark`,
+`Screenshot`, `Docked`, `Fileheader`, `LoadGame`, `Commander`, `Died`,
+`Resurrect`, `SellExplorationData`, `MultiSellExplorationData`, `FSDTarget`,
+`NavRoute`, `NavRouteClear`.
+
+## Hard exclusions
+
+Latitude/Longitude, credits (`Value`/`Bonus`/`TotalValue`), `MarketID`,
+commander name/FID, and localised display names are never emitted, even when
+present in the event key or payload.
+
+## Arbitrated unit conversions
+
+| Output | Journal source | Conversion |
+|--------|----------------|------------|
+| `radius_km` | `Radius` (metres) | `/ 1000`, rounded to 4 decimal places |
+| `surface_gravity_g` | `SurfaceGravity` (m/s²) | `/ 9.80665`, rounded to 6 decimal places |
+
+## Signals projection
+
+`signals` entries are projected to `{ "Type": str, "Count": int }` only.
+Journal extras such as `Type_Localised` are dropped. `genuses` is a separate
+optional string array of canonical genus tokens from `SAASignalsFound.Genuses`.
+JSON `null` values are never emitted.
+
+## Sale object
+
+For `SellOrganicData`, `sale` is `{ "count": int, "items": [...] }` where
+`count` is the number of `BioData` items (the journal carries a list, not
+per-item counts). Each item carries `genus`/`species` plus `variant` when
+present. `MarketID`, credits, and localised names are excluded.

--- a/frontend/src/lib/api/journal.ts
+++ b/frontend/src/lib/api/journal.ts
@@ -44,8 +44,8 @@ export interface V3JournalImportReceipt {
   duplicates_skipped: number;
   privacy_stripped_fields: number;
   event_counts: Record<string, number>;
-  started_at: string | null;
-  finished_at: string | null;
+  started_at: string;
+  finished_at: string;
 }
 
 export interface V3JournalSummaryResponse {
@@ -135,8 +135,9 @@ export interface V3ResearchExportReceipt {
   created_at: string;
 }
 
-/** Receipt + the deterministically rebuilt export payload. */
-export interface V3ResearchExportDetail extends V3ResearchExportReceipt {
+/** Receipt + the deterministically rebuilt export payload (wire wrapper). */
+export interface V3ResearchExportDetail {
+  receipt: V3ResearchExportReceipt;
   payload: Record<string, unknown>;
 }
 

--- a/tests/test_v3_journal_store.py
+++ b/tests/test_v3_journal_store.py
@@ -283,7 +283,7 @@ def test_quota_exceeded_raises_and_writes_nothing():
             events=_events('Scan', 'Scan'),
         ))
     kinds = [_classify(sql) for sql, _args in conn.calls]
-    assert kinds == ['quota']
+    assert kinds == ['other', 'quota']
 
 
 def test_privacy_stripped_fields_are_counted():


### PR DESCRIPTION
## Summary

Remediates the accepted-risk findings from PR #678's replacement review, in order.

## Findings addressed

- **F1 (High)** — export selection is now chronological (newest first) instead of `event_type`-ordered, so limit truncation no longer drops the science/observation types. Adds a receipt-internal `truncated` flag (the EDRE-visible manifest stays schema-frozen, so the flag is deliberately receipt-only).
- **F2 (Medium)** — `frontend/src/lib/api/journal.ts` now declares `V3ResearchExportDetail` as the `{ receipt, payload }` wrapper and makes `started_at`/`finished_at` non-nullable to match the server.
- **F3 (Medium)** — commits `docs/development/cre-export-schema.md` as the sanitization authority (A1-A14, unit conversions, signals/sale shapes, exclusions).
- **F4 (Low)** — no code change required: already remediated by content-sha admission keying; the remaining name→sha bridge is intentionally deterministic last-wins (pinned by an existing test).
- **F5 (Low)** — adds a per-account advisory transaction lock so the daily-quota read-then-insert cannot race. Quota still counts received events (documented; switching to admitted-only would move the gate after admission and change existing pinned semantics).
- **F6 (Low)** — documented the accepted client-supplied `source_record_hash` limitation at the store call site.
- **F7 (Medium, Octopus)** — `stations()` now fetches station economies in one grouped query instead of one query per station.
- **F8/F9 (informational)** — decisions left as-is (canonical-read rate-limit convention; RLS remains an application-predicate boundary), documented below.

## Verification

Local: `pytest` on the nine `test_v3_journal_*` unit files passes (160 passed, 1 skipped); `yarn typecheck` passes.