### PR TITLE
fix(v3): add ratings derived migration 003 to production lineage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@ tests/fixtures/ratings_v4_sources/spansh-system-dumps.zip -text
 apps/importer/src/v3_spansh/*.py -text
 sql/v3/migrations/001_v3_baseline.sql -text
 sql/v3/migrations/002_v3_accounts_identity.sql -text
+sql/v3/migrations/003_ratings_v4_derived.sql -text
 sql/v3/migrations/004_v3_search_spatial_clusters.sql -text
 sql/v3/migrations/005_v3_journal_intelligence.sql -text
 sql/r1_v3/001_structural_shell.sql -text

--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -95,7 +95,7 @@
     "api_env_owner_uid": 0,
     "api_env_mode": "0600",
     "schema_identity_file": "/etc/ed-finder/v3-production/schema-identity.json",
-    "schema_identity_sha256": "5669ee535a6dc4410ce16001eca15807cad95d5b50930cc44141e0dbdfd7a5c0",
+    "schema_identity_sha256": "9299110ac7ec318dc9294dedb0e2ac386a29137d22ff5020f10a0410b94d61c0",
     "schema_identity_owner_uid": 0,
     "schema_identity_mode": "0600",
     "active_origin_bind": "127.0.0.1:58080",

--- a/sql/v3/migration-manifest.txt
+++ b/sql/v3/migration-manifest.txt
@@ -24,16 +24,16 @@
 #                                 R1 normalized shell; recovered from the
 #                                 chatgpt-ed-new-ops-requests branch
 #
-#   005_v3_journal_intelligence.sql is declared but NOT applied. It is this
-#                                 branch's own contribution: the account-scoped
-#                                 private journal lane from the personal-journal
-#                                 workstream. It follows every applied row, so the
-#                                 reviewed live ledger stays an exact prefix of
-#                                 this file and the migration operation reports
-#                                 exactly one pending migration.
+#   003_ratings_v4_derived.sql, 004_v3_search_spatial_clusters.sql and
+#   005_v3_journal_intelligence.sql are declared but NOT applied. They follow
+#                                 every applied row, so the reviewed live ledger
+#                                 stays an exact prefix of this file and the
+#                                 migration operation reports three pending
+#                                 migrations in order (003 -> 004 -> 005).
 
 ee08c17eb3f87f614468db5a038d2f23273ce2b72906226c9aa1f669e724cd2e  001_v3_baseline.sql  v3/migrations/001_v3_baseline.sql
 e7a2f404b7d8194d74ba4e807ae450c7520a1c8a186ca77e41377307e7b12b07  002_v3_accounts_identity.sql  v3/migrations/002_v3_accounts_identity.sql
 1a2d15c2db5cff7714a01a5d0c710a22326ed57d90d9a20e362495714ad97a40  r1_v3/001_structural_shell.sql  r1_v3/001_structural_shell.sql
+c7818f98ad00b4b99b7ce0f7c3fa12ece555e59e761b7b1ca15d437a39c499cb  003_ratings_v4_derived.sql  v3/migrations/003_ratings_v4_derived.sql
 e1c59def52b6a92a337f1da35c921bd0c135877f7843049ca9dec718aa01a1f2  004_v3_search_spatial_clusters.sql  v3/migrations/004_v3_search_spatial_clusters.sql
 e5c853bcc35da054aff67356a95cbe3d668f6bf2dd1d97b497b9ba7d8cae02ac  005_v3_journal_intelligence.sql  v3/migrations/005_v3_journal_intelligence.sql

--- a/tests/test_v3_production_migration_operation.py
+++ b/tests/test_v3_production_migration_operation.py
@@ -50,11 +50,12 @@ def test_desired_entries_are_the_committed_lineage_with_verified_hashes():
     entries = module.desired_entries(ROOT)
 
     assert [entry["ledger_name"] for entry in entries] == [
-        "001_v3_baseline.sql",
-        "002_v3_accounts_identity.sql",
-        "r1_v3/001_structural_shell.sql",
-        "004_v3_search_spatial_clusters.sql",
-        "005_v3_journal_intelligence.sql",
+         "001_v3_baseline.sql",
+         "002_v3_accounts_identity.sql",
+         "r1_v3/001_structural_shell.sql",
+         "003_ratings_v4_derived.sql",
+         "004_v3_search_spatial_clusters.sql",
+         "005_v3_journal_intelligence.sql",
     ]
     for entry in entries:
         source = (ROOT / entry["path"]).read_bytes()
@@ -72,6 +73,7 @@ def test_plan_reports_pending_only_when_the_live_ledger_is_an_exact_prefix():
     ]
     assert [entry["ledger_name"] for entry in pending] == [
         "r1_v3/001_structural_shell.sql",
+        "003_ratings_v4_derived.sql",
         "004_v3_search_spatial_clusters.sql",
         "005_v3_journal_intelligence.sql",
     ]


### PR DESCRIPTION
## What this does

Prepares the production V3 migration lineage so the ratings derived schema can be applied. This is repo-side authority work only; it does not touch production.

## Changes

- Add `003_ratings_v4_derived.sql` to `sql/v3/migration-manifest.txt` in the correct position (after `r1_v3/001`, before `004`), with its LF SHA-256.
- Add `sql/v3/migrations/003_ratings_v4_derived.sql` to `.gitattributes` as `-text` so it stays LF like the other V3 migrations.
- Regenerate the schema identity and re-pin `external_authority.schema_identity_sha256` in `deploy/v3-production/target-authority.json`.
- Update `tests/test_v3_production_migration_operation.py` to the now-correct lineage (`001 → 002 → r1 → 003 → 004 → 005`).

## Why

`003` creates `v3_derived`/`v3_app` (ratings storage). `004` already has a foreign key into `v3_derived.system_rating_vector`, so `003` must be applied before `004`. It was previously absent from the lineage manifest, which is the blocker for bringing ratings online.

## Verification

- `tests/test_v3_lineage_migrations.py` and `tests/test_v3_production_migration_operation.py` pass (15 tests).
- `target-authority.json` parses as valid JSON.

## Still required (gated, not in this PR)

Run `scripts/operator/v3_production_migrate.py authority-gate → plan → apply` on the production host to apply `003`, `004`, `005` to the live retained database.