### PR TITLE
fix(v3): order migration ledger by applied_at

### DIFF
--- a/scripts/operator/v3_production_deploy.py
+++ b/scripts/operator/v3_production_deploy.py
@@ -85,7 +85,7 @@ SELECT json_build_object(
         'filename', migration_name,
         'checksum_sha256', encode(migration_sha256, 'hex')
       )
-      ORDER BY migration_name
+       ORDER BY applied_at, migration_name
     ) FROM v3_meta.schema_migration
   ), '[]'::json)
 )::text;

--- a/scripts/operator/v3_production_inventory.py
+++ b/scripts/operator/v3_production_inventory.py
@@ -83,7 +83,7 @@ SELECT json_build_object(
     SELECT json_agg(
       json_build_object('filename', migration_name,
                         'checksum_sha256', encode(migration_sha256, 'hex'))
-      ORDER BY migration_name
+       ORDER BY applied_at, migration_name
     ) FROM v3_meta.schema_migration
   ), '[]'::json)
 )::text;

--- a/tests/test_v3_production_application_deployment.py
+++ b/tests/test_v3_production_application_deployment.py
@@ -150,7 +150,7 @@ def test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_read
     assert 'DB_USER = "edfinder_v3"' in source
     assert 'DB_NAME = "edfinder_v3_phase4c_full_20260827_r5"' in source
     assert "FROM v3_meta.schema_migration" in source
-    assert "ORDER BY migration_name" in source
+    assert "ORDER BY applied_at, migration_name" in source
     assert '"container_environment_read": False' in source
     assert '"filesystem_writes_performed": False' in source
     for required_inventory_fact in (


### PR DESCRIPTION
## What this does

Fixes the production migration ledger read order so the lineage prefix check is stable once the numeric `003`/`004`/`005` migrations are applied alongside the `r1_v3/001_structural_shell.sql` row.

## Why

The deployer and inventory scripts read `v3_meta.schema_migration` with `ORDER BY migration_name`. That is lexicographic, so `r1_v3/001_structural_shell.sql` sorts after `003`/`004`/`005` even though it was applied before them chronologically. Once `003`-`005` are applied, the lexicographic ledger is `001,002,003,004,005,r1`, which does not match the chronologically-ordered committed manifest `001,002,r1,003,004,005` — so the migration authority stops even though the migrations applied correctly.

Change the ledger read to `ORDER BY applied_at, migration_name`, which reflects actual application order and matches the committed lineage.

## Verification

- `test_read_only_inventory_has_exact_guards_complete_ledger_and_no_secret_reads` passes locally.
- Lineage/migration-operation tests continue to pass.

## Production note

Migrations `003`, `004`, `005` are already applied to the retained database; this change repairs the authority's ledger-ordering verification so it can re-verify the now-complete lineage.