### PR TITLE
Add bounded Ratings V4 production generation operation

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -13,6 +13,8 @@ on:
           - recover-v3-runtime-contract
           - octopus-qdrant-healthcheck-repair
           - v3-app-status
+          - ratings-v4-generation-start
+          - ratings-v4-generation-status
   push:
     branches:
       - chatgpt-ed-new-ops-requests
@@ -69,7 +71,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair|v3-app-status) ;;
+            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair|v3-app-status|ratings-v4-generation-start|ratings-v4-generation-status) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -244,3 +246,75 @@ jobs:
             ${{ runner.temp }}/edfinder-v3-runtime-recovery/recovery-receipt.json
           if-no-files-found: error
           retention-days: 14
+
+      - name: Prepare offline Ratings V4 generation bundle
+        if: steps.request.outputs.operation == 'ratings-v4-generation-start'
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_sha="$(git -C trusted-main rev-parse HEAD)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || exit 64
+          printf '%s\n' "$source_sha" > trusted-main/.ratings-v4-source-sha
+          rm -rf trusted-main/.ratings-v4-wheelhouse
+          mkdir -p trusted-main/.ratings-v4-wheelhouse
+          python -m pip download --disable-pip-version-check --only-binary=:all: --dest trusted-main/.ratings-v4-wheelhouse \
+            'psycopg[binary]==3.3.4' 'ijson==3.5.1'
+
+      - name: Stage trusted main and launch Ratings V4 generation
+        if: steps.request.outputs.operation == 'ratings-v4-generation-start'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/ratings-v4-generation-operation.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          source_sha="$(git -C trusted-main rev-parse HEAD)"
+          stage="/var/tmp/edfinder-ratings-v4-${source_sha}"
+          tar -C trusted-main --exclude=.git -cf - . | \
+            ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              "set -eu; umask 077; rm -rf '$stage'; mkdir -p '$stage'; tar --no-same-owner --no-same-permissions -C '$stage' -xf -"
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              "bash -s -- start '$stage' '$source_sha'" \
+              < trusted-main/scripts/operator/actions/ratings-v4-generation.sh | tee "$RECEIPT"
+
+      - name: Inspect Ratings V4 generation status
+        if: steps.request.outputs.operation == 'ratings-v4-generation-status'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/ratings-v4-generation-operation.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              'bash -s -- status' \
+              < trusted-main/scripts/operator/actions/ratings-v4-generation.sh | tee "$RECEIPT"
+
+      - name: Upload Ratings V4 generation operation receipt
+        if: always() && (steps.request.outputs.operation == 'ratings-v4-generation-start' || steps.request.outputs.operation == 'ratings-v4-generation-status')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ratings-v4-generation-operation
+          path: ${{ runner.temp }}/ratings-v4-generation-operation.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/operator/actions/ratings-v4-generation.sh
+++ b/scripts/operator/actions/ratings-v4-generation.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+REPO_ROOT="${2:-}"
+SOURCE_SHA="${3:-}"
+
+TARGET_HOSTNAME="ed-finder-prod"
+TARGET_FQDN="nb79a3d.mevnode.com"
+POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_USER="edfinder_v3"
+DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5"
+APPLICATION_NETWORK="edfinder-v3-production"
+OPERATION_LABEL="ed-finder.operation=ratings-v4-generation"
+STATE_ROOT="${HOME}/.local/state/ed-finder/ratings-v4"
+
+fail() {
+  printf 'ratings-v4 generation: %s\n' "$*" >&2
+  exit 64
+}
+
+require_target() {
+  command -v docker >/dev/null 2>&1 || fail "docker is unavailable"
+  command -v python3.14 >/dev/null 2>&1 || fail "python3.14 is unavailable"
+  [ "$(hostname)" = "$TARGET_HOSTNAME" ] || fail "unexpected hostname"
+  [ "$(hostname -f 2>/dev/null || true)" = "$TARGET_FQDN" ] || fail "unexpected fqdn"
+  [ "$(docker context show)" = "default" ] || fail "unexpected docker context"
+  docker context inspect default 2>/dev/null | grep -F 'unix:///var/run/docker.sock' >/dev/null \
+    || fail "default docker context is not the local rootful socket"
+  docker inspect "$POSTGRES_CONTAINER" >/dev/null 2>&1 || fail "retained postgres container is unavailable"
+  [ "$(docker inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER")" = "true" ] \
+    || fail "retained postgres container is not running"
+}
+
+db_query() {
+  docker exec "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+    --tuples-only --no-align --quiet --set ON_ERROR_STOP=1 \
+    --username "$DATABASE_USER" --dbname "$DATABASE_NAME" --command "$1"
+}
+
+active_api_container() {
+  local -a matches=()
+  local container service
+  while IFS= read -r container; do
+    [ -n "$container" ] || continue
+    service="$(docker inspect -f '{{index .Config.Labels "com.docker.compose.service"}}' "$container")"
+    case "$service" in
+      api-*) matches+=("$container") ;;
+    esac
+  done < <(docker ps --filter "label=com.docker.compose.project=${APPLICATION_NETWORK}" --format '{{.Names}}')
+  [ "${#matches[@]}" -eq 1 ] || fail "expected exactly one running production API slot, found ${#matches[@]}"
+  printf '%s\n' "${matches[0]}"
+}
+
+api_database_url() {
+  local api="$1" value count
+  value="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$api" | sed -n 's/^DATABASE_URL=//p')"
+  count="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$api" | grep -c '^DATABASE_URL=' || true)"
+  [ "$count" -eq 1 ] || fail "active API does not expose exactly one DATABASE_URL"
+  case "$value" in
+    postgresql://*|postgres://*) ;;
+    *) fail "active API DATABASE_URL is not a PostgreSQL DSN" ;;
+  esac
+  printf '%s' "$value"
+}
+
+source_metadata() {
+  db_query "BEGIN READ ONLY; SELECT c.publication_sequence::text || E'\\t' || g.generation_id::text || E'\\t' || a.size_bytes::text || E'\\t' || encode(a.content_sha256,'hex') || E'\\t' || a.storage_locator FROM v3_meta.current_canonical_generation c JOIN v3_meta.canonical_generation g USING(generation_id) JOIN v3_source.source_run r ON r.source_run_id=g.build_source_run_id JOIN v3_source.source_artifact a ON a.artifact_id=r.artifact_id WHERE g.lifecycle_state='PUBLISHED'; COMMIT;"
+}
+
+resolve_source_path() {
+  local locator="$1" expected_size="$2"
+  local -a candidates=()
+  local id src dst rel candidate root base actual_size
+
+  case "$locator" in
+    /*) ;;
+    *) fail "canonical artifact storage locator is not an absolute path" ;;
+  esac
+  [[ "$locator" != *$'\n'* && "$locator" != *$'\r'* && "$locator" != *:* ]] \
+    || fail "canonical artifact storage locator is unsafe"
+
+  if [ -f "$locator" ] && [ ! -L "$locator" ]; then
+    actual_size="$(stat -c '%s' "$locator")"
+    [ "$actual_size" = "$expected_size" ] && candidates+=("$locator")
+  fi
+
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    while IFS=$'\t' read -r src dst; do
+      [ -n "$src" ] && [ -n "$dst" ] || continue
+      if [ "$locator" = "$dst" ]; then
+        candidate="$src"
+      elif [[ "$locator" == "$dst/"* ]]; then
+        rel="${locator#"$dst"}"
+        candidate="${src}${rel}"
+      else
+        continue
+      fi
+      if [ -f "$candidate" ] && [ ! -L "$candidate" ] && [ "$(stat -c '%s' "$candidate")" = "$expected_size" ]; then
+        candidates+=("$candidate")
+      fi
+    done < <(docker inspect -f '{{range .Mounts}}{{printf "%s\t%s\n" .Source .Destination}}{{end}}' "$id")
+  done < <(docker ps -aq)
+
+  if [ "${#candidates[@]}" -eq 0 ]; then
+    base="$(basename "$locator")"
+    for root in /data /srv /opt "$HOME"; do
+      [ -d "$root" ] || continue
+      while IFS= read -r candidate; do
+        [ -n "$candidate" ] && candidates+=("$candidate")
+      done < <(find "$root" -xdev -type f -name "$base" -size "${expected_size}c" -print 2>/dev/null)
+    done
+  fi
+
+  mapfile -t candidates < <(printf '%s\n' "${candidates[@]}" | awk 'NF && !seen[$0]++')
+  [ "${#candidates[@]}" -eq 1 ] \
+    || fail "expected exactly one retained canonical artifact with the reviewed size, found ${#candidates[@]}"
+  printf '%s\n' "${candidates[0]}"
+}
+
+latest_generation_status() {
+  db_query "BEGIN READ ONLY; SELECT COALESCE((SELECT json_build_object('generation_key',g.generation_key,'lifecycle_state',g.lifecycle_state,'canonical_generation_id',g.canonical_generation_id,'canonical_publication_sequence',g.canonical_publication_sequence,'expected_systems',g.expected_systems,'completed_chunks',(SELECT count(*) FROM v3_derived.build_chunk b WHERE b.derived_generation_id=g.derived_generation_id),'completed_systems',(SELECT COALESCE(sum(b.systems),0) FROM v3_derived.build_chunk b WHERE b.derived_generation_id=g.derived_generation_id),'source_receipt_present',g.source_receipt IS NOT NULL,'validation_status',g.validation_receipt->>'status','validated_at',g.validated_at,'published_at',g.published_at) FROM v3_meta.derived_generation g ORDER BY g.created_at DESC LIMIT 1)::text,'null'); COMMIT;"
+}
+
+status_operation() {
+  require_target
+  printf 'operation=ratings-v4-generation-status\n'
+  printf 'publication_performed=false\n'
+  printf 'migrations_performed=false\n'
+  printf 'canonical_writes_performed=false\n'
+  printf 'worker_containers:\n'
+  docker ps -a --filter "label=${OPERATION_LABEL}" \
+    --format '  {{.Names}}\t{{.Status}}\t{{.Image}}' || true
+  printf 'latest_generation=%s\n' "$(latest_generation_status)"
+  local -a workers=()
+  mapfile -t workers < <(docker ps -a --filter "label=${OPERATION_LABEL}" --format '{{.Names}}')
+  if [ "${#workers[@]}" -gt 0 ]; then
+    printf 'latest_worker_log_tail:\n'
+    docker logs --tail 40 "${workers[0]}" 2>&1 | sed 's/^/  /' || true
+  fi
+}
+
+start_operation() {
+  require_target
+  [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] || fail "trusted main bundle path is required"
+  [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "trusted main SHA is invalid"
+  case "$REPO_ROOT" in
+    /var/tmp/edfinder-ratings-v4-"$SOURCE_SHA") ;;
+    *) fail "trusted main bundle path is outside the reviewed staging namespace" ;;
+  esac
+  [ "$(cat "$REPO_ROOT/.ratings-v4-source-sha" 2>/dev/null || true)" = "$SOURCE_SHA" ] \
+    || fail "trusted main bundle SHA marker mismatch"
+  [ -f "$REPO_ROOT/scripts/ratings_v4/run_generation.py" ] || fail "generation runner is missing"
+  [ -f "$REPO_ROOT/scripts/ratings_v4/production_generation.py" ] || fail "generation builder is missing"
+  [ -d "$REPO_ROOT/.ratings-v4-wheelhouse" ] || fail "offline dependency wheelhouse is missing"
+
+  install -d -m 700 "$STATE_ROOT"
+  command -v flock >/dev/null 2>&1 || fail "flock is unavailable"
+  exec 9>"$STATE_ROOT/start.lock"
+  flock -n 9 || fail "another Ratings V4 generation start is in progress"
+
+  local metadata sequence canonical_generation expected_size expected_sha storage_locator
+  metadata="$(source_metadata)"
+  [ "$(printf '%s\n' "$metadata" | wc -l)" -eq 1 ] || fail "canonical source metadata is ambiguous"
+  IFS=$'\t' read -r sequence canonical_generation expected_size expected_sha storage_locator <<< "$metadata"
+  [[ "$sequence" =~ ^[1-9][0-9]*$ ]] || fail "canonical publication sequence is invalid"
+  [[ "$canonical_generation" =~ ^[0-9a-f-]{36}$ ]] || fail "canonical generation id is invalid"
+  [[ "$expected_size" =~ ^[1-9][0-9]*$ ]] || fail "canonical artifact size is invalid"
+  [[ "$expected_sha" =~ ^[0-9a-f]{64}$ ]] || fail "canonical artifact sha256 is invalid"
+  [ -n "$storage_locator" ] || fail "canonical artifact storage locator is empty"
+
+  local source_path generation_key worker api api_image dsn env_file worker_state
+  source_path="$(resolve_source_path "$storage_locator" "$expected_size")"
+  generation_key="ratings_v4_prod_p${sequence}"
+  worker="edfinder-ratings-v4-prod-p${sequence}"
+  api="$(active_api_container)"
+  api_image="$(docker inspect -f '{{.Config.Image}}' "$api")"
+  [ -n "$api_image" ] || fail "active API image identity is empty"
+  dsn="$(api_database_url "$api")"
+
+  if docker inspect "$worker" >/dev/null 2>&1; then
+    worker_state="$(docker inspect -f '{{.State.Status}}' "$worker")"
+    if [ "$worker_state" = "running" ]; then
+      printf 'operation=ratings-v4-generation-start\n'
+      printf 'result=already-running\n'
+      printf 'worker_container=%s\n' "$worker"
+      printf 'generation_key=%s\n' "$generation_key"
+      printf 'canonical_generation_id=%s\n' "$canonical_generation"
+      printf 'canonical_publication_sequence=%s\n' "$sequence"
+      printf 'publication_performed=false\n'
+      exit 0
+    fi
+    docker rm "$worker" >/dev/null
+  fi
+
+  env_file="$STATE_ROOT/${generation_key}.env"
+  umask 077
+  {
+    printf 'RATINGS_V4_CANONICAL_DATABASE_URL=%s\n' "$dsn"
+    printf 'RATINGS_V4_DERIVED_DATABASE_URL=%s\n' "$dsn"
+    printf 'RATINGS_V4_SOURCE=/source/galaxy.json.gz\n'
+    printf 'RATINGS_V4_GENERATION_KEY=%s\n' "$generation_key"
+  } > "$env_file"
+  chmod 600 "$env_file"
+
+  docker run -d \
+    --name "$worker" \
+    --label "$OPERATION_LABEL" \
+    --label "ed-finder.generation-key=${generation_key}" \
+    --label "ed-finder.source-sha=${SOURCE_SHA}" \
+    --network "$APPLICATION_NETWORK" \
+    --cpus 2 \
+    --memory 12g \
+    --pids-limit 512 \
+    --restart no \
+    --log-driver json-file \
+    --log-opt max-size=20m \
+    --log-opt max-file=3 \
+    --env-file "$env_file" \
+    --mount "type=bind,src=${REPO_ROOT},dst=/work,readonly" \
+    --mount "type=bind,src=${source_path},dst=/source/galaxy.json.gz,readonly" \
+    --entrypoint /bin/sh \
+    "$api_image" -lc '
+      set -eu
+      /usr/local/bin/python -m pip install --disable-pip-version-check --no-input --no-index \
+        --find-links /work/.ratings-v4-wheelhouse --target /tmp/ratings-v4-deps \
+        "psycopg[binary]==3.3.4" "ijson==3.5.1"
+      export PYTHONPATH="/tmp/ratings-v4-deps:/work:/work/apps/api/src"
+      cd /work
+      /app/.venv/bin/python scripts/ratings_v4/verify_freeze.py >/tmp/ratings-v4-freeze-receipt.json
+      exec /app/.venv/bin/python scripts/ratings_v4/run_generation.py \
+        --source "$RATINGS_V4_SOURCE" \
+        --generation-key "$RATINGS_V4_GENERATION_KEY" \
+        --chunk-size 500
+    ' >/dev/null
+  rm -f "$env_file"
+
+  sleep 2
+  worker_state="$(docker inspect -f '{{.State.Status}}' "$worker")"
+  if [ "$worker_state" = "exited" ]; then
+    docker logs --tail 80 "$worker" >&2 || true
+    fail "Ratings V4 worker exited during startup"
+  fi
+
+  printf 'operation=ratings-v4-generation-start\n'
+  printf 'result=launched\n'
+  printf 'source_sha=%s\n' "$SOURCE_SHA"
+  printf 'canonical_generation_id=%s\n' "$canonical_generation"
+  printf 'canonical_publication_sequence=%s\n' "$sequence"
+  printf 'source_artifact_sha256=%s\n' "$expected_sha"
+  printf 'source_artifact_size_bytes=%s\n' "$expected_size"
+  printf 'generation_key=%s\n' "$generation_key"
+  printf 'worker_container=%s\n' "$worker"
+  printf 'worker_state=%s\n' "$worker_state"
+  printf 'cpu_limit=2\n'
+  printf 'memory_limit=12g\n'
+  printf 'publication_performed=false\n'
+  printf 'migrations_performed=false\n'
+  printf 'canonical_writes_performed=false\n'
+  printf 'derived_writes_authorized=true\n'
+}
+
+case "$ACTION" in
+  start) start_operation ;;
+  status) status_operation ;;
+  *) fail "expected start or status" ;;
+esac

--- a/tests/test_ratings_v4_production_generation_operator.py
+++ b/tests/test_ratings_v4_production_generation_operator.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/chatgpt-ed-new-ops.yml"
+ACTION = ROOT / "scripts/operator/actions/ratings-v4-generation.sh"
+
+
+def test_generation_request_uses_trusted_main_and_is_allowlisted():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    assert "ratings-v4-generation-start" in workflow
+    assert "ratings-v4-generation-status" in workflow
+    assert "ref: main" in workflow
+    assert "trusted-main/scripts/operator/actions/ratings-v4-generation.sh" in workflow
+    assert ".github/ed-new-ops-requests/*.json" in workflow
+    assert 'extra=set(d)-{"operation"}' in workflow
+
+
+def test_generation_worker_is_bounded_and_cannot_publish_or_migrate():
+    action = ACTION.read_text(encoding="utf-8")
+    assert "--cpus 2" in action
+    assert "--memory 12g" in action
+    assert "--pids-limit 512" in action
+    assert "--restart no" in action
+    assert "dst=/work,readonly" in action
+    assert "dst=/source/galaxy.json.gz,readonly" in action
+    assert "--chunk-size 500" in action
+    assert "publication_performed=false" in action
+    assert "canonical_writes_performed=false" in action
+    assert "publish_derived_generation(" not in action
+    assert "v3_production_migrate.py" not in action
+    assert "DROP " not in action
+    assert "TRUNCATE " not in action
+
+
+def test_generation_dependencies_are_offline_and_pinned():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    action = ACTION.read_text(encoding="utf-8")
+    for requirement in ("psycopg[binary]==3.3.4", "ijson==3.5.1"):
+        assert requirement in workflow
+        assert requirement in action
+    assert "--only-binary=:all:" in workflow
+    assert "--no-index" in action
+    assert ".ratings-v4-wheelhouse" in workflow
+    assert ".ratings-v4-wheelhouse" in action
+
+
+def test_generation_reuses_live_database_secret_without_printing_it():
+    action = ACTION.read_text(encoding="utf-8")
+    assert "DATABASE_URL=" in action
+    assert "RATINGS_V4_CANONICAL_DATABASE_URL=%s" in action
+    assert "RATINGS_V4_DERIVED_DATABASE_URL=%s" in action
+    assert 'printf \'%s\' "$value"' in action
+    assert 'printf \'%s\\n\' "$dsn"' not in action


### PR DESCRIPTION
## What this does

Adds the missing operator lane for the first real Ratings V4 production generation.

- `ratings-v4-generation-start` stages an exact trusted-`main` bundle, downloads the two importer-only runtime dependencies as pinned Linux/CPython 3.14 wheels on the GitHub runner, then launches a detached worker container on the existing production application network.
- `ratings-v4-generation-status` reports the worker state plus the latest `v3_meta.derived_generation` lifecycle/chunk progress without changing anything.
- The worker is bounded to 2 CPUs, 12 GiB RAM and 512 pids, mounts the retained galaxy artifact and trusted source read-only, and uses the active API's existing PostgreSQL DSN without printing it.
- The generation key is tied to the current canonical publication sequence, so reruns resume the same generation and a changed canonical publication cannot silently reuse it.

## Safety boundary

This operation can write **derived generation data only** through the existing `scripts/ratings_v4/run_generation.py` lifecycle. It cannot apply migrations, change canonical data, restart the application, or publish a derived generation. Publication remains a separate explicit decision after the generation reaches READY/VERIFIED.

The push-request lane remains data-only: a request file may contain only `{ "operation": ... }`, while the implementation is always checked out from trusted `main` before SSH execution.

## Runtime shape

The production API image intentionally does not carry `psycopg` or `ijson`; the workflow therefore downloads the exact pinned importer wheels before connecting to production and installs them offline into the temporary worker at startup. No production internet dependency is introduced.

## Verification

Adds focused guards covering the trusted-main request path, resource limits, read-only mounts, pinned offline dependencies, secret handling, and the explicit no-publish/no-migration boundary.