### PR TITLE
Fix Ratings V4 acceleration worker-name guard

### DIFF
--- a/scripts/operator/actions/ratings-v4-accelerate.sh
+++ b/scripts/operator/actions/ratings-v4-accelerate.sh
@@ -26,10 +26,8 @@ mapfile -t workers < <(docker ps --filter "label=${OPERATION_LABEL}" --format '{
 [ "${#workers[@]}" -eq 1 ] || fail "expected exactly one running Ratings V4 worker, found ${#workers[@]}"
 worker="${workers[0]}"
 
-case "$worker" in
-  edfinder-ratings-v4-prod-p[1-9][0-9]*) ;;
-  *) fail "unexpected Ratings V4 worker name" ;;
-esac
+[[ "$worker" =~ ^edfinder-ratings-v4-prod-p[1-9][0-9]*$ ]] \
+  || fail "unexpected Ratings V4 worker name"
 
 [ "$(docker inspect -f '{{.State.Running}}' "$worker")" = "true" ] || fail "Ratings V4 worker is not running"
 


### PR DESCRIPTION
The acceleration guard used a shell glob that accidentally required at least two digits after `p`, so the real worker `edfinder-ratings-v4-prod-p4` was rejected before any update. Replace it with an anchored regex accepting publication sequence 4 and future positive integer sequences. No production change occurred in the failed attempt.