### PR TITLE
Fix Ratings V4 worker memory ceiling update

### DIFF
--- a/scripts/operator/actions/ratings-v4-accelerate.sh
+++ b/scripts/operator/actions/ratings-v4-accelerate.sh
@@ -6,6 +6,7 @@ TARGET_FQDN="nb79a3d.mevnode.com"
 OPERATION_LABEL="ed-finder.operation=ratings-v4-generation"
 TARGET_CPUS="16"
 TARGET_MEMORY="64g"
+TARGET_MEMORY_SWAP="64g"
 TARGET_MEMORY_BYTES="68719476736"
 TARGET_NANO_CPUS="16000000000"
 TARGET_PIDS="512"
@@ -31,18 +32,20 @@ worker="${workers[0]}"
 
 [ "$(docker inspect -f '{{.State.Running}}' "$worker")" = "true" ] || fail "Ratings V4 worker is not running"
 
-before="$(docker inspect -f '{{.HostConfig.NanoCpus}} {{.HostConfig.Memory}} {{.HostConfig.PidsLimit}}' "$worker")"
+before="$(docker inspect -f '{{.HostConfig.NanoCpus}} {{.HostConfig.Memory}} {{.HostConfig.MemorySwap}} {{.HostConfig.PidsLimit}}' "$worker")"
 
 docker update \
   --cpus "$TARGET_CPUS" \
   --memory "$TARGET_MEMORY" \
+  --memory-swap "$TARGET_MEMORY_SWAP" \
   --pids-limit "$TARGET_PIDS" \
   "$worker" >/dev/null
 
-after="$(docker inspect -f '{{.HostConfig.NanoCpus}} {{.HostConfig.Memory}} {{.HostConfig.PidsLimit}}' "$worker")"
-read -r nano_cpus memory_bytes pids <<< "$after"
+after="$(docker inspect -f '{{.HostConfig.NanoCpus}} {{.HostConfig.Memory}} {{.HostConfig.MemorySwap}} {{.HostConfig.PidsLimit}}' "$worker")"
+read -r nano_cpus memory_bytes memory_swap_bytes pids <<< "$after"
 [ "$nano_cpus" = "$TARGET_NANO_CPUS" ] || fail "CPU limit verification failed"
 [ "$memory_bytes" = "$TARGET_MEMORY_BYTES" ] || fail "memory limit verification failed"
+[ "$memory_swap_bytes" = "$TARGET_MEMORY_BYTES" ] || fail "memory-swap limit verification failed"
 [ "$pids" = "$TARGET_PIDS" ] || fail "pid limit verification failed"
 
 printf 'operation=ratings-v4-generation-accelerate\n'
@@ -51,6 +54,7 @@ printf 'worker_container=%s\n' "$worker"
 printf 'before_limits=%s\n' "$before"
 printf 'cpu_limit=%s\n' "$TARGET_CPUS"
 printf 'memory_limit=%s\n' "$TARGET_MEMORY"
+printf 'memory_swap_limit=%s\n' "$TARGET_MEMORY_SWAP"
 printf 'pids_limit=%s\n' "$TARGET_PIDS"
 printf 'worker_running=%s\n' "$(docker inspect -f '{{.State.Running}}' "$worker")"
 printf 'publication_performed=false\n'


### PR DESCRIPTION
Docker correctly refused the 64 GiB memory increase because the worker still had its original lower memory+swap ceiling. Update memory and memory-swap together, both to 64 GiB, and verify both values after the in-place change. This preserves the no-restart/no-publication boundary.