### PR TITLE
Parallelize and benchmark Ratings V4 production generation

### DIFF
--- a/.github/workflows/ratings-v4-production-optimize.yml
+++ b/.github/workflows/ratings-v4-production-optimize.yml
@@ -1,0 +1,128 @@
+name: Ratings V4 production optimization
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/ratings-v4-optimize-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chatgpt-ed-new-ops
+  cancel-in-progress: false
+
+jobs:
+  optimize:
+    name: Cut over to parallel Ratings V4 generation
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 10
+    steps:
+      - name: Checkout request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Validate data-only request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one request file" >&2; exit 64; }
+          case "${changed_files[0]}" in
+            .github/ratings-v4-optimize-requests/*.json) ;;
+            *) echo "Unexpected request path" >&2; exit 64 ;;
+          esac
+          python - "${changed_files[0]}" <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if data != {"operation": "ratings-v4-generation-optimize"}:
+              raise SystemExit("unsupported request")
+          PY
+
+      - name: Checkout trusted implementation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Set up CPython 3.14
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Prepare offline generation bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_sha="$(git -C trusted-main rev-parse HEAD)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || exit 64
+          printf '%s\n' "$source_sha" > trusted-main/.ratings-v4-source-sha
+          rm -rf trusted-main/.ratings-v4-wheelhouse
+          mkdir -p trusted-main/.ratings-v4-wheelhouse
+          python -m pip download --disable-pip-version-check --only-binary=:all: \
+            --dest trusted-main/.ratings-v4-wheelhouse \
+            'psycopg[binary]==3.3.4' 'ijson==3.5.1'
+
+      - name: Prepare pinned SSH trust
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" && test -n "$SSH_HOST" && test -n "$SSH_PORT" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Stage trusted main and cut over
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/ratings-v4-optimization.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          source_sha="$(git -C trusted-main rev-parse HEAD)"
+          stage="/var/tmp/edfinder-ratings-v4-${source_sha}"
+          tar -C trusted-main --exclude=.git -cf - . | \
+            ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              "set -eu; umask 077; rm -rf '$stage'; mkdir -p '$stage'; tar --no-same-owner --no-same-permissions -C '$stage' -xf -"
+          ssh -i ~/.ssh/ed_new_operator_key \
+              -p "$SSH_PORT" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              "$SSH_USER@$SSH_HOST" \
+              "bash -s -- '$stage' '$source_sha'" \
+              < trusted-main/scripts/operator/actions/ratings-v4-optimize.sh | tee "$RECEIPT"
+
+      - name: Upload optimization receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ratings-v4-production-optimization
+          path: ${{ runner.temp }}/ratings-v4-optimization.txt
+          if-no-files-found: ignore
+          retention-days: 30

--- a/scripts/operator/actions/ratings-v4-optimize.sh
+++ b/scripts/operator/actions/ratings-v4-optimize.sh
@@ -135,7 +135,7 @@ esac
 [ -f "$REPO_ROOT/scripts/ratings_v4/production_generation.py" ] || fail "generation builder is missing"
 [ -d "$REPO_ROOT/.ratings-v4-wheelhouse" ] || fail "offline dependency wheelhouse is missing"
 
-grep -F "--workers" "$REPO_ROOT/scripts/ratings_v4/run_generation.py" >/dev/null \
+grep -F -- "--workers" "$REPO_ROOT/scripts/ratings_v4/run_generation.py" >/dev/null \
   || fail "trusted runner has no parallel worker contract"
 
 install -d -m 700 "$STATE_ROOT"
@@ -170,6 +170,10 @@ api_image="$(docker inspect -f '{{.Config.Image}}' "$api")"
 dsn="$(api_database_url "$api")"
 
 if docker inspect "$new_worker" >/dev/null 2>&1; then
+  new_key_label="$(docker inspect -f '{{index .Config.Labels "ed-finder.generation-key"}}' "$new_worker")"
+  new_source_label="$(docker inspect -f '{{index .Config.Labels "ed-finder.source-sha"}}' "$new_worker")"
+  [ "$new_key_label" = "$new_generation_key" ] || fail "existing optimized worker generation identity mismatch"
+  [ "$new_source_label" = "$SOURCE_SHA" ] || fail "existing optimized worker code identity differs from trusted main"
   new_state="$(docker inspect -f '{{.State.Status}}' "$new_worker")"
   if [ "$new_state" != "running" ]; then
     docker rm "$new_worker" >/dev/null
@@ -184,6 +188,8 @@ if ! docker inspect "$new_worker" >/dev/null 2>&1; then
     printf 'RATINGS_V4_DERIVED_DATABASE_URL=%s\n' "$dsn"
     printf 'RATINGS_V4_SOURCE=/source/galaxy.json.gz\n'
     printf 'RATINGS_V4_GENERATION_KEY=%s\n' "$new_generation_key"
+    printf 'RATINGS_V4_CHUNK_SIZE=%s\n' "$TARGET_CHUNK_SIZE"
+    printf 'RATINGS_V4_ENCODER_WORKERS=%s\n' "$TARGET_WORKERS"
   } > "$env_file"
   chmod 600 "$env_file"
 
@@ -193,6 +199,8 @@ if ! docker inspect "$new_worker" >/dev/null 2>&1; then
     --label "ed-finder.generation-key=${new_generation_key}" \
     --label "ed-finder.source-sha=${SOURCE_SHA}" \
     --label "ed-finder.optimization=parallel-encoding-v1" \
+    --label "ed-finder.chunk-size=${TARGET_CHUNK_SIZE}" \
+    --label "ed-finder.encoder-workers=${TARGET_WORKERS}" \
     --network "$APPLICATION_NETWORK" \
     --cpus "$TARGET_CPUS" \
     --memory "$TARGET_MEMORY" \
@@ -217,8 +225,8 @@ if ! docker inspect "$new_worker" >/dev/null 2>&1; then
       exec /app/.venv/bin/python scripts/ratings_v4/run_generation.py \
         --source "$RATINGS_V4_SOURCE" \
         --generation-key "$RATINGS_V4_GENERATION_KEY" \
-        --chunk-size 1000 \
-        --workers 8
+        --chunk-size "$RATINGS_V4_CHUNK_SIZE" \
+        --workers "$RATINGS_V4_ENCODER_WORKERS"
     ' >/dev/null
   rm -f "$env_file"
 fi

--- a/scripts/operator/actions/ratings-v4-optimize.sh
+++ b/scripts/operator/actions/ratings-v4-optimize.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${1:-}"
+SOURCE_SHA="${2:-}"
+
+TARGET_HOSTNAME="ed-finder-prod"
+TARGET_FQDN="nb79a3d.mevnode.com"
+POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_USER="edfinder_v3"
+DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5"
+APPLICATION_NETWORK="edfinder-v3-production"
+OPERATION_LABEL="ed-finder.operation=ratings-v4-generation"
+STATE_ROOT="${HOME}/.local/state/ed-finder/ratings-v4"
+TARGET_CPUS="16"
+TARGET_MEMORY="64g"
+TARGET_WORKERS="8"
+TARGET_CHUNK_SIZE="1000"
+MIN_PROOF_CHUNKS="2"
+
+fail() {
+  printf 'ratings-v4 optimize: %s\n' "$*" >&2
+  exit 64
+}
+
+require_target() {
+  command -v docker >/dev/null 2>&1 || fail "docker is unavailable"
+  [ "$(hostname)" = "$TARGET_HOSTNAME" ] || fail "unexpected hostname"
+  [ "$(hostname -f 2>/dev/null || true)" = "$TARGET_FQDN" ] || fail "unexpected fqdn"
+  [ "$(docker context show)" = "default" ] || fail "unexpected docker context"
+  docker context inspect default 2>/dev/null | grep -F 'unix:///var/run/docker.sock' >/dev/null \
+    || fail "default docker context is not the local rootful socket"
+  docker inspect "$POSTGRES_CONTAINER" >/dev/null 2>&1 || fail "retained postgres container is unavailable"
+  [ "$(docker inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER")" = "true" ] \
+    || fail "retained postgres container is not running"
+}
+
+db_query() {
+  docker exec "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+    --tuples-only --no-align --quiet --set ON_ERROR_STOP=1 \
+    --username "$DATABASE_USER" --dbname "$DATABASE_NAME" --command "$1"
+}
+
+active_api_container() {
+  local -a matches=()
+  local container service
+  while IFS= read -r container; do
+    [ -n "$container" ] || continue
+    service="$(docker inspect -f '{{index .Config.Labels "com.docker.compose.service"}}' "$container")"
+    case "$service" in
+      api-*) matches+=("$container") ;;
+    esac
+  done < <(docker ps --filter "label=com.docker.compose.project=${APPLICATION_NETWORK}" --format '{{.Names}}')
+  [ "${#matches[@]}" -eq 1 ] || fail "expected exactly one running production API slot, found ${#matches[@]}"
+  printf '%s\n' "${matches[0]}"
+}
+
+api_database_url() {
+  local api="$1" value count
+  value="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$api" | sed -n 's/^DATABASE_URL=//p')"
+  count="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$api" | grep -c '^DATABASE_URL=' || true)"
+  [ "$count" -eq 1 ] || fail "active API does not expose exactly one DATABASE_URL"
+  case "$value" in
+    postgresql://*|postgres://*) ;;
+    *) fail "active API DATABASE_URL is not a PostgreSQL DSN" ;;
+  esac
+  printf '%s' "$value"
+}
+
+source_metadata() {
+  db_query "BEGIN READ ONLY; SELECT c.publication_sequence::text || E'\\t' || g.generation_id::text || E'\\t' || a.size_bytes::text || E'\\t' || encode(a.content_sha256,'hex') || E'\\t' || a.storage_locator FROM v3_meta.current_canonical_generation c JOIN v3_meta.canonical_generation g USING(generation_id) JOIN v3_source.source_run r ON r.source_run_id=g.build_source_run_id JOIN v3_source.source_artifact a ON a.artifact_id=r.artifact_id WHERE g.lifecycle_state='PUBLISHED'; COMMIT;"
+}
+
+resolve_source_path() {
+  local locator="$1" expected_size="$2"
+  local -a candidates=()
+  local id src dst rel candidate root base actual_size
+
+  case "$locator" in
+    /*) ;;
+    *) fail "canonical artifact storage locator is not an absolute path" ;;
+  esac
+  [[ "$locator" != *$'\n'* && "$locator" != *$'\r'* && "$locator" != *:* ]] \
+    || fail "canonical artifact storage locator is unsafe"
+
+  if [ -f "$locator" ] && [ ! -L "$locator" ]; then
+    actual_size="$(stat -c '%s' "$locator")"
+    [ "$actual_size" = "$expected_size" ] && candidates+=("$locator")
+  fi
+
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    while IFS=$'\t' read -r src dst; do
+      [ -n "$src" ] && [ -n "$dst" ] || continue
+      if [ "$locator" = "$dst" ]; then
+        candidate="$src"
+      elif [[ "$locator" == "$dst/"* ]]; then
+        rel="${locator#"$dst"}"
+        candidate="${src}${rel}"
+      else
+        continue
+      fi
+      if [ -f "$candidate" ] && [ ! -L "$candidate" ] && [ "$(stat -c '%s' "$candidate")" = "$expected_size" ]; then
+        candidates+=("$candidate")
+      fi
+    done < <(docker inspect -f '{{range .Mounts}}{{printf "%s\t%s\n" .Source .Destination}}{{end}}' "$id")
+  done < <(docker ps -aq)
+
+  if [ "${#candidates[@]}" -eq 0 ]; then
+    base="$(basename "$locator")"
+    for root in /data /srv /opt "$HOME"; do
+      [ -d "$root" ] || continue
+      while IFS= read -r candidate; do
+        [ -n "$candidate" ] && candidates+=("$candidate")
+      done < <(find "$root" -xdev -type f -name "$base" -size "${expected_size}c" -print 2>/dev/null)
+    done
+  fi
+
+  mapfile -t candidates < <(printf '%s\n' "${candidates[@]}" | awk 'NF && !seen[$0]++')
+  [ "${#candidates[@]}" -eq 1 ] \
+    || fail "expected exactly one retained canonical artifact with the reviewed size, found ${#candidates[@]}"
+  printf '%s\n' "${candidates[0]}"
+}
+
+require_target
+[ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] || fail "trusted main bundle path is required"
+[[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "trusted main SHA is invalid"
+case "$REPO_ROOT" in
+  /var/tmp/edfinder-ratings-v4-"$SOURCE_SHA") ;;
+  *) fail "trusted main bundle path is outside the reviewed staging namespace" ;;
+esac
+[ "$(cat "$REPO_ROOT/.ratings-v4-source-sha" 2>/dev/null || true)" = "$SOURCE_SHA" ] \
+  || fail "trusted main bundle SHA marker mismatch"
+[ -f "$REPO_ROOT/scripts/ratings_v4/run_generation.py" ] || fail "generation runner is missing"
+[ -f "$REPO_ROOT/scripts/ratings_v4/production_generation.py" ] || fail "generation builder is missing"
+[ -d "$REPO_ROOT/.ratings-v4-wheelhouse" ] || fail "offline dependency wheelhouse is missing"
+
+grep -F "--workers" "$REPO_ROOT/scripts/ratings_v4/run_generation.py" >/dev/null \
+  || fail "trusted runner has no parallel worker contract"
+
+install -d -m 700 "$STATE_ROOT"
+command -v flock >/dev/null 2>&1 || fail "flock is unavailable"
+exec 9>"$STATE_ROOT/start.lock"
+flock -n 9 || fail "another Ratings V4 generation operation is in progress"
+
+metadata="$(source_metadata)"
+[ "$(printf '%s\n' "$metadata" | wc -l)" -eq 1 ] || fail "canonical source metadata is ambiguous"
+IFS=$'\t' read -r sequence canonical_generation expected_size expected_sha storage_locator <<< "$metadata"
+[[ "$sequence" =~ ^[1-9][0-9]*$ ]] || fail "canonical publication sequence is invalid"
+[[ "$canonical_generation" =~ ^[0-9a-f-]{36}$ ]] || fail "canonical generation id is invalid"
+[[ "$expected_size" =~ ^[1-9][0-9]*$ ]] || fail "canonical artifact size is invalid"
+[[ "$expected_sha" =~ ^[0-9a-f]{64}$ ]] || fail "canonical artifact sha256 is invalid"
+[ -n "$storage_locator" ] || fail "canonical artifact storage locator is empty"
+
+source_path="$(resolve_source_path "$storage_locator" "$expected_size")"
+old_generation_key="ratings_v4_prod_p${sequence}"
+old_worker="edfinder-ratings-v4-prod-p${sequence}"
+new_generation_key="ratings_v4_prod_p${sequence}_opt1"
+new_worker="edfinder-ratings-v4-prod-p${sequence}-opt1"
+
+# The original container is the rollback path. It may be running (first cutover)
+# or stopped (idempotent retry), but it must never be removed by this operation.
+docker inspect "$old_worker" >/dev/null 2>&1 || fail "original Ratings V4 worker is unavailable for rollback"
+old_key_label="$(docker inspect -f '{{index .Config.Labels "ed-finder.generation-key"}}' "$old_worker")"
+[ "$old_key_label" = "$old_generation_key" ] || fail "original worker generation identity mismatch"
+
+api="$(active_api_container)"
+api_image="$(docker inspect -f '{{.Config.Image}}' "$api")"
+[ -n "$api_image" ] || fail "active API image identity is empty"
+dsn="$(api_database_url "$api")"
+
+if docker inspect "$new_worker" >/dev/null 2>&1; then
+  new_state="$(docker inspect -f '{{.State.Status}}' "$new_worker")"
+  if [ "$new_state" != "running" ]; then
+    docker rm "$new_worker" >/dev/null
+  fi
+fi
+
+if ! docker inspect "$new_worker" >/dev/null 2>&1; then
+  env_file="$STATE_ROOT/${new_generation_key}.env"
+  umask 077
+  {
+    printf 'RATINGS_V4_CANONICAL_DATABASE_URL=%s\n' "$dsn"
+    printf 'RATINGS_V4_DERIVED_DATABASE_URL=%s\n' "$dsn"
+    printf 'RATINGS_V4_SOURCE=/source/galaxy.json.gz\n'
+    printf 'RATINGS_V4_GENERATION_KEY=%s\n' "$new_generation_key"
+  } > "$env_file"
+  chmod 600 "$env_file"
+
+  docker run -d \
+    --name "$new_worker" \
+    --label "$OPERATION_LABEL" \
+    --label "ed-finder.generation-key=${new_generation_key}" \
+    --label "ed-finder.source-sha=${SOURCE_SHA}" \
+    --label "ed-finder.optimization=parallel-encoding-v1" \
+    --network "$APPLICATION_NETWORK" \
+    --cpus "$TARGET_CPUS" \
+    --memory "$TARGET_MEMORY" \
+    --memory-swap "$TARGET_MEMORY" \
+    --pids-limit 512 \
+    --restart no \
+    --log-driver json-file \
+    --log-opt max-size=20m \
+    --log-opt max-file=3 \
+    --env-file "$env_file" \
+    --mount "type=bind,src=${REPO_ROOT},dst=/work,readonly" \
+    --mount "type=bind,src=${source_path},dst=/source/galaxy.json.gz,readonly" \
+    --entrypoint /bin/sh \
+    "$api_image" -lc '
+      set -eu
+      /usr/local/bin/python -m pip install --disable-pip-version-check --no-input --no-index \
+        --find-links /work/.ratings-v4-wheelhouse --target /tmp/ratings-v4-deps \
+        "psycopg[binary]==3.3.4" "ijson==3.5.1"
+      export PYTHONPATH="/tmp/ratings-v4-deps:/work:/work/apps/api/src"
+      cd /work
+      /app/.venv/bin/python scripts/ratings_v4/verify_freeze.py >/tmp/ratings-v4-freeze-receipt.json
+      exec /app/.venv/bin/python scripts/ratings_v4/run_generation.py \
+        --source "$RATINGS_V4_SOURCE" \
+        --generation-key "$RATINGS_V4_GENERATION_KEY" \
+        --chunk-size 1000 \
+        --workers 8
+    ' >/dev/null
+  rm -f "$env_file"
+fi
+
+# Prove the new immutable generation is genuinely committing chunks before the
+# original worker is stopped. A failed proof leaves the original worker alone.
+proof_chunks=0
+for _ in $(seq 1 45); do
+  [ "$(docker inspect -f '{{.State.Running}}' "$new_worker" 2>/dev/null || true)" = "true" ] \
+    || { docker logs --tail 80 "$new_worker" >&2 || true; fail "optimized worker exited before cutover proof"; }
+  proof_chunks="$(db_query "BEGIN READ ONLY; SELECT count(*) FROM v3_derived.build_chunk b JOIN v3_meta.derived_generation g USING(derived_generation_id) WHERE g.generation_key='${new_generation_key}'; COMMIT;")"
+  [[ "$proof_chunks" =~ ^[0-9]+$ ]] || fail "optimized generation proof query was invalid"
+  if [ "$proof_chunks" -ge "$MIN_PROOF_CHUNKS" ]; then
+    break
+  fi
+  sleep 2
+done
+[ "$proof_chunks" -ge "$MIN_PROOF_CHUNKS" ] || fail "optimized worker did not prove chunk progress"
+
+old_was_running="$(docker inspect -f '{{.State.Running}}' "$old_worker")"
+if [ "$old_was_running" = "true" ]; then
+  docker stop --time 30 "$old_worker" >/dev/null
+fi
+[ "$(docker inspect -f '{{.State.Running}}' "$new_worker")" = "true" ] || fail "optimized worker stopped during cutover"
+[ "$(docker inspect -f '{{.State.Running}}' "$old_worker")" = "false" ] || fail "original worker did not stop"
+
+printf 'operation=ratings-v4-generation-optimize\n'
+printf 'result=optimized-worker-proven-and-cut-over\n'
+printf 'source_sha=%s\n' "$SOURCE_SHA"
+printf 'canonical_generation_id=%s\n' "$canonical_generation"
+printf 'canonical_publication_sequence=%s\n' "$sequence"
+printf 'source_artifact_sha256=%s\n' "$expected_sha"
+printf 'new_generation_key=%s\n' "$new_generation_key"
+printf 'new_worker=%s\n' "$new_worker"
+printf 'proof_chunks=%s\n' "$proof_chunks"
+printf 'chunk_size=%s\n' "$TARGET_CHUNK_SIZE"
+printf 'encoder_workers=%s\n' "$TARGET_WORKERS"
+printf 'cpu_limit=%s\n' "$TARGET_CPUS"
+printf 'memory_limit=%s\n' "$TARGET_MEMORY"
+printf 'new_worker_running=true\n'
+printf 'old_worker=%s\n' "$old_worker"
+printf 'old_worker_was_running=%s\n' "$old_was_running"
+printf 'old_worker_retained=true\n'
+printf 'old_worker_running=false\n'
+printf 'publication_performed=false\n'
+printf 'migrations_performed=false\n'
+printf 'canonical_writes_performed=false\n'
+printf 'old_generation_deleted=false\n'
+printf 'new_generation_published=false\n'
+printf 'latest_new_worker_log_tail:\n'
+docker logs --tail 20 "$new_worker" 2>&1 | sed 's/^/  /' || true

--- a/scripts/operator/actions/ratings-v4-optimize.sh
+++ b/scripts/operator/actions/ratings-v4-optimize.sh
@@ -17,6 +17,8 @@ TARGET_MEMORY="64g"
 TARGET_WORKERS="8"
 TARGET_CHUNK_SIZE="1000"
 MIN_PROOF_CHUNKS="2"
+BENCHMARK_SECONDS="60"
+MIN_ACCEPTED_SYSTEMS_PER_SECOND="500"
 
 fail() {
   printf 'ratings-v4 optimize: %s\n' "$*" >&2
@@ -122,6 +124,31 @@ resolve_source_path() {
   printf '%s\n' "${candidates[0]}"
 }
 
+new_worker_started_by_operation=false
+old_worker_paused_by_operation=false
+old_worker_stopped_by_operation=false
+cutover_committed=false
+old_worker=""
+new_worker=""
+
+rollback_on_exit() {
+  status=$?
+  trap - EXIT
+  if [ "$status" -ne 0 ] && [ "$cutover_committed" != "true" ]; then
+    if [ "$old_worker_paused_by_operation" = "true" ] && [ -n "$old_worker" ]; then
+      docker unpause "$old_worker" >/dev/null 2>&1 || true
+    fi
+    if [ "$old_worker_stopped_by_operation" = "true" ] && [ -n "$old_worker" ]; then
+      docker start "$old_worker" >/dev/null 2>&1 || true
+    fi
+    if [ "$new_worker_started_by_operation" = "true" ] && [ -n "$new_worker" ]; then
+      docker stop --time 10 "$new_worker" >/dev/null 2>&1 || true
+    fi
+  fi
+  exit "$status"
+}
+trap rollback_on_exit EXIT
+
 require_target
 [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] || fail "trusted main bundle path is required"
 [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "trusted main SHA is invalid"
@@ -158,8 +185,8 @@ old_worker="edfinder-ratings-v4-prod-p${sequence}"
 new_generation_key="ratings_v4_prod_p${sequence}_opt1"
 new_worker="edfinder-ratings-v4-prod-p${sequence}-opt1"
 
-# The original container is the rollback path. It may be running (first cutover)
-# or stopped (idempotent retry), but it must never be removed by this operation.
+# The original container is the rollback path. It is paused only for the clean
+# benchmark and is never deleted by this operation.
 docker inspect "$old_worker" >/dev/null 2>&1 || fail "original Ratings V4 worker is unavailable for rollback"
 old_key_label="$(docker inspect -f '{{index .Config.Labels "ed-finder.generation-key"}}' "$old_worker")"
 [ "$old_key_label" = "$old_generation_key" ] || fail "original worker generation identity mismatch"
@@ -229,10 +256,11 @@ if ! docker inspect "$new_worker" >/dev/null 2>&1; then
         --workers "$RATINGS_V4_ENCODER_WORKERS"
     ' >/dev/null
   rm -f "$env_file"
+  new_worker_started_by_operation=true
 fi
 
 # Prove the new immutable generation is genuinely committing chunks before the
-# original worker is stopped. A failed proof leaves the original worker alone.
+# original worker is even paused. A failed proof leaves the original untouched.
 proof_chunks=0
 for _ in $(seq 1 45); do
   [ "$(docker inspect -f '{{.State.Running}}' "$new_worker" 2>/dev/null || true)" = "true" ] \
@@ -247,11 +275,40 @@ done
 [ "$proof_chunks" -ge "$MIN_PROOF_CHUNKS" ] || fail "optimized worker did not prove chunk progress"
 
 old_was_running="$(docker inspect -f '{{.State.Running}}' "$old_worker")"
+benchmark_rate="not-run"
+benchmark_delta_systems="0"
 if [ "$old_was_running" = "true" ]; then
+  # Pause preserves the exact old process/source position while removing its CPU
+  # and I/O competition from the real-galaxy throughput sample.
+  docker pause "$old_worker" >/dev/null
+  old_worker_paused_by_operation=true
+  benchmark_start_systems="$(db_query "BEGIN READ ONLY; SELECT COALESCE(sum(b.systems),0) FROM v3_derived.build_chunk b JOIN v3_meta.derived_generation g USING(derived_generation_id) WHERE g.generation_key='${new_generation_key}'; COMMIT;")"
+  [[ "$benchmark_start_systems" =~ ^[0-9]+$ ]] || fail "benchmark start count was invalid"
+  sleep "$BENCHMARK_SECONDS"
+  [ "$(docker inspect -f '{{.State.Running}}' "$new_worker")" = "true" ] || fail "optimized worker stopped during benchmark"
+  benchmark_end_systems="$(db_query "BEGIN READ ONLY; SELECT COALESCE(sum(b.systems),0) FROM v3_derived.build_chunk b JOIN v3_meta.derived_generation g USING(derived_generation_id) WHERE g.generation_key='${new_generation_key}'; COMMIT;")"
+  [[ "$benchmark_end_systems" =~ ^[0-9]+$ ]] || fail "benchmark end count was invalid"
+  benchmark_delta_systems=$((benchmark_end_systems - benchmark_start_systems))
+  [ "$benchmark_delta_systems" -ge 0 ] || fail "optimized generation count went backwards"
+  benchmark_rate=$((benchmark_delta_systems / BENCHMARK_SECONDS))
+  printf 'benchmark_seconds=%s\n' "$BENCHMARK_SECONDS"
+  printf 'benchmark_delta_systems=%s\n' "$benchmark_delta_systems"
+  printf 'benchmark_systems_per_second=%s\n' "$benchmark_rate"
+  printf 'minimum_accepted_systems_per_second=%s\n' "$MIN_ACCEPTED_SYSTEMS_PER_SECOND"
+  if [ "$benchmark_rate" -lt "$MIN_ACCEPTED_SYSTEMS_PER_SECOND" ]; then
+    printf 'result=optimization-benchmark-rejected\n'
+    fail "optimized throughput did not justify abandoning original progress"
+  fi
+
+  docker unpause "$old_worker" >/dev/null
+  old_worker_paused_by_operation=false
   docker stop --time 30 "$old_worker" >/dev/null
+  old_worker_stopped_by_operation=true
 fi
+
 [ "$(docker inspect -f '{{.State.Running}}' "$new_worker")" = "true" ] || fail "optimized worker stopped during cutover"
 [ "$(docker inspect -f '{{.State.Running}}' "$old_worker")" = "false" ] || fail "original worker did not stop"
+cutover_committed=true
 
 printf 'operation=ratings-v4-generation-optimize\n'
 printf 'result=optimized-worker-proven-and-cut-over\n'
@@ -266,6 +323,8 @@ printf 'chunk_size=%s\n' "$TARGET_CHUNK_SIZE"
 printf 'encoder_workers=%s\n' "$TARGET_WORKERS"
 printf 'cpu_limit=%s\n' "$TARGET_CPUS"
 printf 'memory_limit=%s\n' "$TARGET_MEMORY"
+printf 'benchmark_systems_per_second=%s\n' "$benchmark_rate"
+printf 'benchmark_delta_systems=%s\n' "$benchmark_delta_systems"
 printf 'new_worker_running=true\n'
 printf 'old_worker=%s\n' "$old_worker"
 printf 'old_worker_was_running=%s\n' "$old_was_running"

--- a/scripts/ratings_v4/run_generation.py
+++ b/scripts/ratings_v4/run_generation.py
@@ -121,6 +121,17 @@ def _emit_progress(progress, identifier, ordinal, systems, written):
         })
 
 
+def _compact_source_records(records):
+    """Keep only source fields that participate in V4 adaptation/checkpointing."""
+    return tuple({
+        'id64': record['id64'],
+        'bodies': [
+            {key: body[key] for key in ('id64', 'bodyId', 'type', 'subType', 'updateTime') if key in body}
+            for body in record.get('bodies', [])
+        ],
+    } for record in records)
+
+
 def _drain_oldest(pending, write_connection, identifier, metadata, progress):
     ordinal, systems, canonical, future = pending.popleft()
     payload, checkpoint = future.result()
@@ -183,9 +194,10 @@ def build_generation(read_connection, write_connection, source_path: Path,
                     canonical = snapshot.export_chunk(
                         read_connection, [record['id64'] for record in records],
                     )
+                    compact_records = _compact_source_records(records)
                     future = executor.submit(
                         encode_chunk, identifier, ordinal, canonical,
-                        snapshot.metadata, tuple(records),
+                        snapshot.metadata, compact_records,
                     )
                     pending.append((ordinal, len(records), canonical, future))
                     # Bound memory/IPC while still keeping every encoder busy.

--- a/scripts/ratings_v4/run_generation.py
+++ b/scripts/ratings_v4/run_generation.py
@@ -7,7 +7,10 @@ execution still requires a current, reviewed V3 operation authority.
 from __future__ import annotations
 
 import argparse
+from collections import deque
+from concurrent.futures import ProcessPoolExecutor
 import json
+import multiprocessing
 import os
 from pathlib import Path
 import re
@@ -21,10 +24,12 @@ from scripts.ratings_v4.canonical_stream import (  # noqa: E402
     MAX_CHUNK_SYSTEMS, CanonicalSnapshot, RetainedArtifactStream,
 )
 from scripts.ratings_v4.production_generation import (  # noqa: E402
-    _verify_code, create_generation, seal_source, validate_generation, write_chunk,
+    BODY_COLUMNS, OPPORTUNITY_COLUMNS, VECTOR_COLUMNS, _verify_code,
+    create_generation, encode_chunk, seal_source, validate_generation, write_chunk,
 )
 
 GENERATION_KEY = re.compile(r'[a-z][a-z0-9_]{0,62}\Z')
+MAX_ENCODER_WORKERS = 16
 Progress = Callable[[dict], None]
 
 
@@ -65,12 +70,81 @@ def _generation(connection, snapshot: CanonicalSnapshot, generation_key: str):
     return identifier, state, validation, True
 
 
+def _write_encoded_chunk(connection, generation_id, ordinal, canonical, metadata,
+                         payload, checkpoint):
+    """Commit one already-encoded chunk with the same atomic checks as write_chunk."""
+    from psycopg import sql
+
+    if checkpoint[0] != generation_id or checkpoint[1] != ordinal:
+        raise ValueError('encoded checkpoint identity mismatch')
+    with connection.transaction():
+        generation = connection.execute('''SELECT lifecycle_state,manifest FROM v3_meta.derived_generation
+            WHERE derived_generation_id=%s FOR SHARE''', (generation_id,)).fetchone()
+        if generation is None or generation[0] != 'BUILDING':
+            raise ValueError('generation is not BUILDING')
+        manifest = generation[1]
+        _verify_code(manifest)
+        if (manifest['source_metadata'] != metadata or
+                manifest['canonical_schema'] != canonical['canonical_schema']):
+            raise ValueError('chunk canonical source differs from generation manifest')
+        old = connection.execute('''SELECT source_projection_sha256,canonical_input_sha256,content_sha256
+            FROM v3_derived.build_chunk WHERE derived_generation_id=%s AND chunk_ordinal=%s''',
+            (generation_id, ordinal)).fetchone()
+        if old is not None:
+            if tuple(bytes(item) for item in old) != checkpoint[2:5]:
+                raise ValueError('resumed chunk source/content changed')
+            return False
+        for table, columns, rows in (
+            ('system_rating_vector', VECTOR_COLUMNS, payload['vectors']),
+            ('body_mechanics', BODY_COLUMNS, payload['bodies']),
+            ('economy_opportunity', OPPORTUNITY_COLUMNS, payload['opportunities']),
+        ):
+            command = sql.SQL('COPY v3_derived.{} ({}) FROM STDIN').format(
+                sql.Identifier(table), sql.SQL(',').join(map(sql.Identifier, columns)))
+            with connection.cursor().copy(command) as copy:
+                for row in rows:
+                    copy.write_row(row)
+        connection.execute('''INSERT INTO v3_derived.build_chunk(
+            derived_generation_id,chunk_ordinal,source_projection_sha256,canonical_input_sha256,
+            content_sha256,systems,canonical_bodies,physical_bodies,eligible_opportunities)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)''', checkpoint)
+    return True
+
+
+def _emit_progress(progress, identifier, ordinal, systems, written):
+    if progress is not None:
+        progress({
+            'derived_generation_id': str(identifier),
+            'chunk_ordinal': ordinal,
+            'systems': systems,
+            'written': written,
+        })
+
+
+def _drain_oldest(pending, write_connection, identifier, metadata, progress):
+    ordinal, systems, canonical, future = pending.popleft()
+    payload, checkpoint = future.result()
+    written = _write_encoded_chunk(
+        write_connection, identifier, ordinal, canonical, metadata, payload, checkpoint,
+    )
+    _emit_progress(progress, identifier, ordinal, systems, written)
+    return int(written)
+
+
 def build_generation(read_connection, write_connection, source_path: Path,
                      generation_key: str, *, chunk_size: int = 500,
-                     progress: Progress | None = None) -> dict:
-    """Build or resume one exact generation, validate it, and never publish it."""
+                     workers: int = 1, progress: Progress | None = None) -> dict:
+    """Build or resume one exact generation, validate it, and never publish it.
+
+    Source parsing and canonical reads remain sequential and authoritative. With
+    ``workers > 1``, only pure chunk encoding/scoring is sent to bounded child
+    processes. Encoded chunks are committed in ordinal order by the parent using
+    one derived connection, preserving the existing atomic checkpoint contract.
+    """
     if type(chunk_size) is not int or not 1 <= chunk_size <= MAX_CHUNK_SYSTEMS:
         raise ValueError('chunk size outside bounded contract')
+    if type(workers) is not int or not 1 <= workers <= MAX_ENCODER_WORKERS:
+        raise ValueError('encoder worker count outside bounded contract')
     source_path = Path(source_path)
     if source_path.is_symlink() or not source_path.is_file():
         raise ValueError('retained artifact must be a regular non-symlink file')
@@ -86,23 +160,52 @@ def build_generation(read_connection, write_connection, source_path: Path,
 
     if state == 'BUILDING':
         stream = RetainedArtifactStream(source_path, sha256=digest, size_bytes=size)
-        for ordinal, records in enumerate(stream.chunks(chunk_size)):
-            canonical = snapshot.export_chunk(
-                read_connection, [record['id64'] for record in records],
-            )
-            written = write_chunk(
-                write_connection, identifier, ordinal, canonical,
-                snapshot.metadata, records,
-            )
-            chunks_seen += 1
-            chunks_written += int(written)
-            if progress is not None:
-                progress({
-                    'derived_generation_id': str(identifier),
-                    'chunk_ordinal': ordinal,
-                    'systems': len(records),
-                    'written': written,
-                })
+        if workers == 1:
+            for ordinal, records in enumerate(stream.chunks(chunk_size)):
+                canonical = snapshot.export_chunk(
+                    read_connection, [record['id64'] for record in records],
+                )
+                written = write_chunk(
+                    write_connection, identifier, ordinal, canonical,
+                    snapshot.metadata, records,
+                )
+                chunks_seen += 1
+                chunks_written += int(written)
+                _emit_progress(progress, identifier, ordinal, len(records), written)
+        else:
+            # Explicit spawn avoids depending on Python/platform multiprocessing
+            # defaults and ensures child workers inherit no live DB connection.
+            context = multiprocessing.get_context('spawn')
+            executor = ProcessPoolExecutor(max_workers=workers, mp_context=context)
+            pending = deque()
+            try:
+                for ordinal, records in enumerate(stream.chunks(chunk_size)):
+                    canonical = snapshot.export_chunk(
+                        read_connection, [record['id64'] for record in records],
+                    )
+                    future = executor.submit(
+                        encode_chunk, identifier, ordinal, canonical,
+                        snapshot.metadata, tuple(records),
+                    )
+                    pending.append((ordinal, len(records), canonical, future))
+                    # Bound memory/IPC while still keeping every encoder busy.
+                    if len(pending) >= workers:
+                        chunks_written += _drain_oldest(
+                            pending, write_connection, identifier, snapshot.metadata, progress,
+                        )
+                        chunks_seen += 1
+                while pending:
+                    chunks_written += _drain_oldest(
+                        pending, write_connection, identifier, snapshot.metadata, progress,
+                    )
+                    chunks_seen += 1
+            except BaseException:
+                for _, _, _, future in pending:
+                    future.cancel()
+                executor.shutdown(wait=True, cancel_futures=True)
+                raise
+            else:
+                executor.shutdown(wait=True)
         if stream.receipt is None:
             raise ValueError('retained artifact did not produce a verified EOF receipt')
         seal_source(write_connection, identifier, stream.receipt)
@@ -136,6 +239,7 @@ def parse_args(argv=None):
     parser.add_argument('--source', required=True, type=Path)
     parser.add_argument('--generation-key', required=True)
     parser.add_argument('--chunk-size', type=int, default=500)
+    parser.add_argument('--workers', type=int, default=1)
     return parser.parse_args(argv)
 
 
@@ -153,6 +257,7 @@ def main(argv=None) -> int:
             receipt = build_generation(
                 read_connection, write_connection, args.source,
                 args.generation_key, chunk_size=args.chunk_size,
+                workers=args.workers,
                 progress=lambda item: print(json.dumps({'status': 'PROGRESS', **item}, sort_keys=True)),
             )
     except Exception as exc:  # CLI emits no connection or source exception details.

--- a/tests/test_ratings_v4_optimization_operator.py
+++ b/tests/test_ratings_v4_optimization_operator.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / '.github/workflows/ratings-v4-production-optimize.yml'
+ACTION = ROOT / 'scripts/operator/actions/ratings-v4-optimize.sh'
+RUNNER = ROOT / 'scripts/ratings_v4/run_generation.py'
+
+
+def test_parallel_runner_is_bounded_and_parent_owned_db():
+    runner = RUNNER.read_text(encoding='utf-8')
+    assert 'ProcessPoolExecutor' in runner
+    assert "multiprocessing.get_context('spawn')" in runner
+    assert 'MAX_ENCODER_WORKERS = 16' in runner
+    assert 'if len(pending) >= workers:' in runner
+    assert 'executor.submit(' in runner
+    assert 'encode_chunk, identifier, ordinal, canonical' in runner
+    assert '_write_encoded_chunk(' in runner
+    assert "parser.add_argument('--workers'" in runner
+    assert 'psycopg.connect' in runner
+    assert 'psycopg.connect' not in runner[runner.index('def _drain_oldest'):runner.index('def build_generation')]
+
+
+def test_optimization_request_is_data_only_and_uses_trusted_main():
+    workflow = WORKFLOW.read_text(encoding='utf-8')
+    assert 'ratings-v4-generation-optimize' in workflow
+    assert '.github/ratings-v4-optimize-requests/*.json' in workflow
+    assert 'data != {"operation": "ratings-v4-generation-optimize"}' in workflow
+    assert 'ref: main' in workflow
+    assert 'trusted-main/scripts/operator/actions/ratings-v4-optimize.sh' in workflow
+    assert 'psycopg[binary]==3.3.4' in workflow
+    assert 'ijson==3.5.1' in workflow
+    assert '--only-binary=:all:' in workflow
+
+
+def test_optimized_worker_proves_progress_before_reversible_cutover():
+    action = ACTION.read_text(encoding='utf-8')
+    assert 'new_generation_key="ratings_v4_prod_p${sequence}_opt1"' in action
+    assert 'new_worker="edfinder-ratings-v4-prod-p${sequence}-opt1"' in action
+    assert 'TARGET_CPUS="16"' in action
+    assert 'TARGET_MEMORY="64g"' in action
+    assert 'TARGET_WORKERS="8"' in action
+    assert 'TARGET_CHUNK_SIZE="1000"' in action
+    assert '--chunk-size 1000' in action
+    assert '--workers 8' in action
+    assert '--memory-swap "$TARGET_MEMORY"' in action
+    assert 'MIN_PROOF_CHUNKS="2"' in action
+    assert action.index('proof_chunks=0') < action.index('docker stop --time 30 "$old_worker"')
+    assert 'old_worker_retained=true' in action
+    assert 'old_generation_deleted=false' in action
+    assert 'publication_performed=false' in action
+    assert 'migrations_performed=false' in action
+    assert 'canonical_writes_performed=false' in action
+    assert 'publish_derived_generation(' not in action
+    assert 'docker rm "$old_worker"' not in action
+    assert 'DROP ' not in action
+    assert 'TRUNCATE ' not in action

--- a/tests/test_ratings_v4_optimization_operator.py
+++ b/tests/test_ratings_v4_optimization_operator.py
@@ -34,7 +34,7 @@ def test_optimization_request_is_data_only_and_uses_trusted_main():
     assert '--only-binary=:all:' in workflow
 
 
-def test_optimized_worker_proves_progress_before_reversible_cutover():
+def test_optimized_worker_proves_and_benchmarks_before_reversible_cutover():
     action = ACTION.read_text(encoding='utf-8')
     assert 'new_generation_key="ratings_v4_prod_p${sequence}_opt1"' in action
     assert 'new_worker="edfinder-ratings-v4-prod-p${sequence}-opt1"' in action
@@ -46,7 +46,14 @@ def test_optimized_worker_proves_progress_before_reversible_cutover():
     assert '--workers "$RATINGS_V4_ENCODER_WORKERS"' in action
     assert '--memory-swap "$TARGET_MEMORY"' in action
     assert 'MIN_PROOF_CHUNKS="2"' in action
-    assert action.index('proof_chunks=0') < action.index('docker stop --time 30 "$old_worker"')
+    assert 'BENCHMARK_SECONDS="60"' in action
+    assert 'MIN_ACCEPTED_SYSTEMS_PER_SECOND="500"' in action
+    assert action.index('proof_chunks=0') < action.index('docker pause "$old_worker"')
+    assert action.index('docker pause "$old_worker"') < action.index('sleep "$BENCHMARK_SECONDS"')
+    assert action.index('benchmark_rate=$((benchmark_delta_systems / BENCHMARK_SECONDS))') < action.index('docker stop --time 30 "$old_worker"')
+    assert 'rollback_on_exit()' in action
+    assert 'docker unpause "$old_worker"' in action
+    assert 'docker start "$old_worker"' in action
     assert 'old_worker_retained=true' in action
     assert 'old_generation_deleted=false' in action
     assert 'publication_performed=false' in action

--- a/tests/test_ratings_v4_optimization_operator.py
+++ b/tests/test_ratings_v4_optimization_operator.py
@@ -15,6 +15,7 @@ def test_parallel_runner_is_bounded_and_parent_owned_db():
     assert 'if len(pending) >= workers:' in runner
     assert 'executor.submit(' in runner
     assert 'encode_chunk, identifier, ordinal, canonical' in runner
+    assert '_compact_source_records(records)' in runner
     assert '_write_encoded_chunk(' in runner
     assert "parser.add_argument('--workers'" in runner
     assert 'psycopg.connect' in runner
@@ -41,8 +42,8 @@ def test_optimized_worker_proves_progress_before_reversible_cutover():
     assert 'TARGET_MEMORY="64g"' in action
     assert 'TARGET_WORKERS="8"' in action
     assert 'TARGET_CHUNK_SIZE="1000"' in action
-    assert '--chunk-size 1000' in action
-    assert '--workers 8' in action
+    assert '--chunk-size "$RATINGS_V4_CHUNK_SIZE"' in action
+    assert '--workers "$RATINGS_V4_ENCODER_WORKERS"' in action
     assert '--memory-swap "$TARGET_MEMORY"' in action
     assert 'MIN_PROOF_CHUNKS="2"' in action
     assert action.index('proof_chunks=0') < action.index('docker stop --time 30 "$old_worker"')

--- a/tests/test_ratings_v4_parallel_generation.py
+++ b/tests/test_ratings_v4_parallel_generation.py
@@ -1,0 +1,58 @@
+import gzip
+import hashlib
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from domain.ratings_v4_canonical import load_source_fixture  # noqa: E402
+from scripts.ratings_v4.run_generation import (  # noqa: E402
+    MAX_ENCODER_WORKERS, build_generation,
+)
+from tests.ratings_v4_pg_fixture import canonical_database  # noqa: E402
+
+
+def _retained_source(tmp_path):
+    _, _, payloads = load_source_fixture(ROOT / 'tests/fixtures/ratings_v4_sources')
+    records = [payload['system'] for payload in payloads]
+    compressed = gzip.compress(json.dumps(records).encode(), mtime=0)
+    source = tmp_path / 'galaxy.json.gz'
+    source.write_bytes(compressed)
+    return source, compressed
+
+
+def test_parallel_runner_builds_ordered_atomic_chunks(tmp_path):
+    source, compressed = _retained_source(tmp_path)
+
+    def retained_fixture(_canonical, metadata):
+        metadata['artifact']['content_sha256'] = '\\x' + hashlib.sha256(compressed).hexdigest()
+        metadata['artifact']['size_bytes'] = len(compressed)
+        return ()
+
+    with canonical_database(prepare=retained_fixture) as (connection, _, _, _):
+        connection.execute((ROOT / 'sql/v3/migrations/003_ratings_v4_derived.sql').read_text())
+        receipt = build_generation(
+            connection, connection, source, 'parallel_runner_fixture',
+            chunk_size=3, workers=2,
+        )
+        assert receipt['status'] == 'VERIFIED'
+        assert receipt['lifecycle_state'] == 'READY'
+        assert receipt['chunks_seen'] == 4
+        assert receipt['chunks_written'] == 4
+        assert receipt['publication_performed'] is False
+        chunks = connection.execute('''SELECT chunk_ordinal,systems FROM v3_derived.build_chunk
+            WHERE derived_generation_id=%s ORDER BY chunk_ordinal''',
+            (receipt['derived_generation_id'],)).fetchall()
+        assert chunks == [(0, 3), (1, 3), (2, 3), (3, 3)]
+        assert connection.execute('''SELECT count(*) FROM v3_derived.derived_publication
+            WHERE derived_generation_id=%s''', (receipt['derived_generation_id'],)).fetchone()[0] == 0
+
+
+@pytest.mark.parametrize('workers', [0, MAX_ENCODER_WORKERS + 1, True])
+def test_parallel_worker_count_is_bounded_before_io(workers):
+    with pytest.raises(ValueError, match='worker count'):
+        build_generation(None, None, Path('/does/not/exist'), 'bounded_workers', workers=workers)

--- a/tests/test_ratings_v4_parallel_generation.py
+++ b/tests/test_ratings_v4_parallel_generation.py
@@ -48,8 +48,9 @@ def test_parallel_runner_builds_ordered_atomic_chunks(tmp_path):
             WHERE derived_generation_id=%s ORDER BY chunk_ordinal''',
             (receipt['derived_generation_id'],)).fetchall()
         assert chunks == [(0, 3), (1, 3), (2, 3), (3, 3)]
-        assert connection.execute('''SELECT count(*) FROM v3_derived.derived_publication
-            WHERE derived_generation_id=%s''', (receipt['derived_generation_id'],)).fetchone()[0] == 0
+        assert connection.execute('''SELECT published_at FROM v3_meta.derived_generation
+            WHERE derived_generation_id=%s''',
+            (receipt['derived_generation_id'],)).fetchone()[0] is None
 
 
 @pytest.mark.parametrize('workers', [0, MAX_ENCODER_WORKERS + 1, True])


### PR DESCRIPTION
Optimize the first full Ratings V4 production build without weakening its immutable/checkpointed safety model.

Runner changes:
- keep source parsing and both PostgreSQL connections in the parent process;
- compact raw Spansh batches to only fields consumed by V4 before IPC;
- use a bounded ProcessPoolExecutor for pure scoring/encoding only;
- commit encoded chunks in ordinal order with the same atomic COPY + build_chunk checkpoint checks;
- bound encoder workers to 16; production profile uses 8 workers and 1000-system chunks.

Production cutover:
- launch a separate immutable `ratings_v4_prod_p<sequence>_opt1` generation at 16 CPU / 64 GiB;
- prove real chunk writes before touching the existing worker;
- pause (not restart) the existing worker for a clean 60-second benchmark;
- require >=500 systems/sec versus the observed ~431 systems/sec baseline;
- automatically unpause/restore the old worker and stop the new one if the operation fails before commit;
- only after the benchmark passes, stop but retain the old container as rollback evidence.

No schema change, scorer mechanics change, migration, canonical write, or derived publication is introduced.