### PR TITLE
Build and independently validate the V3 Search projection

### DIFF
--- a/.github/workflows/ratings-v4-production-accelerate.yml
+++ b/.github/workflows/ratings-v4-production-accelerate.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Set up CPython 3.14
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.14"
+
       - name: Validate data-only request
         shell: bash
         env:

--- a/.github/workflows/ratings-v4-production-optimize.yml
+++ b/.github/workflows/ratings-v4-production-optimize.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Set up CPython 3.14
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
       - name: Validate data-only request
         shell: bash
         env:
@@ -52,11 +57,6 @@ jobs:
           ref: main
           path: trusted-main
           persist-credentials: false
-
-      - name: Set up CPython 3.14
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.14"
 
       - name: Prepare offline generation bundle
         shell: bash

--- a/scripts/v3_system_search.py
+++ b/scripts/v3_system_search.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+'''Build and validate the generation-scoped V3 system-search product.
+
+Ratings V4 owns the base derived generation. Search attaches an independent
+manifest and lifecycle to that same generation, consumes only committed Ratings
+chunks plus the pinned canonical generation, and never publishes anything.
+'''
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+import time
+from typing import Callable
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+PRODUCT_CODE = 'system_search'
+PRODUCT_VERSION = 'v3-system-search-1'
+GENERATION_KEY = re.compile(r'[a-z][a-z0-9_]{0,62}\Z')
+SCHEMA_NAME = re.compile(r'v3_gen_[a-z][a-z0-9_]{0,30}\Z')
+Progress = Callable[[dict], None]
+
+
+@dataclass(frozen=True)
+class Generation:
+    identifier: str
+    key: str
+    state: str
+    canonical_generation_id: str
+    canonical_publication_sequence: int
+    canonical_schema: str
+    expected_systems: int
+
+
+def _json(value) -> str:
+    def convert(item):
+        if isinstance(item, (bytes, bytearray, memoryview)):
+            return bytes(item).hex()
+        if isinstance(item, datetime):
+            return item.astimezone(timezone.utc).isoformat()
+        return str(item)
+
+    return json.dumps(
+        value, default=convert, sort_keys=True, separators=(',', ':'),
+        ensure_ascii=True, allow_nan=False,
+    )
+
+
+def _digest(value) -> bytes:
+    return hashlib.sha256(_json(value).encode()).digest()
+
+
+def code_identity(root: Path = ROOT) -> dict[str, str]:
+    files = (
+        'scripts/v3_system_search.py',
+        'sql/v3/migrations/004_v3_search_spatial_clusters.sql',
+        'sql/v3/migrations/006_v3_derived_product_lifecycle.sql',
+    )
+    return {
+        name: hashlib.sha256((root / name).read_bytes()).hexdigest()
+        for name in files
+    }
+
+
+def _generation(connection, generation_key: str) -> Generation:
+    if not GENERATION_KEY.fullmatch(generation_key):
+        raise ValueError('invalid derived generation key')
+    row = connection.execute(
+        '''SELECT derived_generation_id::text,generation_key,lifecycle_state,
+                  canonical_generation_id::text,canonical_publication_sequence,
+                  manifest,expected_systems
+             FROM v3_meta.derived_generation
+            WHERE generation_key=%s''',
+        (generation_key,),
+    ).fetchone()
+    if row is None:
+        raise ValueError('unknown derived generation')
+    manifest = row[5]
+    schema = manifest.get('canonical_schema') if isinstance(manifest, dict) else None
+    if not isinstance(schema, str) or not SCHEMA_NAME.fullmatch(schema):
+        raise ValueError('derived generation has invalid canonical schema')
+    return Generation(
+        identifier=row[0],
+        key=row[1],
+        state=row[2],
+        canonical_generation_id=row[3],
+        canonical_publication_sequence=int(row[4]),
+        canonical_schema=schema,
+        expected_systems=int(row[6]),
+    )
+
+
+def product_manifest(generation: Generation) -> dict:
+    return {
+        'product_code': PRODUCT_CODE,
+        'product_version': PRODUCT_VERSION,
+        'derived_generation_id': generation.identifier,
+        'generation_key': generation.key,
+        'canonical_generation_id': generation.canonical_generation_id,
+        'canonical_publication_sequence': generation.canonical_publication_sequence,
+        'canonical_schema': generation.canonical_schema,
+        'expected_rows': generation.expected_systems,
+        'code_sha256': code_identity(),
+        'field_policy': {
+            'position': 'canonical systems x/y/z; cube point is derived from those exact LY coordinates',
+            'body_count': 'Ratings V4 loaded_body_count for the same generation/system',
+            'landable_count': 'ACTIVE canonical bodies with is_landable=true',
+            'station_count': 'ACTIVE canonical stations',
+            'has_rings': 'positive observation of an ACTIVE canonical RING; asteroid BELT rows do not set this Finder flag',
+            'has_biologicals': 'positive biological signal_count on an ACTIVE canonical body',
+            'has_geologicals': 'positive geological signal_count on an ACTIVE canonical body',
+            'has_terraformable': 'ACTIVE canonical body with terraforming state terraformable/terraformed/terraforming',
+            'main_star_class': 'lowest-body_pk Ratings V4 mechanics body explicitly marked is_main_star=true',
+            'source_observed_at': 'canonical systems.source_updated_at',
+            'completeness': 'minimum of the seven frozen Ratings V4 completeness values',
+            'confidence': 'minimum of the seven frozen Ratings V4 confidence values',
+            'false_flags': 'false means no positive observation in the pinned canonical generation, not proof of known absence',
+        },
+    }
+
+
+def _product(connection, generation_id: str):
+    return connection.execute(
+        '''SELECT product_version,lifecycle_state,manifest,manifest_sha256,
+                  expected_rows,validation_receipt,validation_sha256
+             FROM v3_meta.derived_product
+            WHERE derived_generation_id=%s AND product_code=%s''',
+        (generation_id, PRODUCT_CODE),
+    ).fetchone()
+
+
+def register_product(connection, generation_key: str) -> tuple[Generation, str, bytes]:
+    generation = _generation(connection, generation_key)
+    if generation.state not in {'BUILDING', 'VALIDATING', 'READY'}:
+        raise ValueError('generation cannot accept a Search product')
+    manifest = product_manifest(generation)
+    manifest_sha = _digest(manifest)
+
+    existing = _product(connection, generation.identifier)
+    if existing is None:
+        with connection.transaction():
+            connection.execute(
+                '''INSERT INTO v3_meta.derived_product(
+                       derived_generation_id,product_code,product_version,
+                       manifest,manifest_sha256,expected_rows)
+                   VALUES (%s,%s,%s,%s::jsonb,%s,%s)''',
+                (
+                    generation.identifier, PRODUCT_CODE, PRODUCT_VERSION,
+                    _json(manifest), manifest_sha, generation.expected_systems,
+                ),
+            )
+        existing = _product(connection, generation.identifier)
+
+    if existing is None:
+        raise ValueError('Search product registration failed')
+    if (
+        existing[0] != PRODUCT_VERSION
+        or existing[2] != manifest
+        or bytes(existing[3]) != manifest_sha
+        or int(existing[4]) != generation.expected_systems
+    ):
+        raise ValueError('existing Search product manifest differs from current code/input')
+    return generation, existing[1], manifest_sha
+
+
+def _source_projection_sha(
+    generation: Generation,
+    manifest_sha: bytes,
+    ordinal: int,
+    canonical_input_sha: bytes,
+    ratings_content_sha: bytes,
+) -> bytes:
+    return _digest({
+        'product': PRODUCT_CODE,
+        'product_version': PRODUCT_VERSION,
+        'derived_generation_id': generation.identifier,
+        'canonical_generation_id': generation.canonical_generation_id,
+        'canonical_publication_sequence': generation.canonical_publication_sequence,
+        'chunk_ordinal': ordinal,
+        'product_manifest_sha256': manifest_sha.hex(),
+        'ratings_canonical_input_sha256': bytes(canonical_input_sha).hex(),
+        'ratings_content_sha256': bytes(ratings_content_sha).hex(),
+    })
+
+
+def _rating_chunks(connection, generation_id: str, *, missing_search_only: bool = False):
+    if missing_search_only:
+        return connection.execute(
+            '''SELECT b.chunk_ordinal,b.systems,b.canonical_input_sha256,b.content_sha256
+                 FROM v3_derived.build_chunk b
+            LEFT JOIN v3_derived.search_build_chunk s
+                   ON s.derived_generation_id=b.derived_generation_id
+                  AND s.chunk_ordinal=b.chunk_ordinal
+                WHERE b.derived_generation_id=%s
+                  AND s.chunk_ordinal IS NULL
+                ORDER BY b.chunk_ordinal''',
+            (generation_id,),
+        ).fetchall()
+    return connection.execute(
+        '''SELECT chunk_ordinal,systems,canonical_input_sha256,content_sha256
+             FROM v3_derived.build_chunk
+            WHERE derived_generation_id=%s
+            ORDER BY chunk_ordinal''',
+        (generation_id,),
+    ).fetchall()
+
+
+def _chunk_content_sha(connection, generation_id: str, ordinal: int) -> bytes:
+    rows = connection.execute(
+        '''SELECT s.system_id64,s.name,s.x_ly,s.y_ly,s.z_ly,
+                  s.galaxy_region_id,s.region_name,s.main_star_class,
+                  s.body_count,s.landable_count,s.station_count,s.has_rings,
+                  s.has_biologicals,s.has_geologicals,s.has_terraformable,
+                  s.source_observed_at,s.completeness,s.confidence
+             FROM v3_derived.system_search s
+             JOIN v3_derived.system_rating_vector v
+               ON v.derived_generation_id=s.derived_generation_id
+              AND v.system_id64=s.system_id64
+            WHERE s.derived_generation_id=%s AND v.chunk_ordinal=%s
+            ORDER BY s.system_id64''',
+        (generation_id, ordinal),
+    ).fetchall()
+    return _digest(rows)
+
+
+def _insert_chunk(
+    connection,
+    generation: Generation,
+    manifest_sha: bytes,
+    chunk,
+) -> bool:
+    from psycopg import sql
+
+    ordinal, systems, canonical_input_sha, ratings_content_sha = chunk
+    ordinal = int(ordinal)
+    systems = int(systems)
+    source_sha = _source_projection_sha(
+        generation, manifest_sha, ordinal,
+        bytes(canonical_input_sha), bytes(ratings_content_sha),
+    )
+
+    with connection.transaction():
+        product = connection.execute(
+            '''SELECT lifecycle_state,manifest_sha256
+                 FROM v3_meta.derived_product
+                WHERE derived_generation_id=%s AND product_code=%s
+                FOR UPDATE''',
+            (generation.identifier, PRODUCT_CODE),
+        ).fetchone()
+        if product is None or product[0] != 'BUILDING':
+            raise ValueError('Search product is not BUILDING')
+        if bytes(product[1]) != manifest_sha:
+            raise ValueError('Search product manifest changed')
+
+        receipt = connection.execute(
+            '''SELECT projection_version,source_projection_sha256,content_sha256,systems
+                 FROM v3_derived.search_build_chunk
+                WHERE derived_generation_id=%s AND chunk_ordinal=%s''',
+            (generation.identifier, ordinal),
+        ).fetchone()
+        if receipt is not None:
+            if (
+                receipt[0] != PRODUCT_VERSION
+                or bytes(receipt[1]) != source_sha
+                or int(receipt[3]) != systems
+            ):
+                raise ValueError('resumed Search chunk source/coverage changed')
+            return False
+
+        preexisting = connection.execute(
+            '''SELECT count(*)
+                 FROM v3_derived.system_search s
+                 JOIN v3_derived.system_rating_vector v
+                   ON v.derived_generation_id=s.derived_generation_id
+                  AND v.system_id64=s.system_id64
+                WHERE s.derived_generation_id=%s AND v.chunk_ordinal=%s''',
+            (generation.identifier, ordinal),
+        ).fetchone()[0]
+        if preexisting:
+            raise ValueError('unreceipted Search rows already exist for chunk')
+
+        schema = sql.Identifier(generation.canonical_schema)
+        query = sql.SQL(
+            '''
+            WITH target AS MATERIALIZED (
+                SELECT v.system_id64,v.loaded_body_count,v.completeness,v.confidence
+                  FROM v3_derived.system_rating_vector v
+                 WHERE v.derived_generation_id=%s AND v.chunk_ordinal=%s
+            ),
+            body_summary AS (
+                SELECT b.system_id64,
+                       (count(*) FILTER (
+                           WHERE b.lifecycle_state='ACTIVE' AND b.is_landable IS TRUE
+                       ))::integer AS landable_count,
+                       bool_or(
+                           b.lifecycle_state='ACTIVE'
+                           AND ts.public_code IN ('terraformable','terraformed','terraforming')
+                       ) AS has_terraformable
+                  FROM {}.bodies b
+                  JOIN target t ON t.system_id64=b.system_id64
+             LEFT JOIN v3_vocab.terraforming_state ts
+                    ON ts.terraforming_state_id=b.terraforming_state_id
+              GROUP BY b.system_id64
+            ),
+            ring_summary AS (
+                SELECT r.system_id64,true AS has_rings
+                  FROM {}.rings r
+                  JOIN target t ON t.system_id64=r.system_id64
+                 WHERE r.lifecycle_state='ACTIVE' AND r.kind='RING'
+              GROUP BY r.system_id64
+            ),
+            signal_summary AS (
+                SELECT b.system_id64,
+                       bool_or(st.public_code='saa_signaltype_biological'
+                               AND bs.signal_count>0) AS has_biologicals,
+                       bool_or(st.public_code='saa_signaltype_geological'
+                               AND bs.signal_count>0) AS has_geologicals
+                  FROM {}.body_signal_current bs
+                  JOIN {}.bodies b ON b.body_pk=bs.body_pk
+                  JOIN target t ON t.system_id64=b.system_id64
+                  JOIN v3_vocab.signal_type st ON st.signal_type_id=bs.signal_type_id
+                 WHERE b.lifecycle_state='ACTIVE'
+              GROUP BY b.system_id64
+            ),
+            station_summary AS (
+                SELECT st.system_id64,
+                       (count(*) FILTER (WHERE st.lifecycle_state='ACTIVE'))::integer
+                           AS station_count
+                  FROM {}.stations st
+                  JOIN target t ON t.system_id64=st.system_id64
+              GROUP BY st.system_id64
+            ),
+            main_star AS (
+                SELECT DISTINCT ON (bm.system_id64)
+                       bm.system_id64,bm.body_class AS main_star_class
+                  FROM v3_derived.body_mechanics bm
+                  JOIN target t ON t.system_id64=bm.system_id64
+                 WHERE bm.derived_generation_id=%s AND bm.is_main_star IS TRUE
+              ORDER BY bm.system_id64,bm.body_pk
+            )
+            INSERT INTO v3_derived.system_search(
+                derived_generation_id,system_id64,name,x_ly,y_ly,z_ly,position_ly,
+                galaxy_region_id,region_name,main_star_class,body_count,landable_count,
+                station_count,has_rings,has_biologicals,has_geologicals,
+                has_terraformable,source_observed_at,completeness,confidence
+            )
+            SELECT %s,t.system_id64,s.name,s.x_ly,s.y_ly,s.z_ly,
+                   cube(ARRAY[s.x_ly,s.y_ly,s.z_ly]),
+                   s.galaxy_region_id,gr.display_name,ms.main_star_class,
+                   t.loaded_body_count,COALESCE(bs.landable_count,0),
+                   COALESCE(ss.station_count,0),COALESCE(rs.has_rings,false),
+                   COALESCE(sig.has_biologicals,false),
+                   COALESCE(sig.has_geologicals,false),
+                   COALESCE(bs.has_terraformable,false),
+                   s.source_updated_at,
+                   (SELECT min(value)::double precision/10000
+                      FROM unnest(t.completeness) AS value),
+                   (SELECT min(value)::double precision/10000
+                      FROM unnest(t.confidence) AS value)
+              FROM target t
+              JOIN {}.systems s ON s.id64=t.system_id64
+         LEFT JOIN v3_vocab.galaxy_region gr
+                ON gr.galaxy_region_id=s.galaxy_region_id
+         LEFT JOIN body_summary bs USING(system_id64)
+         LEFT JOIN ring_summary rs USING(system_id64)
+         LEFT JOIN signal_summary sig USING(system_id64)
+         LEFT JOIN station_summary ss USING(system_id64)
+         LEFT JOIN main_star ms USING(system_id64)
+            ORDER BY t.system_id64
+            '''
+        ).format(schema, schema, schema, schema, schema, schema)
+
+        cursor = connection.execute(
+            query,
+            (
+                generation.identifier, ordinal,
+                generation.identifier,
+                generation.identifier,
+            ),
+        )
+        if cursor.rowcount != systems:
+            raise ValueError('Search chunk did not cover every Ratings system')
+
+        content_sha = _chunk_content_sha(connection, generation.identifier, ordinal)
+        connection.execute(
+            '''INSERT INTO v3_derived.search_build_chunk(
+                   derived_generation_id,chunk_ordinal,product_code,projection_version,
+                   source_projection_sha256,content_sha256,systems)
+               VALUES (%s,%s,%s,%s,%s,%s,%s)''',
+            (
+                generation.identifier, ordinal, PRODUCT_CODE, PRODUCT_VERSION,
+                source_sha, content_sha, systems,
+            ),
+        )
+    return True
+
+
+def build_available(
+    connection,
+    generation: Generation,
+    manifest_sha: bytes,
+    *,
+    max_chunks: int | None = None,
+    progress: Progress | None = None,
+) -> dict:
+    if max_chunks is not None and (type(max_chunks) is not int or max_chunks <= 0):
+        raise ValueError('max_chunks must be a positive integer')
+    chunks_seen = chunks_written = 0
+    for chunk in _rating_chunks(connection, generation.identifier, missing_search_only=True):
+        written = _insert_chunk(connection, generation, manifest_sha, chunk)
+        chunks_seen += 1
+        chunks_written += int(written)
+        if written and progress is not None:
+            progress({
+                'derived_generation_id': generation.identifier,
+                'product_code': PRODUCT_CODE,
+                'chunk_ordinal': int(chunk[0]),
+                'systems': int(chunk[1]),
+                'written': True,
+            })
+        if max_chunks is not None and chunks_written >= max_chunks:
+            break
+    return {'chunks_seen': chunks_seen, 'chunks_written': chunks_written}
+
+
+def validate_product(
+    connection,
+    generation: Generation,
+    manifest_sha: bytes,
+) -> dict:
+    generation = _generation(connection, generation.key)
+    product = _product(connection, generation.identifier)
+    if product is None:
+        raise ValueError('Search product is not registered')
+    if product[1] == 'READY':
+        receipt = product[5]
+        if not isinstance(receipt, dict) or receipt.get('status') != 'VERIFIED':
+            raise ValueError('READY Search product has no VERIFIED receipt')
+        return receipt
+    if product[1] != 'BUILDING':
+        raise ValueError('Search product cannot be validated from current state')
+
+    vector_count = int(connection.execute(
+        'SELECT count(*) FROM v3_derived.system_rating_vector WHERE derived_generation_id=%s',
+        (generation.identifier,),
+    ).fetchone()[0])
+    search_count = int(connection.execute(
+        'SELECT count(*) FROM v3_derived.system_search WHERE derived_generation_id=%s',
+        (generation.identifier,),
+    ).fetchone()[0])
+    rating_chunks = _rating_chunks(connection, generation.identifier)
+    search_chunks = connection.execute(
+        '''SELECT chunk_ordinal,projection_version,source_projection_sha256,
+                  content_sha256,systems
+             FROM v3_derived.search_build_chunk
+            WHERE derived_generation_id=%s
+            ORDER BY chunk_ordinal''',
+        (generation.identifier,),
+    ).fetchall()
+
+    complete = (
+        generation.state in {'VALIDATING', 'READY'}
+        and vector_count == generation.expected_systems
+        and search_count == generation.expected_systems
+        and len(rating_chunks) == len(search_chunks)
+        and sum(int(row[1]) for row in rating_chunks) == generation.expected_systems
+        and all(int(row[0]) == index for index, row in enumerate(rating_chunks))
+    )
+    if not complete:
+        return {
+            'status': 'INCOMPLETE',
+            'derived_generation_id': generation.identifier,
+            'product_code': PRODUCT_CODE,
+            'base_lifecycle_state': generation.state,
+            'expected_systems': generation.expected_systems,
+            'rating_systems': vector_count,
+            'search_systems': search_count,
+            'rating_chunks': len(rating_chunks),
+            'search_chunks': len(search_chunks),
+        }
+
+    validation_digest = hashlib.sha256()
+    validation_digest.update(manifest_sha)
+    for rating, search in zip(rating_chunks, search_chunks, strict=True):
+        ordinal, systems, canonical_input_sha, ratings_content_sha = rating
+        if int(search[0]) != int(ordinal):
+            raise ValueError('Search chunk receipt ordinal gap')
+        if search[1] != PRODUCT_VERSION or int(search[4]) != int(systems):
+            raise ValueError('Search chunk receipt version/coverage mismatch')
+        expected_source = _source_projection_sha(
+            generation, manifest_sha, int(ordinal),
+            bytes(canonical_input_sha), bytes(ratings_content_sha),
+        )
+        if bytes(search[2]) != expected_source:
+            raise ValueError('Search chunk source seal mismatch')
+        validation_digest.update(_json({
+            'chunk_ordinal': int(ordinal),
+            'source_projection_sha256': bytes(search[2]).hex(),
+            'content_sha256': bytes(search[3]).hex(),
+            'systems': int(search[4]),
+        }).encode())
+
+    invalid_positions = int(connection.execute(
+        '''SELECT count(*)
+             FROM v3_derived.system_search
+            WHERE derived_generation_id=%s
+              AND cube_distance(position_ly,cube(ARRAY[x_ly,y_ly,z_ly]))<>0''',
+        (generation.identifier,),
+    ).fetchone()[0])
+    if invalid_positions:
+        raise ValueError('Search cube position differs from numeric LY truth')
+
+    receipt = {
+        'status': 'VERIFIED',
+        'derived_generation_id': generation.identifier,
+        'product_code': PRODUCT_CODE,
+        'product_version': PRODUCT_VERSION,
+        'expected_systems': generation.expected_systems,
+        'systems': search_count,
+        'chunks': len(search_chunks),
+        'coverage_complete': True,
+        'source_seals_verified': True,
+        'position_truth_verified': True,
+        'base_lifecycle_state': generation.state,
+        'product_manifest_sha256': manifest_sha.hex(),
+    }
+    validation_digest.update(_json(receipt).encode())
+    validation_sha = validation_digest.digest()
+    with connection.transaction():
+        updated = connection.execute(
+            '''UPDATE v3_meta.derived_product
+                  SET lifecycle_state='READY',validation_receipt=%s::jsonb,
+                      validation_sha256=%s,validated_at=now()
+                WHERE derived_generation_id=%s AND product_code=%s
+                  AND lifecycle_state='BUILDING' ''',
+            (_json(receipt), validation_sha, generation.identifier, PRODUCT_CODE),
+        ).rowcount
+        if updated != 1:
+            raise ValueError('Search product validation state changed')
+    return receipt
+
+
+def run(
+    connection,
+    generation_key: str,
+    *,
+    follow: bool = False,
+    poll_seconds: float = 5.0,
+    max_chunks: int | None = None,
+    progress: Progress | None = None,
+) -> dict:
+    if not isinstance(poll_seconds, (int, float)) or poll_seconds <= 0:
+        raise ValueError('poll_seconds must be positive')
+    generation, state, manifest_sha = register_product(connection, generation_key)
+    total_seen = total_written = 0
+
+    if state == 'READY':
+        receipt = validate_product(connection, generation, manifest_sha)
+        return {
+            'status': 'VERIFIED',
+            'derived_generation_id': generation.identifier,
+            'product_code': PRODUCT_CODE,
+            'chunks_seen': 0,
+            'chunks_written': 0,
+            'validation_receipt': receipt,
+        }
+    if state != 'BUILDING':
+        raise ValueError('Search product cannot resume from current state')
+
+    while True:
+        result = build_available(
+            connection, generation, manifest_sha,
+            max_chunks=max_chunks, progress=progress,
+        )
+        total_seen += result['chunks_seen']
+        total_written += result['chunks_written']
+        generation = _generation(connection, generation_key)
+
+        receipt = validate_product(connection, generation, manifest_sha)
+        if receipt.get('status') == 'VERIFIED':
+            return {
+                'status': 'VERIFIED',
+                'derived_generation_id': generation.identifier,
+                'product_code': PRODUCT_CODE,
+                'chunks_seen': total_seen,
+                'chunks_written': total_written,
+                'validation_receipt': receipt,
+            }
+        if not follow or max_chunks is not None:
+            return {
+                'status': 'INCOMPLETE',
+                'derived_generation_id': generation.identifier,
+                'product_code': PRODUCT_CODE,
+                'chunks_seen': total_seen,
+                'chunks_written': total_written,
+                'validation_receipt': receipt,
+            }
+        time.sleep(float(poll_seconds))
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--generation-key', required=True)
+    parser.add_argument('--follow', action='store_true')
+    parser.add_argument('--poll-seconds', type=float, default=5.0)
+    parser.add_argument('--max-chunks', type=int)
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    dsn = os.environ.get('V3_SYSTEM_SEARCH_DATABASE_URL')
+    if not dsn:
+        print(json.dumps({'status': 'FAILED', 'error': 'database_authority_missing'}), file=sys.stderr)
+        return 64
+    try:
+        import psycopg
+        with psycopg.connect(dsn, autocommit=True) as connection:
+            result = run(
+                connection, args.generation_key,
+                follow=args.follow,
+                poll_seconds=args.poll_seconds,
+                max_chunks=args.max_chunks,
+                progress=lambda item: print(json.dumps(
+                    {'status': 'PROGRESS', **item}, sort_keys=True
+                ), flush=True),
+            )
+    except Exception as exc:
+        print(json.dumps({'status': 'FAILED', 'error': type(exc).__name__}), file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True, separators=(',', ':')))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/v3_system_search.py
+++ b/scripts/v3_system_search.py
@@ -114,7 +114,10 @@ def product_manifest(generation: Generation) -> dict:
             'body_count': 'Ratings V4 loaded_body_count for the same generation/system',
             'landable_count': 'ACTIVE canonical bodies with is_landable=true',
             'station_count': 'ACTIVE canonical stations',
-            'has_rings': 'positive observation of an ACTIVE canonical RING; asteroid BELT rows do not set this Finder flag',
+            'has_rings': (
+                'positive observation of an ACTIVE canonical RING; asteroid BELT rows '
+                'do not set this Finder flag'
+            ),
             'has_biologicals': 'positive biological signal_count on an ACTIVE canonical body',
             'has_geologicals': 'positive geological signal_count on an ACTIVE canonical body',
             'has_terraformable': 'ACTIVE canonical body with terraforming state terraformable/terraformed/terraforming',
@@ -122,7 +125,10 @@ def product_manifest(generation: Generation) -> dict:
             'source_observed_at': 'canonical systems.source_updated_at',
             'completeness': 'minimum of the seven frozen Ratings V4 completeness values',
             'confidence': 'minimum of the seven frozen Ratings V4 confidence values',
-            'false_flags': 'false means no positive observation in the pinned canonical generation, not proof of known absence',
+            'false_flags': (
+                'false means no positive observation in the pinned canonical generation, '
+                'not proof of known absence'
+            ),
         },
     }
 

--- a/sql/v3/migration-manifest.txt
+++ b/sql/v3/migration-manifest.txt
@@ -12,8 +12,7 @@
 # guessing at a naming convention. <path-under-sql> locates the bytes that hash
 # to <sha256>.
 #
-# Provenance of the reviewed rows, all three re-verified by byte hash against the
-# live ledger read under BEGIN READ ONLY by the 2026-09-10 inventory receipt:
+# Provenance of the retained production rows:
 #
 #   001_v3_baseline.sql           applied 2026-08-27T12:05:58Z by the
 #                                 edfinder-v3-phase4c-full-20260827_r5 rehearsal
@@ -23,13 +22,17 @@
 #   r1_v3/001_structural_shell.sql applied 2026-08-31T16:22:56Z as the additive
 #                                 R1 normalized shell; recovered from the
 #                                 chatgpt-ed-new-ops-requests branch
+#   003_ratings_v4_derived.sql,
+#   004_v3_search_spatial_clusters.sql and
+#   005_v3_journal_intelligence.sql were confirmed applied in retained production
+#                                 on 2026-09-12 before the first full Ratings V4
+#                                 generation was started.
 #
-#   003_ratings_v4_derived.sql, 004_v3_search_spatial_clusters.sql and
-#   005_v3_journal_intelligence.sql are declared but NOT applied. They follow
-#                                 every applied row, so the reviewed live ledger
-#                                 stays an exact prefix of this file and the
-#                                 migration operation reports three pending
-#                                 migrations in order (003 -> 004 -> 005).
+#   006_v3_derived_product_lifecycle.sql is the next declared migration. It adds
+#                                 independently validated derived products and a
+#                                 publication gate; it must be applied through the
+#                                 reviewed V3 migration operation before Search is
+#                                 attached to a production generation.
 
 ee08c17eb3f87f614468db5a038d2f23273ce2b72906226c9aa1f669e724cd2e  001_v3_baseline.sql  v3/migrations/001_v3_baseline.sql
 e7a2f404b7d8194d74ba4e807ae450c7520a1c8a186ca77e41377307e7b12b07  002_v3_accounts_identity.sql  v3/migrations/002_v3_accounts_identity.sql
@@ -37,3 +40,4 @@ e7a2f404b7d8194d74ba4e807ae450c7520a1c8a186ca77e41377307e7b12b07  002_v3_account
 c7818f98ad00b4b99b7ce0f7c3fa12ece555e59e761b7b1ca15d437a39c499cb  003_ratings_v4_derived.sql  v3/migrations/003_ratings_v4_derived.sql
 e1c59def52b6a92a337f1da35c921bd0c135877f7843049ca9dec718aa01a1f2  004_v3_search_spatial_clusters.sql  v3/migrations/004_v3_search_spatial_clusters.sql
 e5c853bcc35da054aff67356a95cbe3d668f6bf2dd1d97b497b9ba7d8cae02ac  005_v3_journal_intelligence.sql  v3/migrations/005_v3_journal_intelligence.sql
+85f38fe5f0251bf3d5f81485a8a5b7de439750b4cc12ef9449755454898767f4  006_v3_derived_product_lifecycle.sql  v3/migrations/006_v3_derived_product_lifecycle.sql

--- a/sql/v3/migrations/006_v3_derived_product_lifecycle.sql
+++ b/sql/v3/migrations/006_v3_derived_product_lifecycle.sql
@@ -1,0 +1,288 @@
+-- Independent lifecycle and coverage receipts for derived products attached to
+-- one Ratings V4 generation. This lets Search/Spatial products finish after the
+-- base ratings generation reaches READY without weakening atomic publication.
+BEGIN;
+
+CREATE TABLE v3_meta.derived_product (
+    derived_generation_id uuid NOT NULL REFERENCES v3_meta.derived_generation,
+    product_code text NOT NULL CHECK(product_code ~ '^[a-z][a-z0-9_]{0,62}$'),
+    product_version text NOT NULL CHECK(length(product_version) BETWEEN 1 AND 128),
+    lifecycle_state text NOT NULL DEFAULT 'BUILDING'
+        CHECK(lifecycle_state IN ('BUILDING','READY','FAILED')),
+    manifest jsonb NOT NULL CHECK(jsonb_typeof(manifest)='object'),
+    manifest_sha256 bytea NOT NULL CHECK(octet_length(manifest_sha256)=32),
+    expected_rows bigint NOT NULL CHECK(expected_rows > 0),
+    validation_receipt jsonb
+        CHECK(validation_receipt IS NULL OR jsonb_typeof(validation_receipt)='object'),
+    validation_sha256 bytea CHECK(validation_sha256 IS NULL OR octet_length(validation_sha256)=32),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    validated_at timestamptz,
+    failed_at timestamptz,
+    failure text,
+    PRIMARY KEY(derived_generation_id,product_code),
+    CHECK(lifecycle_state <> 'READY' OR
+          (validation_receipt IS NOT NULL AND validation_sha256 IS NOT NULL
+           AND validated_at IS NOT NULL)),
+    CHECK((lifecycle_state='FAILED')=(failed_at IS NOT NULL))
+);
+
+COMMENT ON TABLE v3_meta.derived_product IS
+    'Independently validated products attached to one derived generation. Publication requires every registered product to be READY/VERIFIED.';
+
+CREATE FUNCTION v3_meta.guard_derived_product()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE base_state text;
+BEGIN
+    -- The publication function takes the same lock. Registration/finalization
+    -- therefore cannot race a generation pointer swap.
+    PERFORM pg_advisory_xact_lock(764003001);
+
+    IF TG_OP='DELETE' THEN
+        RAISE EXCEPTION 'derived product manifests are retained';
+    END IF;
+
+    SELECT lifecycle_state INTO base_state
+      FROM v3_meta.derived_generation
+     WHERE derived_generation_id=NEW.derived_generation_id
+     FOR SHARE;
+    IF base_state IS NULL THEN
+        RAISE EXCEPTION 'unknown derived generation %',NEW.derived_generation_id;
+    END IF;
+    IF base_state NOT IN ('BUILDING','VALIDATING','READY') THEN
+        RAISE EXCEPTION 'derived products cannot change while generation is %',base_state;
+    END IF;
+
+    IF TG_OP='INSERT' THEN
+        IF NEW.lifecycle_state<>'BUILDING'
+           OR NEW.validation_receipt IS NOT NULL
+           OR NEW.validation_sha256 IS NOT NULL
+           OR NEW.validated_at IS NOT NULL
+           OR NEW.failed_at IS NOT NULL
+           OR NEW.failure IS NOT NULL THEN
+            RAISE EXCEPTION 'new derived products must start BUILDING without a terminal receipt';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF ROW(NEW.derived_generation_id,NEW.product_code,NEW.product_version,
+           NEW.manifest,NEW.manifest_sha256,NEW.expected_rows,NEW.created_at)
+       IS DISTINCT FROM
+       ROW(OLD.derived_generation_id,OLD.product_code,OLD.product_version,
+           OLD.manifest,OLD.manifest_sha256,OLD.expected_rows,OLD.created_at) THEN
+        RAISE EXCEPTION 'derived product manifest identity is immutable';
+    END IF;
+    IF OLD.lifecycle_state<>'BUILDING'
+       OR NEW.lifecycle_state NOT IN ('READY','FAILED') THEN
+        RAISE EXCEPTION 'invalid derived product lifecycle transition';
+    END IF;
+    IF NEW.lifecycle_state='READY' AND
+       (NEW.validation_receipt IS NULL
+        OR NEW.validation_receipt->>'status'<>'VERIFIED'
+        OR NEW.validation_sha256 IS NULL
+        OR NEW.validated_at IS NULL
+        OR NEW.failed_at IS NOT NULL
+        OR NEW.failure IS NOT NULL) THEN
+        RAISE EXCEPTION 'READY derived product requires a VERIFIED validation receipt';
+    END IF;
+    IF NEW.lifecycle_state='FAILED' AND
+       (NEW.failed_at IS NULL OR NEW.failure IS NULL OR btrim(NEW.failure)='') THEN
+        RAISE EXCEPTION 'FAILED derived product requires failure evidence';
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER immutable_derived_product
+BEFORE INSERT OR UPDATE OR DELETE ON v3_meta.derived_product
+FOR EACH ROW EXECUTE FUNCTION v3_meta.guard_derived_product();
+
+CREATE TRIGGER immutable_derived_product_truncate
+BEFORE TRUNCATE ON v3_meta.derived_product
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.guard_generation_write();
+
+CREATE TABLE v3_derived.search_build_chunk (
+    derived_generation_id uuid NOT NULL,
+    chunk_ordinal bigint NOT NULL CHECK(chunk_ordinal >= 0),
+    product_code text NOT NULL DEFAULT 'system_search'
+        CHECK(product_code='system_search'),
+    projection_version text NOT NULL CHECK(length(projection_version) BETWEEN 1 AND 128),
+    source_projection_sha256 bytea NOT NULL CHECK(octet_length(source_projection_sha256)=32),
+    content_sha256 bytea NOT NULL CHECK(octet_length(content_sha256)=32),
+    systems integer NOT NULL CHECK(systems BETWEEN 1 AND 1000),
+    completed_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY(derived_generation_id,chunk_ordinal),
+    FOREIGN KEY(derived_generation_id,chunk_ordinal)
+        REFERENCES v3_derived.build_chunk(derived_generation_id,chunk_ordinal)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY(derived_generation_id,product_code)
+        REFERENCES v3_meta.derived_product(derived_generation_id,product_code)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+COMMENT ON TABLE v3_derived.search_build_chunk IS
+    'Per-Ratings-chunk Search projection receipt. Source seal binds the immutable Ratings input plus Search product manifest; content seal binds the materialized Search rows.';
+
+-- Migration 004 attached system_search directly to the base generation lifecycle.
+-- Search is now an independently validated product, so replace only that table's
+-- triggers. Other 004 relations keep the original generation guard unchanged.
+DROP TRIGGER immutable_insert ON v3_derived.system_search;
+DROP TRIGGER immutable_update_old ON v3_derived.system_search;
+DROP TRIGGER immutable_update_new ON v3_derived.system_search;
+DROP TRIGGER immutable_delete ON v3_derived.system_search;
+DROP TRIGGER immutable_truncate ON v3_derived.system_search;
+
+CREATE FUNCTION v3_derived.guard_system_search_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE identifier uuid; base_state text; product_state text;
+BEGIN
+    FOR identifier IN SELECT DISTINCT derived_generation_id FROM changed_rows ORDER BY 1 LOOP
+        SELECT lifecycle_state INTO base_state
+          FROM v3_meta.derived_generation
+         WHERE derived_generation_id=identifier
+         FOR SHARE;
+        IF base_state NOT IN ('BUILDING','VALIDATING','READY') THEN
+            RAISE EXCEPTION 'system_search generation % is immutable in state %',
+                identifier,base_state;
+        END IF;
+
+        SELECT lifecycle_state INTO product_state
+          FROM v3_meta.derived_product
+         WHERE derived_generation_id=identifier
+           AND product_code='system_search'
+         FOR SHARE;
+        IF product_state IS DISTINCT FROM 'BUILDING' THEN
+            RAISE EXCEPTION 'system_search product % is not BUILDING',identifier;
+        END IF;
+    END LOOP;
+    RETURN NULL;
+END
+$$;
+
+CREATE FUNCTION v3_derived.reject_system_search_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'system_search rows and receipts are insert-only';
+END
+$$;
+
+CREATE TRIGGER product_insert
+AFTER INSERT ON v3_derived.system_search
+REFERENCING NEW TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.guard_system_search_insert();
+
+CREATE TRIGGER product_update
+BEFORE UPDATE ON v3_derived.system_search
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.reject_system_search_mutation();
+
+CREATE TRIGGER product_delete
+BEFORE DELETE ON v3_derived.system_search
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.reject_system_search_mutation();
+
+CREATE TRIGGER product_truncate
+BEFORE TRUNCATE ON v3_derived.system_search
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.reject_system_search_mutation();
+
+CREATE TRIGGER product_receipt_insert
+AFTER INSERT ON v3_derived.search_build_chunk
+REFERENCING NEW TABLE AS changed_rows
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.guard_system_search_insert();
+
+CREATE TRIGGER product_receipt_update
+BEFORE UPDATE ON v3_derived.search_build_chunk
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.reject_system_search_mutation();
+
+CREATE TRIGGER product_receipt_delete
+BEFORE DELETE ON v3_derived.search_build_chunk
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.reject_system_search_mutation();
+
+CREATE TRIGGER product_receipt_truncate
+BEFORE TRUNCATE ON v3_derived.search_build_chunk
+FOR EACH STATEMENT EXECUTE FUNCTION v3_derived.reject_system_search_mutation();
+
+-- Preserve the 003 compare-and-swap publication contract and add one rule:
+-- every product registered on the candidate must independently be READY/VERIFIED.
+CREATE OR REPLACE FUNCTION v3_meta.publish_derived_generation(
+    target_ uuid, expected_current_ uuid, expected_sequence_ bigint,
+    expected_canonical_ uuid, expected_canonical_sequence_ bigint,
+    actor_ text, reason_ text
+) RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE candidate_ v3_meta.derived_generation%ROWTYPE;
+        current_ uuid; sequence_ bigint; canonical_ uuid; canonical_sequence_ bigint;
+BEGIN
+    IF actor_ IS NULL OR length(trim(actor_))=0
+       OR reason_ IS NULL OR length(trim(reason_))=0 THEN
+        RAISE EXCEPTION 'publication needs actor and reason';
+    END IF;
+
+    PERFORM pg_advisory_xact_lock(764003001);
+
+    SELECT generation_id,publication_sequence INTO canonical_,canonical_sequence_
+      FROM v3_meta.current_canonical_generation
+     WHERE singleton
+     FOR SHARE;
+    IF canonical_ IS DISTINCT FROM expected_canonical_
+       OR canonical_sequence_ IS DISTINCT FROM expected_canonical_sequence_ THEN
+        RAISE EXCEPTION 'canonical publication changed';
+    END IF;
+
+    SELECT derived_generation_id,publication_sequence INTO current_,sequence_
+      FROM v3_meta.current_derived_generation
+     WHERE singleton
+     FOR UPDATE;
+    IF current_ IS DISTINCT FROM expected_current_
+       OR COALESCE(sequence_,0)<>expected_sequence_ THEN
+        RAISE EXCEPTION 'derived publication changed';
+    END IF;
+
+    SELECT * INTO candidate_
+      FROM v3_meta.derived_generation
+     WHERE derived_generation_id=target_
+     FOR UPDATE;
+    IF NOT FOUND
+       OR candidate_.lifecycle_state NOT IN ('READY','RETIRED')
+       OR candidate_.canonical_generation_id<>canonical_
+       OR candidate_.validation_receipt->>'status'<>'VERIFIED' THEN
+        RAISE EXCEPTION 'candidate is not validated for current canonical generation';
+    END IF;
+    IF candidate_.validation_receipt->>'status' IS NULL THEN
+        RAISE EXCEPTION 'candidate validation receipt missing';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+          FROM v3_meta.derived_product p
+         WHERE p.derived_generation_id=target_
+           AND (p.lifecycle_state<>'READY'
+                OR p.validation_receipt->>'status' IS DISTINCT FROM 'VERIFIED')
+    ) THEN
+        RAISE EXCEPTION 'candidate has unverified derived products';
+    END IF;
+
+    sequence_ := COALESCE(sequence_,0)+1;
+    UPDATE v3_meta.derived_generation
+       SET lifecycle_state='RETIRED'
+     WHERE derived_generation_id=current_;
+    UPDATE v3_meta.derived_generation
+       SET lifecycle_state='PUBLISHED',published_at=now()
+     WHERE derived_generation_id=target_;
+    INSERT INTO v3_meta.current_derived_generation
+        VALUES(true,target_,sequence_,now())
+    ON CONFLICT(singleton) DO UPDATE
+        SET derived_generation_id=EXCLUDED.derived_generation_id,
+            publication_sequence=EXCLUDED.publication_sequence,
+            published_at=EXCLUDED.published_at;
+    INSERT INTO v3_meta.derived_publication_audit
+        VALUES(sequence_,current_,target_,canonical_,now(),actor_,reason_);
+    RETURN sequence_;
+END
+$$;
+
+COMMIT;

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -48,6 +48,8 @@ CHECKED_WORKFLOWS = (
     'coverage.yml',
     'cypress-parity.yml',
     'ratings-v4-freeze.yml',
+    'ratings-v4-production-accelerate.yml',
+    'ratings-v4-production-optimize.yml',
     'remove-ollama-production.yml',
     'review-lab.yml',
     'semgrep.yml',

--- a/tests/test_ratings_v4_system_search.py
+++ b/tests/test_ratings_v4_system_search.py
@@ -1,0 +1,169 @@
+from pathlib import Path
+import sys
+from uuid import uuid4
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.ratings_v4.canonical_stream import CanonicalSnapshot  # noqa: E402
+from scripts.ratings_v4.production_generation import (  # noqa: E402
+    create_generation, seal_source, validate_generation, write_chunk,
+)
+from scripts.v3_system_search import (  # noqa: E402
+    build_available, register_product, validate_product,
+)
+from tests.ratings_v4_pg_fixture import canonical_database  # noqa: E402
+
+
+@pytest.fixture
+def database():
+    with canonical_database() as (connection, canonical, metadata, payloads):
+        connection.execute((ROOT / 'sql/v3/migrations/003_ratings_v4_derived.sql').read_text())
+        connection.execute((ROOT / 'sql/v3/migrations/004_v3_search_spatial_clusters.sql').read_text())
+        connection.execute((ROOT / 'sql/v3/migrations/006_v3_derived_product_lifecycle.sql').read_text())
+        yield connection, canonical, metadata, payloads
+
+
+def _ratings_generation(database, *, chunk_size=4):
+    connection, _, _, payloads = database
+    snapshot = CanonicalSnapshot.pin(connection)
+    key = 'search_test_' + uuid4().hex
+    generation_id = create_generation(connection, snapshot, key)
+    records = [payload['system'] for payload in payloads]
+    for ordinal, start in enumerate(range(0, len(records), chunk_size)):
+        chunk = records[start:start + chunk_size]
+        canonical = snapshot.export_chunk(
+            connection, [record['id64'] for record in chunk],
+        )
+        assert write_chunk(
+            connection, generation_id, ordinal, canonical,
+            snapshot.metadata, chunk,
+        )
+    return key, generation_id, snapshot, records
+
+
+def _eof_receipt(database):
+    _, canonical, metadata, _ = database
+    return {
+        'consumed_to_eof': True,
+        'artifact_sha256': metadata['artifact']['content_sha256'].removeprefix('\\x'),
+        'size_bytes': metadata['artifact']['size_bytes'],
+        'systems': len(canonical['systems']),
+        'bodies': len(canonical['bodies']),
+    }
+
+
+def _ready_ratings(database, generation_id):
+    connection, _, _, _ = database
+    seal_source(connection, generation_id, _eof_receipt(database))
+    receipt = validate_generation(connection, generation_id)
+    assert receipt['status'] == 'VERIFIED'
+    return receipt
+
+
+def _publish(connection, generation_id, snapshot):
+    return connection.execute(
+        'SELECT v3_meta.publish_derived_generation(%s,%s,%s,%s,%s,%s,%s)',
+        (
+            generation_id, None, 0, snapshot.generation_id,
+            snapshot.publication_sequence, 'test', 'Search product fixture',
+        ),
+    ).fetchone()[0]
+
+
+def test_search_projection_builds_resumes_and_has_exact_generation_coverage(database):
+    connection, canonical, _, _ = database
+    key, generation_id, _, _ = _ratings_generation(database)
+
+    generation, state, manifest_sha = register_product(connection, key)
+    assert state == 'BUILDING'
+    first = build_available(connection, generation, manifest_sha)
+    second = build_available(connection, generation, manifest_sha)
+    assert first['chunks_written'] == 3
+    assert second['chunks_written'] == 0
+
+    counts = connection.execute(
+        '''SELECT
+               (SELECT count(*) FROM v3_derived.system_rating_vector
+                 WHERE derived_generation_id=%s),
+               (SELECT count(*) FROM v3_derived.system_search
+                 WHERE derived_generation_id=%s),
+               (SELECT count(*) FROM v3_derived.search_build_chunk
+                 WHERE derived_generation_id=%s)''',
+        (generation_id, generation_id, generation_id),
+    ).fetchone()
+    assert counts == (12, 12, 3)
+
+    mismatches = connection.execute(
+        '''SELECT count(*)
+             FROM v3_derived.system_search s
+             JOIN v3_derived.system_rating_vector v
+               ON v.derived_generation_id=s.derived_generation_id
+              AND v.system_id64=s.system_id64
+            WHERE s.derived_generation_id=%s
+              AND (s.body_count<>v.loaded_body_count
+                   OR cube_distance(s.position_ly,cube(ARRAY[s.x_ly,s.y_ly,s.z_ly]))<>0)''',
+        (generation_id,),
+    ).fetchone()[0]
+    assert mismatches == 0
+
+    expected_names = {row['id64']: row['name'] for row in canonical['systems']}
+    actual_names = dict(connection.execute(
+        '''SELECT system_id64,name FROM v3_derived.system_search
+            WHERE derived_generation_id=%s''',
+        (generation_id,),
+    ).fetchall())
+    assert actual_names == expected_names
+
+    incomplete = validate_product(connection, generation, manifest_sha)
+    assert incomplete['status'] == 'INCOMPLETE'
+    assert incomplete['base_lifecycle_state'] == 'BUILDING'
+
+    _ready_ratings(database, generation_id)
+    verified = validate_product(connection, generation, manifest_sha)
+    assert verified['status'] == 'VERIFIED'
+    assert verified['systems'] == 12
+    assert verified['coverage_complete'] is True
+
+    import psycopg
+    with pytest.raises(psycopg.errors.RaiseException, match='insert-only'):
+        connection.execute(
+            '''UPDATE v3_derived.system_search SET station_count=station_count
+                WHERE derived_generation_id=%s''',
+            (generation_id,),
+        )
+
+
+def test_search_can_finish_after_ratings_ready_and_blocks_publication_until_verified(database):
+    connection, _, _, _ = database
+    key, generation_id, snapshot, _ = _ratings_generation(database)
+    generation, state, manifest_sha = register_product(connection, key)
+    assert state == 'BUILDING'
+
+    _ready_ratings(database, generation_id)
+    assert connection.execute(
+        '''SELECT lifecycle_state FROM v3_meta.derived_generation
+            WHERE derived_generation_id=%s''',
+        (generation_id,),
+    ).fetchone()[0] == 'READY'
+
+    import psycopg
+    with pytest.raises(psycopg.errors.RaiseException, match='unverified derived products'):
+        _publish(connection, generation_id, snapshot)
+
+    # Product-aware 006 guards deliberately allow this while the base generation
+    # is READY. Ratings rows remain immutable; only the Search product can append.
+    built = build_available(connection, generation, manifest_sha)
+    assert built['chunks_written'] == 3
+    verified = validate_product(connection, generation, manifest_sha)
+    assert verified['status'] == 'VERIFIED'
+
+    assert _publish(connection, generation_id, snapshot) == 1
+    assert connection.execute(
+        'SELECT count(*) FROM v3_app.system_search'
+    ).fetchone()[0] == 12
+
+    with pytest.raises(ValueError, match='cannot accept'):
+        register_product(connection, key)

--- a/tests/test_v3_app_status.py
+++ b/tests/test_v3_app_status.py
@@ -15,7 +15,7 @@ def test_v3_app_status_is_allowlisted_through_trusted_main_operator_path():
     workflow = _read(WORKFLOW)
 
     assert '          - v3-app-status\n' in workflow
-    assert 'v3-app-status)' in workflow
+    assert '|v3-app-status|' in workflow or 'v3-app-status)' in workflow
     assert "steps.request.outputs.operation == 'v3-app-status'" in workflow
     assert 'trusted-main/scripts/operator/actions/v3-app-status.sh' in workflow
     assert 'StrictHostKeyChecking=yes' in workflow

--- a/tests/test_v3_production_migration_operation.py
+++ b/tests/test_v3_production_migration_operation.py
@@ -56,6 +56,7 @@ def test_desired_entries_are_the_committed_lineage_with_verified_hashes():
          "003_ratings_v4_derived.sql",
          "004_v3_search_spatial_clusters.sql",
          "005_v3_journal_intelligence.sql",
+         "006_v3_derived_product_lifecycle.sql",
     ]
     for entry in entries:
         source = (ROOT / entry["path"]).read_bytes()
@@ -76,6 +77,7 @@ def test_plan_reports_pending_only_when_the_live_ledger_is_an_exact_prefix():
         "003_ratings_v4_derived.sql",
         "004_v3_search_spatial_clusters.sql",
         "005_v3_journal_intelligence.sql",
+        "006_v3_derived_product_lifecycle.sql",
     ]
 
     # Nothing pending is a legitimate state, not an error.


### PR DESCRIPTION
Implement Finder F1 so it can proceed while the full Ratings V4 generation is running, without forcing a second Ratings rebuild.

Key changes:
- add migration 006 with `v3_meta.derived_product`, giving attached derived products an immutable manifest and independent BUILDING -> READY/FAILED lifecycle;
- replace only `system_search`'s generation-level write guard with a product-aware insert-only guard, allowing Search to finish while the base generation is BUILDING, VALIDATING, or READY but never after publication;
- strengthen `publish_derived_generation` so any registered product must be READY with a VERIFIED receipt before the live derived pointer can move;
- add a resumable `scripts/v3_system_search.py` builder that consumes committed Ratings chunks as its work queue, projects canonical Finder facts into `v3_derived.system_search`, and writes atomic per-chunk source/content receipts;
- validate exact system coverage, contiguous Ratings coverage, source seals, and cube/numeric coordinate identity;
- add PostgreSQL integration tests for resume/coverage and the important Ratings-READY-before-Search case;
- register migration 006 in the V3 production lineage and correct the stale note that 003-005 were still pending.

No change is made to the running Ratings V4 scorer/runner/code-identity files. This PR does not apply migration 006 or write Search rows in production; those remain separate reviewed operations after CI proves the lifecycle and builder.