### PR TITLE
Launch the V3 Search F1 production follower

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -15,6 +15,8 @@ on:
           - v3-app-status
           - ratings-v4-generation-start
           - ratings-v4-generation-status
+          - v3-system-search-f1-start
+          - v3-system-search-f1-status
   push:
     branches:
       - chatgpt-ed-new-ops-requests
@@ -71,7 +73,7 @@ jobs:
             exit 64
           fi
           case "$operation" in
-            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair|v3-app-status|ratings-v4-generation-start|ratings-v4-generation-status) ;;
+            host-status|octopus-edge-status|recover-v3-runtime-contract|octopus-qdrant-healthcheck-repair|v3-app-status|ratings-v4-generation-start|ratings-v4-generation-status|v3-system-search-f1-start|v3-system-search-f1-status) ;;
             *) echo "Unsupported operation: $operation" >&2; exit 64 ;;
           esac
           echo "operation=$operation" >> "$GITHUB_OUTPUT"
@@ -122,13 +124,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'set -eu; echo "== ed-new bootstrap status =="; printf "hostname: "; hostname; printf "fqdn: "; hostname -f 2>/dev/null || true; printf "kernel: "; uname -sr; echo "== filesystem =="; df -hT /; echo "== docker =="; if command -v docker >/dev/null 2>&1; then docker ps --format "{{.Names}}\t{{.Status}}\t{{.Image}}" | head -50; else echo "docker: not installed"; fi; echo "== repo candidates =="; for p in /opt/ed-finder /root/ed-finder /srv/ed-finder; do [ -d "$p" ] && echo "$p"; done; echo "== safety =="; echo "db_access_performed: false"; echo "db_writes_performed: false"; echo "migrations_performed: false"; echo "canonical_apply_performed: false"'
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'set -eu; echo "== ed-new bootstrap status =="; printf "hostname: "; hostname; printf "fqdn: "; hostname -f 2>/dev/null || true; printf "kernel: "; uname -sr; echo "== filesystem =="; df -hT /; echo "== docker =="; if command -v docker >/dev/null 2>&1; then docker ps --format "{{.Names}}\t{{.Status}}\t{{.Image}}" | head -50; else echo "docker: not installed"; fi; echo "== repo candidates =="; for p in /opt/ed-finder /root/ed-finder /srv/ed-finder; do [ -d "$p" ] && echo "$p"; done; echo "== safety =="; echo "db_access_performed: false"; echo "db_writes_performed: false"; echo "migrations_performed: false"; echo "canonical_apply_performed: false"'
 
       - name: Inspect V3 app status
         if: steps.request.outputs.operation == 'v3-app-status'
@@ -140,14 +137,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'cd /opt/ed-finder && bash -s' \
-              < trusted-main/scripts/operator/actions/v3-app-status.sh
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'cd /opt/ed-finder && bash -s' < trusted-main/scripts/operator/actions/v3-app-status.sh
 
       - name: Repair Octopus Qdrant healthcheck and boot web
         if: steps.request.outputs.operation == 'octopus-qdrant-healthcheck-repair'
@@ -159,14 +150,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'cd /opt/ed-finder && bash -s' \
-              < trusted-main/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'cd /opt/ed-finder && bash -s' < trusted-main/scripts/operator/actions/octopus-qdrant-healthcheck-repair.sh
 
       - name: Inspect Octopus edge status
         if: steps.request.outputs.operation == 'octopus-edge-status'
@@ -178,14 +163,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'cd /opt/ed-finder && bash -s' \
-              < trusted-main/scripts/operator/actions/octopus-edge-status.sh
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'cd /opt/ed-finder && bash -s' < trusted-main/scripts/operator/actions/octopus-edge-status.sh
 
       - name: Recover retained V3 runtime contract
         if: steps.request.outputs.operation == 'recover-v3-runtime-contract'
@@ -200,15 +179,9 @@ jobs:
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
           mkdir -p "$RECOVERY_DIR"
           archive="$RECOVERY_DIR/edfinder-v3-phase4c-r5-runtime-contract.tar.gz"
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'python3.14 - --container edfinder-v3-phase4c-full-20260827_r5-postgres' \
-              < trusted-main/scripts/operator/recover_v3_runtime_contract.py \
-              > "$archive"
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'python3.14 - --container edfinder-v3-phase4c-full-20260827_r5-postgres' \
+            < trusted-main/scripts/operator/recover_v3_runtime_contract.py > "$archive"
           test -s "$archive"
           (cd "$RECOVERY_DIR" && sha256sum "$(basename "$archive")" > "$(basename "$archive").sha256")
           python3 - "$archive" <<'PY'
@@ -216,7 +189,6 @@ jobs:
           import shutil
           import sys
           import tarfile
-
           archive = pathlib.Path(sys.argv[1])
           output = archive.parent
           expected = ("recovery-manifest.json", "recovery-receipt.json")
@@ -273,22 +245,11 @@ jobs:
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
           source_sha="$(git -C trusted-main rev-parse HEAD)"
           stage="/var/tmp/edfinder-ratings-v4-${source_sha}"
-          tar -C trusted-main --exclude=.git -cf - . | \
-            ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              "set -eu; umask 077; rm -rf '$stage'; mkdir -p '$stage'; tar --no-same-owner --no-same-permissions -C '$stage' -xf -"
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              "bash -s -- start '$stage' '$source_sha'" \
-              < trusted-main/scripts/operator/actions/ratings-v4-generation.sh | tee "$RECEIPT"
+          tar -C trusted-main --exclude=.git -cf - . | ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            "set -eu; umask 077; rm -rf '$stage'; mkdir -p '$stage'; tar --no-same-owner --no-same-permissions -C '$stage' -xf -"
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            "bash -s -- start '$stage' '$source_sha'" \
+            < trusted-main/scripts/operator/actions/ratings-v4-generation.sh | tee "$RECEIPT"
 
       - name: Inspect Ratings V4 generation status
         if: steps.request.outputs.operation == 'ratings-v4-generation-status'
@@ -301,14 +262,8 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
-          ssh -i ~/.ssh/ed_new_operator_key \
-              -p "$SSH_PORT" \
-              -o IdentitiesOnly=yes \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              "$SSH_USER@$SSH_HOST" \
-              'bash -s -- status' \
-              < trusted-main/scripts/operator/actions/ratings-v4-generation.sh | tee "$RECEIPT"
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'bash -s -- status' < trusted-main/scripts/operator/actions/ratings-v4-generation.sh | tee "$RECEIPT"
 
       - name: Upload Ratings V4 generation operation receipt
         if: always() && (steps.request.outputs.operation == 'ratings-v4-generation-start' || steps.request.outputs.operation == 'ratings-v4-generation-status')
@@ -316,5 +271,56 @@ jobs:
         with:
           name: ratings-v4-generation-operation
           path: ${{ runner.temp }}/ratings-v4-generation-operation.txt
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Prepare trusted V3 Search bundle marker
+        if: steps.request.outputs.operation == 'v3-system-search-f1-start'
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_sha="$(git -C trusted-main rev-parse HEAD)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || exit 64
+          printf '%s\n' "$source_sha" > trusted-main/.v3-search-source-sha
+
+      - name: Stage trusted main and launch V3 Search F1
+        if: steps.request.outputs.operation == 'v3-system-search-f1-start'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/v3-system-search-f1-operation.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          source_sha="$(git -C trusted-main rev-parse HEAD)"
+          stage="/var/tmp/edfinder-v3-search-${source_sha}"
+          tar -C trusted-main --exclude=.git -cf - . | ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            "set -eu; umask 077; rm -rf '$stage'; mkdir -p '$stage'; tar --no-same-owner --no-same-permissions -C '$stage' -xf -"
+          remote="if [ \"\$(id -u)\" -eq 0 ]; then exec bash -s -- start '$stage' '$source_sha'; elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then exec sudo -n bash -s -- start '$stage' '$source_sha'; else echo 'V3 Search start requires root or passwordless sudo before any schema change' >&2; exit 64; fi"
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" "$remote" \
+            < trusted-main/scripts/operator/actions/v3-system-search-f1.sh | tee "$RECEIPT"
+
+      - name: Inspect V3 Search F1 status
+        if: steps.request.outputs.operation == 'v3-system-search-f1-status'
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/v3-system-search-f1-operation.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER" || { echo "Missing ED_NEW_OPERATOR_USER" >&2; exit 1; }
+          ssh -i ~/.ssh/ed_new_operator_key -p "$SSH_PORT" -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts "$SSH_USER@$SSH_HOST" \
+            'bash -s -- status' < trusted-main/scripts/operator/actions/v3-system-search-f1.sh | tee "$RECEIPT"
+
+      - name: Upload V3 Search F1 operation receipt
+        if: always() && (steps.request.outputs.operation == 'v3-system-search-f1-start' || steps.request.outputs.operation == 'v3-system-search-f1-status')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-system-search-f1-operation
+          path: ${{ runner.temp }}/v3-system-search-f1-operation.txt
           if-no-files-found: warn
           retention-days: 30

--- a/deploy/v3-production/target-authority.json
+++ b/deploy/v3-production/target-authority.json
@@ -95,7 +95,7 @@
     "api_env_owner_uid": 0,
     "api_env_mode": "0600",
     "schema_identity_file": "/etc/ed-finder/v3-production/schema-identity.json",
-    "schema_identity_sha256": "9299110ac7ec318dc9294dedb0e2ac386a29137d22ff5020f10a0410b94d61c0",
+    "schema_identity_sha256": "05bbf65bcb06d59249cd0436aeeca6e529934f999cafc099aa5af8fa7cf4303d",
     "schema_identity_owner_uid": 0,
     "schema_identity_mode": "0600",
     "active_origin_bind": "127.0.0.1:58080",

--- a/scripts/operator/actions/v3-system-search-f1.sh
+++ b/scripts/operator/actions/v3-system-search-f1.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+REPO_ROOT="${2:-}"
+SOURCE_SHA="${3:-}"
+
+TARGET_HOSTNAME="ed-finder-prod"
+TARGET_FQDN="nb79a3d.mevnode.com"
+POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_USER="edfinder_v3"
+DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5"
+APPLICATION_NETWORK="edfinder-v3-production"
+TARGET_GENERATION_KEY="ratings_v4_prod_p4_opt1"
+TARGET_CANONICAL_SEQUENCE="4"
+TARGET_CANONICAL_GENERATION="a7076522-54cd-52f3-a291-4e5406bea230"
+MIGRATION_NAME="006_v3_derived_product_lifecycle.sql"
+MIGRATION_SHA="85f38fe5f0251bf3d5f81485a8a5b7de439750b4cc12ef9449755454898767f4"
+WORKER="edfinder-v3-system-search-p4-opt1"
+OPERATION_LABEL="ed-finder.operation=v3-system-search-f1"
+STATE_ROOT="${HOME}/.local/state/ed-finder/v3-system-search"
+TARGET_CPUS="8"
+TARGET_MEMORY="32g"
+
+fail() {
+  printf 'v3 system search f1: %s\n' "$*" >&2
+  exit 64
+}
+
+require_target() {
+  command -v docker >/dev/null 2>&1 || fail "docker is unavailable"
+  command -v python3.14 >/dev/null 2>&1 || fail "python3.14 is unavailable"
+  [ "$(hostname)" = "$TARGET_HOSTNAME" ] || fail "unexpected hostname"
+  [ "$(hostname -f 2>/dev/null || true)" = "$TARGET_FQDN" ] || fail "unexpected fqdn"
+  [ "$(docker context show)" = "default" ] || fail "unexpected docker context"
+  docker context inspect default 2>/dev/null | grep -F 'unix:///var/run/docker.sock' >/dev/null \
+    || fail "default docker context is not the local rootful socket"
+  docker inspect "$POSTGRES_CONTAINER" >/dev/null 2>&1 || fail "retained postgres container is unavailable"
+  [ "$(docker inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER")" = "true" ] \
+    || fail "retained postgres container is not running"
+}
+
+db_query() {
+  docker exec "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+    --tuples-only --no-align --quiet --set ON_ERROR_STOP=1 \
+    --username "$DATABASE_USER" --dbname "$DATABASE_NAME" --command "$1"
+}
+
+active_api_container() {
+  local -a matches=()
+  local container service
+  while IFS= read -r container; do
+    [ -n "$container" ] || continue
+    service="$(docker inspect -f '{{index .Config.Labels "com.docker.compose.service"}}' "$container")"
+    case "$service" in
+      api-*) matches+=("$container") ;;
+    esac
+  done < <(docker ps --filter "label=com.docker.compose.project=${APPLICATION_NETWORK}" --format '{{.Names}}')
+  [ "${#matches[@]}" -eq 1 ] || fail "expected exactly one running production API slot, found ${#matches[@]}"
+  printf '%s\n' "${matches[0]}"
+}
+
+api_database_url() {
+  local api="$1" value count
+  value="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$api" | sed -n 's/^DATABASE_URL=//p')"
+  count="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$api" | grep -c '^DATABASE_URL=' || true)"
+  [ "$count" -eq 1 ] || fail "active API does not expose exactly one DATABASE_URL"
+  case "$value" in
+    postgresql://*|postgres://*) ;;
+    *) fail "active API DATABASE_URL is not a PostgreSQL DSN" ;;
+  esac
+  printf '%s' "$value"
+}
+
+require_generation() {
+  local row key state canonical sequence expected
+  row="$(db_query "BEGIN READ ONLY; SELECT generation_key || E'\\t' || lifecycle_state || E'\\t' || canonical_generation_id::text || E'\\t' || canonical_publication_sequence::text || E'\\t' || expected_systems::text FROM v3_meta.derived_generation WHERE generation_key='${TARGET_GENERATION_KEY}'; COMMIT;")"
+  [ "$(printf '%s\n' "$row" | wc -l)" -eq 1 ] || fail "target derived generation is missing or ambiguous"
+  IFS=$'\t' read -r key state canonical sequence expected <<< "$row"
+  [ "$key" = "$TARGET_GENERATION_KEY" ] || fail "target generation key mismatch"
+  case "$state" in BUILDING|VALIDATING|READY) ;; *) fail "target generation cannot accept Search in state $state" ;; esac
+  [ "$canonical" = "$TARGET_CANONICAL_GENERATION" ] || fail "target canonical generation mismatch"
+  [ "$sequence" = "$TARGET_CANONICAL_SEQUENCE" ] || fail "target canonical publication sequence mismatch"
+  [ "$expected" = "198528286" ] || fail "target expected system count mismatch"
+}
+
+latest_status() {
+  db_query "BEGIN READ ONLY; SELECT json_build_object(
+    'generation_key',g.generation_key,
+    'generation_state',g.lifecycle_state,
+    'ratings_completed_chunks',(SELECT count(*) FROM v3_derived.build_chunk b WHERE b.derived_generation_id=g.derived_generation_id),
+    'ratings_completed_systems',(SELECT COALESCE(sum(b.systems),0) FROM v3_derived.build_chunk b WHERE b.derived_generation_id=g.derived_generation_id),
+    'ratings_source_receipt_present',g.source_receipt IS NOT NULL,
+    'ratings_validation_status',g.validation_receipt->>'status',
+    'search_product_state',(SELECT p.lifecycle_state FROM v3_meta.derived_product p WHERE p.derived_generation_id=g.derived_generation_id AND p.product_code='system_search'),
+    'search_expected_rows',(SELECT p.expected_rows FROM v3_meta.derived_product p WHERE p.derived_generation_id=g.derived_generation_id AND p.product_code='system_search'),
+    'search_validation_status',(SELECT p.validation_receipt->>'status' FROM v3_meta.derived_product p WHERE p.derived_generation_id=g.derived_generation_id AND p.product_code='system_search'),
+    'search_validated_at',(SELECT p.validated_at FROM v3_meta.derived_product p WHERE p.derived_generation_id=g.derived_generation_id AND p.product_code='system_search'),
+    'search_completed_chunks',(SELECT count(*) FROM v3_derived.search_build_chunk s WHERE s.derived_generation_id=g.derived_generation_id),
+    'search_completed_systems',(SELECT COALESCE(sum(s.systems),0) FROM v3_derived.search_build_chunk s WHERE s.derived_generation_id=g.derived_generation_id),
+    'search_rows',(SELECT count(*) FROM v3_derived.system_search s WHERE s.derived_generation_id=g.derived_generation_id),
+    'published_at',g.published_at
+  )::text FROM v3_meta.derived_generation g WHERE g.generation_key='${TARGET_GENERATION_KEY}'; COMMIT;"
+}
+
+install_target_schema_identity() {
+  local api_image="$1" identity_file expected_sha actual_sha authority
+  authority="$REPO_ROOT/deploy/v3-production/target-authority.json"
+  identity_file="$STATE_ROOT/schema-identity-${SOURCE_SHA}.json"
+  python3.14 "$REPO_ROOT/scripts/operator/v3_schema_identity.py" --output "$identity_file" >/dev/null
+  expected_sha="$(python3.14 - "$authority" <<'PY'
+import json, pathlib, sys
+value=json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(value['external_authority']['schema_identity_sha256'])
+PY
+)"
+  actual_sha="$(sha256sum "$identity_file" | awk '{print $1}')"
+  [[ "$expected_sha" =~ ^[0-9a-f]{64}$ ]] || fail "target authority schema identity pin is invalid"
+  [ "$actual_sha" = "$expected_sha" ] || fail "derived schema identity does not match target authority pin"
+  [ -d /etc/ed-finder/v3-production ] || fail "production authority directory is missing"
+
+  docker run --rm -i --network none --user 0:0 \
+    --mount type=bind,src=/etc/ed-finder/v3-production,dst=/target \
+    --entrypoint /bin/sh "$api_image" -c '
+      set -eu
+      umask 077
+      temp=/target/.schema-identity.json.new
+      cat > "$temp"
+      chmod 0600 "$temp"
+      chown 0:0 "$temp"
+      mv -f "$temp" /target/schema-identity.json
+    ' < "$identity_file" >/dev/null
+
+  [ "$(sha256sum /etc/ed-finder/v3-production/schema-identity.json | awk '{print $1}')" = "$expected_sha" ] \
+    || fail "installed production schema identity checksum mismatch"
+  printf '%s' "$expected_sha"
+}
+
+apply_pending_migration() {
+  local plan_file apply_file pending_count pending_name
+  plan_file="$STATE_ROOT/migration-plan-${SOURCE_SHA}.json"
+  apply_file="$STATE_ROOT/migration-apply-${SOURCE_SHA}.json"
+  python3.14 "$REPO_ROOT/scripts/operator/v3_production_migrate.py" \
+    --operation plan --authority "$REPO_ROOT/deploy/v3-production/target-authority.json" \
+    --root "$REPO_ROOT" > "$plan_file"
+  read -r pending_count pending_name < <(python3.14 - "$plan_file" <<'PY'
+import json, pathlib, sys
+value=json.loads(pathlib.Path(sys.argv[1]).read_text())
+p=value.get('pending') or []
+print(len(p), p[0]['ledger_name'] if len(p)==1 else '-')
+PY
+)
+  if [ "$pending_count" = "1" ]; then
+    [ "$pending_name" = "$MIGRATION_NAME" ] || fail "unexpected pending production migration: $pending_name"
+    python3.14 "$REPO_ROOT/scripts/operator/v3_production_migrate.py" \
+      --operation apply --authority "$REPO_ROOT/deploy/v3-production/target-authority.json" \
+      --root "$REPO_ROOT" > "$apply_file"
+  elif [ "$pending_count" != "0" ]; then
+    fail "expected only migration 006 to be pending, found $pending_count"
+  fi
+  python3.14 "$REPO_ROOT/scripts/operator/v3_production_migrate.py" \
+    --operation authority-gate --authority "$REPO_ROOT/deploy/v3-production/target-authority.json" \
+    --root "$REPO_ROOT" | grep -F '"pending": 0' >/dev/null \
+    || fail "production migration authority still reports pending migrations"
+  local ledger_sha
+  ledger_sha="$(db_query "BEGIN READ ONLY; SELECT encode(migration_sha256,'hex') FROM v3_meta.schema_migration WHERE migration_name='${MIGRATION_NAME}'; COMMIT;")"
+  [ "$ledger_sha" = "$MIGRATION_SHA" ] || fail "migration 006 live ledger hash mismatch"
+}
+
+start_operation() {
+  require_target
+  [ -n "$REPO_ROOT" ] && [ -d "$REPO_ROOT" ] || fail "trusted main bundle path is required"
+  [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "trusted main SHA is invalid"
+  case "$REPO_ROOT" in /var/tmp/edfinder-v3-search-"$SOURCE_SHA") ;; *) fail "trusted main bundle path is outside reviewed staging namespace" ;; esac
+  [ "$(cat "$REPO_ROOT/.v3-search-source-sha" 2>/dev/null || true)" = "$SOURCE_SHA" ] || fail "trusted main bundle SHA marker mismatch"
+  [ -f "$REPO_ROOT/scripts/v3_system_search.py" ] || fail "Search builder is missing"
+  [ -f "$REPO_ROOT/sql/v3/migrations/006_v3_derived_product_lifecycle.sql" ] || fail "migration 006 is missing"
+
+  install -d -m 700 "$STATE_ROOT"
+  command -v flock >/dev/null 2>&1 || fail "flock is unavailable"
+  exec 9>"$STATE_ROOT/start.lock"
+  flock -n 9 || fail "another V3 Search start is in progress"
+
+  local api api_image dsn identity_sha worker_state env_file
+  api="$(active_api_container)"
+  api_image="$(docker inspect -f '{{.Config.Image}}' "$api")"
+  [ -n "$api_image" ] || fail "active API image identity is empty"
+  identity_sha="$(install_target_schema_identity "$api_image")"
+  apply_pending_migration
+  require_generation
+  dsn="$(api_database_url "$api")"
+
+  if docker inspect "$WORKER" >/dev/null 2>&1; then
+    worker_state="$(docker inspect -f '{{.State.Status}}' "$WORKER")"
+    if [ "$worker_state" = "running" ]; then
+      printf 'operation=v3-system-search-f1-start\nresult=already-running\nworker=%s\nschema_identity_sha256=%s\n' "$WORKER" "$identity_sha"
+      printf 'latest_status=%s\n' "$(latest_status)"
+      printf 'publication_performed=false\ncanonical_writes_performed=false\n'
+      exit 0
+    fi
+    docker rm "$WORKER" >/dev/null
+  fi
+
+  env_file="$STATE_ROOT/search.env"
+  umask 077
+  printf 'V3_SYSTEM_SEARCH_DATABASE_URL=%s\n' "$dsn" > "$env_file"
+  chmod 600 "$env_file"
+  docker run -d \
+    --name "$WORKER" \
+    --label "$OPERATION_LABEL" \
+    --label "ed-finder.generation-key=${TARGET_GENERATION_KEY}" \
+    --label "ed-finder.source-sha=${SOURCE_SHA}" \
+    --network "$APPLICATION_NETWORK" \
+    --cpus "$TARGET_CPUS" \
+    --memory "$TARGET_MEMORY" \
+    --memory-swap "$TARGET_MEMORY" \
+    --pids-limit 256 \
+    --restart no \
+    --log-driver json-file --log-opt max-size=20m --log-opt max-file=3 \
+    --env-file "$env_file" \
+    --mount "type=bind,src=${REPO_ROOT},dst=/work,readonly" \
+    --entrypoint /bin/sh \
+    "$api_image" -lc '
+      set -eu
+      export PYTHONPATH="/work:/work/apps/api/src"
+      cd /work
+      exec /app/.venv/bin/python scripts/v3_system_search.py \
+        --generation-key ratings_v4_prod_p4_opt1 --follow --poll-seconds 5
+    ' >/dev/null
+  rm -f "$env_file"
+
+  sleep 3
+  worker_state="$(docker inspect -f '{{.State.Status}}' "$WORKER")"
+  if [ "$worker_state" != "running" ]; then
+    docker logs --tail 80 "$WORKER" >&2 || true
+    fail "Search worker did not remain running"
+  fi
+
+  local proof=0
+  for _ in $(seq 1 30); do
+    proof="$(db_query "BEGIN READ ONLY; SELECT count(*) FROM v3_derived.search_build_chunk s JOIN v3_meta.derived_generation g USING(derived_generation_id) WHERE g.generation_key='${TARGET_GENERATION_KEY}'; COMMIT;")"
+    [[ "$proof" =~ ^[0-9]+$ ]] || fail "Search proof query was invalid"
+    [ "$proof" -ge 1 ] && break
+    sleep 2
+  done
+  [ "$proof" -ge 1 ] || { docker logs --tail 80 "$WORKER" >&2 || true; fail "Search worker did not prove a committed chunk"; }
+
+  printf 'operation=v3-system-search-f1-start\n'
+  printf 'result=launched\n'
+  printf 'source_sha=%s\n' "$SOURCE_SHA"
+  printf 'schema_identity_sha256=%s\n' "$identity_sha"
+  printf 'migration_006_verified=true\n'
+  printf 'generation_key=%s\n' "$TARGET_GENERATION_KEY"
+  printf 'worker=%s\n' "$WORKER"
+  printf 'worker_state=%s\n' "$worker_state"
+  printf 'proof_chunks=%s\n' "$proof"
+  printf 'cpu_limit=%s\n' "$TARGET_CPUS"
+  printf 'memory_limit=%s\n' "$TARGET_MEMORY"
+  printf 'latest_status=%s\n' "$(latest_status)"
+  printf 'publication_performed=false\n'
+  printf 'canonical_writes_performed=false\n'
+  printf 'application_service_changes_performed=false\n'
+}
+
+status_operation() {
+  require_target
+  require_generation
+  printf 'operation=v3-system-search-f1-status\n'
+  printf 'worker_containers:\n'
+  docker ps -a --filter "label=${OPERATION_LABEL}" --format '  {{.Names}}\t{{.Status}}\t{{.Image}}' || true
+  printf 'latest_status=%s\n' "$(latest_status)"
+  if docker inspect "$WORKER" >/dev/null 2>&1; then
+    printf 'latest_worker_log_tail:\n'
+    docker logs --tail 40 "$WORKER" 2>&1 | sed 's/^/  /' || true
+  fi
+  printf 'publication_performed=false\ncanonical_writes_performed=false\napplication_service_changes_performed=false\n'
+}
+
+case "$ACTION" in
+  start) start_operation ;;
+  status) status_operation ;;
+  *) fail "expected start or status" ;;
+esac

--- a/tests/test_v3_system_search_production_operator.py
+++ b/tests/test_v3_system_search_production_operator.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / "scripts/operator/actions/v3-system-search-f1.sh"
+WORKFLOW = ROOT / ".github/workflows/chatgpt-ed-new-ops.yml"
+AUTHORITY = ROOT / "deploy/v3-production/target-authority.json"
+IDENTITY_TOOL = ROOT / "scripts/operator/v3_schema_identity.py"
+MIGRATION = ROOT / "sql/v3/migrations/006_v3_derived_product_lifecycle.sql"
+
+
+def test_search_production_operation_is_allowlisted_through_trusted_main():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    for operation in ("v3-system-search-f1-start", "v3-system-search-f1-status"):
+        assert f"          - {operation}\n" in workflow
+        assert operation in workflow
+    assert "trusted-main/scripts/operator/actions/v3-system-search-f1.sh" in workflow
+    assert ".github/ed-new-ops-requests/*.json" in workflow
+    assert "ref: main" in workflow
+    assert "V3 Search start requires root or passwordless sudo before any schema change" in workflow
+    assert workflow.index("V3 Search start requires root or passwordless sudo") < workflow.index(
+        "trusted-main/scripts/operator/actions/v3-system-search-f1.sh"
+    )
+
+
+def test_search_operator_pins_exact_generation_and_migration():
+    source = ACTION.read_text(encoding="utf-8")
+    assert 'TARGET_GENERATION_KEY="ratings_v4_prod_p4_opt1"' in source
+    assert 'TARGET_CANONICAL_SEQUENCE="4"' in source
+    assert 'TARGET_CANONICAL_GENERATION="a7076522-54cd-52f3-a291-4e5406bea230"' in source
+    assert 'MIGRATION_NAME="006_v3_derived_product_lifecycle.sql"' in source
+    expected = hashlib.sha256(MIGRATION.read_bytes()).hexdigest()
+    assert f'MIGRATION_SHA="{expected}"' in source
+    assert "expected only migration 006 to be pending" in source
+    assert "production migration authority still reports pending migrations" in source
+
+
+def test_search_operator_is_bounded_and_cannot_publish_or_touch_canonical():
+    source = ACTION.read_text(encoding="utf-8")
+    assert 'TARGET_CPUS="8"' in source
+    assert 'TARGET_MEMORY="32g"' in source
+    assert '--memory-swap "$TARGET_MEMORY"' in source
+    assert "--pids-limit 256" in source
+    assert "--restart no" in source
+    assert "--generation-key ratings_v4_prod_p4_opt1 --follow --poll-seconds 5" in source
+    assert "publication_performed=false" in source
+    assert "canonical_writes_performed=false" in source
+    assert "application_service_changes_performed=false" in source
+    assert "publish_derived_generation(" not in source
+    assert "docker compose" not in source
+    assert "docker restart" not in source
+    assert "docker stop" not in source
+    assert "TRUNCATE " not in source
+    assert "DROP TABLE" not in source
+    assert "DROP SCHEMA" not in source
+
+
+def test_search_operator_uses_reviewed_migration_authority_before_worker_launch():
+    source = ACTION.read_text(encoding="utf-8")
+    identity = source.index("install_target_schema_identity")
+    migrate = source.index("apply_pending_migration")
+    launch = source.index("docker run -d")
+    assert identity < migrate < launch
+    assert "scripts/operator/v3_production_migrate.py" in source
+    assert "--operation plan" in source
+    assert "--operation apply" in source
+    assert "--operation authority-gate" in source
+    assert 'dst=/work,readonly' in source
+
+
+def test_target_authority_pins_identity_derived_from_lineage_006():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("v3_schema_identity_test", IDENTITY_TOOL)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    document = module.build(ROOT)
+    payload = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode()
+    expected_sha = hashlib.sha256(payload).hexdigest()
+    authority = json.loads(AUTHORITY.read_text(encoding="utf-8"))
+    assert authority["external_authority"]["schema_identity_sha256"] == expected_sha
+    assert expected_sha == "05bbf65bcb06d59249cd0436aeeca6e529934f999cafc099aa5af8fa7cf4303d"
+    assert document["migration_set_entries"][-1]["ledger_name"] == "006_v3_derived_product_lifecycle.sql"
+
+
+def test_search_status_is_read_only_and_reports_both_products():
+    source = ACTION.read_text(encoding="utf-8")
+    assert "ratings_completed_systems" in source
+    assert "search_completed_systems" in source
+    assert "search_product_state" in source
+    assert "search_validation_status" in source
+    assert "search_rows" in source
+    status = source[source.index("status_operation()") :]
+    assert "docker logs --tail 40" in status
+    assert "INSERT " not in status
+    assert "UPDATE " not in status
+    assert "DELETE " not in status


### PR DESCRIPTION
Put the merged Finder F1 Search projection into the existing governed production operator lane without changing Ratings V4 or application services.

This change:
- pins the production schema identity for the committed lineage through migration 006;
- adds `v3-system-search-f1-start` and `v3-system-search-f1-status` to the existing data-only `chatgpt-ed-new-ops` request lane;
- stages exact trusted `main`, requires root or passwordless sudo before any schema change, installs the reviewed root-owned schema identity, and invokes the existing `v3_production_migrate.py` plan/apply/authority-gate path;
- refuses unless 006 is the only pending migration (or is already applied with the exact committed hash);
- attaches Search only to `ratings_v4_prod_p4_opt1` / canonical publication 4 and launches a bounded 8 CPU / 32 GiB follower using the active API image and internal DATABASE_URL;
- proves at least one committed Search chunk before reporting launch success;
- adds a read-only status path reporting Ratings and Search progress together.

The worker cannot publish, migrate, mutate canonical data, or change application services.