### PR TITLE
Bundle pinned Psycopg for the V3 Search worker

### DIFF
--- a/.github/workflows/chatgpt-ed-new-ops.yml
+++ b/.github/workflows/chatgpt-ed-new-ops.yml
@@ -274,7 +274,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Prepare trusted V3 Search bundle marker
+      - name: Prepare trusted V3 Search bundle marker and dependencies
         if: steps.request.outputs.operation == 'v3-system-search-f1-start'
         shell: bash
         run: |
@@ -282,6 +282,10 @@ jobs:
           source_sha="$(git -C trusted-main rev-parse HEAD)"
           [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || exit 64
           printf '%s\n' "$source_sha" > trusted-main/.v3-search-source-sha
+          rm -rf trusted-main/.v3-search-wheelhouse
+          mkdir -p trusted-main/.v3-search-wheelhouse
+          python -m pip download --disable-pip-version-check --only-binary=:all: \
+            --dest trusted-main/.v3-search-wheelhouse 'psycopg[binary]==3.3.4'
 
       - name: Stage trusted main and launch V3 Search F1
         if: steps.request.outputs.operation == 'v3-system-search-f1-start'

--- a/scripts/operator/actions/v3-system-search-f1.sh
+++ b/scripts/operator/actions/v3-system-search-f1.sh
@@ -175,6 +175,7 @@ start_operation() {
   [ "$(cat "$REPO_ROOT/.v3-search-source-sha" 2>/dev/null || true)" = "$SOURCE_SHA" ] || fail "trusted main bundle SHA marker mismatch"
   [ -f "$REPO_ROOT/scripts/v3_system_search.py" ] || fail "Search builder is missing"
   [ -f "$REPO_ROOT/sql/v3/migrations/006_v3_derived_product_lifecycle.sql" ] || fail "migration 006 is missing"
+  [ -d "$REPO_ROOT/.v3-search-wheelhouse" ] || fail "offline Search dependency wheelhouse is missing"
 
   install -d -m 700 "$STATE_ROOT"
   command -v flock >/dev/null 2>&1 || fail "flock is unavailable"
@@ -222,7 +223,10 @@ start_operation() {
     --entrypoint /bin/sh \
     "$api_image" -lc '
       set -eu
-      export PYTHONPATH="/work:/work/apps/api/src"
+      /usr/local/bin/python -m pip install --disable-pip-version-check --no-input --no-index \
+        --find-links /work/.v3-search-wheelhouse --target /tmp/v3-search-deps \
+        "psycopg[binary]==3.3.4"
+      export PYTHONPATH="/tmp/v3-search-deps:/work:/work/apps/api/src"
       cd /work
       exec /app/.venv/bin/python scripts/v3_system_search.py \
         --generation-key ratings_v4_prod_p4_opt1 --follow --poll-seconds 5

--- a/tests/test_v3_system_search_production_operator.py
+++ b/tests/test_v3_system_search_production_operator.py
@@ -59,6 +59,21 @@ def test_search_operator_is_bounded_and_cannot_publish_or_touch_canonical():
     assert "DROP SCHEMA" not in source
 
 
+def test_search_worker_dependencies_are_offline_and_pinned():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    source = ACTION.read_text(encoding="utf-8")
+    requirement = "psycopg[binary]==3.3.4"
+    assert requirement in workflow
+    assert requirement in source
+    assert "--only-binary=:all:" in workflow
+    assert ".v3-search-wheelhouse" in workflow
+    assert ".v3-search-wheelhouse" in source
+    assert "--no-index" in source
+    assert "--find-links /work/.v3-search-wheelhouse" in source
+    assert "--target /tmp/v3-search-deps" in source
+    assert 'PYTHONPATH="/tmp/v3-search-deps:/work:/work/apps/api/src"' in source
+
+
 def test_search_operator_uses_reviewed_migration_authority_before_worker_launch():
     source = ACTION.read_text(encoding="utf-8")
     identity = source.index("install_target_schema_identity")


### PR DESCRIPTION
Fix the safe first production Search F1 startup failure. Migration 006 is already applied, Ratings continues normally, and the failed Search container registered no product and wrote zero Search rows/chunks.

The production API image does not provide synchronous Psycopg to the Search script. This change mirrors the proven Ratings worker dependency pattern:
- download exact CPython 3.14 wheels for `psycopg[binary]==3.3.4` on the GitHub runner;
- ship them in the trusted Search bundle;
- install only from that offline wheelhouse into `/tmp/v3-search-deps` inside the worker;
- prepend that target to PYTHONPATH before launching `v3_system_search.py`;
- assert the pin/offline contract in focused operator tests.

No schema, Search projection logic, Ratings code, publication path, or canonical data changes.