### PR TITLE
Profile the live V3 Search hot path

### DIFF
--- a/.github/workflows/v3-system-search-profile.yml
+++ b/.github/workflows/v3-system-search-profile.yml
@@ -1,0 +1,100 @@
+name: V3 Search production profile
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/v3-search-profile-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chatgpt-ed-new-ops
+  cancel-in-progress: false
+
+jobs:
+  profile:
+    name: Profile Search F1 read path
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 5
+    steps:
+      - name: Checkout request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Validate data-only request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one Search profile request file" >&2; exit 64; }
+          case "${changed_files[0]}" in
+            .github/v3-search-profile-requests/*.json) ;;
+            *) echo "Unexpected request path" >&2; exit 64 ;;
+          esac
+          python - "${changed_files[0]}" <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if data != {"operation": "v3-system-search-f1-profile"}:
+              raise SystemExit("unsupported request")
+          PY
+
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" && test -n "$SSH_HOST" && test -n "$SSH_PORT" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Run read-only Search profile
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/v3-system-search-profile.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          ssh -i ~/.ssh/ed_new_operator_key \
+            -p "$SSH_PORT" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "$SSH_USER@$SSH_HOST" \
+            'bash -s' \
+            < trusted-main/scripts/operator/actions/v3-system-search-profile.sh | tee "$RECEIPT"
+
+      - name: Upload profile receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-system-search-profile
+          path: ${{ runner.temp }}/v3-system-search-profile.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/operator/actions/v3-system-search-profile.sh
+++ b/scripts/operator/actions/v3-system-search-profile.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_HOSTNAME="ed-finder-prod"
+TARGET_FQDN="nb79a3d.mevnode.com"
+POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_USER="edfinder_v3"
+DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5"
+TARGET_GENERATION_KEY="ratings_v4_prod_p4_opt1"
+
+fail() {
+  printf 'v3 system search profile: %s\n' "$*" >&2
+  exit 64
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is unavailable"
+[ "$(hostname)" = "$TARGET_HOSTNAME" ] || fail "unexpected hostname"
+[ "$(hostname -f 2>/dev/null || true)" = "$TARGET_FQDN" ] || fail "unexpected fqdn"
+[ "$(docker context show)" = "default" ] || fail "unexpected docker context"
+docker context inspect default 2>/dev/null | grep -F 'unix:///var/run/docker.sock' >/dev/null \
+  || fail "default docker context is not the local rootful socket"
+[ "$(docker inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)" = "true" ] \
+  || fail "retained postgres container is not running"
+
+psql_base=(
+  docker exec "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password
+  --tuples-only --no-align --quiet --set ON_ERROR_STOP=1
+  --username "$DATABASE_USER" --dbname "$DATABASE_NAME"
+)
+
+meta="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT g.derived_generation_id::text || E'\\t' ||
+       (g.manifest->>'canonical_schema') || E'\\t' ||
+       COALESCE((SELECT max(b.chunk_ordinal)::text
+                   FROM v3_derived.build_chunk b
+                  WHERE b.derived_generation_id=g.derived_generation_id),'')
+  FROM v3_meta.derived_generation g
+ WHERE g.generation_key='${TARGET_GENERATION_KEY}';
+COMMIT;")"
+[ "$(printf '%s\n' "$meta" | wc -l)" -eq 1 ] || fail "target generation metadata is missing or ambiguous"
+IFS=$'\t' read -r generation_id canonical_schema chunk_ordinal <<< "$meta"
+[[ "$generation_id" =~ ^[0-9a-f-]{36}$ ]] || fail "derived generation id is invalid"
+[[ "$canonical_schema" =~ ^v3_gen_[a-z0-9_]{1,31}$ ]] || fail "canonical schema is invalid"
+[[ "$chunk_ordinal" =~ ^[0-9]+$ ]] || fail "profile chunk ordinal is invalid"
+
+printf 'operation=v3-system-search-f1-profile\n'
+printf 'generation_key=%s\n' "$TARGET_GENERATION_KEY"
+printf 'derived_generation_id=%s\n' "$generation_id"
+printf 'canonical_schema=%s\n' "$canonical_schema"
+printf 'profile_chunk_ordinal=%s\n' "$chunk_ordinal"
+printf 'latest_status='
+"${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT json_build_object(
+  'ratings_completed_chunks',(SELECT count(*) FROM v3_derived.build_chunk b WHERE b.derived_generation_id=g.derived_generation_id),
+  'ratings_completed_systems',(SELECT COALESCE(sum(b.systems),0) FROM v3_derived.build_chunk b WHERE b.derived_generation_id=g.derived_generation_id),
+  'search_completed_chunks',(SELECT count(*) FROM v3_derived.search_build_chunk s WHERE s.derived_generation_id=g.derived_generation_id),
+  'search_completed_systems',(SELECT COALESCE(sum(s.systems),0) FROM v3_derived.search_build_chunk s WHERE s.derived_generation_id=g.derived_generation_id),
+  'search_rows',(SELECT count(*) FROM v3_derived.system_search s WHERE s.derived_generation_id=g.derived_generation_id)
+)::text
+FROM v3_meta.derived_generation g
+WHERE g.derived_generation_id='${generation_id}'::uuid;
+COMMIT;"
+
+printf 'select_plan_json=\n'
+docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+  --no-align --quiet --set ON_ERROR_STOP=1 \
+  --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
+BEGIN READ ONLY;
+SET LOCAL statement_timeout='60s';
+EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)
+WITH target AS MATERIALIZED (
+    SELECT v.system_id64,v.loaded_body_count,v.completeness,v.confidence
+      FROM v3_derived.system_rating_vector v
+     WHERE v.derived_generation_id='${generation_id}'::uuid
+       AND v.chunk_ordinal=${chunk_ordinal}
+),
+body_summary AS (
+    SELECT b.system_id64,
+           (count(*) FILTER (
+               WHERE b.lifecycle_state='ACTIVE' AND b.is_landable IS TRUE
+           ))::integer AS landable_count,
+           bool_or(
+               b.lifecycle_state='ACTIVE'
+               AND ts.public_code IN ('terraformable','terraformed','terraforming')
+           ) AS has_terraformable
+      FROM ${canonical_schema}.bodies b
+      JOIN target t ON t.system_id64=b.system_id64
+ LEFT JOIN v3_vocab.terraforming_state ts
+        ON ts.terraforming_state_id=b.terraforming_state_id
+  GROUP BY b.system_id64
+),
+ring_summary AS (
+    SELECT r.system_id64,true AS has_rings
+      FROM ${canonical_schema}.rings r
+      JOIN target t ON t.system_id64=r.system_id64
+     WHERE r.lifecycle_state='ACTIVE' AND r.kind='RING'
+  GROUP BY r.system_id64
+),
+signal_summary AS (
+    SELECT b.system_id64,
+           bool_or(st.public_code='saa_signaltype_biological'
+                   AND bs.signal_count>0) AS has_biologicals,
+           bool_or(st.public_code='saa_signaltype_geological'
+                   AND bs.signal_count>0) AS has_geologicals
+      FROM ${canonical_schema}.body_signal_current bs
+      JOIN ${canonical_schema}.bodies b ON b.body_pk=bs.body_pk
+      JOIN target t ON t.system_id64=b.system_id64
+      JOIN v3_vocab.signal_type st ON st.signal_type_id=bs.signal_type_id
+     WHERE b.lifecycle_state='ACTIVE'
+  GROUP BY b.system_id64
+),
+station_summary AS (
+    SELECT st.system_id64,
+           (count(*) FILTER (WHERE st.lifecycle_state='ACTIVE'))::integer AS station_count
+      FROM ${canonical_schema}.stations st
+      JOIN target t ON t.system_id64=st.system_id64
+  GROUP BY st.system_id64
+),
+main_star AS (
+    SELECT DISTINCT ON (bm.system_id64)
+           bm.system_id64,bm.body_class AS main_star_class
+      FROM v3_derived.body_mechanics bm
+      JOIN target t ON t.system_id64=bm.system_id64
+     WHERE bm.derived_generation_id='${generation_id}'::uuid
+       AND bm.is_main_star IS TRUE
+  ORDER BY bm.system_id64,bm.body_pk
+)
+SELECT t.system_id64,s.name,s.x_ly,s.y_ly,s.z_ly,
+       cube(ARRAY[s.x_ly,s.y_ly,s.z_ly]),
+       s.galaxy_region_id,gr.display_name,ms.main_star_class,
+       t.loaded_body_count,COALESCE(bs.landable_count,0),
+       COALESCE(ss.station_count,0),COALESCE(rs.has_rings,false),
+       COALESCE(sig.has_biologicals,false),
+       COALESCE(sig.has_geologicals,false),
+       COALESCE(bs.has_terraformable,false),
+       s.source_updated_at,
+       (SELECT min(value)::double precision/10000 FROM unnest(t.completeness) AS value),
+       (SELECT min(value)::double precision/10000 FROM unnest(t.confidence) AS value)
+  FROM target t
+  JOIN ${canonical_schema}.systems s ON s.id64=t.system_id64
+ LEFT JOIN v3_vocab.galaxy_region gr ON gr.galaxy_region_id=s.galaxy_region_id
+ LEFT JOIN body_summary bs USING(system_id64)
+ LEFT JOIN ring_summary rs USING(system_id64)
+ LEFT JOIN signal_summary sig USING(system_id64)
+ LEFT JOIN station_summary ss USING(system_id64)
+ LEFT JOIN main_star ms USING(system_id64)
+ ORDER BY t.system_id64;
+ROLLBACK;
+SQL
+
+printf 'database_writes_performed=false\n'
+printf 'schema_changes_performed=false\n'
+printf 'publication_performed=false\n'
+printf 'canonical_writes_performed=false\n'
+printf 'application_service_changes_performed=false\n'

--- a/tests/test_v3_system_search_profile_operator.py
+++ b/tests/test_v3_system_search_profile_operator.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/operator/actions/v3-system-search-profile.sh"
+WORKFLOW = ROOT / ".github/workflows/v3-system-search-profile.yml"
+
+
+def test_search_profile_is_read_only_and_exact_targeted():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'TARGET_GENERATION_KEY="ratings_v4_prod_p4_opt1"' in source
+    assert 'POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"' in source
+    assert 'BEGIN READ ONLY;' in source
+    assert 'EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)' in source
+    assert "statement_timeout='60s'" in source
+    assert "database_writes_performed=false" in source
+    assert "schema_changes_performed=false" in source
+    assert "publication_performed=false" in source
+    for forbidden in (
+        "INSERT INTO ",
+        "UPDATE ",
+        "DELETE FROM ",
+        "TRUNCATE ",
+        "DROP ",
+        "CREATE INDEX",
+        "ALTER TABLE",
+        "docker stop",
+        "docker restart",
+        "docker rm",
+    ):
+        assert forbidden not in source
+
+
+def test_search_profile_workflow_is_data_only_and_uses_trusted_main():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    assert "chatgpt-ed-new-ops-requests" in source
+    assert ".github/v3-search-profile-requests/*.json" in source
+    assert '{"operation": "v3-system-search-f1-profile"}' in source
+    assert "Expected exactly one Search profile request file" in source
+    assert "ref: main" in source
+    assert "trusted-main/scripts/operator/actions/v3-system-search-profile.sh" in source
+    assert "environment: ed-new-operator" in source
+    assert "group: chatgpt-ed-new-ops" in source


### PR DESCRIPTION
Add a narrowly scoped, read-only production profiler for the existing Finder F1 Search projection. It runs the SELECT half of one real 1,000-system Search chunk under BEGIN READ ONLY with EXPLAIN ANALYZE + BUFFERS and a 60-second statement timeout, through the existing ed-new SSH authority. It cannot write rows, change schema, publish data, or alter services. The live Search worker and its product code identity are untouched.