### PR TITLE
Refresh planner statistics for the Search hot path

### DIFF
--- a/.github/workflows/v3-system-search-analyze-stats.yml
+++ b/.github/workflows/v3-system-search-analyze-stats.yml
@@ -1,0 +1,100 @@
+name: V3 Search production planner statistics
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/v3-search-analyze-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chatgpt-ed-new-ops
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    name: Refresh Search planner statistics
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 20
+    steps:
+      - name: Checkout request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Validate data-only request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one Search ANALYZE request file" >&2; exit 64; }
+          case "${changed_files[0]}" in
+            .github/v3-search-analyze-requests/*.json) ;;
+            *) echo "Unexpected request path" >&2; exit 64 ;;
+          esac
+          python - "${changed_files[0]}" <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if data != {"operation": "v3-system-search-f1-analyze-stats"}:
+              raise SystemExit("unsupported request")
+          PY
+
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" && test -n "$SSH_HOST" && test -n "$SSH_PORT" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Refresh bounded canonical planner statistics
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/v3-system-search-analyze-stats.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          ssh -i ~/.ssh/ed_new_operator_key \
+            -p "$SSH_PORT" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "$SSH_USER@$SSH_HOST" \
+            'bash -s' \
+            < trusted-main/scripts/operator/actions/v3-system-search-analyze-stats.sh | tee "$RECEIPT"
+
+      - name: Upload statistics receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-system-search-analyze-stats
+          path: ${{ runner.temp }}/v3-system-search-analyze-stats.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/operator/actions/v3-system-search-analyze-stats.sh
+++ b/scripts/operator/actions/v3-system-search-analyze-stats.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_HOSTNAME="ed-finder-prod"
+TARGET_FQDN="nb79a3d.mevnode.com"
+POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_USER="edfinder_v3"
+DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5"
+CANONICAL_GENERATION="a7076522-54cd-52f3-a291-4e5406bea230"
+CANONICAL_SEQUENCE="4"
+CANONICAL_SCHEMA="v3_gen_phase4c_full_20260827_r5"
+DERIVED_KEY="ratings_v4_prod_p4_opt1"
+
+fail() {
+  printf 'v3 system search analyze stats: %s\n' "$*" >&2
+  exit 64
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is unavailable"
+[ "$(hostname)" = "$TARGET_HOSTNAME" ] || fail "unexpected hostname"
+[ "$(hostname -f 2>/dev/null || true)" = "$TARGET_FQDN" ] || fail "unexpected fqdn"
+[ "$(docker context show)" = "default" ] || fail "unexpected docker context"
+docker context inspect default 2>/dev/null | grep -F 'unix:///var/run/docker.sock' >/dev/null \
+  || fail "default docker context is not the local rootful socket"
+[ "$(docker inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)" = "true" ] \
+  || fail "retained postgres container is not running"
+
+psql_base=(
+  docker exec "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password
+  --tuples-only --no-align --quiet --set ON_ERROR_STOP=1
+  --username "$DATABASE_USER" --dbname "$DATABASE_NAME"
+)
+
+authority="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT c.generation_id::text || E'\\t' || c.publication_sequence::text || E'\\t' ||
+       d.canonical_generation_id::text || E'\\t' || d.canonical_publication_sequence::text || E'\\t' ||
+       (d.manifest->>'canonical_schema')
+  FROM v3_meta.current_canonical_generation c
+  JOIN v3_meta.derived_generation d
+    ON d.generation_key='${DERIVED_KEY}'
+ WHERE c.singleton;
+COMMIT;")"
+[ "$(printf '%s\n' "$authority" | wc -l)" -eq 1 ] || fail "production generation authority is missing or ambiguous"
+IFS=$'\t' read -r current_canonical current_sequence derived_canonical derived_sequence derived_schema <<< "$authority"
+[ "$current_canonical" = "$CANONICAL_GENERATION" ] || fail "current canonical generation changed"
+[ "$current_sequence" = "$CANONICAL_SEQUENCE" ] || fail "current canonical publication sequence changed"
+[ "$derived_canonical" = "$CANONICAL_GENERATION" ] || fail "derived generation canonical identity changed"
+[ "$derived_sequence" = "$CANONICAL_SEQUENCE" ] || fail "derived generation canonical sequence changed"
+[ "$derived_schema" = "$CANONICAL_SCHEMA" ] || fail "derived generation canonical schema changed"
+
+for relation in bodies body_signal_current; do
+  exists="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+ WHERE n.nspname='${CANONICAL_SCHEMA}' AND c.relname='${relation}' AND c.relkind='r';
+COMMIT;")"
+  [ "$exists" = "1" ] || fail "required canonical relation ${relation} is missing or ambiguous"
+done
+
+stats_json() {
+  "${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT json_agg(row_to_json(q) ORDER BY q.relation)::text
+FROM (
+  SELECT s.relname AS relation,
+         s.n_live_tup,
+         s.last_analyze,
+         s.last_autoanalyze,
+         c.reltuples::bigint AS reltuples,
+         pg_relation_size(c.oid) AS table_bytes,
+         pg_total_relation_size(c.oid) AS total_bytes
+    FROM pg_stat_all_tables s
+    JOIN pg_class c ON c.oid=s.relid
+   WHERE s.schemaname='${CANONICAL_SCHEMA}'
+     AND s.relname IN ('bodies','body_signal_current')
+) q;
+COMMIT;"
+}
+
+printf 'operation=v3-system-search-f1-analyze-stats\n'
+printf 'canonical_generation=%s\n' "$CANONICAL_GENERATION"
+printf 'canonical_sequence=%s\n' "$CANONICAL_SEQUENCE"
+printf 'canonical_schema=%s\n' "$CANONICAL_SCHEMA"
+printf 'before_stats=%s\n' "$(stats_json)"
+
+# ANALYZE updates planner statistics/catalog metadata only. The canonical tables
+# are immutable inputs here: this operation performs no INSERT/UPDATE/DELETE and
+# changes no application rows, constraints, indexes, services or publication.
+docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+  --set ON_ERROR_STOP=1 --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
+SET statement_timeout='15min';
+SET lock_timeout='5s';
+ANALYZE ${CANONICAL_SCHEMA}.bodies (system_id64, lifecycle_state, is_landable, terraforming_state_id);
+ANALYZE ${CANONICAL_SCHEMA}.body_signal_current (body_pk, signal_type_id, signal_count);
+SQL
+
+after="$(stats_json)"
+printf 'after_stats=%s\n' "$after"
+
+verification="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT
+  (SELECT (last_analyze IS NOT NULL)::int FROM pg_stat_all_tables
+    WHERE schemaname='${CANONICAL_SCHEMA}' AND relname='bodies') || E'\\t' ||
+  (SELECT (last_analyze IS NOT NULL)::int FROM pg_stat_all_tables
+    WHERE schemaname='${CANONICAL_SCHEMA}' AND relname='body_signal_current') || E'\\t' ||
+  (SELECT count(*) FROM pg_stats
+    WHERE schemaname='${CANONICAL_SCHEMA}' AND tablename='bodies'
+      AND attname IN ('system_id64','lifecycle_state','is_landable','terraforming_state_id')) || E'\\t' ||
+  (SELECT count(*) FROM pg_stats
+    WHERE schemaname='${CANONICAL_SCHEMA}' AND tablename='body_signal_current'
+      AND attname IN ('body_pk','signal_type_id','signal_count'));
+COMMIT;")"
+IFS=$'\t' read -r bodies_analyzed signals_analyzed bodies_stats_cols signal_stats_cols <<< "$verification"
+[ "$bodies_analyzed" = "1" ] || fail "bodies ANALYZE receipt was not visible"
+[ "$signals_analyzed" = "1" ] || fail "body_signal_current ANALYZE receipt was not visible"
+[ "$bodies_stats_cols" = "4" ] || fail "bodies planner statistics are incomplete"
+[ "$signal_stats_cols" = "3" ] || fail "body_signal_current planner statistics are incomplete"
+
+printf 'result=planner-statistics-refreshed\n'
+printf 'planner_statistics_updated=true\n'
+printf 'canonical_row_writes_performed=false\n'
+printf 'application_data_writes_performed=false\n'
+printf 'schema_changes_performed=false\n'
+printf 'publication_performed=false\n'
+printf 'application_service_changes_performed=false\n'

--- a/tests/test_v3_system_search_analyze_stats_operator.py
+++ b/tests/test_v3_system_search_analyze_stats_operator.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/operator/actions/v3-system-search-analyze-stats.sh"
+WORKFLOW = ROOT / ".github/workflows/v3-system-search-analyze-stats.yml"
+
+
+def test_analyze_operation_is_exactly_scoped_and_has_no_row_or_schema_mutations():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'CANONICAL_GENERATION="a7076522-54cd-52f3-a291-4e5406bea230"' in source
+    assert 'CANONICAL_SEQUENCE="4"' in source
+    assert 'CANONICAL_SCHEMA="v3_gen_phase4c_full_20260827_r5"' in source
+    assert 'DERIVED_KEY="ratings_v4_prod_p4_opt1"' in source
+    assert "ANALYZE ${CANONICAL_SCHEMA}.bodies (system_id64, lifecycle_state, is_landable, terraforming_state_id);" in source
+    assert "ANALYZE ${CANONICAL_SCHEMA}.body_signal_current (body_pk, signal_type_id, signal_count);" in source
+    assert "statement_timeout='15min'" in source
+    assert "lock_timeout='5s'" in source
+    assert "planner_statistics_updated=true" in source
+    assert "canonical_row_writes_performed=false" in source
+    assert "application_data_writes_performed=false" in source
+    assert "schema_changes_performed=false" in source
+    assert "publication_performed=false" in source
+    assert "application_service_changes_performed=false" in source
+    for forbidden in (
+        "INSERT INTO ",
+        "UPDATE ",
+        "DELETE FROM ",
+        "TRUNCATE ",
+        "DROP ",
+        "CREATE INDEX",
+        "ALTER TABLE",
+        "docker stop",
+        "docker restart",
+        "docker rm",
+        "publish_derived_generation",
+    ):
+        assert forbidden not in source
+
+
+def test_analyze_operation_verifies_generation_authority_before_statistics_refresh():
+    source = SCRIPT.read_text(encoding="utf-8")
+    authority = source.index("production generation authority is missing or ambiguous")
+    analyze = source.index("ANALYZE ${CANONICAL_SCHEMA}.bodies")
+    assert authority < analyze
+    assert "current canonical generation changed" in source
+    assert "current canonical publication sequence changed" in source
+    assert "derived generation canonical identity changed" in source
+    assert "derived generation canonical schema changed" in source
+    assert "bodies ANALYZE receipt was not visible" in source
+    assert "body_signal_current ANALYZE receipt was not visible" in source
+
+
+def test_analyze_workflow_is_data_only_and_executes_trusted_main():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    assert "chatgpt-ed-new-ops-requests" in source
+    assert ".github/v3-search-analyze-requests/*.json" in source
+    assert '{"operation": "v3-system-search-f1-analyze-stats"}' in source
+    assert "Expected exactly one Search ANALYZE request file" in source
+    assert "ref: main" in source
+    assert "trusted-main/scripts/operator/actions/v3-system-search-analyze-stats.sh" in source
+    assert "environment: ed-new-operator" in source
+    assert "group: chatgpt-ed-new-ops" in source


### PR DESCRIPTION
Add one tightly scoped production operation to refresh PostgreSQL planner statistics for the two canonical tables implicated by the live Search profile: `bodies` and `body_signal_current`. The operation pins the exact production host, canonical generation/publication/schema and `ratings_v4_prod_p4_opt1`, then runs column-scoped ANALYZE only. It performs no INSERT/UPDATE/DELETE, no schema/index changes, no publication, and no service changes. Focused tests assert those boundaries.