### PR TITLE
Raise Search bodies system-id statistics target

### DIFF
--- a/.github/workflows/v3-system-search-tune-systemid-stats.yml
+++ b/.github/workflows/v3-system-search-tune-systemid-stats.yml
@@ -1,0 +1,100 @@
+name: V3 Search production system-id statistics tuning
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/v3-search-systemid-stats-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chatgpt-ed-new-ops
+  cancel-in-progress: false
+
+jobs:
+  tune:
+    name: Tune Search system-id planner statistics
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 20
+    steps:
+      - name: Checkout request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Validate data-only request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one Search system-id statistics request file" >&2; exit 64; }
+          case "${changed_files[0]}" in
+            .github/v3-search-systemid-stats-requests/*.json) ;;
+            *) echo "Unexpected request path" >&2; exit 64 ;;
+          esac
+          python - "${changed_files[0]}" <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if data != {"operation": "v3-system-search-f1-tune-systemid-stats"}:
+              raise SystemExit("unsupported request")
+          PY
+
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" && test -n "$SSH_HOST" && test -n "$SSH_PORT" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Tune bounded system-id planner statistics
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/v3-system-search-tune-systemid-stats.txt
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          ssh -i ~/.ssh/ed_new_operator_key \
+            -p "$SSH_PORT" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "$SSH_USER@$SSH_HOST" \
+            'bash -s' \
+            < trusted-main/scripts/operator/actions/v3-system-search-tune-systemid-stats.sh | tee "$RECEIPT"
+
+      - name: Upload tuning receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v3-system-search-tune-systemid-stats
+          path: ${{ runner.temp }}/v3-system-search-tune-systemid-stats.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/scripts/operator/actions/v3-system-search-tune-systemid-stats.sh
+++ b/scripts/operator/actions/v3-system-search-tune-systemid-stats.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_HOSTNAME="ed-finder-prod"
+TARGET_FQDN="nb79a3d.mevnode.com"
+POSTGRES_CONTAINER="edfinder-v3-phase4c-full-20260827_r5-postgres"
+DATABASE_USER="edfinder_v3"
+DATABASE_NAME="edfinder_v3_phase4c_full_20260827_r5"
+CANONICAL_GENERATION="a7076522-54cd-52f3-a291-4e5406bea230"
+CANONICAL_SEQUENCE="4"
+CANONICAL_SCHEMA="v3_gen_phase4c_full_20260827_r5"
+DERIVED_KEY="ratings_v4_prod_p4_opt1"
+STATISTICS_TARGET="1000"
+
+fail() {
+  printf 'v3 system search tune system-id stats: %s\n' "$*" >&2
+  exit 64
+}
+
+command -v docker >/dev/null 2>&1 || fail "docker is unavailable"
+[ "$(hostname)" = "$TARGET_HOSTNAME" ] || fail "unexpected hostname"
+[ "$(hostname -f 2>/dev/null || true)" = "$TARGET_FQDN" ] || fail "unexpected fqdn"
+[ "$(docker context show)" = "default" ] || fail "unexpected docker context"
+docker context inspect default 2>/dev/null | grep -F 'unix:///var/run/docker.sock' >/dev/null \
+  || fail "default docker context is not the local rootful socket"
+[ "$(docker inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)" = "true" ] \
+  || fail "retained postgres container is not running"
+
+psql_base=(
+  docker exec "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password
+  --tuples-only --no-align --quiet --set ON_ERROR_STOP=1
+  --username "$DATABASE_USER" --dbname "$DATABASE_NAME"
+)
+
+authority="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT c.generation_id::text || E'\\t' || c.publication_sequence::text || E'\\t' ||
+       d.canonical_generation_id::text || E'\\t' || d.canonical_publication_sequence::text || E'\\t' ||
+       (d.manifest->>'canonical_schema')
+  FROM v3_meta.current_canonical_generation c
+  JOIN v3_meta.derived_generation d
+    ON d.generation_key='${DERIVED_KEY}'
+ WHERE c.singleton;
+COMMIT;")"
+[ "$(printf '%s\n' "$authority" | wc -l)" -eq 1 ] || fail "production generation authority is missing or ambiguous"
+IFS=$'\t' read -r current_canonical current_sequence derived_canonical derived_sequence derived_schema <<< "$authority"
+[ "$current_canonical" = "$CANONICAL_GENERATION" ] || fail "current canonical generation changed"
+[ "$current_sequence" = "$CANONICAL_SEQUENCE" ] || fail "current canonical publication sequence changed"
+[ "$derived_canonical" = "$CANONICAL_GENERATION" ] || fail "derived generation canonical identity changed"
+[ "$derived_sequence" = "$CANONICAL_SEQUENCE" ] || fail "derived generation canonical sequence changed"
+[ "$derived_schema" = "$CANONICAL_SCHEMA" ] || fail "derived generation canonical schema changed"
+
+relation_count="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT count(*)
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid=c.relnamespace
+ WHERE n.nspname='${CANONICAL_SCHEMA}'
+   AND c.relname='bodies'
+   AND c.relkind='r';
+COMMIT;")"
+[ "$relation_count" = "1" ] || fail "canonical bodies relation is missing or ambiguous"
+
+stats_json() {
+  "${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT json_build_object(
+  'relation_reltuples',c.reltuples::bigint,
+  'statistics_target',a.attstattarget,
+  'n_distinct',s.n_distinct,
+  'implied_distinct',CASE
+      WHEN s.n_distinct IS NULL THEN NULL
+      WHEN s.n_distinct < 0 THEN round((-s.n_distinct * c.reltuples)::numeric)
+      ELSE round(s.n_distinct::numeric)
+    END,
+  'implied_rows_per_system',CASE
+      WHEN s.n_distinct IS NULL OR s.n_distinct=0 THEN NULL
+      WHEN s.n_distinct < 0 THEN round((1 / -s.n_distinct)::numeric,2)
+      ELSE round((c.reltuples / s.n_distinct)::numeric,2)
+    END,
+  'last_analyze',st.last_analyze,
+  'last_autoanalyze',st.last_autoanalyze
+)::text
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid=c.relnamespace
+  JOIN pg_attribute a ON a.attrelid=c.oid AND a.attname='system_id64' AND a.attnum>0 AND NOT a.attisdropped
+  LEFT JOIN pg_stats s ON s.schemaname=n.nspname AND s.tablename=c.relname AND s.attname=a.attname
+  LEFT JOIN pg_stat_all_tables st ON st.relid=c.oid
+ WHERE n.nspname='${CANONICAL_SCHEMA}' AND c.relname='bodies';
+COMMIT;"
+}
+
+printf 'operation=v3-system-search-f1-tune-systemid-stats\n'
+printf 'canonical_generation=%s\n' "$CANONICAL_GENERATION"
+printf 'canonical_sequence=%s\n' "$CANONICAL_SEQUENCE"
+printf 'canonical_schema=%s\n' "$CANONICAL_SCHEMA"
+printf 'statistics_target=%s\n' "$STATISTICS_TARGET"
+printf 'before_stats=%s\n' "$(stats_json)"
+
+docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+  --set ON_ERROR_STOP=1 --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
+SET statement_timeout='15min';
+SET lock_timeout='5s';
+ALTER TABLE ${CANONICAL_SCHEMA}.bodies
+  ALTER COLUMN system_id64 SET STATISTICS ${STATISTICS_TARGET};
+ANALYZE ${CANONICAL_SCHEMA}.bodies (system_id64);
+SQL
+
+printf 'after_stats=%s\n' "$(stats_json)"
+
+verification="$("${psql_base[@]}" --command "BEGIN READ ONLY;
+SELECT a.attstattarget::text || E'\\t' ||
+       COALESCE(s.n_distinct::text,'') || E'\\t' ||
+       (st.last_analyze IS NOT NULL)::int::text
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid=c.relnamespace
+  JOIN pg_attribute a ON a.attrelid=c.oid AND a.attname='system_id64' AND a.attnum>0 AND NOT a.attisdropped
+  LEFT JOIN pg_stats s ON s.schemaname=n.nspname AND s.tablename=c.relname AND s.attname=a.attname
+  LEFT JOIN pg_stat_all_tables st ON st.relid=c.oid
+ WHERE n.nspname='${CANONICAL_SCHEMA}' AND c.relname='bodies';
+COMMIT;")"
+IFS=$'\t' read -r observed_target observed_n_distinct analyzed <<< "$verification"
+[ "$observed_target" = "$STATISTICS_TARGET" ] || fail "system_id64 statistics target was not applied"
+[ -n "$observed_n_distinct" ] || fail "system_id64 n_distinct is missing after ANALYZE"
+[ "$analyzed" = "1" ] || fail "bodies ANALYZE receipt was not visible"
+
+printf 'result=planner-statistics-target-refreshed\n'
+printf 'planner_statistics_updated=true\n'
+printf 'planner_metadata_changes_performed=true\n'
+printf 'canonical_row_writes_performed=false\n'
+printf 'application_data_writes_performed=false\n'
+printf 'publication_performed=false\n'
+printf 'application_service_changes_performed=false\n'

--- a/tests/test_v3_system_search_systemid_stats_operator.py
+++ b/tests/test_v3_system_search_systemid_stats_operator.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/operator/actions/v3-system-search-tune-systemid-stats.sh"
+WORKFLOW = ROOT / ".github/workflows/v3-system-search-tune-systemid-stats.yml"
+
+
+def test_systemid_stats_tuning_is_exact_and_row_safe():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'CANONICAL_GENERATION="a7076522-54cd-52f3-a291-4e5406bea230"' in source
+    assert 'CANONICAL_SEQUENCE="4"' in source
+    assert 'CANONICAL_SCHEMA="v3_gen_phase4c_full_20260827_r5"' in source
+    assert 'DERIVED_KEY="ratings_v4_prod_p4_opt1"' in source
+    assert 'STATISTICS_TARGET="1000"' in source
+    assert "ALTER COLUMN system_id64 SET STATISTICS ${STATISTICS_TARGET};" in source
+    assert "ANALYZE ${CANONICAL_SCHEMA}.bodies (system_id64);" in source
+    assert "statement_timeout='15min'" in source
+    assert "lock_timeout='5s'" in source
+    assert "planner_statistics_updated=true" in source
+    assert "planner_metadata_changes_performed=true" in source
+    assert "canonical_row_writes_performed=false" in source
+    assert "application_data_writes_performed=false" in source
+    assert "publication_performed=false" in source
+    assert "application_service_changes_performed=false" in source
+    for forbidden in (
+        "INSERT INTO ",
+        "UPDATE ",
+        "DELETE FROM ",
+        "TRUNCATE ",
+        "DROP ",
+        "CREATE INDEX",
+        "docker stop",
+        "docker restart",
+        "docker rm",
+        "publish_derived_generation",
+    ):
+        assert forbidden not in source
+
+
+def test_systemid_stats_tuning_reports_before_and_after_selectivity():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert "before_stats=" in source
+    assert "after_stats=" in source
+    assert "'n_distinct',s.n_distinct" in source
+    assert "'implied_distinct'" in source
+    assert "'implied_rows_per_system'" in source
+    assert "system_id64 statistics target was not applied" in source
+    assert "system_id64 n_distinct is missing after ANALYZE" in source
+
+
+def test_systemid_stats_workflow_is_data_only_and_uses_trusted_main():
+    source = WORKFLOW.read_text(encoding="utf-8")
+    assert "chatgpt-ed-new-ops-requests" in source
+    assert ".github/v3-search-systemid-stats-requests/*.json" in source
+    assert '{"operation": "v3-system-search-f1-tune-systemid-stats"}' in source
+    assert "Expected exactly one Search system-id statistics request file" in source
+    assert "ref: main" in source
+    assert "trusted-main/scripts/operator/actions/v3-system-search-tune-systemid-stats.sh" in source
+    assert "environment: ed-new-operator" in source
+    assert "group: chatgpt-ed-new-ops" in source


### PR DESCRIPTION
Tune one PostgreSQL planner metadata setting implicated by the live Search F1 profile. The operation pins the exact production host, canonical generation/publication/schema and `ratings_v4_prod_p4_opt1`, raises only `bodies.system_id64` to statistics target 1000, re-ANALYZEs that column, and records before/after `n_distinct` plus implied rows per system. It performs no canonical/application row writes, no index changes, no publication, and no service changes. Search and Ratings code identity are untouched.