### PR TITLE
Capture complete indexed Search planner evidence

### DIFF
--- a/.github/workflows/v3-system-search-profile.yml
+++ b/.github/workflows/v3-system-search-profile.yml
@@ -19,7 +19,7 @@ jobs:
     name: Profile Search F1 read path
     runs-on: ubuntu-latest
     environment: ed-new-operator
-    timeout-minutes: 5
+    timeout-minutes: 12
     steps:
       - name: Checkout request branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/scripts/operator/actions/v3-system-search-profile.sh
+++ b/scripts/operator/actions/v3-system-search-profile.sh
@@ -61,12 +61,16 @@ FROM v3_meta.derived_generation g
 WHERE g.derived_generation_id='${generation_id}'::uuid;
 COMMIT;"
 
-printf 'select_plan_json=\n'
-docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
-  --no-align --quiet --set ON_ERROR_STOP=1 \
-  --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
+run_full_query_variant() {
+  local label="$1" settings="$2" plan_key="$3"
+  printf 'full_query_variant=%s\n' "$label"
+  printf '%s=\n' "$plan_key"
+  docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
+    --no-align --quiet --set ON_ERROR_STOP=1 \
+    --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
 BEGIN READ ONLY;
 SET LOCAL statement_timeout='60s';
+${settings}
 EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)
 WITH target AS MATERIALIZED (
     SELECT v.system_id64,v.loaded_body_count,v.completeness,v.confidence
@@ -147,6 +151,13 @@ SELECT t.system_id64,s.name,s.x_ly,s.y_ly,s.z_ly,
  ORDER BY t.system_id64;
 ROLLBACK;
 SQL
+}
+
+run_full_query_variant baseline "" select_plan_json
+run_full_query_variant jit_off "SET LOCAL jit=off;" jit_off_select_plan_json
+run_full_query_variant indexed_no_seqscan \
+  "SET LOCAL jit=off; SET LOCAL enable_seqscan=off;" \
+  indexed_select_plan_json
 
 printf 'database_writes_performed=false\n'
 printf 'schema_changes_performed=false\n'

--- a/scripts/operator/actions/v3-system-search-signal-plan-profile.sh
+++ b/scripts/operator/actions/v3-system-search-signal-plan-profile.sh
@@ -59,14 +59,14 @@ COMMIT;"
 run_variant() {
   local label="$1" settings="$2" query_kind="$3"
   printf 'signal_variant=%s\n' "$label"
+  printf 'signal_plan_json=\n'
   if [ "$query_kind" = "current" ]; then
     docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
-      --no-align --quiet --set ON_ERROR_STOP=1 --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL \
-      | grep -E '^( *(Seq Scan|Index Scan|Index Only Scan|Bitmap|Nested Loop|Hash Join|Merge Join|HashAggregate|GroupAggregate)| *Buffers:| *Execution Time:| *JIT:| *Settings:)'
+      --no-align --quiet --set ON_ERROR_STOP=1 --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
 BEGIN READ ONLY;
 SET LOCAL statement_timeout='60s';
 ${settings}
-EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY)
+EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)
 WITH target AS MATERIALIZED (
     SELECT v.system_id64
       FROM v3_derived.system_rating_vector v
@@ -86,14 +86,13 @@ ROLLBACK;
 SQL
   else
     docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
-      --no-align --quiet --set ON_ERROR_STOP=1 --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL \
-      | grep -E '^( *(Seq Scan|Index Scan|Index Only Scan|Bitmap|Nested Loop|Hash Join|Merge Join|HashAggregate|GroupAggregate)| *Buffers:| *Execution Time:| *JIT:| *Settings:)'
+      --no-align --quiet --set ON_ERROR_STOP=1 --username "$DATABASE_USER" --dbname "$DATABASE_NAME" <<SQL
 BEGIN READ ONLY;
 SET LOCAL statement_timeout='60s';
 SET LOCAL jit=off;
 SET LOCAL join_collapse_limit=1;
 SET LOCAL from_collapse_limit=1;
-EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY)
+EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)
 WITH target AS MATERIALIZED (
     SELECT v.system_id64
       FROM v3_derived.system_rating_vector v

--- a/tests/test_v3_system_search_profile_operator.py
+++ b/tests/test_v3_system_search_profile_operator.py
@@ -46,3 +46,4 @@ def test_search_profile_workflow_is_data_only_and_uses_trusted_main():
     assert "trusted-main/scripts/operator/actions/v3-system-search-profile.sh" in source
     assert "environment: ed-new-operator" in source
     assert "group: chatgpt-ed-new-ops" in source
+    assert "timeout-minutes: 12" in source

--- a/tests/test_v3_system_search_profile_operator.py
+++ b/tests/test_v3_system_search_profile_operator.py
@@ -13,6 +13,11 @@ def test_search_profile_is_read_only_and_exact_targeted():
     assert 'BEGIN READ ONLY;' in source
     assert 'EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)' in source
     assert "statement_timeout='60s'" in source
+    assert "run_full_query_variant baseline \"\" select_plan_json" in source
+    assert 'run_full_query_variant jit_off "SET LOCAL jit=off;" jit_off_select_plan_json' in source
+    assert "run_full_query_variant indexed_no_seqscan" in source
+    assert "SET LOCAL enable_seqscan=off;" in source
+    assert "full_query_variant=%s" in source
     assert "database_writes_performed=false" in source
     assert "schema_changes_performed=false" in source
     assert "publication_performed=false" in source

--- a/tests/test_v3_system_search_signal_profile_operator.py
+++ b/tests/test_v3_system_search_signal_profile_operator.py
@@ -10,7 +10,9 @@ def test_signal_profile_only_explains_read_only_variants():
     source = SCRIPT.read_text(encoding="utf-8")
     assert 'TARGET_GENERATION_KEY="ratings_v4_prod_p4_opt1"' in source
     assert "BEGIN READ ONLY;" in source
-    assert "EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY)" in source
+    assert "EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)" in source
+    assert "signal_plan_json=" in source
+    assert "grep -E" not in source
     assert "statement_timeout='60s'" in source
     assert "enable_hashjoin=off" in source
     assert "enable_seqscan=off" in source


### PR DESCRIPTION
## What this does

Improves the existing read-only V3 Search production profiler so the next diagnostic artifact can prove the indexed alternative end to end.

- emit complete `FORMAT JSON` plans for every signal-summary variant instead of filtering out child nodes beginning with `->`;
- preserve the existing baseline `select_plan_json` marker;
- add full-query `jit_off` and `indexed_no_seqscan` variants alongside the baseline;
- keep every statement under `BEGIN READ ONLY` with the existing 60-second statement timeout;
- strengthen focused tests for the new variants, JSON evidence, and mutation exclusions.

## Safety boundary

This PR does not add a production request, trigger the profiling workflow, change the Search builder, modify planner settings outside the read-only transaction, write rows, change schema/indexes, publish data, or alter services.

## Verification

- `bash -n scripts/operator/actions/v3-system-search-profile.sh scripts/operator/actions/v3-system-search-signal-plan-profile.sh`
- `python -m pytest -q tests/test_v3_system_search_*operator.py` — 17 passed