### PR TITLE
Remove residual Search self-joins and transaction-scope JIT

### DIFF
--- a/docs/development/v3-search-indexed-projection.md
+++ b/docs/development/v3-search-indexed-projection.md
@@ -52,3 +52,31 @@ that existing manifest; do not edit the manifest or bypass its identity check.
 A live cutover needs a separately reviewed, explicitly authorized product
 identity/resume strategy after the read-only proof passes. Until then the
 currently running worker remains on its original immutable source bundle.
+
+## Run 6 result and remaining executor costs
+
+[Run 6](https://github.com/brianstewart377-rgb/ed-finder/actions/runs/34714066271)
+succeeded at 19:25 UTC on 12 September 2026, following PR #704. Both cohorts
+returned exactly 1,000 rows and zero bidirectional EXCEPT ALL differences.
+Natural candidate plans used the existing body, signal and mechanics indexes
+and had no temporary I/O or broad signal/mechanics scans.
+
+| Full SELECT | Search frontier 5533 | Ratings tip 44779 |
+| --- | ---: | ---: |
+| Legacy defaults | 10,312.683 ms | 10,169.324 ms |
+| Candidate defaults | 474.447 ms | 483.622 ms |
+| Candidate JIT off | 129.009 ms | 137.227 ms |
+| Legacy forced-index diagnostic | 21.414 ms | 33.536 ms |
+
+The indexed access path is proved for these cohorts, but not live worker
+throughput. The candidate paid 359.505/363.714 ms for JIT compilation. Its two
+target-scanning LATERAL CTEs also induced two joins each rejecting 999,000 rows.
+
+The follow-up correlates both LATERAL lookups directly with the final target
+row and disables JIT only inside the writer's transaction. A test verifies that
+the connection's JIT setting is restored after the chunk commits. The profiler
+retains defaults as a counterfactual and JIT-off as the candidate writer setting;
+it also explains a forced-generic prepared SELECT with generation/ordinal
+parameters. That additional profile is required before claiming the follow-up
+meets the indexed-path target. The immutable product identity rollout gate above
+still applies; no live worker or persistent database setting is changed.

--- a/scripts/operator/actions/v3-system-search-profile.sh
+++ b/scripts/operator/actions/v3-system-search-profile.sh
@@ -42,6 +42,12 @@ __SEARCH_CANDIDATE_SQL__
 SQL
 }
 
+prepared_query() {
+  cat <<SQL
+__SEARCH_PREPARED_SQL__
+SQL
+}
+
 meta="$("${psql_base[@]}" --command "BEGIN READ ONLY;
 SET LOCAL statement_timeout='60s';
 SELECT g.derived_generation_id::text || E'\\t' ||
@@ -75,10 +81,11 @@ printf 'search_frontier_chunk_ordinal=%s\n' "$search_frontier"
 printf 'profile_started_at=%s\n' "$(date -u +%FT%TZ)"
 
 run_cohort() {
-  local cohort="$1" chunk_ordinal="$2" legacy candidate
+  local cohort="$1" chunk_ordinal="$2" legacy candidate prepared
   legacy="$(legacy_query)"
   candidate="$(candidate_query)"
-  [[ "$legacy" != *__SEARCH_* && "$candidate" != *__SEARCH_* ]] \
+  prepared="$(prepared_query)"
+  [[ "$legacy" != *__SEARCH_* && "$candidate" != *__SEARCH_* && "$prepared" != *__SEARCH_* ]] \
     || fail "profile template was not rendered"
   printf 'profile_cohort=%s\nprofile_chunk_ordinal=%s\n' "$cohort" "$chunk_ordinal"
   docker exec -i "$POSTGRES_CONTAINER" psql -X --no-psqlrc --no-password \
@@ -111,6 +118,15 @@ SET LOCAL jit=off;
 \\echo candidate_jit_off_select_plan_json=
 EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)
 ${candidate};
+SET LOCAL plan_cache_mode=force_generic_plan;
+PREPARE search_candidate(uuid,bigint) AS
+${prepared};
+\\echo full_query_variant=candidate_generic_jit_off
+\\echo candidate_generic_select_plan_json=
+EXPLAIN (ANALYZE, BUFFERS, SETTINGS, SUMMARY, FORMAT JSON)
+EXECUTE search_candidate('${generation_id}'::uuid,${chunk_ordinal});
+DEALLOCATE search_candidate;
+SET LOCAL plan_cache_mode=DEFAULT;
 SET LOCAL jit=DEFAULT;
 WITH baseline AS MATERIALIZED (${legacy}),
      candidate AS MATERIALIZED (${candidate}),

--- a/scripts/operator/render_v3_system_search_profile.py
+++ b/scripts/operator/render_v3_system_search_profile.py
@@ -13,7 +13,13 @@ sys.path.insert(0, str(ROOT))
 from scripts.v3_system_search import projection_query_sql  # noqa: E402
 
 
-def shell_query(query: str) -> str:
+def shell_query(query: str, *, prepared: bool = False) -> str:
+    if prepared:
+        # The first shell heredoc unescapes these dollars; the resulting query
+        # is then expanded as a variable, without recursive shell evaluation.
+        return (query.replace('{schema}', '${canonical_schema}')
+                .replace('%(generation_id)s', r'\$1')
+                .replace('%(chunk_ordinal)s', r'\$2'))
     return (query
             .replace('{schema}', '${canonical_schema}')
             .replace('%(generation_id)s', "'${generation_id}'::uuid")
@@ -32,6 +38,10 @@ def render_profile() -> str:
         if source.count(marker) != 1:
             raise ValueError(f'expected exactly one {marker} marker')
         source = source.replace(marker, shell_query(query))
+    marker = '__SEARCH_PREPARED_SQL__'
+    if source.count(marker) != 1:
+        raise ValueError(f'expected exactly one {marker} marker')
+    source = source.replace(marker, shell_query(projection_query_sql(), prepared=True))
     return source
 
 

--- a/scripts/v3_system_search.py
+++ b/scripts/v3_system_search.py
@@ -241,8 +241,9 @@ def projection_query_sql() -> str:
     """Read projection shared by the writer and the read-only operator profiler.
 
     Only {schema} is an SQL-format identifier; values are named DB parameters.
-    LATERAL aggregates keep signals system-keyed, while LIMIT 1 preserves the
-    lowest-body_pk main-star rule and bounds the generation/system lookup.
+    LATERAL lookups correlate directly with the final target row: putting these
+    in target-scanning CTEs creates quadratic joins back to that same target.
+    LIMIT 1 preserves the lowest-body_pk main-star rule.
     """
     return '''
 WITH target AS MATERIALIZED (
@@ -272,20 +273,6 @@ ring_summary AS (
      WHERE r.lifecycle_state='ACTIVE' AND r.kind='RING'
   GROUP BY r.system_id64
 ),
-signal_summary AS (
-    SELECT t.system_id64,sig.has_biologicals,sig.has_geologicals
-      FROM target t
-CROSS JOIN LATERAL (
-    SELECT bool_or(st.public_code='saa_signaltype_biological'
-                   AND bs.signal_count>0) AS has_biologicals,
-           bool_or(st.public_code='saa_signaltype_geological'
-                   AND bs.signal_count>0) AS has_geologicals
-      FROM {schema}.bodies b
-      JOIN {schema}.body_signal_current bs ON bs.body_pk=b.body_pk
-      JOIN v3_vocab.signal_type st ON st.signal_type_id=bs.signal_type_id
-     WHERE b.system_id64=t.system_id64 AND b.lifecycle_state='ACTIVE'
-) sig
-),
 station_summary AS (
     SELECT st.system_id64,
            (count(*) FILTER (WHERE st.lifecycle_state='ACTIVE'))::integer
@@ -293,18 +280,6 @@ station_summary AS (
       FROM {schema}.stations st
       JOIN target t ON t.system_id64=st.system_id64
   GROUP BY st.system_id64
-),
-main_star AS (
-    SELECT t.system_id64,ms.main_star_class
-      FROM target t
- LEFT JOIN LATERAL (
-    SELECT bm.body_class AS main_star_class
-      FROM v3_derived.body_mechanics bm
-     WHERE bm.derived_generation_id=%(generation_id)s
-       AND bm.system_id64=t.system_id64 AND bm.is_main_star IS TRUE
-  ORDER BY bm.body_pk
-     LIMIT 1
-) ms ON true
 )
 SELECT %(generation_id)s,t.system_id64,s.name,s.x_ly,s.y_ly,s.z_ly,
        cube(ARRAY[s.x_ly,s.y_ly,s.z_ly]),
@@ -324,9 +299,25 @@ SELECT %(generation_id)s,t.system_id64,s.name,s.x_ly,s.y_ly,s.z_ly,
  LEFT JOIN v3_vocab.galaxy_region gr ON gr.galaxy_region_id=s.galaxy_region_id
  LEFT JOIN body_summary bs USING(system_id64)
  LEFT JOIN ring_summary rs USING(system_id64)
- LEFT JOIN signal_summary sig USING(system_id64)
  LEFT JOIN station_summary ss USING(system_id64)
- LEFT JOIN main_star ms USING(system_id64)
+ LEFT JOIN LATERAL (
+    SELECT bool_or(st.public_code='saa_signaltype_biological'
+                   AND bs.signal_count>0) AS has_biologicals,
+           bool_or(st.public_code='saa_signaltype_geological'
+                   AND bs.signal_count>0) AS has_geologicals
+      FROM {schema}.bodies b
+      JOIN {schema}.body_signal_current bs ON bs.body_pk=b.body_pk
+      JOIN v3_vocab.signal_type st ON st.signal_type_id=bs.signal_type_id
+     WHERE b.system_id64=t.system_id64 AND b.lifecycle_state='ACTIVE'
+ ) sig ON true
+ LEFT JOIN LATERAL (
+    SELECT bm.body_class AS main_star_class
+      FROM v3_derived.body_mechanics bm
+     WHERE bm.derived_generation_id=%(generation_id)s
+       AND bm.system_id64=t.system_id64 AND bm.is_main_star IS TRUE
+  ORDER BY bm.body_pk
+     LIMIT 1
+ ) ms ON true
 ORDER BY t.system_id64
     '''.strip()
 
@@ -398,6 +389,9 @@ def _insert_chunk(
         ) + sql.SQL(projection_query_sql()).format(
             schema=sql.Identifier(generation.canonical_schema),
         )
+        # The bounded indexed projection is too short to amortize compilation.
+        # READ ONLY profiles prove this; keep the setting transaction-local.
+        connection.execute('SET LOCAL jit=off')
         cursor = connection.execute(
             query,
             {'generation_id': generation.identifier, 'chunk_ordinal': ordinal},

--- a/tests/test_ratings_v4_search_projection.py
+++ b/tests/test_ratings_v4_search_projection.py
@@ -102,6 +102,15 @@ def _query(source):
     ).format(schema=sql.Identifier('search_plan_fixture'))
 
 
+def test_projection_laterals_correlate_directly_with_the_final_target():
+    source = projection_query_sql()
+    assert source.count('JOIN LATERAL') == 2
+    assert 'signal_summary AS' not in source
+    assert 'main_star AS' not in source
+    assert 'WHERE b.system_id64=t.system_id64' in source
+    assert 'AND bm.system_id64=t.system_id64' in source
+
+
 def test_projection_matches_legacy_for_sparse_and_adversarial_rows(projection_database):
     connection = projection_database
     rows = []
@@ -140,3 +149,24 @@ def test_profile_equivalence_sql_executes_with_duplicate_output_names(projection
     assert connection.execute(query, {
         'generation_id': GENERATION, 'chunk_ordinal': 0,
     }).fetchone() == (5, 5, 0)
+
+
+def test_projection_prepared_generic_plan_preserves_results(projection_database):
+    from psycopg import sql
+    connection = projection_database
+    prepared = _query(projection_query_sql()
+                      .replace('%(generation_id)s', '$1')
+                      .replace('%(chunk_ordinal)s', '$2'))
+    expected = connection.execute(_query(LEGACY.read_text()), {
+        'generation_id': GENERATION, 'chunk_ordinal': 0,
+    }).fetchall()
+    with connection.transaction():
+        connection.execute('SET TRANSACTION READ ONLY')
+        connection.execute('SET LOCAL plan_cache_mode=force_generic_plan')
+        connection.execute('SET LOCAL jit=off')
+        connection.execute(sql.SQL('PREPARE search_candidate(uuid,bigint) AS ') + prepared)
+        actual = connection.execute(
+            sql.SQL('EXECUTE search_candidate({},0)').format(sql.Literal(GENERATION))
+        ).fetchall()
+        assert actual == expected
+        connection.execute('DEALLOCATE search_candidate')

--- a/tests/test_ratings_v4_system_search.py
+++ b/tests/test_ratings_v4_system_search.py
@@ -79,7 +79,9 @@ def test_search_projection_builds_resumes_and_has_exact_generation_coverage(data
 
     generation, state, manifest_sha = register_product(connection, key)
     assert state == 'BUILDING'
+    connection.execute('SET jit=on')
     first = build_available(connection, generation, manifest_sha)
+    assert connection.execute('SHOW jit').fetchone()[0] == 'on'
     second = build_available(connection, generation, manifest_sha)
     assert first['chunks_written'] == 3
     assert second['chunks_written'] == 0

--- a/tests/test_v3_system_search_profile_operator.py
+++ b/tests/test_v3_system_search_profile_operator.py
@@ -27,6 +27,10 @@ def test_search_profile_is_read_only_and_exact_targeted():
     assert "full_query_variant=indexed_no_seqscan" in source
     assert "full_query_variant=candidate_default" in source
     assert "full_query_variant=candidate_jit_off" in source
+    assert "full_query_variant=candidate_generic_jit_off" in source
+    assert "SET LOCAL plan_cache_mode=force_generic_plan;" in source
+    assert "PREPARE search_candidate(uuid,bigint) AS" in source
+    assert "DEALLOCATE search_candidate;" in source
     assert "SET LOCAL enable_seqscan=off;" in source
     assert "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY;" in source
     assert 'run_cohort search_frontier "$search_frontier"' in source
@@ -71,6 +75,7 @@ def test_profile_uses_exact_writer_select_and_has_valid_shell_syntax():
     assert shell_query(projection_query_sql()) in source
     assert '__SEARCH_CANDIDATE_SQL__' not in source
     assert '__SEARCH_LEGACY_SQL__' not in source
+    assert '__SEARCH_PREPARED_SQL__' not in source
     subprocess.run(['bash', '-n'], input=source, text=True, check=True)
     # Only the diagnostic control may disable sequential scans. The candidate
     # is measured after both settings have been restored to session defaults.
@@ -78,3 +83,16 @@ def test_profile_uses_exact_writer_select_and_has_valid_shell_syntax():
     candidate = source.index('full_query_variant=candidate_default')
     assert reset < candidate
     assert 'SET LOCAL jit=DEFAULT;' in source[reset:candidate]
+
+
+def test_prepared_query_dollars_survive_the_shell_without_positional_expansion():
+    source = render_profile()
+    body = source.split('prepared_query() {', 1)[1].split('\n}\n', 1)[0]
+    script = ('set -eu\ncanonical_schema=v3_gen_fixture\n'
+              + 'prepared_query() {' + body + '\n}\nprepared_query\n')
+    result = subprocess.run(
+        ['bash', '-c', script], text=True, capture_output=True, check=True,
+    )
+    assert 'v.derived_generation_id=$1 AND v.chunk_ordinal=$2' in result.stdout
+    assert 'FROM v3_gen_fixture.bodies' in result.stdout
+    assert '%(' not in result.stdout


### PR DESCRIPTION
Follow-up to #704 and successful read-only profile #6: https://github.com/brianstewart377-rgb/ed-finder/actions/runs/34714066271

## Measured motivation
Both cohorts had 1,000 rows and zero differences. Natural indexed SELECTs fell from 10.2 seconds to 474/484 ms. JIT consumed 359/364 ms; JIT-off reduced them to 129/137 ms. Two joins back to the 1,000-row target each rejected 999,000 rows. Forced-index legacy controls were 21/34 ms.

## Changes
- Correlate signal and main-star LATERAL lookups directly to the final target row, eliminating those two target self-joins.
- SET LOCAL jit=off inside the writer transaction only; test restoration of the connection setting after chunk commit.
- Extend the read-only profiler with a forced-generic prepared SELECT using generation/ordinal parameters, in addition to full defaults/JIT-off comparisons and exact legacy parity.
- Regression tests for direct correlation, prepared result parity, and shell preservation of SQL parameter dollars.

## Validation / authority
Local focused checks: 7 passed, six DB tests awaiting isolated PostgreSQL 18 CI; Ruff and shell syntax passed.
This is code-only plus the already governed READ ONLY profile. The current production worker remains on its original bundle. No persistent setting changes, worker restarts, schema/statistics changes, manifest edits or publication. Existing immutable product identity guard remains mandatory. No live cutover in this PR.