### PR TITLE
Profile running Ratings V4 CPU, I/O and database waits read-only

### DIFF
--- a/.github/workflows/ratings-v4-freeze.yml
+++ b/.github/workflows/ratings-v4-freeze.yml
@@ -11,6 +11,8 @@ on:
       - 'scripts/ratings_v4/**'
       - 'scripts/v3_system_search.py'
       - 'scripts/operator/render_v3_system_search_profile.py'
+      - 'scripts/operator/ratings_v4_runtime_profile.py'
+      - '.github/workflows/ratings-v4-production-profile.yml'
       - 'scripts/operator/v3_system_search_legacy.sql'
       - 'scripts/checks/requirements.txt'
       - 'tests/test_ratings_v4*'

--- a/.github/workflows/ratings-v4-production-profile.yml
+++ b/.github/workflows/ratings-v4-production-profile.yml
@@ -1,0 +1,108 @@
+name: Ratings V4 runtime profile
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/ratings-v4-profile-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chatgpt-ed-new-ops
+  cancel-in-progress: false
+
+jobs:
+  profile:
+    name: Observe Ratings V4 CPU and database waits
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 8
+    steps:
+      - name: Checkout request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Set up CPython 3.14 for operator request validation
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Validate data-only request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one Ratings profile request file" >&2; exit 64; }
+          case "${changed_files[0]}" in
+            .github/ratings-v4-profile-requests/*.json) ;;
+            *) echo "Unexpected request path" >&2; exit 64 ;;
+          esac
+          python - "${changed_files[0]}" <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if data != {"operation": "ratings-v4-runtime-profile"}:
+              raise SystemExit("unsupported request")
+          PY
+
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" && test -n "$SSH_HOST" && test -n "$SSH_PORT" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Run bounded read-only Ratings profile
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/ratings-v4-runtime-profile.jsonl
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          printf '{"kind":"provenance","trusted_main_sha":"%s","profiler_sha256":"%s"}\n' \
+            "$(git -C trusted-main rev-parse HEAD)" \
+            "$(sha256sum trusted-main/scripts/operator/ratings_v4_runtime_profile.py | cut -d' ' -f1)" | tee "$RECEIPT"
+          ssh -i ~/.ssh/ed_new_operator_key \
+            -p "$SSH_PORT" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "$SSH_USER@$SSH_HOST" \
+            'timeout 210s python3.14 -' \
+            < trusted-main/scripts/operator/ratings_v4_runtime_profile.py | tee -a "$RECEIPT"
+
+      - name: Upload profile receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ratings-v4-runtime-profile
+          path: ${{ runner.temp }}/ratings-v4-runtime-profile.jsonl
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/development/ratings-v4-runtime-profile.md
+++ b/docs/development/ratings-v4-runtime-profile.md
@@ -37,6 +37,11 @@ The artifact contains:
 
 Compute throughput from committed count deltas and their database timestamps.
 CPU percentages use one CPU core as 100%; compare totals with the recorded quota.
+Process CPU sums matching PID/start-time deltas across adjacent observations,
+including processes absent at either endpoint. Process lists refresh each sample.
+Unobserved entry/exit intervals and lifetimes shorter than the sample cadence remain
+unknown; cgroup counters provide the full container total. The receipt reports
+observed restarts, running-state changes and resource-limit changes separately.
 Do not sum disk counters across partitions, RAID devices and their members.
 Database I/O/WAL counters are database/cluster-wide, not attributable solely to
 Ratings. Timing counters are uninformative when the corresponding tracking

--- a/docs/development/ratings-v4-runtime-profile.md
+++ b/docs/development/ratings-v4-runtime-profile.md
@@ -1,0 +1,50 @@
+# Ratings V4 runtime observation
+
+The protected Ratings V4 runtime profile observes the existing optimized Ratings
+worker, PostgreSQL and Search for 120 seconds. It makes no worker, resource-limit,
+schema, publication or persistent-setting changes. It does not attach a debugger,
+read process environments or command arguments, execute application queries, or
+reset statistics. Unreadable OS counters are reported without an elevated fallback.
+
+Use a single new JSON file in .github/ratings-v4-profile-requests on the governed
+chatgpt-ed-new-ops-requests branch, containing only:
+
+```json
+{"operation":"ratings-v4-runtime-profile"}
+```
+
+The workflow validates the one-file request, checks out trusted main, records
+source checksums, and runs the standalone standard-library profiler through the
+existing pinned SSH connection and ed-new-operator environment. The remote command
+is bounded to 210 seconds and the workflow to eight minutes. Partial JSONL output
+is retained even if a required observation fails.
+
+The artifact contains:
+
+- Container identities, unchanged-limit checks and network addresses for attributing
+  database sessions. Ambiguous addresses remain unattributed.
+- Per-process CPU ticks, kernel wait channel, namespace PID and available I/O
+  counters; PID/start-time pairs prevent interpreting PID reuse as CPU work.
+- Container cgroup CPU/throttling, memory and I/O counters, host CPU/disk counters,
+  memory availability and pressure; compressed source offsets when readable.
+- Fresh, short READ ONLY snapshots of database activity and COPY progress roughly
+  every two seconds. Queries are classified into fixed categories; raw SQL is
+  never returned.
+- Before/after committed Ratings and Search counts and cumulative database,
+  WAL, checkpoint and I/O statistics, including their reset timestamps and timing
+  settings. No canonical or derived data tables are scanned for these counts:
+  only the bounded chunk-receipt tables.
+
+Compute throughput from committed count deltas and their database timestamps.
+CPU percentages use one CPU core as 100%; compare totals with the recorded quota.
+Do not sum disk counters across partitions, RAID devices and their members.
+Database I/O/WAL counters are database/cluster-wide, not attributable solely to
+Ratings. Timing counters are uninformative when the corresponding tracking
+setting is off. Sampled waits describe observations, not exact wall-time shares;
+an idle backend or ClientRead wait can indicate that PostgreSQL is waiting for
+its client. Correlate with coordinator/encoder CPU and COPY progress before
+choosing an optimization.
+
+The sampler does not change any generation-bound builder file or its code
+identity. Any subsequent performance change must preserve the current generation
+and its immutable source/code/receipt guarantees under separate review.

--- a/scripts/operator/ratings_v4_runtime_profile.py
+++ b/scripts/operator/ratings_v4_runtime_profile.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Observe the existing Ratings V4 processes for two minutes; never attach/modify.
+
+Stream JSONL to the protected workflow artifact. Only standard-library, Docker
+inspection, readable procfs/cgroup counters, and short READ ONLY SQL are used.
+Missing OS permissions remain missing; there is no privileged fallback.
+"""
+from collections import Counter
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import time
+
+HOST = 'ed-finder-prod'
+FQDN = 'nb79a3d.mevnode.com'
+GENERATION = 'ratings_v4_prod_p4_opt1'
+DATABASE = 'edfinder_v3_phase4c_full_20260827_r5'
+CONTAINERS = {
+    'ratings': 'edfinder-ratings-v4-prod-p4-opt1',
+    'postgres': 'edfinder-v3-phase4c-full-20260827_r5-postgres',
+    'search': 'edfinder-v3-system-search-p4-opt1',
+}
+DURATION_SECONDS = 120
+INTERVAL_SECONDS = 2
+
+ACTIVITY_SQL = """
+SELECT json_build_object(
+  'observed_at',clock_timestamp(),
+  'activity',COALESCE((SELECT json_agg(x) FROM (
+    SELECT pid,backend_type,host(client_addr) AS client_addr,state,wait_event_type,wait_event,
+           CASE WHEN state='active' THEN
+             extract(epoch FROM clock_timestamp()-query_start) END AS active_seconds,
+           CASE WHEN state IS DISTINCT FROM 'active' THEN 'not_active'
+                WHEN query IS NULL THEN 'unavailable'
+                WHEN query ~* '^COPY' AND query LIKE '%system_rating_vector%' THEN 'copy_vectors'
+                WHEN query ~* '^COPY' AND query LIKE '%body_mechanics%' THEN 'copy_mechanics'
+                WHEN query ~* '^COPY' AND query LIKE '%economy_opportunity%' THEN 'copy_opportunities'
+                WHEN query ~* '^COMMIT' THEN 'commit'
+                WHEN query LIKE '%system_search%' THEN 'search'
+                WHEN query LIKE '%build_chunk%' THEN 'chunk_receipt'
+                WHEN query LIKE '%derived_generation%' THEN 'generation_check'
+                WHEN query LIKE '%body_signal_current%' THEN 'canonical_signals'
+                WHEN query LIKE '%rings%' THEN 'canonical_rings'
+                WHEN query LIKE '%bodies%' THEN 'canonical_bodies'
+                WHEN query LIKE '%systems%' THEN 'canonical_systems'
+                ELSE 'other' END AS query_kind
+      FROM pg_stat_activity
+     WHERE datname=current_database() AND pid<>pg_backend_pid()
+     ORDER BY pid
+  ) x),'[]'::json),
+  'copy',COALESCE((SELECT json_agg(x) FROM (
+    SELECT pid,relid::regclass::text AS relation,command,type,
+           bytes_processed,bytes_total,tuples_processed
+      FROM pg_stat_progress_copy WHERE datname=current_database()
+  ) x),'[]'::json)
+)::text
+"""
+
+TOTALS_SQL = """
+SELECT json_build_object(
+ 'observed_at',clock_timestamp(),
+ 'generation',(SELECT json_build_object(
+     'id',g.derived_generation_id,'state',g.lifecycle_state,
+     'expected_systems',g.expected_systems,
+     'ratings_chunks',(SELECT count(*) FROM v3_derived.build_chunk b
+                       WHERE b.derived_generation_id=g.derived_generation_id),
+     'ratings_systems',(SELECT COALESCE(sum(b.systems),0) FROM v3_derived.build_chunk b
+                        WHERE b.derived_generation_id=g.derived_generation_id),
+     'search_systems',(SELECT COALESCE(sum(b.systems),0) FROM v3_derived.search_build_chunk b
+                       WHERE b.derived_generation_id=g.derived_generation_id))
+   FROM v3_meta.derived_generation g WHERE g.generation_key='ratings_v4_prod_p4_opt1'),
+ 'database',(SELECT to_jsonb(d) FROM pg_stat_database d WHERE datname=current_database()),
+ 'wal',(SELECT to_jsonb(w) FROM pg_stat_wal w),
+ 'checkpointer',(SELECT to_jsonb(c) FROM pg_stat_checkpointer c),
+ 'io',(SELECT json_agg(i) FROM pg_stat_io i),
+ 'settings',(SELECT json_object_agg(name,setting) FROM pg_settings WHERE name IN (
+     'server_version','track_io_timing','track_wal_io_timing','track_activities',
+     'shared_buffers','work_mem','jit','max_parallel_workers_per_gather'))
+)::text
+"""
+
+
+def emit(kind, **data):
+    print(json.dumps({'kind': kind, 'utc': datetime.now(timezone.utc).isoformat(),
+                      **data}, sort_keys=True), flush=True)
+
+
+def command(args):
+    result = subprocess.run(args, text=True, capture_output=True, timeout=8, check=False)
+    if result.returncode:
+        raise RuntimeError(f'{args[0]} failed ({result.returncode}): {result.stderr[:400]}')
+    return result.stdout.strip()
+
+
+def database_query(query):
+    # A new connection/transaction gives each observation a fresh stats snapshot.
+    result = command([
+        'docker', 'exec', CONTAINERS['postgres'], 'psql',
+        '-X', '--no-psqlrc', '--no-password', '--quiet', '--tuples-only', '--no-align',
+        '--set', 'ON_ERROR_STOP=1', '--username', 'edfinder_v3', '--dbname', DATABASE,
+        '--command', "BEGIN READ ONLY; SET LOCAL statement_timeout='5s'; "
+        "SET LOCAL lock_timeout='1s'; " + query + '; COMMIT;',
+    ])
+    return json.loads(result)
+
+
+def optional_read(path, missing):
+    try:
+        return path.read_text()
+    except (OSError, UnicodeError) as exc:
+        missing.add(f'{path}:{type(exc).__name__}')
+        return None
+
+
+def parse_stat(source):
+    # comm may itself contain spaces and parentheses.
+    prefix, _, suffix = source.rpartition(')')
+    fields = suffix.split()  # Starts with field 3 (state).
+    return {
+        'comm': prefix.split('(', 1)[1], 'state': fields[0], 'ppid': int(fields[1]),
+        'cpu_ticks': int(fields[11]) + int(fields[12]),
+        'start_ticks': int(fields[19]), 'rss_pages': int(fields[21]),
+    }
+
+
+def numeric_lines(source):
+    if source is None:
+        return None
+    return {parts[0].rstrip(':'): int(parts[1]) for line in source.splitlines()
+            if len(parts := line.split()) == 2 and parts[1].isdigit()}
+
+
+def process_snapshot(pid, missing):
+    base = Path('/proc') / str(pid)
+    raw = optional_read(base / 'stat', missing)
+    if raw is None:
+        return None
+    row = {'pid': pid, **parse_stat(raw)}
+    row['io'] = numeric_lines(optional_read(base / 'io', missing))
+    row['wchan'] = (optional_read(base / 'wchan', missing) or '').strip()
+    status = optional_read(base / 'status', missing) or ''
+    namespaces = next((s.split()[1:] for s in status.splitlines() if s.startswith('NSpid:')), [])
+    row['namespace_pid'] = int(namespaces[-1]) if namespaces else None
+    return row
+
+
+def container_info(name):
+    # Explicit selected fields: no environment, arguments, mounts or credentials.
+    template = ('{"id":{{json .Id}},"pid":{{.State.Pid}},'
+                '"running":{{.State.Running}},"started_at":{{json .State.StartedAt}},'
+                '"nano_cpus":{{.HostConfig.NanoCpus}},"memory":{{.HostConfig.Memory}},'
+                '"ips":"{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}",'
+                '"generation":{{json (index .Config.Labels "ed-finder.generation-key")}},'
+                '"source_sha":{{json (index .Config.Labels "ed-finder.source-sha")}},'
+                '"encoder_workers":{{json (index .Config.Labels "ed-finder.encoder-workers")}}}')
+    info = json.loads(command(['docker', 'inspect', '--format', template, name]))
+    info['ips'] = info['ips'].split()
+    return info
+
+
+def process_ids(name):
+    rows = command(['docker', 'top', name, '-eo', 'pid']).splitlines()[1:]
+    return [int(row.strip()) for row in rows]
+
+
+def cgroup_directory(pid, missing):
+    source = optional_read(Path('/proc') / str(pid) / 'cgroup', missing) or ''
+    unified = next((row[3:] for row in source.splitlines() if row.startswith('0::')), None)
+    if unified is None:
+        return None
+    root = Path('/sys/fs/cgroup')
+    candidate = root / unified.lstrip('/')
+    if '..' in Path(unified).parts or not candidate.resolve().is_relative_to(root):
+        raise ValueError('unexpected cgroup path')
+    return candidate
+
+
+def cgroup_snapshot(directory, missing):
+    if directory is None:
+        return {'available': False}
+    return {name: optional_read(directory / name, missing) for name in (
+        'cpu.stat', 'cpu.max', 'cpu.pressure', 'memory.current', 'memory.events',
+        'memory.pressure', 'io.stat', 'io.pressure',
+    )}
+
+
+def host_snapshot(missing):
+    stat = optional_read(Path('/proc/stat'), missing) or ''
+    cpu = next((list(map(int, line.split()[1:9])) for line in stat.splitlines()
+                if line.startswith('cpu ')), None)
+    disks = {}
+    for line in (optional_read(Path('/proc/diskstats'), missing) or '').splitlines():
+        fields = line.split()
+        if len(fields) >= 14 and not fields[2].startswith(('loop', 'ram', 'zram')):
+            disks[fields[2]] = list(map(int, fields[3:14]))
+    memory = {parts[0].rstrip(':'): int(parts[1])
+              for line in (optional_read(Path('/proc/meminfo'), missing) or '').splitlines()
+              if len(parts := line.split()) == 3 and parts[2] == 'kB'}
+    return {'cpu_ticks': cpu, 'disks': disks, 'memory_kib': memory,
+            'pressure': {name: optional_read(Path('/proc/pressure') / name, missing)
+                         for name in ('cpu', 'memory', 'io')}}
+
+
+def source_position(pid, missing):
+    directory = Path('/proc') / str(pid) / 'fd'
+    positions = []
+    try:
+        for fd in directory.iterdir():
+            try:
+                target = os.readlink(fd)
+                if target.endswith('/galaxy.json.gz'):
+                    raw = optional_read(directory.parent / 'fdinfo' / fd.name, missing)
+                    positions.append(numeric_lines(raw).get('pos') if raw else None)
+            except FileNotFoundError:
+                pass  # Descriptors may close while being observed.
+    except OSError as exc:
+        missing.add(f'{directory}:{type(exc).__name__}')
+    return positions
+
+
+def process_rates(before, after, seconds, ticks_per_second):
+    result = []
+    prior = {row['pid']: row for row in before}
+    for row in after:
+        old = prior.get(row['pid'])
+        if old is None or old['start_ticks'] != row['start_ticks']:
+            continue
+        delta = row['cpu_ticks'] - old['cpu_ticks']
+        if delta < 0:
+            continue
+        result.append({'pid': row['pid'], 'namespace_pid': row['namespace_pid'],
+                       'comm': row['comm'], 'one_core_cpu_percent':
+                           100 * delta / ticks_per_second / seconds})
+    return result
+
+
+def main():
+    if len(sys.argv) != 1:
+        raise ValueError('this fixed profiler accepts no arguments')
+    if socket.gethostname() != HOST or command(['hostname', '-f']) != FQDN:
+        raise ValueError('unexpected production host')
+    if command(['docker', 'context', 'show']) != 'default':
+        raise ValueError('unexpected docker context')
+    endpoint = command(['docker', 'context', 'inspect', 'default',
+                        '--format', '{{.Endpoints.docker.Host}}'])
+    if endpoint != 'unix:///var/run/docker.sock':
+        raise ValueError('docker context is not the local rootful socket')
+    identities = {role: container_info(name) for role, name in CONTAINERS.items()}
+    if any(not value['running'] for value in identities.values()):
+        raise ValueError('expected existing Ratings, Search and PostgreSQL processes')
+    if identities['ratings']['generation'] != GENERATION:
+        raise ValueError('Ratings worker generation mismatch')
+    missing = set()
+    groups = {role: cgroup_directory(info['pid'], missing) for role, info in identities.items()}
+    pids = {role: process_ids(name) for role, name in CONTAINERS.items()}
+    ticks = os.sysconf('SC_CLK_TCK')
+    emit('identity', containers=identities, duration_seconds=DURATION_SECONDS,
+         interval_seconds=INTERVAL_SECONDS, clock_ticks_per_second=ticks,
+         host_logical_cpus=os.cpu_count())
+    before_totals = database_query(TOTALS_SQL)
+    if before_totals['generation'] is None:
+        raise ValueError('target Ratings generation is absent')
+    emit('totals_before', data=before_totals)
+    started = time.monotonic()
+    first = last = None
+    sample = 0
+    wait_counts = Counter()
+    while True:
+        if sample and sample % 15 == 0:
+            pids = {role: process_ids(name) for role, name in CONTAINERS.items()}
+        processes = {role: [row for pid in members
+                           if (row := process_snapshot(pid, missing)) is not None]
+                     for role, members in pids.items()}
+        os_time = time.monotonic()
+        frame = {'elapsed_seconds': os_time - started, 'processes': processes,
+                 'cgroups': {role: cgroup_snapshot(path, missing) for role, path in groups.items()},
+                 'host': host_snapshot(missing),
+                 'source_compressed_positions': source_position(identities['ratings']['pid'], missing)}
+        activity_started = time.monotonic()
+        activity = database_query(ACTIVITY_SQL)
+        frame['observer_query_seconds'] = time.monotonic() - activity_started
+        for row in activity['activity']:
+            roles = [role for role, info in identities.items() if row['client_addr'] in info['ips']]
+            row['container_role'] = roles[0] if len(roles) == 1 else 'unattributed'
+            wait_counts[(row['container_role'], row['state'], row['wait_event_type'],
+                         row['wait_event'], row['query_kind'])] += 1
+        frame['database'] = activity
+        emit('sample', index=sample, **frame)
+        if first is None:
+            first = frame
+        last = frame
+        sample += 1
+        remaining = DURATION_SECONDS - (time.monotonic() - started)
+        if remaining <= 0:
+            break
+        time.sleep(min(INTERVAL_SECONDS, remaining))
+    after_totals = database_query(TOTALS_SQL)
+    emit('totals_after', data=after_totals)
+    end_identities = {role: container_info(name) for role, name in CONTAINERS.items()}
+    stable = all(end_identities[role][key] == info[key] for role, info in identities.items()
+                 for key in ('id', 'pid', 'started_at', 'running', 'nano_cpus', 'memory'))
+    seconds = last['elapsed_seconds'] - first['elapsed_seconds']
+    emit('summary', samples=sample, sample_seconds=seconds, identity_unchanged=stable,
+         process_cpu={role: process_rates(first['processes'][role], last['processes'][role],
+                                         seconds, ticks) for role in CONTAINERS},
+         database_wait_samples=[{'role': key[0], 'state': key[1], 'type': key[2],
+                                 'event': key[3], 'query_kind': key[4], 'count': value}
+                                for key, value in wait_counts.items()],
+         unavailable_counters=sorted(missing), worker_restarted=False,
+         configuration_changes_performed=False, database_writes_performed=False,
+         schema_changes_performed=False, publication_performed=False)
+    if not stable:
+        raise ValueError('observed processes or resource limits changed during the profile')
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as exc:
+        emit('error', error_type=type(exc).__name__, detail=str(exc))
+        raise SystemExit(1) from None

--- a/scripts/operator/ratings_v4_runtime_profile.py
+++ b/scripts/operator/ratings_v4_runtime_profile.py
@@ -217,6 +217,8 @@ def source_position(pid, missing):
                     positions.append(numeric_lines(raw).get('pos') if raw else None)
             except FileNotFoundError:
                 pass  # Descriptors may close while being observed.
+            except OSError as exc:
+                missing.add(f'{fd}:{type(exc).__name__}')
     except OSError as exc:
         missing.add(f'{directory}:{type(exc).__name__}')
     return positions
@@ -233,9 +235,51 @@ def process_rates(before, after, seconds, ticks_per_second):
         if delta < 0:
             continue
         result.append({'pid': row['pid'], 'namespace_pid': row['namespace_pid'],
+                       'start_ticks': row['start_ticks'], 'cpu_ticks_delta': delta,
                        'comm': row['comm'], 'one_core_cpu_percent':
                            100 * delta / ticks_per_second / seconds})
     return result
+
+
+def process_cpu_summary(frames, role, ticks_per_second):
+    """Retain matched interval deltas even for processes absent at an endpoint.
+
+    CPU outside a process's observed intervals is unknown. Cgroup counters provide
+    the full container total, including lifetimes shorter than the sample cadence.
+    """
+    totals = {}
+    seconds = frames[-1]['elapsed_seconds'] - frames[0]['elapsed_seconds']
+    for before, after in zip(frames, frames[1:]):
+        interval = after['elapsed_seconds'] - before['elapsed_seconds']
+        for row in process_rates(before['processes'][role], after['processes'][role],
+                                 interval, ticks_per_second):
+            key = row['pid'], row['start_ticks']
+            total = totals.setdefault(key, {
+                'pid': row['pid'], 'namespace_pid': row['namespace_pid'],
+                'start_ticks': row['start_ticks'], 'comm': row['comm'],
+                'observed_cpu_seconds': 0, 'observed_seconds': 0,
+            })
+            total['observed_cpu_seconds'] += row['cpu_ticks_delta'] / ticks_per_second
+            total['observed_seconds'] += interval
+    return [dict(row, one_core_cpu_percent=100 * row['observed_cpu_seconds'] / seconds)
+            for row in totals.values()]
+
+
+def identity_changes(before, after):
+    def changed(keys):
+        return any(after[role][key] != info[key] for role, info in before.items()
+                   for key in keys)
+    return {
+        'worker_restarted': changed(('id', 'pid', 'started_at')),
+        'running_state_changed': changed(('running',)),
+        'resource_limits_changed': changed(('nano_cpus', 'memory')),
+    }
+
+
+def verify_generations(identities):
+    for role in ('ratings', 'search'):
+        if identities[role]['generation'] != GENERATION:
+            raise ValueError(f'{role} worker generation mismatch')
 
 
 def main():
@@ -252,11 +296,9 @@ def main():
     identities = {role: container_info(name) for role, name in CONTAINERS.items()}
     if any(not value['running'] for value in identities.values()):
         raise ValueError('expected existing Ratings, Search and PostgreSQL processes')
-    if identities['ratings']['generation'] != GENERATION:
-        raise ValueError('Ratings worker generation mismatch')
+    verify_generations(identities)
     missing = set()
     groups = {role: cgroup_directory(info['pid'], missing) for role, info in identities.items()}
-    pids = {role: process_ids(name) for role, name in CONTAINERS.items()}
     ticks = os.sysconf('SC_CLK_TCK')
     emit('identity', containers=identities, duration_seconds=DURATION_SECONDS,
          interval_seconds=INTERVAL_SECONDS, clock_ticks_per_second=ticks,
@@ -266,12 +308,11 @@ def main():
         raise ValueError('target Ratings generation is absent')
     emit('totals_before', data=before_totals)
     started = time.monotonic()
-    first = last = None
+    process_frames = []
     sample = 0
     wait_counts = Counter()
     while True:
-        if sample and sample % 15 == 0:
-            pids = {role: process_ids(name) for role, name in CONTAINERS.items()}
+        pids = {role: process_ids(name) for role, name in CONTAINERS.items()}
         processes = {role: [row for pid in members
                            if (row := process_snapshot(pid, missing)) is not None]
                      for role, members in pids.items()}
@@ -290,9 +331,8 @@ def main():
                          row['wait_event'], row['query_kind'])] += 1
         frame['database'] = activity
         emit('sample', index=sample, **frame)
-        if first is None:
-            first = frame
-        last = frame
+        process_frames.append({'elapsed_seconds': frame['elapsed_seconds'],
+                               'processes': processes})
         sample += 1
         remaining = DURATION_SECONDS - (time.monotonic() - started)
         if remaining <= 0:
@@ -301,16 +341,16 @@ def main():
     after_totals = database_query(TOTALS_SQL)
     emit('totals_after', data=after_totals)
     end_identities = {role: container_info(name) for role, name in CONTAINERS.items()}
-    stable = all(end_identities[role][key] == info[key] for role, info in identities.items()
-                 for key in ('id', 'pid', 'started_at', 'running', 'nano_cpus', 'memory'))
-    seconds = last['elapsed_seconds'] - first['elapsed_seconds']
+    changes = identity_changes(identities, end_identities)
+    stable = not any(changes.values())
+    seconds = process_frames[-1]['elapsed_seconds'] - process_frames[0]['elapsed_seconds']
     emit('summary', samples=sample, sample_seconds=seconds, identity_unchanged=stable,
-         process_cpu={role: process_rates(first['processes'][role], last['processes'][role],
-                                         seconds, ticks) for role in CONTAINERS},
+         process_cpu={role: process_cpu_summary(process_frames, role, ticks)
+                      for role in CONTAINERS},
          database_wait_samples=[{'role': key[0], 'state': key[1], 'type': key[2],
                                  'event': key[3], 'query_kind': key[4], 'count': value}
                                 for key, value in wait_counts.items()],
-         unavailable_counters=sorted(missing), worker_restarted=False,
+         unavailable_counters=sorted(missing), **changes,
          configuration_changes_performed=False, database_writes_performed=False,
          schema_changes_performed=False, publication_performed=False)
     if not stable:

--- a/scripts/operator/ratings_v4_runtime_profile.py
+++ b/scripts/operator/ratings_v4_runtime_profile.py
@@ -249,7 +249,7 @@ def process_cpu_summary(frames, role, ticks_per_second):
     """
     totals = {}
     seconds = frames[-1]['elapsed_seconds'] - frames[0]['elapsed_seconds']
-    for before, after in zip(frames, frames[1:]):
+    for before, after in zip(frames, frames[1:], strict=False):
         interval = after['elapsed_seconds'] - before['elapsed_seconds']
         for row in process_rates(before['processes'][role], after['processes'][role],
                                  interval, ticks_per_second):

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -50,6 +50,7 @@ CHECKED_WORKFLOWS = (
     'ratings-v4-freeze.yml',
     'ratings-v4-production-accelerate.yml',
     'ratings-v4-production-optimize.yml',
+    'ratings-v4-production-profile.yml',
     'remove-ollama-production.yml',
     'review-lab.yml',
     'semgrep.yml',

--- a/tests/test_ratings_v4_runtime_profile.py
+++ b/tests/test_ratings_v4_runtime_profile.py
@@ -93,3 +93,60 @@ def test_observation_queries_execute_on_postgresql18_catalogs():
         assert data['generation'] is None
         assert data['database']['datname'].startswith('v4_test_')
         assert isinstance(data['io'], list)
+
+
+def test_cpu_summary_retains_processes_between_endpoints_and_separates_pid_reuse():
+    def process(pid, start, cpu):
+        return {'pid': pid, 'start_ticks': start, 'cpu_ticks': cpu,
+                'namespace_pid': pid, 'comm': 'python'}
+    inventories = [
+        [process(1, 10, 0)],
+        [process(1, 10, 100), process(2, 20, 10)],
+        [process(2, 20, 110), process(1, 30, 50)],
+        [process(1, 30, 150)],
+    ]
+    frames = [{'elapsed_seconds': index, 'processes': {'ratings': rows}}
+              for index, rows in enumerate(inventories)]
+    result = profile.process_cpu_summary(frames, 'ratings', 100)
+    by_identity = {(row['pid'], row['start_ticks']): row for row in result}
+    assert set(by_identity) == {(1, 10), (2, 20), (1, 30)}
+    for row in result:
+        assert row['observed_cpu_seconds'] == 1
+        assert row['observed_seconds'] == 1
+        assert row['one_core_cpu_percent'] == pytest.approx(100 / 3)
+
+
+def test_identity_change_receipt_distinguishes_restart_limits_and_exit():
+    original = {'ratings': {'id': 'a', 'pid': 1, 'started_at': 'before',
+                            'running': True, 'nano_cpus': 16, 'memory': 64}}
+    assert not any(profile.identity_changes(original, original).values())
+    for key, value, expected in (
+        ('pid', 2, 'worker_restarted'), ('started_at', 'after', 'worker_restarted'),
+        ('id', 'b', 'worker_restarted'), ('memory', 32, 'resource_limits_changed'),
+        ('running', False, 'running_state_changed'),
+    ):
+        after = {'ratings': dict(original['ratings'], **{key: value})}
+        changes = profile.identity_changes(original, after)
+        assert changes[expected] is True
+        assert sum(changes.values()) == 1
+
+
+def test_search_generation_must_match_ratings():
+    identities = {role: {'generation': profile.GENERATION} for role in ('ratings', 'search')}
+    profile.verify_generations(identities)
+    identities['search']['generation'] = 'stale_generation'
+    with pytest.raises(ValueError, match='search worker generation mismatch'):
+        profile.verify_generations(identities)
+
+
+def test_unreadable_descriptor_does_not_prevent_observing_other_descriptors(monkeypatch):
+    monkeypatch.setattr(Path, 'iterdir', lambda self: iter([self / '1', self / '2']))
+    def link(path):
+        if path.name == '1':
+            raise PermissionError('fixture')
+        return '/retained/galaxy.json.gz'
+    monkeypatch.setattr(profile.os, 'readlink', link)
+    monkeypatch.setattr(profile, 'optional_read', lambda *_: 'pos: 123\n')
+    missing = set()
+    assert profile.source_position(42, missing) == [123]
+    assert missing == {'/proc/42/fd/1:PermissionError'}

--- a/tests/test_ratings_v4_runtime_profile.py
+++ b/tests/test_ratings_v4_runtime_profile.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+import sys
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.operator import ratings_v4_runtime_profile as profile  # noqa: E402
+from tests.ratings_v4_pg_fixture import canonical_database  # noqa: E402
+
+
+def test_proc_stat_handles_comm_parentheses_and_linux_field_offsets():
+    fields = ['S', '17'] + ['0'] * 19 + ['12']
+    fields[11], fields[12], fields[19] = '150', '50', '123456'
+    row = profile.parse_stat('42 (worker (encoder)) ' + ' '.join(fields))
+    assert row == {'comm': 'worker (encoder)', 'state': 'S', 'ppid': 17,
+                   'cpu_ticks': 200, 'start_ticks': 123456, 'rss_pages': 12}
+
+
+def test_cpu_rates_are_one_core_percent_and_reject_pid_reuse():
+    before = [{'pid': 42, 'cpu_ticks': 100, 'start_ticks': 9}]
+    after = [{'pid': 42, 'namespace_pid': 1, 'comm': 'python',
+              'cpu_ticks': 300, 'start_ticks': 9}]
+    assert profile.process_rates(before, after, 2, 100)[0]['one_core_cpu_percent'] == 100
+    after[0]['start_ticks'] = 10
+    assert profile.process_rates(before, after, 2, 100) == []
+
+
+def test_permission_denial_is_recorded_without_a_fallback(tmp_path, monkeypatch):
+    def denied(self):
+        raise PermissionError('fixture')
+    monkeypatch.setattr(Path, 'read_text', denied)
+    missing = set()
+    assert profile.optional_read(tmp_path / 'stat', missing) is None
+    assert len(missing) == 1
+    assert next(iter(missing)).endswith(':PermissionError')
+
+
+def test_cgroup_path_cannot_escape_host_cgroup_tree(monkeypatch):
+    monkeypatch.setattr(profile, 'optional_read', lambda *_: '0::/../../tmp\n')
+    with pytest.raises(ValueError, match='unexpected cgroup path'):
+        profile.cgroup_directory(1, set())
+
+
+def test_database_observations_use_fresh_read_only_bounded_transactions(monkeypatch):
+    commands = []
+    monkeypatch.setattr(profile, 'command', lambda args: commands.append(args) or '{"ok":true}')
+    assert profile.database_query(profile.ACTIVITY_SQL) == {'ok': True}
+    args = commands[0]
+    statement = args[args.index('--command') + 1]
+    assert statement.startswith("BEGIN READ ONLY; SET LOCAL statement_timeout='5s';")
+    assert "SET LOCAL lock_timeout='1s';" in statement
+    assert statement.endswith('; COMMIT;')
+    assert 'ON_ERROR_STOP=1' in args
+    assert profile.CONTAINERS['postgres'] in args
+    assert 'query_kind' in statement
+    assert 'host(client_addr) AS client_addr' in statement
+    assert 'SELECT * FROM pg_stat_activity' not in statement
+
+
+def test_profile_workflow_has_fixed_request_and_trusted_read_only_implementation():
+    path = ROOT / '.github/workflows/ratings-v4-production-profile.yml'
+    source = path.read_text()
+    workflow = yaml.load(source, Loader=yaml.BaseLoader)
+    job = workflow['jobs']['profile']
+    assert job['environment'] == 'ed-new-operator'
+    assert job['timeout-minutes'] == '8'
+    assert workflow['concurrency']['cancel-in-progress'] == 'false'
+    assert '.github/ratings-v4-profile-requests/*.json' in source
+    assert '{"operation": "ratings-v4-runtime-profile"}' in source
+    assert 'ref: main' in source
+    assert 'timeout 210s python3.14 -' in source
+    assert 'trusted-main/scripts/operator/ratings_v4_runtime_profile.py' in source
+    assert '"profiler_sha256"' in source
+    assert 'always()' in source
+
+
+def test_observation_queries_execute_on_postgresql18_catalogs():
+    with canonical_database() as (connection, _, _, _):
+        for name in ('003_ratings_v4_derived.sql', '004_v3_search_spatial_clusters.sql',
+                     '006_v3_derived_product_lifecycle.sql'):
+            connection.execute((ROOT / 'sql/v3/migrations' / name).read_text())
+        with connection.transaction():
+            connection.execute('SET TRANSACTION READ ONLY')
+            activity = connection.execute(profile.ACTIVITY_SQL).fetchone()[0]
+            totals = connection.execute(profile.TOTALS_SQL).fetchone()[0]
+        # SQL explicitly returns text for the standalone psql transport.
+        import json
+        assert isinstance(json.loads(activity)['activity'], list)
+        data = json.loads(totals)
+        assert data['generation'] is None
+        assert data['database']['datname'].startswith('v4_test_')
+        assert isinstance(data['io'], list)


### PR DESCRIPTION
The existing Ratings status operation reports progress but cannot show whether encoding, the coordinator, database work or storage limits throughput.

This adds a fixed 120-second observer for the existing Ratings, Search and retained PostgreSQL containers. It records per-process CPU and readable I/O counters, cgroup throttling/memory/I/O, host disk/pressure counters, compressed-source offsets, database waits/COPY progress and before/after committed chunk counts. Queries use new READ ONLY transactions with 5-second statement/1-second lock limits. Raw SQL, process environments and arguments are not emitted; unavailable OS counters are reported without a privileged fallback.

The protected workflow accepts exactly one data-only request, reads implementation from trusted main, records source hashes, uses the existing pinned SSH/environment/concurrency, bounds the remote command to 210 seconds and retains partial JSONL on failure. No debugger attachment, worker control, persistent settings, stats resets, schema/publication changes or builder-identity changes.

Validation: 22 focused local checks passed; the PostgreSQL catalog-execution test awaits isolated PostgreSQL 18 CI. Added CPU/PID-reuse, proc parser, denied-counter and cgroup-path tests, and registered the workflow/runtime profile in CI contracts.

Production collection will occur only after review and green CI. This PR authorizes no performance tuning or worker restart.