### PR TITLE
Reduce Ratings V4 coordinator overhead with direct source parsing

### DIFF
--- a/.github/workflows/ratings-v4-freeze.yml
+++ b/.github/workflows/ratings-v4-freeze.yml
@@ -64,3 +64,15 @@ jobs:
           name: ratings-v4-validation-receipt
           path: /tmp/ratings-v4-validation-receipt.json
           if-no-files-found: error
+      - name: Benchmark source parsing and complete disposable PostgreSQL builds
+        env:
+          RATINGS_V4_VALIDATION_DATABASE_URL: postgresql://v4validator:v4test@127.0.0.1:5432/ratings_v4_validation
+        run: >-
+          python scripts/ratings_v4/benchmark_source_parser.py --rounds 4 --postgres
+          --receipt /tmp/ratings-v4-parser-benchmark.json
+      - name: Retain parser and builder benchmark receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ratings-v4-parser-benchmark
+          path: /tmp/ratings-v4-parser-benchmark.json
+          if-no-files-found: error

--- a/docs/development/ratings-v4-direct-source-parser.md
+++ b/docs/development/ratings-v4-direct-source-parser.md
@@ -1,0 +1,63 @@
+# Ratings V4 direct source parsing
+
+The production observer in PR #706 measured Ratings using approximately 4.05 of
+its 16 allocated CPU cores. Its coordinator used approximately 81% of one core;
+encoder processes were partly idle, and database sessions mostly waited for the
+application. This motivates reducing sequential coordinator work before adding
+encoder workers or changing the pipeline architecture.
+
+The existing reader called `ijson.parse()` and passed its Python event iterator
+to `ijson.items()`. Every JSON token crossed into Python before record assembly.
+The new reader passes the gzip byte stream directly to `ijson.items()` so the
+native backend can assemble complete records. A bounded, transparent read wrapper
+retains the root-array check, including long leading whitespace and the existing
+YAJL whitespace behavior. It forwards bytes unchanged and ignores binary-stream
+`read(0)` probes.
+
+All fields, float handling, chunk limits, compressed-byte hashing, verified EOF
+receipts, canonical adaptation, scoring, ordered atomic writes and validation
+remain in the existing builder. No source projection or parsing field is dropped.
+The parser still validates the entire document and gzip stream; malformed or
+truncated inputs cannot produce an EOF receipt.
+
+## Evidence
+
+The exploratory CPython 3.14.7 / ijson 3.5.1 comparison used eight repetitions of
+the retained twelve-system cohort: 96 records, 3,112 bodies and approximately
+87 MB of JSON. Across six alternating AB/BA rounds, median parsing time fell from
+3.098 seconds to 1.515 seconds (2.05× parsing throughput). Full record digests and
+compressed-source receipts matched.
+
+This cohort contains substantially richer records than many galaxy systems.
+Repeated identifiers are acceptable only in the parsing benchmark, which never
+writes those repeated records to a database. These numbers are not a production
+throughput forecast.
+
+Run the reproducible comparison with:
+
+```bash
+python scripts/ratings_v4/benchmark_source_parser.py --receipt /tmp/parser.json
+```
+
+The Ratings freeze workflow also uses `--postgres --rounds 4` against its isolated
+PostgreSQL 18 service. Each complete-builder case uses the original unique
+twelve-system cohort in a new disposable database, two encoder workers and
+three-system chunks. It measures source parsing, canonical reads, compaction,
+ordered writes, encoder wait, validation and total time. Warmups are excluded;
+measured ordering alternates. Every build must validate and produce identical
+stored rows and chunk hashes. The `ratings-v4-parser-benchmark` artifact records
+all samples, medians, runtime versions and source checksums. Timing is reported;
+there is no fragile wall-clock pass threshold.
+
+The full-build fixture has small chunks and includes process startup and complete
+validation. It proves behavior and measures this isolated workload; it does not
+reproduce production chunk sizes, storage, canonical query plans or data mix.
+
+## Current production generation
+
+This changes a generation-bound source file, so the existing code-identity guard
+will reject resuming the running generation with the new builder. Do not replace
+its code, edit its manifest, relax the guard, or restart it to apply this change.
+Any deployment for the current generation requires a separately reviewed
+compatibility/cutover design. No operator workflow or running worker is changed
+by this development work.

--- a/scripts/ratings_v4/benchmark_source_parser.py
+++ b/scripts/ratings_v4/benchmark_source_parser.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Compare source parsers on repeated frozen inputs without production access.
+
+This is a parsing benchmark, not an estimate of complete-generation throughput.
+Both paths retain all record fields, bounded chunks and compressed EOF checks.
+An optional complete-builder comparison uses only the local validation database.
+"""
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from contextlib import ExitStack, contextmanager, nullcontext
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import statistics
+import sys
+import tempfile
+import time
+from unittest.mock import patch
+from uuid import UUID
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from scripts.ratings_v4.canonical_stream import (  # noqa: E402
+    RetainedArtifactStream, _ArrayRootReader,
+)
+from domain.ratings_v4_canonical import load_source_fixture  # noqa: E402
+
+
+@contextmanager
+def legacy_event_parser():
+    """Reproduce the previous parse → Python events → items path for comparison."""
+    import ijson
+
+    original_items = ijson.items
+
+    def items(source, prefix, **kwargs):
+        if isinstance(source, _ArrayRootReader):
+            source = source.stream
+        events = ijson.parse(source, **kwargs)
+        if next(events, None) != ('', 'start_array', None):
+            raise ValueError('Spansh artifact must be a JSON array')
+        return original_items(events, prefix)
+
+    with patch.object(ijson, 'items', items):
+        yield
+
+
+def consume(path, sha256, size_bytes, *, legacy, verify=False):
+    stream = RetainedArtifactStream(path, sha256=sha256, size_bytes=size_bytes)
+    digest = hashlib.sha256() if verify else None
+    systems = chunks = 0
+    context = legacy_event_parser() if legacy else nullcontext()
+    with context:
+        started = time.perf_counter()
+        for chunk in stream.chunks(12):
+            systems += len(chunk)
+            chunks += 1
+            if digest is not None:
+                # Separate parity runs keep JSON reserialization out of timings.
+                digest.update(json.dumps(chunk, sort_keys=True, separators=(',', ':'),
+                                         allow_nan=False).encode())
+        seconds = time.perf_counter() - started
+    if stream.receipt is None:
+        raise ValueError('benchmark source was not verified to EOF')
+    return {'seconds': seconds, 'systems': systems, 'chunks': chunks,
+            'records_sha256': digest.hexdigest() if digest is not None else None,
+            'source_receipt': stream.receipt}
+
+
+def benchmark(*, repetitions=8, rounds=6):
+    import ijson
+
+    if type(repetitions) is not int or not 1 <= repetitions <= 8:
+        raise ValueError('benchmark repetitions must be between 1 and 8')
+    if type(rounds) is not int or not 2 <= rounds <= 10:
+        raise ValueError('benchmark rounds must be between 2 and 10')
+    _, _, payloads = load_source_fixture(ROOT / 'tests/fixtures/ratings_v4_sources')
+    cohort = [payload['system'] for payload in payloads]
+    cohort_bytes = json.dumps(cohort, separators=(',', ':')).encode()[1:-1]
+    samples = []
+    with tempfile.TemporaryDirectory(prefix='ratings-v4-parser-') as temporary:
+        source = Path(temporary) / 'galaxy.json.gz'
+        with source.open('wb') as output:
+            with gzip.GzipFile(fileobj=output, mode='wb', mtime=0) as compressed:
+                compressed.write(b'[')
+                for repeat in range(repetitions):
+                    if repeat:
+                        compressed.write(b',')
+                    compressed.write(cohort_bytes)
+                compressed.write(b']')
+        digest = hashlib.sha256(source.read_bytes()).hexdigest()
+        size = source.stat().st_size
+        parity = [consume(source, digest, size, legacy=legacy, verify=True)
+                  for legacy in (True, False)]
+        for field in ('systems', 'chunks', 'records_sha256', 'source_receipt'):
+            if parity[0][field] != parity[1][field]:
+                raise ValueError(f'parser parity failed: {field}')
+        # Warm both paths, then alternate AB / BA to reduce ordering bias.
+        for legacy in (True, False):
+            consume(source, digest, size, legacy=legacy)
+        for repeat in range(rounds):
+            order = (True, False) if repeat % 2 == 0 else (False, True)
+            for legacy in order:
+                result = consume(source, digest, size, legacy=legacy)
+                samples.append({'round': repeat, 'parser': 'legacy' if legacy else 'direct',
+                                'seconds': result['seconds']})
+    medians = {name: statistics.median(row['seconds'] for row in samples if row['parser'] == name)
+               for name in ('legacy', 'direct')}
+    return {
+        'status': 'VERIFIED', 'scope': 'source parsing only; repeated frozen cohort',
+        'python': sys.version, 'platform': platform.platform(), 'logical_cpus': os.cpu_count(),
+        'ijson_version': ijson.__version__, 'ijson_backend': ijson.backend,
+        'source_sha256': {name: hashlib.sha256((ROOT / name).read_bytes()).hexdigest()
+                          for name in ('scripts/ratings_v4/canonical_stream.py',
+                                       'scripts/ratings_v4/benchmark_source_parser.py')},
+        'systems': len(cohort) * repetitions,
+        'bodies': sum(len(record.get('bodies', [])) for record in cohort) * repetitions,
+        'json_bytes': len(cohort_bytes) * repetitions + repetitions + 1,
+        'gzip_bytes': size, 'gzip_sha256': digest,
+        'rounds': rounds, 'samples': samples, 'median_seconds': medians,
+        'parsing_speedup': medians['legacy'] / medians['direct'],
+        'full_record_parity': True, 'records_sha256': parity[0]['records_sha256'],
+        'source_receipt': parity[0]['source_receipt'],
+        'database_access_performed': False, 'production_changes_performed': False,
+    }
+
+
+def benchmark_postgres_builder(*, rounds=4):
+    """Measure complete builds only in the guarded disposable validation DB."""
+    from psycopg import sql
+    from scripts.ratings_v4 import production_generation as production, run_generation as runner
+    from tests.ratings_v4_pg_fixture import canonical_database
+
+    if not os.environ.get('RATINGS_V4_VALIDATION_DATABASE_URL'):
+        raise ValueError('isolated PostgreSQL validation URL is required')
+    if type(rounds) is not int or not 2 <= rounds <= 10:
+        raise ValueError('benchmark rounds must be between 2 and 10')
+    _, _, payloads = load_source_fixture(ROOT / 'tests/fixtures/ratings_v4_sources')
+    records = [payload['system'] for payload in payloads]
+    compressed = gzip.compress(json.dumps(records).encode(), mtime=0)
+
+    def retained_fixture(_canonical, metadata):
+        metadata['artifact']['content_sha256'] = '\\x' + hashlib.sha256(compressed).hexdigest()
+        metadata['artifact']['size_bytes'] = len(compressed)
+        return ()
+
+    def build_one(source, legacy):
+        stages = defaultdict(float)
+
+        def timed(name, function):
+            def wrapped(*args, **kwargs):
+                started = time.perf_counter()
+                try:
+                    return function(*args, **kwargs)
+                finally:
+                    stages[name] += time.perf_counter() - started
+            return wrapped
+
+        original_chunks = runner.RetainedArtifactStream.chunks
+
+        def chunks(stream, *args, **kwargs):
+            iterator = original_chunks(stream, *args, **kwargs)
+            while True:
+                started = time.perf_counter()
+                try:
+                    chunk = next(iterator)
+                except StopIteration:
+                    return
+                finally:
+                    stages['source_parse'] += time.perf_counter() - started
+                yield chunk
+
+        # canonical_database rejects remote hosts and every non-validation DB
+        # before creating its random v4_test_* database. No production DSN is read.
+        with canonical_database(prepare=retained_fixture) as (connection, _, _, _):
+            connection.execute((ROOT / 'sql/v3/migrations/003_ratings_v4_derived.sql').read_text())
+            with ExitStack() as stack:
+                stack.enter_context(patch.object(production, 'uuid4', lambda: UUID(
+                    '6842309d-9775-448d-b8c7-44f081c11563')))
+                if legacy:
+                    stack.enter_context(legacy_event_parser())
+                stack.enter_context(patch.object(runner.RetainedArtifactStream, 'chunks', chunks))
+                stack.enter_context(patch.object(runner.CanonicalSnapshot, 'export_chunk',
+                    timed('canonical_reads', runner.CanonicalSnapshot.export_chunk)))
+                for name, label in (('_compact_source_records', 'source_compaction'),
+                                    ('_write_encoded_chunk', 'ordered_writes'),
+                                    ('_drain_oldest', 'drain_including_writes'),
+                                    ('seal_source', 'source_seal'),
+                                    ('validate_generation', 'validation')):
+                    stack.enter_context(patch.object(runner, name, timed(label, getattr(runner, name))))
+                started = time.perf_counter()
+                receipt = runner.build_generation(connection, connection, source, 'parser_benchmark',
+                                                  chunk_size=3, workers=2)
+                seconds = time.perf_counter() - started
+            if receipt['status'] != 'VERIFIED' or receipt['lifecycle_state'] != 'READY':
+                raise ValueError('benchmark build did not pass full generation validation')
+            output = {}
+            for table, columns, order in (
+                ('system_rating_vector', production.VECTOR_COLUMNS, 'system_id64'),
+                ('body_mechanics', production.BODY_COLUMNS, 'system_id64,body_pk'),
+                ('economy_opportunity', production.OPPORTUNITY_COLUMNS,
+                 'system_id64,body_pk,economy_ordinal'),
+            ):
+                query = sql.SQL('SELECT {} FROM v3_derived.{} ORDER BY {}').format(
+                    sql.SQL(',').join(map(sql.Identifier, columns)),
+                    sql.Identifier(table), sql.SQL(order))
+                output[table] = connection.execute(query).fetchall()
+            output['chunks'] = connection.execute('''SELECT chunk_ordinal,
+                source_projection_sha256,canonical_input_sha256,content_sha256,systems,
+                canonical_bodies,physical_bodies,eligible_opportunities
+                FROM v3_derived.build_chunk ORDER BY chunk_ordinal''').fetchall()
+            output_sha256 = production._digest(output).hex()
+        stages['encoder_wait_and_drain_overhead'] = (
+            stages.pop('drain_including_writes') - stages['ordered_writes'])
+        stages['setup_pool_and_other'] = seconds - sum(stages.values())
+        return {'parser': 'legacy' if legacy else 'direct', 'seconds': seconds,
+                'stages_seconds': dict(stages), 'output_sha256': output_sha256,
+                'rows': {table: len(rows) for table, rows in output.items()},
+                'validated': True, 'publication_performed': receipt['publication_performed']}
+
+    samples = []
+    with tempfile.TemporaryDirectory(prefix='ratings-v4-parser-build-') as temporary:
+        source = Path(temporary) / 'galaxy.json.gz'
+        source.write_bytes(compressed)
+        warmups = [build_one(source, legacy) for legacy in (True, False)]
+        for repeat in range(rounds):
+            for legacy in (True, False) if repeat % 2 == 0 else (False, True):
+                samples.append(dict(build_one(source, legacy), round=repeat))
+    if len({row['output_sha256'] for row in [*warmups, *samples]}) != 1:
+        raise ValueError('complete builder rows or chunk hashes differ between parsers')
+    medians = {name: statistics.median(row['seconds'] for row in samples if row['parser'] == name)
+               for name in ('legacy', 'direct')}
+    stage_medians = {name: {stage: statistics.median(
+        row['stages_seconds'][stage] for row in samples if row['parser'] == name)
+        for stage in samples[0]['stages_seconds']} for name in ('legacy', 'direct')}
+    return {'status': 'VERIFIED', 'scope': 'complete disposable PostgreSQL build and validation',
+            'systems': len(records), 'chunk_size': 3, 'encoder_workers': 2,
+            'rounds': rounds, 'samples': samples, 'median_seconds': medians,
+            'stage_median_seconds': stage_medians,
+            'fixture_build_speedup': medians['legacy'] / medians['direct'],
+            'exact_rows_and_chunk_hashes_match': True,
+            'output_sha256': samples[0]['output_sha256'],
+            'production_changes_performed': False}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--repetitions', type=int, default=8)
+    parser.add_argument('--rounds', type=int, default=6)
+    parser.add_argument('--receipt', type=Path)
+    parser.add_argument('--postgres', action='store_true',
+                        help='also benchmark complete builds in the guarded local validation DB')
+    args = parser.parse_args()
+    result = benchmark(repetitions=args.repetitions, rounds=args.rounds)
+    if args.postgres:
+        result['postgres_builder'] = benchmark_postgres_builder(rounds=args.rounds)
+        result['database_access_performed'] = True
+        result['database_scope'] = 'new disposable local validation databases only'
+    text = json.dumps(result, indent=2, sort_keys=True) + '\n'
+    if args.receipt:
+        args.receipt.write_text(text)
+    print(text, end='')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ratings_v4/canonical_stream.py
+++ b/scripts/ratings_v4/canonical_stream.py
@@ -58,6 +58,32 @@ class _HashedReader:
         return data
 
 
+class _ArrayRootReader:
+    """Check the root while forwarding unchanged bytes to the native parser.
+
+    Checking each bounded read also handles arbitrarily long leading whitespace
+    without retaining a prefix or depending on gzip.peek(). read(0) is the parser's
+    binary-stream probe and must not be mistaken for end of input.
+    """
+    def __init__(self, stream):
+        self.stream = stream
+        self.checked = False
+
+    def read(self, size=-1):
+        data = self.stream.read(size)
+        if size != 0 and not self.checked:
+            # Match the existing YAJL backend's ASCII whitespace handling. The
+            # parser still validates the complete document, including its tail.
+            prefix = data.lstrip(b' \t\r\n\v\f')
+            if prefix:
+                if prefix[:1] != b'[':
+                    raise ValueError('Spansh artifact must be a JSON array')
+                self.checked = True
+            elif not data:
+                raise ValueError('Spansh artifact must be a JSON array')
+        return data
+
+
 class RetainedArtifactStream:
     """Hash the compressed bytes actually parsed; only EOF produces a receipt.
 
@@ -90,10 +116,8 @@ class RetainedArtifactStream:
             chunk = []
             chunk_bodies = 0
             with gzip.GzipFile(fileobj=reader, mode='rb') as decoded:
-                events = ijson.parse(decoded, use_float=True)
-                if next(events, None) != ('', 'start_array', None):
-                    raise ValueError('Spansh artifact must be a JSON array')
-                for record in ijson.items(events, 'item'):
+                records = ijson.items(_ArrayRootReader(decoded), 'item', use_float=True)
+                for record in records:
                     if not isinstance(record, dict) or not isinstance(record.get('bodies', []), list):
                         raise ValueError('invalid Spansh system record')
                     _system_ids([record.get('id64')])

--- a/tests/test_ratings_v4_direct_parser.py
+++ b/tests/test_ratings_v4_direct_parser.py
@@ -1,0 +1,120 @@
+from contextlib import nullcontext
+import gzip
+import hashlib
+import io
+import json
+from pathlib import Path
+import sys
+from uuid import UUID
+
+import ijson
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.ratings_v4 import production_generation  # noqa: E402
+from scripts.ratings_v4.benchmark_source_parser import legacy_event_parser  # noqa: E402
+from scripts.ratings_v4.canonical_stream import RetainedArtifactStream, _ArrayRootReader  # noqa: E402
+from scripts.ratings_v4.run_generation import build_generation  # noqa: E402
+from domain.ratings_v4_canonical import load_source_fixture  # noqa: E402
+from tests.ratings_v4_pg_fixture import canonical_database  # noqa: E402
+
+
+def stream_for(tmp_path, raw):
+    compressed = gzip.compress(raw, mtime=0)
+    path = tmp_path / 'galaxy.json.gz'
+    path.write_bytes(compressed)
+    return RetainedArtifactStream(path, sha256=hashlib.sha256(compressed).hexdigest(),
+                                  size_bytes=len(compressed))
+
+
+def test_root_guard_preserves_bytes_across_reads_and_ignores_read_zero():
+    data = b' \t\r\n\v\f' * 20 + b'[{"id64":1}]  \n'
+    source = io.BytesIO(data)
+    reader = _ArrayRootReader(source)
+    assert reader.read(0) == b''
+    assert source.tell() == 0 and reader.checked is False
+    pieces = []
+    while piece := reader.read(3):
+        pieces.append(piece)
+    assert b''.join(pieces) == data
+    assert reader.checked is True
+
+
+@pytest.mark.parametrize('raw', [
+    b'', b' \t\r\n', b'{"item":{"id64":1}}', b'null', b'1',
+    b'"array"', b'\xef\xbb\xbf[{"id64":1}]',
+    b'[{"id64":1}', b'[{"id64":1}] {}', b'[{"id64":1}] []',
+    b'[{"id64":1,"bad":NaN}]', b'[{"id64":1,"bad":1e400}]',
+    b'[{"id64":1,"name":"\xff"}]',
+])
+@pytest.mark.parametrize('legacy', [False, True], ids=['direct', 'legacy'])
+def test_invalid_or_incomplete_json_never_produces_an_eof_receipt(tmp_path, raw, legacy):
+    stream = stream_for(tmp_path, raw)
+    with legacy_event_parser() if legacy else nullcontext():
+        with pytest.raises((ValueError, ijson.JSONError, EOFError)):
+            list(stream.chunks())
+    assert stream.receipt is None
+
+
+@pytest.mark.parametrize('prefix', [b'', b' \t\r\n\v\f'])
+def test_direct_parser_preserves_numeric_unicode_and_backend_whitespace(tmp_path, prefix):
+    raw = prefix + ('[{"id64":9223372036854775807,"bodies":[],"n":1.25,"z":-0.0,'
+           '"name":"Étoile 🌟","nested":[true,null,{"s":"\\\\\\\""}]}]').encode()
+    direct = stream_for(tmp_path, raw)
+    actual = list(direct.chunks())
+    legacy = stream_for(tmp_path, raw)
+    with legacy_event_parser():
+        expected = list(legacy.chunks())
+    assert json.dumps(actual, sort_keys=True) == json.dumps(expected, sort_keys=True)
+    assert direct.receipt == legacy.receipt
+
+
+def test_complete_parallel_build_has_identical_rows_and_chunk_hashes_for_both_parsers(tmp_path, monkeypatch):
+    _, _, payloads = load_source_fixture(ROOT / 'tests/fixtures/ratings_v4_sources')
+    records = [payload['system'] for payload in payloads]
+    compressed = gzip.compress(json.dumps(records).encode(), mtime=0)
+    source = tmp_path / 'galaxy.json.gz'
+    source.write_bytes(compressed)
+
+    def retained_fixture(_canonical, metadata):
+        metadata['artifact']['content_sha256'] = '\\x' + hashlib.sha256(compressed).hexdigest()
+        metadata['artifact']['size_bytes'] = len(compressed)
+        return ()
+
+    identifier = UUID('6842309d-9775-448d-b8c7-44f081c11563')
+    monkeypatch.setattr(production_generation, 'uuid4', lambda: identifier)
+    results = []
+    for legacy in (True, False):
+        with canonical_database(prepare=retained_fixture) as (connection, _, _, _):
+            connection.execute((ROOT / 'sql/v3/migrations/003_ratings_v4_derived.sql').read_text())
+            with legacy_event_parser() if legacy else nullcontext():
+                receipt = build_generation(connection, connection, source, 'parser_parity',
+                                           chunk_size=3, workers=2)
+            assert receipt['status'] == 'VERIFIED'
+            assert receipt['lifecycle_state'] == 'READY'
+            assert receipt['publication_performed'] is False
+            rows = {}
+            for table, columns, order in (
+                ('system_rating_vector', production_generation.VECTOR_COLUMNS, 'system_id64'),
+                ('body_mechanics', production_generation.BODY_COLUMNS, 'system_id64,body_pk'),
+                ('economy_opportunity', production_generation.OPPORTUNITY_COLUMNS,
+                 'system_id64,body_pk,economy_ordinal'),
+            ):
+                from psycopg import sql
+                query = sql.SQL('SELECT {} FROM v3_derived.{} ORDER BY {}').format(
+                    sql.SQL(',').join(map(sql.Identifier, columns)),
+                    sql.Identifier(table), sql.SQL(order))
+                rows[table] = connection.execute(query).fetchall()
+            rows['chunks'] = connection.execute('''SELECT chunk_ordinal,
+                source_projection_sha256,canonical_input_sha256,content_sha256,systems,
+                canonical_bodies,physical_bodies,eligible_opportunities
+                FROM v3_derived.build_chunk ORDER BY chunk_ordinal''').fetchall()
+            # A completed resume must retain the already committed output.
+            resumed = build_generation(connection, connection, source, 'parser_parity',
+                                       chunk_size=3, workers=2)
+            assert resumed['resumed'] is True
+            assert resumed['chunks_written'] == 0
+            results.append(rows)
+    assert results[0] == results[1]


### PR DESCRIPTION
Ratings' live profile (PR #706) showed spare CPU capacity, partially occupied encoders and a busy coordinator. The retained source reader sends every JSON token through a Python iterator before assembling records, adding sequential coordinator work.

This change feeds the unchanged gzip bytes directly to ijson's record parser. A bounded wrapper preserves root-array validation, long leading whitespace, the existing YAJL whitespace behavior and read(0) probes. Complete records, chunk bounds, compressed checksums, EOF receipts, scoring and ordered writes are preserved.

The repeatable local CPython 3.14.7 / ijson 3.5.1 benchmark measured median parsing time of 3.098s → 1.515s (2.05×), with matching full-record digests and EOF receipts. That is a repeated, rich twelve-system fixture; it is not a production throughput forecast.

Validation prepared:
- 56 focused local tests passed; 5 PostgreSQL cases await isolated CI.
- All 84 frozen ratings verified unchanged; Ruff passed.
- New malformed-input, numeric/Unicode and transparent-read tests.
- PostgreSQL comparison checks exact stored vectors, mechanics, opportunities and chunk hashes after full validation and resume.
- CI runs alternating parser benchmarks and complete disposable PostgreSQL builds, retaining stage timings and all samples in the ratings-v4-parser-benchmark artifact. Timing is reported without a flaky speed threshold.

Production is untouched. This changes a generation-bound file, so existing code identity intentionally rejects resuming the running generation with it. Do not hot-swap code, edit manifests, relax identity checks or restart workers to deploy this PR. A separately reviewed compatibility/cutover design would be required for the existing generation.