### PR TITLE
Prove Ratings V4 parser upgrades preserve committed progress

### DIFF
--- a/.github/workflows/ratings-v4-freeze.yml
+++ b/.github/workflows/ratings-v4-freeze.yml
@@ -17,6 +17,7 @@ on:
       - 'scripts/checks/requirements.txt'
       - 'tests/test_ratings_v4*'
       - 'tests/ratings_v4_pg_fixture.py'
+      - 'tests/ratings_v4_legacy_resume_fixture.py'
       - 'tests/fixtures/ratings_v4*'
       - 'tests/fixtures/ratings_v4_sources/**'
       - 'docs/development/ratings-v4*'
@@ -46,6 +47,8 @@ jobs:
           --health-timeout 3s --health-retries 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Fetch exact legacy builder for cross-version resume proof
+        run: git fetch --no-tags --depth=1 origin fe0c058134b6fec33690fa937c2ac74338b401dc
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.14'

--- a/docs/development/ratings-v4-compatible-resume.md
+++ b/docs/development/ratings-v4-compatible-resume.md
@@ -1,0 +1,103 @@
+# Ratings V4 compatible parser resume
+
+This is a reviewable implementation and isolated PostgreSQL proof of an upgrade
+that preserves progress. It is not a production cutover operation. The running
+worker stays on its original bundle until the remaining deployment gates below
+are satisfied.
+
+## What remains the same
+
+The derived generation UUID and key, immutable original manifest and its hash,
+canonical generation, saved ratings/mechanics/opportunities, chunk ordinals and
+all three checkpoint hashes are retained. Search continues to refer to that same
+derived generation. No ratings are copied to a replacement generation, and no
+published pointer is changed.
+
+Ordinary restart already preserves committed chunks. Previously it also repeated
+canonical reads and scoring for every saved chunk before reaching new work. The
+upgrade path parses and hashes the saved source prefix, compares every chunk's
+source projection and inventories with its checkpoint, then continues the same
+stream at the first uncommitted chunk. It skips only canonical reads and encoding
+for that verified prefix. It does not seek into gzip, trust a byte offset, omit
+the compressed checksum at EOF, or skip the final full stored-output validation.
+
+Canonical relations are immutable and are pinned against the original manifest
+before prefix replay. Final validation still reads every saved chunk, checks its
+content hash and inventories, and recomputes every rating and opportunity with
+the frozen scorer. Corrupted saved output cannot reach READY.
+
+## Explicit compatibility, not a version-name exception
+
+Only the exact four-file identity of production builder
+`fe0c058134b6fec33690fa937c2ac74338b401dc` is an eligible origin. A new generation
+or any other historical identity is not eligible for this transition. Scorer,
+mechanics, adapter, importer and freeze identity are checked before replay.
+
+An explicit `--upgrade-parser-actor` initiates the transition. The proposed
+additive SQL in `sql/v3/proposals/007_ratings_v4_code_upgrade.sql` must already be
+installed by a reviewed operator. It adds one append-only attestation per derived
+generation, containing the old and actual new code hashes, original manifest
+hash, verified checkpoint frontier/digest, system count and actor. The original
+manifest is never edited or relabelled as having used the new code throughout.
+
+Registration occurs only after every saved source chunk has matched. The
+generation row is then locked and its identity, lifecycle and complete checkpoint
+frontier are rechecked. A concurrent frontier change aborts without registering
+or writing new chunks. Subsequent writes, source sealing, validation and
+explanations require the recorded target identity to equal the actual code. The
+new identity also covers the upgrade implementation, proposed SQL, scorer,
+canonical adapter and freeze verifier. Changed target files fail closed.
+
+This detects a writer that advanced during verification; it is not a replacement
+for stopping the old writer. The old binary does not know about a new advisory
+lock. A deployment operator must establish sole writer ownership before starting
+the upgrade and must preserve the old container/bundle for rollback.
+
+## Interruption and rollback
+
+Before the attestation is registered, an interrupted attempt has only read the
+existing generation. Restarting either the old worker or another upgrade attempt
+retains its committed progress.
+
+After registration, the same new code can resume without registering another
+upgrade. It verifies all chunks now present, including any committed after the
+first handoff. Pending encodes or failed transactions are not checkpoints.
+
+The old code can also resume the same generation because its original manifest
+is intact and the new parser produces identical chunk data. The isolated test
+executes that rollback using the actual old files, then runs the old full
+validator across both old and new chunks. An old-code rollback performs its
+original, slower complete prefix replay. Its validation receipt remains truthful
+to the code doing that validation; the separate upgrade attestation is retained.
+
+## Proof and deployment gates
+
+The freeze workflow fetches the exact original commit and verifies the four
+normalized file hashes before executing it in a separate process. Database
+helpers accept only the local `ratings_v4_validation` service and freshly created
+`v4_test_*` databases. Neither the old guard nor its manifest is monkeypatched.
+
+The tests cover actual old-code partial build to new-code completion, interrupted
+new-code resume, rollback to old code, unchanged saved rows and checkpoints,
+source mismatch, different chunk size, a moving frontier, missing migration,
+immutable attestation, changed target code and final detection of corrupt saved
+rows. The source parser's malformed-input and EOF parity suite remains in place.
+
+Before production cutover:
+
+1. Pass this cross-version PostgreSQL 18 proof and review the exact candidate.
+2. Measure prefix replay against retained production data read-only. Parsing must
+   still start at the beginning; a cheap resume is not an instantaneous resume.
+   Include the measured catch-up delay in the completion-time comparison, and
+   measure production throughput rather than treating fixture speedup as fact.
+3. Promote the proposed additive SQL into the declared V3 migration lineage with
+   the matching schema identity and a bounded operator. The proposal is expressly
+   outside that lineage today, so a normal migration/deploy cannot apply it.
+4. The operator must check the exact target, bundle and generation identities,
+   acquire the existing start lock, stop the old worker cleanly, retain it, start
+   the same-generation upgrade with unchanged chunk boundaries, and prove new
+   committed progress. Restore the retained old worker on a failed handoff, after
+   stopping the candidate. Do not restart Search or publish either product.
+
+There is no automatic production launch, migration application, manifest edit,
+container replacement or pointer publication in this change.

--- a/docs/development/ratings-v4-compatible-resume.md
+++ b/docs/development/ratings-v4-compatible-resume.md
@@ -32,6 +32,8 @@ Only the exact four-file identity of production builder
 `fe0c058134b6fec33690fa937c2ac74338b401dc` is an eligible origin. A new generation
 or any other historical identity is not eligible for this transition. Scorer,
 mechanics, adapter, importer and freeze identity are checked before replay.
+The parser target is also pinned to the exact normalized source hash from PR
+#707. An unrelated future parser cannot reuse this transition identifier.
 
 An explicit `--upgrade-parser-actor` initiates the transition. The proposed
 additive SQL in `sql/v3/proposals/007_ratings_v4_code_upgrade.sql` must already be
@@ -39,6 +41,16 @@ installed by a reviewed operator. It adds one append-only attestation per derive
 generation, containing the old and actual new code hashes, original manifest
 hash, verified checkpoint frontier/digest, system count and actor. The original
 manifest is never edited or relabelled as having used the new code throughout.
+
+The operator first installs the independently reviewed target hashes from
+`sql/v3/proposals/007_ratings_v4_code_upgrade_target.json` into an immutable policy
+table. This policy is separate from the candidate's own execution hashes: the
+builder cannot approve itself, insert policy, update policy, or accept an unknown
+initial target. Both the Python gate and the SQL attestation-insert trigger check
+that target. CI reads the committed policy unchanged and fails on candidate drift.
+The future production operator must verify the reviewed policy artifact/bundle
+identity before installing it. Editing candidate files and recomputing their own
+hashes does not satisfy the already installed policy.
 
 Registration occurs only after every saved source chunk has matched. The
 generation row is then locked and its identity, lifecycle and complete checkpoint
@@ -62,6 +74,8 @@ retains its committed progress.
 After registration, the same new code can resume without registering another
 upgrade. It verifies all chunks now present, including any committed after the
 first handoff. Pending encodes or failed transactions are not checkpoints.
+The checkpoint subset recorded at the first upgrade must still match its audit
+digest. Progress receipts report both reused chunks and newly written chunks.
 
 The old code can also resume the same generation because its original manifest
 is intact and the new parser produces identical chunk data. The isolated test

--- a/scripts/ratings_v4/production_generation.py
+++ b/scripts/ratings_v4/production_generation.py
@@ -47,12 +47,22 @@ def code_identity():
             for name in ('scripts/ratings_v4/production_generation.py',
                          'scripts/ratings_v4/run_generation.py',
                          'scripts/ratings_v4/canonical_stream.py',
-                         'sql/v3/migrations/003_ratings_v4_derived.sql')}
+                         'sql/v3/migrations/003_ratings_v4_derived.sql',
+                         'scripts/ratings_v4/resume_upgrade.py',
+                         'sql/v3/proposals/007_ratings_v4_code_upgrade.sql',
+                         'apps/api/src/domain/ratings_v4.py',
+                         'apps/api/src/domain/ratings_v4_canonical.py',
+                         'scripts/ratings_v4/verify_freeze.py')}
 
 
-def _verify_code(manifest):
+def _verify_code(manifest, connection=None, generation_id=None):
     if manifest.get('code_sha256_lf') != code_identity():
-        raise ValueError('generation builder/adapter/schema code identity changed')
+        from scripts.ratings_v4.resume_upgrade import recorded_upgrade
+        receipt = recorded_upgrade(connection, generation_id, manifest)
+        if receipt is None:
+            raise ValueError('generation builder/adapter/schema code identity changed')
+        return receipt
+    return None
 
 
 def _json(value):
@@ -170,7 +180,7 @@ def write_chunk(connection, generation_id, ordinal, canonical, metadata, source_
         if generation is None or generation[0] != 'BUILDING':
             raise ValueError('generation is not BUILDING')
         manifest = generation[1]
-        _verify_code(manifest)
+        _verify_code(manifest, connection, generation_id)
         if (manifest['source_metadata'] != metadata or manifest['canonical_schema'] != canonical['canonical_schema']):
             raise ValueError('chunk canonical source differs from generation manifest')
         old = connection.execute('''SELECT source_projection_sha256,canonical_input_sha256,content_sha256
@@ -262,6 +272,7 @@ def seal_source(connection, generation_id, receipt):
         if row is None or row[0] != 'BUILDING':
             raise ValueError('generation is not BUILDING')
         manifest = row[1]
+        _verify_code(manifest, connection, generation_id)
         artifact = manifest['source_metadata']['artifact']
         if (receipt.get('artifact_sha256') != artifact['content_sha256'].removeprefix('\\x') or
                 receipt.get('size_bytes') != artifact['size_bytes'] or
@@ -289,7 +300,7 @@ def validate_generation(connection, generation_id):
     if row is None or row[0] != 'VALIDATING':
         raise ValueError('generation is not VALIDATING')
     manifest = row[1]
-    _verify_code(manifest)
+    upgrade = _verify_code(manifest, connection, generation_id)
     if _digest(manifest) != bytes(row[2]):
         raise ValueError('generation manifest checksum mismatch')
     if (manifest['scorer_version'] != SCORER_VERSION or manifest['mechanics_version'] != MECHANICS_VERSION or
@@ -341,6 +352,8 @@ def validate_generation(connection, generation_id):
                'content_sha256': bytes(row[3]).hex(), 'manifest_sha256': bytes(row[2]).hex(),
                'every_system_replayed': True, 'every_stored_chunk_read_back': True,
                'elapsed_seconds': (datetime.now(timezone.utc) - started).total_seconds()}
+    if upgrade is not None:
+        receipt['code_upgrade'] = upgrade
     with connection.transaction():
         updated = connection.execute('''UPDATE v3_meta.derived_generation SET lifecycle_state='READY',
             validation_receipt=%s::jsonb,validated_at=now()
@@ -358,7 +371,7 @@ def explain_system(connection, generation_id, system_id64):
         WHERE derived_generation_id=%s''', (generation_id,)).fetchone()
     if row is None or row[1] not in {'READY', 'PUBLISHED', 'RETIRED'}:
         raise ValueError('no validated generation')
-    _verify_code(row[0])
+    _verify_code(row[0], connection, generation_id)
     vector = connection.execute(sql.SQL('SELECT {} FROM v3_derived.system_rating_vector WHERE derived_generation_id=%s AND system_id64=%s').format(
         sql.SQL(',').join(map(sql.Identifier, VECTOR_COLUMNS))), (generation_id, system_id64)).fetchone()
     if vector is None:

--- a/scripts/ratings_v4/resume_upgrade.py
+++ b/scripts/ratings_v4/resume_upgrade.py
@@ -8,9 +8,12 @@ reject a checkpoint frontier that changed during prefix verification.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
+from pathlib import Path
 
 LEGACY_SOURCE_SHA = 'fe0c058134b6fec33690fa937c2ac74338b401dc'
 UPGRADE_ID = 'ratings-v4-direct-parser-1'
+DIRECT_PARSER_SHA256_LF = '9a501bd1584f05b68612dca672e68dfaf69867412abb75a68fad72ce2cc9ad8e'
 LEGACY_CODE = {
     'scripts/ratings_v4/production_generation.py': 'd47815984c257261c6e306f7a842f24fd8a0e7732633e47c9e013fb3a007f7b5',
     'scripts/ratings_v4/run_generation.py': '43c4554e83545560bb4fceb2cb3b889c1eebc1f9bbb53c0a97423f8511c8b361',
@@ -26,6 +29,10 @@ def verify_origin(manifest, *, check_contract=False):
     )
     if manifest.get('code_sha256_lf') != LEGACY_CODE:
         raise ValueError('unsupported parser upgrade origin')
+    root = Path(__file__).resolve().parents[2]
+    parser = (root / 'scripts/ratings_v4/canonical_stream.py').read_text(encoding='utf-8')
+    if hashlib.sha256(parser.encode()).hexdigest() != DIRECT_PARSER_SHA256_LF:
+        raise ValueError('unsupported parser upgrade target')
     expected = {
         'builder_version': BUILDER_VERSION, 'mechanics_version': MECHANICS_VERSION,
         'scorer_version': SCORER_VERSION, 'adapter_version': STREAM_VERSION,
@@ -40,7 +47,7 @@ def verify_origin(manifest, *, check_contract=False):
 
 def recorded_upgrade(connection, generation_id, manifest):
     """Return an exact execution attestation, or None when none was registered."""
-    from scripts.ratings_v4.production_generation import _digest, code_identity
+    from scripts.ratings_v4.production_generation import _digest
 
     if connection is None or generation_id is None:
         return None
@@ -51,16 +58,32 @@ def recorded_upgrade(connection, generation_id, manifest):
     if row is None:
         return None
     verify_origin(manifest)
+    approved = approved_target(connection)
     receipt = row[0]
     expected = {
         'upgrade_id': UPGRADE_ID, 'derived_generation_id': str(generation_id),
         'manifest_sha256': _digest(manifest).hex(), 'from_code_sha256_lf': LEGACY_CODE,
-        'to_code_sha256_lf': code_identity(),
+        'to_code_sha256_lf': approved,
     }
     if (_digest(receipt) != bytes(row[1]) or
             any(receipt.get(key) != value for key, value in expected.items())):
         raise ValueError('recorded parser upgrade identity mismatch')
     return receipt
+
+
+def approved_target(connection):
+    """The migration operator installs this independent, immutable policy first.
+
+    The builder never inserts or updates policy. Capturing its own hashes is not
+    approval: they must match the exact separately reviewed policy in the DB.
+    """
+    from scripts.ratings_v4.production_generation import code_identity
+
+    row = connection.execute('''SELECT code_sha256_lf FROM v3_meta.derived_code_upgrade_target
+        WHERE upgrade_id=%s''', (UPGRADE_ID,)).fetchone()
+    if row is None or row[0] != code_identity():
+        raise ValueError('parser upgrade target differs from independently approved identity')
+    return row[0]
 
 
 @dataclass
@@ -88,6 +111,15 @@ class CommittedPrefix:
             raise ValueError(f'committed source prefix mismatch at chunk {ordinal}')
         self.verified_chunks += 1
 
+    def verify_attestation(self, receipt):
+        count = receipt.get('prefix_chunks')
+        if type(count) is not int or not 0 <= count <= len(self.rows):
+            raise ValueError('attested checkpoint prefix is missing')
+        original = CommittedPrefix(self.rows[:count])
+        if (original.digest.hex() != receipt.get('prefix_sha256') or
+                original.systems != receipt.get('prefix_systems')):
+            raise ValueError('attested checkpoint prefix changed')
+
 
 def committed_prefix(connection, generation_id):
     rows = connection.execute('''SELECT chunk_ordinal,source_projection_sha256,
@@ -106,7 +138,7 @@ def accept_verified_prefix(connection, generation_id, manifest, prefix, *, actor
     changes only the new append-only audit table. No old chunk or manifest moves.
     Repeated resumes require the previously recorded exact execution identity.
     """
-    from scripts.ratings_v4.production_generation import _digest, _json, code_identity
+    from scripts.ratings_v4.production_generation import _digest, _json
 
     if prefix.verified_chunks != len(prefix.rows):
         raise ValueError('every committed source chunk must be verified before upgrade')
@@ -121,14 +153,16 @@ def accept_verified_prefix(connection, generation_id, manifest, prefix, *, actor
             raise ValueError('committed frontier changed; stop the old writer before upgrading')
         existing = recorded_upgrade(connection, generation_id, manifest)
         if existing is not None:
+            prefix.verify_attestation(existing)
             return existing
         verify_origin(manifest)
+        target = approved_target(connection)
         if not isinstance(actor, str) or not actor.strip() or len(actor) > 200:
             raise ValueError('explicit parser upgrade actor is required')
         receipt = {
             'upgrade_id': UPGRADE_ID, 'derived_generation_id': str(generation_id),
             'manifest_sha256': _digest(manifest).hex(), 'from_code_sha256_lf': LEGACY_CODE,
-            'to_code_sha256_lf': code_identity(), 'prefix_sha256': prefix.digest.hex(),
+            'to_code_sha256_lf': target, 'prefix_sha256': prefix.digest.hex(),
             'prefix_chunks': len(prefix.rows), 'prefix_systems': prefix.systems,
             'actor': actor, 'source_prefix_verified': True,
         }

--- a/scripts/ratings_v4/resume_upgrade.py
+++ b/scripts/ratings_v4/resume_upgrade.py
@@ -1,0 +1,167 @@
+"""One explicit, audited parser upgrade; never rewrite a generation manifest.
+
+This is deliberately not a general version-compatibility switch. Only the exact
+parallel builder used for prod-p4-opt1 may enter this transition. Deployment must
+stop its old writer before starting the upgrade; database locks additionally
+reject a checkpoint frontier that changed during prefix verification.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+LEGACY_SOURCE_SHA = 'fe0c058134b6fec33690fa937c2ac74338b401dc'
+UPGRADE_ID = 'ratings-v4-direct-parser-1'
+LEGACY_CODE = {
+    'scripts/ratings_v4/production_generation.py': 'd47815984c257261c6e306f7a842f24fd8a0e7732633e47c9e013fb3a007f7b5',
+    'scripts/ratings_v4/run_generation.py': '43c4554e83545560bb4fceb2cb3b889c1eebc1f9bbb53c0a97423f8511c8b361',
+    'scripts/ratings_v4/canonical_stream.py': '160322dbeac52908a1dddf41efa5d5f97e1cb7b6bfa46ab4bc658671108ca738',
+    'sql/v3/migrations/003_ratings_v4_derived.sql': 'c7818f98ad00b4b99b7ce0f7c3fa12ece555e59e761b7b1ca15d437a39c499cb',
+}
+
+
+def verify_origin(manifest, *, check_contract=False):
+    from scripts.ratings_v4.production_generation import (
+        BUILDER_VERSION, MECHANICS_VERSION, SCORER_VERSION, STREAM_VERSION,
+        normalized_sha256, verify_contract, verify_recovered_source,
+    )
+    if manifest.get('code_sha256_lf') != LEGACY_CODE:
+        raise ValueError('unsupported parser upgrade origin')
+    expected = {
+        'builder_version': BUILDER_VERSION, 'mechanics_version': MECHANICS_VERSION,
+        'scorer_version': SCORER_VERSION, 'adapter_version': STREAM_VERSION,
+    }
+    if check_contract:
+        frozen, _, _ = verify_contract()
+        expected.update(freeze_sha256=normalized_sha256(frozen),
+                        importer_sha256=verify_recovered_source()['importer_package_sha256'])
+    if any(manifest.get(key) != value for key, value in expected.items()):
+        raise ValueError('parser upgrade frozen contract changed')
+
+
+def recorded_upgrade(connection, generation_id, manifest):
+    """Return an exact execution attestation, or None when none was registered."""
+    from scripts.ratings_v4.production_generation import _digest, code_identity
+
+    if connection is None or generation_id is None:
+        return None
+    if connection.execute("SELECT to_regclass('v3_meta.derived_code_upgrade')").fetchone()[0] is None:
+        return None
+    row = connection.execute('''SELECT receipt,receipt_sha256 FROM v3_meta.derived_code_upgrade
+        WHERE derived_generation_id=%s''', (generation_id,)).fetchone()
+    if row is None:
+        return None
+    verify_origin(manifest)
+    receipt = row[0]
+    expected = {
+        'upgrade_id': UPGRADE_ID, 'derived_generation_id': str(generation_id),
+        'manifest_sha256': _digest(manifest).hex(), 'from_code_sha256_lf': LEGACY_CODE,
+        'to_code_sha256_lf': code_identity(),
+    }
+    if (_digest(receipt) != bytes(row[1]) or
+            any(receipt.get(key) != value for key, value in expected.items())):
+        raise ValueError('recorded parser upgrade identity mismatch')
+    return receipt
+
+
+@dataclass
+class CommittedPrefix:
+    rows: tuple
+    verified_chunks: int = 0
+
+    @property
+    def systems(self):
+        return sum(row[4] for row in self.rows)
+
+    @property
+    def digest(self):
+        from scripts.ratings_v4.production_generation import _digest
+        return _digest(self.rows)
+
+    def verify_source(self, ordinal, records):
+        from scripts.ratings_v4.production_generation import _digest, _projection
+        if ordinal != self.verified_chunks:
+            raise ValueError('source prefix verification must be contiguous')
+        row = self.rows[ordinal]
+        if (len(records) != row[4] or
+                sum(len(record.get('bodies', [])) for record in records) != row[5] or
+                _digest([_projection(record) for record in records]) != bytes(row[1])):
+            raise ValueError(f'committed source prefix mismatch at chunk {ordinal}')
+        self.verified_chunks += 1
+
+
+def committed_prefix(connection, generation_id):
+    rows = connection.execute('''SELECT chunk_ordinal,source_projection_sha256,
+        canonical_input_sha256,content_sha256,systems,canonical_bodies,
+        physical_bodies,eligible_opportunities FROM v3_derived.build_chunk
+        WHERE derived_generation_id=%s ORDER BY chunk_ordinal''', (generation_id,)).fetchall()
+    if any(row[0] != index for index, row in enumerate(rows)):
+        raise ValueError('committed checkpoint prefix is not contiguous')
+    return CommittedPrefix(tuple(rows))
+
+
+def accept_verified_prefix(connection, generation_id, manifest, prefix, *, actor=None):
+    """Register once, only after the caller verified every committed source chunk.
+
+    The caller holds the stream at the first uncommitted record. This transaction
+    changes only the new append-only audit table. No old chunk or manifest moves.
+    Repeated resumes require the previously recorded exact execution identity.
+    """
+    from scripts.ratings_v4.production_generation import _digest, _json, code_identity
+
+    if prefix.verified_chunks != len(prefix.rows):
+        raise ValueError('every committed source chunk must be verified before upgrade')
+    with connection.transaction():
+        row = connection.execute('''SELECT lifecycle_state,manifest,manifest_sha256
+            FROM v3_meta.derived_generation WHERE derived_generation_id=%s FOR UPDATE''',
+            (generation_id,)).fetchone()
+        if (row is None or row[0] != 'BUILDING' or row[1] != manifest or
+                bytes(row[2]) != _digest(manifest)):
+            raise ValueError('parser upgrade generation identity/state changed')
+        if committed_prefix(connection, generation_id).digest != prefix.digest:
+            raise ValueError('committed frontier changed; stop the old writer before upgrading')
+        existing = recorded_upgrade(connection, generation_id, manifest)
+        if existing is not None:
+            return existing
+        verify_origin(manifest)
+        if not isinstance(actor, str) or not actor.strip() or len(actor) > 200:
+            raise ValueError('explicit parser upgrade actor is required')
+        receipt = {
+            'upgrade_id': UPGRADE_ID, 'derived_generation_id': str(generation_id),
+            'manifest_sha256': _digest(manifest).hex(), 'from_code_sha256_lf': LEGACY_CODE,
+            'to_code_sha256_lf': code_identity(), 'prefix_sha256': prefix.digest.hex(),
+            'prefix_chunks': len(prefix.rows), 'prefix_systems': prefix.systems,
+            'actor': actor, 'source_prefix_verified': True,
+        }
+        connection.execute('''INSERT INTO v3_meta.derived_code_upgrade(
+            derived_generation_id,receipt,receipt_sha256) VALUES (%s,%s::jsonb,%s)''',
+            (generation_id, _json(receipt), _digest(receipt)))
+        return receipt
+
+
+def remaining_chunks(stream, chunk_size, connection, generation_id, manifest, *, actor=None,
+                     progress=None):
+    """Parse/hash the retained prefix without repeating canonical reads/scoring.
+
+    Canonical relations are immutable and pinned by the unchanged manifest.
+    Stored content is still read back and scored in full by final validation.
+    The stream continues normally, including the compressed checksum at EOF.
+    """
+    prefix = committed_prefix(connection, generation_id)
+    accepted = False
+    seen = 0
+    for ordinal, records in enumerate(stream.chunks(chunk_size)):
+        if ordinal < len(prefix.rows):
+            prefix.verify_source(ordinal, records)
+            seen += 1
+            if progress is not None:
+                progress({'derived_generation_id': str(generation_id), 'chunk_ordinal': ordinal,
+                          'systems': len(records), 'written': False, 'resume_verified': True})
+            continue
+        if not accepted:
+            accept_verified_prefix(connection, generation_id, manifest, prefix, actor=actor)
+            accepted = True
+        yield ordinal, records
+    if seen != len(prefix.rows):
+        raise ValueError('source ended before committed prefix')
+    if not accepted:
+        accept_verified_prefix(connection, generation_id, manifest, prefix, actor=actor)

--- a/scripts/ratings_v4/run_generation.py
+++ b/scripts/ratings_v4/run_generation.py
@@ -65,12 +65,13 @@ def _generation(connection, snapshot: CanonicalSnapshot, generation_key: str, *,
         from scripts.ratings_v4.resume_upgrade import verify_origin
         verify_origin(manifest, check_contract=True)
     if compatible and upgrade_actor is not None:
-        from scripts.ratings_v4.resume_upgrade import recorded_upgrade
+        from scripts.ratings_v4.resume_upgrade import approved_target, recorded_upgrade
         if recorded_upgrade(connection, identifier, manifest) is None:
             if state != 'BUILDING':
                 raise ValueError('parser upgrade requires a BUILDING generation')
             if connection.execute("SELECT to_regclass('v3_meta.derived_code_upgrade')").fetchone()[0] is None:
                 raise ValueError('reviewed parser upgrade migration is not installed')
+            approved_target(connection)
     else:
         _verify_code(manifest, connection, identifier)
     expected = {
@@ -188,13 +189,22 @@ def build_generation(read_connection, write_connection, source_path: Path,
         write_connection, snapshot, generation_key, upgrade_actor=upgrade_actor,
     )
     chunks_seen = chunks_written = 0
+    chunks_reused = 0
 
     if state == 'BUILDING':
         stream = RetainedArtifactStream(source_path, sha256=digest, size_bytes=size)
         if upgrade_manifest is not None:
             from scripts.ratings_v4.resume_upgrade import remaining_chunks
+
+            def reused(item):
+                nonlocal chunks_seen, chunks_reused
+                chunks_seen += 1
+                chunks_reused += 1
+                if progress is not None:
+                    progress(item)
+
             chunks = remaining_chunks(stream, chunk_size, write_connection, identifier,
-                                      upgrade_manifest, actor=upgrade_actor, progress=progress)
+                                      upgrade_manifest, actor=upgrade_actor, progress=reused)
         else:
             chunks = enumerate(stream.chunks(chunk_size))
         if workers == 1:
@@ -266,6 +276,7 @@ def build_generation(read_connection, write_connection, source_path: Path,
         'canonical_publication_sequence': snapshot.publication_sequence,
         'chunks_seen': chunks_seen,
         'chunks_written': chunks_written,
+        'chunks_reused': chunks_reused,
         'resumed': resumed,
         'publication_performed': False,
         'validation_receipt': validation,

--- a/scripts/ratings_v4/run_generation.py
+++ b/scripts/ratings_v4/run_generation.py
@@ -25,7 +25,7 @@ from scripts.ratings_v4.canonical_stream import (  # noqa: E402
 )
 from scripts.ratings_v4.production_generation import (  # noqa: E402
     BODY_COLUMNS, OPPORTUNITY_COLUMNS, VECTOR_COLUMNS, _verify_code,
-    create_generation, encode_chunk, seal_source, validate_generation, write_chunk,
+    _digest, code_identity, create_generation, encode_chunk, seal_source, validate_generation, write_chunk,
 )
 
 GENERATION_KEY = re.compile(r'[a-z][a-z0-9_]{0,62}\Z')
@@ -46,17 +46,33 @@ def _artifact(snapshot: CanonicalSnapshot) -> tuple[str, int]:
     return digest.removeprefix('\\x'), size
 
 
-def _generation(connection, snapshot: CanonicalSnapshot, generation_key: str):
+def _generation(connection, snapshot: CanonicalSnapshot, generation_key: str, *, upgrade_actor=None):
     if not GENERATION_KEY.fullmatch(generation_key):
         raise ValueError('invalid derived generation key')
     row = connection.execute('''SELECT derived_generation_id,lifecycle_state,manifest,
-        validation_receipt FROM v3_meta.derived_generation WHERE generation_key=%s''',
+        validation_receipt,manifest_sha256 FROM v3_meta.derived_generation WHERE generation_key=%s''',
         (generation_key,)).fetchone()
     if row is None:
+        if upgrade_actor is not None:
+            raise ValueError('parser upgrade requires an existing generation')
         identifier = create_generation(connection, snapshot, generation_key)
-        return identifier, 'BUILDING', None, False
-    identifier, state, manifest, validation = row
-    _verify_code(manifest)
+        return identifier, 'BUILDING', None, False, None
+    identifier, state, manifest, validation, manifest_hash = row
+    if _digest(manifest) != bytes(manifest_hash):
+        raise ValueError('generation manifest checksum mismatch')
+    compatible = manifest.get('code_sha256_lf') != code_identity()
+    if compatible:
+        from scripts.ratings_v4.resume_upgrade import verify_origin
+        verify_origin(manifest, check_contract=True)
+    if compatible and upgrade_actor is not None:
+        from scripts.ratings_v4.resume_upgrade import recorded_upgrade
+        if recorded_upgrade(connection, identifier, manifest) is None:
+            if state != 'BUILDING':
+                raise ValueError('parser upgrade requires a BUILDING generation')
+            if connection.execute("SELECT to_regclass('v3_meta.derived_code_upgrade')").fetchone()[0] is None:
+                raise ValueError('reviewed parser upgrade migration is not installed')
+    else:
+        _verify_code(manifest, connection, identifier)
     expected = {
         'canonical_generation_id': snapshot.generation_id,
         'canonical_publication_sequence': snapshot.publication_sequence,
@@ -67,7 +83,7 @@ def _generation(connection, snapshot: CanonicalSnapshot, generation_key: str):
     }
     if any(manifest.get(key) != value for key, value in expected.items()):
         raise ValueError('existing generation key belongs to another canonical input')
-    return identifier, state, validation, True
+    return identifier, state, validation, True, manifest if compatible else None
 
 
 def _write_encoded_chunk(connection, generation_id, ordinal, canonical, metadata,
@@ -83,7 +99,7 @@ def _write_encoded_chunk(connection, generation_id, ordinal, canonical, metadata
         if generation is None or generation[0] != 'BUILDING':
             raise ValueError('generation is not BUILDING')
         manifest = generation[1]
-        _verify_code(manifest)
+        _verify_code(manifest, connection, generation_id)
         if (manifest['source_metadata'] != metadata or
                 manifest['canonical_schema'] != canonical['canonical_schema']):
             raise ValueError('chunk canonical source differs from generation manifest')
@@ -144,7 +160,8 @@ def _drain_oldest(pending, write_connection, identifier, metadata, progress):
 
 def build_generation(read_connection, write_connection, source_path: Path,
                      generation_key: str, *, chunk_size: int = 500,
-                     workers: int = 1, progress: Progress | None = None) -> dict:
+                     workers: int = 1, progress: Progress | None = None,
+                     upgrade_actor: str | None = None) -> dict:
     """Build or resume one exact generation, validate it, and never publish it.
 
     Source parsing and canonical reads remain sequential and authoritative. With
@@ -156,6 +173,9 @@ def build_generation(read_connection, write_connection, source_path: Path,
         raise ValueError('chunk size outside bounded contract')
     if type(workers) is not int or not 1 <= workers <= MAX_ENCODER_WORKERS:
         raise ValueError('encoder worker count outside bounded contract')
+    if upgrade_actor is not None and (not isinstance(upgrade_actor, str) or
+                                     not upgrade_actor.strip() or len(upgrade_actor) > 200):
+        raise ValueError('explicit parser upgrade actor is required')
     source_path = Path(source_path)
     if source_path.is_symlink() or not source_path.is_file():
         raise ValueError('retained artifact must be a regular non-symlink file')
@@ -164,15 +184,21 @@ def build_generation(read_connection, write_connection, source_path: Path,
     digest, size = _artifact(snapshot)
     if source_path.stat().st_size != size:
         raise ValueError('retained artifact size differs from canonical metadata')
-    identifier, state, validation, resumed = _generation(
-        write_connection, snapshot, generation_key,
+    identifier, state, validation, resumed, upgrade_manifest = _generation(
+        write_connection, snapshot, generation_key, upgrade_actor=upgrade_actor,
     )
     chunks_seen = chunks_written = 0
 
     if state == 'BUILDING':
         stream = RetainedArtifactStream(source_path, sha256=digest, size_bytes=size)
+        if upgrade_manifest is not None:
+            from scripts.ratings_v4.resume_upgrade import remaining_chunks
+            chunks = remaining_chunks(stream, chunk_size, write_connection, identifier,
+                                      upgrade_manifest, actor=upgrade_actor, progress=progress)
+        else:
+            chunks = enumerate(stream.chunks(chunk_size))
         if workers == 1:
-            for ordinal, records in enumerate(stream.chunks(chunk_size)):
+            for ordinal, records in chunks:
                 canonical = snapshot.export_chunk(
                     read_connection, [record['id64'] for record in records],
                 )
@@ -190,7 +216,7 @@ def build_generation(read_connection, write_connection, source_path: Path,
             executor = ProcessPoolExecutor(max_workers=workers, mp_context=context)
             pending = deque()
             try:
-                for ordinal, records in enumerate(stream.chunks(chunk_size)):
+                for ordinal, records in chunks:
                     canonical = snapshot.export_chunk(
                         read_connection, [record['id64'] for record in records],
                     )
@@ -252,6 +278,9 @@ def parse_args(argv=None):
     parser.add_argument('--generation-key', required=True)
     parser.add_argument('--chunk-size', type=int, default=500)
     parser.add_argument('--workers', type=int, default=1)
+    parser.add_argument('--upgrade-parser-actor', default=None,
+                        help='Explicit actor for the reviewed legacy-parser transition; '
+                             'requires its additive audit migration and a stopped old writer')
     return parser.parse_args(argv)
 
 
@@ -270,6 +299,7 @@ def main(argv=None) -> int:
                 read_connection, write_connection, args.source,
                 args.generation_key, chunk_size=args.chunk_size,
                 workers=args.workers,
+                upgrade_actor=args.upgrade_parser_actor,
                 progress=lambda item: print(json.dumps({'status': 'PROGRESS', **item}, sort_keys=True)),
             )
     except Exception as exc:  # CLI emits no connection or source exception details.

--- a/sql/v3/proposals/007_ratings_v4_code_upgrade.sql
+++ b/sql/v3/proposals/007_ratings_v4_code_upgrade.sql
@@ -1,6 +1,13 @@
 -- Proposed additive migration. Not in the production migration manifest yet.
 -- Promote through the reviewed migration operation together with its operator.
 BEGIN;
+-- Populated separately from the reviewed target JSON by the migration operator.
+-- The candidate builder has no policy-registration path.
+CREATE TABLE v3_meta.derived_code_upgrade_target (
+    upgrade_id text PRIMARY KEY CHECK(upgrade_id='ratings-v4-direct-parser-1'),
+    code_sha256_lf jsonb NOT NULL CHECK(jsonb_typeof(code_sha256_lf)='object'),
+    created_at timestamptz NOT NULL DEFAULT now()
+);
 CREATE TABLE v3_meta.derived_code_upgrade (
     derived_generation_id uuid PRIMARY KEY REFERENCES v3_meta.derived_generation,
     receipt jsonb NOT NULL CHECK(jsonb_typeof(receipt)='object'),
@@ -21,6 +28,11 @@ BEGIN
           AND g.manifest->'code_sha256_lf'=NEW.receipt->'from_code_sha256_lf') THEN
         RAISE EXCEPTION 'upgrade must match the original BUILDING generation';
     END IF;
+    IF NOT EXISTS (SELECT 1 FROM v3_meta.derived_code_upgrade_target t
+        WHERE t.upgrade_id=NEW.receipt->>'upgrade_id'
+          AND t.code_sha256_lf=NEW.receipt->'to_code_sha256_lf') THEN
+        RAISE EXCEPTION 'upgrade must match the independently approved target';
+    END IF;
     RETURN NEW;
 END $$;
 CREATE TRIGGER guard_code_upgrade BEFORE INSERT OR UPDATE OR DELETE
@@ -28,5 +40,11 @@ CREATE TRIGGER guard_code_upgrade BEFORE INSERT OR UPDATE OR DELETE
     EXECUTE FUNCTION v3_meta.guard_derived_code_upgrade();
 CREATE TRIGGER guard_code_upgrade_truncate BEFORE TRUNCATE
     ON v3_meta.derived_code_upgrade FOR EACH STATEMENT
+    EXECUTE FUNCTION v3_meta.guard_derived_code_upgrade();
+CREATE TRIGGER guard_code_upgrade_target BEFORE UPDATE OR DELETE
+    ON v3_meta.derived_code_upgrade_target FOR EACH ROW
+    EXECUTE FUNCTION v3_meta.guard_derived_code_upgrade();
+CREATE TRIGGER guard_code_upgrade_target_truncate BEFORE TRUNCATE
+    ON v3_meta.derived_code_upgrade_target FOR EACH STATEMENT
     EXECUTE FUNCTION v3_meta.guard_derived_code_upgrade();
 COMMIT;

--- a/sql/v3/proposals/007_ratings_v4_code_upgrade.sql
+++ b/sql/v3/proposals/007_ratings_v4_code_upgrade.sql
@@ -1,0 +1,32 @@
+-- Proposed additive migration. Not in the production migration manifest yet.
+-- Promote through the reviewed migration operation together with its operator.
+BEGIN;
+CREATE TABLE v3_meta.derived_code_upgrade (
+    derived_generation_id uuid PRIMARY KEY REFERENCES v3_meta.derived_generation,
+    receipt jsonb NOT NULL CHECK(jsonb_typeof(receipt)='object'),
+    receipt_sha256 bytea NOT NULL CHECK(octet_length(receipt_sha256)=32),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CHECK(receipt->>'upgrade_id' = 'ratings-v4-direct-parser-1'),
+    CHECK(receipt->>'derived_generation_id' = derived_generation_id::text)
+);
+CREATE FUNCTION v3_meta.guard_derived_code_upgrade() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP <> 'INSERT' THEN
+        RAISE EXCEPTION 'derived code upgrade attestations are retained and immutable';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM v3_meta.derived_generation g
+        WHERE g.derived_generation_id=NEW.derived_generation_id
+          AND g.lifecycle_state='BUILDING'
+          AND encode(g.manifest_sha256,'hex')=NEW.receipt->>'manifest_sha256'
+          AND g.manifest->'code_sha256_lf'=NEW.receipt->'from_code_sha256_lf') THEN
+        RAISE EXCEPTION 'upgrade must match the original BUILDING generation';
+    END IF;
+    RETURN NEW;
+END $$;
+CREATE TRIGGER guard_code_upgrade BEFORE INSERT OR UPDATE OR DELETE
+    ON v3_meta.derived_code_upgrade FOR EACH ROW
+    EXECUTE FUNCTION v3_meta.guard_derived_code_upgrade();
+CREATE TRIGGER guard_code_upgrade_truncate BEFORE TRUNCATE
+    ON v3_meta.derived_code_upgrade FOR EACH STATEMENT
+    EXECUTE FUNCTION v3_meta.guard_derived_code_upgrade();
+COMMIT;

--- a/sql/v3/proposals/007_ratings_v4_code_upgrade_target.json
+++ b/sql/v3/proposals/007_ratings_v4_code_upgrade_target.json
@@ -1,0 +1,14 @@
+{
+  "code_sha256_lf": {
+    "apps/api/src/domain/ratings_v4.py": "344c620fa29cda725fcecf6aaa18acd7ae68730b9919f22d86a23dea643d29ad",
+    "apps/api/src/domain/ratings_v4_canonical.py": "99882b08aa112c80f8b673b553a374fbc58c4da4db27619042367ba6fdfa6e84",
+    "scripts/ratings_v4/canonical_stream.py": "9a501bd1584f05b68612dca672e68dfaf69867412abb75a68fad72ce2cc9ad8e",
+    "scripts/ratings_v4/production_generation.py": "29e169aa01671175770253bc30e493a10849cfacbb7f0c4043dee9e25bcc00f8",
+    "scripts/ratings_v4/resume_upgrade.py": "98b7d775ece2718e3304d0e7227da2ed8f61ea6e526021ea7d69da83ce7ff4d2",
+    "scripts/ratings_v4/run_generation.py": "f8dc1c169e497a3f15593a5b2e0cca392ca8f124c6160e8e3020f97ada38f9cd",
+    "scripts/ratings_v4/verify_freeze.py": "479b16028c08e5c2352dcf8d75e831f919e43820ec8b92552ce6bb48bbad32dc",
+    "sql/v3/migrations/003_ratings_v4_derived.sql": "c7818f98ad00b4b99b7ce0f7c3fa12ece555e59e761b7b1ca15d437a39c499cb",
+    "sql/v3/proposals/007_ratings_v4_code_upgrade.sql": "adc9fc5dcf8ee500b29fe49886367fe71c539a75c7e4df84dfa490a367796c2e"
+  },
+  "upgrade_id": "ratings-v4-direct-parser-1"
+}

--- a/tests/ratings_v4_legacy_resume_fixture.py
+++ b/tests/ratings_v4_legacy_resume_fixture.py
@@ -1,0 +1,44 @@
+"""Execute the real pinned old builder only against a disposable local database."""
+import json
+import os
+from pathlib import Path
+import re
+import sys
+
+
+def main():
+    import psycopg
+    from psycopg.conninfo import conninfo_to_dict, make_conninfo
+
+    request = json.load(sys.stdin)
+    settings = conninfo_to_dict(os.environ['RATINGS_V4_VALIDATION_DATABASE_URL'])
+    if (settings.get('host') not in {'127.0.0.1', 'localhost'} or
+            settings.get('dbname') != 'ratings_v4_validation' or
+            not re.fullmatch(r'v4_test_[0-9a-f]{32}', request['database'])):
+        raise ValueError('legacy fixture requires a disposable local database')
+    sys.path.insert(0, request['legacy_root'])
+    from scripts.ratings_v4.run_generation import build_generation
+    from scripts.ratings_v4.production_generation import code_identity
+
+    if code_identity() != request['expected_identity']:
+        raise ValueError('legacy fixture source identity differs from production')
+
+    class Interrupted(Exception):
+        pass
+
+    def progress(item):
+        if (request['stop_after'] and item['written'] and
+                item['chunk_ordinal'] + 1 >= request['stop_after']):
+            raise Interrupted
+
+    with psycopg.connect(make_conninfo(**{**settings, 'dbname': request['database']}), autocommit=True) as connection:
+        try:
+            receipt = build_generation(connection, connection, Path(request['source']),
+                                       request['key'], chunk_size=3, workers=2, progress=progress)
+        except Interrupted:
+            receipt = {'status': 'INTERRUPTED'}
+    print(json.dumps(receipt))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ratings_v4_resume_upgrade.py
+++ b/tests/test_ratings_v4_resume_upgrade.py
@@ -1,0 +1,208 @@
+"""Cross-version restart proof using the real old files, not a patched guard."""
+from contextlib import contextmanager
+from copy import deepcopy
+import gzip
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / 'apps/api/src'))
+
+from domain.ratings_v4_canonical import load_source_fixture  # noqa: E402
+from scripts.ratings_v4 import production_generation as generation  # noqa: E402
+from scripts.ratings_v4.canonical_stream import CanonicalSnapshot  # noqa: E402
+from scripts.ratings_v4.resume_upgrade import (  # noqa: E402
+    LEGACY_CODE, LEGACY_SOURCE_SHA, CommittedPrefix, accept_verified_prefix,
+    committed_prefix, verify_origin,
+)
+from scripts.ratings_v4.run_generation import build_generation  # noqa: E402
+from tests.ratings_v4_pg_fixture import canonical_database  # noqa: E402
+
+
+@pytest.fixture(scope='module')
+def legacy_root(tmp_path_factory):
+    if not os.environ.get('RATINGS_V4_VALIDATION_DATABASE_URL'):
+        pytest.skip('isolated PostgreSQL validation URL not set')
+    root = tmp_path_factory.mktemp('legacy-v4')
+    freeze = 'docs/development/ratings-v4-freeze/manifest.json'
+    recovery = 'docs/development/v3-canonical-source-recovery.json'
+    paths = {freeze, recovery, *LEGACY_CODE}
+    paths.update(json.loads((ROOT / freeze).read_text())['text_files_sha256_lf'])
+    paths.update(json.loads((ROOT / recovery).read_text())['files_sha256'])
+    for pattern in ('scripts/ratings_v4/*.py', 'docs/development/ratings-v4-freeze/*',
+                    'tests/fixtures/ratings_v4_sources/*'):
+        paths.update(str(path.relative_to(ROOT)) for path in ROOT.glob(pattern) if path.is_file())
+    for name in paths:
+        destination = root / name
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if name in LEGACY_CODE:
+            raw = subprocess.check_output(['git', 'show', f'{LEGACY_SOURCE_SHA}:{name}'], cwd=ROOT)
+            assert hashlib.sha256(raw.decode().replace('\r\n', '\n').encode()).hexdigest() == LEGACY_CODE[name]
+            destination.write_bytes(raw)
+        else:
+            shutil.copyfile(ROOT / name, destination)
+    return root
+
+
+def old_run(root, connection, source, *, stop_after=2):
+    request = {'database': connection.info.dbname, 'legacy_root': str(root),
+               'expected_identity': LEGACY_CODE, 'source': str(source),
+               'key': 'upgrade_fixture', 'stop_after': stop_after}
+    result = subprocess.run([sys.executable, str(ROOT / 'tests/ratings_v4_legacy_resume_fixture.py')],
+                            input=json.dumps(request), text=True, capture_output=True, timeout=90,
+                            cwd=root, check=True)
+    return json.loads(result.stdout)
+
+
+@contextmanager
+def interrupted_database(tmp_path, legacy_root, *, install_upgrade=True):
+    _, _, payloads = load_source_fixture(ROOT / 'tests/fixtures/ratings_v4_sources')
+    compressed = gzip.compress(json.dumps([item['system'] for item in payloads]).encode(), mtime=0)
+    source = tmp_path / 'galaxy.json.gz'
+    source.write_bytes(compressed)
+
+    def prepare(_canonical, metadata):
+        metadata['artifact']['content_sha256'] = '\\x' + hashlib.sha256(compressed).hexdigest()
+        metadata['artifact']['size_bytes'] = len(compressed)
+        return ()
+
+    with canonical_database(prepare=prepare) as (connection, _, _, _):
+        connection.execute((ROOT / 'sql/v3/migrations/003_ratings_v4_derived.sql').read_text())
+        if install_upgrade:
+            connection.execute((ROOT / 'sql/v3/proposals/007_ratings_v4_code_upgrade.sql').read_text())
+        assert old_run(legacy_root, connection, source)['status'] == 'INTERRUPTED'
+        identifier, manifest, digest = connection.execute('''SELECT derived_generation_id,
+            manifest,manifest_sha256 FROM v3_meta.derived_generation''').fetchone()
+        assert manifest['code_sha256_lf'] == LEGACY_CODE
+        assert len(committed_prefix(connection, identifier).rows) == 2
+        yield connection, source, identifier, manifest, bytes(digest)
+
+
+def saved_rows(connection, identifier):
+    return [generation._read_chunk(connection, identifier, ordinal) for ordinal in (0, 1)]
+
+
+def resume(connection, source, **kwargs):
+    return build_generation(connection, connection, source, 'upgrade_fixture',
+                            chunk_size=3, workers=2, **kwargs)
+
+
+def test_real_old_builder_upgrades_same_generation_without_rewriting_saved_chunks(tmp_path, legacy_root, monkeypatch):
+    with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, manifest, digest):
+        saved = saved_rows(connection, identifier)
+        checkpoints = committed_prefix(connection, identifier).rows
+        with pytest.raises(ValueError, match='code identity changed'):
+            resume(connection, source)
+        exported = []
+        original = CanonicalSnapshot.export_chunk
+
+        def count_export(self, read_connection, identifiers):
+            exported.append(identifiers)
+            return original(self, read_connection, identifiers)
+
+        monkeypatch.setattr(CanonicalSnapshot, 'export_chunk', count_export)
+        progress = []
+        result = resume(connection, source, upgrade_actor='disposable-test', progress=progress.append)
+        assert result['derived_generation_id'] == str(identifier)
+        assert result['status'] == 'VERIFIED' and result['lifecycle_state'] == 'READY'
+        assert result['publication_performed'] is False and result['chunks_written'] == 2
+        assert len(exported) == 2  # Saved chunks caused no canonical reads or encoding.
+        assert [item['chunk_ordinal'] for item in progress if item.get('resume_verified')] == [0, 1]
+        assert saved_rows(connection, identifier) == saved
+        assert committed_prefix(connection, identifier).rows[:2] == checkpoints
+        assert connection.execute('SELECT manifest,manifest_sha256 FROM v3_meta.derived_generation').fetchone() == (manifest, digest)
+        audit = result['validation_receipt']['code_upgrade']
+        assert audit['prefix_chunks'] == 2 and audit['prefix_systems'] == 6
+        assert audit['from_code_sha256_lf'] == LEGACY_CODE
+        assert audit['to_code_sha256_lf'] == generation.code_identity()
+        assert result['validation_receipt']['every_system_replayed']
+        assert resume(connection, source)['chunks_written'] == 0
+
+
+@pytest.mark.parametrize('rollback', [False, True], ids=['new-builder-resume', 'old-builder-rollback'])
+def test_interrupted_upgrade_can_resume_or_roll_back_without_losing_chunks(tmp_path, legacy_root, rollback):
+    class StopAfterNewChunk(Exception):
+        pass
+
+    def stop(item):
+        if item['written']:
+            raise StopAfterNewChunk
+
+    with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, _, _):
+        with pytest.raises(StopAfterNewChunk):
+            resume(connection, source, upgrade_actor='disposable-test', progress=stop)
+        saved = [generation._read_chunk(connection, identifier, ordinal) for ordinal in range(3)]
+        assert len(committed_prefix(connection, identifier).rows) == 3
+        if rollback:
+            result = old_run(legacy_root, connection, source, stop_after=0)
+        else:
+            result = resume(connection, source)  # No second approval/registration required.
+        assert result['status'] == 'VERIFIED' and result['chunks_written'] == 1
+        assert [generation._read_chunk(connection, identifier, ordinal) for ordinal in range(3)] == saved
+        assert connection.execute('SELECT count(*) FROM v3_meta.derived_code_upgrade').fetchone()[0] == 1
+
+
+@pytest.mark.parametrize('fault', ['source-checkpoint', 'chunk-size', 'concurrent-writer'])
+def test_bad_prefix_or_moving_frontier_cannot_register_upgrade(tmp_path, legacy_root, fault):
+    with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, _, _):
+        if fault == 'source-checkpoint':
+            connection.execute('UPDATE v3_derived.build_chunk SET source_projection_sha256=%s WHERE chunk_ordinal=0',
+                               (bytes(32),))
+
+        def progress(item):
+            if fault == 'concurrent-writer' and item['chunk_ordinal'] == 1:
+                old_run(legacy_root, connection, source, stop_after=3)
+
+        with pytest.raises(ValueError, match='prefix mismatch|frontier changed'):
+            build_generation(connection, connection, source, 'upgrade_fixture', workers=2,
+                             chunk_size=4 if fault == 'chunk-size' else 3,
+                             upgrade_actor='disposable-test', progress=progress)
+        assert connection.execute('SELECT count(*) FROM v3_meta.derived_code_upgrade').fetchone()[0] == 0
+        assert len(committed_prefix(connection, identifier).rows) == (3 if fault == 'concurrent-writer' else 2)
+
+
+def test_missing_migration_fails_before_changing_any_rows(tmp_path, legacy_root):
+    with interrupted_database(tmp_path, legacy_root, install_upgrade=False) as (connection, source, identifier, _, _):
+        with pytest.raises(ValueError, match='migration is not installed'):
+            resume(connection, source, upgrade_actor='disposable-test')
+        assert len(committed_prefix(connection, identifier).rows) == 2
+
+
+def test_final_validation_still_detects_corrupt_saved_output(tmp_path, legacy_root):
+    with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, _, _):
+        connection.execute("UPDATE v3_derived.body_mechanics SET body_class=CASE WHEN body_class='Rocky body' THEN 'Water world' ELSE 'Rocky body' END WHERE system_id64=(SELECT min(system_id64) FROM v3_derived.body_mechanics)")
+        with pytest.raises(ValueError, match='content checksum mismatch'):
+            resume(connection, source, upgrade_actor='disposable-test')
+        assert connection.execute('SELECT lifecycle_state FROM v3_meta.derived_generation').fetchone()[0] == 'VALIDATING'
+
+
+def test_upgrade_attestation_is_immutable_and_rejects_different_target_code(tmp_path, legacy_root, monkeypatch):
+    import psycopg
+
+    with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, manifest, _):
+        resume(connection, source, upgrade_actor='disposable-test')
+        for sql in ("UPDATE v3_meta.derived_code_upgrade SET receipt='{}'::jsonb",
+                    'DELETE FROM v3_meta.derived_code_upgrade', 'TRUNCATE v3_meta.derived_code_upgrade'):
+            with pytest.raises(psycopg.errors.RaiseException, match='retained and immutable'):
+                connection.execute(sql)
+        changed = {**generation.code_identity(), 'scripts/ratings_v4/run_generation.py': '0' * 64}
+        monkeypatch.setattr(generation, 'code_identity', lambda: changed)
+        with pytest.raises(ValueError, match='upgrade identity mismatch'):
+            generation._verify_code(manifest, connection, identifier)
+
+
+def test_unknown_origin_and_unverified_prefix_fail_before_database_access():
+    changed = deepcopy(LEGACY_CODE)
+    changed['scripts/ratings_v4/canonical_stream.py'] = '0' * 64
+    with pytest.raises(ValueError, match='unsupported parser upgrade origin'):
+        verify_origin({'code_sha256_lf': changed})
+    with pytest.raises(ValueError, match='every committed source chunk'):
+        accept_verified_prefix(None, None, {}, CommittedPrefix(((0,),)), actor='test')

--- a/tests/test_ratings_v4_resume_upgrade.py
+++ b/tests/test_ratings_v4_resume_upgrade.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(ROOT / 'apps/api/src'))
 
 from domain.ratings_v4_canonical import load_source_fixture  # noqa: E402
 from scripts.ratings_v4 import production_generation as generation  # noqa: E402
+from scripts.ratings_v4 import resume_upgrade  # noqa: E402
 from scripts.ratings_v4.canonical_stream import CanonicalSnapshot  # noqa: E402
 from scripts.ratings_v4.resume_upgrade import (  # noqa: E402
     LEGACY_CODE, LEGACY_SOURCE_SHA, CommittedPrefix, accept_verified_prefix,
@@ -78,6 +79,12 @@ def interrupted_database(tmp_path, legacy_root, *, install_upgrade=True):
         connection.execute((ROOT / 'sql/v3/migrations/003_ratings_v4_derived.sql').read_text())
         if install_upgrade:
             connection.execute((ROOT / 'sql/v3/proposals/007_ratings_v4_code_upgrade.sql').read_text())
+            # Load a separately committed policy, never derive expected hashes
+            # from the candidate at test time. CI must catch any target drift.
+            target = json.loads((ROOT / 'sql/v3/proposals/007_ratings_v4_code_upgrade_target.json').read_text())
+            connection.execute('''INSERT INTO v3_meta.derived_code_upgrade_target(
+                upgrade_id,code_sha256_lf) VALUES (%s,%s::jsonb)''',
+                (target['upgrade_id'], json.dumps(target['code_sha256_lf'])))
         assert old_run(legacy_root, connection, source)['status'] == 'INTERRUPTED'
         identifier, manifest, digest = connection.execute('''SELECT derived_generation_id,
             manifest,manifest_sha256 FROM v3_meta.derived_generation''').fetchone()
@@ -114,6 +121,7 @@ def test_real_old_builder_upgrades_same_generation_without_rewriting_saved_chunk
         assert result['derived_generation_id'] == str(identifier)
         assert result['status'] == 'VERIFIED' and result['lifecycle_state'] == 'READY'
         assert result['publication_performed'] is False and result['chunks_written'] == 2
+        assert result['chunks_seen'] == 4 and result['chunks_reused'] == 2
         assert len(exported) == 2  # Saved chunks caused no canonical reads or encoding.
         assert [item['chunk_ordinal'] for item in progress if item.get('resume_verified')] == [0, 1]
         assert saved_rows(connection, identifier) == saved
@@ -190,13 +198,40 @@ def test_upgrade_attestation_is_immutable_and_rejects_different_target_code(tmp_
     with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, manifest, _):
         resume(connection, source, upgrade_actor='disposable-test')
         for sql in ("UPDATE v3_meta.derived_code_upgrade SET receipt='{}'::jsonb",
-                    'DELETE FROM v3_meta.derived_code_upgrade', 'TRUNCATE v3_meta.derived_code_upgrade'):
+                    'DELETE FROM v3_meta.derived_code_upgrade', 'TRUNCATE v3_meta.derived_code_upgrade',
+                    "UPDATE v3_meta.derived_code_upgrade_target SET code_sha256_lf='{}'::jsonb",
+                    'DELETE FROM v3_meta.derived_code_upgrade_target',
+                    'TRUNCATE v3_meta.derived_code_upgrade_target'):
             with pytest.raises(psycopg.errors.RaiseException, match='retained and immutable'):
                 connection.execute(sql)
         changed = {**generation.code_identity(), 'scripts/ratings_v4/run_generation.py': '0' * 64}
         monkeypatch.setattr(generation, 'code_identity', lambda: changed)
-        with pytest.raises(ValueError, match='upgrade identity mismatch'):
+        with pytest.raises(ValueError, match='independently approved identity'):
             generation._verify_code(manifest, connection, identifier)
+
+
+def test_first_handoff_refuses_unknown_target_before_reading_source(tmp_path, legacy_root, monkeypatch):
+    import psycopg
+
+    with interrupted_database(tmp_path, legacy_root) as (connection, source, identifier, manifest, _):
+        changed = {**generation.code_identity(), 'scripts/ratings_v4/run_generation.py': '0' * 64}
+        monkeypatch.setattr(generation, 'code_identity', lambda: changed)
+        with pytest.raises(ValueError, match='independently approved identity'):
+            resume(connection, source, upgrade_actor='disposable-test')
+        assert len(committed_prefix(connection, identifier).rows) == 2
+        assert connection.execute('SELECT count(*) FROM v3_meta.derived_code_upgrade').fetchone()[0] == 0
+        unapproved = {'upgrade_id': resume_upgrade.UPGRADE_ID, 'derived_generation_id': str(identifier),
+                      'manifest_sha256': generation._digest(manifest).hex(),
+                      'from_code_sha256_lf': LEGACY_CODE, 'to_code_sha256_lf': changed}
+        with pytest.raises(psycopg.errors.RaiseException, match='independently approved target'):
+            connection.execute('''INSERT INTO v3_meta.derived_code_upgrade(
+                derived_generation_id,receipt,receipt_sha256) VALUES (%s,%s::jsonb,%s)''',
+                (identifier, generation._json(unapproved), generation._digest(unapproved)))
+
+
+def test_committed_approval_matches_this_exact_candidate():
+    target = json.loads((ROOT / 'sql/v3/proposals/007_ratings_v4_code_upgrade_target.json').read_text())
+    assert target['code_sha256_lf'] == generation.code_identity()
 
 
 def test_unknown_origin_and_unverified_prefix_fail_before_database_access():
@@ -206,3 +241,16 @@ def test_unknown_origin_and_unverified_prefix_fail_before_database_access():
         verify_origin({'code_sha256_lf': changed})
     with pytest.raises(ValueError, match='every committed source chunk'):
         accept_verified_prefix(None, None, {}, CommittedPrefix(((0,),)), actor='test')
+
+
+def test_transition_rejects_another_parser_and_changed_attested_prefix(monkeypatch):
+    monkeypatch.setattr(resume_upgrade, 'DIRECT_PARSER_SHA256_LF', '0' * 64)
+    with pytest.raises(ValueError, match='unsupported parser upgrade target'):
+        verify_origin({'code_sha256_lf': LEGACY_CODE})
+    prefix = CommittedPrefix(((0, bytes(32), bytes(32), bytes(32), 3, 0, 0, 0),))
+    receipt = {'prefix_chunks': 1, 'prefix_sha256': prefix.digest.hex(), 'prefix_systems': 3}
+    prefix.verify_attestation(receipt)
+    with pytest.raises(ValueError, match='attested checkpoint prefix changed'):
+        prefix.verify_attestation({**receipt, 'prefix_sha256': 'f' * 64})
+    with pytest.raises(ValueError, match='attested checkpoint prefix is missing'):
+        CommittedPrefix(()).verify_attestation(receipt)


### PR DESCRIPTION
The running Ratings V4 generation can survive a normal restart, but PR #707 changes a generation-bound file and therefore cannot resume it. Starting a replacement generation would waste substantial committed work.

This implements a narrow, explicit upgrade from the exact production builder `fe0c058134b6fec33690fa937c2ac74338b401dc`. It retains the generation UUID/key, original manifest/hash, all saved rows and checkpoints, and Search's generation reference. After verifying every saved source chunk, it records the old/new code identities and checkpoint frontier in a separate append-only attestation. New writes, source sealing, validation and explanations require that exact recorded target identity. The original identity check still rejects unregistered or different code.

The verified prefix skips repeated canonical reads and encoding. Source parsing still starts at the beginning, compressed hashing and EOF verification remain, and final validation still reads and scores all stored output. A changed source projection, chunk boundary or checkpoint frontier aborts before registration/new writes.

Tests execute the actual pinned old files in a separate process against disposable local PostgreSQL databases: partial old build → new completion, interrupted new resume, rollback to old code and old full validation, unchanged saved rows/checkpoints, moving frontier, corrupt input/output, missing migration and immutable attestation. Old guards/manifests are not patched. Local focused tests and Ruff pass; PostgreSQL cases await this PR's isolated CI.

This is the compatibility proof, not the production cutover. The additive SQL is intentionally a proposal outside the declared production migration lineage. No production workflow, authority/schema pin, live worker or published pointer is changed. Before rollout we still need production read-only catch-up measurements, migration promotion and a bounded operator that stops/retains the old writer and proves new committed progress with rollback. The old writer does not know any new advisory lock; the frontier check cannot replace sole-writer ownership.

Details and concrete rollout requirements: `docs/development/ratings-v4-compatible-resume.md`.