### PR TITLE
Measure Ratings V4 prefix catch-up read-only before upgrade

### DIFF
--- a/.github/workflows/ratings-v4-freeze.yml
+++ b/.github/workflows/ratings-v4-freeze.yml
@@ -12,6 +12,8 @@ on:
       - 'scripts/v3_system_search.py'
       - 'scripts/operator/render_v3_system_search_profile.py'
       - 'scripts/operator/ratings_v4_runtime_profile.py'
+      - 'scripts/operator/ratings_v4_resume_profile.py'
+      - '.github/workflows/ratings-v4-resume-profile.yml'
       - '.github/workflows/ratings-v4-production-profile.yml'
       - 'scripts/operator/v3_system_search_legacy.sql'
       - 'scripts/checks/requirements.txt'

--- a/.github/workflows/ratings-v4-resume-profile.yml
+++ b/.github/workflows/ratings-v4-resume-profile.yml
@@ -1,0 +1,119 @@
+name: Ratings V4 resume prefix profile
+
+on:
+  push:
+    branches:
+      - chatgpt-ed-new-ops-requests
+    paths:
+      - '.github/ratings-v4-resume-profile-requests/*.json'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: chatgpt-ed-new-ops
+  cancel-in-progress: false
+
+jobs:
+  profile:
+    name: Measure retained prefix replay read-only
+    runs-on: ubuntu-latest
+    environment: ed-new-operator
+    timeout-minutes: 8
+    steps:
+      - name: Checkout request branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 2
+
+      - name: Set up CPython 3.14 for operator request validation
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Validate data-only request
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t changed_files < <(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA")
+          [ "${#changed_files[@]}" -eq 1 ] || { echo "Expected exactly one Ratings profile request file" >&2; exit 64; }
+          case "${changed_files[0]}" in
+            .github/ratings-v4-resume-profile-requests/*.json) ;;
+            *) echo "Unexpected request path" >&2; exit 64 ;;
+          esac
+          python - "${changed_files[0]}" <<'PY'
+          import json, pathlib, sys
+          data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+          if data != {"operation": "ratings-v4-resume-profile"}:
+              raise SystemExit("unsupported request")
+          PY
+
+      - name: Checkout trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          path: trusted-main
+          persist-credentials: false
+
+      - name: Prepare SSH
+        shell: bash
+        env:
+          SSH_KEY: ${{ secrets.ED_NEW_OPERATOR_SSH_KEY }}
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_KNOWN_HOSTS: ${{ secrets.ED_NEW_OPERATOR_SSH_KNOWN_HOSTS || secrets.ED_NEW_OPERATOR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$SSH_KEY" && test -n "$SSH_HOST" && test -n "$SSH_PORT" && test -n "$SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/ed_new_operator_key
+          chmod 600 ~/.ssh/ed_new_operator_key
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+          lookup="$SSH_HOST"; [ "$SSH_PORT" = "22" ] || lookup="[$SSH_HOST]:$SSH_PORT"
+          ssh-keygen -F "$lookup" -f ~/.ssh/known_hosts >/dev/null
+
+      - name: Run bounded read-only Ratings profile
+        shell: bash
+        env:
+          SSH_HOST: ${{ secrets.ED_NEW_OPERATOR_HOST }}
+          SSH_PORT: ${{ secrets.ED_NEW_OPERATOR_PORT }}
+          SSH_USER: ${{ secrets.ED_NEW_OPERATOR_USER }}
+          RECEIPT: ${{ runner.temp }}/ratings-v4-resume-profile.jsonl
+        run: |
+          set -euo pipefail
+          test -n "$SSH_USER"
+          printf '{"kind":"provenance","trusted_main_sha":"%s","profiler_sha256":"%s"}\n' \
+            "$(git -C trusted-main rev-parse HEAD)" \
+            "$(sha256sum trusted-main/scripts/operator/ratings_v4_resume_profile.py | cut -d' ' -f1)" | tee "$RECEIPT"
+          ssh -i ~/.ssh/ed_new_operator_key \
+            -p "$SSH_PORT" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            "$SSH_USER@$SSH_HOST" \
+            '
+            set -eu
+            [ "$(hostname)" = "ed-finder-prod" ]
+            [ "$(hostname -f)" = "nb79a3d.mevnode.com" ]
+            [ "$(docker context show)" = "default" ]
+            [ "$(docker context inspect default --format "{{.Endpoints.docker.Host}}")" = "unix:///var/run/docker.sock" ]
+            worker="edfinder-ratings-v4-prod-p4-opt1"
+            [ "$(docker inspect -f "{{.State.Running}}" "$worker")" = "true" ]
+            [ "$(docker inspect -f "{{index .Config.Labels \"ed-finder.source-sha\"}}" "$worker")" = "fe0c058134b6fec33690fa937c2ac74338b401dc" ]
+            [ "$(docker inspect -f "{{index .Config.Labels \"ed-finder.generation-key\"}}" "$worker")" = "ratings_v4_prod_p4_opt1" ]
+            exec timeout 180s docker exec -i -e PYTHONPATH=/tmp/ratings-v4-deps:/work:/work/apps/api/src "$worker" /app/.venv/bin/python -
+            ' \
+            < trusted-main/scripts/operator/ratings_v4_resume_profile.py | tee -a "$RECEIPT"
+
+      - name: Upload profile receipt
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ratings-v4-resume-profile
+          path: ${{ runner.temp }}/ratings-v4-resume-profile.jsonl
+          if-no-files-found: warn
+          retention-days: 14

--- a/scripts/operator/ratings_v4_resume_profile.py
+++ b/scripts/operator/ratings_v4_resume_profile.py
@@ -1,0 +1,179 @@
+"""Read-only, bounded prefix timing inside the existing Ratings container.
+
+This separate process never patches/imports into the running builder process.
+It uses the old builder's checkpoint projection and a transparent direct parser.
+Only complete verified chunks count toward timing; a partial scan is not an EOF
+receipt and extrapolation is explicitly conditional on the sampled data mix.
+"""
+from datetime import datetime, timezone
+import gzip
+import json
+import os
+from pathlib import Path
+import signal
+import sys
+import time
+
+GENERATION_KEY = 'ratings_v4_prod_p4_opt1'
+GENERATION_ID = '403b2d43-820c-414a-ad57-0d4de0ca3e82'
+DATABASE = 'edfinder_v3_phase4c_full_20260827_r5'
+DURATION_SECONDS = 120
+CHUNK_SIZE = 1000
+MAX_CHUNK_BODIES = 100_000
+LEGACY_CODE = {
+    'scripts/ratings_v4/production_generation.py': 'd47815984c257261c6e306f7a842f24fd8a0e7732633e47c9e013fb3a007f7b5',
+    'scripts/ratings_v4/run_generation.py': '43c4554e83545560bb4fceb2cb3b889c1eebc1f9bbb53c0a97423f8511c8b361',
+    'scripts/ratings_v4/canonical_stream.py': '160322dbeac52908a1dddf41efa5d5f97e1cb7b6bfa46ab4bc658671108ca738',
+    'sql/v3/migrations/003_ratings_v4_derived.sql': 'c7818f98ad00b4b99b7ce0f7c3fa12ece555e59e761b7b1ca15d437a39c499cb',
+}
+
+
+class ArrayRootReader:
+    """Same bounded transparent root check as the reviewed PR #707 parser."""
+    def __init__(self, stream):
+        self.stream = stream
+        self.checked = False
+
+    def read(self, size=-1):
+        data = self.stream.read(size)
+        if size != 0 and not self.checked:
+            prefix = data.lstrip(b' \t\r\n\v\f')
+            if prefix:
+                if prefix[:1] != b'[':
+                    raise ValueError('Spansh artifact must be a JSON array')
+                self.checked = True
+            elif not data:
+                raise ValueError('Spansh artifact must be a JSON array')
+        return data
+
+
+def direct_chunks(decoded, chunk_size=CHUNK_SIZE):
+    import ijson
+    from scripts.ratings_v4.canonical_stream import _system_ids
+
+    chunk, bodies = [], 0
+    for record in ijson.items(ArrayRootReader(decoded), 'item', use_float=True):
+        if not isinstance(record, dict) or not isinstance(record.get('bodies', []), list):
+            raise ValueError('invalid Spansh system record')
+        _system_ids([record.get('id64')])
+        count = len(record.get('bodies', []))
+        if count > MAX_CHUNK_BODIES:
+            raise ValueError('system exceeds bounded body inventory')
+        if chunk and (len(chunk) >= chunk_size or bodies + count > MAX_CHUNK_BODIES):
+            yield chunk
+            chunk, bodies = [], 0
+        chunk.append(record)
+        bodies += count
+    if chunk:
+        yield chunk
+
+
+def verify_chunk(checkpoint, ordinal, records):
+    from scripts.ratings_v4.production_generation import _digest, _projection
+
+    if (checkpoint[0] != ordinal or checkpoint[2] != len(records) or
+            checkpoint[3] != sum(len(record.get('bodies', [])) for record in records) or
+            bytes(checkpoint[1]) != _digest([_projection(record) for record in records])):
+        raise ValueError('source/checkpoint prefix mismatch')
+
+
+def emit(kind, **data):
+    print(json.dumps({'kind': kind, 'utc': datetime.now(timezone.utc).isoformat(), **data},
+                     sort_keys=True), flush=True)
+
+
+def main():
+    import psycopg
+    import resource
+    from scripts.ratings_v4.canonical_stream import _HashedReader
+    from scripts.ratings_v4.production_generation import _digest, code_identity
+
+    resource.setrlimit(resource.RLIMIT_AS, (2 * 1024**3, 2 * 1024**3))
+    resource.setrlimit(resource.RLIMIT_CPU, (150, 160))
+    os.nice(10)
+
+    class Deadline(Exception):
+        pass
+
+    def deadline(_signum, _frame):
+        raise Deadline
+
+    signal.signal(signal.SIGALRM, deadline)
+    signal.alarm(150)
+    if code_identity() != LEGACY_CODE:
+        raise ValueError('unexpected production builder identity')
+    source = Path('/source/galaxy.json.gz')
+    if not source.is_file() or source.is_symlink():
+        raise ValueError('retained artifact must be a regular source mount')
+    dsn = os.environ['RATINGS_V4_DERIVED_DATABASE_URL']
+    with psycopg.connect(dsn, autocommit=True,
+                         options='-c default_transaction_read_only=on -c statement_timeout=5000 -c lock_timeout=1000') as connection:
+        if connection.execute('SELECT current_database()').fetchone()[0] != DATABASE:
+            raise ValueError('unexpected database')
+        if connection.execute('SHOW transaction_read_only').fetchone()[0] != 'on':
+            raise ValueError('read-only connection required')
+        row = connection.execute('''SELECT derived_generation_id,lifecycle_state,manifest,manifest_sha256
+            FROM v3_meta.derived_generation WHERE generation_key=%s''', (GENERATION_KEY,)).fetchone()
+        if (row is None or str(row[0]) != GENERATION_ID or row[1] != 'BUILDING' or
+                row[2]['code_sha256_lf'] != LEGACY_CODE or _digest(row[2]) != bytes(row[3])):
+            raise ValueError('unexpected generation identity/state')
+        manifest = row[2]
+        if source.stat().st_size != manifest['source_metadata']['artifact']['size_bytes']:
+            raise ValueError('source size differs from manifest')
+        checkpoints = connection.execute('''SELECT chunk_ordinal,source_projection_sha256,systems,canonical_bodies
+            FROM v3_derived.build_chunk WHERE derived_generation_id=%s ORDER BY chunk_ordinal''', (GENERATION_ID,)).fetchall()
+        if not checkpoints or any(row[0] != i for i, row in enumerate(checkpoints)):
+            raise ValueError('committed prefix is empty or noncontiguous')
+        before = sum(row[2] for row in checkpoints)
+        emit('start', generation_id=GENERATION_ID, committed_systems=before,
+             committed_chunks=len(checkpoints), expected_systems=manifest['expected_systems'],
+             database_read_only=True, duration_seconds=DURATION_SECONDS)
+        started = last_complete = time.monotonic()
+        verified_systems = verified_chunks = 0
+        deadline_reached = False
+        with source.open('rb') as raw:
+            reader = _HashedReader(raw)
+            try:
+                with gzip.GzipFile(fileobj=reader, mode='rb') as decoded:
+                    for ordinal, records in enumerate(direct_chunks(decoded)):
+                        if ordinal >= len(checkpoints):
+                            break
+                        verify_chunk(checkpoints[ordinal], ordinal, records)
+                        verified_chunks += 1
+                        verified_systems += len(records)
+                        last_complete = time.monotonic()
+                        if verified_chunks % 1000 == 0:
+                            emit('progress', verified_chunks=verified_chunks,
+                                 verified_systems=verified_systems, elapsed_seconds=last_complete-started)
+                        if last_complete - started >= DURATION_SECONDS:
+                            break
+            except Deadline:
+                deadline_reached = True
+            signal.alarm(15)
+            elapsed = time.monotonic() - started
+            after = connection.execute('''SELECT COALESCE(sum(systems),0) FROM v3_derived.build_chunk
+                WHERE derived_generation_id=%s''', (GENERATION_ID,)).fetchone()[0]
+            sample_seconds = last_complete - started
+            rate = verified_systems / sample_seconds if verified_systems and sample_seconds else None
+            emit('summary', generation_id=GENERATION_ID, database_read_only=True,
+                 ratings_writes_performed=False, worker_restarted=False,
+                 elapsed_seconds=elapsed, completed_chunk_seconds=sample_seconds,
+                 verified_chunks=verified_chunks, verified_systems=verified_systems,
+                 prefix_systems_at_start=before, compressed_bytes_read=reader.bytes_read,
+                 compressed_prefix_sha256=reader.digest.hexdigest(), source_eof_verified=False,
+                 all_initial_checkpoints_verified=verified_chunks == len(checkpoints),
+                 verified_systems_per_second=rate,
+                 projected_prefix_seconds_if_same_mix=before / rate if rate else None,
+                 projection_is_not_a_production_eta=True, deadline_reached=deadline_reached,
+                 builder_systems_committed_during_sample=after-before,
+                 builder_systems_per_second=(after-before)/elapsed)
+    signal.alarm(0)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as exc:
+        # Never emit DSNs or raw database errors into an artifact.
+        emit('failed', error_type=type(exc).__name__)
+        sys.exit(1)

--- a/tests/test_ci_stall_detection.py
+++ b/tests/test_ci_stall_detection.py
@@ -51,6 +51,7 @@ CHECKED_WORKFLOWS = (
     'ratings-v4-production-accelerate.yml',
     'ratings-v4-production-optimize.yml',
     'ratings-v4-production-profile.yml',
+    'ratings-v4-resume-profile.yml',
     'remove-ollama-production.yml',
     'review-lab.yml',
     'semgrep.yml',

--- a/tests/test_ratings_v4_resume_profile.py
+++ b/tests/test_ratings_v4_resume_profile.py
@@ -1,0 +1,87 @@
+import io
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts.operator.ratings_v4_resume_profile import (  # noqa: E402
+    ArrayRootReader, direct_chunks, verify_chunk,
+)
+from scripts.ratings_v4.canonical_stream import _ArrayRootReader  # noqa: E402
+from scripts.ratings_v4.production_generation import _digest, _projection  # noqa: E402
+
+
+def test_observer_uses_equivalent_transparent_array_guard():
+    raw = b' \t\r\n\v\f' * 2000 + b'[{"id64":1}]'
+    for reader_type in (ArrayRootReader, _ArrayRootReader):
+        reader = reader_type(io.BytesIO(raw))
+        assert reader.read(0) == b''
+        parts = []
+        while part := reader.read(3):
+            parts.append(part)
+        assert b''.join(parts) == raw
+    with pytest.raises(ValueError, match='JSON array'):
+        list(direct_chunks(io.BytesIO(b'{"item":{"id64":1}}')))
+
+
+def test_observer_verifies_source_order_projection_and_inventory():
+    records = [{'id64': i, 'bodies': []} for i in range(3)]
+    import json
+    chunks = list(direct_chunks(io.BytesIO(json.dumps(records).encode()), chunk_size=2))
+    assert chunks == [records[:2], records[2:]]
+    checkpoint = (0, _digest([_projection(r) for r in chunks[0]]), 2, 0)
+    verify_chunk(checkpoint, 0, chunks[0])
+    for bad in (list(reversed(chunks[0])), chunks[0][:1], [{'id64': 9, 'bodies': []}, records[1]]):
+        with pytest.raises(ValueError, match='source/checkpoint'):
+            verify_chunk(checkpoint, 0, bad)
+
+
+def test_observer_is_bounded_and_database_read_only():
+    source = (ROOT / 'scripts/operator/ratings_v4_resume_profile.py').read_text()
+    assert 'default_transaction_read_only=on' in source
+    assert 'RLIMIT_AS' in source and 'RLIMIT_CPU' in source
+    assert 'signal.alarm(150)' in source
+    assert 'source_eof_verified=False' in source
+    assert 'INSERT INTO' not in source and 'UPDATE v3_' not in source
+
+
+@pytest.mark.parametrize('wrong_source', [False, True])
+def test_remote_wrapper_checks_exact_container_before_executing_observer(tmp_path, wrong_source):
+    import yaml
+
+    workflow = yaml.safe_load((ROOT / '.github/workflows/ratings-v4-resume-profile.yml').read_text())
+    step = next(s for s in workflow['jobs']['profile']['steps']
+                if s.get('name') == 'Run bounded read-only Ratings profile')
+    lines = step['run'].splitlines()
+    start = next(i for i, line in enumerate(lines) if line.strip() == "'")
+    end = next(i for i, line in enumerate(lines[start+1:], start+1) if line.strip().startswith("' "))
+    remote = '\n'.join(lines[start+1:end])
+    hostname = tmp_path / 'hostname'
+    hostname.write_text('#!/bin/sh\nif [ "$#" = 0 ]; then echo ed-finder-prod; else echo nb79a3d.mevnode.com; fi\n')
+    hostname.chmod(0o700)
+    docker = tmp_path / 'docker'
+    docker.write_text('#!' + sys.executable + '\n' + '''import os,sys
+args=sys.argv[1:]
+if args==['context','show']: print('default')
+elif args[:2]==['context','inspect']: print('unix:///var/run/docker.sock')
+elif args[:2]==['inspect','-f']:
+    values={'{{.State.Running}}':'true',
+      '{{index .Config.Labels "ed-finder.source-sha"}}': 'wrong' if os.environ['WRONG_SOURCE']=='1' else 'fe0c058134b6fec33690fa937c2ac74338b401dc',
+      '{{index .Config.Labels "ed-finder.generation-key"}}':'ratings_v4_prod_p4_opt1'}
+    print(values[args[2]])
+elif args==['exec','-i','-e','PYTHONPATH=/tmp/ratings-v4-deps:/work:/work/apps/api/src',
+            'edfinder-ratings-v4-prod-p4-opt1','/app/.venv/bin/python','-']:
+    print('observer launched')
+else: raise SystemExit(64)
+''')
+    docker.chmod(0o700)
+    result = subprocess.run(['bash', '-c', remote], text=True, capture_output=True,
+                            env={**os.environ, 'PATH': str(tmp_path)+os.pathsep+os.environ['PATH'],
+                                 'WRONG_SOURCE': str(int(wrong_source))}, timeout=5)
+    assert result.returncode == int(wrong_source), result.stderr
+    assert ('observer launched' in result.stdout) is not wrong_source


### PR DESCRIPTION
PR #708 proves that a parser upgrade can preserve the running generation's rows and checkpoints. We still need a bounded measurement of the source-prefix replay cost before deciding whether a production handoff will save time.

This adds a 120-second read-only observer in a separate process inside the existing Ratings container. It verifies the exact old four-file code identity, generation UUID/key, manifest hash, source size and contiguous saved checkpoints. It directly parses the retained source and compares every counted chunk's projection hash and inventories with its saved checkpoint. It also measures the real builder's concurrent committed-system progress.

The observer uses a read-only PostgreSQL session, 5-second SQL/1-second lock limits, a 2 GiB address-space limit, CPU/wall-clock deadlines and lower scheduling priority. It does not change the running Python process, code files, worker configuration, rows, manifests or published pointers. A partial scan explicitly reports `source_eof_verified=false`; any full-prefix time projection is labelled conditional on the sampled data mix, not a production ETA.

The data-only request workflow executes reviewed main through the existing pinned SSH operator environment. Host, FQDN, local Docker context, worker state and exact source/generation labels are checked before execution. Receipts include profiler/main provenance and retain no source records, DSNs or raw database errors.

Validation: five focused local tests pass, including correct/mismatched worker guards exercised through a mock remote shell, source order/projection/inventory rejection and transparent root-reader equivalence. Ruff and workflow/shell parsing pass. Ratings CI includes the observer changes.

This PR only installs the observer capability. After review/merge, the authorized read-only request will gather the measurement while Ratings and Search continue running. No upgrade migration or runtime cutover is included.