### PR TITLE
fix(ratings): align profiler throughput with database snapshots

### DIFF
--- a/scripts/operator/ratings_v4_resume_profile.py
+++ b/scripts/operator/ratings_v4_resume_profile.py
@@ -82,6 +82,29 @@ def emit(kind, **data):
                      sort_keys=True), flush=True)
 
 
+def builder_snapshot(connection):
+    # The count and clock belong to the same database statement. Source parsing
+    # has a different interval and must not be used to time builder commits.
+    return connection.execute('''SELECT COALESCE(sum(systems),0), statement_timestamp()
+        FROM v3_derived.build_chunk WHERE derived_generation_id=%s''', (GENERATION_ID,)).fetchone()
+
+
+def builder_progress(before, after):
+    elapsed = (after[1] - before[1]).total_seconds()
+    committed = int(after[0] - before[0])
+    if elapsed <= 0 or committed < 0:
+        raise ValueError('invalid builder snapshot interval')
+    return {
+        'builder_systems_at_start': int(before[0]),
+        'builder_systems_at_end': int(after[0]),
+        'builder_snapshot_started_at': before[1].isoformat(),
+        'builder_snapshot_ended_at': after[1].isoformat(),
+        'builder_elapsed_seconds': elapsed,
+        'builder_systems_committed_during_sample': committed,
+        'builder_systems_per_second': committed / elapsed,
+    }
+
+
 def main():
     import psycopg
     import resource
@@ -124,10 +147,11 @@ def main():
             FROM v3_derived.build_chunk WHERE derived_generation_id=%s ORDER BY chunk_ordinal''', (GENERATION_ID,)).fetchall()
         if not checkpoints or any(row[0] != i for i, row in enumerate(checkpoints)):
             raise ValueError('committed prefix is empty or noncontiguous')
-        before = sum(row[2] for row in checkpoints)
-        emit('start', generation_id=GENERATION_ID, committed_systems=before,
+        prefix_systems = sum(row[2] for row in checkpoints)
+        emit('start', generation_id=GENERATION_ID, committed_systems=prefix_systems,
              committed_chunks=len(checkpoints), expected_systems=manifest['expected_systems'],
              database_read_only=True, duration_seconds=DURATION_SECONDS)
+        builder_before = builder_snapshot(connection)
         started = last_complete = time.monotonic()
         verified_systems = verified_chunks = 0
         deadline_reached = False
@@ -151,22 +175,20 @@ def main():
                 deadline_reached = True
             signal.alarm(15)
             elapsed = time.monotonic() - started
-            after = connection.execute('''SELECT COALESCE(sum(systems),0) FROM v3_derived.build_chunk
-                WHERE derived_generation_id=%s''', (GENERATION_ID,)).fetchone()[0]
+            builder_after = builder_snapshot(connection)
             sample_seconds = last_complete - started
             rate = verified_systems / sample_seconds if verified_systems and sample_seconds else None
             emit('summary', generation_id=GENERATION_ID, database_read_only=True,
                  ratings_writes_performed=False, worker_restarted=False,
                  elapsed_seconds=elapsed, completed_chunk_seconds=sample_seconds,
                  verified_chunks=verified_chunks, verified_systems=verified_systems,
-                 prefix_systems_at_start=before, compressed_bytes_read=reader.bytes_read,
+                 prefix_systems_at_start=prefix_systems, compressed_bytes_read=reader.bytes_read,
                  compressed_prefix_sha256=reader.digest.hexdigest(), source_eof_verified=False,
                  all_initial_checkpoints_verified=verified_chunks == len(checkpoints),
                  verified_systems_per_second=rate,
-                 projected_prefix_seconds_if_same_mix=before / rate if rate else None,
+                 projected_prefix_seconds_if_same_mix=prefix_systems / rate if rate else None,
                  projection_is_not_a_production_eta=True, deadline_reached=deadline_reached,
-                 builder_systems_committed_during_sample=after-before,
-                 builder_systems_per_second=(after-before)/elapsed)
+                 **builder_progress(builder_before, builder_after))
     signal.alarm(0)
 
 

--- a/tests/test_ratings_v4_resume_profile.py
+++ b/tests/test_ratings_v4_resume_profile.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 import io
 import os
 from pathlib import Path
@@ -10,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from scripts.operator.ratings_v4_resume_profile import (  # noqa: E402
-    ArrayRootReader, direct_chunks, verify_chunk,
+    ArrayRootReader, builder_progress, direct_chunks, verify_chunk,
 )
 from scripts.ratings_v4.canonical_stream import _ArrayRootReader  # noqa: E402
 from scripts.ratings_v4.production_generation import _digest, _projection  # noqa: E402
@@ -48,6 +49,29 @@ def test_observer_is_bounded_and_database_read_only():
     assert 'signal.alarm(150)' in source
     assert 'source_eof_verified=False' in source
     assert 'INSERT INTO' not in source and 'UPDATE v3_' not in source
+
+
+def test_builder_rate_uses_database_snapshot_interval():
+    started = datetime(2026, 9, 12, 23, 35, 33, tzinfo=timezone.utc)
+    # A 120-second parser sample can have a longer database count interval.
+    # Builder throughput must include that extra time in its denominator.
+    ended = started + timedelta(seconds=123)
+    result = builder_progress((78_510_000, started), (78_756_000, ended))
+    assert result['builder_elapsed_seconds'] == 123
+    assert result['builder_systems_per_second'] == 2000
+    assert result['builder_systems_committed_during_sample'] == 246_000
+    assert result['builder_systems_at_start'] == 78_510_000
+    assert result['builder_systems_at_end'] == 78_756_000
+    assert result['builder_snapshot_started_at'] == started.isoformat()
+    assert result['builder_snapshot_ended_at'] == ended.isoformat()
+    assert builder_progress((1000, started), (1000, ended))['builder_systems_per_second'] == 0
+
+
+@pytest.mark.parametrize(('seconds', 'end_count'), [(0, 2000), (-1, 2000), (120, 999)])
+def test_builder_rate_rejects_invalid_snapshot_interval(seconds, end_count):
+    started = datetime(2026, 9, 12, tzinfo=timezone.utc)
+    with pytest.raises(ValueError, match='invalid builder snapshot interval'):
+        builder_progress((1000, started), (end_count, started + timedelta(seconds=seconds)))
 
 
 @pytest.mark.parametrize('wrong_source', [False, True])


### PR DESCRIPTION
The read-only prefix profiler used source parsing elapsed time to divide builder commits captured over a slightly wider database interval. This could inflate the builder rate and distort the conditional parser-upgrade break-even calculation (late P2 review on #709).

Capture committed count and statement_timestamp() together at both endpoints. Report their explicit counts, timestamps, and elapsed interval, and calculate builder throughput from those pairs. Keep source-prefix verification timing separate. Reject nonpositive intervals and decreasing counts.

Validation: Ruff and 14 focused observer/workflow tests pass, including a regression where the database interval exceeds parsing time. Only the separate observer and its tests change; generation-bound code and the running production worker are unchanged. After merge, rerun the bounded read-only sample before relying on the break-even estimate.